### PR TITLE
feat(chart-tabs): position toggle + compact mode settings (3d)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/chart-frame.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-frame.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+export type ChartTabPosition = "top" | "bottom";
+
+export interface ChartFrameSettings {
+  position: ChartTabPosition;
+  setPosition: (p: ChartTabPosition) => void;
+  /** True when the tab bar should render as dots + counts only, hiding labels. */
+  compact: boolean;
+  setCompact: (c: boolean) => void;
+  /** False until localStorage hydration has run once. Consumers can use
+   * this to avoid rendering personalized UI before the preference loads. */
+  hydrated: boolean;
+}
+
+const Ctx = React.createContext<ChartFrameSettings | null>(null);
+
+const STORAGE_KEY = "chart-tabs:settings:v1";
+
+type StoredSettings = {
+  position?: ChartTabPosition;
+  compact?: boolean;
+};
+
+function readStored(): StoredSettings {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    const out: StoredSettings = {};
+    if (parsed?.position === "top" || parsed?.position === "bottom") {
+      out.position = parsed.position;
+    }
+    if (typeof parsed?.compact === "boolean") {
+      out.compact = parsed.compact;
+    }
+    return out;
+  } catch {
+    // Corrupt JSON / blocked storage — silently use defaults.
+    return {};
+  }
+}
+
+function writeStored(settings: { position: ChartTabPosition; compact: boolean }) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Safari private mode or quota exhausted — keep state in memory.
+  }
+}
+
+export function useChartFrame(): ChartFrameSettings {
+  const ctx = React.useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useChartFrame must be used inside <ChartFrame>");
+  }
+  return ctx;
+}
+
+/**
+ * ChartFrame wraps the patient chart's tab bar + tab content so both
+ * can respond to a shared position / compact preference that the
+ * clinician controls from the tab bar itself.
+ *
+ * Why a wrapper instead of CSS on the nav alone: the tab *content* is
+ * a sibling of the nav, so controlling vertical order (top vs bottom
+ * nav) requires wrapping both in a single flex container and flipping
+ * its direction. Putting that container here — with state + storage
+ * centralized — keeps the patient page itself declarative.
+ *
+ * SSR-safety: renders with default settings on the server so the
+ * markup is deterministic; hydrates from localStorage in a useEffect
+ * after mount. `hydrated` flips true once, and consumers that want
+ * to avoid a default-then-personalized flash can gate on it.
+ */
+export function ChartFrame({
+  nav,
+  children,
+}: {
+  nav: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [position, setPositionState] = React.useState<ChartTabPosition>("top");
+  const [compact, setCompactState] = React.useState<boolean>(false);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    const stored = readStored();
+    if (stored.position) setPositionState(stored.position);
+    if (stored.compact !== undefined) setCompactState(stored.compact);
+    setHydrated(true);
+  }, []);
+
+  const setPosition = (p: ChartTabPosition) => {
+    setPositionState(p);
+    writeStored({ position: p, compact });
+  };
+  const setCompact = (c: boolean) => {
+    setCompactState(c);
+    writeStored({ position, compact: c });
+  };
+
+  return (
+    <Ctx.Provider
+      value={{ position, setPosition, compact, setCompact, hydrated }}
+    >
+      <div
+        className={cn(
+          "flex flex-col",
+          position === "bottom" && "flex-col-reverse"
+        )}
+      >
+        {nav}
+        <div className="flex-1 min-w-0">{children}</div>
+      </div>
+    </Ctx.Provider>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
+import { useChartFrame } from "./chart-frame";
 
 const TABS = [
   { key: "demographics", label: "Demographics", dot: "bg-[color:var(--info)]" },
@@ -70,6 +71,11 @@ interface ChartTabsProps {
 export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
   const searchParams = useSearchParams();
   const active = (searchParams.get("tab") as TabKey) || "records";
+
+  // Position + compact come from the ChartFrame wrapper so the tab bar
+  // and the tab content share one source of truth about layout.
+  const { position, setPosition, compact, setCompact } = useChartFrame();
+  const onBottom = position === "bottom";
 
   // Tab order. Seeded with the canonical order so SSR output matches
   // the server render; hydrated from localStorage in an effect so the
@@ -190,7 +196,13 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
 
   return (
     <nav
-      className="relative flex flex-wrap items-center gap-1 border-b border-border mb-8"
+      className={cn(
+        "relative flex flex-wrap items-center gap-1 border-border",
+        // Border + outer margin swap sides based on where the bar
+        // is anchored, so the hairline sits against the tab content
+        // (not the page edge) regardless of position.
+        onBottom ? "border-t mt-8" : "border-b mb-8"
+      )}
       aria-label="Chart sections"
     >
       {order.map((key) => {
@@ -244,8 +256,11 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
               draggable={false}
               aria-haspopup={hasPeek ? "true" : undefined}
               aria-expanded={hasPeek ? isOpen : undefined}
+              title={compact ? tab.label : undefined}
               className={cn(
-                "relative flex items-center gap-2 pl-3 pr-4 py-2.5 text-sm font-medium transition-colors rounded-t-md whitespace-nowrap cursor-grab active:cursor-grabbing",
+                "relative flex items-center gap-2 pl-3 py-2.5 text-sm font-medium transition-colors whitespace-nowrap cursor-grab active:cursor-grabbing",
+                compact ? "pr-3" : "pr-4",
+                onBottom ? "rounded-b-md" : "rounded-t-md",
                 isActive
                   ? "text-accent"
                   : "text-text-muted hover:text-text hover:bg-surface-muted"
@@ -267,7 +282,7 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
                   isActive ? tab.dot : "bg-border-strong/50"
                 )}
               />
-              {tab.label}
+              {!compact && <span>{tab.label}</span>}
               <span
                 className={cn(
                   "inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium rounded-full tabular-nums",
@@ -279,7 +294,12 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
                 {count}
               </span>
               {isActive && (
-                <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full" />
+                <span
+                  className={cn(
+                    "absolute left-2 right-2 h-0.5 bg-accent rounded-full",
+                    onBottom ? "top-0" : "bottom-0"
+                  )}
+                />
               )}
             </Link>
 
@@ -290,28 +310,39 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
                 seeAllHref={`/clinic/patients/${patientId}?tab=${tab.key}`}
                 onLeave={scheduleClose}
                 onEnter={cancelClose}
+                anchor={onBottom ? "above" : "below"}
               />
             )}
           </div>
         );
       })}
 
-      {isReordered && (
-        <button
-          type="button"
-          onClick={resetOrder}
-          className="ml-auto mr-2 text-[11px] text-text-subtle hover:text-accent transition-colors"
-          title="Restore the default tab order"
-        >
-          Reset order
-        </button>
-      )}
+      <div className="ml-auto mr-1 flex items-center gap-1">
+        {isReordered && (
+          <button
+            type="button"
+            onClick={resetOrder}
+            className="text-[11px] text-text-subtle hover:text-accent transition-colors px-2 py-1"
+            title="Restore the default tab order"
+          >
+            Reset order
+          </button>
+        )}
+        <ChartTabsSettingsMenu
+          position={position}
+          setPosition={setPosition}
+          compact={compact}
+          setCompact={setCompact}
+          anchor={onBottom ? "above" : "below"}
+        />
+      </div>
     </nav>
   );
 }
 
 /**
- * Hover-peek popover. Anchored beneath its tab, shows the last five
+ * Hover-peek popover. Anchored beside its tab (below when the bar is
+ * on top, above when the bar is on bottom), shows the last five
  * entries from that section plus a "See all" link. Keeps the popover
  * open while the cursor is inside it via the onEnter/onLeave hooks
  * (the parent tab container handles open/close timing).
@@ -322,12 +353,14 @@ function TabPeekPopover({
   seeAllHref,
   onEnter,
   onLeave,
+  anchor,
 }: {
   label: string;
   entries: PeekEntry[];
   seeAllHref: string;
   onEnter: () => void;
   onLeave: () => void;
+  anchor: "above" | "below";
 }) {
   return (
     <div
@@ -336,8 +369,9 @@ function TabPeekPopover({
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
       className={cn(
-        "absolute left-0 top-full mt-1 z-30 w-80 max-w-[calc(100vw-2rem)]",
-        "rounded-lg border border-border bg-surface shadow-lg"
+        "absolute left-0 z-30 w-80 max-w-[calc(100vw-2rem)]",
+        "rounded-lg border border-border bg-surface shadow-lg",
+        anchor === "above" ? "bottom-full mb-1" : "top-full mt-1"
       )}
     >
       <div className="px-4 pt-3 pb-2 border-b border-border/60">
@@ -380,5 +414,173 @@ function TabPeekPopover({
         </Link>
       </div>
     </div>
+  );
+}
+
+
+/**
+ * Right-end settings menu on the tab bar. Two toggles — tab position
+ * (top vs bottom) and compact mode (dots + counts, labels hidden).
+ * Closes on outside-click and Escape. Anchors above or below the bar
+ * so the panel never collides with the chart content.
+ */
+function ChartTabsSettingsMenu({
+  position,
+  setPosition,
+  compact,
+  setCompact,
+  anchor,
+}: {
+  position: "top" | "bottom";
+  setPosition: (p: "top" | "bottom") => void;
+  compact: boolean;
+  setCompact: (c: boolean) => void;
+  anchor: "above" | "below";
+}) {
+  const [open, setOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Tab bar settings"
+        title="Tab bar settings"
+        className={cn(
+          "flex items-center justify-center h-7 w-7 rounded-md text-text-subtle hover:text-text hover:bg-surface-muted transition-colors",
+          open && "bg-surface-muted text-text"
+        )}
+      >
+        <SettingsIcon />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Tab bar settings"
+          className={cn(
+            "absolute right-0 z-40 w-56",
+            "rounded-lg border border-border bg-surface shadow-lg p-1",
+            anchor === "above" ? "bottom-full mb-1" : "top-full mt-1"
+          )}
+        >
+          <SettingsSection label="Position">
+            <SettingsToggle
+              active={position === "top"}
+              onClick={() => setPosition("top")}
+              label="Top"
+            />
+            <SettingsToggle
+              active={position === "bottom"}
+              onClick={() => setPosition("bottom")}
+              label="Bottom"
+            />
+          </SettingsSection>
+          <SettingsSection label="Density">
+            <SettingsToggle
+              active={!compact}
+              onClick={() => setCompact(false)}
+              label="Show labels"
+            />
+            <SettingsToggle
+              active={compact}
+              onClick={() => setCompact(true)}
+              label="Dots only"
+            />
+          </SettingsSection>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SettingsSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="px-1 py-1">
+      <p className="text-[10px] uppercase tracking-wider text-text-subtle font-medium px-2 pt-1 pb-1.5">
+        {label}
+      </p>
+      <div className="flex flex-col gap-0.5">{children}</div>
+    </div>
+  );
+}
+
+function SettingsToggle({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitemradio"
+      aria-checked={active}
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-2 w-full px-2 py-1.5 rounded-md text-sm text-left transition-colors",
+        active
+          ? "bg-accent-soft/60 text-accent"
+          : "text-text-muted hover:bg-surface-muted hover:text-text"
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "h-1.5 w-1.5 rounded-full shrink-0",
+          active ? "bg-accent" : "bg-border-strong/40"
+        )}
+      />
+      {label}
+    </button>
+  );
+}
+
+function SettingsIcon() {
+  // Inline SVG — keeps bundle free of an icon dep, matches the
+  // text-subtle stroke weight of the rest of the bar chrome.
+  return (
+    <svg
+      aria-hidden="true"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+    </svg>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -13,6 +13,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
 import { formatDate, formatRelative } from "@/lib/utils/format";
 import { ChartTabs, type TabKey, type TabPeeks } from "./chart-tabs";
+import { ChartFrame } from "./chart-frame";
 import { TrackPatientView } from "@/components/shell/recent-patients";
 import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
@@ -472,10 +473,13 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
         </div>
       )}
 
