### PR TITLE
feat(nav): semantic badges (severity + context, not just count)

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -7,6 +7,11 @@ import { BreathingBreak } from "@/components/ui/breathing-break";
 import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { prisma } from "@/lib/db/prisma";
+import {
+  computeApprovalsBadge,
+  computeLabsBadge,
+  computeRefillsBadge,
+} from "@/lib/domain/nav-badges";
 
 export default async function ClinicianLayout({
   children,
@@ -34,9 +39,15 @@ export default async function ClinicianLayout({
     }
   };
 
-  const [pendingCount, emergencyCount, labsPendingCount, refillsPendingCount] = await (async () => {
+  const [
+    pendingCount,
+    emergencyCount,
+    labsPendingCount,
+    labsAbnormalCount,
+    refillsPendingCount,
+  ] = await (async () => {
     const orgId = user.organizationId;
-    if (!orgId) return [0, 0, 0, 0] as const;
+    if (!orgId) return [0, 0, 0, 0, 0] as const;
     return Promise.all([
       safeCount(() =>
         prisma.message.count({
@@ -64,6 +75,15 @@ export default async function ClinicianLayout({
           where: {
             organizationId: orgId,
             signedAt: null,
+          },
+        })
+      ),
+      safeCount(() =>
+        prisma.labResult.count({
+          where: {
+            organizationId: orgId,
+            signedAt: null,
+            abnormalFlag: true,
           },
         })
       ),
@@ -100,20 +120,23 @@ export default async function ClinicianLayout({
         {
           label: "Approvals",
           href: "/clinic/approvals",
-          count: pendingCount,
-          countTone: emergencyCount > 0 ? "danger" : "highlight",
+          badge: computeApprovalsBadge({
+            pendingCount,
+            emergencyCount,
+          }),
         },
         {
           label: "Labs",
           href: "/clinic/labs-review",
-          count: labsPendingCount,
-          countTone: "highlight",
+          badge: computeLabsBadge({
+            unsignedCount: labsPendingCount,
+            abnormalCount: labsAbnormalCount,
+          }),
         },
         {
           label: "Refills",
           href: "/clinic/refills",
-          count: refillsPendingCount,
-          countTone: "highlight",
+          badge: computeRefillsBadge({ pendingCount: refillsPendingCount }),
         },
       ],
     },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -3,89 +3,20 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ROLE_HOME } from "@/lib/rbac/roles";
+import { prisma } from "@/lib/db/prisma";
+import {
+  computeAgingBadge,
+  computeDenialsBadge,
+} from "@/lib/domain/nav-badges";
 
-// 3-tier IA for the operator console.
-//
-//   Tier 1 (always visible) — 5 daily-use items plus the Command Center
-//                             escape hatch into the clinician space.
-//   Tier 2 (collapsible)    — Billing (hot zone, expanded by default),
-//                             Operations, Practice Setup, Intelligence,
-//                             System (quiet by default).
-//   Tier 3 (⌘K palette)     — all 35 routes, searchable by name.
-//
-// Groups are verb-framed where possible ("Review", "Clear") so the operator
-// thinks "I'm clearing denials" rather than "I'm in the Billing tab".
-const OPS_SECTIONS: NavSection[] = [
-  {
-    items: [
-      { label: "Overview", href: "/ops" },
-      { label: "Mission Control", href: "/ops/mission-control" },
-      { label: "Schedule", href: "/ops/schedule" },
-      { label: "Patients", href: "/ops/patients" },
-      { label: "Command Center", href: "/clinic/command" },
-    ],
-  },
-  {
-    label: "Billing",
-    items: [
-      { label: "Billing", href: "/ops/billing" },
-      { label: "Scrub", href: "/ops/scrub" },
-      { label: "Denials", href: "/ops/denials" },
-      { label: "Aging", href: "/ops/aging" },
-      { label: "Agents", href: "/ops/billing-agents" },
-      { label: "Revenue", href: "/ops/revenue" },
-      { label: "Eligibility", href: "/ops/eligibility" },
-    ],
-    // Hot zone — expanded on first visit.
-  },
-  {
-    label: "Operations",
-    items: [
-      { label: "Staff schedule", href: "/ops/staff-schedule" },
-      { label: "Time clock", href: "/ops/time-clock" },
-      { label: "Training", href: "/ops/training" },
-      { label: "Policies", href: "/ops/policies" },
-      { label: "Incidents", href: "/ops/incidents" },
-      { label: "Supplies", href: "/ops/supplies" },
-      { label: "Vendors", href: "/ops/vendors" },
-      { label: "Feedback", href: "/ops/feedback" },
-      { label: "Marketing", href: "/ops/marketing" },
-      { label: "Announcements", href: "/ops/announcements" },
-    ],
-    defaultCollapsed: true,
-  },
-  {
-    label: "Practice Setup",
-    items: [
-      { label: "Onboarding", href: "/ops/onboarding" },
-      { label: "Practice launch", href: "/ops/launch" },
-      { label: "Intake Builder", href: "/ops/intake-builder" },
-      { label: "Export", href: "/ops/export" },
-    ],
-    defaultCollapsed: true,
-  },
-  {
-    label: "Intelligence",
-    items: [
-      { label: "Analytics", href: "/ops/analytics" },
-      { label: "Analytics Lab", href: "/ops/analytics-lab" },
-      { label: "Population", href: "/ops/population" },
-    ],
-    defaultCollapsed: true,
-  },
-  {
-    label: "System",
-    items: [
-      { label: "AI Config", href: "/ops/settings/ai-config" },
-      { label: "Webhooks", href: "/ops/webhooks" },
-      { label: "API keys", href: "/ops/api-keys" },
-      { label: "Performance", href: "/ops/performance" },
-      { label: "Feature flags", href: "/ops/feature-flags" },
-      { label: "Backups", href: "/ops/backups" },
-    ],
-    defaultCollapsed: true,
-  },
-];
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const MS_PER_HOUR = 1000 * 60 * 60;
+
+// Standard 90-day appeal window from the date of denial. Real payer-specific
+// rules vary; this is a conservative default the badge uses to estimate the
+// "next appeal deadline" so we can flash critical when a claim is about to age
+// out of its appeal window.
+const APPEAL_WINDOW_DAYS = 90;
 
 export default async function OperatorLayout({
   children,
@@ -111,11 +42,179 @@ export default async function OperatorLayout({
     redirect("/login");
   }
 
+  const orgId = user.organizationId;
+
+  // Per-section state for semantic badges. Each load is wrapped — a missing
+  // table or transient DB hiccup must never block the operator from logging
+  // in. The nav silently degrades to "no badge" on failure.
+  const safe = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await fn();
+    } catch (err) {
+      console.error("[operator-layout] badge load failed:", err);
+      return fallback;
+    }
+  };
+
+  const [denialsState, agingState] = await Promise.all([
+    safe(
+      async () => {
+        const denials = await prisma.denialEvent.findMany({
+          where: {
+            resolution: "pending",
+            claim: { organizationId: orgId },
+          },
+          select: { createdAt: true },
+        });
+        const now = Date.now();
+        let oldestDays: number | null = null;
+        let minHoursToDeadline: number | null = null;
+        for (const d of denials) {
+          const ageDays = Math.floor((now - d.createdAt.getTime()) / MS_PER_DAY);
+          if (oldestDays === null || ageDays > oldestDays) oldestDays = ageDays;
+          const deadlineMs =
+            d.createdAt.getTime() + APPEAL_WINDOW_DAYS * MS_PER_DAY;
+          const hoursLeft = (deadlineMs - now) / MS_PER_HOUR;
+          // Only count not-yet-elapsed deadlines for the "imminent" check.
+          if (hoursLeft >= 0) {
+            if (minHoursToDeadline === null || hoursLeft < minHoursToDeadline) {
+              minHoursToDeadline = hoursLeft;
+            }
+          }
+        }
+        return {
+          unresolvedCount: denials.length,
+          oldestDays,
+          criticalDeadlineHours: minHoursToDeadline,
+        };
+      },
+      { unresolvedCount: 0, oldestDays: null, criticalDeadlineHours: null }
+    ),
+    safe(
+      async () => {
+        // Past-due = open claims older than 30 days with outstanding balance.
+        const cutoff = new Date(Date.now() - 30 * MS_PER_DAY);
+        const claims = await prisma.claim.findMany({
+          where: {
+            organizationId: orgId,
+            status: { notIn: ["written_off", "paid", "voided"] },
+            serviceDate: { lt: cutoff },
+          },
+          select: {
+            billedAmountCents: true,
+            paidAmountCents: true,
+            serviceDate: true,
+          },
+        });
+        const now = Date.now();
+        let totalPastDueCents = 0;
+        let oldestDays: number | null = null;
+        for (const c of claims) {
+          const balance = c.billedAmountCents - c.paidAmountCents;
+          if (balance <= 0) continue;
+          totalPastDueCents += balance;
+          const ageDays = Math.floor(
+            (now - c.serviceDate.getTime()) / MS_PER_DAY
+          );
+          if (oldestDays === null || ageDays > oldestDays) oldestDays = ageDays;
+        }
+        return { totalPastDueCents, oldestDays };
+      },
+      { totalPastDueCents: 0, oldestDays: null as number | null }
+    ),
+  ]);
+
+  const denialsBadge = computeDenialsBadge(denialsState);
+  const agingBadge = computeAgingBadge(agingState);
+
+  // 3-tier IA for the operator console.
+  //
+  //   Tier 1 (always visible) — 5 daily-use items plus the Command Center
+  //                             escape hatch into the clinician space.
+  //   Tier 2 (collapsible)    — Billing (hot zone, expanded by default),
+  //                             Operations, Practice Setup, Intelligence,
+  //                             System (quiet by default).
+  //   Tier 3 (⌘K palette)     — all 35 routes, searchable by name.
+  //
+  // Groups are verb-framed where possible ("Review", "Clear") so the operator
+  // thinks "I'm clearing denials" rather than "I'm in the Billing tab".
+  const sections: NavSection[] = [
+    {
+      items: [
+        { label: "Overview", href: "/ops" },
+        { label: "Mission Control", href: "/ops/mission-control" },
+        { label: "Schedule", href: "/ops/schedule" },
+        { label: "Patients", href: "/ops/patients" },
+        { label: "Command Center", href: "/clinic/command" },
+      ],
+    },
+    {
+      label: "Billing",
+      items: [
+        { label: "Billing", href: "/ops/billing" },
+        { label: "Scrub", href: "/ops/scrub" },
+        { label: "Denials", href: "/ops/denials", badge: denialsBadge },
+        { label: "Aging", href: "/ops/aging", badge: agingBadge },
+        { label: "Agents", href: "/ops/billing-agents" },
+        { label: "Revenue", href: "/ops/revenue" },
+        { label: "Eligibility", href: "/ops/eligibility" },
+      ],
+      // Hot zone — expanded on first visit.
+    },
+    {
+      label: "Operations",
+      items: [
+        { label: "Staff schedule", href: "/ops/staff-schedule" },
+        { label: "Time clock", href: "/ops/time-clock" },
+        { label: "Training", href: "/ops/training" },
+        { label: "Policies", href: "/ops/policies" },
+        { label: "Incidents", href: "/ops/incidents" },
+        { label: "Supplies", href: "/ops/supplies" },
+        { label: "Vendors", href: "/ops/vendors" },
+        { label: "Feedback", href: "/ops/feedback" },
+        { label: "Marketing", href: "/ops/marketing" },
+        { label: "Announcements", href: "/ops/announcements" },
+      ],
+      defaultCollapsed: true,
+    },
+    {
+      label: "Practice Setup",
+      items: [
+        { label: "Onboarding", href: "/ops/onboarding" },
+        { label: "Practice launch", href: "/ops/launch" },
+        { label: "Intake Builder", href: "/ops/intake-builder" },
+        { label: "Export", href: "/ops/export" },
+      ],
+      defaultCollapsed: true,
+    },
+    {
+      label: "Intelligence",
+      items: [
+        { label: "Analytics", href: "/ops/analytics" },
+        { label: "Analytics Lab", href: "/ops/analytics-lab" },
+        { label: "Population", href: "/ops/population" },
+      ],
+      defaultCollapsed: true,
+    },
+    {
+      label: "System",
+      items: [
+        { label: "AI Config", href: "/ops/settings/ai-config" },
+        { label: "Webhooks", href: "/ops/webhooks" },
+        { label: "API keys", href: "/ops/api-keys" },
+        { label: "Performance", href: "/ops/performance" },
+        { label: "Feature flags", href: "/ops/feature-flags" },
+        { label: "Backups", href: "/ops/backups" },
+      ],
+      defaultCollapsed: true,
+    },
+  ];
+
   return (
     <AppShell
       user={user}
       activeRole="operator"
-      sections={OPS_SECTIONS}
+      sections={sections}
       roleLabel="Practice ops"
     >
       <CommandPalette role="operator" />

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import type { NavItem, NavSection } from "./nav-sections";
 // Re-export so existing consumers (each layout) can keep importing the
 // NavItem / NavSection types from this module.
 export type { NavItem, NavSection } from "./nav-sections";
+export type { BadgeSeverity, NavBadge } from "@/lib/domain/nav-badges";
 
 export interface AppShellProps {
   user: AuthedUser;

--- a/src/components/shell/NavSections.tsx
+++ b/src/components/shell/NavSections.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils/cn";
 import {
   aggregateSectionBadge,
   collapseStorageKey,
+  getSectionBadge,
   readPersistedCollapseState,
   resolveInitialCollapseState,
   sectionContainsPath,
@@ -14,6 +15,7 @@ import {
   type NavItem,
   type NavSection,
 } from "./nav-sections";
+import type { BadgeSeverity, NavBadge } from "@/lib/domain/nav-badges";
 
 /**
  * Rail renderer for the 3-tier IA.
@@ -49,6 +51,75 @@ function CountBadge({ count, tone }: { count: number; tone: CountTone }) {
   );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Semantic badge presentation
+// ─────────────────────────────────────────────────────────────────────────────
+// `ok` severity renders nothing — the section is silent-green. The dot color
+// signals severity at a glance; the label gives the punchline; `context`
+// becomes a native title-attribute tooltip.
+
+const SEVERITY_DOT_CLASS: Record<Exclude<BadgeSeverity, "ok">, string> = {
+  critical: "bg-red-600",
+  warn: "bg-amber-500",
+  info: "bg-accent",
+};
+
+const SEVERITY_TEXT_CLASS: Record<Exclude<BadgeSeverity, "ok">, string> = {
+  critical: "text-red-700",
+  warn: "text-amber-700",
+  info: "text-text-muted",
+};
+
+export function SemanticBadge({ badge }: { badge: NavBadge }) {
+  if (badge.severity === "ok") return null;
+  const dot = SEVERITY_DOT_CLASS[badge.severity];
+  const text = SEVERITY_TEXT_CLASS[badge.severity];
+  return (
+    <span
+      title={badge.context}
+      className={cn(
+        "inline-flex items-center gap-1.5 text-[11px] font-medium tabular-nums",
+        text,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-1.5 w-1.5 rounded-full", dot)}
+      />
+      {badge.label}
+    </span>
+  );
+}
+
+/**
+ * Render the right-side indicator on a nav row. Prefers semantic badge over
+ * legacy count-based pill, returning null when nothing to show.
+ */
+export function NavItemBadge({ item }: { item: NavItem }) {
+  if (item.badge) {
+    if (item.badge.severity === "ok") return null;
+    return <SemanticBadge badge={item.badge} />;
+  }
+  const count = item.count ?? 0;
+  if (count <= 0) return null;
+  const tone = item.countTone ?? "highlight";
+  return <CountBadge count={count} tone={tone} />;
+}
+
+/**
+ * Compose the aria-label for a nav row, surfacing badge context to screen
+ * readers.
+ */
+export function navItemAriaLabel(item: NavItem): string {
+  if (item.badge && item.badge.severity !== "ok") {
+    const ctx = item.badge.context ? `, ${item.badge.context}` : "";
+    return `${item.label}: ${item.badge.label}${ctx}`;
+  }
+  const count = item.count ?? 0;
+  if (count > 0) return `${item.label} (${count} waiting)`;
+  return item.label;
+}
+
 function ItemLink({
   item,
   onClick,
@@ -58,13 +129,11 @@ function ItemLink({
   onClick?: () => void;
   isActive: boolean;
 }) {
-  const count = item.count ?? 0;
-  const tone = item.countTone ?? "highlight";
   return (
     <Link
       href={item.href}
       onClick={onClick}
-      aria-label={count > 0 ? `${item.label} (${count} waiting)` : item.label}
+      aria-label={navItemAriaLabel(item)}
       aria-current={isActive ? "page" : undefined}
       className={cn(
         "group flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors duration-200 ease-smooth",
@@ -81,7 +150,7 @@ function ItemLink({
         )}
       />
       <span className="flex-1">{item.label}</span>
-      {count > 0 && <CountBadge count={count} tone={tone} />}
+      <NavItemBadge item={item} />
     </Link>
   );
 }
@@ -168,7 +237,11 @@ export function NavSections({ sections, onItemClick, variant = "rail" }: NavSect
 
         const label = section.label!;
         const isCollapsed = collapsed[label] ?? section.defaultCollapsed ?? false;
-        const badge = aggregateSectionBadge(section);
+        // Prefer the semantic rollup (severity-ranked across child `badge`
+        // fields) when any item in the section carries a semantic badge.
+        // Fall back to the legacy count aggregate otherwise.
+        const semanticBadge = getSectionBadge(section);
+        const countBadge = semanticBadge ? null : aggregateSectionBadge(section);
         const headerId = `nav-group-${label.toLowerCase().replace(/\s+/g, "-")}`;
         const panelId = `${headerId}-panel`;
         const activeWithin = sectionContainsPath(section, pathname);
@@ -200,7 +273,12 @@ export function NavSections({ sections, onItemClick, variant = "rail" }: NavSect
               >
                 {label}
               </span>
-              {badge && <CountBadge count={badge.count} tone={badge.tone} />}
+              {semanticBadge && semanticBadge.severity !== "ok" && (
+                <SemanticBadge badge={semanticBadge} />
+              )}
+              {countBadge && (
+                <CountBadge count={countBadge.count} tone={countBadge.tone} />
+              )}
               <svg
                 aria-hidden="true"
                 width="12"

--- a/src/components/shell/nav-sections.ts
+++ b/src/components/shell/nav-sections.ts
@@ -4,12 +4,16 @@
  * These are framework-free so they can be covered by the node-only vitest
  * suite. The AppShell + MobileNav consume them at render time.
  *
- *   NavItem     — a single leaf link (existing shape, unchanged).
- *   NavSection  — a group of items with an optional label + default state.
- *   Helpers     — aggregate counts, smart-collapse resolution, localStorage
- *                 merge. Every helper is pure: given the same inputs it
- *                 returns the same output, no side effects.
+ *   NavItem        — a single leaf link with legacy count + optional semantic badge.
+ *   NavSection     — a group of items with an optional label + default state.
+ *   NavBadge       — re-exported from lib/domain/nav-badges (severity + context).
+ *   Helpers        — aggregate counts, aggregate semantic badge, smart-collapse
+ *                    resolution, localStorage merge, pathname matching.
  */
+
+import { aggregateBadge, type NavBadge } from "@/lib/domain/nav-badges";
+
+export type { NavBadge } from "@/lib/domain/nav-badges";
 
 export type CountTone = "highlight" | "danger" | "accent";
 
@@ -17,8 +21,11 @@ export interface NavItem {
   label: string;
   href: string;
   icon?: unknown;
+  /** Legacy numeric badge — still rendered if `badge` is not set. */
   count?: number;
   countTone?: CountTone;
+  /** Semantic badge — preferred. Takes precedence over count/countTone. */
+  badge?: NavBadge | null;
 }
 
 export interface NavSection {
@@ -34,6 +41,11 @@ export interface NavSection {
    * Defaults to false (expanded).
    */
   defaultCollapsed?: boolean;
+  /**
+   * Optional explicit semantic badge for the group. When omitted, the
+   * aggregate of the child items' `badge` fields is used.
+   */
+  badge?: NavBadge | null;
 }
 
 /**
@@ -52,9 +64,13 @@ export interface AggregateBadge {
 }
 
 /**
- * Sum the counts on a section's items and pick the loudest tone among
- * items that actually contribute a non-zero count. Returns null if the
- * section has no live badges worth showing.
+ * Legacy count-based aggregate: sum the numeric counts on a section's items
+ * and pick the loudest tone among items that actually contribute a non-zero
+ * count. Returns null if the section has no live count badges worth showing.
+ *
+ * Kept for backward compatibility on items still using the count/countTone
+ * fields. New nav items should use `badge` (semantic) and rely on
+ * `getSectionBadge` below.
  */
 export function aggregateSectionBadge(section: NavSection): AggregateBadge | null {
   let total = 0;
@@ -76,10 +92,31 @@ export function aggregateSectionBadge(section: NavSection): AggregateBadge | nul
 }
 
 /**
+ * Semantic badge for a section header. If the section has an explicit
+ * `badge`, use it; otherwise aggregate the items' `badge` fields via the
+ * severity-ranked rollup in `lib/domain/nav-badges`.
+ *
+ * Returns null when the entire section is silent-green ("ok") — the header
+ * badge slot stays empty.
+ */
+export function getSectionBadge(section: NavSection): NavBadge | null {
+  if (section.badge !== undefined) return section.badge;
+  return aggregateBadge(section.items.map((i) => i.badge ?? null));
+}
+
+/**
+ * Type guard so a renderer can walk a mixed list of items and sections.
+ */
+export function isNavSection(node: NavItem | NavSection): node is NavSection {
+  return Array.isArray((node as NavSection).items);
+}
+
+export type NavNode = NavItem | NavSection;
+
+/**
  * Does the current pathname match any item in the given section?
  *
- * Match rules (intentionally strict to avoid "everything under /clinic"
- * lighting up every section):
+ * Match rules:
  *   • exact pathname === item.href, OR
  *   • pathname starts with `item.href + "/"`.
  *
@@ -95,8 +132,6 @@ export function sectionContainsPath(section: NavSection, pathname: string): bool
 
 export function itemMatchesPath(href: string, pathname: string): boolean {
   if (href === pathname) return true;
-  // Short top-level hrefs only match exactly — otherwise "/clinic" would
-  // claim every child route in the clinician tree.
   const segments = href.split("/").filter(Boolean);
   if (segments.length <= 1) return false;
   return pathname.startsWith(href + "/");
@@ -118,11 +153,8 @@ export interface ResolveCollapseInput {
  * Rules, in order:
  *   1. A section with no label is never collapsible — skipped.
  *   2. If the section contains the current pathname, force expanded.
- *      (This is the "follow me into the group I just clicked" rule.)
  *   3. Else if the user explicitly persisted a choice, honor it.
  *   4. Else fall back to section.defaultCollapsed (default: false).
- *
- * Returns a map keyed by section label → collapsed boolean.
  */
 export function resolveInitialCollapseState(
   input: ResolveCollapseInput,
@@ -146,18 +178,14 @@ export function resolveInitialCollapseState(
 
 /**
  * localStorage key convention: `nav:group:<label>:collapsed`.
- * Exported so both the renderer and any test can reach it.
  */
 export function collapseStorageKey(label: string): string {
   return `nav:group:${label}:collapsed`;
 }
 
 /**
- * Given a raw localStorage-like getter, read the persisted collapsed state
- * for every labeled section into a plain map.
- *
- * The getter is abstracted so tests can pass a stub. Missing, malformed, or
- * non-boolean values are ignored (the key is simply absent from the output).
+ * Read persisted collapsed state from any localStorage-like getter.
+ * Missing, malformed, or non-boolean values are omitted.
  */
 export function readPersistedCollapseState(
   sections: NavSection[],
@@ -174,8 +202,7 @@ export function readPersistedCollapseState(
 }
 
 /**
- * Merge a user toggle into an existing resolved map. Pure so tests can
- * verify we never mutate the input.
+ * Merge a user toggle into an existing resolved map. Pure — never mutates.
  */
 export function toggleCollapseState(
   state: Record<string, boolean>,
@@ -185,8 +212,7 @@ export function toggleCollapseState(
 }
 
 /**
- * Flatten a set of sections back to a plain item list — useful when the
- * consumer (e.g. a test, or a legacy surface) just wants every link.
+ * Flatten sections back to a plain item list.
  */
 export function flattenSectionItems(sections: NavSection[]): NavItem[] {
   const out: NavItem[] = [];

--- a/src/lib/domain/nav-badges.test.ts
+++ b/src/lib/domain/nav-badges.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateBadge,
+  computeAgingBadge,
+  computeApprovalsBadge,
+  computeDenialsBadge,
+  computeLabsBadge,
+  computeRefillsBadge,
+  SEVERITY_RANK,
+  type NavBadge,
+} from "./nav-badges";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeDenialsBadge
+// ─────────────────────────────────────────────────────────────────────────────
+describe("computeDenialsBadge", () => {
+  it("returns null when there are no unresolved denials (silent green)", () => {
+    expect(
+      computeDenialsBadge({
+        unresolvedCount: 0,
+        oldestDays: null,
+        criticalDeadlineHours: null,
+      })
+    ).toBeNull();
+  });
+
+  it("returns null even when negative unresolved count is somehow passed", () => {
+    expect(
+      computeDenialsBadge({
+        unresolvedCount: -1,
+        oldestDays: 10,
+        criticalDeadlineHours: 5,
+      })
+    ).toBeNull();
+  });
+
+  it("flags critical when an appeal deadline is within 48h", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 1,
+      oldestDays: 5,
+      criticalDeadlineHours: 24,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.label).toBe("1 CRITICAL");
+    expect(badge?.context).toBe("appeal due 24h");
+  });
+
+  it("treats 48h exactly as still critical (boundary)", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 3,
+      oldestDays: 10,
+      criticalDeadlineHours: 48,
+    });
+    expect(badge?.severity).toBe("critical");
+  });
+
+  it("flags critical when oldest unresolved is > 60d, regardless of deadline", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 2,
+      oldestDays: 75,
+      criticalDeadlineHours: null,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.context).toBe("oldest 75d");
+  });
+
+  it("does not flag critical at exactly 60d (boundary — must be strictly greater)", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 1,
+      oldestDays: 60,
+      criticalDeadlineHours: null,
+    });
+    expect(badge?.severity).toBe("warn");
+  });
+
+  it("flags warn when oldest is > 30d and < 60d", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 4,
+      oldestDays: 45,
+      criticalDeadlineHours: 200,
+    });
+    expect(badge?.severity).toBe("warn");
+    expect(badge?.label).toBe("4 aging");
+    expect(badge?.context).toBe("oldest 45d");
+  });
+
+  it("flags info when at least one unresolved but nothing aged", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 1,
+      oldestDays: 5,
+      criticalDeadlineHours: 240,
+    });
+    expect(badge?.severity).toBe("info");
+    expect(badge?.label).toBe("1 pending");
+  });
+
+  it("rounds fractional deadline hours for display", () => {
+    const badge = computeDenialsBadge({
+      unresolvedCount: 1,
+      oldestDays: 1,
+      criticalDeadlineHours: 12.6,
+    });
+    expect(badge?.context).toBe("appeal due 13h");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeApprovalsBadge
+// ─────────────────────────────────────────────────────────────────────────────
+describe("computeApprovalsBadge", () => {
+  it("returns null when queue is empty", () => {
+    expect(
+      computeApprovalsBadge({ pendingCount: 0, emergencyCount: 0 })
+    ).toBeNull();
+  });
+
+  it("flags critical when an emergency is in the queue", () => {
+    const badge = computeApprovalsBadge({
+      pendingCount: 5,
+      emergencyCount: 1,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.label).toBe("1 EMERGENCY");
+    expect(badge?.context).toBe("5 total pending");
+  });
+
+  it("omits context when the emergency count equals the pending count", () => {
+    const badge = computeApprovalsBadge({
+      pendingCount: 2,
+      emergencyCount: 2,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.context).toBeUndefined();
+  });
+
+  it("flags warn when only normal pending requests are present", () => {
+    const badge = computeApprovalsBadge({
+      pendingCount: 4,
+      emergencyCount: 0,
+    });
+    expect(badge?.severity).toBe("warn");
+    expect(badge?.label).toBe("4 pending");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeLabsBadge
+// ─────────────────────────────────────────────────────────────────────────────
+describe("computeLabsBadge", () => {
+  it("returns null when nothing is unsigned", () => {
+    expect(
+      computeLabsBadge({ unsignedCount: 0, abnormalCount: 0 })
+    ).toBeNull();
+  });
+
+  it("flags critical when an abnormal lab sits unsigned", () => {
+    const badge = computeLabsBadge({
+      unsignedCount: 5,
+      abnormalCount: 2,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.label).toBe("2 abnormal");
+    expect(badge?.context).toBe("5 unsigned total");
+  });
+
+  it("flags warn when unsigned exists but none are abnormal", () => {
+    const badge = computeLabsBadge({
+      unsignedCount: 3,
+      abnormalCount: 0,
+    });
+    expect(badge?.severity).toBe("warn");
+    expect(badge?.label).toBe("3 unsigned");
+  });
+
+  it("uses singular context when abnormal == unsigned (all abnormal)", () => {
+    const badge = computeLabsBadge({
+      unsignedCount: 2,
+      abnormalCount: 2,
+    });
+    expect(badge?.context).toBe("2 unsigned");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeRefillsBadge
+// ─────────────────────────────────────────────────────────────────────────────
+describe("computeRefillsBadge", () => {
+  it("returns null when nothing is pending", () => {
+    expect(computeRefillsBadge({ pendingCount: 0 })).toBeNull();
+  });
+
+  it("flags warn for any pending refill", () => {
+    const badge = computeRefillsBadge({ pendingCount: 1 });
+    expect(badge?.severity).toBe("warn");
+    expect(badge?.label).toBe("1 pending");
+  });
+
+  it("scales label with pending count", () => {
+    const badge = computeRefillsBadge({ pendingCount: 25 });
+    expect(badge?.label).toBe("25 pending");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeAgingBadge
+// ─────────────────────────────────────────────────────────────────────────────
+describe("computeAgingBadge", () => {
+  it("returns null when nothing is past due", () => {
+    expect(
+      computeAgingBadge({ totalPastDueCents: 0, oldestDays: null })
+    ).toBeNull();
+  });
+
+  it("flags critical when past due exceeds $10k", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 12_500 * 100, // $12,500
+      oldestDays: 20,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.label).toBe("$13k past-due");
+    expect(badge?.context).toBe("over $10k threshold");
+  });
+
+  it("does NOT flag critical at exactly $10k (boundary — must be strictly greater)", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 10_000 * 100,
+      oldestDays: 20,
+    });
+    expect(badge?.severity).toBe("warn");
+  });
+
+  it("flags critical when oldest is > 60d even if dollar amount is small", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 500 * 100, // $500
+      oldestDays: 90,
+    });
+    expect(badge?.severity).toBe("critical");
+    expect(badge?.context).toBe("oldest 90d");
+  });
+
+  it("flags warn for any past-due under both critical thresholds", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 250 * 100,
+      oldestDays: 15,
+    });
+    expect(badge?.severity).toBe("warn");
+    expect(badge?.context).toBe("oldest 15d");
+  });
+
+  it("formats dollars in millions for very large amounts", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 2_500_000 * 100,
+      oldestDays: null,
+    });
+    expect(badge?.label).toBe("$2.5M past-due");
+  });
+
+  it("formats dollars under $1k as raw dollars", () => {
+    const badge = computeAgingBadge({
+      totalPastDueCents: 750 * 100,
+      oldestDays: 10,
+    });
+    expect(badge?.label).toBe("$750 past-due");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// aggregateBadge — group rollup
+// ─────────────────────────────────────────────────────────────────────────────
+describe("aggregateBadge", () => {
+  const critical: NavBadge = { label: "x", severity: "critical" };
+  const warn: NavBadge = { label: "x", severity: "warn" };
+  const info: NavBadge = { label: "x", severity: "info" };
+  const ok: NavBadge = { label: "OK", severity: "ok" };
+
+  it("returns null for an empty list", () => {
+    expect(aggregateBadge([])).toBeNull();
+  });
+
+  it("returns null when all entries are null/undefined", () => {
+    expect(aggregateBadge([null, undefined, null])).toBeNull();
+  });
+
+  it("picks critical over warn over info", () => {
+    expect(aggregateBadge([info, warn, critical])?.severity).toBe("critical");
+    expect(aggregateBadge([info, warn])?.severity).toBe("warn");
+    expect(aggregateBadge([info])?.severity).toBe("info");
+  });
+
+  it("ignores nulls mixed in among badges", () => {
+    expect(aggregateBadge([null, warn, null, info])?.severity).toBe("warn");
+  });
+
+  it("treats ok as the lowest severity", () => {
+    expect(aggregateBadge([ok, info])?.severity).toBe("info");
+    expect(aggregateBadge([ok, ok])?.severity).toBe("ok");
+  });
+
+  it("returns the first matching badge object when severities tie", () => {
+    const a: NavBadge = { label: "first", severity: "warn" };
+    const b: NavBadge = { label: "second", severity: "warn" };
+    expect(aggregateBadge([a, b])?.label).toBe("first");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEVERITY_RANK exposure (sanity check for downstream consumers)
+// ─────────────────────────────────────────────────────────────────────────────
+describe("SEVERITY_RANK", () => {
+  it("orders ok < info < warn < critical", () => {
+    expect(SEVERITY_RANK.ok).toBeLessThan(SEVERITY_RANK.info);
+    expect(SEVERITY_RANK.info).toBeLessThan(SEVERITY_RANK.warn);
+    expect(SEVERITY_RANK.warn).toBeLessThan(SEVERITY_RANK.critical);
+  });
+});

--- a/src/lib/domain/nav-badges.ts
+++ b/src/lib/domain/nav-badges.ts
@@ -1,0 +1,223 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Nav badge semantic computation
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure functions that translate raw counts/state into a semantic "what should
+// the user actually know about this section?" badge.
+//
+// Each `compute*Badge` returns `null` for the silent-green ("ok") case so the
+// nav rail stays calm — only sections that need attention render a pill.
+//
+// Severity ladder (lowest → highest):
+//   ok < info < warn < critical
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BadgeSeverity = "critical" | "warn" | "info" | "ok";
+
+export interface NavBadge {
+  /** Short scannable text. e.g. "8" | "1 CRITICAL" | "OK" */
+  label: string;
+  /** Optional one-phrase context shown on hover or below. e.g. "appeal due 48h" */
+  context?: string;
+  severity: BadgeSeverity;
+}
+
+/** Numeric rank for severity comparison. Higher = more urgent. */
+export const SEVERITY_RANK: Record<BadgeSeverity, number> = {
+  ok: 0,
+  info: 1,
+  warn: 2,
+  critical: 3,
+};
+
+/**
+ * Pick the most-urgent badge from a list. Used by group headers to roll up
+ * child item badges. Returns null when the list is empty or all entries are
+ * null (silent green).
+ */
+export function aggregateBadge(badges: Array<NavBadge | null | undefined>): NavBadge | null {
+  let best: NavBadge | null = null;
+  for (const b of badges) {
+    if (!b) continue;
+    if (!best || SEVERITY_RANK[b.severity] > SEVERITY_RANK[best.severity]) {
+      best = b;
+    }
+  }
+  return best;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Denials — the worst offender on most operator dashboards.
+// Severity rules:
+//   critical : any deadline ≤ 48h OR any unresolved item > 60d
+//   warn     : any unresolved item > 30d
+//   info     : at least one unresolved item but nothing aged
+//   ok       : zero unresolved
+// ─────────────────────────────────────────────────────────────────────────────
+export function computeDenialsBadge(input: {
+  unresolvedCount: number;
+  oldestDays: number | null;
+  /** Hours until next appeal deadline, or null if no upcoming deadline. */
+  criticalDeadlineHours: number | null;
+}): NavBadge | null {
+  const { unresolvedCount, oldestDays, criticalDeadlineHours } = input;
+
+  if (unresolvedCount <= 0) return null;
+
+  const deadlineImminent =
+    criticalDeadlineHours !== null && criticalDeadlineHours <= 48;
+  const veryAged = oldestDays !== null && oldestDays > 60;
+
+  if (deadlineImminent || veryAged) {
+    const label = `${unresolvedCount} CRITICAL`;
+    let context: string | undefined;
+    if (deadlineImminent) {
+      const hrs = Math.max(0, Math.round(criticalDeadlineHours!));
+      context = `appeal due ${hrs}h`;
+    } else if (veryAged) {
+      context = `oldest ${oldestDays}d`;
+    }
+    return { label, context, severity: "critical" };
+  }
+
+  if (oldestDays !== null && oldestDays > 30) {
+    return {
+      label: `${unresolvedCount} aging`,
+      context: `oldest ${oldestDays}d`,
+      severity: "warn",
+    };
+  }
+
+  return {
+    label: `${unresolvedCount} pending`,
+    severity: "info",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Approvals
+//   critical : any emergency in the queue
+//   warn     : any pending
+//   ok       : empty queue
+// ─────────────────────────────────────────────────────────────────────────────
+export function computeApprovalsBadge(input: {
+  pendingCount: number;
+  emergencyCount: number;
+}): NavBadge | null {
+  const { pendingCount, emergencyCount } = input;
+
+  if (emergencyCount > 0) {
+    return {
+      label: `${emergencyCount} EMERGENCY`,
+      context:
+        pendingCount > emergencyCount
+          ? `${pendingCount} total pending`
+          : undefined,
+      severity: "critical",
+    };
+  }
+
+  if (pendingCount > 0) {
+    return {
+      label: `${pendingCount} pending`,
+      severity: "warn",
+    };
+  }
+
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Labs
+//   critical : any abnormal AND unsigned (something genuinely off + not seen)
+//   warn     : unsigned exists, none flagged abnormal
+//   ok       : everything signed
+// ─────────────────────────────────────────────────────────────────────────────
+export function computeLabsBadge(input: {
+  unsignedCount: number;
+  abnormalCount: number;
+}): NavBadge | null {
+  const { unsignedCount, abnormalCount } = input;
+
+  if (unsignedCount <= 0) return null;
+
+  if (abnormalCount > 0) {
+    return {
+      label: `${abnormalCount} abnormal`,
+      context:
+        unsignedCount > abnormalCount
+          ? `${unsignedCount} unsigned total`
+          : `${unsignedCount} unsigned`,
+      severity: "critical",
+    };
+  }
+
+  return {
+    label: `${unsignedCount} unsigned`,
+    severity: "warn",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Refills — never critical on its own; pending requests just need a sign-off.
+//   warn : any pending
+//   ok   : empty
+// ─────────────────────────────────────────────────────────────────────────────
+export function computeRefillsBadge(input: { pendingCount: number }): NavBadge | null {
+  const { pendingCount } = input;
+  if (pendingCount <= 0) return null;
+  return {
+    label: `${pendingCount} pending`,
+    severity: "warn",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Aging A/R
+//   critical : > $10k past-due OR oldest > 60d
+//   warn     : any past-due > $0
+//   ok       : nothing past-due
+// ─────────────────────────────────────────────────────────────────────────────
+export function computeAgingBadge(input: {
+  totalPastDueCents: number;
+  oldestDays: number | null;
+}): NavBadge | null {
+  const { totalPastDueCents, oldestDays } = input;
+
+  if (totalPastDueCents <= 0) return null;
+
+  const overTenK = totalPastDueCents > 10_000 * 100;
+  const veryAged = oldestDays !== null && oldestDays > 60;
+
+  const dollars = formatDollarsShort(totalPastDueCents);
+
+  if (overTenK || veryAged) {
+    return {
+      label: `${dollars} past-due`,
+      context: veryAged ? `oldest ${oldestDays}d` : "over $10k threshold",
+      severity: "critical",
+    };
+  }
+
+  return {
+    label: `${dollars} past-due`,
+    context:
+      oldestDays !== null && oldestDays > 0 ? `oldest ${oldestDays}d` : undefined,
+    severity: "warn",
+  };
+}
+
+/**
+ * Compact dollar formatting for badges. $0–$999 → "$N", $1k+ → "$Nk", $1M+
+ * → "$N.NM". Trims trailing zeroes for the M case so badges stay scannable.
+ */
+function formatDollarsShort(cents: number): string {
+  const dollars = Math.round(cents / 100);
+  if (dollars < 1_000) return `$${dollars}`;
+  if (dollars < 1_000_000) return `$${Math.round(dollars / 1000)}k`;
+  const millions = dollars / 1_000_000;
+  const trimmed =
+    millions >= 10
+      ? Math.round(millions).toString()
+      : (Math.round(millions * 10) / 10).toString();
+  return `$${trimmed}M`;
+}


### PR DESCRIPTION
## Summary

Upgrades the nav rail from raw counts ("8 denials") to semantic, scannable signal ("Denials: 1 CRITICAL · appeal due 48h"). Each section now reports the most urgent thing the user actually needs to know — color-coded by severity. Sections with nothing to flag stay silent (no badge), so the nav projects signal instead of noise.

## Type extension

New `NavBadge` type lives in `src/lib/domain/nav-badges.ts`:

```ts
export type BadgeSeverity = "critical" | "warn" | "info" | "ok";

export interface NavBadge {
  label: string;          // "1 CRITICAL", "4 pending", "$13k past-due"
  context?: string;       // "appeal due 48h", "oldest 75d"
  severity: BadgeSeverity;
}
```

`NavItem` is extended with an optional `badge: NavBadge | null`. Legacy `count` / `countTone` props are kept untouched so any nav row that hasn't been upgraded keeps rendering exactly as before. When both are present, semantic badge wins.

## Severity rules per section

All implemented as pure functions in `src/lib/domain/nav-badges.ts`:

- **Denials** (`computeDenialsBadge`)
  - `critical` if any deadline ≤ 48h OR any unresolved > 60d
  - `warn` if any unresolved > 30d
  - `info` if any unresolved
  - `ok` (→ null) otherwise
- **Approvals** (`computeApprovalsBadge`)
  - `critical` if any emergency in queue
  - `warn` if pending > 0
  - `ok` otherwise
- **Labs** (`computeLabsBadge`)
  - `critical` if any abnormal AND unsigned
  - `warn` if any unsigned
  - `ok` otherwise
- **Refills** (`computeRefillsBadge`)
  - `warn` if any pending
  - `ok` otherwise
- **Aging** (`computeAgingBadge`)
  - `critical` if past-due > $10k OR oldest > 60d
  - `warn` if past-due > $0
  - `ok` otherwise

Every "ok" path returns `null` so the badge slot stays empty (saves a render, keeps the rail calm).

## Aggregate rollup

`src/components/shell/nav-sections.ts` introduces a `NavSection` group type plus `aggregateBadge()` — a pure helper that picks the highest-severity child badge using a numeric `SEVERITY_RANK` (`critical > warn > info > ok`). Group headers can roll up child item badges automatically; child items still render their own pill when expanded.

## Visual

- Severity → dot color: critical=red, warn=amber, info=accent, ok=hidden.
- Label text: `text-[11px] font-medium tabular-nums`, color tracks severity.
- `context` is surfaced via the native `title` attribute (simple, accessible, polishable later) and reflected in the link's `aria-label` for screen readers.
- Mobile drawer shares the exact same `NavItemBadge` renderer so behavior is identical across breakpoints.

## Backward compatibility

`count` + `countTone` still render the legacy pill (warm pill for "highlight", red+pulse for "danger", etc.) on any nav item that hasn't been upgraded. Rolling out section-by-section is safe — no flag day required.

## Wire-up

- `src/app/(clinician)/layout.tsx` — Approvals / Labs / Refills now load org-scoped counts (including the new abnormal-labs count) and pass them through `compute*Badge`.
- `src/app/(operator)/layout.tsx` — Denials and Aging now load `DenialEvent` + `Claim` state, compute oldest-day + estimated 90-day appeal-deadline-hours, and produce semantic badges. Each load is wrapped so a DB hiccup silently degrades to "no badge" rather than blocking login.

## Test coverage

`src/lib/domain/nav-badges.test.ts` — 34 tests:

- Each `compute*Badge` function across every severity boundary (including strict `>` boundaries: 60d, $10k, etc.).
- `aggregateBadge` rollup: empty list, all-null list, severity precedence, tie-breaking by first match, mixed-with-null lists.
- `SEVERITY_RANK` ordering sanity check.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 78/78 pass (34 new + 44 pre-existing)
- [x] Old NavItem `count` / `countTone` items still render with no code change

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C