### PR TITLE
feat(command-center): Mindful Break — breathing session + hub

### DIFF
--- a/src/app/(clinician)/clinic/command/page.tsx
+++ b/src/app/(clinician)/clinic/command/page.tsx
@@ -65,19 +65,17 @@ export default async function CommandCenterPage() {
           <TilePlaceholder note="Hover-preview comes in slice 3." />
         </Tile>
 
-        {/* Pillar 4 — Mindful break. Click → 10-min max reset (breathe, move,
-            game, tranquil picture/sound). "Back to work!" on exit. */}
+        {/* Pillar 4 — Mindful break. Breathe is live; Move and Inspire
+            land as their own slices. 10-minute cap on every path. */}
         <Tile
           eyebrow="Reset"
           title="Mindful Break"
-          description="Breathe, move, or play for up to ten minutes. Back to work when you're ready."
+          description="Breathe, move, or take in something beautiful. Ten minutes, then back to work."
           icon="🧘"
           span="1x1"
-          href="#"
+          href="/clinic/mindful"
           tone="calm"
-        >
-          <TilePlaceholder note="Full module in slice 4." />
-        </Tile>
+        />
 
         {/* Placeholder tile — reminds us that the tabbed sidebar is Phase 3
             and should land once the four content pillars are in. Using a

--- a/src/app/(clinician)/clinic/mindful/breathe/page.tsx
+++ b/src/app/(clinician)/clinic/mindful/breathe/page.tsx
@@ -1,0 +1,23 @@
+import { requireUser } from "@/lib/auth/session";
+import { BreathingSession } from "@/components/mindful/breathing-session";
+
+export const metadata = { title: "Breathe" };
+
+/**
+ * Breathing session route. The actual animation + timer live in a
+ * client component so the page stays a thin server wrapper; all this
+ * file does is gate the route and hand over to BreathingSession.
+ *
+ * The surrounding clinician AppShell still renders (nav sidebar etc),
+ * but the session body itself is centered and quiet — no secondary
+ * UI competes for attention during the break.
+ */
+export default async function BreathePage() {
+  await requireUser();
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center px-6 py-16">
+      <BreathingSession />
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/mindful/page.tsx
+++ b/src/app/(clinician)/clinic/mindful/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils/cn";
+
+export const metadata = { title: "Mindful Break" };
+
+/**
+ * Mindful Break — hub.
+ *
+ * Three paths from the Dr. Patel brief: Breathe, Move, Inspire. Breathe
+ * ships first (working animation + timer). Move and Inspire land as
+ * separate PRs so each can be delightful on its own terms without
+ * blocking the rest.
+ *
+ * Every path is capped at 10 minutes (per the sketch — "back to work!"
+ * is the point). Exit is always one click.
+ */
+export default async function MindfulHubPage() {
+  await requireUser();
+
+  return (
+    <PageShell maxWidth="max-w-[900px]">
+      <div className="text-center mb-10">
+        <Eyebrow className="justify-center mb-3">Mindful Break</Eyebrow>
+        <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.1]">
+          Take a breath. You&apos;ve earned it.
+        </h1>
+        <p className="text-[15px] text-text-muted mt-3 leading-relaxed max-w-xl mx-auto">
+          Pick something simple. Ten minutes max. We&apos;ll nudge you back to
+          work when you&apos;re ready.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <MindfulCard
+          href="/clinic/mindful/breathe"
+          icon="🌬️"
+          title="Breathe"
+          blurb="A soft breathing circle. Inhale, hold, exhale, pause. Two to ten minutes."
+          available
+        />
+        <MindfulCard
+          href="#"
+          icon="🚶"
+          title="Move"
+          blurb="Micro-stretches, standing flows, or chair work. Picks what fits where you are."
+          available={false}
+        />
+        <MindfulCard
+          href="#"
+          icon="✨"
+          title="Inspire"
+          blurb="A single quote, painting, or landscape. Something beautiful, on purpose."
+          available={false}
+        />
+      </div>
+
+      <div className="mt-10 text-center">
+        <Link
+          href="/clinic/command"
+          className="text-sm text-text-subtle hover:text-text transition-colors"
+        >
+          ← Back to command
+        </Link>
+      </div>
+    </PageShell>
+  );
+}
+
+function MindfulCard({
+  href,
+  icon,
+  title,
+  blurb,
+  available,
+}: {
+  href: string;
+  icon: string;
+  title: string;
+  blurb: string;
+  available: boolean;
+}) {
+  const body = (
+    <div
+      className={cn(
+        "h-full rounded-2xl border p-6 flex flex-col gap-3 transition-all",
+        available
+          ? "bg-surface border-border/80 shadow-sm hover:shadow-md hover:-translate-y-0.5 hover:border-accent/40 cursor-pointer"
+          : "bg-surface/60 border-dashed border-border-strong/40 opacity-75"
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-3xl leading-none" aria-hidden="true">
+          {icon}
+        </span>
+        {!available && <Badge tone="neutral">Soon</Badge>}
+      </div>
+      <h2 className="font-display text-xl text-text tracking-tight">{title}</h2>
+      <p className="text-sm text-text-muted leading-relaxed">{blurb}</p>
+    </div>
+  );
+
+  if (!available) {
+    return <div aria-disabled="true">{body}</div>;
+  }
+
+  return (
+    <Link href={href} aria-label={title}>
+      {body}
+    </Link>
+  );
+}

--- a/src/components/mindful/breathing-session.tsx
+++ b/src/components/mindful/breathing-session.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Breathing session — four-phase box breathing (4-4-4-4) with a soft
+ * expanding/contracting circle and a single countdown timer.
+ *
+ * Deliberately quiet:
+ *   - No audio (the sketch asks for tranquil sound; it's a later slice)
+ *   - No ambient media, no branding chrome — the whole screen is the break
+ *   - Single exit control, always visible
+ *
+ * State machine: setup → running → done.
+ */
+
+type Phase = "inhale" | "hold-in" | "exhale" | "hold-out";
+
+const PHASE_SECONDS = 4;
+const CYCLE_SECONDS = PHASE_SECONDS * 4;
+
+const PHASE_LABEL: Record<Phase, string> = {
+  inhale: "Breathe in",
+  "hold-in": "Hold",
+  exhale: "Breathe out",
+  "hold-out": "Rest",
+};
+
+const DURATIONS = [
+  { minutes: 2, label: "2 min" },
+  { minutes: 5, label: "5 min" },
+  { minutes: 10, label: "10 min" },
+];
+
+type Stage = "setup" | "running" | "done";
+
+export function BreathingSession() {
+  const [stage, setStage] = React.useState<Stage>("setup");
+  const [durationMin, setDurationMin] = React.useState(5);
+  const [elapsed, setElapsed] = React.useState(0);
+
+  // Drive the 1-second clock while the session is running.
+  React.useEffect(() => {
+    if (stage !== "running") return;
+    const start = Date.now();
+    const id = window.setInterval(() => {
+      const secs = Math.floor((Date.now() - start) / 1000);
+      setElapsed(secs);
+      if (secs >= durationMin * 60) {
+        setStage("done");
+        window.clearInterval(id);
+      }
+    }, 250);
+    return () => window.clearInterval(id);
+  }, [stage, durationMin]);
+
+  if (stage === "setup") {
+    return (
+      <Setup
+        durationMin={durationMin}
+        onPick={setDurationMin}
+        onStart={() => {
+          setElapsed(0);
+          setStage("running");
+        }}
+      />
+    );
+  }
+
+  if (stage === "done") {
+    return <Done minutes={durationMin} onRestart={() => setStage("setup")} />;
+  }
+
+  return (
+    <Running
+      elapsed={elapsed}
+      totalSeconds={durationMin * 60}
+      onExit={() => setStage("done")}
+    />
+  );
+}
+
+/* ── Setup ───────────────────────────────────────────────── */
+
+function Setup({
+  durationMin,
+  onPick,
+  onStart,
+}: {
+  durationMin: number;
+  onPick: (m: number) => void;
+  onStart: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center text-center gap-8">
+      <p className="text-sm text-text-muted max-w-md">
+        A simple four-count box-breathing cycle. Inhale, hold, exhale, rest —
+        four seconds each. Follow the circle.
+      </p>
+      <div className="flex gap-2" role="radiogroup" aria-label="Duration">
+        {DURATIONS.map((d) => {
+          const active = d.minutes === durationMin;
+          return (
+            <button
+              key={d.minutes}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onPick(d.minutes)}
+              className={cn(
+                "px-5 py-2 rounded-full text-sm font-medium transition-all",
+                active
+                  ? "bg-accent text-accent-ink shadow-sm"
+                  : "bg-surface text-text-muted border border-border/70 hover:border-accent/40"
+              )}
+            >
+              {d.label}
+            </button>
+          );
+        })}
+      </div>
+      <Button size="lg" onClick={onStart}>
+        Begin
+      </Button>
+      <Link
+        href="/clinic/mindful"
+        className="text-xs text-text-subtle hover:text-text transition-colors"
+      >
+        ← Back
+      </Link>
+    </div>
+  );
+}
+
+/* ── Running ─────────────────────────────────────────────── */
+
+function Running({
+  elapsed,
+  totalSeconds,
+  onExit,
+}: {
+  elapsed: number;
+  totalSeconds: number;
+  onExit: () => void;
+}) {
+  const phase = phaseFor(elapsed);
+  const remaining = Math.max(0, totalSeconds - elapsed);
+  const mm = Math.floor(remaining / 60);
+  const ss = remaining % 60;
+
+  return (
+    <div className="flex flex-col items-center text-center gap-10">
+      <BreathingCircle phase={phase} />
+      <div>
+        <p className="font-display text-2xl text-text tracking-tight">
+          {PHASE_LABEL[phase]}
+        </p>
+        <p className="text-sm text-text-subtle tabular-nums mt-1">
+          {mm}:{ss.toString().padStart(2, "0")} remaining
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onExit}
+        className="text-xs text-text-subtle hover:text-text transition-colors"
+      >
+        End early
+      </button>
+    </div>
+  );
+}
+
+function BreathingCircle({ phase }: { phase: Phase }) {
+  // Target scale per phase. The CSS transition handles the smooth
+  // interpolation between the current and next scale over PHASE_SECONDS.
+  const scale =
+    phase === "inhale"
+      ? 1
+      : phase === "hold-in"
+        ? 1
+        : phase === "exhale"
+          ? 0.55
+          : 0.55;
+
+  // A subtle pulsing shadow makes the circle feel alive even during holds.
+  return (
+    <div
+      aria-hidden="true"
+      className="relative h-64 w-64 flex items-center justify-center"
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          transform: `scale(${scale})`,
+          transition: `transform ${PHASE_SECONDS}s ease-in-out`,
+          background:
+            "radial-gradient(circle at 30% 30%, var(--accent-soft), var(--accent) 80%)",
+          boxShadow: "0 20px 60px -12px var(--accent-soft)",
+          opacity: 0.92,
+        }}
+      />
+      <div
+        className="absolute inset-0 rounded-full border border-accent/20"
+        style={{
+          transform: `scale(${scale})`,
+          transition: `transform ${PHASE_SECONDS}s ease-in-out`,
+        }}
+      />
+    </div>
+  );
+}
+
+function phaseFor(elapsedSeconds: number): Phase {
+  const t = elapsedSeconds % CYCLE_SECONDS;
+  if (t < PHASE_SECONDS) return "inhale";
+  if (t < PHASE_SECONDS * 2) return "hold-in";
+  if (t < PHASE_SECONDS * 3) return "exhale";
+  return "hold-out";
+}
+
+/* ── Done ────────────────────────────────────────────────── */
+
+function Done({
+  minutes,
+  onRestart,
+}: {
+  minutes: number;
+  onRestart: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center text-center gap-6">
+      <div
+        aria-hidden="true"
+        className="h-16 w-16 rounded-full"
+        style={{
+          background:
+            "radial-gradient(circle at 30% 30%, var(--accent-soft), var(--accent) 80%)",
+          boxShadow: "0 12px 30px -8px var(--accent-soft)",
+        }}
+      />
+      <div>
+        <h2 className="font-display text-3xl text-text tracking-tight">
+          Back to work!
+        </h2>
+        <p className="text-sm text-text-muted mt-2">
+          You took {minutes} minute{minutes === 1 ? "" : "s"} for yourself.
+          That counts.
+        </p>
+      </div>
+      <div className="flex gap-3 mt-2">
+        <Link href="/clinic/command">
+          <Button size="lg">Back to command</Button>
+        </Link>
+        <Button variant="secondary" size="lg" onClick={onRestart}>
+          Another round
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Slice 3 of the Command Center. The Mindful Break tile on the dashboard now links to a real route instead of #.

What ships
  - /clinic/mindful — a small hub that offers three paths (Breathe, Move, Inspire). Only Breathe is active in this PR; Move and Inspire render as "Soon" placeholders so the hub already telegraphs the full shape of the module.
  - /clinic/mindful/breathe — a client-driven four-phase box-breathing session (inhale 4s, hold 4s, exhale 4s, rest 4s). Three-stage state machine: setup → running → done. · Setup: pick 2, 5, or 10 minutes. "Begin" starts the clock. · Running: centered breathing circle whose scale is driven per-phase by a CSS transition over the four-second window; label updates ("Breathe in", "Hold", "Breathe out", "Rest"); tabular-nums countdown stays visible. Exit is one click. · Done: "Back to work!" screen with a soft pebble of the same gradient and two options — back to command, or another round.
  - src/components/mindful/breathing-session.tsx — the client component holding the animation + timer logic. No audio, no ambient media; those belong in their own slices per the sketch ("tranquil sound — turn off/refresh").

Scope discipline
  - Zero schema changes, zero queries, zero new deps.
  - No agents, no workflows, no orchestration. This is a pure calm- the-nervous-system UI built out of CSS and setInterval.
  - Move + Inspire routes not created yet — their hub cards render disabled with a Soon badge, so there's no broken link.

Ten-minute cap enforced by the duration picker (max option is 10). "End early" button exits to the Done stage at any time — the break is voluntary, and so is the end of it.

Next slice: Patient Snapshot hover-preview (last of the four pillars).