### PR TITLE
feat(agents): persist preVisitIntelligence briefing to Encounter.briefingContext

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
@@ -70,6 +70,32 @@ export async function generateBriefing(patientId: string): Promise<BriefingResul
     };
   }
 
+  // Find the encounter that should receive this briefing (if any). We prefer
+  // an in-progress encounter (clinician is already in the room) and fall back
+  // to today's scheduled encounter. When neither exists, the briefing still
+  // runs but won't be persisted — the user can click "Start Visit" and
+  // `startVisitWithBriefing` will create the encounter with the briefing
+  // attached. Passing encounterId here lets the Schedule tile's brief line
+  // and any other downstream surface read the briefing the moment it's
+  // generated, without waiting for the physician to start the visit.
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayEnd = new Date();
+  todayEnd.setHours(23, 59, 59, 999);
+
+  const encounterForBriefing = await prisma.encounter.findFirst({
+    where: {
+      patientId,
+      organizationId: user.organizationId!,
+      OR: [
+        { status: "in_progress" },
+        { scheduledFor: { gte: todayStart, lte: todayEnd } },
+      ],
+    },
+    orderBy: [{ status: "asc" }, { scheduledFor: "asc" }],
+    select: { id: true },
+  });
+
   // Build a mock context that captures logs as steps
   const logs: AgentLogEntry[] = [];
   const steps: BriefingStep[] = STEP_LABELS.map((label, i) => ({
@@ -117,7 +143,7 @@ export async function generateBriefing(patientId: string): Promise<BriefingResul
 
   try {
     const result = await preVisitIntelligenceAgent.run(
-      { patientId },
+      { patientId, encounterId: encounterForBriefing?.id },
       ctx,
     );
 

--- a/src/lib/agents/pre-visit-intelligence-agent.ts
+++ b/src/lib/agents/pre-visit-intelligence-agent.ts
@@ -45,6 +45,34 @@ function daysAgo(date: Date): number {
   return Math.floor((Date.now() - date.getTime()) / (86_400_000));
 }
 
+/**
+ * Best-effort write of the generated briefing to `Encounter.briefingContext`.
+ * A db failure must never abort a successful briefing — the agent's primary
+ * contract is to return the briefing to the caller; persistence is a
+ * side-effect that lets downstream surfaces (Schedule tile brief line, scribe
+ * pre-seed) read it without re-running the agent. On failure we log via
+ * `console.warn` with a clear prefix so the issue surfaces in server logs
+ * without breaking the calling flow.
+ */
+async function persistBriefingToEncounter(
+  encounterId: string | undefined,
+  briefing: unknown,
+): Promise<void> {
+  if (!encounterId) return;
+  try {
+    await prisma.encounter.update({
+      where: { id: encounterId },
+      data: { briefingContext: briefing as any },
+    });
+  } catch (err) {
+    console.warn(
+      "[preVisitIntelligence] persistence failed:",
+      err instanceof Error ? err.message : String(err),
+      { encounterId },
+    );
+  }
+}
+
 function trendDirection(values: number[]): "improving" | "stable" | "worsening" | "insufficient" {
   if (values.length < 2) return "insufficient";
   const recent = values.slice(-3);
@@ -60,7 +88,17 @@ function trendDirection(values: number[]): "improving" | "stable" | "worsening" 
 // Schemas
 // ---------------------------------------------------------------------------
 
-const input = z.object({ patientId: z.string() });
+const input = z.object({
+  patientId: z.string(),
+  /**
+   * When provided, the agent will best-effort persist the generated briefing
+   * to `Encounter.briefingContext` on this encounter so downstream surfaces
+   * (e.g. the Schedule tile's brief line, the scribe's pre-seeded note) can
+   * read it without re-running the agent. A db write failure never aborts
+   * the briefing — callers always receive the output regardless.
+   */
+  encounterId: z.string().optional(),
+});
 
 const briefingSection = z.object({
   title: z.string(),
@@ -348,7 +386,7 @@ export const preVisitIntelligenceAgent: Agent<
       });
       await trace.persist();
 
-      return {
+      const briefing = {
         patientSummary: parsed.patientSummary ?? buildFallbackSummary(patient, age),
         lastVisitSummary: parsed.lastVisitSummary ?? lastNoteSummary,
         talkingPoints: parsed.talkingPoints ?? [],
@@ -356,6 +394,10 @@ export const preVisitIntelligenceAgent: Agent<
         riskFlags: parsed.riskFlags ?? [],
         confidence: parsed.confidence ?? 0.8,
       };
+
+      await persistBriefingToEncounter(input.encounterId, briefing);
+
+      return briefing;
     }
 
     // Fallback: build deterministic briefing from data
@@ -459,7 +501,7 @@ export const preVisitIntelligenceAgent: Agent<
     });
     await trace.persist();
 
-    return {
+    const briefing = {
       patientSummary: buildFallbackSummary(patient, age),
       lastVisitSummary: lastNoteSummary,
       talkingPoints,
@@ -467,6 +509,10 @@ export const preVisitIntelligenceAgent: Agent<
       riskFlags,
       confidence: 0.75,
     };
+
+    await persistBriefingToEncounter(input.encounterId, briefing);
+
+    return briefing;
   },
 };
 


### PR DESCRIPTION
## Summary

Wires `preVisitIntelligenceAgent`'s briefing output into `Encounter.briefingContext` so it's queryable from the rest of the app. PR #20 already reads from that field for the Schedule card brief line, but the agent wasn't writing there — so the brief line always silently fell back to observations/memories. This PR closes the loop.

## Approach

**Inline persistence in the agent** (Approach A of the two options considered).

**Why:** The codebase already uses inline domain-table writes inside agents (e.g. `correspondenceNurseAgent.run()` writes `prisma.message.create/update` for triage drafts directly). The existing runner (`src/lib/orchestration/runner.ts`) has no post-success hook mechanism — it just calls `markSucceeded(jobId, output, logs)` which persists to `AgentJob.output`, not to domain tables. Approach B (runner hook / name-specific branch) would have required either a new hook system or name-specific `if` branches in the generic runner, both of which expand the runner's responsibility. **Inline persistence colocates the write with the data that produced it and matches the existing correspondenceNurse pattern.**

## Files changed

- **`src/lib/agents/pre-visit-intelligence-agent.ts`**
  - Added optional `encounterId` to the agent's input schema.
  - Added `persistBriefingToEncounter()` helper wrapped in try/catch with `console.warn("[preVisitIntelligence] persistence failed:", …)`.
  - Invoked from **both** return paths — the LLM-structured path and the deterministic fallback — so the schedule tile gets a brief either way.
  - Return shape unchanged.
- **`src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts`**
  - `generateBriefing()` now looks up the relevant encounter (in_progress or today's scheduled) and passes `encounterId` through to the agent.

## Migration

Agent input type gained an **optional** `encounterId`. Fully backward-compatible — existing/future callers with just `{ patientId }` continue to work; persistence is simply skipped when `encounterId` is absent.

## Failure handling

- No encounter today for the patient → helper early-returns, no persistence, briefing still returned.
- Deleted encounter (race) → Prisma throws, caught + logged via `console.warn`, briefing still returned.
- Double-write when clinician later clicks "Start Visit" → `startVisitWithBriefing` overwrites with same data, no conflict.

## Known limitation

When multiple encounters match the lookup window (e.g. patient has both `in_progress` and `scheduled` encounters today), we pick one via `orderBy: [status asc, scheduledFor asc]` — deterministic but not perfectly user-intent-aware. Acceptable because `startVisitWithBriefing` still writes to whichever encounter the clinician actually starts.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — both pass locally
- [ ] Trigger `generateBriefing()` for a patient with an encounter scheduled today → Encounter.briefingContext is populated
- [ ] Refresh `/clinic/command` (after the Command Center tiles unbreak) → Schedule card brief line now shows the AI-authored summary instead of falling back to the top observation
- [ ] Patient with no encounter today → agent still returns briefing, no persistence, no crash
- [ ] Drop/restore `DATABASE_URL` mid-request → persistence fails with a warn log, briefing still returned

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1