### PR TITLE
feat(agents): diagnosisSafety — fifth ambient agent

### DIFF
--- a/src/lib/agents/diagnosis-safety-agent.test.ts
+++ b/src/lib/agents/diagnosis-safety-agent.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHistoryText,
+  filterNewContraindications,
+} from "./diagnosis-safety-agent";
+import {
+  CANNABIS_CONTRAINDICATIONS,
+  type CannabisContraindication,
+} from "@/lib/domain/contraindications";
+
+const bipolar = CANNABIS_CONTRAINDICATIONS.find(
+  (c) => c.id === "bipolar_type_1",
+) as CannabisContraindication;
+const schizophrenia = CANNABIS_CONTRAINDICATIONS.find(
+  (c) => c.id === "schizophrenia",
+) as CannabisContraindication;
+
+describe("buildHistoryText", () => {
+  it("concatenates presenting concerns and contraindications lower-cased", () => {
+    expect(
+      buildHistoryText({
+        presentingConcerns: "Chronic pain with Bipolar I Disorder",
+        contraindications: ["Schizoaffective disorder"],
+      }),
+    ).toBe("chronic pain with bipolar i disorder schizoaffective disorder");
+  });
+
+  it("handles null fields without throwing", () => {
+    expect(
+      buildHistoryText({ presentingConcerns: null, contraindications: null }),
+    ).toBe("");
+    expect(buildHistoryText({})).toBe("");
+  });
+
+  it("handles empty contraindication arrays", () => {
+    expect(
+      buildHistoryText({
+        presentingConcerns: "pain",
+        contraindications: [],
+      }),
+    ).toBe("pain");
+  });
+});
+
+describe("filterNewContraindications", () => {
+  const regimenId = "regimen-A";
+  const otherRegimenId = "regimen-B";
+
+  it("returns every matched contraindication when no observations exist", () => {
+    const result = filterNewContraindications(
+      [bipolar, schizophrenia],
+      regimenId,
+      [],
+    );
+    expect(result.map((c) => c.id)).toEqual([bipolar.id, schizophrenia.id]);
+  });
+
+  it("drops a contraindication already covered by an unresolved observation on the same regimen", () => {
+    const result = filterNewContraindications(
+      [bipolar, schizophrenia],
+      regimenId,
+      [
+        {
+          metadata: { regimenId, contraindicationId: bipolar.id },
+          resolvedAt: null,
+        },
+      ],
+    );
+    expect(result.map((c) => c.id)).toEqual([schizophrenia.id]);
+  });
+
+  it("does NOT drop when the existing observation is resolved", () => {
+    const result = filterNewContraindications(
+      [bipolar],
+      regimenId,
+      [
+        {
+          metadata: { regimenId, contraindicationId: bipolar.id },
+          resolvedAt: new Date(),
+        },
+      ],
+    );
+    expect(result.map((c) => c.id)).toEqual([bipolar.id]);
+  });
+
+  it("does NOT drop when the existing observation is against a different regimen", () => {
+    const result = filterNewContraindications(
+      [bipolar],
+      regimenId,
+      [
+        {
+          metadata: {
+            regimenId: otherRegimenId,
+            contraindicationId: bipolar.id,
+          },
+          resolvedAt: null,
+        },
+      ],
+    );
+    expect(result.map((c) => c.id)).toEqual([bipolar.id]);
+  });
+
+  it("ignores observations whose metadata is null or malformed", () => {
+    const result = filterNewContraindications(
+      [bipolar],
+      regimenId,
+      [
+        { metadata: null, resolvedAt: null },
+        { metadata: "not-an-object", resolvedAt: null },
+        { metadata: { regimenId }, resolvedAt: null }, // missing contraindicationId
+        {
+          metadata: { regimenId, contraindicationId: 42 }, // wrong type
+          resolvedAt: null,
+        },
+      ],
+    );
+    expect(result.map((c) => c.id)).toEqual([bipolar.id]);
+  });
+
+  it("returns [] when every match is already covered", () => {
+    const result = filterNewContraindications(
+      [bipolar, schizophrenia],
+      regimenId,
+      [
+        {
+          metadata: { regimenId, contraindicationId: bipolar.id },
+          resolvedAt: null,
+        },
+        {
+          metadata: { regimenId, contraindicationId: schizophrenia.id },
+          resolvedAt: null,
+        },
+      ],
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/agents/diagnosis-safety-agent.ts
+++ b/src/lib/agents/diagnosis-safety-agent.ts
@@ -1,0 +1,270 @@
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import type { Agent } from "@/lib/orchestration/types";
+import {
+  CANNABIS_CONTRAINDICATIONS,
+  type CannabisContraindication,
+} from "@/lib/domain/contraindications";
+import { recordObservation } from "@/lib/agents/memory/clinical-observation";
+import type { ObservationSeverity } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// Diagnosis Safety Agent
+// ---------------------------------------------------------------------------
+// The mirror image of prescriptionSafetyAgent. Fires when a patient's
+// diagnosis / contraindication / presenting-concern record changes (via
+// the `patient.diagnosis.updated` event) and re-checks every ACTIVE
+// DosingRegimen against CANNABIS_CONTRAINDICATIONS.
+//
+// Clinical rationale: a patient may have been safely prescribed THC six
+// months ago. Today they get diagnosed with bipolar I disorder. Nothing
+// in the existing pipeline re-evaluates the regimen against the new
+// diagnosis — prescriptionSafety only runs at prescribe-time. This agent
+// closes that gap.
+//
+// For each active regimen × each newly-matched contraindication (where
+// "newly" means: not already covered by an existing unresolved
+// ClinicalObservation against the same regimen+contraindication) a new
+// ClinicalObservation is written. Severity mapping mirrors
+// prescriptionSafety: absolute → urgent, relative → concern,
+// caution → notable.
+//
+// Cold-temperature, deterministic, no LLM, no approval gate.
+// ---------------------------------------------------------------------------
+
+const input = z.object({
+  patientId: z.string(),
+});
+
+const output = z.object({
+  regimensChecked: z.number(),
+  contraindicationsFound: z.number(),
+  observationsWritten: z.number(),
+  observationIds: z.array(z.string()),
+});
+
+// absolute → urgent, relative → concern, caution → notable.
+// Same mapping prescriptionSafetyAgent uses.
+const CONTRAINDICATION_SEVERITY: Record<
+  CannabisContraindication["severity"],
+  ObservationSeverity
+> = {
+  absolute: "urgent",
+  relative: "concern",
+  caution: "notable",
+};
+
+/**
+ * Build the searchable patient history text from the patient's
+ * presenting concerns + stored contraindication strings. Lower-cased,
+ * space-joined — same shape prescriptionSafetyAgent uses so that the
+ * keyword matching behaves identically.
+ */
+export function buildHistoryText(input: {
+  presentingConcerns?: string | null;
+  contraindications?: string[] | null;
+}): string {
+  return [input.presentingConcerns ?? "", ...(input.contraindications ?? [])]
+    .join(" ")
+    .toLowerCase();
+}
+
+/**
+ * From the set of contraindications matched against a patient's history,
+ * drop any that are ALREADY covered by an existing unresolved observation
+ * against the same regimen. This prevents the agent from writing a new
+ * observation every time the event fires when the flag hasn't changed.
+ *
+ * An existing observation "covers" a contraindication if:
+ *   - metadata.regimenId === regimenId, AND
+ *   - metadata.contraindicationId === contraindication.id, AND
+ *   - resolvedAt === null (observation still open).
+ */
+export function filterNewContraindications(
+  matched: CannabisContraindication[],
+  regimenId: string,
+  existingObservations: Array<{
+    metadata: unknown;
+    resolvedAt: Date | null;
+  }>,
+): CannabisContraindication[] {
+  const coveredIds = new Set<string>();
+  for (const obs of existingObservations) {
+    if (obs.resolvedAt !== null) continue;
+    const meta = obs.metadata;
+    if (!meta || typeof meta !== "object") continue;
+    const m = meta as { regimenId?: unknown; contraindicationId?: unknown };
+    if (m.regimenId !== regimenId) continue;
+    if (typeof m.contraindicationId !== "string") continue;
+    coveredIds.add(m.contraindicationId);
+  }
+  return matched.filter((c) => !coveredIds.has(c.id));
+}
+
+export const diagnosisSafetyAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "diagnosisSafety",
+  version: "1.0.0",
+  description:
+    "Re-check every active dosing regimen against cannabis contraindications " +
+    "whenever the patient's diagnosis or presenting-concern record changes. " +
+    "Writes a ClinicalObservation for each newly-flagged regimen×contraindication " +
+    "pair; stays silent when nothing new is flagged.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: ["read.patient", "write.outcome.reminder"],
+  requiresApproval: false,
+
+  async run({ patientId }, ctx) {
+    ctx.assertCan("read.patient");
+
+    const patient = await prisma.patient.findUnique({
+      where: { id: patientId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        presentingConcerns: true,
+        contraindications: true,
+      },
+    });
+    if (!patient) throw new Error(`Patient not found: ${patientId}`);
+
+    const regimens = await prisma.dosingRegimen.findMany({
+      where: { patientId, active: true },
+      include: { product: true },
+    });
+
+    if (regimens.length === 0) {
+      ctx.log("info", "No active regimens — nothing to check", { patientId });
+      return {
+        regimensChecked: 0,
+        contraindicationsFound: 0,
+        observationsWritten: 0,
+        observationIds: [],
+      };
+    }
+
+    const historyText = buildHistoryText(patient);
+
+    // If history is entirely empty there's no text to match keywords
+    // against — short-circuit before querying observations.
+    if (!historyText.trim()) {
+      ctx.log("info", "Patient history empty — no keywords to match", {
+        patientId,
+        regimensChecked: regimens.length,
+      });
+      return {
+        regimensChecked: regimens.length,
+        contraindicationsFound: 0,
+        observationsWritten: 0,
+        observationIds: [],
+      };
+    }
+
+    // Load every unresolved red-flag observation for this patient a single
+    // time; we'll filter per-regimen in memory.
+    const existingObservations = await prisma.clinicalObservation.findMany({
+      where: {
+        patientId,
+        category: "red_flag",
+        resolvedAt: null,
+      },
+      select: { metadata: true, resolvedAt: true },
+    });
+
+    const matchedAll = CANNABIS_CONTRAINDICATIONS.filter((c) =>
+      c.matchKeywords.some((kw) => historyText.includes(kw.toLowerCase())),
+    );
+
+    ctx.log("info", "Diagnosis safety scan started", {
+      patientId,
+      regimensChecked: regimens.length,
+      matchedContraindications: matchedAll.length,
+    });
+
+    const observationIds: string[] = [];
+    let totalContraindicationsFound = 0;
+
+    if (matchedAll.length > 0) {
+      ctx.assertCan("write.outcome.reminder");
+    }
+
+    for (const regimen of regimens) {
+      // The prescription-time agent only surfaces contraindications
+      // relevant to the cannabinoids actually in the product. We preserve
+      // that behavior here: if the product contains no cannabinoids at
+      // all (a placeholder / custom product), skip it.
+      const cannabinoids: string[] = [];
+      if (
+        regimen.product.thcConcentration &&
+        regimen.product.thcConcentration > 0
+      )
+        cannabinoids.push("THC");
+      if (
+        regimen.product.cbdConcentration &&
+        regimen.product.cbdConcentration > 0
+      )
+        cannabinoids.push("CBD");
+      if (
+        regimen.product.cbnConcentration &&
+        regimen.product.cbnConcentration > 0
+      )
+        cannabinoids.push("CBN");
+      if (
+        regimen.product.cbgConcentration &&
+        regimen.product.cbgConcentration > 0
+      )
+        cannabinoids.push("CBG");
+
+      if (cannabinoids.length === 0) continue;
+
+      const newContraindications = filterNewContraindications(
+        matchedAll,
+        regimen.id,
+        existingObservations,
+      );
+
+      totalContraindicationsFound += newContraindications.length;
+
+      for (const c of newContraindications) {
+        const obs = await recordObservation({
+          patientId,
+          observedBy: "diagnosisSafety@1.0.0",
+          observedByKind: "agent",
+          category: "red_flag",
+          severity: CONTRAINDICATION_SEVERITY[c.severity],
+          summary: `Diagnosis update — ${c.label} now flagged against active ${regimen.product.name} regimen: ${c.rationale}`,
+          actionSuggested:
+            "Patient's regimen predates this flag. Review whether to taper, " +
+            "switch, or continue with documented override.",
+          evidence: {},
+          metadata: {
+            regimenId: regimen.id,
+            productId: regimen.productId,
+            checkKind: "post_diagnosis_contraindication",
+            contraindicationId: c.id,
+            contraindicationSeverity: c.severity,
+          },
+        });
+        observationIds.push(obs.id);
+      }
+    }
+
+    ctx.log("info", "Diagnosis safety scan complete", {
+      patientId,
+      regimensChecked: regimens.length,
+      contraindicationsFound: totalContraindicationsFound,
+      observationsWritten: observationIds.length,
+    });
+
+    return {
+      regimensChecked: regimens.length,
+      contraindicationsFound: totalContraindicationsFound,
+      observationsWritten: observationIds.length,
+      observationIds,
+    };
+  },
+};

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -19,6 +19,7 @@ import { dosingRecommendationAgent } from "./dosing-recommendation-agent";
 import { trendAlertAgent } from "./trend-alert-agent";
 import { titrationAgent } from "./titration-agent";
 import { prescriptionSafetyAgent } from "./prescription-safety-agent";
+import { diagnosisSafetyAgent } from "./diagnosis-safety-agent";
 import { adherenceDriftDetectorAgent } from "./adherence-drift-detector-agent";
 import { messageUrgencyObserverAgent } from "./message-urgency-observer-agent";
 import { visitDiscoveryWhispererAgent } from "./visit-discovery-whisperer-agent";
@@ -87,6 +88,7 @@ export const agentRegistry = {
   trendAlert: trendAlertAgent,
   titration: titrationAgent,
   prescriptionSafety: prescriptionSafetyAgent,
+  diagnosisSafety: diagnosisSafetyAgent,
   adherenceDriftDetector: adherenceDriftDetectorAgent,
   messageUrgencyObserver: messageUrgencyObserverAgent,
   visitDiscoveryWhisperer: visitDiscoveryWhispererAgent,

--- a/src/lib/orchestration/workflows.ts
+++ b/src/lib/orchestration/workflows.ts
@@ -415,6 +415,16 @@ export const workflows: WorkflowDefinition[] = [
     ],
   },
   {
+    name: "diagnosis-safety-check",
+    on: ["patient.diagnosis.updated"],
+    steps: [
+      {
+        agent: "diagnosisSafety",
+        input: (e) => ({ patientId: (e as any).patientId }),
+      },
+    ],
+  },
+  {
     name: "adherence-drift-check",
     on: ["adherence.checkup.requested"],
     steps: [


### PR DESCRIPTION
## Summary

Adds the fifth ambient agent: **`diagnosisSafety`**. Mirror of `prescriptionSafety` — instead of checking a new regimen against existing history, it re-checks every existing active regimen against a newly-updated diagnosis / contraindication record.

### Clinical rationale
A patient is safely prescribed THC. Six months later they are diagnosed with bipolar I. Today, nothing re-evaluates that regimen — `prescriptionSafety` only runs at prescribe-time. This agent closes that gap.

## Pattern (same as `prescriptionSafetyAgent`)

- `Agent<I, O>` with zod input/output schemas
- `allowedActions: ["read.patient", "write.outcome.reminder"]`
- `requiresApproval: false`, deterministic, no LLM
- Severity mapping: `absolute → urgent`, `relative → concern`, `caution → notable`
- Writes `ClinicalObservation` rows with `category: "red_flag"` and `metadata.checkKind: "post_diagnosis_contraindication"`

## Agent behavior

Input: `{ patientId }`. Output: `{ regimensChecked, contraindicationsFound, observationsWritten, observationIds }`.

1. Load patient (`presentingConcerns`, `contraindications`).
2. Load all active `DosingRegimen`s with product.
3. Short-circuit: no active regimens → return zeros. Empty history text → return zeros.
4. Keyword-match `CANNABIS_CONTRAINDICATIONS` against the concatenated history text.
5. For each active regimen (with at least one cannabinoid > 0), filter the matched set against existing unresolved observations keyed by `metadata.regimenId === regimen.id && metadata.contraindicationId === c.id && resolvedAt === null`. This dedup prevents spamming observations on repeat event fires.
6. For each newly-matched pair, write a `ClinicalObservation` with:
   - `summary: "Diagnosis update — {label} now flagged against active {productName} regimen: {rationale}"`
   - `actionSuggested: "Patient's regimen predates this flag. Review whether to taper, switch, or continue with documented override."`

## Event wiring status

The `patient.diagnosis.updated` event is declared in `src/lib/orchestration/events.ts` but **remains a ghost** — no code path dispatches it today. I grepped every `prisma.patient.update` call; none of them touch `contraindications` or act as a clinician-facing diagnosis edit. The registered update sites are the patient portal intake (`patient.intake.updated`) and profile actions (no event).

**Gap to close in a follow-up:** when a clinician-facing diagnosis / contraindication edit UI lands, the action should call:

```ts
await dispatch({
  name: "patient.diagnosis.updated",
  patientId: patient.id,
  organizationId: patient.organizationId,
});
```

Once emitted, `diagnosis-safety-check` + the pre-existing `registry-refresh` workflow both run in parallel.

## Registration

- `agentRegistry.diagnosisSafety` in `src/lib/agents/index.ts`
- Workflow `diagnosis-safety-check` in `src/lib/orchestration/workflows.ts`, listening on `patient.diagnosis.updated`

## Test coverage

`src/lib/agents/diagnosis-safety-agent.test.ts` — 9 tests for the two exported pure helpers:

- `buildHistoryText` — 3 tests (concatenation / null fields / empty array)
- `filterNewContraindications` — 6 tests (no observations / same-regimen dedup / resolved observations don't dedup / cross-regimen doesn't dedup / malformed metadata / fully-covered case)

Total suite: **44 passing** (up from 35).

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm test` — 44/44 passing
- [x] `npm run build` — succeeds

## Test plan

- [ ] Ensure existing `prescriptionSafety` tests still pass (they do)
- [ ] Once diagnosis-edit UI exists, integration-test the end-to-end flow: edit diagnosis → event dispatch → observation appears in Clinical Discovery feed

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C