### PR TITLE
feat(command): multi-metric sparklines (pain + sleep + anxiety + mood + adherence)

### DIFF
--- a/src/components/command/schedule-card-data.ts
+++ b/src/components/command/schedule-card-data.ts
@@ -362,8 +362,16 @@ export interface FeaturedSnapshot {
     actionSuggested: string | null;
     createdAt: Date;
   }>;
-  /** Last 30 days of pain OutcomeLog values for the sparkline. Oldest first. */
-  painSparkline: Array<{ value: number; loggedAt: Date }>;
+  /** Last 30 days of OutcomeLog values per metric for the peek sparkline
+   *  stack. Oldest first. Metrics with no logs return an empty array; the
+   *  caller filters out metrics with <2 points before rendering. */
+  metricSparklines: {
+    pain: Array<{ value: number; loggedAt: Date }>;
+    sleep: Array<{ value: number; loggedAt: Date }>;
+    anxiety: Array<{ value: number; loggedAt: Date }>;
+    mood: Array<{ value: number; loggedAt: Date }>;
+    adherence: Array<{ value: number; loggedAt: Date }>;
+  };
   /** Snippet from the most recently completed encounter's finalized note. */
   lastEncounter: {
     reason: string | null;
@@ -384,7 +392,7 @@ export async function loadFeaturedSnapshot(
     activeMeds,
     regimens,
     observations,
-    painLogs,
+    metricLogs,
     lastEncounter,
   ] = await Promise.all([
     prisma.patient
@@ -445,17 +453,21 @@ export async function loadFeaturedSnapshot(
         },
       })
       .catch(() => []),
+    // One grouped query for all five sparkline metrics; split in-memory
+    // below. Avoids five round-trips to the database per featured peek.
     prisma.outcomeLog
       .findMany({
         where: {
           patientId,
-          metric: "pain",
+          metric: { in: ["pain", "sleep", "anxiety", "mood", "adherence"] },
           loggedAt: { gte: thirtyDaysAgo },
         },
         orderBy: { loggedAt: "asc" },
-        select: { value: true, loggedAt: true },
+        select: { metric: true, value: true, loggedAt: true },
       })
-      .catch(() => []),
+      .catch(
+        () => [] as Array<{ metric: string; value: number; loggedAt: Date }>,
+      ),
     prisma.encounter
       .findFirst({
         where: {
@@ -505,6 +517,24 @@ export async function loadFeaturedSnapshot(
       }
     : null;
 
+  // Split the single grouped outcome-log query into per-metric arrays.
+  // The DB query is already sorted by loggedAt asc, so each bucket stays
+  // oldest-first after the push.
+  const metricSparklines: FeaturedSnapshot["metricSparklines"] = {
+    pain: [],
+    sleep: [],
+    anxiety: [],
+    mood: [],
+    adherence: [],
+  };
+  for (const log of metricLogs) {
+    const bucket =
+      metricSparklines[log.metric as keyof typeof metricSparklines];
+    if (bucket) {
+      bucket.push({ value: log.value, loggedAt: log.loggedAt });
+    }
+  }
+
   return {
     allergies: patient.allergies ?? [],
     activeMedCount,
@@ -517,7 +547,7 @@ export async function loadFeaturedSnapshot(
       frequencyPerDay: r.frequencyPerDay,
     })),
     recentObservations,
-    painSparkline: painLogs,
+    metricSparklines,
     lastEncounter: lastEncounterSummary,
   };
 }

--- a/src/components/command/schedule-tile.tsx
+++ b/src/components/command/schedule-tile.tsx
@@ -472,9 +472,23 @@ function SchedulePeek({
         </div>
       )}
 
-      {/* Pain sparkline — featured only, only if >=2 data points */}
-      {snapshot && snapshot.painSparkline.length >= 2 && (
-        <PainSparkline points={snapshot.painSparkline} />
+      {/* Multi-metric sparkline stack — featured only. Each metric renders
+          only if it has >=2 data points in the last 30 days. Rendered server-
+          side; no hydration cost. */}
+      {snapshot && (
+        <div className="mt-3 space-y-2">
+          {METRIC_ORDER.map((m) =>
+            snapshot.metricSparklines[m].length >= 2 ? (
+              <MetricSparkline
+                key={m}
+                label={METRIC_LABELS[m]}
+                points={snapshot.metricSparklines[m]}
+                invertTrend={INVERTED_TRENDS.has(m)}
+                yMax={m === "adherence" ? 100 : 10}
+              />
+            ) : null,
+          )}
+        </div>
       )}
 
       {/* Active meds list — featured only */}
@@ -643,58 +657,103 @@ function formatRegimenDose(r: {
 }
 
 /**
- * Inline SVG sparkline of the patient's pain scores (0-10 scale) over the
- * last 30 days. Pure SVG — no chart library, no hydration cost. Y-axis
- * is inverted so higher pain points visually rise to the top.
+ * Peek sparkline-stack configuration. Keeps the peek's render call site
+ * terse while letting us centralize label copy and trend-direction polarity.
+ *
+ * `invertTrend` controls the color semantics: for pain / anxiety, LOWER is
+ * clinically better, so a dropping line is green. For sleep / mood /
+ * adherence, HIGHER is clinically better — the color rule flips.
  */
-function PainSparkline({
+const METRIC_ORDER = ["pain", "sleep", "anxiety", "mood", "adherence"] as const;
+
+type SparklineMetric = (typeof METRIC_ORDER)[number];
+
+const METRIC_LABELS: Record<SparklineMetric, string> = {
+  pain: "Pain",
+  sleep: "Sleep",
+  anxiety: "Anxiety",
+  mood: "Mood",
+  adherence: "Adherence",
+};
+
+const INVERTED_TRENDS: ReadonlySet<SparklineMetric> = new Set([
+  "sleep",
+  "mood",
+  "adherence",
+]);
+
+/**
+ * Inline SVG sparkline of a single outcome metric (pain / sleep / anxiety /
+ * mood / adherence) over the last 30 days. Pure SVG — no chart library, no
+ * hydration cost. Y-axis is inverted so higher values visually rise to the top.
+ *
+ * `invertTrend` flips the trend-color semantics: when true (sleep / mood /
+ * adherence), a RISING line is green because higher is clinically better.
+ * When false (pain / anxiety), a DROPPING line is green.
+ *
+ * `yMax` lets adherence scale to its 0-100% range while other metrics stay
+ * on the 0-10 outcome scale.
+ */
+function MetricSparkline({
+  label,
   points,
+  invertTrend = false,
+  yMax = 10,
 }: {
+  label: string;
   points: Array<{ value: number; loggedAt: Date }>;
+  invertTrend?: boolean;
+  yMax?: number;
 }) {
   if (points.length < 2) return null;
   const first = points[0].value;
   const last = points[points.length - 1].value;
   const delta = last - first;
-  // Pain is inverted — lower is clinically better. Trend colors follow
-  // clinical direction, not axis direction.
-  const trendColor =
-    delta <= -1
-      ? "var(--success, #16a34a)"
-      : delta >= 1
-        ? "#dc2626"
-        : "var(--text-subtle, #737373)";
+
+  // "Improving" means delta < 0 for pain/anxiety (lower = better), delta > 0
+  // for sleep/mood/adherence (higher = better). A small threshold keeps
+  // near-flat noise from reading as a trend.
+  const threshold = yMax >= 100 ? 5 : 1;
+  const isImproving = invertTrend ? delta >= threshold : delta <= -threshold;
+  const isWorsening = invertTrend ? delta <= -threshold : delta >= threshold;
+  const trendColor = isImproving
+    ? "var(--success, #16a34a)"
+    : isWorsening
+      ? "#dc2626"
+      : "var(--text-subtle, #737373)";
 
   const width = 320;
   const height = 40;
   const pad = 2;
   const xStep = (width - pad * 2) / Math.max(1, points.length - 1);
-  // Pain is 0-10. Pin to the full range so sparkline doesn't exaggerate
-  // small swings on a patient who lives at 3-4.
-  const yMax = 10;
   const coords = points.map((p, i) => {
     const x = pad + i * xStep;
-    // Invert: higher pain → higher on chart.
-    const y = height - pad - (Math.min(yMax, Math.max(0, p.value)) / yMax) * (height - pad * 2);
+    // Invert: higher raw value → higher on chart.
+    const y =
+      height - pad - (Math.min(yMax, Math.max(0, p.value)) / yMax) * (height - pad * 2);
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   });
   const pathD = `M ${coords.join(" L ")}`;
 
+  // Adherence shows as a percentage; everything else as a raw 0-10 score.
+  const fmt = (v: number) =>
+    yMax >= 100 ? `${Math.round(v)}%` : `${Math.round(v * 10) / 10}`;
+
   return (
-    <div className="mt-3">
+    <div>
       <div className="flex items-baseline justify-between">
-        <p className="text-[11px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
-          Pain · 30d
+        <p className="text-[10px] uppercase tracking-[0.1em] text-text-subtle font-semibold">
+          {label} · 30d
         </p>
-        <p className="text-[11px] tabular-nums" style={{ color: trendColor }}>
-          {first} → {last}
+        <p className="text-[10px] tabular-nums" style={{ color: trendColor }}>
+          {fmt(first)} → {fmt(last)}
         </p>
       </div>
       <svg
         role="img"
-        aria-label={`Pain trend sparkline. Started at ${first}, currently ${last}, ${points.length} data points.`}
+        aria-label={`${label} trend sparkline. Started at ${fmt(first)}, currently ${fmt(last)}, ${points.length} data points.`}
         viewBox={`0 0 ${width} ${height}`}
-        className="mt-1 w-full h-8"
+        className="mt-0.5 w-full h-6"
         preserveAspectRatio="none"
       >
         <path


### PR DESCRIPTION
## Summary

Extends the featured-appointment peek's single pain sparkline into a vertical
stack of up to five mini-sparklines — Pain, Sleep, Anxiety, Mood, and
Adherence — each labeled with its metric name and start-to-end values.
Stays a Server Component (no client state, no hydration cost).

Stacks on top of #40 — base branch is `claude/peek-chart-at-a-glance`, not
`main`, because this PR extends the sparkline component that lands there.

### Data loader (single-query optimization)

`loadFeaturedSnapshot` used to issue one `outcomeLog.findMany` filtered to
`metric: "pain"`. It now issues **one grouped query** with
`metric: { in: ["pain", "sleep", "anxiety", "mood", "adherence"] }` and splits
the result in-memory into per-metric buckets. One round-trip to the database
instead of five, and the `(patientId, metric, loggedAt)` index on `OutcomeLog`
still serves the filter efficiently.

The snapshot type replaces `painSparkline: Array<…>` with
`metricSparklines: { pain, sleep, anxiety, mood, adherence }`, each carrying
the same `Array<{ value, loggedAt }>` shape (oldest first).

### `invertTrend` semantics

`PainSparkline` became `MetricSparkline` with a new `invertTrend` prop that
flips the trend-color polarity:

- `invertTrend=false` (pain, anxiety) — LOWER is clinically better, so a
  dropping line renders green and a rising line renders red.
- `invertTrend=true` (sleep, mood, adherence) — HIGHER is clinically better,
  so the color rule flips: rising line is green, dropping line is red.

A small `threshold` keeps near-flat noise from reading as a trend (±1 on the
0-10 scale, ±5 on the 0-100 adherence scale).

### `yMax` for adherence

Mood / anxiety / pain / sleep share the 0-10 outcome scale. Adherence is a
0-100 percentage. The new `yMax` prop lets the sparkline scale adherence to
its own range (so a 70% adherence log doesn't plot at the very top of a 0-10
chart), and the inline `start → end` readout formats adherence as a percent
while the other metrics show raw values.

### Visual

Each mini-sparkline is more condensed than the original single-sparkline
layout (`h-6` vs `h-8`, `text-[10px]` labels), and the stack uses
`space-y-2` so the five lines read as a compact dashboard rather than a
wall of charts. Metrics with fewer than 2 data points in the last 30 days
are omitted.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [ ] Hover a featured appointment in `/clinic/command` and verify the peek
      renders up to five stacked sparklines (only metrics with ≥2 logs appear)
- [ ] Verify adherence sparkline displays `%` in the start→end readout and
      scales its y-axis to 0-100
- [ ] Verify sleep / mood / adherence lines render green when rising,
      red when dropping; pain / anxiety render green when dropping, red
      when rising
- [ ] Verify the "Fleet is noticing" observation block below the sparklines
      is untouched (another agent's territory)

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C