### PR TITLE
fix(command-center): null-guard Patient.allergies on Snapshot + Schedule tiles

### DIFF
--- a/src/components/command/patient-snapshot-tile.tsx
+++ b/src/components/command/patient-snapshot-tile.tsx
@@ -135,6 +135,13 @@ async function renderSnapshotTile(user: AuthedUser) {
     );
   }
 
+  // Legacy rows can have allergies=NULL in the DB even though the
+  // Prisma schema declares a non-null default — the default is applied
+  // at write time, not retroactively. Normalize once so downstream
+  // code can treat it as a plain array. Same defensive guard the
+  // patient chart page + share page already apply.
+  const allergies = patient.allergies ?? [];
+
   const age = computeAge(patient.dateOfBirth);
   const isUpcoming = featured.startAt.getTime() > now.getTime();
   const apptLabel = isUpcoming ? "Up next" : "Today";
@@ -163,9 +170,9 @@ async function renderSnapshotTile(user: AuthedUser) {
           </div>
         </div>
 
-        {patient.allergies.length > 0 && (
+        {allergies.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {patient.allergies.slice(0, 3).map((a) => (
+            {allergies.slice(0, 3).map((a) => (
               <span
                 key={a}
                 className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-red-50 text-red-800 border border-red-200/70"
@@ -174,9 +181,9 @@ async function renderSnapshotTile(user: AuthedUser) {
                 ⚠ {a}
               </span>
             ))}
-            {patient.allergies.length > 3 && (
+            {allergies.length > 3 && (
               <span className="text-[10px] text-text-subtle self-center">
-                +{patient.allergies.length - 3}
+                +{allergies.length - 3}
               </span>
             )}
           </div>

--- a/src/components/command/schedule-card-data.ts
+++ b/src/components/command/schedule-card-data.ts
@@ -164,13 +164,17 @@ export async function loadScheduleEnrichment(
   const out = new Map<string, ScheduleEnrichment>();
   for (const id of patientIds) out.set(id, emptyEnrichment());
 
-  // allergies
+  // allergies — null-guard because legacy rows may have allergies=NULL
+  // despite the schema default (default applies at write time, not to
+  // pre-existing data).
   for (const p of patients) {
     const e = out.get(p.id);
-    if (e && p.allergies.length > 0) {
+    if (!e) continue;
+    const allergies = p.allergies ?? [];
+    if (allergies.length > 0) {
       e.chips.push({
         emoji: "⚠",
-        label: p.allergies.length === 1 ? p.allergies[0] : `${p.allergies.length} allergies`,
+        label: allergies.length === 1 ? allergies[0] : `${allergies.length} allergies`,
         tone: "danger",
       });
     }


### PR DESCRIPTION
## Summary

The Patient Snapshot tile has been crashing on `/clinic/command` with `digest 2018575199` (isolated to this tile by PR #17). Root cause identified without needing server logs — three other places in the codebase already null-guard `patient.allergies`, which strongly suggested the column can be NULL in the wild.

**Why `patient.allergies` can be null despite `String[] @default([])`**: Prisma's `@default` is applied at write time, not retroactively to pre-existing rows. Any patient created before the `allergies` column was added (or before the default was set) keeps `allergies = NULL` in Postgres. The snapshot tile was calling `patient.allergies.length` directly, so the moment such a patient became the featured one (first upcoming appointment today), the tile threw `Cannot read properties of null (reading 'length')`.

## What changed

- **`patient-snapshot-tile.tsx`** — normalize once after the Prisma fetch: `const allergies = patient.allergies ?? []`. All subsequent references use the local variable, so the tile can never dereference null.
- **`schedule-card-data.ts`** — same normalization on the batched enrichment loader shipped in PR #20. The loader would have hit the same crash for any patient on today's schedule with a NULL-allergies row, which — thanks to the per-tile try/catch from PR #17 — would manifest as the whole Schedule tile falling back to "Couldn't load today's schedule" instead of just one card.

## How the crash was diagnosed

No Render logs required. The pattern was detectable statically:
- `src/app/(clinician)/clinic/patients/[id]/page.tsx:404` — `patient.allergies?.length > 0`
- `src/app/share/[token]/page.tsx:71` — `patient.allergies && patient.allergies.length > 0`
- `src/app/(clinician)/clinic/patients/[id]/leaflet/actions.ts:99` — `patient.allergies ?? []`

Three existing defensive guards that the Snapshot tile missed. Whoever wrote those knew the column can be null in prod.

## Leaving in place

The segment `error.tsx` (PR #16) and per-tile `try/catch` (PR #17) stay. They're still the second line of defense for any future bug of the same shape — the Command Center should degrade gracefully no matter what.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — both pass locally
- [ ] After deploy, `/clinic/command` → Patient Snapshot tile renders with the featured patient. No fallback body.
- [ ] Patient with `allergies = []` → card renders, no allergy chip. Unchanged.
- [ ] Patient with `allergies = ['Penicillin']` → card renders with one "⚠ Penicillin" chip. Unchanged.
- [ ] Patient with `allergies = NULL` (legacy row) → card renders, no chip, no crash. Previously crashed the tile.
- [ ] Schedule tile cards continue to render with allergy chips for patients who have them; no crash for legacy rows.

---

After this merges, consider a backfill migration — `UPDATE Patient SET allergies = '{}' WHERE allergies IS NULL;` — so we don't keep accumulating defensive guards in every new read path. Low-risk one-liner, but out of scope for this hotfix.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1