### PR TITLE
fix(command-center): isolate tile failures so one crash doesn't nuke the page

### DIFF
--- a/src/components/command/messages-tile.tsx
+++ b/src/components/command/messages-tile.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db/prisma";
 import type { AuthedUser } from "@/lib/auth/session";
 import { Tile } from "@/components/ui/tile";
 import { EmptyState } from "@/components/ui/empty-state";
+import { TileErrorBody } from "@/components/command/tile-error";
 import {
   triageThread,
   type MessagePriority,
@@ -55,8 +56,23 @@ export async function MessagesTile({ user }: { user: AuthedUser }) {
     return <MessagesTileShell count={0} urgentCount={0} />;
   }
 
+  try {
+    return await renderMessagesTile(user.organizationId);
+  } catch (err) {
+    // Keep the Command Center usable if messaging or triage explodes —
+    // log the stack for Render logs and show a calm fallback body.
+    console.error("[command-center] MessagesTile render failed:", err);
+    return (
+      <MessagesTileShell count={0} urgentCount={0}>
+        <TileErrorBody label="the messages inbox" />
+      </MessagesTileShell>
+    );
+  }
+}
+
+async function renderMessagesTile(organizationId: string) {
   const threads = await prisma.messageThread.findMany({
-    where: { patient: { organizationId: user.organizationId } },
+    where: { patient: { organizationId } },
     orderBy: { lastMessageAt: "desc" },
     include: {
       patient: { select: { id: true, userId: true, firstName: true, lastName: true } },

--- a/src/components/command/patient-snapshot-tile.tsx
+++ b/src/components/command/patient-snapshot-tile.tsx
@@ -4,6 +4,7 @@ import type { AuthedUser } from "@/lib/auth/session";
 import { Tile } from "@/components/ui/tile";
 import { Avatar } from "@/components/ui/avatar";
 import { EmptyState } from "@/components/ui/empty-state";
+import { TileErrorBody } from "@/components/command/tile-error";
 import { cn } from "@/lib/utils/cn";
 
 /**
@@ -31,6 +32,23 @@ export async function PatientSnapshotTile({ user }: { user: AuthedUser }) {
   if (!user.organizationId) {
     return <SnapshotShell />;
   }
+
+  try {
+    return await renderSnapshotTile(user);
+  } catch (err) {
+    // Never take down the whole Command Center because one tile threw.
+    // Log the stack so Render logs surface it, render a calm fallback.
+    console.error("[command-center] PatientSnapshotTile render failed:", err);
+    return (
+      <SnapshotShell>
+        <TileErrorBody label="the patient snapshot" />
+      </SnapshotShell>
+    );
+  }
+}
+
+async function renderSnapshotTile(user: AuthedUser) {
+  if (!user.organizationId) return <SnapshotShell />;
 
   const provider = user.roles.includes("clinician")
     ? await prisma.provider.findFirst({

--- a/src/components/command/schedule-tile.tsx
+++ b/src/components/command/schedule-tile.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db/prisma";
 import type { AuthedUser } from "@/lib/auth/session";
 import { Tile } from "@/components/ui/tile";
 import { EmptyState } from "@/components/ui/empty-state";
+import { TileErrorBody } from "@/components/command/tile-error";
 import { cn } from "@/lib/utils/cn";
 
 /**
@@ -28,69 +29,81 @@ export async function ScheduleTile({ user }: { user: AuthedUser }) {
     return <ScheduleTileShell count={0} />;
   }
 
-  // Scope to this provider's day when the user has a Provider record.
-  // Owners always see the full org.
-  const provider = user.roles.includes("clinician")
-    ? await prisma.provider.findFirst({
-        where: { userId: user.id, organizationId: user.organizationId },
-        select: { id: true },
-      })
-    : null;
+  try {
+    // Scope to this provider's day when the user has a Provider record.
+    // Owners always see the full org.
+    const provider = user.roles.includes("clinician")
+      ? await prisma.provider.findFirst({
+          where: { userId: user.id, organizationId: user.organizationId },
+          select: { id: true },
+        })
+      : null;
 
-  const now = new Date();
-  const startOfDay = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-    0,
-    0,
-    0,
-    0
-  );
-  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
+    const now = new Date();
+    const startOfDay = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      0,
+      0,
+      0,
+      0
+    );
+    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
 
-  const appointments = await prisma.appointment.findMany({
-    where: {
-      startAt: { gte: startOfDay, lt: endOfDay },
-      patient: { organizationId: user.organizationId, deletedAt: null },
-      ...(provider ? { providerId: provider.id } : {}),
-    },
-    orderBy: { startAt: "asc" },
-    include: {
-      patient: {
-        select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          dateOfBirth: true,
+    const appointments = await prisma.appointment.findMany({
+      where: {
+        startAt: { gte: startOfDay, lt: endOfDay },
+        patient: { organizationId: user.organizationId, deletedAt: null },
+        ...(provider ? { providerId: provider.id } : {}),
+      },
+      orderBy: { startAt: "asc" },
+      include: {
+        patient: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            dateOfBirth: true,
+          },
         },
       },
-    },
-    take: 12,
-  });
+      take: 12,
+    });
 
-  return (
-    <ScheduleTileShell count={appointments.length}>
-      {appointments.length === 0 ? (
-        <div className="h-full flex items-center justify-center">
-          <EmptyState
-            title="No visits today"
-            description="A quiet day. Time to catch up on notes."
-          />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2 h-full overflow-y-auto pr-1">
-          {appointments.map((appt) => (
-            <ScheduleCard
-              key={appt.id}
-              appointment={appt}
-              nowTs={now.getTime()}
+    return (
+      <ScheduleTileShell count={appointments.length}>
+        {appointments.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <EmptyState
+              title="No visits today"
+              description="A quiet day. Time to catch up on notes."
             />
-          ))}
-        </div>
-      )}
-    </ScheduleTileShell>
-  );
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 h-full overflow-y-auto pr-1">
+            {appointments.map((appt) => (
+              <ScheduleCard
+                key={appt.id}
+                appointment={appt}
+                nowTs={now.getTime()}
+              />
+            ))}
+          </div>
+        )}
+      </ScheduleTileShell>
+    );
+  } catch (err) {
+    // A single tile crash should never take down the whole Command
+    // Center. Log the stack so Render has it, and render the Shell
+    // with a fallback body so the grid layout + other tiles survive.
+    console.error("[command-center] ScheduleTile render failed:", err);
+    return (
+      <ScheduleTileShell count={0}>
+        <TileErrorBody label="today's schedule" />
+      </ScheduleTileShell>
+    );
+  }
 }
 
 function ScheduleTileShell({

--- a/src/components/command/tile-error.tsx
+++ b/src/components/command/tile-error.tsx
@@ -1,0 +1,21 @@
+/**
+ * Standardized fallback body rendered inside a Command-Center tile's
+ * Shell when its data fetch throws. The Shell keeps the tile's grid
+ * slot (span / tone / header) intact so the surrounding layout doesn't
+ * reflow, and the clinician sees something calm + honest instead of a
+ * crash of the whole dashboard.
+ *
+ * The actual error is logged server-side with console.error — visible
+ * in Render logs alongside the Next.js request digest — so the team
+ * can diagnose without the clinician having to copy anything.
+ */
+export function TileErrorBody({ label }: { label: string }) {
+  return (
+    <div className="h-full flex items-center justify-center text-center p-4">
+      <p className="text-xs text-text-muted italic max-w-[220px] leading-relaxed">
+        Couldn&rsquo;t load {label} right now. The other tiles still work —
+        we&rsquo;ve logged the error for the team.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up to #16. That PR's diagnostic error page revealed `digest: 2018575199` — a Server Component render error somewhere inside the three Command Center tiles — but **Next.js masks the specific message in production builds**, so we couldn't tell which tile from the browser alone.

This PR pushes a `try / catch` down into each data-fetching tile so:

1. **A single tile throwing no longer propagates** to the page-level error boundary — the Command Center keeps rendering.
2. **The full error + stack is logged via `console.error`** with a tile label, which Render logs surface alongside the Next.js digest. The real root cause will print itself on the next reload without us touching the UI again.
3. **The failing tile renders its Shell** (preserving grid slot + header) with a calm "couldn't load … right now" body, so the clinician sees something honest rather than an empty panel.

## What changed

- **`src/components/command/tile-error.tsx`** (new) — shared `TileErrorBody` component. One copy instead of three near-duplicates.
- **`schedule-tile.tsx`** — wraps the provider lookup + `Appointment` query + render in a single try/catch. On throw, renders the Shell with `count={0}` and the fallback body.
- **`messages-tile.tsx`** — extracts the triage/fetch body into `renderMessagesTile(orgId)`; the exported tile calls it inside a try/catch.
- **`patient-snapshot-tile.tsx`** — same pattern: `renderSnapshotTile(user)` holds the Prisma work, outer tile wraps it.

## Why this pattern over a client error boundary

- These tiles are **async React Server Components**. Errors thrown during their server render bubble past client `error.tsx` boundaries as opaque digests in production. Handling the error inside the component is the only way to get the actual message + stack logged.
- Each tile already had a `*Shell` abstraction, so the fallback body slots in with zero layout reflow — the grid keeps its shape.

## Scope discipline

- Zero schema changes. Zero new queries. No dependency additions.
- Leaves the segment `error.tsx` from #16 in place as a second line of defense for anything else that might throw at the page level (e.g., `PageHeader` / `PageShell` / the `Tile` primitive itself).

## Test plan

- [ ] CI green (`typecheck · lint · build`) — both pass locally
- [ ] After deploy, visit `/clinic/command` → page renders, failing tile shows the fallback body with its label, other tiles render normally
- [ ] Render logs: `grep command-center` returns a `[command-center] <Label>Tile render failed:` line with the full stack
- [ ] Once we see which tile + error, follow up with the real underlying fix (schema drift, null guard, whatever the logs say) in a new PR

---

Unblocks the Command Center and converts an opaque digest into an actionable server log. Real underlying bug gets fixed in the next PR once the logs tell us which query failed and why.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1