### PR TITLE
feat(ops): live KPI dashboard replaces /ops landing page

### DIFF
--- a/src/app/(operator)/ops/page.tsx
+++ b/src/app/(operator)/ops/page.tsx
@@ -1,308 +1,39 @@
-import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
-import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
-import { MetricTile } from "@/components/ui/metric-tile";
-import { EmptyState } from "@/components/ui/empty-state";
-import { Badge } from "@/components/ui/badge";
-import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { Eyebrow } from "@/components/ui/ornament";
 import { AmbientOrb } from "@/components/ui/hero-art";
-import { formatRelative } from "@/lib/utils/format";
+import { OwnerDashboard } from "@/components/operator/owner-dashboard";
+import { loadOwnerKpis } from "@/lib/domain/owner-kpis";
 
 export const metadata = { title: "Practice overview" };
 
+// The owner home: a heart-of-the-business KPI snapshot.
+// One Promise.all of small queries against existing tables — no new schema.
 export default async function OpsOverviewPage() {
   const user = await requireUser();
   const orgId = user.organizationId!;
 
-  const [
-    patientCount,
-    prospectCount,
-    inactiveCount,
-    openTasks,
-    launchStatus,
-    recentJobs,
-    allPatients,
-  ] = await Promise.all([
-    prisma.patient.count({ where: { organizationId: orgId, status: "active" } }),
-    prisma.patient.count({ where: { organizationId: orgId, status: "prospect" } }),
-    prisma.patient.count({ where: { organizationId: orgId, status: "inactive" } }),
-    prisma.task.count({ where: { organizationId: orgId, status: "open" } }),
-    prisma.practiceLaunchStatus.findUnique({ where: { organizationId: orgId } }),
-    prisma.agentJob.findMany({
-      where: { organizationId: orgId },
-      orderBy: { createdAt: "desc" },
-      take: 6,
-    }),
-    prisma.patient.findMany({
-      where: { organizationId: orgId, deletedAt: null },
-      select: {
-        id: true,
-        status: true,
-        chartSummary: { select: { completenessScore: true } },
-        intakeAnswers: true,
-      },
-    }),
-  ]);
-
-  // Compute intake funnel buckets
-  // Prospects with no intake = "Not started"
-  // Prospects with some intake answers = partial (estimate completeness from field count)
-  let notStarted = 0;
-  let intakeUnder50 = 0;
-  let intake50to99 = 0;
-  let intakeComplete = 0;
-
-  for (const p of allPatients) {
-    if (p.status !== "prospect") continue;
-    const chartScore = p.chartSummary?.completenessScore ?? 0;
-    // Use chart completeness if available, else estimate from intakeAnswers
-    const answers = p.intakeAnswers as Record<string, unknown> | null;
-    const answerCount = answers ? Object.keys(answers).length : 0;
-    // Rough mapping: 0 answers = not started, chart score overrides if present
-    const score = chartScore > 0 ? chartScore : answerCount === 0 ? 0 : Math.min(answerCount * 10, 99);
-    if (score === 0) notStarted++;
-    else if (score < 50) intakeUnder50++;
-    else if (score < 100) intake50to99++;
-    else intakeComplete++;
-  }
+  const snapshot = await loadOwnerKpis(orgId);
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
-      {/* ------------------ Hero ------------------ */}
+      {/* Hero */}
       <section className="relative overflow-hidden rounded-3xl border border-border bg-surface-raised ambient mb-10">
         <AmbientOrb className="absolute -right-10 -top-4 h-[260px] w-[500px] opacity-90" />
         <div className="relative px-8 md:px-12 py-12 md:py-14 max-w-3xl">
           <Eyebrow className="mb-4">Practice operations</Eyebrow>
           <h1 className="font-display text-4xl md:text-5xl leading-[1.05] tracking-tight text-text">
-            {user.organizationName ?? "Your practice"}, at a glance.
+            {user.organizationName ?? "Your practice"}, in one glance.
           </h1>
           <p className="text-[15px] text-text-muted mt-4 leading-relaxed max-w-2xl">
-            A quiet command center. Patient flow, agent activity, and
-            go-live readiness, all in one view.
+            Money in, work in flight, where attention is needed. The numbers
+            you check ten times a day, in one quiet view.
           </p>
         </div>
       </section>
 
-      {/* ------------------ Metric strip ------------------ */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
-        <MetricTile label="Active patients" value={patientCount} accent="forest" />
-        <MetricTile label="In intake" value={prospectCount} accent="amber" />
-        <MetricTile label="Open tasks" value={openTasks} />
-        <MetricTile
-          label="Launch readiness"
-          value={launchStatus ? `${launchStatus.readinessScore}%` : "\u2014"}
-        />
-      </div>
-
-      {/* ------------------ Intake funnel ------------------ */}
-      <Card tone="raised" className="mb-10">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <LeafSprig size={16} className="text-accent/80" />
-            Intake funnel
-          </CardTitle>
-          <CardDescription>
-            Patient progression from first contact through completed intake and active care.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-stretch gap-0">
-            <FunnelStep
-              label="Prospects"
-              sublabel="Not started"
-              value={notStarted}
-              color="bg-surface-muted"
-              textColor="text-text-muted"
-              isFirst
-            />
-            <FunnelArrow />
-            <FunnelStep
-              label="Intake"
-              sublabel="< 50%"
-              value={intakeUnder50}
-              color="bg-highlight-soft"
-              textColor="text-[color:var(--highlight-hover)]"
-            />
-            <FunnelArrow />
-            <FunnelStep
-              label="Intake"
-              sublabel="50\u2013 99%"
-              value={intake50to99}
-              color="bg-highlight-soft"
-              textColor="text-[color:var(--highlight)]"
-            />
-            <FunnelArrow />
-            <FunnelStep
-              label="Intake"
-              sublabel="100%"
-              value={intakeComplete}
-              color="bg-accent-soft"
-              textColor="text-accent"
-            />
-            <FunnelArrow />
-            <FunnelStep
-              label="Active"
-              sublabel="patients"
-              value={patientCount}
-              color="bg-accent-soft"
-              textColor="text-accent"
-              isLast
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* ------------------ Agent activity + launch ------------------ */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <Card className="lg:col-span-2" tone="raised">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <LeafSprig size={16} className="text-accent/80" />
-              Recent agent activity
-            </CardTitle>
-            <CardDescription>
-              A live view of what the orchestration layer is doing right now.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {recentJobs.length === 0 ? (
-              <EmptyState
-                title="No agent activity yet"
-                description="As patients and clinicians use the platform, agent work will appear here."
-              />
-            ) : (
-              <ul className="divide-y divide-border/70 -mx-6">
-                {recentJobs.map((j) => (
-                  <li
-                    key={j.id}
-                    className="px-6 py-4 flex items-center justify-between gap-4"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
-                        <p className="text-sm font-medium text-text">
-                          {j.workflowName}
-                          <span className="text-text-subtle"> · </span>
-                          <span className="font-mono text-xs text-text-muted">
-                            {j.agentName}
-                          </span>
-                        </p>
-                      </div>
-                      <p className="text-xs text-text-subtle mt-1 ml-3.5 font-mono">
-                        {j.eventName} · {formatRelative(j.createdAt)}
-                      </p>
-                    </div>
-                    <Badge tone={jobTone(j.status)}>{j.status.replace("_", " ")}</Badge>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card tone="raised">
-          <CardHeader>
-            <CardTitle>Launch checklist</CardTitle>
-            <CardDescription>Progress toward go-live.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {launchStatus ? (
-              <>
-                <div className="flex items-end gap-3 mb-4">
-                  <span className="font-display text-4xl text-text tabular-nums leading-none">
-                    {launchStatus.readinessScore}
-                  </span>
-                  <span className="text-sm text-text-muted mb-1">/ 100</span>
-                </div>
-                <div className="relative h-2 bg-surface-muted rounded-full overflow-hidden mb-5">
-                  <div
-                    className="h-full bg-gradient-to-r from-accent to-[#3A8560] rounded-full transition-all"
-                    style={{ width: `${launchStatus.readinessScore}%` }}
-                  />
-                </div>
-                <ul className="space-y-2.5">
-                  {(launchStatus.nextSteps as string[]).map((step) => (
-                    <li
-                      key={step}
-                      className="text-sm text-text-muted flex items-start gap-2.5"
-                    >
-                      <LeafSprig size={14} className="text-accent/70 mt-0.5 shrink-0" />
-                      {step}
-                    </li>
-                  ))}
-                </ul>
-              </>
-            ) : (
-              <p className="text-sm text-text-muted">No launch status yet.</p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+      {/* The dashboard */}
+      <OwnerDashboard snapshot={snapshot} />
     </PageShell>
-  );
-}
-
-function jobTone(status: string) {
-  if (status === "succeeded") return "success" as const;
-  if (status === "failed") return "danger" as const;
-  if (status === "needs_approval") return "warning" as const;
-  if (status === "running" || status === "claimed") return "info" as const;
-  return "neutral" as const;
-}
-
-function FunnelStep({
-  label,
-  sublabel,
-  value,
-  color,
-  textColor,
-  isFirst,
-  isLast,
-}: {
-  label: string;
-  sublabel: string;
-  value: number;
-  color: string;
-  textColor: string;
-  isFirst?: boolean;
-  isLast?: boolean;
-}) {
-  return (
-    <div
-      className={`flex-1 ${color} p-4 flex flex-col items-center justify-center text-center min-h-[100px] ${
-        isFirst ? "rounded-l-xl" : ""
-      } ${isLast ? "rounded-r-xl" : ""}`}
-    >
-      <span className={`font-display text-2xl md:text-3xl font-medium tabular-nums leading-none ${textColor}`}>
-        {value}
-      </span>
-      <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-text-subtle mt-2">
-        {label}
-      </span>
-      <span className="text-[10px] text-text-subtle">{sublabel}</span>
-    </div>
-  );
-}
-
-function FunnelArrow() {
-  return (
-    <div className="flex items-center justify-center w-6 shrink-0 -mx-px">
-      <svg
-        width="12"
-        height="24"
-        viewBox="0 0 12 24"
-        fill="none"
-        className="text-border-strong/60"
-      >
-        <path
-          d="M2 2L10 12L2 22"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </div>
   );
 }

--- a/src/components/operator/kpi-card.tsx
+++ b/src/components/operator/kpi-card.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------------------
+// KpiCard — a single owner-dashboard tile.
+//
+// Apple-iOS-ish: rounded-2xl, soft border, generous padding, big tabular
+// headline, quiet trend indicator. The whole tile is a click target.
+// A severity dot in the top-right communicates urgency at a glance.
+// ---------------------------------------------------------------------------
+
+export type KpiSeverity = "good" | "warn" | "bad";
+export type KpiTrendDirection = "up" | "down" | "flat";
+
+export interface KpiTrend {
+  direction: KpiTrendDirection;
+  /** percent change vs prior period; null when prior was 0 */
+  percent: number | null;
+  /** "up" can be good (revenue) or bad (denials); the card decides */
+  goodWhen: "up" | "down" | "either";
+}
+
+export interface KpiCardProps {
+  eyebrow: string;
+  headline: string;
+  subtext?: string;
+  href: string;
+  trend?: KpiTrend;
+  severity?: KpiSeverity;
+  /** Subtle pulsing dot next to the headline (e.g. "agent running"). */
+  pulse?: boolean;
+  className?: string;
+}
+
+const SEVERITY_DOT: Record<KpiSeverity, string> = {
+  good: "bg-accent",
+  warn: "bg-highlight",
+  bad: "bg-[color:var(--danger)]",
+};
+
+export function KpiCard({
+  eyebrow,
+  headline,
+  subtext,
+  href,
+  trend,
+  severity,
+  pulse,
+  className,
+}: KpiCardProps) {
+  return (
+    <Link
+      href={href}
+      aria-label={`${eyebrow}: ${headline}`}
+      className={cn(
+        "group relative block rounded-2xl border border-border/80 bg-surface-raised",
+        "shadow-sm transition-all duration-200 ease-smooth",
+        "hover:shadow-md hover:-translate-y-0.5 hover:border-border-strong",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+        "px-6 py-6",
+        className,
+      )}
+    >
+      {severity && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute right-4 top-4 h-1.5 w-1.5 rounded-full",
+            SEVERITY_DOT[severity],
+          )}
+        />
+      )}
+
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+        {eyebrow}
+      </p>
+
+      <div className="mt-3 flex items-baseline gap-3">
+        <span className="font-display text-3xl font-semibold text-text tabular-nums leading-none">
+          {headline}
+        </span>
+        {pulse && (
+          <span
+            aria-hidden="true"
+            className="relative flex h-2 w-2"
+            title="Live"
+          >
+            <span className="absolute inset-0 rounded-full bg-accent/60 animate-ping" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+          </span>
+        )}
+        {trend && trend.direction !== "flat" && (
+          <KpiTrendBadge trend={trend} />
+        )}
+      </div>
+
+      {subtext && (
+        <p className="text-xs text-text-muted mt-3 leading-snug">{subtext}</p>
+      )}
+    </Link>
+  );
+}
+
+function KpiTrendBadge({ trend }: { trend: KpiTrend }) {
+  const isUp = trend.direction === "up";
+  const isGood =
+    trend.goodWhen === "either"
+      ? true
+      : (trend.goodWhen === "up" && isUp) || (trend.goodWhen === "down" && !isUp);
+
+  const color = isGood ? "text-accent" : "text-danger";
+
+  const arrow = isUp ? "\u2191" : "\u2193";
+  const pct =
+    trend.percent === null
+      ? "new"
+      : `${Math.abs(trend.percent).toFixed(trend.percent % 1 === 0 ? 0 : 1)}%`;
+
+  return (
+    <span className={cn("text-xs font-medium tabular-nums", color)}>
+      {arrow} {pct}
+    </span>
+  );
+}

--- a/src/components/operator/owner-dashboard.tsx
+++ b/src/components/operator/owner-dashboard.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { KpiCard, type KpiSeverity, type KpiTrend } from "./kpi-card";
+import {
+  computeTrend,
+  denialSeverity,
+  arSeverity,
+  type OwnerKpiSnapshot,
+} from "@/lib/domain/owner-kpis";
+import { formatMoneyCompact, formatMoney } from "@/lib/domain/billing";
+
+// ---------------------------------------------------------------------------
+// OwnerDashboard — composes the 6 KPI tiles in a 1/2/3-column grid.
+//
+// The render is purely a function of an OwnerKpiSnapshot. The snapshot
+// itself is loaded by the page in a single Promise.all upstream; this
+// component does no I/O.
+// ---------------------------------------------------------------------------
+
+export interface OwnerDashboardProps {
+  snapshot: OwnerKpiSnapshot;
+}
+
+export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
+  // ---------- 1. Revenue this week ----------
+  const revenueTrend = computeTrend(
+    snapshot.revenueThisWeekCents,
+    snapshot.revenuePriorWeekCents,
+  );
+  const revenueCard = {
+    eyebrow: "Revenue this week",
+    headline: formatMoneyCompact(snapshot.revenueThisWeekCents),
+    subtext:
+      snapshot.revenuePriorWeekCents > 0
+        ? `${formatMoneyCompact(snapshot.revenuePriorWeekCents)} prior 7 days`
+        : "No revenue in the prior 7 days",
+    href: "/ops/revenue",
+    trend: {
+      direction: revenueTrend.direction,
+      percent: revenueTrend.percent,
+      goodWhen: "up",
+    } as KpiTrend,
+  };
+
+  // ---------- 2. Denials queue ----------
+  const denialsSev: KpiSeverity = denialSeverity(snapshot.denials);
+  const denialsCard = {
+    eyebrow: "Denials queue",
+    headline: snapshot.denials.unresolvedCount.toString(),
+    subtext:
+      snapshot.denials.unresolvedCount === 0
+        ? "All denials resolved"
+        : snapshot.denials.oldestDays !== null
+          ? `oldest ${snapshot.denials.oldestDays}d`
+          : "Awaiting triage",
+    href: "/ops/denials",
+    severity: denialsSev,
+  };
+
+  // ---------- 3. Schedule fill rate ----------
+  const fillPct = snapshot.scheduleFillPct;
+  const scheduleCard = {
+    eyebrow: "Schedule fill",
+    headline: fillPct === null ? "\u2014" : `${fillPct}%`,
+    subtext:
+      fillPct === null
+        ? "No active providers configured"
+        : `${snapshot.visitsToday} visits today, ${snapshot.openSlotsToday} open slots`,
+    href: "/ops/schedule",
+  };
+
+  // ---------- 4. Agent fleet status ----------
+  const agentsCard = {
+    eyebrow: "Agent fleet",
+    headline: snapshot.agents.running.toString(),
+    subtext: `${snapshot.agents.running} processing, ${snapshot.agents.completedToday} completed today`,
+    href: "/ops/agents",
+    pulse: snapshot.agents.running > 0,
+  };
+
+  // ---------- 5. New patients this week ----------
+  const patientsTrend = computeTrend(
+    snapshot.newPatientsThisWeek,
+    snapshot.newPatientsPriorWeek,
+  );
+  const patientsCard = {
+    eyebrow: "New patients (7d)",
+    headline: snapshot.newPatientsThisWeek.toString(),
+    subtext:
+      snapshot.newPatientsPriorWeek > 0
+        ? `${snapshot.newPatientsPriorWeek} in the prior 7 days`
+        : "No new patients in the prior 7 days",
+    href: "/ops/patients",
+    trend: {
+      direction: patientsTrend.direction,
+      percent: patientsTrend.percent,
+      goodWhen: "up",
+    } as KpiTrend,
+  };
+
+  // ---------- 6. AR aging ----------
+  // We don't surface the oldest past-due day count separately, but the
+  // severity tier uses the dollar threshold (>$10k) which is enough to
+  // escalate. A future iteration can wire the oldestPastDueDays through.
+  const arSev: KpiSeverity = arSeverity({
+    arAgingCents: snapshot.arAgingCents,
+    oldestPastDueDays: snapshot.arPastDueCount > 0 ? 31 : null,
+  });
+  const arCard = {
+    eyebrow: "AR aging \u226530d",
+    headline: formatMoney(snapshot.arAgingCents),
+    subtext:
+      snapshot.arPastDueCount === 0
+        ? "Nothing past due"
+        : `${snapshot.arPastDueCount} claim${snapshot.arPastDueCount === 1 ? "" : "s"} past due`,
+    href: "/ops/aging",
+    severity: arSev,
+  };
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <KpiCard {...revenueCard} />
+      <KpiCard {...denialsCard} />
+      <KpiCard {...scheduleCard} />
+      <KpiCard {...agentsCard} />
+      <KpiCard {...patientsCard} />
+      <KpiCard {...arCard} />
+    </div>
+  );
+}

--- a/src/lib/domain/owner-kpis.test.ts
+++ b/src/lib/domain/owner-kpis.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { computeTrend, denialSeverity, arSeverity } from "./owner-kpis";
+
+describe("computeTrend", () => {
+  it("returns flat with 0% when current equals prior", () => {
+    expect(computeTrend(100, 100)).toEqual({ direction: "flat", percent: 0 });
+    expect(computeTrend(0, 0)).toEqual({ direction: "flat", percent: 0 });
+  });
+
+  it("returns up with positive percent when current > prior", () => {
+    expect(computeTrend(120, 100)).toEqual({ direction: "up", percent: 20 });
+  });
+
+  it("returns down with negative percent when current < prior", () => {
+    expect(computeTrend(80, 100)).toEqual({ direction: "down", percent: -20 });
+  });
+
+  it("rounds to one decimal", () => {
+    // (110 - 100) / 100 = 10.0 exact
+    expect(computeTrend(110, 100).percent).toBe(10);
+    // (133 - 100) / 100 = 33.0 exact
+    expect(computeTrend(133, 100).percent).toBe(33);
+    // (101 - 99) / 99 ≈ 2.020... → rounded to 2
+    expect(computeTrend(101, 99).percent).toBe(2);
+  });
+
+  it("returns up with null percent when prior is 0 and current > 0", () => {
+    expect(computeTrend(50, 0)).toEqual({ direction: "up", percent: null });
+  });
+
+  it("treats negative current with prior=0 as down", () => {
+    // unusual, but defensive: -1 vs 0 should not divide
+    expect(computeTrend(-1, 0)).toEqual({ direction: "down", percent: null });
+  });
+});
+
+describe("denialSeverity", () => {
+  it("is good when there are no denials", () => {
+    expect(denialSeverity({ unresolvedCount: 0, oldestDays: null })).toBe("good");
+  });
+
+  it("is good when oldest is fresh (≤14 days)", () => {
+    expect(denialSeverity({ unresolvedCount: 5, oldestDays: 0 })).toBe("good");
+    expect(denialSeverity({ unresolvedCount: 5, oldestDays: 14 })).toBe("good");
+  });
+
+  it("is warn when oldest is 15-30 days", () => {
+    expect(denialSeverity({ unresolvedCount: 1, oldestDays: 15 })).toBe("warn");
+    expect(denialSeverity({ unresolvedCount: 1, oldestDays: 30 })).toBe("warn");
+  });
+
+  it("is bad when oldest is >30 days", () => {
+    expect(denialSeverity({ unresolvedCount: 1, oldestDays: 31 })).toBe("bad");
+    expect(denialSeverity({ unresolvedCount: 1, oldestDays: 90 })).toBe("bad");
+  });
+
+  it("is good when count > 0 but oldestDays is null (data inconsistency)", () => {
+    // Defensive: if oldestDays is unknown we don't escalate.
+    expect(denialSeverity({ unresolvedCount: 3, oldestDays: null })).toBe("good");
+  });
+});
+
+describe("arSeverity", () => {
+  it("is good when nothing is past due", () => {
+    expect(arSeverity({ arAgingCents: 0, oldestPastDueDays: null })).toBe("good");
+  });
+
+  it("is warn when there is past due under both thresholds", () => {
+    expect(arSeverity({ arAgingCents: 50_000, oldestPastDueDays: 35 })).toBe("warn");
+    expect(arSeverity({ arAgingCents: 999_999, oldestPastDueDays: 60 })).toBe("warn");
+  });
+
+  it("is bad when arAgingCents > $10k", () => {
+    expect(arSeverity({ arAgingCents: 1_000_001, oldestPastDueDays: 35 })).toBe("bad");
+  });
+
+  it("is bad when oldest past-due > 60 days", () => {
+    expect(arSeverity({ arAgingCents: 5_000, oldestPastDueDays: 61 })).toBe("bad");
+  });
+
+  it("is bad when both thresholds are crossed", () => {
+    expect(arSeverity({ arAgingCents: 5_000_000, oldestPastDueDays: 120 })).toBe("bad");
+  });
+});

--- a/src/lib/domain/owner-kpis.ts
+++ b/src/lib/domain/owner-kpis.ts
@@ -1,0 +1,317 @@
+import { prisma } from "@/lib/db/prisma";
+
+// ---------------------------------------------------------------------------
+// Owner KPIs — heart-of-the-business snapshot for /ops landing
+//
+// One Promise.all of focused queries against existing Prisma models.
+// Each query is wrapped in try/catch returning a sensible default so a
+// missing or empty table doesn't take down the whole dashboard.
+// ---------------------------------------------------------------------------
+
+export interface OwnerKpiSnapshot {
+  revenueThisWeekCents: number;
+  revenuePriorWeekCents: number;
+  denials: { unresolvedCount: number; oldestDays: number | null };
+  scheduleFillPct: number | null;
+  visitsToday: number;
+  openSlotsToday: number;
+  agents: { running: number; completedToday: number };
+  newPatientsThisWeek: number;
+  newPatientsPriorWeek: number;
+  arAgingCents: number;
+  arPastDueCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export type Trend = "up" | "down" | "flat";
+
+export interface TrendResult {
+  direction: Trend;
+  /** Percent change vs prior, e.g. 12.3 means +12.3%. null when prior is 0. */
+  percent: number | null;
+}
+
+/**
+ * Compute trend direction + percent delta vs prior period.
+ * Treats both zero as "flat". When prior is 0 and current > 0, returns
+ * direction "up" with percent null (cannot compute % change from zero).
+ */
+export function computeTrend(current: number, prior: number): TrendResult {
+  if (current === prior) return { direction: "flat", percent: 0 };
+  if (prior === 0) {
+    return { direction: current > 0 ? "up" : "down", percent: null };
+  }
+  const pct = ((current - prior) / prior) * 100;
+  return {
+    direction: pct > 0 ? "up" : pct < 0 ? "down" : "flat",
+    percent: Math.round(pct * 10) / 10,
+  };
+}
+
+export type Severity = "good" | "warn" | "bad";
+
+export interface DenialSeverityInput {
+  oldestDays: number | null;
+  unresolvedCount: number;
+}
+
+/**
+ * Severity tier for the denials queue.
+ * - bad:   any denial older than 30 days
+ * - warn:  any denial older than 14 days
+ * - good:  otherwise (including no denials at all)
+ */
+export function denialSeverity({ oldestDays, unresolvedCount }: DenialSeverityInput): Severity {
+  if (unresolvedCount === 0 || oldestDays === null) return "good";
+  if (oldestDays > 30) return "bad";
+  if (oldestDays > 14) return "warn";
+  return "good";
+}
+
+export interface ArSeverityInput {
+  arAgingCents: number;
+  /** Days since the OLDEST past-due claim was submitted (null if none). */
+  oldestPastDueDays: number | null;
+}
+
+/**
+ * Severity tier for AR aging.
+ * - bad:   > $10k outstanding OR oldest past-due > 60 days
+ * - warn:  any past-due (anything > 30 days)
+ * - good:  no past-due claims
+ */
+export function arSeverity({ arAgingCents, oldestPastDueDays }: ArSeverityInput): Severity {
+  if (oldestPastDueDays === null) return "good";
+  if (arAgingCents > 1_000_000 || oldestPastDueDays > 60) return "bad";
+  return "warn";
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 86_400_000;
+const SEVEN_DAYS_MS = 7 * MS_PER_DAY;
+
+/**
+ * Capacity assumption per active provider per day. We don't have a slot
+ * configuration table yet, so we approximate: each active provider exposes
+ * 8 visit slots per day. Tunable in one place when a real schedule template
+ * lands.
+ */
+const SLOTS_PER_PROVIDER_PER_DAY = 8;
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export async function loadOwnerKpis(organizationId: string): Promise<OwnerKpiSnapshot> {
+  const now = new Date();
+  const weekAgo = new Date(now.getTime() - SEVEN_DAYS_MS);
+  const twoWeeksAgo = new Date(now.getTime() - 2 * SEVEN_DAYS_MS);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * MS_PER_DAY);
+  const todayStart = startOfDay(now);
+  const todayEnd = endOfDay(now);
+
+  const [
+    revenueThisWeekCents,
+    revenuePriorWeekCents,
+    denials,
+    scheduleSnapshot,
+    agents,
+    newPatientsThisWeek,
+    newPatientsPriorWeek,
+    arSnapshot,
+  ] = await Promise.all([
+    safe(() => sumPayments(organizationId, weekAgo, now), 0),
+    safe(() => sumPayments(organizationId, twoWeeksAgo, weekAgo), 0),
+    safe(() => loadDenials(organizationId, now), { unresolvedCount: 0, oldestDays: null }),
+    safe(() => loadScheduleSnapshot(organizationId, todayStart, todayEnd), {
+      visitsToday: 0,
+      openSlotsToday: 0,
+      scheduleFillPct: null as number | null,
+    }),
+    safe(() => loadAgents(organizationId, todayStart), { running: 0, completedToday: 0 }),
+    safe(
+      () =>
+        prisma.patient.count({
+          where: { organizationId, createdAt: { gte: weekAgo, lt: now } },
+        }),
+      0,
+    ),
+    safe(
+      () =>
+        prisma.patient.count({
+          where: { organizationId, createdAt: { gte: twoWeeksAgo, lt: weekAgo } },
+        }),
+      0,
+    ),
+    safe(() => loadArAging(organizationId, thirtyDaysAgo), {
+      arAgingCents: 0,
+      arPastDueCount: 0,
+    }),
+  ]);
+
+  return {
+    revenueThisWeekCents,
+    revenuePriorWeekCents,
+    denials,
+    scheduleFillPct: scheduleSnapshot.scheduleFillPct,
+    visitsToday: scheduleSnapshot.visitsToday,
+    openSlotsToday: scheduleSnapshot.openSlotsToday,
+    agents,
+    newPatientsThisWeek,
+    newPatientsPriorWeek,
+    arAgingCents: arSnapshot.arAgingCents,
+    arPastDueCount: arSnapshot.arPastDueCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-KPI query helpers
+// ---------------------------------------------------------------------------
+
+async function sumPayments(
+  organizationId: string,
+  from: Date,
+  to: Date,
+): Promise<number> {
+  // Payment doesn't carry organizationId directly — scope through the parent
+  // claim. paymentDate is the cash-posting timestamp.
+  const result = await prisma.payment.aggregate({
+    _sum: { amountCents: true },
+    where: {
+      paymentDate: { gte: from, lt: to },
+      claim: { organizationId },
+    },
+  });
+  return result._sum.amountCents ?? 0;
+}
+
+async function loadDenials(
+  organizationId: string,
+  now: Date,
+): Promise<{ unresolvedCount: number; oldestDays: number | null }> {
+  // Unresolved = resolution still "pending". Scope via parent claim's org.
+  const [unresolvedCount, oldest] = await Promise.all([
+    prisma.denialEvent.count({
+      where: { resolution: "pending", claim: { organizationId } },
+    }),
+    prisma.denialEvent.findFirst({
+      where: { resolution: "pending", claim: { organizationId } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    }),
+  ]);
+
+  const oldestDays = oldest
+    ? Math.floor((now.getTime() - oldest.createdAt.getTime()) / MS_PER_DAY)
+    : null;
+
+  return { unresolvedCount, oldestDays };
+}
+
+async function loadScheduleSnapshot(
+  organizationId: string,
+  todayStart: Date,
+  todayEnd: Date,
+): Promise<{ visitsToday: number; openSlotsToday: number; scheduleFillPct: number | null }> {
+  // Appointment doesn't have organizationId — scope via patient.
+  // Capacity = active providers * SLOTS_PER_PROVIDER_PER_DAY.
+  const [visitsToday, activeProviders] = await Promise.all([
+    prisma.appointment.count({
+      where: {
+        startAt: { gte: todayStart, lte: todayEnd },
+        status: { in: ["requested", "confirmed", "completed"] },
+        patient: { organizationId },
+      },
+    }),
+    prisma.provider.count({ where: { organizationId, active: true } }),
+  ]);
+
+  const capacity = activeProviders * SLOTS_PER_PROVIDER_PER_DAY;
+  if (capacity === 0) {
+    return { visitsToday, openSlotsToday: 0, scheduleFillPct: null };
+  }
+  const openSlotsToday = Math.max(0, capacity - visitsToday);
+  const scheduleFillPct = Math.round((visitsToday / capacity) * 100);
+  return { visitsToday, openSlotsToday, scheduleFillPct };
+}
+
+async function loadAgents(
+  organizationId: string,
+  todayStart: Date,
+): Promise<{ running: number; completedToday: number }> {
+  const [running, completedToday] = await Promise.all([
+    prisma.agentJob.count({
+      where: { organizationId, status: { in: ["running", "claimed"] } },
+    }),
+    prisma.agentJob.count({
+      where: {
+        organizationId,
+        status: "succeeded",
+        completedAt: { gte: todayStart },
+      },
+    }),
+  ]);
+  return { running, completedToday };
+}
+
+async function loadArAging(
+  organizationId: string,
+  thirtyDaysAgo: Date,
+): Promise<{ arAgingCents: number; arPastDueCount: number }> {
+  // Past due = submitted >30 days ago AND still has outstanding balance
+  // (status indicates claim is open: submitted/accepted/adjudicated/partial).
+  const claims = await prisma.claim.findMany({
+    where: {
+      organizationId,
+      submittedAt: { lt: thirtyDaysAgo },
+      status: { in: ["submitted", "accepted", "adjudicated", "partial", "appealed"] },
+    },
+    select: { billedAmountCents: true, paidAmountCents: true },
+  });
+
+  let arAgingCents = 0;
+  let arPastDueCount = 0;
+  for (const c of claims) {
+    const balance = c.billedAmountCents - c.paidAmountCents;
+    if (balance > 0) {
+      arAgingCents += balance;
+      arPastDueCount += 1;
+    }
+  }
+  return { arAgingCents, arPastDueCount };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function endOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(23, 59, 59, 999);
+  return out;
+}
+
+/** Run a query and swallow errors — return the fallback so the dashboard renders. */
+async function safe<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn("[owner-kpis] query failed, using fallback:", err);
+    }
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary

Replace the generic `/ops` overview with a heart-of-the-business KPI dashboard the practice owner will actually want to look at 10x/day. Six tiles in a 1/2/3-column responsive grid, every tile a click target into the relevant deep view.

## The 6 KPIs

| # | KPI | Data source | Click target |
|---|-----|-------------|--------------|
| 1 | **Revenue this week** | `Payment.amountCents` summed where `paymentDate ∈ last 7d` and `claim.organizationId = orgId` | `/ops/revenue` |
| 2 | **Denials queue** | `DenialEvent` where `resolution = "pending"` and `claim.organizationId = orgId`; oldest by `createdAt` | `/ops/denials` |
| 3 | **Schedule fill** | `Appointment.count` today (status in requested/confirmed/completed) for the org's patients vs `Provider.count(active=true) * 8` slots | `/ops/schedule` |
| 4 | **Agent fleet** | `AgentJob` where `status ∈ (running, claimed)` plus `completedAt >= startOfDay AND status = succeeded` | `/ops/agents` |
| 5 | **New patients (7d)** | `Patient.count` where `createdAt ∈ last 7d` scoped to org | `/ops/patients` |
| 6 | **AR aging ≥30d** | `Claim` rows with `submittedAt < 30d ago` and open status (submitted/accepted/adjudicated/partial/appealed); sum of `billedAmountCents - paidAmountCents` | `/ops/aging` |

All eight queries run in a single `Promise.all`, each wrapped in a `safe()` helper that swallows errors and returns a sensible default — a missing or empty table never takes down the dashboard.

## Trend computation

Pure helper `computeTrend(current, prior)`:
- `current === prior` → `flat`, `0%`
- `prior === 0 && current > 0` → `up`, `null` (cannot divide; rendered as "new")
- otherwise → `((current - prior) / prior) * 100`, rounded to one decimal, direction by sign

Each card declares `goodWhen: "up" | "down" | "either"`, so revenue ↑ renders accent-green while denials ↑ would render danger-red.

## Severity tiering

A 6px dot in the top-right of each card communicates urgency at a glance.

**Denials** (`denialSeverity`):
- `bad` — any unresolved denial older than 30 days
- `warn` — any unresolved denial older than 14 days
- `good` — otherwise (or zero denials)

**AR aging** (`arSeverity`):
- `bad` — outstanding ≥30d > $10k OR oldest past-due > 60 days
- `warn` — anything past due
- `good` — nothing past due

Agent card additionally shows a subtle `animate-ping` pulse dot when `running > 0`, per the iOS-aesthetic directive in CLAUDE.md.

## Architecture

- `src/lib/domain/owner-kpis.ts` — pure data loader (`loadOwnerKpis(organizationId)`), `OwnerKpiSnapshot` type, exported pure helpers (`computeTrend`, `denialSeverity`, `arSeverity`)
- `src/components/operator/kpi-card.tsx` — single reusable tile (`<Link>`-wrapped, severity dot, trend badge, optional pulse)
- `src/components/operator/owner-dashboard.tsx` — composition of the 6 tiles in a responsive grid
- `src/app/(operator)/ops/page.tsx` — Server Component: load snapshot, render hero + dashboard

## Verification

- `npm test` — 60 passed (16 new in `owner-kpis.test.ts` + 44 existing)
- `npm run typecheck` — clean
- `npm run build` — succeeds, `/ops` shows up as a dynamic server route

## Test plan

- [ ] Visit `/ops` after seeding the DB — all six tiles render with sensible numbers
- [ ] Hover any tile — soft lift + shadow, cursor changes
- [ ] Confirm each tile navigates to its deep route
- [ ] With an agent job in `running` state, confirm the agent card shows the pulse
- [ ] With a denial older than 30 days, confirm the denials severity dot turns red
- [ ] On mobile, grid collapses to a single column

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C