### PR TITLE
feat(chart-tabs): AI section summaries atop hover-peek popovers

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -66,9 +66,11 @@ interface ChartTabsProps {
   patientId: string;
   counts: Record<TabKey, number>;
   peeks?: TabPeeks;
+  /** AI-generated 1-2 sentence summary per tab, rendered atop the peek popover. */
+  peekSummaries?: Partial<Record<TabKey, string>>;
 }
 
-export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
+export function ChartTabs({ patientId, counts, peeks, peekSummaries }: ChartTabsProps) {
   const searchParams = useSearchParams();
   const active = (searchParams.get("tab") as TabKey) || "records";
 
@@ -307,6 +309,7 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
               <TabPeekPopover
                 label={tab.label}
                 entries={entries}
+                summary={peekSummaries?.[tab.key]}
                 seeAllHref={`/clinic/patients/${patientId}?tab=${tab.key}`}
                 onLeave={scheduleClose}
                 onEnter={cancelClose}
@@ -350,6 +353,7 @@ export function ChartTabs({ patientId, counts, peeks }: ChartTabsProps) {
 function TabPeekPopover({
   label,
   entries,
+  summary,
   seeAllHref,
   onEnter,
   onLeave,
@@ -357,6 +361,7 @@ function TabPeekPopover({
 }: {
   label: string;
   entries: PeekEntry[];
+  summary?: string;
   seeAllHref: string;
   onEnter: () => void;
   onLeave: () => void;
@@ -375,6 +380,11 @@ function TabPeekPopover({
       )}
     >
       <div className="px-4 pt-3 pb-2 border-b border-border/60">
+        {summary && (
+          <p className="text-[12px] italic text-text-muted leading-snug mb-1.5">
+            {summary}
+          </p>
+        )}
         <p className="text-[10px] uppercase tracking-wider text-text-subtle font-medium">
           Recent · {label}
         </p>

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
 import { formatDate, formatRelative } from "@/lib/utils/format";
 import { ChartTabs, type TabKey, type TabPeeks } from "./chart-tabs";
 import { ChartFrame } from "./chart-frame";
+import { loadPeekSummaries } from "./peek-summary";
 import { TrackPatientView } from "@/components/shell/recent-patients";
 import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
@@ -271,6 +272,19 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     })),
   };
 
+  /* ── AI peek summaries (slice 3) ────────────────────────────
+   * One-to-two sentence narrative per tab, rendered atop the hover
+   * popover. Wrapped in try/catch so an LLM outage degrades gracefully
+   * to the existing entry-list peek (same pattern as Command Center
+   * tile loaders). */
+  let peekSummaries: Partial<Record<TabKey, string>> | undefined;
+  try {
+    peekSummaries = await loadPeekSummaries(patient.firstName, tabPeeks);
+  } catch (err) {
+    console.error("[patient-chart] peek summary generation failed:", err);
+    peekSummaries = undefined;
+  }
+
   /* ── Clinical Decision Support alerts (EMR-166) ──────────── */
   const cannabinoids: string[] = [];
   for (const regimen of dosingRegimens) {
@@ -478,7 +492,14 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
           bottom) and density (labels / dots). Both preferences are
           persisted in localStorage and scoped to the whole chart. */}
       <ChartFrame
-        nav={<ChartTabs patientId={params.id} counts={counts} peeks={tabPeeks} />}
+        nav={
+          <ChartTabs
+            patientId={params.id}
+            counts={counts}
+            peeks={tabPeeks}
+            peekSummaries={peekSummaries}
+          />
+        }
       >
       {tab === "demographics" && (
         <DemographicsTab

--- a/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+import { resolveModelClient } from "@/lib/orchestration/model-client";
+import { formatPersonaForPrompt, resolvePersona } from "@/lib/agents/persona";
+import type { TabKey, TabPeeks, PeekEntry } from "./chart-tabs";
+
+// ---------------------------------------------------------------------------
+// Per-tab AI summaries for the chart hover-peek popovers (slice 3).
+//
+// The popover already lists the last five entries from each tab. This adds
+// a one-to-two sentence summary on top so a clinician can scan "what's
+// been happening here" without reading every row. Computed server-side
+// once per page render and serialized to the client alongside `peeks` —
+// no client fetch, no spinners, no API route.
+// ---------------------------------------------------------------------------
+
+/** Human label per tab, used inside the prompt so the model knows what it's summarizing. */
+const TAB_LABELS: Record<TabKey, string> = {
+  demographics: "Demographics",
+  memory: "Memory",
+  records: "Records",
+  images: "Images",
+  labs: "Labs",
+  notes: "Notes",
+  correspondence: "Correspondence",
+  rx: "Cannabis Rx",
+  billing: "Billing",
+};
+
+/**
+ * Produce a 1-2 sentence summary for one tab's recent entries. Returns
+ * `undefined` on any failure so the popover renders unchanged.
+ */
+async function summarizeTab(
+  tab: TabKey,
+  patientFirstName: string,
+  entries: PeekEntry[],
+): Promise<string | undefined> {
+  // We borrow Nora's voice profile — the project Constitution wants
+  // every patient-adjacent surface to sound like a real care team
+  // member, not a dashboard label. The "no AI filler, no liability-
+  // cover clichés" directive is baked into the persona prompt block.
+  const personaBlock = formatPersonaForPrompt(resolvePersona("correspondenceNurse"));
+  const label = TAB_LABELS[tab];
+
+  const lines = entries
+    .slice(0, 5)
+    .map((e, i) => {
+      const meta = e.meta ? ` — ${e.meta}` : "";
+      return `${i + 1}. ${e.title}${meta}`;
+    })
+    .join("\n");
+
+  const prompt = `${personaBlock}
+
+You are summarizing the "${label}" tab on ${patientFirstName}'s chart for a clinician hovering the tab. Read the recent entries below and return ONE OR TWO short sentences capturing the through-line — what's been happening, the trend, the open question. Plain prose only, no bullets, no quotes, no preamble. Under 30 words. If there's no real pattern, name the most recent item and stop.
+
+Recent ${label} entries:
+${lines}
+
+Summary:`;
+
+  const client = resolveModelClient();
+  const raw = await client.complete(prompt, { maxTokens: 120, temperature: 0.3 });
+  const cleaned = raw.trim().replace(/^["']|["']$/g, "").trim();
+  if (!cleaned) return undefined;
+  // Cap at ~220 chars so a runaway model can't blow out the popover header.
+  return cleaned.length > 220 ? cleaned.slice(0, 217).trimEnd() + "…" : cleaned;
+}
+
+/**
+ * Generate AI summaries for every tab in `peeks` that has at least one
+ * entry. All per-tab calls run in parallel (the chart has ≤9 tabs, well
+ * under any sane concurrency cap) and each is wrapped in its own
+ * try/catch so a single LLM hiccup doesn't take the others down.
+ */
+export async function loadPeekSummaries(
+  patientFirstName: string,
+  peeks: TabPeeks,
+): Promise<Partial<Record<TabKey, string>>> {
+  const targets = (Object.entries(peeks) as Array<[TabKey, PeekEntry[] | undefined]>)
+    .filter(([, entries]) => entries && entries.length > 0)
+    .map(([tab, entries]) => ({ tab, entries: entries! }));
+
+  if (targets.length === 0) return {};
+
+  const settled = await Promise.allSettled(
+    targets.map(async ({ tab, entries }) => {
+      try {
+        const summary = await summarizeTab(tab, patientFirstName, entries);
+        return { tab, summary };
+      } catch (err) {
+        console.warn(`[peek-summary] ${tab} summarization failed:`, err);
+        return { tab, summary: undefined };
+      }
+    }),
+  );
+
+  const out: Partial<Record<TabKey, string>> = {};
+  for (const result of settled) {
+    if (result.status === "fulfilled" && result.value.summary) {
+      out[result.value.tab] = result.value.summary;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Each chart-tab hover popover already lists the last five entries from that section. This adds a one-to-two sentence AI-generated summary on top so a clinician can scan "what's been happening on this tab" without reading the rows.

Computation
  Server-side, once per page render. A new helper iterates the
  peek map, builds a small per-tab prompt (titles + meta), and
  fans out parallel calls to resolveModelClient(). All calls run
  through Promise.allSettled with each wrapped in its own
  try/catch — a single LLM failure returns undefined for that tab
  and the others still render. The whole loader is also wrapped
  in a page-level try/catch so a total outage degrades to the
  pre-existing peek with no summary line, matching the per-tile
  resilience pattern used in the Command Center.

Voice
  Borrows the warm-clinical Nurse Nora persona block so the
  summary inherits the Constitution's "no AI filler, no
  liability-cover clichés" directive instead of reading like a
  dashboard label.

UI
  TabPeekPopover gains an optional `summary` prop and renders it
  as an italic, dim, small line above the existing
  "Recent · {label}" eyebrow. When summary is missing the
  popover renders identically to before.

No new dependencies, no client fetch, no API route.