### PR TITLE
fix(clinic): 404 on Prepare when patient is soft-deleted or cross-org

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -212,10 +212,14 @@ export default async function ClinicHomePage() {
     recentObservations,
   ] = await Promise.all([
     // 1. Today's encounters
+    //    Exclude encounters whose patient has been soft-deleted — otherwise
+    //    the card would render with a ghost patient and the Prepare button
+    //    would 404 downstream.
     prisma.encounter.findMany({
       where: {
         organizationId,
         scheduledFor: { gte: startOfDay, lt: endOfDay },
+        patient: { deletedAt: null },
       },
       include: { patient: { include: { chartSummary: true } } },
       orderBy: { scheduledFor: "asc" },
@@ -277,8 +281,13 @@ export default async function ClinicHomePage() {
     }),
 
     // 9. Recent completed encounters (activity feed)
+    //    Same deleted-patient guard as the today list.
     prisma.encounter.findMany({
-      where: { organizationId, status: "complete" },
+      where: {
+        organizationId,
+        status: "complete",
+        patient: { deletedAt: null },
+      },
       include: { patient: { select: { id: true, firstName: true, lastName: true } } },
       orderBy: { completedAt: "desc" },
       take: 5,

--- a/src/app/(clinician)/clinic/patients/[id]/not-found.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/not-found.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+
+/**
+ * Segment-level not-found for /clinic/patients/[id] and every sub-route
+ * underneath it (chart, prepare, prescribe, documents, etc).
+ *
+ * Triggered when the page can't resolve the patient — usually because
+ * the patient has been removed, belongs to another practice, or the
+ * link is stale. The app-wide "This path doesn't lead anywhere" screen
+ * is misleading here, because the path itself is real; what's missing
+ * is the patient at the end of it.
+ */
+export default function PatientNotFound() {
+  return (
+    <PageShell maxWidth="max-w-[720px]">
+      <Card tone="raised">
+        <CardContent className="py-10 text-center">
+          <Eyebrow className="justify-center mb-3">Patient unavailable</Eyebrow>
+          <h1 className="font-display text-2xl text-text tracking-tight">
+            This patient isn&apos;t in your roster.
+          </h1>
+          <p className="text-sm text-text-muted mt-3 max-w-md mx-auto leading-relaxed">
+            They may have been removed, belong to another practice, or
+            the link may be stale. Head back to the roster to find the
+            right chart.
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Link href="/clinic/patients">
+              <Button>Back to roster</Button>
+            </Link>
+            <Link href="/clinic">
+              <Button variant="secondary">Today</Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}


### PR DESCRIPTION
User landed on /clinic/patients/{id}/prepare → hit the generic "This path doesn't lead anywhere" screen. Two problems:

  1. Today view (/clinic) was listing encounters for soft-deleted patients, so the rendered card looked real but the Prepare button linked to a ghost. Fixed by adding `patient: { deletedAt: null }` to both encounter queries on that page — today's schedule and the recent-completed feed.

  2. When the prepare page did fail to resolve a patient, the only not-found handler was the app-wide one, whose copy ("this path doesn't lead anywhere") is wrong in this context — the path is real, the patient at the end of it is what's missing. Added a segment-level not-found.tsx at /clinic/patients/[id]/ that cascades to every sub-route (prepare, prescribe, documents, …) and tells the clinician the patient was removed, with links back to the roster and Today view.

Net effect: deleted patients stop surfacing in the Today card, and when a stale link does slip through, the error is helpful instead of confusing.