### PR TITLE
fix(command-center): make Schedule enrichment loader query-resilient

### DIFF
--- a/src/components/command/schedule-card-data.ts
+++ b/src/components/command/schedule-card-data.ts
@@ -48,6 +48,27 @@ function emptyEnrichment(): ScheduleEnrichment {
 }
 
 /**
+ * Run a Prisma query and swallow + log any failure. The Schedule tile
+ * has nine independent enrichment queries; if any one of them throws
+ * (a missing table after schema drift, a Prisma client mismatch, an
+ * enum-in-where surprise) the whole tile falls back to its error
+ * body — even though the other eight queries would have been fine.
+ *
+ * Wrapping each query individually lets the tile degrade gracefully:
+ * the failing piece returns an empty array, the others render their
+ * data, and the failure is logged so Render shows it in the stack
+ * trace without us having to chase it via per-tile fallbacks.
+ */
+async function safeQuery<T>(label: string, fn: () => Promise<T[]>): Promise<T[]> {
+  try {
+    return await fn();
+  } catch (err) {
+    console.error(`[command-center] schedule enrichment "${label}" failed:`, err);
+    return [];
+  }
+}
+
+/**
  * Load enrichment for a batch of patients. Returns a Map from patientId
  * to its enrichment record. Patients with no data still get an entry
  * (all fields null / empty chips) so the caller can use `.get()` without
@@ -79,86 +100,97 @@ export async function loadScheduleEnrichment(
     concernObservations,
     concernMemories,
   ] = await Promise.all([
-    // allergies for the allergy chip
-    prisma.patient.findMany({
-      where: { id: { in: patientIds } },
-      select: { id: true, allergies: true },
-    }),
-    // today's Encounter (reason + briefing) per patient if one exists
-    prisma.encounter.findMany({
-      where: {
-        patientId: { in: patientIds },
-        scheduledFor: { gte: todayStart, lt: tomorrowStart },
-      },
-      orderBy: { scheduledFor: "asc" },
-      select: {
-        patientId: true,
-        reason: true,
-        briefingContext: true,
-      },
-    }),
-    // pain logs for the trend arrow
-    prisma.outcomeLog.findMany({
-      where: {
-        patientId: { in: patientIds },
-        metric: "pain",
-        loggedAt: { gte: thirtyDaysAgo },
-      },
-      orderBy: { loggedAt: "asc" },
-      select: { patientId: true, value: true, loggedAt: true },
-    }),
-    // active regimens → expected doses/day for adherence math
-    prisma.dosingRegimen.findMany({
-      where: { patientId: { in: patientIds }, active: true },
-      select: { patientId: true, frequencyPerDay: true },
-    }),
-    // actual doses last 7 days
-    prisma.doseLog.findMany({
-      where: {
-        patientId: { in: patientIds },
-        loggedAt: { gte: sevenDaysAgo },
-      },
-      select: { patientId: true },
-    }),
-    // pending refill → chip
-    prisma.refillRequest.findMany({
-      where: {
-        patientId: { in: patientIds },
-        status: { in: ["new", "flagged"] },
-      },
-      select: { patientId: true },
-    }),
-    // latest abnormal lab → chip
-    prisma.labResult.findMany({
-      where: { patientId: { in: patientIds }, abnormalFlag: true },
-      orderBy: { receivedAt: "desc" },
-      select: { patientId: true, panelName: true },
-    }),
-    // open urgent/concern observation → chip + fallback brief line
-    prisma.clinicalObservation.findMany({
-      where: {
-        patientId: { in: patientIds },
-        severity: { in: ["urgent", "concern"] },
-        resolvedAt: null,
-      },
-      orderBy: [{ severity: "desc" }, { createdAt: "desc" }],
-      select: {
-        patientId: true,
-        severity: true,
-        summary: true,
-      },
-    }),
-    // concern memory → fallback brief line
-    prisma.patientMemory.findMany({
-      where: {
-        patientId: { in: patientIds },
-        kind: "concern",
-        validUntil: null,
-        supersededById: null,
-      },
-      orderBy: { updatedAt: "desc" },
-      select: { patientId: true, content: true },
-    }),
+    safeQuery("patients", () =>
+      prisma.patient.findMany({
+        where: { id: { in: patientIds } },
+        select: { id: true, allergies: true },
+      })
+    ),
+    safeQuery("encounters", () =>
+      prisma.encounter.findMany({
+        where: {
+          patientId: { in: patientIds },
+          scheduledFor: { gte: todayStart, lt: tomorrowStart },
+        },
+        orderBy: { scheduledFor: "asc" },
+        select: {
+          patientId: true,
+          reason: true,
+          briefingContext: true,
+        },
+      })
+    ),
+    safeQuery("painLogs", () =>
+      prisma.outcomeLog.findMany({
+        where: {
+          patientId: { in: patientIds },
+          metric: "pain",
+          loggedAt: { gte: thirtyDaysAgo },
+        },
+        orderBy: { loggedAt: "asc" },
+        select: { patientId: true, value: true, loggedAt: true },
+      })
+    ),
+    safeQuery("regimens", () =>
+      prisma.dosingRegimen.findMany({
+        where: { patientId: { in: patientIds }, active: true },
+        select: { patientId: true, frequencyPerDay: true },
+      })
+    ),
+    safeQuery("doseLogs", () =>
+      prisma.doseLog.findMany({
+        where: {
+          patientId: { in: patientIds },
+          loggedAt: { gte: sevenDaysAgo },
+        },
+        select: { patientId: true },
+      })
+    ),
+    safeQuery("pendingRefills", () =>
+      prisma.refillRequest.findMany({
+        where: {
+          patientId: { in: patientIds },
+          status: { in: ["new", "flagged"] },
+        },
+        select: { patientId: true },
+      })
+    ),
+    safeQuery("abnormalLabs", () =>
+      prisma.labResult.findMany({
+        where: { patientId: { in: patientIds }, abnormalFlag: true },
+        orderBy: { receivedAt: "desc" },
+        select: { patientId: true, panelName: true },
+      })
+    ),
+    safeQuery("concernObservations", () =>
+      prisma.clinicalObservation.findMany({
+        where: {
+          patientId: { in: patientIds },
+          severity: { in: ["urgent", "concern"] },
+          resolvedAt: null,
+        },
+        // Sort by createdAt only; some Prisma versions reject orderBy
+        // on enum fields, and recency is the right tiebreaker anyway.
+        orderBy: { createdAt: "desc" },
+        select: {
+          patientId: true,
+          severity: true,
+          summary: true,
+        },
+      })
+    ),
+    safeQuery("concernMemories", () =>
+      prisma.patientMemory.findMany({
+        where: {
+          patientId: { in: patientIds },
+          kind: "concern",
+          validUntil: null,
+          supersededById: null,
+        },
+        orderBy: { updatedAt: "desc" },
+        select: { patientId: true, content: true },
+      })
+    ),
   ]);
 
   const out = new Map<string, ScheduleEnrichment>();


### PR DESCRIPTION
## Summary

After PR #21 the allergies bug was fixed but the **Schedule tile is still falling back** to "Couldn't load today's schedule." Root cause is structural rather than per-row data: the loader runs **nine parallel Prisma queries** inside `Promise.all`, so any single one of them throwing — for any reason — rejects the whole `Promise.all` and takes down the tile.

Plausible single-query failures we don't want to keep chasing one by one:

- **Schema-drift table** that hasn't migrated to prod yet (the clinician layout already wraps its counts in `safeCount()` with a comment specifically about `P2021` missing-table errors — same class of problem)
- **Prisma client generated against a slightly different schema revision** than the one deployed
- **Enum-value-in-where surprise** — the previous `orderBy: [{ severity: "desc" }, ...]` on `ClinicalObservation` was one such risk; collapsed to `{ createdAt: "desc" }` since some Prisma versions reject enum sorting and recency is the right tiebreaker anyway
- Any new query we add later that turns out to break in prod

## Fix

Introduce `safeQuery(label, fn)` that runs each Prisma call, returns its result on success, and on failure logs the error with the label and returns `[]`. Wrap each of the nine queries.

## Net effect

- **All 9 succeed** → cards render with full enrichment. Unchanged.
- **One query throws** → that piece is empty, the card still renders the rest. The tile stays up. Render logs show `[command-center] schedule enrichment <label> failed:` with the stack — we'll see exactly which query is the culprit and can fix the underlying issue in a follow-up.
- **All 9 throw** → cards render with header + name + age only. Tile stays up. Nine clearly-labelled log lines pinpoint each failing query.

## Side cleanup

`ClinicalObservation` `orderBy` collapsed from `[{ severity: "desc" }, { createdAt: "desc" }]` to just `{ createdAt: "desc" }`. Some Prisma versions reject enum sorting; recency is the right tiebreaker anyway.

## Why a different shape than per-tile try/catch

PR #17's per-tile fault isolation catches at the *tile* boundary — useful for true tile-render bugs, but for an enrichment loader that aggregates data of nine independent kinds, all-or-nothing is wrong: one missing table shouldn't hide the other eight rows of useful info. This PR moves the boundary one level deeper, where the data ownership actually lives.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — both pass locally
- [ ] After deploy, `/clinic/command` → Schedule tile renders. Cards show whatever enrichment is available.
- [ ] Render logs: tail and look for `[command-center] schedule enrichment` lines — that tells us exactly which queries (if any) are failing in prod, so the next PR can fix the underlying schema/data issue cleanly.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1