### PR TITLE
feat(chart-tabs): extend hover-peek to remaining five tabs (3b)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -201,11 +201,11 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     billing: openClaimCount,
   };
 
-  /* ── Hover-peek entries (slice 3a) ───────────────────────────
+  /* ── Hover-peek entries (slices 3a + 3b) ────────────────────
    * Five most recent items per tab, derived from the data we already
-   * fetched. No new queries — just a reshape. Starts with labs, notes,
-   * and rx; the remaining tabs (records, correspondence, etc.) ship in
-   * slice 3b once the peek pattern has been battle-tested here. */
+   * fetched. No new queries — just a reshape. 3a introduced labs,
+   * notes, and rx; 3b adds records, images, correspondence, memory,
+   * and billing so every tab that carries a list has a peek. */
   const tabPeeks: TabPeeks = {
     labs: labDocs.slice(0, 5).map((d) => ({
       id: d.id,
@@ -234,6 +234,39 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       title: r.product?.name ?? "Cannabis regimen",
       meta: [r.dosage, r.product?.format].filter(Boolean).join(" · ") || "Active",
       href: `/clinic/patients/${params.id}?tab=rx`,
+    })),
+    records: recordDocs.slice(0, 5).map((d) => ({
+      id: d.id,
+      title: d.originalName || "Untitled document",
+      meta: `${d.kind} · ${formatRelative(d.createdAt)}`,
+      href: `/clinic/patients/${params.id}?tab=records`,
+    })),
+    images: imageDocs.slice(0, 5).map((d) => ({
+      id: d.id,
+      title: d.originalName || "Untitled image",
+      meta: formatRelative(d.createdAt),
+      href: `/clinic/patients/${params.id}?tab=images`,
+    })),
+    correspondence: threads.slice(0, 5).map((t) => ({
+      id: t.id,
+      title: t.subject || "No subject",
+      meta: `${t.messages.length} message${t.messages.length === 1 ? "" : "s"} · ${formatRelative(t.lastMessageAt)}`,
+      href: `/clinic/patients/${params.id}?tab=correspondence`,
+    })),
+    memory: patientMemories.slice(0, 5).map((m) => ({
+      id: m.id,
+      title:
+        m.content.length > 60 ? m.content.slice(0, 60) + "…" : m.content,
+      meta: `${m.kind} · ${formatRelative(m.createdAt)}`,
+      href: `/clinic/patients/${params.id}?tab=memory`,
+    })),
+    billing: patientClaims.slice(0, 5).map((c) => ({
+      id: c.id,
+      // Money is stored in cents; peek rows render the dollar amount
+      // rounded to the nearest dollar — we're not trying to be a ledger.
+      title: `${c.payerName ?? "Claim"} · $${Math.round(c.billedAmountCents / 100)}`,
+      meta: `${c.status} · ${formatRelative(c.serviceDate)}`,
+      href: `/clinic/patients/${params.id}?tab=billing`,
     })),
   };
 


### PR DESCRIPTION
Slice 3a introduced the peek popover on Labs, Notes, and Cannabis Rx. This slice turns it on for every other list-bearing tab so a clinician can preview recent activity from any section without clicking in.

New peeks
  - Records    — recent non-lab, non-image documents (name + kind + date)
  - Images     — recent image documents (name + date)
  - Correspondence — recent message threads (subject + message count
                  + last-message relative time)
  - Memory     — recent PatientMemory entries (content + kind + date)
  - Billing    — recent claims (payer + rounded $ + status + service date)

All five entries per tab, same component, same data (reshape of what the page already fetched). Demographics stays peek-less — it's a single summary, not a list.

Accuracy notes
  - Claim money is stored in cents and rendered rounded to the nearest dollar in peek rows. This is a preview, not a ledger — the tab itself remains the source of truth for exact amounts.
  - Long titles (memory content, long filenames) are truncated to 60 chars with an ellipsis so the popover stays tidy.
  - All meta lines use the existing formatRelative helper for consistency with the first three peeks.

Still deferred (slices 3c, 3d):
  - drag-to-reorder + localStorage persistence
  - position toggle + emoji-only mode
  - AI-generated section summaries