### PR TITLE
chore: gitignore .claude/ (Claude Code local state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 .vscode/
 .idea/
 
+# Claude Code local state (agent worktrees, hook outputs, transcripts)
+.claude/
+
 # Prisma
 prisma/dev.db
 prisma/*.db-journal


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so Claude Code's local state directory (agent worktrees, hook outputs, transcripts) doesn't show up as untracked in `git status`.

This is purely environmental hygiene — nothing in `.claude/` belongs in the repo. The directory is created automatically by the harness when running parallel agents in worktrees, and the existing pre-commit `stop-hook-git-check.sh` was flagging it on every turn.

## Test plan

- [ ] After merge, `git status` on a fresh checkout (or after a parallel-agent run) shows no `.claude/` entry.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1