### PR TITLE
Command Center peek → chart-at-a-glance

### DIFF
--- a/src/components/command/schedule-card-data.ts
+++ b/src/components/command/schedule-card-data.ts
@@ -340,12 +340,53 @@ export interface FeaturedSnapshot {
     receivedAt: Date;
     abnormalFlag: boolean;
   } | null;
+  /** Top-5 active meds (conventional + supplements). Display order: prescription > otc > supplement. */
+  activeMeds: Array<{
+    name: string;
+    dosage: string | null;
+    type: string;
+  }>;
+  /** Top-5 active cannabis regimens with product name + calculated mg/day. */
+  activeRegimens: Array<{
+    productName: string;
+    thcMgPerDay: number | null;
+    cbdMgPerDay: number | null;
+    frequencyPerDay: number;
+  }>;
+  /** Top-3 unacknowledged, unresolved ClinicalObservations. Severity desc, createdAt desc. */
+  recentObservations: Array<{
+    id: string;
+    severity: string;
+    category: string;
+    summary: string;
+    actionSuggested: string | null;
+    createdAt: Date;
+  }>;
+  /** Last 30 days of pain OutcomeLog values for the sparkline. Oldest first. */
+  painSparkline: Array<{ value: number; loggedAt: Date }>;
+  /** Snippet from the most recently completed encounter's finalized note. */
+  lastEncounter: {
+    reason: string | null;
+    snippet: string | null;
+    completedAt: Date;
+  } | null;
 }
 
 export async function loadFeaturedSnapshot(
   patientId: string
 ): Promise<FeaturedSnapshot | null> {
-  const [patient, activeMeds, latestLab] = await Promise.all([
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000);
+
+  const [
+    patient,
+    activeMedCount,
+    latestLab,
+    activeMeds,
+    regimens,
+    observations,
+    painLogs,
+    lastEncounter,
+  ] = await Promise.all([
     prisma.patient
       .findUnique({
         where: { id: patientId },
@@ -362,12 +403,143 @@ export async function loadFeaturedSnapshot(
         select: { panelName: true, receivedAt: true, abnormalFlag: true },
       })
       .catch(() => null),
+    prisma.patientMedication
+      .findMany({
+        where: { patientId, active: true },
+        orderBy: { startDate: "desc" },
+        take: 5,
+        select: { name: true, dosage: true, type: true },
+      })
+      .catch(() => []),
+    prisma.dosingRegimen
+      .findMany({
+        where: { patientId, active: true },
+        orderBy: { startDate: "desc" },
+        take: 5,
+        select: {
+          frequencyPerDay: true,
+          calculatedThcMgPerDay: true,
+          calculatedCbdMgPerDay: true,
+          product: { select: { name: true } },
+        },
+      })
+      .catch(() => []),
+    prisma.clinicalObservation
+      .findMany({
+        where: {
+          patientId,
+          acknowledgedAt: null,
+          resolvedAt: null,
+        },
+        // Sort by createdAt only; some Prisma versions reject orderBy
+        // on severity enum, and in-memory sort handles priority below.
+        orderBy: { createdAt: "desc" },
+        take: 10,
+        select: {
+          id: true,
+          severity: true,
+          category: true,
+          summary: true,
+          actionSuggested: true,
+          createdAt: true,
+        },
+      })
+      .catch(() => []),
+    prisma.outcomeLog
+      .findMany({
+        where: {
+          patientId,
+          metric: "pain",
+          loggedAt: { gte: thirtyDaysAgo },
+        },
+        orderBy: { loggedAt: "asc" },
+        select: { value: true, loggedAt: true },
+      })
+      .catch(() => []),
+    prisma.encounter
+      .findFirst({
+        where: {
+          patientId,
+          status: "complete",
+          completedAt: { not: null },
+        },
+        orderBy: { completedAt: "desc" },
+        select: {
+          reason: true,
+          completedAt: true,
+          notes: {
+            where: { status: "finalized" },
+            orderBy: { finalizedAt: "desc" },
+            take: 1,
+            select: { blocks: true, narrative: true },
+          },
+        },
+      })
+      .catch(() => null),
   ]);
 
   if (!patient) return null;
+
+  // Pick the top-3 observations by severity then recency. Severity rank
+  // handles the common case where Prisma's enum orderBy misbehaves.
+  const severityRank: Record<string, number> = {
+    urgent: 0,
+    concern: 1,
+    notable: 2,
+    info: 3,
+  };
+  const recentObservations = [...observations]
+    .sort((a, b) => {
+      const rank =
+        (severityRank[a.severity] ?? 9) - (severityRank[b.severity] ?? 9);
+      if (rank !== 0) return rank;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    })
+    .slice(0, 3);
+
+  const lastEncounterSummary = lastEncounter?.completedAt
+    ? {
+        reason: lastEncounter.reason,
+        snippet: snippetFromNote(lastEncounter.notes[0]),
+        completedAt: lastEncounter.completedAt,
+      }
+    : null;
+
   return {
     allergies: patient.allergies ?? [],
-    activeMedCount: activeMeds,
+    activeMedCount,
     latestLab,
+    activeMeds,
+    activeRegimens: regimens.map((r) => ({
+      productName: r.product.name,
+      thcMgPerDay: r.calculatedThcMgPerDay,
+      cbdMgPerDay: r.calculatedCbdMgPerDay,
+      frequencyPerDay: r.frequencyPerDay,
+    })),
+    recentObservations,
+    painSparkline: painLogs,
+    lastEncounter: lastEncounterSummary,
   };
+}
+
+/** Extract a ~140-char snippet from the finalized note's assessment / plan /
+ *  narrative, whichever is present. Favors assessment > plan > narrative. */
+function snippetFromNote(
+  note: { blocks: unknown; narrative: string | null } | undefined,
+): string | null {
+  if (!note) return null;
+  const blocks = Array.isArray(note.blocks)
+    ? (note.blocks as Array<{ type?: string; body?: string }>)
+    : [];
+  const preferred = ["assessment", "plan", "findings", "summary"];
+  for (const type of preferred) {
+    const block = blocks.find((b) => b.type === type);
+    if (block?.body && block.body.trim().length > 0) {
+      return truncate(block.body.trim(), 140);
+    }
+  }
+  if (note.narrative && note.narrative.trim().length > 0) {
+    return truncate(note.narrative.trim(), 140);
+  }
+  return null;
 }

--- a/src/components/command/schedule-tile.tsx
+++ b/src/components/command/schedule-tile.tsx
@@ -349,10 +349,19 @@ function ChipRow({
 }
 
 /**
- * Hover preview popover. Same CSS-only hover pattern used elsewhere
- * (LabTooltip, AgentSignal popover) — no state, no JS. Anchors to the
- * right of the card so a long tile of cards doesn't cover the row
- * beneath with the popover for the row above.
+ * Chart-at-a-glance peek. Two visual modes:
+ *
+ *   - Non-featured cards → minimal pre-visit brief (reason, chips,
+ *     outcome row, agent brief line). Same as before.
+ *   - Featured card (next-upcoming or in-progress) → full
+ *     "walking into the room" dashboard: allergies + meds list +
+ *     active cannabis regimens + 30-day pain sparkline + top-3
+ *     unacknowledged observations + last-encounter snippet.
+ *
+ * Pure CSS hover/focus mechanic — no state, no client JS. Anchors
+ * to the right of the card; width scales to content with
+ * max-w-[calc(100vw-2rem)] so it clips rather than overflows on
+ * narrow viewports.
  */
 function SchedulePeek({
   patient,
@@ -370,26 +379,38 @@ function SchedulePeek({
   snapshot: FeaturedSnapshot | null;
 }) {
   const age = computeAge(patient.dateOfBirth);
+  const isFeatured = snapshot != null;
   const labDate = snapshot?.latestLab?.receivedAt
     ? snapshot.latestLab.receivedAt.toLocaleDateString("en-US", {
         month: "short",
         day: "numeric",
       })
     : null;
+
   return (
     <div
       role="tooltip"
       className={cn(
-        "pointer-events-none absolute z-40 top-0 left-full ml-2 w-80 max-w-[calc(100vw-2rem)]",
+        "pointer-events-none absolute z-40 top-0 left-full ml-2",
+        isFeatured ? "w-96" : "w-80",
+        "max-w-[calc(100vw-2rem)] max-h-[calc(100vh-6rem)] overflow-y-auto",
         "rounded-xl border border-border bg-surface shadow-lg p-4",
         "opacity-0 translate-x-1 transition-all duration-150",
         "group-hover/card:opacity-100 group-hover/card:translate-x-0 group-hover/card:pointer-events-auto",
         "group-focus-within/card:opacity-100 group-focus-within/card:translate-x-0 group-focus-within/card:pointer-events-auto"
       )}
     >
-      <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
-        {snapshot ? "Walking in" : "Pre-visit brief"}
-      </p>
+      {/* Header */}
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+          {isFeatured ? "Walking in" : "Pre-visit brief"}
+        </p>
+        {isFeatured && (
+          <span className="text-[11px] text-accent font-semibold">
+            Chart at a glance
+          </span>
+        )}
+      </div>
       <p className="text-sm font-semibold text-text mt-1.5">
         {patient.firstName} {patient.lastName}
         {age != null && (
@@ -402,25 +423,27 @@ function SchedulePeek({
         {timeLabel} · {durationMin}m
       </p>
 
+      {/* Allergies strip — featured only */}
       {snapshot && snapshot.allergies.length > 0 && (
         <div className="mt-3 flex items-center gap-1.5 flex-wrap">
           <span aria-hidden="true" className="text-red-600 text-xs">⚠</span>
-          {snapshot.allergies.slice(0, 4).map((a, i) => (
+          {snapshot.allergies.slice(0, 6).map((a, i) => (
             <span key={a} className="text-[11px] font-medium text-red-700">
               {a}
-              {i < Math.min(snapshot.allergies.length, 4) - 1 && (
+              {i < Math.min(snapshot.allergies.length, 6) - 1 && (
                 <span className="ml-1.5 text-red-300">·</span>
               )}
             </span>
           ))}
-          {snapshot.allergies.length > 4 && (
+          {snapshot.allergies.length > 6 && (
             <span className="text-[11px] text-red-500/70 font-medium">
-              +{snapshot.allergies.length - 4}
+              +{snapshot.allergies.length - 6}
             </span>
           )}
         </div>
       )}
 
+      {/* Lab summary line — featured only */}
       {snapshot && (
         <div className="mt-2 flex items-center gap-2.5 text-xs text-text-muted tabular-nums">
           <span>
@@ -449,29 +472,127 @@ function SchedulePeek({
         </div>
       )}
 
-      {reason && (
-        <p className="text-xs text-text-muted mt-3 leading-relaxed">
-          <span className="font-semibold text-text">Reason. </span>
-          {reason}
-        </p>
+      {/* Pain sparkline — featured only, only if >=2 data points */}
+      {snapshot && snapshot.painSparkline.length >= 2 && (
+        <PainSparkline points={snapshot.painSparkline} />
       )}
 
-      {enrichment && (enrichment.painTrend || enrichment.adherencePct != null) && (
-        <div className="mt-3">
-          <OutcomeRow enrichment={enrichment} />
+      {/* Active meds list — featured only */}
+      {snapshot &&
+        (snapshot.activeMeds.length > 0 ||
+          snapshot.activeRegimens.length > 0) && (
+          <div className="mt-3 border-t border-border/60 pt-2.5">
+            <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+              On these meds
+            </p>
+            <ul className="mt-1.5 space-y-0.5 text-xs text-text-muted">
+              {snapshot.activeRegimens.slice(0, 5).map((r, i) => (
+                <li key={`r-${i}`} className="flex items-baseline gap-1.5">
+                  <span className="font-medium text-text">{r.productName}</span>
+                  <span className="text-text-subtle tabular-nums">
+                    {formatRegimenDose(r)}
+                  </span>
+                </li>
+              ))}
+              {snapshot.activeMeds.slice(0, 5).map((m, i) => (
+                <li key={`m-${i}`} className="flex items-baseline gap-1.5">
+                  <span className="font-medium text-text">{m.name}</span>
+                  {m.dosage && (
+                    <span className="text-text-subtle tabular-nums">
+                      {m.dosage}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+      {/* Recent observations — featured only */}
+      {snapshot && snapshot.recentObservations.length > 0 && (
+        <div className="mt-3 border-t border-border/60 pt-2.5">
+          <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+            The fleet is noticing
+          </p>
+          <ul className="mt-1.5 space-y-1.5">
+            {snapshot.recentObservations.map((o) => (
+              <li key={o.id} className="flex items-baseline gap-1.5">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full shrink-0 translate-y-[-2px]",
+                    o.severity === "urgent" && "bg-red-500",
+                    o.severity === "concern" && "bg-amber-500",
+                    o.severity === "notable" && "bg-accent",
+                    o.severity === "info" && "bg-border-strong/60",
+                  )}
+                />
+                <p className="text-xs text-text line-clamp-2 leading-snug">
+                  {o.summary}
+                </p>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 
-      {enrichment && enrichment.chips.length > 0 && (
-        <div className="mt-3">
-          <ChipRow chips={enrichment.chips} />
+      {/* Today's visit context */}
+      {(reason || enrichment?.briefLine) && (
+        <div className="mt-3 border-t border-border/60 pt-2.5">
+          <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+            Today
+          </p>
+          {reason && (
+            <p className="text-xs text-text-muted mt-1.5 leading-relaxed">
+              <span className="font-semibold text-text">Reason. </span>
+              {reason}
+            </p>
+          )}
+
+          {enrichment &&
+            (enrichment.painTrend || enrichment.adherencePct != null) && (
+              <div className="mt-2">
+                <OutcomeRow enrichment={enrichment} />
+              </div>
+            )}
+
+          {enrichment && enrichment.chips.length > 0 && (
+            <div className="mt-2">
+              <ChipRow chips={enrichment.chips} />
+            </div>
+          )}
+
+          {enrichment?.briefLine && (
+            <p className="text-xs italic text-text-muted mt-2 leading-relaxed border-l-2 border-accent/30 pl-2.5">
+              {enrichment.briefLine}
+            </p>
+          )}
         </div>
       )}
 
-      {enrichment?.briefLine && (
-        <p className="text-xs italic text-text-muted mt-3 leading-relaxed border-l-2 border-accent/30 pl-2.5">
-          {enrichment.briefLine}
-        </p>
+      {/* Last encounter snippet — featured only */}
+      {snapshot?.lastEncounter && (
+        <div className="mt-3 border-t border-border/60 pt-2.5">
+          <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+            Last visit ·{" "}
+            <span className="font-normal text-text-subtle normal-case tracking-normal">
+              {snapshot.lastEncounter.completedAt.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })}
+            </span>
+          </p>
+          {snapshot.lastEncounter.reason && (
+            <p className="text-xs text-text-muted mt-1.5 leading-relaxed">
+              {snapshot.lastEncounter.reason}
+            </p>
+          )}
+          {snapshot.lastEncounter.snippet && (
+            <p className="text-xs text-text-muted mt-1 leading-relaxed italic">
+              {snapshot.lastEncounter.snippet}
+            </p>
+          )}
+        </div>
       )}
 
       <p className="text-[11px] text-text-subtle mt-3 text-right">
@@ -501,4 +622,91 @@ function formatTimeRange(start: Date, end: Date): string {
     return `${startStr.replace(/\s?(AM|PM)$/, "")}–${endStr}`;
   }
   return `${startStr}–${endStr}`;
+}
+
+function formatRegimenDose(r: {
+  thcMgPerDay: number | null;
+  cbdMgPerDay: number | null;
+  frequencyPerDay: number;
+}): string {
+  const parts: string[] = [];
+  if (r.thcMgPerDay && r.thcMgPerDay > 0) parts.push(`${Math.round(r.thcMgPerDay)}mg THC`);
+  if (r.cbdMgPerDay && r.cbdMgPerDay > 0) parts.push(`${Math.round(r.cbdMgPerDay)}mg CBD`);
+  const dose = parts.length > 0 ? parts.join(" + ") : null;
+  const freq =
+    r.frequencyPerDay === 1
+      ? "1×/day"
+      : r.frequencyPerDay === 2
+        ? "2×/day"
+        : `${r.frequencyPerDay}×/day`;
+  return dose ? `${dose} · ${freq}` : freq;
+}
+
+/**
+ * Inline SVG sparkline of the patient's pain scores (0-10 scale) over the
+ * last 30 days. Pure SVG — no chart library, no hydration cost. Y-axis
+ * is inverted so higher pain points visually rise to the top.
+ */
+function PainSparkline({
+  points,
+}: {
+  points: Array<{ value: number; loggedAt: Date }>;
+}) {
+  if (points.length < 2) return null;
+  const first = points[0].value;
+  const last = points[points.length - 1].value;
+  const delta = last - first;
+  // Pain is inverted — lower is clinically better. Trend colors follow
+  // clinical direction, not axis direction.
+  const trendColor =
+    delta <= -1
+      ? "var(--success, #16a34a)"
+      : delta >= 1
+        ? "#dc2626"
+        : "var(--text-subtle, #737373)";
+
+  const width = 320;
+  const height = 40;
+  const pad = 2;
+  const xStep = (width - pad * 2) / Math.max(1, points.length - 1);
+  // Pain is 0-10. Pin to the full range so sparkline doesn't exaggerate
+  // small swings on a patient who lives at 3-4.
+  const yMax = 10;
+  const coords = points.map((p, i) => {
+    const x = pad + i * xStep;
+    // Invert: higher pain → higher on chart.
+    const y = height - pad - (Math.min(yMax, Math.max(0, p.value)) / yMax) * (height - pad * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const pathD = `M ${coords.join(" L ")}`;
+
+  return (
+    <div className="mt-3">
+      <div className="flex items-baseline justify-between">
+        <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+          Pain · 30d
+        </p>
+        <p className="text-[11px] tabular-nums" style={{ color: trendColor }}>
+          {first} → {last}
+        </p>
+      </div>
+      <svg
+        role="img"
+        aria-label={`Pain trend sparkline. Started at ${first}, currently ${last}, ${points.length} data points.`}
+        viewBox={`0 0 ${width} ${height}`}
+        className="mt-1 w-full h-8"
+        preserveAspectRatio="none"
+      >
+        <path
+          d={pathD}
+          fill="none"
+          stroke={trendColor}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Upgrades the Schedule tile's hover peek from a redundant reformatting of the card content into a **real chart-at-a-glance dashboard** for the featured appointment.

Previous peek behavior (on the card that's next-upcoming or in-progress): basically the same information as the card itself, laid out slightly differently. User's observation: *"the user mechanic seems static, those insights exist in the UX without hovering."* Right. Peek wasn't earning its keep.

This PR makes the peek do real work — when the physician hovers the featured card, they get a cockpit-style mini-chart in one glance:

- **Allergies strip** — up to 6 allergies inline, red-accented
- **Med/lab summary line** — active med count + last lab
- **Pain sparkline** — inline 30-day SVG line chart of OutcomeLog pain values on 0-10 scale. Pure SVG, no chart library. Y-axis inverted so higher pain rises visually; line color follows clinical trend direction (green improving / red worsening / gray flat). Start → End values shown above.
- **On these meds** — up to 5 active DosingRegimen entries with calculated dose + frequency (e.g. "10mg THC + 20mg CBD · 2×/day") plus up to 5 active PatientMedication entries.
- **The fleet is noticing** — top 3 unacknowledged, unresolved ClinicalObservations sorted by severity then recency. Severity dots (red/amber/accent/gray). This is the surface the four ambient agents write into.
- **Today** — existing pre-visit brief (reason, chips, outcome row, agent brief line), now in its own labeled section.
- **Last visit** — most recent completed encounter reason + 140-char snippet from the finalized note's assessment / plan / findings / narrative block (preferred order).

Non-featured card peeks are unchanged — still the minimal pre-visit brief.

## Data

`loadFeaturedSnapshot` in `src/components/command/schedule-card-data.ts` extended to one `Promise.all` fetch for all these pieces. Every query wrapped in `.catch` so a missing table doesn't take down the whole peek. Zero new Prisma migrations — uses existing `ClinicalObservation`, `OutcomeLog`, `PatientMedication`, `DosingRegimen`, `Encounter`, and `Note` tables.

**Intentionally not included:** structured vitals (no `Vital` or `VitalSign` model exists). That's a migration for a later slice.

## Layout

- Peek width bumped from `w-80` → `w-96` for featured cards.
- `max-h-[calc(100vh-6rem)] overflow-y-auto` on the peek container so long chart content scrolls rather than overflowing off-screen on short viewports.
- Non-featured peek still at `w-80`.

## Scope

Single commit on top of `main` after PR #32 merged. Two files changed:
- `src/components/command/schedule-card-data.ts` — extend loader
- `src/components/command/schedule-tile.tsx` — redesign peek

## Verification

- `tsc --noEmit` clean
- `next build` succeeds
- `npm test` — all 35 tests passing (no changes to agent logic)

## Test plan

- [ ] On `/clinic/command`, hover the next-upcoming Schedule card: "Walking in / Chart at a glance" peek renders
- [ ] With a patient who has ≥2 pain OutcomeLog entries in the last 30 days: sparkline renders, colored by trend direction
- [ ] With a patient who has active DosingRegimens: "On these meds" section shows with calculated mg/day + frequency
- [ ] With unacknowledged ClinicalObservations on the patient: "The fleet is noticing" renders the top 3 with severity dots
- [ ] With a completed past encounter: "Last visit" section shows reason + note snippet
- [ ] Peek doesn't overflow viewport on narrow windows (scrolls instead)
- [ ] Non-featured card peeks unchanged

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C