### PR TITLE
Overnight tail: visitDiscoveryWhisperer + dictation + vitest + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,23 @@ OPENROUTER_MODEL=anthropic/claude-sonnet-4.5
 OPENROUTER_SITE_URL=
 OPENROUTER_APP_NAME=Leafjourney
 
+# ---- Visit dictation / transcription ----
+# Which speech-to-text provider to use for voice-chart recordings.
+#   "simulated" (default)    — no network calls; voice-chart uses a
+#                              hardcoded demo transcript. Good for CI
+#                              and local dev without API keys.
+#   "openai-whisper"         — POSTs the recording to OpenAI Whisper
+#                              (/v1/audio/transcriptions, whisper-1,
+#                              verbose_json). Requires OPENAI_API_KEY.
+TRANSCRIPTION_PROVIDER=simulated
+
+# OpenAI key, used when TRANSCRIPTION_PROVIDER=openai-whisper.
+# Whisper's 25 MB payload cap covers ~25 min of typical voice audio.
+# Segment-level timestamps are returned; speaker diarization is NOT —
+# every segment comes back as speaker="unknown" and the extraction
+# prompt handles unlabeled turns. Swap provider for real diarization.
+OPENAI_API_KEY=
+
 # ---- Object storage (Supabase Storage for documents) ----
 # Create a private bucket named "documents" in your Supabase project.
 SUPABASE_URL=https://your-project.supabase.co

--- a/docs/agents/ambient-assistant-fleet.md
+++ b/docs/agents/ambient-assistant-fleet.md
@@ -1,0 +1,297 @@
+# Ambient Physician Assistant Fleet
+
+Per Dr. Patel's directive — agents that do cold-temperature work while the
+physician sees patients. They look over the clinician's shoulder, run quiet
+checks in the background, and post findings as `ClinicalObservation`
+records. Those observations surface automatically on the Command Center's
+Clinical Discovery tile (top signal) and Patient Impact tile (ranked
+follow-ups).
+
+No physician action required to invoke them. No approval dialogs. They
+just write notes into the chart when they see something worth a second
+look.
+
+---
+
+## The four patterns
+
+The fleet demonstrates four different triggering patterns. Pick the
+pattern that matches your new skill when extending the fleet.
+
+| # | Agent | Pattern | Trigger | LLM? |
+|---|-------|---------|---------|------|
+| 1 | `prescriptionSafety` | Event-driven safety check | `dosing.regimen.created` | no |
+| 2 | `adherenceDriftDetector` | Scheduled daily sweep | `adherence.checkup.requested` (09:00 UTC cron) | no |
+| 3 | `messageUrgencyObserver` | Parallel event observer | `message.received` | no |
+| 4 | `visitDiscoveryWhisperer` | LLM-powered synthesis | `note.finalized` | yes |
+
+---
+
+## 1. `prescriptionSafety` — interaction + contraindication scan
+
+**File:** `src/lib/agents/prescription-safety-agent.ts`
+**Version:** `1.0.0`
+**Shipped:** commit `5d6b595`, ticket [#37](https://github.com/scwayman1/EMR/issues/37)
+
+### Trigger
+
+Event `dosing.regimen.created` is dispatched from
+`src/app/(clinician)/clinic/patients/[id]/prescribe/actions.ts` after the
+`DosingRegimen.create` call succeeds. Payload:
+
+```
+{ regimenId, patientId, productId, organizationId, prescribedById }
+```
+
+### Behavior
+
+1. Loads the regimen + product + patient (allergies, history,
+   contraindications, active meds).
+2. Derives cannabinoids present in the prescribed product from concentration
+   fields (THC / CBD / CBN / CBG).
+3. Runs `checkInteractions(meds, cannabinoids)` and filters to
+   red / yellow severities.
+4. Matches `CANNABIS_CONTRAINDICATIONS.matchKeywords` against
+   `patient.presentingConcerns + patient.contraindications`.
+5. Skips any contraindications the clinician already overrode via
+   `regimen.contraindicationOverride` — the override reason is the
+   documented record of decision and re-flagging is just noise.
+6. Writes one `ClinicalObservation` per finding.
+
+### Severity mapping
+
+| Finding | Severity | Category |
+|---|---|---|
+| Red interaction | `urgent` | `medication_response` |
+| Yellow interaction | `concern` | `medication_response` |
+| Absolute contraindication | `urgent` | `red_flag` |
+| Relative contraindication | `concern` | `red_flag` |
+| Caution contraindication | `notable` | `red_flag` |
+
+### Tile surface
+
+Every observation flows into the Command Center's Clinical Discovery
+tile. When a physician prescribes, the Discovery tile fills in real
+time with anything the agent caught.
+
+---
+
+## 2. `adherenceDriftDetector` — daily drift sweep
+
+**File:** `src/lib/agents/adherence-drift-detector-agent.ts`
+**Version:** `1.0.0`
+**Shipped:** commit `6ac74cb`, ticket [#38](https://github.com/scwayman1/EMR/issues/38)
+
+### Trigger
+
+`src/workers/scheduler.ts` runs every 15 minutes on Render. The adherence
+sweep fires only on the tick where `utcHour === 9 && utcMinute < 15` — one
+execution per day, fleet-wide. The scheduler queries every patient with at
+least one active regimen and dispatches `adherence.checkup.requested` per
+patient. Payload: `{ patientId, organizationId }`.
+
+### Behavior
+
+For each active `DosingRegimen` on the patient, the pure helper
+`classifyAdherence(regimen, logs, now)` compares the last 7 days of dose
+log activity against the preceding 14-day baseline and returns a
+`DriftFinding | null`. Findings are written as
+category-`adherence` observations.
+
+### Flag conditions (most urgent wins)
+
+| Condition | Severity | checkKind |
+|---|---|---|
+| ≥72h since last dose on regimen that's been live ≥72h | `urgent` | `stalled` |
+| 7-day adherence <30% OR dropped ≥25pp vs baseline | `concern` | `drift` / `low_pace` |
+| 7-day adherence 30–60% with no baseline drop | `notable` | `chronic_low` |
+| Otherwise | (no observation) | — |
+
+### Key design call
+
+The **baseline-drop check** is the heart of this one. A patient who's
+always been at 45% isn't "drifting" — they have a baseline issue that
+belongs in a different conversation. Only flagging real deltas keeps
+the Discovery tile signal, not noise.
+
+Fresh regimens (<72h old) skip the stalled check so a just-filled
+prescription doesn't false-alarm on the first sweep.
+
+### Tile surface
+
+Clinical Discovery tile's care-gaps bucket; top-severity urgent /
+concern findings also bubble up into Patient Impact's ranked list.
+
+---
+
+## 3. `messageUrgencyObserver` — triage persistence
+
+**File:** `src/lib/agents/message-urgency-observer-agent.ts`
+**Version:** `1.0.0`
+**Shipped:** commit `5a11c15`, ticket [#39](https://github.com/scwayman1/EMR/issues/39)
+
+### Trigger
+
+Event `message.received` is dispatched from
+`src/app/(patient)/portal/messages/actions.ts` every time a patient sends a
+message. This agent listens in parallel with `correspondenceNurseAgent`
+(response drafter, approval-gated). Zero conflict — different workflows,
+same event.
+
+Payload: `{ messageId, threadId, patientId, organizationId }`.
+
+### Behavior
+
+1. Loads the thread + up to 10 most recent messages.
+2. Runs the existing `triageThread()` keyword heuristic from
+   `src/lib/domain/smart-inbox.ts`.
+3. Writes a durable `ClinicalObservation` only for:
+   - Urgent keyword (triage priority `urgent`) → `severity: urgent`, `category: red_flag`
+   - Adverse reaction (`high` + `adverse_reaction` category) → `severity: concern`, `category: side_effect`
+4. Every other priority class is a no-op — the inbox preview + nurse
+   drafter already handle those.
+
+### Why durable
+
+Threads fade. The moment a patient replies "thanks, feeling better," the
+red dot clears from the MessagesTile inbox preview — the original urgent
+signal is gone. An observation is durable: shows up on Clinical Discovery
+and Patient Impact until the physician explicitly resolves it. **A 2am
+urgent message lands on the 9am dashboard regardless of whether the patient
+has replied since.**
+
+---
+
+## 4. `visitDiscoveryWhisperer` — LLM-powered synthesis
+
+**File:** `src/lib/agents/visit-discovery-whisperer-agent.ts`
+**Version:** `1.0.0`
+**Shipped:** commit `546f987`
+
+### Trigger
+
+Event `note.finalized`, dispatched when a `Note.status` transitions to
+`finalized`. Runs in parallel with `physicianNudge` and `codingReadiness`
+— same event, different downstream consumers.
+
+Payload: `{ noteId, encounterId, finalizedBy }`.
+
+### Behavior
+
+1. Loads the finalized note's blocks + narrative.
+2. Renders them into a prompt asking the configured model client
+   (`ctx.model`) for the SINGLE most important clinical discovery from the
+   visit. The prompt gives the model an explicit escape hatch
+   (`{"discovery":"none"}`) for routine follow-ups with no standout
+   finding.
+3. Parses the JSON response with a strict parser that strips markdown
+   fences and leading prose.
+4. Coerces `category` and `severity` against the observation enums.
+5. Writes the observation at category / severity the model chose.
+
+### Design principles
+
+1. **Model picks category + severity**, constrained to enum values.
+   Responses with any value outside the allowlist are rejected silently.
+2. **"None" is a valid answer.** Routine follow-ups with no standout
+   finding return an explicit no-observation signal.
+3. **Model failures are silent.** Credit-limit 402s, network blips,
+   malformed JSON — all fall through to "no observation written."
+   Never write garbage into a patient chart.
+4. **The stub client never produces false positives** because its
+   output doesn't parse as JSON.
+
+### Tile surface
+
+Renders as the **Top signal** row on the Clinical Discovery tile.
+
+---
+
+## Shared plumbing
+
+All four agents share the same foundations:
+
+- **Tool permissions** via `ctx.assertCan("read.patient")` and
+  `ctx.assertCan("write.outcome.reminder")`. Gated by each agent's
+  `allowedActions` array (see agent definitions).
+- **Observations** are written via
+  `src/lib/agents/memory/clinical-observation.ts`'s `recordObservation()`.
+  Consistent shape: `observedBy`, `observedByKind: "agent"`, `category`,
+  `severity`, `summary`, optional `actionSuggested`, evidence, metadata.
+- **Model client** is resolved via
+  `src/lib/orchestration/model-client.ts::resolveModelClient()` — uses
+  `StubModelClient` in dev/CI, `OpenRouterModelClient` in production with
+  automatic free-tier fallback on credit-limit failures.
+- **Registration** happens in `src/lib/agents/index.ts::agentRegistry`
+  and workflows in `src/lib/orchestration/workflows.ts`.
+- **Event dispatch** via `src/lib/orchestration/dispatch.ts::dispatch()`.
+
+---
+
+## Testing
+
+The agents have pure-helper unit tests in each `*-agent.test.ts` file.
+Coverage focuses on the classification / parsing logic rather than the
+full agent runtime (which would require Prisma mocking and is a follow-up
+ticket). Run with:
+
+```
+npm test            # one-shot, CI mode
+npm run test:watch  # dev feedback loop
+```
+
+Current test count: 35 passing across 4 agents.
+
+---
+
+## Adding a fifth agent
+
+Adding a new ambient agent is a five-file change:
+
+1. `src/lib/agents/my-new-agent.ts` — the agent itself (follow the
+   existing pattern: `export const Agent<I, O>` with `inputSchema`,
+   `outputSchema`, `allowedActions`, `requiresApproval`, `run()`).
+2. `src/lib/agents/index.ts` — import + add to `agentRegistry`.
+3. `src/lib/orchestration/events.ts` — add a new event type if you
+   need a new trigger; skip if reusing an existing event.
+4. `src/lib/orchestration/workflows.ts` — append a new
+   `WorkflowDefinition` mapping your event to your agent.
+5. `src/lib/agents/my-new-agent.test.ts` — pure-helper tests.
+
+Optional: if your agent runs on a schedule, add the dispatch logic to
+`src/workers/scheduler.ts`.
+
+### When to use which pattern
+
+- **Event-driven safety check** — something happened (prescription
+  created, diagnosis added, lab ingested) and the new state needs
+  checking against some ruleset. Deterministic is fine. Example:
+  `prescriptionSafety`.
+- **Scheduled sweep** — no natural trigger event; you're scanning
+  for drift or silent decay. Runs per patient or fleet-wide on a
+  cron. Example: `adherenceDriftDetector`.
+- **Parallel event observer** — another workflow already listens to
+  the event and does one thing; you want to listen in parallel and
+  enrich durable state. Example: `messageUrgencyObserver`.
+- **LLM-powered synthesis** — the signal isn't in structured data;
+  it's buried in free-text and needs language understanding.
+  Always ship with a silent no-op fallback on model failure.
+  Example: `visitDiscoveryWhisperer`.
+
+---
+
+## Data gaps the fleet can't fill yet
+
+Current observation-based Patient Impact and Clinical Flow tiles
+render `—` for some metrics. The fleet can't fill these without schema
+changes first:
+
+- **`Encounter.chartingCompletedAt`** — needed for Clinical Flow's
+  "Charting carryover" metric. Fill by wiring `note.finalized` handler
+  to set the timestamp. A follow-up ticket.
+- **`PatientRiskScore` table** — needed for proper Patient Impact
+  "Care advanced" and risk-scoring. Current tile proxies from
+  observations; real metric needs a dedicated model + daily batch job.
+
+These gaps are tracked in issue [#36](https://github.com/scwayman1/EMR/issues/36)
+as follow-ups.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,9 @@
       },
       "devDependencies": {
         "eslint": "^8.57.0",
-        "eslint-config-next": "^14.2.35"
+        "eslint-config-next": "^14.2.35",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": ">=20"
@@ -1057,6 +1059,356 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1204,6 +1556,13 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1814,6 +2173,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2082,6 +2554,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2275,6 +2757,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2364,6 +2856,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2379,6 +2888,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2587,6 +3106,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2818,6 +3347,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3362,6 +3898,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3370,6 +3916,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3786,6 +4342,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -4675,12 +5238,29 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5203,6 +5783,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5685,6 +6282,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5939,6 +6581,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5965,6 +6614,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6414,6 +7070,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6459,6 +7129,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6489,6 +7189,27 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -6770,6 +7491,600 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6873,6 +8188,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "db:migrate": "prisma migrate dev",
     "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:smoke": "tsx scripts/smoke-test.ts",
     "pm": "tsx scripts/pm-agent.ts"
   },
@@ -44,7 +46,9 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "eslint-config-next": "^14.2.35"
+    "eslint-config-next": "^14.2.35",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^2.1.9"
   },
   "engines": {
     "node": ">=20"

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
@@ -119,6 +119,95 @@ function buildSimulatedTranscript(
   }));
 }
 
