### PR TITLE
fix(command-center): Patient Snapshot survives missing LabResult table

### DIFF
--- a/src/components/command/patient-snapshot-tile.tsx
+++ b/src/components/command/patient-snapshot-tile.tsx
@@ -101,28 +101,54 @@ async function renderSnapshotTile(user: AuthedUser) {
     );
   }
 
-  // Pull the facesheet bits in parallel. Each query is tiny and scoped
-  // to the featured patient; keeping them separate lets the tile still
-  // render if, say, LabResult is unavailable for any reason.
+  // Pull the facesheet bits in parallel. Each query catches its own
+  // failure and returns a sentinel (null / 0) so a single table being
+  // unavailable — the classic `LabResult` schema-drift case — can't
+  // take down the whole tile. The caller sees "— " where the missing
+  // data would have been and gets the rest of the snapshot.
   const [patient, activeMeds, latestLab] = await Promise.all([
-    prisma.patient.findUnique({
-      where: { id: featured.patientId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        dateOfBirth: true,
-        allergies: true,
-      },
-    }),
-    prisma.patientMedication.count({
-      where: { patientId: featured.patientId, active: true },
-    }),
-    prisma.labResult.findFirst({
-      where: { patientId: featured.patientId },
-      orderBy: { receivedAt: "desc" },
-      select: { panelName: true, receivedAt: true, abnormalFlag: true },
-    }),
+    prisma.patient
+      .findUnique({
+        where: { id: featured.patientId },
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          dateOfBirth: true,
+          allergies: true,
+        },
+      })
+      .catch((err) => {
+        console.error(
+          "[command-center] PatientSnapshot patient load failed:",
+          err
+        );
+        return null;
+      }),
+    prisma.patientMedication
+      .count({
+        where: { patientId: featured.patientId, active: true },
+      })
+      .catch((err) => {
+        console.error(
+          "[command-center] PatientSnapshot meds count failed:",
+          err
+        );
+        return 0;
+      }),
+    prisma.labResult
+      .findFirst({
+        where: { patientId: featured.patientId },
+        orderBy: { receivedAt: "desc" },
+        select: { panelName: true, receivedAt: true, abnormalFlag: true },
+      })
+      .catch((err) => {
+        console.error(
+          "[command-center] PatientSnapshot lab load failed:",
+          err
+        );
+        return null;
+      }),
   ]);
 
   if (!patient) {


### PR DESCRIPTION
## Summary

PR #23's in-tile diagnostic earned its keep — surfaced the exact cause of the Patient Snapshot crash:

```
PrismaClientKnownRequestError:
Invalid `prisma.labResult.findFirst()` invocation:
The table `public.LabResult` does not exist in the current database.
```

**Schema drift**: `LabResult` model exists in `prisma/schema.prisma` but the table was never migrated to prod. The clinician layout already handles this class of problem with `safeCount()` ("a missing table (P2021) or any transient DB error must never block login") — the Patient Snapshot just didn't get the same treatment.

## Root cause

The tile used `Promise.all` across three Prisma queries (patient, active-med count, latest lab). Any one failing rejected the whole Promise.all and took down the tile. The file comment even said *"keeping them separate lets the tile still render if, say, LabResult is unavailable for any reason"* — but that was aspirational. `Promise.all` doesn't actually do that.

## Fix

`.catch()` on each promise individually. A failing query logs with a clear label and returns its sentinel:

| Query | On failure | Renders as |
|---|---|---|
| `patient.findUnique` | `null` | existing "Patient unavailable" empty state |
| `patientMedication.count` | `0` | "Active meds: —" |
| `labResult.findFirst` | `null` | "Last lab: —" |

Leaves the outer try/catch + `TileErrorBody` in place as second-line defense for anything else that might throw during render (e.g. `Avatar` / Prisma client mismatch).

## Scope

- Read-path fix only. The underlying **schema drift** — `LabResult` table missing in prod — is a migration issue and should be resolved separately via `prisma db push` or a proper migration.
- Until the table is back, Last Lab will read as "—" for all patients. Once migrated, it populates automatically with zero tile changes.

## Test plan

- [ ] CI green (`typecheck · lint · build`) — both pass locally
- [ ] After deploy, `/clinic/command` → Patient Snapshot renders. Active meds + allergies + basic facesheet all appear. Last lab shows "—".
- [ ] Render logs contain a single `[command-center] PatientSnapshot lab load failed:` line with the `P2021` stack (so the underlying schema issue stays visible for follow-up).
- [ ] Apply the `prisma db push` migration → refresh → Last Lab now populates with real data, no code change needed.

---

Follow-ups (each its own PR):
- Schema migration to restore `LabResult` in prod.
- Roll this `.catch()` pattern into the Tabbed Sidebar tile when it ships.

https://claude.ai/code/session_01TWbmz3BQSekv1FG6fvyMg1