-      {/* ── Tab bar ───────────────────────────────────────── */}
-      <ChartTabs patientId={params.id} counts={counts} peeks={tabPeeks} />
-
-      {/* ── Tab content ───────────────────────────────────── */}
+      {/* ── Tab bar + content ─────────────────────────────── */}
+      {/* ChartFrame lets the clinician toggle tab bar position (top /
+          bottom) and density (labels / dots). Both preferences are
+          persisted in localStorage and scoped to the whole chart. */}
+      <ChartFrame
+        nav={<ChartTabs patientId={params.id} counts={counts} peeks={tabPeeks} />}
+      >
       {tab === "demographics" && (
         <DemographicsTab
           patient={patient}
@@ -529,6 +533,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
           patientId={params.id}
         />
       )}
+      </ChartFrame>
     </PageShell>
   );
 }


### PR DESCRIPTION
## Summary

Slice 3d of Phase 3 — the chart tab bar becomes fully personalizable. A small gear-icon menu on the right end of the bar exposes two preferences the clinician controls per-device:

1. **Position** — Top (default) or Bottom. The whole bar anchors against the opposite side of the chart content, and the active-tab underline + hover-peek popover flip to anchor from the right side (peek opens upward when the bar is on the bottom so it never extends past the chart).
2. **Density** — "Show labels" (default) or "Dots only". Dots-only keeps the colored dot + count badge + drag grip and hides the text label. Hover shows the label as a `title` tooltip, so the information stays reachable without eating horizontal space.

