### PR TITLE
diag(command-center): surface caught error in tile fallback body

### DIFF
--- a/src/components/command/messages-tile.tsx
+++ b/src/components/command/messages-tile.tsx
@@ -64,7 +64,7 @@ export async function MessagesTile({ user }: { user: AuthedUser }) {
     console.error("[command-center] MessagesTile render failed:", err);
     return (
       <MessagesTileShell count={0} urgentCount={0}>
-        <TileErrorBody label="the messages inbox" />
+        <TileErrorBody label="the messages inbox" error={err} />
       </MessagesTileShell>
     );
   }

--- a/src/components/command/patient-snapshot-tile.tsx
+++ b/src/components/command/patient-snapshot-tile.tsx
@@ -41,7 +41,7 @@ export async function PatientSnapshotTile({ user }: { user: AuthedUser }) {
     console.error("[command-center] PatientSnapshotTile render failed:", err);
     return (
       <SnapshotShell>
-        <TileErrorBody label="the patient snapshot" />
+        <TileErrorBody label="the patient snapshot" error={err} />
       </SnapshotShell>
     );
   }

--- a/src/components/command/schedule-tile.tsx
+++ b/src/components/command/schedule-tile.tsx
@@ -98,7 +98,7 @@ export async function ScheduleTile({ user }: { user: AuthedUser }) {
     console.error("[command-center] ScheduleTile render failed:", err);
     return (
       <ScheduleTileShell count={0}>
-        <TileErrorBody label="today's schedule" />
+        <TileErrorBody label="today's schedule" error={err} />
       </ScheduleTileShell>
     );
   }

--- a/src/components/command/tile-error.tsx
+++ b/src/components/command/tile-error.tsx
@@ -5,17 +5,49 @@
  * reflow, and the clinician sees something calm + honest instead of a
  * crash of the whole dashboard.
  *
- * The actual error is logged server-side with console.error — visible
- * in Render logs alongside the Next.js request digest — so the team
- * can diagnose without the clinician having to copy anything.
+ * When an `error` is passed in, we render its message + first stack
+ * line right in the tile. This is a temporary diagnostic surface —
+ * production normally masks error messages via Next's error boundary,
+ * but these tiles catch in their own code path, so we can safely
+ * expose the details to whoever's looking at the page. Once the
+ * Command Center is stable, the error prop can be dropped and this
+ * reverts to the generic message.
  */
-export function TileErrorBody({ label }: { label: string }) {
+export function TileErrorBody({
+  label,
+  error,
+}: {
+  label: string;
+  error?: unknown;
+}) {
+  const message = formatError(error);
   return (
-    <div className="h-full flex items-center justify-center text-center p-4">
-      <p className="text-xs text-text-muted italic max-w-[220px] leading-relaxed">
+    <div className="h-full flex flex-col items-center justify-center text-center p-4 gap-2">
+      <p className="text-xs text-text-muted italic max-w-[240px] leading-relaxed">
         Couldn&rsquo;t load {label} right now. The other tiles still work —
         we&rsquo;ve logged the error for the team.
       </p>
+      {message && (
+        <pre className="mt-1 w-full max-w-full overflow-auto rounded border border-border/60 bg-surface-muted px-2 py-1.5 text-left text-[10px] leading-snug text-text-subtle tabular-nums whitespace-pre-wrap break-words">
+          {message}
+        </pre>
+      )}
     </div>
   );
+}
+
+function formatError(err: unknown): string | null {
+  if (!err) return null;
+  if (err instanceof Error) {
+    // Keep it short — one line for name+message, first frame of the
+    // stack so the tile doesn't dominate the tile body.
+    const firstFrame = err.stack?.split("\n").slice(1, 2).join("").trim();
+    return `${err.name}: ${err.message}${firstFrame ? `\n${firstFrame}` : ""}`;
+  }
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
 }


### PR DESCRIPTION
## Summary

PR #21 and #22 both merged and are on `main`, but the Command Center tiles are still falling back. Rather than keep guessing, this PR puts the diagnostic directly into the UI — since each tile catches in its own try/catch (not through Next's production error boundary), we're free to render the actual error text right inside the tile body. **The next reload becomes the diagnostic.**

## Changes

- `TileErrorBody` now accepts an optional `error` prop. When set, it formats `err.name`, `err.message`, and the first stack frame into a small `<pre>` below the generic "couldn't load" message.
- `ScheduleTile` / `MessagesTile` / `PatientSnapshotTile` each pass the caught `err` into `TileErrorBody`.

## What reloading will show us

Once this deploys, whichever tile is failing will display something like:

```
Couldn't load today's schedule right now…

┌──────────────────────────────────────────┐
│ PrismaClientKnownRequestError: The       │
│ table `Encounter` does not exist in…     │
│   at async loadScheduleEnrichment (…)    │
└──────────────────────────────────────────┘
```

Or a serialized error on a specific field, or a TypeError on a specific undefined access. **Whatever it is, we'll see it in-page.** Then the fix is targeted, not exploratory.

## Scope note

This is a dev-time aid. Once the Command Center is stable, the `error` prop can be dropped and the fallback reverts to the generic message. I'd rather have the error text visible on the page while we chase a stubborn bug than play "redeploy, then tail logs, then redeploy again."

## Test plan

- [ ] CI green (`typecheck · lint · build`) — typecheck passes locally
- [ ] After deploy, `/clinic/command` → any still-failing tile shows its error message inline. Paste it back to the session and I'll write the final fix.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1