### PR TITLE
feat(command-center): shell + tile primitives + four placeholder tiles

### DIFF
--- a/src/app/(clinician)/clinic/command/page.tsx
+++ b/src/app/(clinician)/clinic/command/page.tsx
@@ -1,0 +1,119 @@
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Tile, TilePlaceholder } from "@/components/ui/tile";
+import { TileGrid } from "@/components/ui/tile-grid";
+
+export const metadata = { title: "Command Center" };
+
+/**
+ * Clinical Command Center — the clinician's single-pane dashboard.
+ *
+ * This page is the *shell* for the feature set sketched in the
+ * Mission Control notebook: schedule, messages, patient snapshot,
+ * mindful break. Each pillar ships as its own PR into its own tile.
+ * The framework here is intentionally empty so the tile layout,
+ * responsive grid, and nav wiring can be reviewed in isolation
+ * before any feature content is written.
+ *
+ * Accessible to: clinician, practice_owner (enforced at the layout).
+ */
+export default async function CommandCenterPage() {
+  const user = await requireUser();
+
+  const now = new Date();
+  const greeting = pickGreeting(now.getHours());
+
+  return (
+    <PageShell maxWidth="max-w-[1400px]">
+      <PageHeader
+        eyebrow="Command Center"
+        title={`${greeting}, ${user.firstName}.`}
+        description="Your day at a glance. Schedule, messages, patient snapshots, and a mindful reset — all in one place."
+      />
+
+      <TileGrid>
+        {/* Pillar 1 — Schedule. Today's patients, card height proportional
+            to visit duration, hover to preview the facesheet. */}
+        <Tile
+          eyebrow="Today"
+          title="Schedule"
+          description="Time-sized patient cards with AI-summarized reason for visit."
+          icon="📅"
+          span="2x2"
+          href="/clinic"
+          tone="default"
+        >
+          <TilePlaceholder note="Schedule tile ships next. Tap to preview today in the current view." />
+        </Tile>
+
+        {/* Pillar 2 — Messages. AI-summarized inbox with keyword priority
+            (urgent in red), inline C/M/Rx/📞 actions, voice dictation. */}
+        <Tile
+          eyebrow="Inbox"
+          title="Messages"
+          description="AI-summarized, priority-sorted. Urgent floats to the top."
+          icon="💬"
+          span="1x2"
+          href="/clinic/messages"
+          tone="warm"
+        >
+          <TilePlaceholder note="Summaries + quick actions land in slice 2." />
+        </Tile>
+
+        {/* Pillar 3 — Patient snapshot. Hover over a patient → facesheet
+            preview (vitals, meds, labs sparklines, surgeries). */}
+        <Tile
+          eyebrow="Roster"
+          title="Patient Snapshot"
+          description="Hover any patient to see vitals, meds, trending labs, and preventatives."
+          icon="👤"
+          span="1x1"
+          href="/clinic/patients"
+          tone="accent"
+        >
+          <TilePlaceholder note="Hover-preview comes in slice 3." />
+        </Tile>
+
+        {/* Pillar 4 — Mindful break. Click → 10-min max reset (breathe, move,
+            game, tranquil picture/sound). "Back to work!" on exit. */}
+        <Tile
+          eyebrow="Reset"
+          title="Mindful Break"
+          description="Breathe, move, or play for up to ten minutes. Back to work when you're ready."
+          icon="🧘"
+          span="1x1"
+          href="#"
+          tone="calm"
+        >
+          <TilePlaceholder note="Full module in slice 4." />
+        </Tile>
+
+        {/* Placeholder tile — reminds us that the tabbed sidebar is Phase 3
+            and should land once the four content pillars are in. Using a
+            non-clickable tile so it doesn't pretend to be functional. */}
+        <Tile
+          eyebrow="Navigation"
+          title="Tabbed Sidebar"
+          description="Google-tab style, draggable, hover to peek the last 3–5 entries per tab."
+          icon="🗂️"
+          span="1x1"
+          tone="default"
+        >
+          <TilePlaceholder note="Phase 3 — after the four pillars are in." />
+        </Tile>
+      </TileGrid>
+
+      <p className="mt-12 text-xs text-text-subtle italic text-center">
+        Framework preview · content ships tile by tile · each slice is its own PR.
+      </p>
+    </PageShell>
+  );
+}
+
+function pickGreeting(hour: number): string {
+  if (hour < 5) return "Still up";
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  if (hour < 21) return "Good evening";
+  return "Good night";
+}

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -80,7 +80,8 @@ export default async function ClinicianLayout({
   })();
 
   const nav: NavItem[] = [
-    { label: "Command", href: "/clinic" },
+    { label: "Command Center", href: "/clinic/command" },
+    { label: "Today", href: "/clinic" },
     { label: "Brief", href: "/clinic/morning-brief" },
     { label: "Roster", href: "/clinic/patients" },
     { label: "Inbox", href: "/clinic/messages" },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -5,6 +5,7 @@ import { ROLE_HOME } from "@/lib/rbac/roles";
 
 const OPS_NAV: NavItem[] = [
   { label: "Overview", href: "/ops" },
+  { label: "Command Center", href: "/clinic/command" },
   { label: "Mission Control", href: "/ops/mission-control" },
   { label: "Schedule", href: "/ops/schedule" },
   { label: "Patients", href: "/ops/patients" },

--- a/src/components/ui/tile-grid.tsx
+++ b/src/components/ui/tile-grid.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * TileGrid — a responsive CSS grid sized for the Command Center.
+ *
+ * Three columns on desktop, two on tablet, one on mobile. Tiles size
+ * themselves via their `span` prop; the grid just provides the track.
+ * Row height is generous so 1x1 tiles feel substantial rather than
+ * cramped.
+ */
+
+export function TileGrid({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-4",
+        "grid-cols-1 sm:grid-cols-2 md:grid-cols-3",
+        "auto-rows-[minmax(180px,auto)]",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/tile.tsx
+++ b/src/components/ui/tile.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Tile — the fundamental unit of the Clinical Command Center.
+ *
+ * Apple-ish aesthetic: generous radius, soft shadow, warm surface, quiet
+ * hover lift. A Tile knows how big it is in the grid (via `span`), carries
+ * its own title + optional eyebrow + optional action, and otherwise gets
+ * out of the way so feature content can breathe.
+ *
+ * When `href` is set the whole tile is clickable; otherwise it's static.
+ */
+
+type TileSpan = "1x1" | "2x1" | "1x2" | "2x2" | "3x1" | "3x2";
+
+type TileTone = "default" | "accent" | "calm" | "warm";
+
+const SPAN_CLASSES: Record<TileSpan, string> = {
+  "1x1": "md:col-span-1 md:row-span-1",
+  "2x1": "md:col-span-2 md:row-span-1",
+  "1x2": "md:col-span-1 md:row-span-2",
+  "2x2": "md:col-span-2 md:row-span-2",
+  "3x1": "md:col-span-3 md:row-span-1",
+  "3x2": "md:col-span-3 md:row-span-2",
+};
+
+const TONE_CLASSES: Record<TileTone, string> = {
+  default: "bg-surface border-border/80",
+  accent: "bg-accent-soft/40 border-accent/20",
+  calm: "bg-[var(--highlight-soft)]/40 border-highlight/20",
+  warm: "bg-surface-raised border-border",
+};
+
+export interface TileProps {
+  title: string;
+  eyebrow?: string;
+  description?: string;
+  href?: string;
+  action?: React.ReactNode;
+  icon?: React.ReactNode;
+  span?: TileSpan;
+  tone?: TileTone;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function Tile({
+  title,
+  eyebrow,
+  description,
+  href,
+  action,
+  icon,
+  span = "1x1",
+  tone = "default",
+  children,
+  className,
+}: TileProps) {
+  const body = (
+    <div
+      className={cn(
+        "group relative h-full rounded-2xl border shadow-sm",
+        "transition-all duration-200 ease-smooth",
+        "flex flex-col overflow-hidden",
+        TONE_CLASSES[tone],
+        href && "hover:shadow-md hover:-translate-y-0.5 hover:border-border-strong cursor-pointer",
+        SPAN_CLASSES[span],
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+        <div className="min-w-0 flex-1">
+          {eyebrow && (
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-text-subtle">
+              {eyebrow}
+            </p>
+          )}
+          <div className="flex items-center gap-2 mt-1">
+            {icon && (
+              <span className="text-xl leading-none" aria-hidden="true">
+                {icon}
+              </span>
+            )}
+            <h3 className="font-display text-base font-medium text-text tracking-tight truncate">
+              {title}
+            </h3>
+          </div>
+          {description && (
+            <p className="text-xs text-text-muted mt-1.5 line-clamp-2">
+              {description}
+            </p>
+          )}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+
+      {children && <div className="flex-1 min-h-0 px-5 pb-5">{children}</div>}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={cn("block h-full", SPAN_CLASSES[span])}
+        aria-label={title}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return body;
+}
+
+/**
+ * Empty-state body for a Tile that hasn't been built yet. Keeps the
+ * placeholder honest — the tile shows up, has the right shape, but
+ * clearly signals that the feature is coming.
+ */
+export function TilePlaceholder({ note }: { note?: string }) {
+  return (
+    <div className="h-full flex flex-col items-center justify-center py-10 text-center gap-2">
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 rounded-full border-2 border-dashed border-border-strong/50"
+      />
+      <p className="text-xs text-text-subtle italic">
+        {note ?? "Coming in the next slice"}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Kicks off the **Clinical Command Center** build. This PR is the **framework only** — no feature content, just the canvas. Sized so the layout, responsive grid, and nav wiring can be reviewed in one sitting before investing in any of the feature pillars.

### What it looks like

Log in as a clinician or practice owner → click **Command Center** in the sidebar → land on `/clinic/command`. Five tiles in a 3-column grid (responsive down to 1 on mobile):

| # | Pillar | Size | Route |
|---|---|---|---|
| 1 | 📅 **Schedule** | 2×2 | `/clinic` |
| 2 | 💬 **Messages** | 1×2 | `/clinic/messages` |
| 3 | 👤 **Patient Snapshot** | 1×1 | `/clinic/patients` |
| 4 | 🧘 **Mindful Break** | 1×1 | *(coming)* |
| 5 | 🗂️ **Tabbed Sidebar** | 1×1 | *(Phase 3)* |

Each tile currently shows a placeholder body — the shape is right, the content is intentionally empty.

### What ships

- **`src/components/ui/tile.tsx`** — Tile primitive. Sizes `1x1`–`3x2`, tones `default / accent / calm / warm`, optional `href` / `eyebrow` / `icon` / `description` / `action` / `children`. Apple-ish aesthetic per CLAUDE.md (generous radius, soft shadow, warm surface, quiet hover lift). `TilePlaceholder` body for unbuilt slices.
- **`src/components/ui/tile-grid.tsx`** — Dumb responsive grid track. Tiles size themselves.
- **`src/app/(clinician)/clinic/command/page.tsx`** — The new route. Greets by first name, lays out the five tiles.

### Nav wiring

- **Clinician sidebar:** new `Command Center` entry at the top. The existing `/clinic` nav item is renamed `Today` so both coexist during the transition — no bookmarks break.
- **Operator sidebar:** new `Command Center` entry right after `Overview`, linking to `/clinic/command`. `practice_owner` already has RBAC access to `/clinic/*`, so no role changes needed.

### Scope discipline

- **Zero schema changes.** No Prisma migrations.
- **Zero new queries.** Feature queries belong in the per-pillar PRs.
- **Zero new dependencies.** Uses the existing design system + Tailwind setup.

### Next slices (separate PRs, gated by CI)

1. Schedule tile — time-sized patient cards, hover → facesheet preview
2. Messages tile — AI summaries, keyword priority (urgent in red), inline C/M/Rx/📞 actions
3. Patient Snapshot hover-preview (requires richer facesheet data)
4. Mindful Break module — breathe / move / game, 10-min cap, "back to work!"
5. Tabbed sidebar nav (Phase 3)

Each slice is reviewable on its own and you can reorder or bail on any of them without unwinding this PR.

## Test plan

- [ ] CI green (`typecheck · lint · build`)
- [ ] Log in as clinician → sidebar shows `Command Center` → click → lands on `/clinic/command` with the greeting + 5 tiles
- [ ] Log in as practice owner → ops sidebar shows `Command Center` → click → lands on same page (switches into clinician layout)
- [ ] Resize browser — grid collapses 3 → 2 → 1 columns gracefully
- [ ] Hover a tile with an `href` — lifts, shadow deepens, cursor is a pointer
- [ ] Tap a tile — navigates to the listed `href`

---
*Framework preview. Content ships tile by tile — each slice its own PR.*