## How it's wired

- **New `src/app/(clinician)/clinic/patients/[id]/chart-frame.tsx`** wraps the tab bar + tab content in a flex container whose direction flips based on position. Settings live in a React context so both the nav (compact/position affect styling) and the frame (position affects order) read from one source.
- Settings are persisted to `localStorage` under `chart-tabs:settings:v1` as `{ position, compact }`. Defaults apply on corrupt JSON / blocked storage — no crash.
- `ChartTabs` consumes `useChartFrame()` and swaps border + margin + underline side + popover anchor based on `onBottom`. The "Reset order" link moves into a right-aligned trailing group next to the settings button for visual balance.
- The settings dropdown is closed on outside-click, on Escape, and anchors above or below the bar depending on position — same direction-aware pattern as the peek popover.
- Patient page now wraps `ChartTabs` + every tab-content block in `<ChartFrame nav={<ChartTabs … />}>…</ChartFrame>`. Zero prop plumbing for callers; the frame handles everything.

## Design rationale

- **Context instead of prop threading** because two disjoint subtrees (nav vs content) need the same position state; threading through the patient page would pollute a long server component with a client concern.
- **Dots-only instead of "emoji-only"** from the sketch — the `TABS` array currently has colored dots, not emojis. When the icon library lands (separate slice), swapping dots for icons is a one-line change in `TABS` with no layout impact.

## Explicitly out of scope

- **Left/right vertical tab rails** — a vertical bar is a bigger layout rethink than a flex-direction flip and belongs in its own slice (3e).
- **AI-generated section summaries** (separate future slice).
- **Keyboard shortcuts for position/density toggles** — the menu is reachable by Tab + Enter like any other button, so fine for V1.
- **Icon swap** — waiting on the shared icon library you mentioned.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — local typecheck and `next build` both pass
- [ ] Patient chart → gear icon → Bottom → bar jumps to below the content; active underline renders on the top edge; peek popovers open upward. Reload → preference persists.
- [ ] Gear icon → Dots only → labels hide, counts + dots stay; hover a tab → label tooltip appears. Reload → preference persists.
- [ ] All existing 3c behaviors still work: drag to reorder, end-of-list drop, Reset order link.
- [ ] `localStorage.setItem('chart-tabs:settings:v1', 'garbage')` → reload → defaults apply, no crash.
- [ ] Menu closes on Escape and on outside-click; gear button `aria-expanded` tracks open state.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1