### PR TITLE
feat(brand): add favicon — leafjourney leaf sprig on cream

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,27 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <title>Leafjourney</title>
+  <defs>
+    <linearGradient id="lj-leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4A8362"/>
+      <stop offset="100%" stop-color="#1F4D37"/>
+    </linearGradient>
+  </defs>
+
+  <!-- warm cream rounded background, matching --bg (#F8F4EB) -->
+  <rect width="32" height="32" rx="7" fill="#F8F4EB"/>
+
+  <!-- central stem -->
+  <path d="M 16 28 L 16 5"
+        stroke="#1F4D37" stroke-width="1.3" stroke-linecap="round" fill="none"/>
+
+  <!-- lower pair -->
+  <path d="M 16 22 C 13 22, 9 20, 7 18 C 11 20, 14 21, 16 22 Z" fill="url(#lj-leaf)"/>
+  <path d="M 16 22 C 19 22, 23 20, 25 18 C 21 20, 18 21, 16 22 Z" fill="url(#lj-leaf)"/>
+
+  <!-- middle pair -->
+  <path d="M 16 15 C 13 15, 10 14, 8 12 C 11 14, 14 14, 16 15 Z" fill="url(#lj-leaf)"/>
+  <path d="M 16 15 C 19 15, 22 14, 24 12 C 21 14, 18 14, 16 15 Z" fill="url(#lj-leaf)"/>
+
+  <!-- top leaf -->
+  <path d="M 16 8 C 13 6, 14 4, 16 3 C 18 4, 19 6, 16 8 Z" fill="url(#lj-leaf)"/>
+</svg>


### PR DESCRIPTION
Next.js App Router auto-discovers src/app/icon.svg and emits the right <link> tags, so no metadata wiring is needed.

Hand-crafted SVG: five almond-leaf shapes in the brand forest-green gradient (#4A8362 → #1F4D37) arranged pinnately on a central stem, over a warm cream rounded square (#F8F4EB — matches --bg). Optimized for readability at 16×16; the whole thing is ~1KB on disk.

Swapping in a real PNG later is a no-op: drop icon.png in the same folder and Next.js prefers it over the SVG. No code change required.