+// ── Real transcription w/ simulated fallback ────────────────────
+
+/**
+ * Posts the recorded audio to /api/transcribe and returns real
+ * segments when the backend is configured. On any failure —
+ * including the "transcription_not_configured" 503 the API
+ * emits when TRANSCRIPTION_PROVIDER=simulated — falls back to
+ * the simulated transcript so the voice-chart flow still works
+ * end-to-end in dev / demo environments.
+ */
+async function transcribeOrFallback(opts: {
+  audioChunks: Blob[];
+  mimeType: string;
+  durationSec: number;
+  patientName: string;
+  presentingConcerns: string | null;
+  treatmentGoals: string | null;
+}): Promise<TranscriptSegment[]> {
+  const {
+    audioChunks,
+    mimeType,
+    durationSec,
+    patientName,
+    presentingConcerns,
+    treatmentGoals,
+  } = opts;
+
+  const fallback = () =>
+    buildSimulatedTranscript(
+      patientName,
+      presentingConcerns,
+      treatmentGoals,
+      durationSec,
+    );
+
+  if (audioChunks.length === 0) {
+    return fallback();
+  }
+
+  const blob = new Blob(audioChunks, { type: mimeType || "audio/webm" });
+  if (blob.size === 0) return fallback();
+
+  try {
+    const form = new FormData();
+    form.append("audio", blob, filenameForMime(mimeType));
+
+    const response = await fetch("/api/transcribe", {
+      method: "POST",
+      body: form,
+    });
+
+    if (response.status === 503) {
+      // Expected in dev: TRANSCRIPTION_PROVIDER=simulated.
+      // Fall back silently — no console noise.
+      return fallback();
+    }
+
+    if (!response.ok) {
+      console.warn(
+        `[VoiceRecorder] /api/transcribe returned ${response.status} — using simulated transcript.`,
+      );
+      return fallback();
+    }
+
+    const payload = (await response.json()) as {
+      segments?: TranscriptSegment[];
+    };
+    if (!Array.isArray(payload.segments) || payload.segments.length === 0) {
+      return fallback();
+    }
+    return payload.segments;
+  } catch (err) {
+    console.warn(
+      "[VoiceRecorder] transcription request failed — using simulated transcript:",
+      err,
+    );
+    return fallback();
+  }
+}
+
+function filenameForMime(mime: string): string {
+  const lower = (mime ?? "").toLowerCase();
+  if (lower.includes("webm")) return "recording.webm";
+  if (lower.includes("mp4")) return "recording.mp4";
+  if (lower.includes("m4a")) return "recording.m4a";
+  if (lower.includes("ogg")) return "recording.ogg";
+  return "recording.webm";
+}
+
 // ── Waveform bar component ─────────────────────────────────────
 
 function WaveformBars({ active }: { active: boolean }) {
@@ -222,6 +311,8 @@ export function VoiceRecorder({
   // Audio refs
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const audioMimeTypeRef = useRef<string>("");
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const durationRef = useRef(0);
 
@@ -268,7 +359,21 @@ export function VoiceRecorder({
       const recorder = new MediaRecorder(stream);
       mediaRecorderRef.current = recorder;
 
-      recorder.start();
+      // Reset + collect audio chunks as they arrive so we can post the
+      // full recording to /api/transcribe on stop. Default to the mime
+      // type the browser actually gave us (webm on Chrome, mp4 on
+      // Safari) so Whisper knows what it's decoding.
+      audioChunksRef.current = [];
+      audioMimeTypeRef.current = recorder.mimeType || "audio/webm";
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      // Fire dataavailable every 1s so a browser crash doesn't lose
+      // the whole recording — we still have partial audio to recover.
+      recorder.start(1000);
       durationRef.current = 0;
       setDuration(0);
       startTimer();
@@ -302,10 +407,17 @@ export function VoiceRecorder({
   const handleStop = async () => {
     stopTimer();
 
-    // Stop the media recorder and tracks
-    if (mediaRecorderRef.current) {
-      mediaRecorderRef.current.stop();
-    }
+    // Stop the media recorder and tracks. MediaRecorder.stop() flushes a
+    // final ondataavailable before firing onstop, so we await that via a
+    // promise before assembling the audio blob for transcription.
+    const recorder = mediaRecorderRef.current;
+    const stopRecorder = recorder
+      ? new Promise<void>((resolve) => {
+          recorder.addEventListener("stop", () => resolve(), { once: true });
+          recorder.stop();
+        })
+      : Promise.resolve();
+
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((t) => t.stop());
       streamRef.current = null;
@@ -313,28 +425,41 @@ export function VoiceRecorder({
 
     setState("processing");
 
-    // Simulate transcript from recorded duration
-    const simulated = buildSimulatedTranscript(
+    await stopRecorder;
+
+    // Try the real transcription pipeline first. If the server isn't
+    // configured (503 transcription_not_configured) or the provider
+    // returns an error, fall back to the simulated transcript so the
+    // demo / dev flow still works end-to-end.
+    const segments = await transcribeOrFallback({
+      audioChunks: audioChunksRef.current,
+      mimeType: audioMimeTypeRef.current,
+      durationSec: durationRef.current,
       patientName,
       presentingConcerns,
       treatmentGoals,
-      durationRef.current
-    );
-    setTranscript(simulated);
+    });
+
+    setTranscript(segments);
 
     // Save transcript to encounter
     if (encounterId) {
       try {
-        await saveTranscriptToEncounter(encounterId, simulated);
+        await saveTranscriptToEncounter(encounterId, segments);
       } catch (err) {
         console.error("[VoiceRecorder] save transcript error:", err);
       }
     }
 
     // Format transcript and process through AI
-    const formatted = simulated
+    const formatted = segments
       .map((s) => {
-        const speaker = s.speaker === "clinician" ? "Dr" : "Pt";
+        const speaker =
+          s.speaker === "clinician"
+            ? "Dr"
+            : s.speaker === "patient"
+              ? "Pt"
+              : "??";
         return `[${formatDuration(s.startTime)}] ${speaker}: ${s.text}`;
       })
       .join("\n");

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/auth/session";
+import {
+  transcribeAudio,
+  TranscriptionNotConfiguredError,
+  TranscriptionFailedError,
+} from "@/lib/domain/transcription";
+
+/**
+ * POST /api/transcribe
+ *
+ * Accepts a multipart/form-data payload with a single "audio" file
+ * field. Sends the audio to the configured transcription provider
+ * (see lib/domain/transcription.ts) and returns canonical
+ * TranscriptSegment records.
+ *
+ * Callers (voice-recorder.tsx) should fall back to the simulated
+ * transcript when this route returns:
+ *   - 404 (shouldn't happen in practice; deployment safety net)
+ *   - 503 with error "transcription_not_configured"
+ *
+ * All other errors surface as 500 so the UI can show a real error.
+ */
+
+export const runtime = "nodejs";
+// Transcription can take tens of seconds for long recordings.
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const user = await requireUser();
+  if (!user.organizationId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_form_data", detail: "Expected multipart/form-data." },
+      { status: 400 },
+    );
+  }
+
+  const file = formData.get("audio");
+  if (!(file instanceof Blob)) {
+    return NextResponse.json(
+      { error: "missing_audio", detail: "Field 'audio' is required." },
+      { status: 400 },
+    );
+  }
+
+  if (file.size === 0) {
+    return NextResponse.json(
+      { error: "empty_audio", detail: "Audio payload is empty." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const segments = await transcribeAudio(file, {
+      mimeType: file.type,
+    });
+    return NextResponse.json({ segments });
+  } catch (err) {
+    if (err instanceof TranscriptionNotConfiguredError) {
+      // Let the UI fall back to the simulated transcript without logging
+      // this as an error — it's the expected state in dev / demo.
+      return NextResponse.json(
+        {
+          error: "transcription_not_configured",
+          detail: err.message,
+        },
+        { status: 503 },
+      );
+    }
+    if (err instanceof TranscriptionFailedError) {
+      console.error("[api/transcribe] provider failure:", err.message);
+      return NextResponse.json(
+        {
+          error: "transcription_failed",
+          provider: err.provider,
+          detail: err.message,
+        },
+        { status: 502 },
+      );
+    }
+    console.error("[api/transcribe] unexpected error:", err);
+    return NextResponse.json(
+      {
+        error: "internal_error",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/agents/adherence-drift-detector-agent.test.ts
+++ b/src/lib/agents/adherence-drift-detector-agent.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyAdherence,
+  type LogInput,
+  type RegimenInput,
+} from "./adherence-drift-detector-agent";
+
+const NOW = new Date("2026-04-19T09:00:00Z");
+
+function hoursAgo(hours: number): Date {
+  return new Date(NOW.getTime() - hours * 3_600_000);
+}
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * 86_400_000);
+}
+
+function regimen(overrides: Partial<RegimenInput> = {}): RegimenInput {
+  return {
+    id: "reg-1",
+    productName: "Test Tincture",
+    frequencyPerDay: 2,
+    startDate: daysAgo(30),
+    ...overrides,
+  };
+}
+
+function logs(...whens: Date[]): LogInput[] {
+  return whens.map((loggedAt) => ({ loggedAt }));
+}
+
+describe("classifyAdherence", () => {
+  it("returns null for healthy adherence (≥60% recent, no drift)", () => {
+    // 12 doses in last 7 days on freq=2/day → expected 14, actual 12 = 86%
+    const recent = Array.from({ length: 12 }, (_, i) => hoursAgo(6 + i * 6));
+    // baseline 25 doses in prior 14 days → expected 28, actual 25 = 89%
+    const baseline = Array.from({ length: 25 }, (_, i) => daysAgo(8 + i * 0.5));
+    const result = classifyAdherence(regimen(), logs(...recent, ...baseline), NOW);
+    expect(result).toBeNull();
+  });
+
+  it("flags urgent when regimen is >72h old AND last dose was >72h ago", () => {
+    // Regimen 30 days old, last dose 4 days ago
+    const result = classifyAdherence(
+      regimen(),
+      logs(daysAgo(4), daysAgo(10)),
+      NOW,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("urgent");
+    expect(result!.metadata.checkKind).toBe("stalled");
+  });
+
+  it("does NOT flag urgent on a fresh regimen (<72h old) with no doses", () => {
+    // Regimen started 48h ago, no doses yet
+    const result = classifyAdherence(
+      regimen({ startDate: hoursAgo(48) }),
+      [],
+      NOW,
+    );
+    // Falls through to other buckets; recentPct=0 so it should hit CONCERN
+    // (under 30% is concern regardless of baseline). But importantly, not urgent.
+    expect(result?.severity).not.toBe("urgent");
+  });
+
+  it("flags concern on a significant drift vs baseline (≥25pp drop)", () => {
+    // Baseline very high: 25 doses in prior 14 days (89%)
+    const baseline = Array.from({ length: 25 }, (_, i) => daysAgo(8 + i * 0.5));
+    // Recent: 7 doses in last 7 days on freq=2/day → 50%. 89 → 50 = 39pp drop.
+    const recent = Array.from({ length: 7 }, (_, i) => hoursAgo(6 + i * 18));
+    const result = classifyAdherence(regimen(), logs(...recent, ...baseline), NOW);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("concern");
+    expect(result!.metadata.checkKind).toBe("drift");
+  });
+
+  it("flags concern on severely low recent pace (<30%)", () => {
+    // Recent: 3 doses in last 7 days on freq=2/day → 21%. Baseline also low.
+    const recent = [hoursAgo(12), hoursAgo(36), hoursAgo(60)];
+    const baseline: Date[] = [];
+    const result = classifyAdherence(regimen(), logs(...recent, ...baseline), NOW);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("concern");
+    expect(result!.metadata.checkKind).toBe("low_pace");
+  });
+
+  it("flags notable on chronic 30-60% adherence without a baseline drop", () => {
+    // Baseline ~45%: 13 doses in prior 14 days → 13/28 = 46%
+    const baseline = Array.from({ length: 13 }, (_, i) => daysAgo(8 + i * 1));
+    // Recent ~50%: 7 doses in last 7 days → 50%. Drop = 46-50 = -4 (no drop).
+    const recent = Array.from({ length: 7 }, (_, i) => hoursAgo(6 + i * 20));
+    const result = classifyAdherence(regimen(), logs(...recent, ...baseline), NOW);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("notable");
+    expect(result!.metadata.checkKind).toBe("chronic_low");
+  });
+
+  it("reports the stalled hoursSinceLastLog in metadata", () => {
+    const result = classifyAdherence(regimen(), logs(hoursAgo(96)), NOW);
+    expect(result?.severity).toBe("urgent");
+    expect(result?.metadata.hoursSinceLastLog).toBe(96);
+  });
+
+  it("does not crash on frequencyPerDay=0 regimens", () => {
+    const result = classifyAdherence(
+      regimen({ frequencyPerDay: 0, startDate: daysAgo(30) }),
+      [],
+      NOW,
+    );
+    // Stalled check still applies (regimen old, no doses)
+    expect(result?.severity).toBe("urgent");
+  });
+});

--- a/src/lib/agents/adherence-drift-detector-agent.ts
+++ b/src/lib/agents/adherence-drift-detector-agent.ts
@@ -40,7 +40,7 @@ const output = z.object({
 
 const DAY_MS = 86_400_000;
 
-type DriftFinding = {
+export type DriftFinding = {
   regimenId: string;
   productName: string;
   severity: ObservationSeverity;
@@ -48,6 +48,129 @@ type DriftFinding = {
   action: string;
   metadata: Record<string, unknown>;
 };
+
+/** Shape the classifier needs. Keeps the pure function Prisma-free. */
+export interface RegimenInput {
+  id: string;
+  productName: string;
+  frequencyPerDay: number;
+  startDate: Date;
+}
+
+export interface LogInput {
+  loggedAt: Date;
+}
+
+/**
+ * Classify a single regimen's adherence against 21 days of dose logs.
+ * Returns the strongest finding (stalled > drift > chronic low), or
+ * null when adherence is healthy. Pure — no I/O, deterministic for a
+ * given `now`.
+ */
+export function classifyAdherence(
+  regimen: RegimenInput,
+  logs: LogInput[],
+  now: Date,
+): DriftFinding | null {
+  const sevenDaysAgo = new Date(now.getTime() - 7 * DAY_MS);
+  const regimenLogs = [...logs].sort(
+    (a, b) => b.loggedAt.getTime() - a.loggedAt.getTime(),
+  );
+  const recentLogs = regimenLogs.filter((l) => l.loggedAt >= sevenDaysAgo);
+  const baselineLogs = regimenLogs.filter((l) => l.loggedAt < sevenDaysAgo);
+
+  const expected7 = regimen.frequencyPerDay * 7;
+  const expected14Baseline = regimen.frequencyPerDay * 14;
+
+  const recentPct =
+    expected7 === 0
+      ? 0
+      : Math.min(100, Math.round((recentLogs.length / expected7) * 100));
+  const baselinePct =
+    baselineLogs.length === 0 || expected14Baseline === 0
+      ? null
+      : Math.min(
+          100,
+          Math.round((baselineLogs.length / expected14Baseline) * 100),
+        );
+
+  const lastLog = regimenLogs[0]?.loggedAt ?? null;
+  const hoursSinceLastLog = lastLog
+    ? (now.getTime() - lastLog.getTime()) / 3_600_000
+    : null;
+
+  const regimenAgeHours =
+    (now.getTime() - regimen.startDate.getTime()) / 3_600_000;
+
+  // URGENT — stalled regimen (at least 72h old, no dose in the last 72h).
+  if (
+    regimenAgeHours >= 72 &&
+    (hoursSinceLastLog == null || hoursSinceLastLog >= 72)
+  ) {
+    return {
+      regimenId: regimen.id,
+      productName: regimen.productName,
+      severity: "urgent",
+      summary: `No doses logged for ${regimen.productName} in ${
+        hoursSinceLastLog == null
+          ? "the regimen's lifetime"
+          : `${Math.round(hoursSinceLastLog)} hours`
+      } — the regimen has stalled.`,
+      action:
+        "Reach out today — confirm the patient has the product, understands the schedule, and isn't hitting a side-effect barrier.",
+      metadata: {
+        checkKind: "stalled",
+        hoursSinceLastLog:
+          hoursSinceLastLog == null ? null : Math.round(hoursSinceLastLog),
+        recentPct,
+        baselinePct,
+      },
+    };
+  }
+
+  const baselineDrop = baselinePct != null ? baselinePct - recentPct : null;
+
+  // CONCERN — real drift (significant drop) or severely low pace.
+  if (recentPct < 30 || (baselineDrop != null && baselineDrop >= 25)) {
+    return {
+      regimenId: regimen.id,
+      productName: regimen.productName,
+      severity: "concern",
+      summary:
+        baselineDrop != null && baselineDrop >= 25
+          ? `${regimen.productName} adherence dropped from ${baselinePct}% to ${recentPct}% this week — a real drift, not a baseline issue.`
+          : `${regimen.productName} adherence at ${recentPct}% over the last 7 days — likely under-dosing the regimen.`,
+      action:
+        "Check in at the next visit — a short conversation about what's changed often surfaces the barrier.",
+      metadata: {
+        checkKind:
+          baselineDrop != null && baselineDrop >= 25 ? "drift" : "low_pace",
+        recentPct,
+        baselinePct,
+        baselineDrop,
+      },
+    };
+  }
+
+  // NOTABLE — chronic middle-range (30-60%) without a recent drop.
+  if (recentPct < 60) {
+    return {
+      regimenId: regimen.id,
+      productName: regimen.productName,
+      severity: "notable",
+      summary: `${regimen.productName} adherence holding at ${recentPct}% — consistent with the patient's baseline but below the regimen as prescribed.`,
+      action:
+        "Worth asking whether the prescribed frequency matches how the patient actually uses it.",
+      metadata: {
+        checkKind: "chronic_low",
+        recentPct,
+        baselinePct,
+      },
+    };
+  }
+
+  return null;
+}
 
 export const adherenceDriftDetectorAgent: Agent<
   z.infer<typeof input>,
@@ -69,7 +192,6 @@ export const adherenceDriftDetectorAgent: Agent<
     ctx.assertCan("read.patient");
 
     const now = new Date();
-    const sevenDaysAgo = new Date(now.getTime() - 7 * DAY_MS);
     const twentyOneDaysAgo = new Date(now.getTime() - 21 * DAY_MS);
 
     const regimens = await prisma.dosingRegimen.findMany({
@@ -94,110 +216,17 @@ export const adherenceDriftDetectorAgent: Agent<
 
     for (const r of regimens) {
       const regimenLogs = allLogs.filter((l) => l.regimenId === r.id);
-      const recentLogs = regimenLogs.filter(
-        (l) => l.loggedAt >= sevenDaysAgo,
-      );
-      const baselineLogs = regimenLogs.filter(
-        (l) => l.loggedAt < sevenDaysAgo,
-      );
-
-      const expected7 = r.frequencyPerDay * 7;
-      const expected14Baseline = r.frequencyPerDay * 14;
-
-      const recentPct = Math.min(
-        100,
-        Math.round((recentLogs.length / expected7) * 100),
-      );
-      const baselinePct =
-        baselineLogs.length === 0
-          ? null
-          : Math.min(
-              100,
-              Math.round((baselineLogs.length / expected14Baseline) * 100),
-            );
-
-      const lastLog = regimenLogs[0]?.loggedAt ?? null;
-      const hoursSinceLastLog = lastLog
-        ? (now.getTime() - lastLog.getTime()) / 3_600_000
-        : null;
-
-      // Regimen that started <72h ago can't have stalled yet — skip the
-      // stale-dose check so a fresh prescription doesn't fire a false alarm.
-      const regimenAgeHours =
-        (now.getTime() - r.startDate.getTime()) / 3_600_000;
-
-      // URGENT — stalled regimen.
-      if (
-        regimenAgeHours >= 72 &&
-        (hoursSinceLastLog == null || hoursSinceLastLog >= 72)
-      ) {
-        findings.push({
-          regimenId: r.id,
+      const finding = classifyAdherence(
+        {
+          id: r.id,
           productName: r.product.name,
-          severity: "urgent",
-          summary: `No doses logged for ${r.product.name} in ${
-            hoursSinceLastLog == null
-              ? "the regimen's lifetime"
-              : `${Math.round(hoursSinceLastLog)} hours`
-          } — the regimen has stalled.`,
-          action:
-            "Reach out today — confirm the patient has the product, understands the schedule, and isn't hitting a side-effect barrier.",
-          metadata: {
-            checkKind: "stalled",
-            hoursSinceLastLog:
-              hoursSinceLastLog == null ? null : Math.round(hoursSinceLastLog),
-            recentPct,
-            baselinePct,
-          },
-        });
-        continue;
-      }
-
-      const baselineDrop =
-        baselinePct != null ? baselinePct - recentPct : null;
-
-      // CONCERN — real drift (significant drop) or severely low pace.
-      if (
-        recentPct < 30 ||
-        (baselineDrop != null && baselineDrop >= 25)
-      ) {
-        findings.push({
-          regimenId: r.id,
-          productName: r.product.name,
-          severity: "concern",
-          summary:
-            baselineDrop != null && baselineDrop >= 25
-              ? `${r.product.name} adherence dropped from ${baselinePct}% to ${recentPct}% this week — a real drift, not a baseline issue.`
-              : `${r.product.name} adherence at ${recentPct}% over the last 7 days — likely under-dosing the regimen.`,
-          action:
-            "Check in at the next visit — a short conversation about what's changed often surfaces the barrier.",
-          metadata: {
-            checkKind:
-              baselineDrop != null && baselineDrop >= 25 ? "drift" : "low_pace",
-            recentPct,
-            baselinePct,
-            baselineDrop,
-          },
-        });
-        continue;
-      }
-
-      // NOTABLE — chronic middle-range (30-60%) without a recent drop.
-      if (recentPct < 60) {
-        findings.push({
-          regimenId: r.id,
-          productName: r.product.name,
-          severity: "notable",
-          summary: `${r.product.name} adherence holding at ${recentPct}% — consistent with the patient's baseline but below the regimen as prescribed.`,
-          action:
-            "Worth asking whether the prescribed frequency matches how the patient actually uses it.",
-          metadata: {
-            checkKind: "chronic_low",
-            recentPct,
-            baselinePct,
-          },
-        });
-      }
+          frequencyPerDay: r.frequencyPerDay,
+          startDate: r.startDate,
+        },
+        regimenLogs,
+        now,
+      );
+      if (finding) findings.push(finding);
     }
 
     if (findings.length === 0) {

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -21,6 +21,7 @@ import { titrationAgent } from "./titration-agent";
 import { prescriptionSafetyAgent } from "./prescription-safety-agent";
 import { adherenceDriftDetectorAgent } from "./adherence-drift-detector-agent";
 import { messageUrgencyObserverAgent } from "./message-urgency-observer-agent";
+import { visitDiscoveryWhispererAgent } from "./visit-discovery-whisperer-agent";
 // Billing agents — Phase 3 of the Revenue Cycle PRD
 import { chargeIntegrityAgent } from "./billing/charge-integrity-agent";
 import { denialTriageAgent } from "./billing/denial-triage-agent";
@@ -88,6 +89,7 @@ export const agentRegistry = {
   prescriptionSafety: prescriptionSafetyAgent,
   adherenceDriftDetector: adherenceDriftDetectorAgent,
   messageUrgencyObserver: messageUrgencyObserverAgent,
+  visitDiscoveryWhisperer: visitDiscoveryWhispererAgent,
   // Billing agents (Phase 3)
   chargeIntegrity: chargeIntegrityAgent,
   denialTriage: denialTriageAgent,

--- a/src/lib/agents/message-urgency-observer-agent.test.ts
+++ b/src/lib/agents/message-urgency-observer-agent.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { truncate } from "./message-urgency-observer-agent";
+
+describe("truncate", () => {
+  it("leaves short strings unchanged", () => {
+    expect(truncate("hello", 20)).toBe("hello");
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  it("collapses internal whitespace runs", () => {
+    expect(truncate("hello   world", 20)).toBe("hello world");
+    expect(truncate("line\n\nbreak", 20)).toBe("line break");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(truncate("   padded   ", 20)).toBe("padded");
+  });
+
+  it("truncates with an ellipsis when the message exceeds max", () => {
+    const result = truncate("a".repeat(100), 10);
+    expect(result.length).toBe(10);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("does not include trailing spaces before the ellipsis", () => {
+    const result = truncate("hello world and more text here", 12);
+    expect(result.endsWith(" …")).toBe(false);
+    expect(result.endsWith("…")).toBe(true);
+  });
+});

--- a/src/lib/agents/message-urgency-observer-agent.ts
+++ b/src/lib/agents/message-urgency-observer-agent.ts
@@ -167,7 +167,7 @@ export const messageUrgencyObserverAgent: Agent<
   },
 };
 
-function truncate(s: string, max: number): string {
+export function truncate(s: string, max: number): string {
   const clean = s.replace(/\s+/g, " ").trim();
   if (clean.length <= max) return clean;
   return clean.slice(0, max - 1).trimEnd() + "…";

--- a/src/lib/agents/prescription-safety-agent.test.ts
+++ b/src/lib/agents/prescription-safety-agent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { extractOverriddenContraindicationIds } from "./prescription-safety-agent";
+
+describe("extractOverriddenContraindicationIds", () => {
+  it("returns the id array from a well-shaped override record", () => {
+    const override = {
+      contraindicationIds: ["schizophrenia", "bipolar_type_1"],
+      reason: "Physician override because...",
+      overriddenByUserId: "user-1",
+      overriddenAt: "2026-04-18T12:00:00Z",
+    };
+    expect(extractOverriddenContraindicationIds(override)).toEqual([
+      "schizophrenia",
+      "bipolar_type_1",
+    ]);
+  });
+
+  it("returns [] when override is null, undefined, or not an object", () => {
+    expect(extractOverriddenContraindicationIds(null)).toEqual([]);
+    expect(extractOverriddenContraindicationIds(undefined)).toEqual([]);
+    expect(extractOverriddenContraindicationIds("not an object")).toEqual([]);
+    expect(extractOverriddenContraindicationIds(42)).toEqual([]);
+  });
+
+  it("returns [] when contraindicationIds field is missing or wrong type", () => {
+    expect(extractOverriddenContraindicationIds({})).toEqual([]);
+    expect(
+      extractOverriddenContraindicationIds({ contraindicationIds: "not-an-array" }),
+    ).toEqual([]);
+    expect(
+      extractOverriddenContraindicationIds({ contraindicationIds: null }),
+    ).toEqual([]);
+  });
+
+  it("filters out non-string entries from the id array", () => {
+    const override = {
+      contraindicationIds: ["schizophrenia", 42, null, "bipolar_type_1"],
+    };
+    expect(extractOverriddenContraindicationIds(override)).toEqual([
+      "schizophrenia",
+      "bipolar_type_1",
+    ]);
+  });
+
+  it("handles an empty id array", () => {
+    expect(
+      extractOverriddenContraindicationIds({ contraindicationIds: [] }),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/agents/prescription-safety-agent.ts
+++ b/src/lib/agents/prescription-safety-agent.ts
@@ -234,7 +234,7 @@ export const prescriptionSafetyAgent: Agent<
   },
 };
 
-function extractOverriddenContraindicationIds(
+export function extractOverriddenContraindicationIds(
   override: unknown,
 ): string[] {
   if (!override || typeof override !== "object") return [];

--- a/src/lib/agents/visit-discovery-whisperer-agent.test.ts
+++ b/src/lib/agents/visit-discovery-whisperer-agent.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceCategory,
+  coerceSeverity,
+  parseDiscoveryResponse,
+  renderNoteForPrompt,
+} from "./visit-discovery-whisperer-agent";
+
+describe("parseDiscoveryResponse", () => {
+  it("parses a clean found response", () => {
+    const raw = JSON.stringify({
+      discovery: "found",
+      category: "medication_response",
+      severity: "concern",
+      summary: "Patient reports new sedation on the higher evening dose.",
+      actionSuggested: "Consider dose reduction.",
+    });
+    const parsed = parseDiscoveryResponse(raw);
+    expect(parsed).toEqual({
+      discovery: "found",
+      category: "medication_response",
+      severity: "concern",
+      summary: "Patient reports new sedation on the higher evening dose.",
+      actionSuggested: "Consider dose reduction.",
+    });
+  });
+
+  it("parses a clean none response", () => {
+    const raw = JSON.stringify({ discovery: "none" });
+    expect(parseDiscoveryResponse(raw)).toEqual({ discovery: "none" });
+  });
+
+  it("strips markdown fences around JSON", () => {
+    const raw = '```json\n{"discovery":"none"}\n```';
+    expect(parseDiscoveryResponse(raw)).toEqual({ discovery: "none" });
+  });
+
+  it("strips leading prose before a JSON object", () => {
+    const raw = 'Sure! Here is the JSON:\n{"discovery":"none"}\nLet me know if you need more.';
+    expect(parseDiscoveryResponse(raw)).toEqual({ discovery: "none" });
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseDiscoveryResponse("not json at all")).toBeNull();
+    expect(parseDiscoveryResponse("{")).toBeNull();
+    expect(parseDiscoveryResponse("{discovery: 'none'}")).toBeNull();
+  });
+
+  it("returns null when discovery field is missing or unknown", () => {
+    expect(parseDiscoveryResponse('{"foo":"bar"}')).toBeNull();
+    expect(parseDiscoveryResponse('{"discovery":"maybe"}')).toBeNull();
+  });
+
+  it("drops non-string category/severity/summary fields", () => {
+    const raw = JSON.stringify({
+      discovery: "found",
+      category: 42,
+      severity: null,
+      summary: ["a", "b"],
+    });
+    const parsed = parseDiscoveryResponse(raw);
+    expect(parsed).toEqual({
+      discovery: "found",
+      category: undefined,
+      severity: undefined,
+      summary: undefined,
+      actionSuggested: undefined,
+    });
+  });
+});
+
+describe("coerceCategory", () => {
+  it("accepts valid enum values", () => {
+    expect(coerceCategory("medication_response")).toBe("medication_response");
+    expect(coerceCategory("red_flag")).toBe("red_flag");
+  });
+
+  it("is case-insensitive", () => {
+    expect(coerceCategory("SYMPTOM_TREND")).toBe("symptom_trend");
+    expect(coerceCategory("  adherence  ")).toBe("adherence");
+  });
+
+  it("rejects unknown values", () => {
+    expect(coerceCategory("concerning")).toBeNull();
+    expect(coerceCategory("")).toBeNull();
+    expect(coerceCategory(undefined)).toBeNull();
+  });
+});
+
+describe("coerceSeverity", () => {
+  it("accepts the four valid levels", () => {
+    expect(coerceSeverity("info")).toBe("info");
+    expect(coerceSeverity("notable")).toBe("notable");
+    expect(coerceSeverity("concern")).toBe("concern");
+    expect(coerceSeverity("urgent")).toBe("urgent");
+  });
+
+  it("rejects unknown severities", () => {
+    expect(coerceSeverity("critical")).toBeNull();
+    expect(coerceSeverity("low")).toBeNull();
+    expect(coerceSeverity(undefined)).toBeNull();
+  });
+});
+
+describe("renderNoteForPrompt", () => {
+  it("joins block heading + body with blank-line separators", () => {
+    const blocks = [
+      { heading: "Assessment", body: "Pain well-controlled." },
+      { heading: "Plan", body: "Continue current regimen." },
+    ];
+    const rendered = renderNoteForPrompt(blocks, null);
+    expect(rendered).toBe(
+      "Assessment:\nPain well-controlled.\n\nPlan:\nContinue current regimen.",
+    );
+  });
+
+  it("falls back to block type when heading is missing", () => {
+    const blocks = [{ type: "assessment", body: "Stable." }];
+    const rendered = renderNoteForPrompt(blocks, null);
+    expect(rendered).toBe("assessment:\nStable.");
+  });
+
+  it("appends narrative when present", () => {
+    const rendered = renderNoteForPrompt(
+      [{ heading: "Plan", body: "Follow up in 4 weeks." }],
+      "Patient is doing well overall.",
+    );
+    expect(rendered).toContain("Plan:\nFollow up in 4 weeks.");
+    expect(rendered).toContain("Narrative:\nPatient is doing well overall.");
+  });
+
+  it("handles non-array blocks gracefully", () => {
+    expect(renderNoteForPrompt(null, "just a narrative")).toBe(
+      "Narrative:\njust a narrative",
+    );
+    expect(renderNoteForPrompt(undefined, null)).toBe("");
+  });
+
+  it("skips blocks with empty bodies", () => {
+    const blocks = [
+      { heading: "Assessment", body: "" },
+      { heading: "Plan", body: "Continue." },
+    ];
+    const rendered = renderNoteForPrompt(blocks, null);
+    expect(rendered).toBe("Plan:\nContinue.");
+  });
+});

--- a/src/lib/agents/visit-discovery-whisperer-agent.ts
+++ b/src/lib/agents/visit-discovery-whisperer-agent.ts
@@ -1,0 +1,341 @@
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import type { Agent } from "@/lib/orchestration/types";
+import { recordObservation } from "@/lib/agents/memory/clinical-observation";
+import { isModelError } from "@/lib/orchestration/model-client";
+import type {
+  ObservationCategory,
+  ObservationSeverity,
+} from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// Visit Discovery Whisperer
+// ---------------------------------------------------------------------------
+// Fourth ambient agent in the fleet, and the first LLM-powered one.
+//
+// Fires when a Note is finalized. Reads the full note body, asks the
+// model for the SINGLE most important clinical discovery from the
+// visit, and writes a ClinicalObservation with that summary. Output
+// surfaces in the Command Center's Clinical Discovery tile as the
+// "Top signal" row.
+//
+// Design principles (different from the three deterministic agents):
+//
+//   1. The model picks category + severity, constrained to enum values.
+//      We ship a strict allowlist and reject any response that deviates.
+//
+//   2. "None" is a valid answer. A routine follow-up with no standout
+//      finding should not pollute the Discovery tile. The prompt gives
+//      the model an explicit escape hatch.
+//
+//   3. Model failures are silent. Network hiccups, credit limits, and
+//      malformed JSON all fall through to "no observation written" —
+//      never write a garbage observation into a patient's chart
+//      just because the LLM was flaky.
+//
+//   4. Runs in parallel with physicianNudge + codingReadiness, which
+//      also listen to note.finalized. Each serves a different tile /
+//      downstream consumer.
+// ---------------------------------------------------------------------------
+
+const input = z.object({
+  noteId: z.string(),
+  encounterId: z.string(),
+});
+
+const output = z.object({
+  observationWritten: z.boolean(),
+  observationId: z.string().nullable(),
+  reason: z.string(),
+});
+
+const VALID_CATEGORIES: ObservationCategory[] = [
+  "symptom_trend",
+  "medication_response",
+  "adherence",
+  "emotional_state",
+  "red_flag",
+  "positive_signal",
+  "side_effect",
+  "lifestyle_shift",
+  "engagement",
+  "other",
+];
+
+const VALID_SEVERITIES: ObservationSeverity[] = [
+  "info",
+  "notable",
+  "concern",
+  "urgent",
+];
+
+interface DiscoveryResponse {
+  discovery: "found" | "none";
+  category?: string;
+  severity?: string;
+  summary?: string;
+  actionSuggested?: string;
+}
+
+export const visitDiscoveryWhispererAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "visitDiscoveryWhisperer",
+  version: "1.0.0",
+  description:
+    "On note.finalized, asks the model for the single most important " +
+    "clinical discovery from the visit and writes it as a ClinicalObservation. " +
+    "Surfaces as the Top signal row on the Clinical Discovery tile.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: ["read.patient", "read.encounter", "write.outcome.reminder"],
+  requiresApproval: false,
+
+  async run({ noteId, encounterId }, ctx) {
+    ctx.assertCan("read.patient");
+    ctx.assertCan("read.encounter");
+
+    const note = await prisma.note.findUnique({
+      where: { id: noteId },
+      select: {
+        id: true,
+        status: true,
+        blocks: true,
+        narrative: true,
+        encounter: {
+          select: {
+            id: true,
+            patientId: true,
+            reason: true,
+            patient: {
+              select: { firstName: true, lastName: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!note) {
+      return noDiscovery("note_not_found");
+    }
+    if (note.status !== "finalized") {
+      // Safety: listener fires on finalize, but re-drafts could race.
+      // Don't analyze drafts — they change.
+      return noDiscovery("note_not_finalized");
+    }
+    if (note.encounter.id !== encounterId) {
+      return noDiscovery("encounter_mismatch");
+    }
+
+    const noteText = renderNoteForPrompt(note.blocks, note.narrative);
+    if (noteText.trim().length < 80) {
+      // Nothing substantive to analyze — a three-line note probably
+      // wasn't a real clinical event.
+      return noDiscovery("note_too_short");
+    }
+
+    const prompt = buildDiscoveryPrompt({
+      patientFirst: note.encounter.patient.firstName,
+      reason: note.encounter.reason,
+      noteText,
+    });
+
+    let rawResponse: string;
+    try {
+      rawResponse = await ctx.model.complete(prompt, {
+        maxTokens: 400,
+        temperature: 0.2,
+      });
+    } catch (err) {
+      // Silent fallback on any model failure — never write garbage.
+      ctx.log("info", "Model call failed — skipping discovery write", {
+        code: isModelError(err) ? err.code : "unknown",
+      });
+      return noDiscovery("model_unavailable");
+    }
+
+    const parsed = parseDiscoveryResponse(rawResponse);
+    if (!parsed) {
+      ctx.log("info", "Model returned unparseable response", {
+        preview: rawResponse.slice(0, 200),
+      });
+      return noDiscovery("parse_failed");
+    }
+
+    if (parsed.discovery === "none") {
+      ctx.log("info", "Model reported no standout discovery");
+      return noDiscovery("no_standout");
+    }
+
+    const category = coerceCategory(parsed.category);
+    const severity = coerceSeverity(parsed.severity);
+    const summary = (parsed.summary ?? "").trim();
+    if (!category || !severity || summary.length < 10) {
+      ctx.log("info", "Model response missing required fields", {
+        category: parsed.category,
+        severity: parsed.severity,
+        summaryLen: summary.length,
+      });
+      return noDiscovery("invalid_shape");
+    }
+
+    ctx.assertCan("write.outcome.reminder");
+
+    const obs = await recordObservation({
+      patientId: note.encounter.patientId,
+      observedBy: "visitDiscoveryWhisperer@1.0.0",
+      observedByKind: "agent",
+      category,
+      severity,
+      summary,
+      actionSuggested: parsed.actionSuggested?.trim() || undefined,
+      evidence: { noteIds: [noteId], encounterIds: [encounterId] },
+      metadata: {
+        source: "note.finalized",
+        modelDrafted: true,
+      },
+    });
+
+    ctx.log("info", "Discovery observation written", {
+      observationId: obs.id,
+      category,
+      severity,
+    });
+
+    return {
+      observationWritten: true,
+      observationId: obs.id,
+      reason: "written",
+    };
+  },
+};
+
+function noDiscovery(reason: string): z.infer<typeof output> {
+  return { observationWritten: false, observationId: null, reason };
+}
+
+// ----- Prompt + parsing -----
+
+function buildDiscoveryPrompt(opts: {
+  patientFirst: string;
+  reason: string | null;
+  noteText: string;
+}): string {
+  return `You are a clinical analyst reviewing a completed visit note.
+Identify the SINGLE most important clinical discovery from this visit —
+the one thing a covering physician should know in five seconds. Skip
+routine findings. Skip administrative details. Skip anything obvious
+from a quick chart glance.
+
+Patient: ${opts.patientFirst}${opts.reason ? `. Visit reason: ${opts.reason}.` : "."}
+
+Respond with STRICT JSON, no prose, no markdown fences. Two valid shapes:
+
+Shape A — a discovery exists:
+{
+  "discovery": "found",
+  "category": one of [${VALID_CATEGORIES.map((c) => `"${c}"`).join(", ")}],
+  "severity": one of [${VALID_SEVERITIES.map((s) => `"${s}"`).join(", ")}],
+  "summary": "one or two sentences, specific, no hedging",
+  "actionSuggested": "what the covering physician should consider — one sentence"
+}
+
+Shape B — routine visit, no standout finding:
+{ "discovery": "none" }
+
+Severity guide:
+  info     — minor context, worth knowing
+  notable  — meaningful change or pattern
+  concern  — warrants follow-up in the next touchpoint
+  urgent   — time-sensitive, needs action within hours
+
+Visit note:
+---
+${opts.noteText}
+---
+
+JSON only:`;
+}
+
+function parseDiscoveryResponse(raw: string): DiscoveryResponse | null {
+  // Strip common model artifacts: markdown fences, leading/trailing chatter.
+  const trimmed = raw.trim();
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed;
+
+  // Find the first { and last } to cope with models that wrap JSON in prose.
+  const firstBrace = candidate.indexOf("{");
+  const lastBrace = candidate.lastIndexOf("}");
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    return null;
+  }
+  const jsonSlice = candidate.slice(firstBrace, lastBrace + 1);
+
+  try {
+    const parsed = JSON.parse(jsonSlice) as Record<string, unknown>;
+    if (parsed.discovery === "none") {
+      return { discovery: "none" };
+    }
+    if (parsed.discovery === "found") {
+      return {
+        discovery: "found",
+        category:
+          typeof parsed.category === "string" ? parsed.category : undefined,
+        severity:
+          typeof parsed.severity === "string" ? parsed.severity : undefined,
+        summary:
+          typeof parsed.summary === "string" ? parsed.summary : undefined,
+        actionSuggested:
+          typeof parsed.actionSuggested === "string"
+            ? parsed.actionSuggested
+            : undefined,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function coerceCategory(raw: string | undefined): ObservationCategory | null {
+  if (!raw) return null;
+  const normalized = raw.toLowerCase().trim();
+  return (
+    VALID_CATEGORIES.find((c) => c === normalized) ?? null
+  );
+}
+
+function coerceSeverity(raw: string | undefined): ObservationSeverity | null {
+  if (!raw) return null;
+  const normalized = raw.toLowerCase().trim();
+  return VALID_SEVERITIES.find((s) => s === normalized) ?? null;
+}
+
+// ----- Note rendering -----
+
+interface NoteBlock {
+  type?: string;
+  heading?: string;
+  body?: string;
+}
+
+function renderNoteForPrompt(blocks: unknown, narrative: string | null): string {
+  const parts: string[] = [];
+
+  if (Array.isArray(blocks)) {
+    for (const b of blocks as NoteBlock[]) {
+      if (!b || typeof b !== "object") continue;
+      const heading = (b.heading ?? b.type ?? "").toString().trim();
+      const body = (b.body ?? "").toString().trim();
+      if (!body) continue;
+      parts.push(heading ? `${heading}:\n${body}` : body);
+    }
+  }
+
+  if (narrative && narrative.trim().length > 0) {
+    parts.push(`Narrative:\n${narrative.trim()}`);
+  }
+
+  return parts.join("\n\n");
+}

--- a/src/lib/agents/visit-discovery-whisperer-agent.ts
+++ b/src/lib/agents/visit-discovery-whisperer-agent.ts
@@ -69,7 +69,7 @@ const VALID_SEVERITIES: ObservationSeverity[] = [
   "urgent",
 ];
 
-interface DiscoveryResponse {
+export interface DiscoveryResponse {
   discovery: "found" | "none";
   category?: string;
   severity?: string;
@@ -258,7 +258,7 @@ ${opts.noteText}
 JSON only:`;
 }
 
-function parseDiscoveryResponse(raw: string): DiscoveryResponse | null {
+export function parseDiscoveryResponse(raw: string): DiscoveryResponse | null {
   // Strip common model artifacts: markdown fences, leading/trailing chatter.
   const trimmed = raw.trim();
   const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
@@ -298,7 +298,9 @@ function parseDiscoveryResponse(raw: string): DiscoveryResponse | null {
   }
 }
 
-function coerceCategory(raw: string | undefined): ObservationCategory | null {
+export function coerceCategory(
+  raw: string | undefined,
+): ObservationCategory | null {
   if (!raw) return null;
   const normalized = raw.toLowerCase().trim();
   return (
@@ -306,7 +308,9 @@ function coerceCategory(raw: string | undefined): ObservationCategory | null {
   );
 }
 
-function coerceSeverity(raw: string | undefined): ObservationSeverity | null {
+export function coerceSeverity(
+  raw: string | undefined,
+): ObservationSeverity | null {
   if (!raw) return null;
   const normalized = raw.toLowerCase().trim();
   return VALID_SEVERITIES.find((s) => s === normalized) ?? null;
@@ -320,7 +324,10 @@ interface NoteBlock {
   body?: string;
 }
 
-function renderNoteForPrompt(blocks: unknown, narrative: string | null): string {
+export function renderNoteForPrompt(
+  blocks: unknown,
+  narrative: string | null,
+): string {
   const parts: string[] = [];
 
   if (Array.isArray(blocks)) {

--- a/src/lib/domain/transcription.ts
+++ b/src/lib/domain/transcription.ts
@@ -1,0 +1,184 @@
+/**
+ * Audio transcription — provider-agnostic server-side module.
+ *
+ * The voice-chart feature ships with a simulated transcript for
+ * demo / local dev. This module is the real path: when
+ * TRANSCRIPTION_PROVIDER is configured, it sends the recorded audio
+ * to a speech-to-text service and returns canonical TranscriptSegment
+ * records the rest of the pipeline already consumes.
+ *
+ * Provider selection:
+ *   TRANSCRIPTION_PROVIDER=simulated      → throws, caller falls back
+ *   TRANSCRIPTION_PROVIDER=openai-whisper → OpenAI /v1/audio/transcriptions
+ *
+ * Speaker diarization: Whisper alone doesn't diarize. Every segment
+ * is returned with speaker="unknown" and the downstream extraction
+ * prompt already handles unlabeled turns. Swap provider (AssemblyAI,
+ * Deepgram, WhisperX) for real speaker labels; the interface stays
+ * the same.
+ */
+
+import type { TranscriptSegment } from "./voice-chart";
+
+export type TranscriptionProvider = "simulated" | "openai-whisper";
+
+export class TranscriptionNotConfiguredError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "TranscriptionNotConfiguredError";
+  }
+}
+
+export class TranscriptionFailedError extends Error {
+  readonly provider: TranscriptionProvider;
+  constructor(provider: TranscriptionProvider, message: string) {
+    super(message);
+    this.name = "TranscriptionFailedError";
+    this.provider = provider;
+  }
+}
+
+export function getTranscriptionProvider(): TranscriptionProvider {
+  const raw = (process.env.TRANSCRIPTION_PROVIDER ?? "simulated").toLowerCase();
+  if (raw === "openai-whisper") return "openai-whisper";
+  return "simulated";
+}
+
+export async function transcribeAudio(
+  audio: Blob,
+  opts: { mimeType?: string; filename?: string } = {},
+): Promise<TranscriptSegment[]> {
+  const provider = getTranscriptionProvider();
+
+  if (provider === "simulated") {
+    throw new TranscriptionNotConfiguredError(
+      "TRANSCRIPTION_PROVIDER is 'simulated' — caller should fall back to the demo transcript generator.",
+    );
+  }
+
+  if (provider === "openai-whisper") {
+    return transcribeWithOpenAIWhisper(audio, opts);
+  }
+
+  throw new TranscriptionNotConfiguredError(
+    `Unknown TRANSCRIPTION_PROVIDER value: ${provider}`,
+  );
+}
+
+async function transcribeWithOpenAIWhisper(
+  audio: Blob,
+  opts: { mimeType?: string; filename?: string },
+): Promise<TranscriptSegment[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new TranscriptionNotConfiguredError(
+      "OPENAI_API_KEY is not set — required when TRANSCRIPTION_PROVIDER=openai-whisper.",
+    );
+  }
+
+  // Whisper's hard upload limit is 25 MB. Clinic visits at typical
+  // voice bitrates come in well under that, but guard anyway so a
+  // stuck recording doesn't hammer the API for a guaranteed 413.
+  const MAX_BYTES = 25 * 1024 * 1024;
+  if (audio.size > MAX_BYTES) {
+    throw new TranscriptionFailedError(
+      "openai-whisper",
+      `Audio payload ${audio.size} bytes exceeds Whisper's 25 MB limit. Split the recording and retry.`,
+    );
+  }
+
+  const filename =
+    opts.filename ?? defaultFilenameForMime(opts.mimeType ?? audio.type);
+
+  const form = new FormData();
+  form.append("file", audio, filename);
+  form.append("model", "whisper-1");
+  form.append("response_format", "verbose_json");
+  form.append("temperature", "0");
+  // Prompting Whisper with medical vocabulary context nudges it toward
+  // correct spellings of common cannabinoids, dose units, and conditions.
+  // Keep short — long prompts bias the transcription.
+  form.append(
+    "prompt",
+    "Medical cannabis clinic visit. THC, CBD, CBN, CBG, mg, mL, tincture, titration, indica, sativa.",
+  );
+
+  const response = await fetch(
+    "https://api.openai.com/v1/audio/transcriptions",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw new TranscriptionFailedError(
+      "openai-whisper",
+      `OpenAI Whisper returned ${response.status}: ${detail}`,
+    );
+  }
+
+  const payload = (await response.json()) as WhisperVerboseResponse;
+  return whisperToTranscriptSegments(payload);
+}
+
+interface WhisperVerboseSegment {
+  id?: number;
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface WhisperVerboseResponse {
+  text: string;
+  segments?: WhisperVerboseSegment[];
+  duration?: number;
+}
+
+function whisperToTranscriptSegments(
+  payload: WhisperVerboseResponse,
+): TranscriptSegment[] {
+  // Prefer segment-level timestamps when Whisper supplies them.
+  if (Array.isArray(payload.segments) && payload.segments.length > 0) {
+    return payload.segments.map((s) => ({
+      speaker: "unknown",
+      text: s.text.trim(),
+      startTime: Math.round(s.start),
+      endTime: Math.round(s.end),
+    }));
+  }
+
+  // Fallback: no segments, one big blob. Return a single segment spanning
+  // the whole recording so the extraction prompt still has something to
+  // work with.
+  const totalDuration = Math.round(payload.duration ?? 0);
+  return [
+    {
+      speaker: "unknown",
+      text: (payload.text ?? "").trim(),
+      startTime: 0,
+      endTime: totalDuration,
+    },
+  ];
+}
+
+function defaultFilenameForMime(mime: string): string {
+  const lower = mime.toLowerCase();
+  if (lower.includes("webm")) return "recording.webm";
+  if (lower.includes("mp4") || lower.includes("mp4a")) return "recording.mp4";
+  if (lower.includes("m4a")) return "recording.m4a";
+  if (lower.includes("mpeg") || lower.includes("mp3")) return "recording.mp3";
+  if (lower.includes("wav")) return "recording.wav";
+  if (lower.includes("ogg")) return "recording.ogg";
+  return "recording.webm";
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return `<unreadable body>`;
+  }
+}

--- a/src/lib/orchestration/workflows.ts
+++ b/src/lib/orchestration/workflows.ts
@@ -440,6 +440,19 @@ export const workflows: WorkflowDefinition[] = [
       },
     ],
   },
+  {
+    name: "visit-discovery-whisper",
+    on: ["note.finalized"],
+    steps: [
+      {
+        agent: "visitDiscoveryWhisperer",
+        input: (e) => ({
+          noteId: (e as any).noteId,
+          encounterId: (e as any).encounterId,
+        }),
+      },
+    ],
+  },
 ];
 
 /** Find every workflow step that should fire for a given event. */

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+// Focused config: unit tests only, no DOM, no Next bundling.
+// Tests import pure helper functions from agents and domain modules —
+// no Prisma, no network, no globals. Keeps CI fast.
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    // Don't load .env — the transcription module reads env vars, and
+    // tests should run deterministically regardless of .env state.
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
## Summary

Tail PR for the four overnight commits that landed on `claude/emr-setup-cicd-5gZga` after PR #32 was merged early at `5a11c15`. All four are from the same overnight agent-storm session documented in #32's description but physically pushed after the merge window closed.

## Commits included

### 1. `9b02974` — Voice dictation: real Whisper transcription with safe fallback

Replaced the simulated-transcript hardcode in `voice-recorder.tsx` with a real audio pipeline:
- New module `src/lib/domain/transcription.ts` — provider-agnostic server-side transcription
- New route `POST /api/transcribe` — multipart audio → `TranscriptSegment[]`
- `MediaRecorder` now actually captures audio chunks; posts to `/api/transcribe`; silently falls back to simulated on 503
- New env vars: `TRANSCRIPTION_PROVIDER` (default `simulated`) and `OPENAI_API_KEY`
- Whisper integration uses `verbose_json`, medical-cannabis vocabulary prompt, 25MB payload guard

### 2. `546f987` — Ambient agent #4: `visitDiscoveryWhisperer` (first LLM-powered)

Listens to `note.finalized`. Asks the configured model for the single most important clinical discovery from the visit and writes it as a `ClinicalObservation`. Surfaces as the Top signal row on the Clinical Discovery tile.

- Strict JSON contract with `{discovery:"none"}` escape hatch for routine visits
- Category + severity coerced against enum allowlists — never writes malformed observations
- Silent no-op on any model failure (credit limit, network, malformed output)
- Stub model client correctly no-ops (its prose doesn't parse as JSON)

### 3. `b315b7b` — Vitest harness + 35 pure-helper tests for the ambient fleet

First test framework in the repo.
- `vitest` + `vite-tsconfig-paths` as devDependencies
- `vitest.config.mts` (.mts because paths plugin is ESM-only)
- New scripts: `npm test` (CI) and `npm run test:watch`
- 35 tests passing across all 4 ambient agents:
  - `adherence-drift-detector-agent.test.ts` — 8 tests on `classifyAdherence` (stalled, drift, chronic-low, edge cases)
  - `visit-discovery-whisperer-agent.test.ts` — 17 tests on JSON parsing, enum coercion, note rendering
  - `prescription-safety-agent.test.ts` — 5 tests on override extraction
  - `message-urgency-observer-agent.test.ts` — 5 tests on `truncate`
- Refactoring extracted pure helpers (`classifyAdherence` from the drift detector, among others) so they're testable without Prisma mocking

Full `agent.run()` tests with Prisma mocks deliberately out of scope — documented as a follow-up.

### 4. `0539d7c` — `docs/agents/ambient-assistant-fleet.md`

Single reference doc for the four-agent ambient fleet: trigger, behavior, severity mapping, tile surface it populates, and design principles for each. Shared plumbing section + "adding a fifth agent" recipe with pattern-selection guidance.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds
- `npm test` — 35/35 passing
- No Prisma migrations
- Voice-chart default flow (simulated transcript) unchanged — no breakage risk

## Test plan

- [ ] Set `TRANSCRIPTION_PROVIDER=openai-whisper` + `OPENAI_API_KEY` in deploy env; confirm `/clinic/patients/[id]/voice-chart` uses real Whisper. Unset and confirm simulated fallback still works.
- [ ] Finalize a note on a seeded patient with `AGENT_MODEL_CLIENT=openrouter` and a real `OPENROUTER_API_KEY`; confirm visitDiscoveryWhisperer writes a Top signal observation to the Discovery tile.
- [ ] Same test with `AGENT_MODEL_CLIENT=stub`; confirm NO observation is written (stub output doesn't parse as JSON — expected silent no-op).
- [ ] `npm test` in CI passes.
- [ ] Worker process starts without registration errors after merge.

## Why a tail PR instead of re-opening #32

PR #32 merged at `5a11c15` before these four commits were pushed. Re-opening a merged PR isn't clean; opening a fresh tail PR for the remainder preserves a linear merge history and keeps the four commits reviewable as one logical batch.

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C