### PR TITLE
docs: pipeline rules + PR-based dev workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,27 @@ See `ARCHITECTURE.md` for the full picture.
 - `emr-scheduler` — a 15-minute cron job that enqueues recurring work
 - `emr-postgres` — the managed Postgres instance
 
-Deploy by pointing Render at this repo and letting it pick up `render.yaml`. `SESSION_SECRET` is auto-generated; `ANTHROPIC_API_KEY` is opt-in (the platform defaults to a stub model client).
+Every service is pinned to `main`. `SESSION_SECRET` is auto-generated; `ANTHROPIC_API_KEY` is opt-in (the platform defaults to a stub model client).
+
+### Pipeline rules — read before changing `render.yaml`
+
+These rules exist because the pipeline drifted badly in the past (`main` was 170 commits behind production, schema migrations silently skipped, interactive `next lint` prompts failing CI). The current setup is deliberately small and reliable.
+
+1. **`main` is the only deploy branch.** Never point a Render service at a feature branch — that's how we ended up with prod and `main` out of sync.
+2. **Schema sync lives in `startCommand`, not `preDeployCommand`.** Render's `preDeployCommand` is not guaranteed to run on Starter plan; silent skips mean new Prisma models never reach the database. `npx prisma db push --accept-data-loss --skip-generate` runs in `startCommand` so the schema is synced immediately before traffic hits.
+3. **Seeding is a one-off.** Run `npm run db:seed` manually from a Render shell when bootstrapping a fresh database. Do not couple it to every deploy.
+
+### Development workflow
+
+Direct pushes to `main` are blocked by a branch-protection ruleset. All changes land via pull request:
+
+1. Branch off `main`, make your changes, push.
+2. Open a PR into `main`. GitHub Actions runs `typecheck · lint · build` (`.github/workflows/ci.yml`).
+3. PR cannot merge until: CI is green, the branch is up to date with `main`, and force-pushes are blocked.
+4. Merge → delete the branch → Render auto-deploys from the new `main`.
+
+If CI fails, fix it on the branch — don't bypass the check. The rules that protect `main` also protect future-you from debugging a silent production outage at 3 AM.
+
 
 ## Security posture
 


### PR DESCRIPTION
## Summary

Closes the pipeline-hardening loop by writing down the rules we just established, so this knowledge doesn't live only in chat logs.

### What's added to `README.md`

Two new sections, slotted next to the existing **Deploying to Render** content:

1. **Pipeline rules — read before changing `render.yaml`** — three non-negotiables:
   - `main` is the only deploy branch
   - schema sync lives in `startCommand` (because `preDeployCommand` silently skipped on Starter)
   - seeding is a one-off, not per-deploy
2. **Development workflow** — short explainer of the PR-based flow enforced by branch protection (CI-gated, no direct pushes, no force-pushes).

Each rule is explicit about *why* it exists, so whoever reads this in six months knows which past-tense mistake they'd be re-introducing if they revert the rule.

### Why this matters

Over the last few hours we fixed:
- `main` being 170 commits behind production
- Login blowing up because `LabResult` / `RefillRequest` tables never made it to the DB
- `preDeployCommand` silently skipping on Starter
- CI not existing at all
- `next lint` failing CI because no `.eslintrc` was committed
- A real React hooks bug in `Sparkline`

Without documentation, the next person (or future-me) will slowly undo all of it. This PR is the paper trail.

## Test plan

- [ ] CI (`typecheck · lint · build`) passes on this PR
- [ ] Skim the rendered README on GitHub → the two new sections read clearly

Docs-only change. No runtime impact.

---
*Final item on the pipeline-hardening punch list. After this merges, the todo list is empty.*