### PR TITLE
feat(chart-tabs): drag-to-reorder + localStorage (3c) + command-center error page

### DIFF
--- a/src/app/(clinician)/clinic/command/error.tsx
+++ b/src/app/(clinician)/clinic/command/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { EmptyIllustration } from "@/components/ui/ornament";
+
+export default function CommandError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[command-center] render failed", error);
+  }, [error]);
+
+  return (
+    <div className="px-6 lg:px-12 py-10">
+      <div className="mx-auto w-full max-w-[720px] flex flex-col items-center text-center py-16">
+        <EmptyIllustration size={120} />
+        <h1 className="font-display text-3xl text-text tracking-tight mt-4">
+          Command Center didn&rsquo;t load.
+        </h1>
+        <p className="text-sm text-text-muted mt-2 max-w-md leading-relaxed">
+          One of the dashboard tiles failed to render. Details below so we can fix the
+          right thing instead of a guess.
+        </p>
+
+        <pre className="mt-5 max-w-full overflow-auto rounded-lg border border-border bg-surface-muted px-4 py-3 text-left text-[11px] leading-relaxed text-text-muted">
+          {error.digest ? `digest: ${error.digest}\n` : ""}
+          {error.name}: {error.message}
+        </pre>
+
+        <div className="mt-6 flex items-center gap-3">
+          <Button onClick={() => reset()} variant="secondary">
+            Try again
+          </Button>
+          <Button
+            onClick={() => (window.location.href = "/clinic")}
+            variant="ghost"
+          >
+            Go to Today
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Two commits on this branch:

### 1. `feat(chart-tabs): drag-to-reorder + localStorage persistence (3c)`

Slice 3c of Phase 3 — the chart tab bar becomes personalizable. Clinicians can grab any tab and drop it anywhere along the row; the new order persists across sessions (per-device, per-browser).

**How it works**
- HTML5 DnD on each tab wrapper. `draggable` on the outer div, `draggable={false}` on the inner `Link` so the browser's URL-drag default doesn't fight our DnD.
- Dragged tab dims to 40% opacity; the tab under the cursor gets a 2px accent bar on its left edge as an insertion indicator.
- A `⋮⋮` grip marker appears on hover as a discoverability affordance so clinicians realize the feature exists without being taught.
- Hover-peek is force-closed during drag — a popover overlapping the drop zones would swallow drop events.
- Drop writes the new order to `localStorage` under `chart-tabs:order:v1`.

**Persistence + SSR-safety**
- Initial state is seeded with the canonical `TABS` order, so the SSR output is deterministic. A `useEffect` hydrates from `localStorage` on mount. Any stored order is reconciled against the canonical keys before use:
  - stale keys (tab removed from the schema) are dropped
  - canonical keys missing from stored order are appended at the end
- Net effect: a clinician can never silently lose access to a tab because their saved order predates a schema change, and there's no crash if the stored blob is corrupt — it silently falls back to default.

**Reset affordance**
- A small "Reset order" link appears (right-aligned) only when the current order differs from the canonical default. Click → clear `localStorage` + restore default.

**Explicitly out of scope**
- 3d: position toggle (top/bottom/left/right) + emoji-only mode
- AI-generated section summaries
- Keyboard reorder + `aria-live` announcements (HTML5 DnD is mouse-only)
- Cross-device sync (`localStorage` is per-browser)

### 2. `diag(command-center): segment error page surfaces digest + message`

Replaces the generic "Something went wrong" screen for `/clinic/command` with a segment-scoped error page that prints the Next.js `digest` and `error.message`. Pure diagnostic — zero runtime behaviour change when the page renders successfully. Already proved useful: caught digest `2018575199` on the first reload, which let me queue up the real per-tile fallback fix in a separate PR.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — local typecheck and `next build` both pass on the branch
- [ ] Patient chart → grab a tab → drop it in a new slot → reload the page → order sticks
- [ ] Click **Reset order** → returns to canonical order, link disappears
- [ ] Drag-then-drop onto the same tab → no-op (not a duplicate)
- [ ] `localStorage.setItem('chart-tabs:order:v1', '"garbage"')` → reload → default order, no crash
- [ ] Visit `/clinic/command` while it's still broken → see `digest` + `Error` prefix, instead of the vague empty-illustration screen

---

Real command-center fix (per-tile try/catch + server logging) ships as a separate PR on a hotfix branch so this one stays focused on Phase 3 chart-tab work.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1