### PR TITLE
feat(chart-tabs): hover-peek for Labs, Notes, and Cannabis Rx (3a)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -18,58 +19,196 @@ const TABS = [
 
 export type TabKey = (typeof TABS)[number]["key"];
 
+/** A single "last N entries" row inside a tab's hover-peek popover. */
+export interface PeekEntry {
+  id: string;
+  /** Primary label — usually the item's title or filename. */
+  title: string;
+  /** Secondary line — relative date, status, tag, whatever reads well. */
+  meta?: string;
+  /** Where clicking the row deep-links to (typically a sub-route). */
+  href: string;
+}
+
+/** Peek data per tab. Only tabs present here show a peek popover. */
+export type TabPeeks = Partial<Record<TabKey, PeekEntry[]>>;
+
 interface ChartTabsProps {
   patientId: string;
   counts: Record<TabKey, number>;
+  peeks?: TabPeeks;
 }
 
-export function ChartTabs({ patientId, counts }: ChartTabsProps) {
+export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
   const searchParams = useSearchParams();
   const active = (searchParams.get("tab") as TabKey) || "records";
 
+  // Which tab's peek popover is open right now. At most one open at a time.
+  const [openKey, setOpenKey] = React.useState<TabKey | null>(null);
+  // A small close delay keeps the popover open while the cursor slides
+  // from the tab onto the popover itself. Without this, the popover
+  // flickers shut as soon as you exit the tab's hit area.
+  const closeTimer = React.useRef<number | null>(null);
+
+  const scheduleClose = () => {
+    if (closeTimer.current) window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(() => setOpenKey(null), 120);
+  };
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  React.useEffect(() => () => cancelClose(), []);
+
   return (
     <nav
-      className="flex flex-wrap items-center gap-1 border-b border-border mb-8"
+      className="relative flex flex-wrap items-center gap-1 border-b border-border mb-8"
       aria-label="Chart sections"
     >
       {TABS.map((tab) => {
         const isActive = active === tab.key;
         const count = counts[tab.key];
+        const entries = peeks?.[tab.key];
+        const hasPeek = entries !== undefined;
+        const isOpen = openKey === tab.key;
+
         return (
-          <Link
+          <div
             key={tab.key}
-            href={`/clinic/patients/${patientId}?tab=${tab.key}`}
-            scroll={false}
-            className={cn(
-              "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors rounded-t-md whitespace-nowrap",
-              isActive
-                ? "text-accent"
-                : "text-text-muted hover:text-text hover:bg-surface-muted"
-            )}
+            className="relative"
+            onMouseEnter={() => {
+              cancelClose();
+              if (hasPeek) setOpenKey(tab.key);
+            }}
+            onMouseLeave={scheduleClose}
+            onFocus={() => {
+              cancelClose();
+              if (hasPeek) setOpenKey(tab.key);
+            }}
+            onBlur={scheduleClose}
           >
-            <span
+            <Link
+              href={`/clinic/patients/${patientId}?tab=${tab.key}`}
+              scroll={false}
+              aria-haspopup={hasPeek ? "true" : undefined}
+              aria-expanded={hasPeek ? isOpen : undefined}
               className={cn(
-                "h-2 w-2 rounded-full shrink-0",
-                isActive ? tab.dot : "bg-border-strong/50"
-              )}
-            />
-            {tab.label}
-            <span
-              className={cn(
-                "inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium rounded-full tabular-nums",
+                "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors rounded-t-md whitespace-nowrap",
                 isActive
-                  ? "bg-accent-soft text-accent"
-                  : "bg-surface-muted text-text-subtle"
+                  ? "text-accent"
+                  : "text-text-muted hover:text-text hover:bg-surface-muted"
               )}
             >
-              {count}
-            </span>
-            {isActive && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full" />
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full shrink-0",
+                  isActive ? tab.dot : "bg-border-strong/50"
+                )}
+              />
+              {tab.label}
+              <span
+                className={cn(
+                  "inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium rounded-full tabular-nums",
+                  isActive
+                    ? "bg-accent-soft text-accent"
+                    : "bg-surface-muted text-text-subtle"
+                )}
+              >
+                {count}
+              </span>
+              {isActive && (
+                <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full" />
+              )}
+            </Link>
+
+            {hasPeek && isOpen && (
+              <TabPeekPopover
+                label={tab.label}
+                entries={entries}
+                seeAllHref={`/clinic/patients/${patientId}?tab=${tab.key}`}
+                onLeave={scheduleClose}
+                onEnter={cancelClose}
+              />
             )}
-          </Link>
+          </div>
         );
       })}
     </nav>
+  );
+}
+
+/**
+ * Hover-peek popover. Anchored beneath its tab, shows the last five
+ * entries from that section plus a "See all" link. Keeps the popover
+ * open while the cursor is inside it via the onEnter/onLeave hooks
+ * (the parent tab container handles open/close timing).
+ */
+function TabPeekPopover({
+  label,
+  entries,
+  seeAllHref,
+  onEnter,
+  onLeave,
+}: {
+  label: string;
+  entries: PeekEntry[];
+  seeAllHref: string;
+  onEnter: () => void;
+  onLeave: () => void;
+}) {
+  return (
+    <div
+      role="menu"
+      aria-label={`${label} recent`}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      className={cn(
+        "absolute left-0 top-full mt-1 z-30 w-80 max-w-[calc(100vw-2rem)]",
+        "rounded-lg border border-border bg-surface shadow-lg"
+      )}
+    >
+      <div className="px-4 pt-3 pb-2 border-b border-border/60">
+        <p className="text-[10px] uppercase tracking-wider text-text-subtle font-medium">
+          Recent · {label}
+        </p>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="px-4 py-5 text-sm text-text-muted italic text-center">
+          Nothing yet.
+        </p>
+      ) : (
+        <ul className="py-1">
+          {entries.slice(0, 5).map((e) => (
+            <li key={e.id}>
+              <Link
+                href={e.href}
+                role="menuitem"
+                className="block px-4 py-2 text-sm hover:bg-surface-muted transition-colors"
+              >
+                <p className="font-medium text-text truncate">{e.title}</p>
+                {e.meta && (
+                  <p className="text-[11px] text-text-subtle mt-0.5 truncate">
+                    {e.meta}
+                  </p>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="px-4 py-2 border-t border-border/60">
+        <Link
+          href={seeAllHref}
+          className="text-xs font-medium text-accent hover:text-accent/80 transition-colors"
+        >
+          See all in {label} →
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
 import { formatDate, formatRelative } from "@/lib/utils/format";
-import { ChartTabs, type TabKey } from "./chart-tabs";
+import { ChartTabs, type TabKey, type TabPeeks } from "./chart-tabs";
 import { TrackPatientView } from "@/components/shell/recent-patients";
 import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
@@ -199,6 +199,42 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     correspondence: threads.length,
     rx: activeRegimens.length,
     billing: openClaimCount,
+  };
+
+  /* ── Hover-peek entries (slice 3a) ───────────────────────────
+   * Five most recent items per tab, derived from the data we already
+   * fetched. No new queries — just a reshape. Starts with labs, notes,
+   * and rx; the remaining tabs (records, correspondence, etc.) ship in
+   * slice 3b once the peek pattern has been battle-tested here. */
+  const tabPeeks: TabPeeks = {
+    labs: labDocs.slice(0, 5).map((d) => ({
+      id: d.id,
+      title: d.originalName || "Untitled lab",
+      meta: formatRelative(d.createdAt),
+      href: `/clinic/patients/${params.id}?tab=labs`,
+    })),
+    notes: allNotes.slice(0, 5).map((n) => {
+      // Notes store their chief complaint inside a Json `blocks` payload
+      // whose shape is validated at write-time. For peek purposes we just
+      // read defensively and fall back to the narrative or a generic label.
+      const chiefComplaint =
+        typeof (n.blocks as { chiefComplaint?: unknown })?.chiefComplaint === "string"
+          ? ((n.blocks as { chiefComplaint: string }).chiefComplaint).trim()
+          : "";
+      const raw = chiefComplaint || n.narrative?.trim() || "Untitled note";
+      return {
+        id: n.id,
+        title: raw.length > 60 ? raw.slice(0, 60) + "…" : raw,
+        meta: `${n.status} · ${formatRelative(n.createdAt)}`,
+        href: `/clinic/patients/${params.id}/notes/${n.id}`,
+      };
+    }),
+    rx: activeRegimens.slice(0, 5).map((r: any) => ({
+      id: r.id,
+      title: r.product?.name ?? "Cannabis regimen",
+      meta: [r.dosage, r.product?.format].filter(Boolean).join(" · ") || "Active",
+      href: `/clinic/patients/${params.id}?tab=rx`,
+    })),
   };
 
   /* ── Clinical Decision Support alerts (EMR-166) ──────────── */
@@ -404,7 +440,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       )}
 
       {/* ── Tab bar ───────────────────────────────────────── */}
-      <ChartTabs patientId={params.id} counts={counts} />
+      <ChartTabs patientId={params.id} counts={counts} peeks={tabPeeks} />
 
       {/* ── Tab content ───────────────────────────────────── */}
       {tab === "demographics" && (


### PR DESCRIPTION
Kicks off Phase 3 — the Google-tab / hover-peek pattern from the Mission Control sketch. Instead of replacing the whole chart tab bar at once, this slice adds hover-peek popovers to three tabs (Labs, Notes, Cannabis Rx) and ships the reusable pattern.

How it works
  - chart-tabs.tsx is already a client component. It now accepts a `peeks` prop, a Partial<Record<TabKey, PeekEntry[]>>. Any tab present in `peeks` gets a popover on hover/focus; the others behave exactly as before.
  - On mouse enter, the tab opens a 320px-wide popover anchored below it. On leave, a 120ms close timer runs so the cursor can slide from the tab onto the popover without flicker. Hovering the popover cancels the timer.
  - Each row shows the item's title + a secondary meta line (status, relative date, dosage, etc) and deep-links to the item.
  - Bottom of the popover: "See all in {tab} →" link.
  - `aria-haspopup` + `aria-expanded` on the tab, `role="menu"` on the popover, `role="menuitem"` on each row. Keyboard focus also opens the peek.

Data
  - Peek entries are derived server-side in the patient page from data that was *already* being fetched (labDocs, allNotes, activeRegimens). Zero new queries.
  - Notes extract chief-complaint defensively from the JSON blocks payload, fall back to the narrative, fall back to "Untitled note". No crashes on malformed blocks.

Explicitly out of scope (future slices)
  - 3b: extend peek to Records, Correspondence, Billing, Memory, Images
  - 3c: drag-to-reorder tabs + localStorage persistence
  - 3d: position toggle (top/bottom/left/right) + emoji-only mode
  - AI-generated section summaries (the sketch's other peek mode)

Net effect: hovering a tab now previews recent activity without clicking. Two-stage disclosure — peek, then open — reduces dead clicks when the clinician is just orienting.