### PR TITLE
feat(nav): pinned favorites + recent destinations

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -8,6 +8,9 @@ import type { Role } from "@prisma/client";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { MobileNav } from "./MobileNav";
 import { NavSections } from "./NavSections";
+import { NavPrefsProvider } from "./NavPrefsContext";
+import { NavPrefsSections } from "./NavPrefsSections";
+import { NavVisitTracker } from "./NavVisitTracker";
 import type { NavItem, NavSection } from "./nav-sections";
 
 // Re-export so existing consumers (each layout) can keep importing the
@@ -55,6 +58,8 @@ export function AppShell({
   const resolved = normalizeSections(sections, nav);
 
   return (
+    <NavPrefsProvider>
+    <NavVisitTracker sections={resolved} />
     <div className="min-h-screen bg-bg flex">
       {/* Side nav */}
       <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-surface relative">
@@ -78,6 +83,7 @@ export function AppShell({
         </div>
 
         <nav aria-label="Main navigation" className="relative px-3 flex-1 mt-2 overflow-y-auto">
+          <NavPrefsSections />
           <NavSections sections={resolved} />
         </nav>
 
@@ -120,5 +126,6 @@ export function AppShell({
         <main id="main-content" className="flex-1 min-w-0">{children}</main>
       </div>
     </div>
+    </NavPrefsProvider>
   );
 }

--- a/src/components/shell/NavPrefsContext.tsx
+++ b/src/components/shell/NavPrefsContext.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import * as React from "react";
+import {
+  PINS_STORAGE_KEY,
+  RECENT_STORAGE_KEY,
+  addPin,
+  parsePins,
+  parseRecents,
+  recordVisit,
+  removePin,
+  type PinnedEntry,
+  type RecentEntry,
+} from "@/lib/domain/nav-prefs";
+
+/**
+ * Client-side nav personalization state. Lives entirely in localStorage —
+ * no server round-trip, no cookies. SSR-safe: initial render is always
+ * empty, then the first client effect hydrates from storage.
+ *
+ *   pins      — pinned routes, newest first, cap 8.
+ *   recents   — last 5 distinct visited routes, newest first.
+ *   pin/unpin — mutate pins by href.
+ *   isPinned  — cheap lookup for star-toggle state.
+ *   visit     — record a route visit (used by NavVisitTracker).
+ *   clearAll  — nuke both lists + their storage keys (Manage action).
+ *
+ * Writes are debounced 250ms so rapid toggles don't hammer localStorage.
+ */
+
+export interface NavPrefsValue {
+  pins: PinnedEntry[];
+  recents: RecentEntry[];
+  pin: (entry: { href: string; label: string }) => void;
+  unpin: (href: string) => void;
+  isPinned: (href: string) => boolean;
+  visit: (entry: { href: string; label: string }) => void;
+  clearAll: () => void;
+  hydrated: boolean;
+}
+
+const NavPrefsCtx = React.createContext<NavPrefsValue | null>(null);
+
+const WRITE_DEBOUNCE_MS = 250;
+
+function safeGet(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* private mode / quota — non-fatal */
+  }
+}
+
+function safeRemove(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export function NavPrefsProvider({ children }: { children: React.ReactNode }) {
+  const [pins, setPins] = React.useState<PinnedEntry[]>([]);
+  const [recents, setRecents] = React.useState<RecentEntry[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  // Read-once on mount. Malformed / missing payloads become [].
+  React.useEffect(() => {
+    setPins(parsePins(safeGet(PINS_STORAGE_KEY)));
+    setRecents(parseRecents(safeGet(RECENT_STORAGE_KEY)));
+    setHydrated(true);
+  }, []);
+
+  // Debounced writes — one timer per key, reset on each change.
+  const pinsTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const recentsTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (pinsTimer.current) clearTimeout(pinsTimer.current);
+    pinsTimer.current = setTimeout(() => {
+      safeSet(PINS_STORAGE_KEY, JSON.stringify(pins));
+    }, WRITE_DEBOUNCE_MS);
+    return () => {
+      if (pinsTimer.current) clearTimeout(pinsTimer.current);
+    };
+  }, [pins, hydrated]);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (recentsTimer.current) clearTimeout(recentsTimer.current);
+    recentsTimer.current = setTimeout(() => {
+      safeSet(RECENT_STORAGE_KEY, JSON.stringify(recents));
+    }, WRITE_DEBOUNCE_MS);
+    return () => {
+      if (recentsTimer.current) clearTimeout(recentsTimer.current);
+    };
+  }, [recents, hydrated]);
+
+  const pin = React.useCallback(
+    (entry: { href: string; label: string }) => {
+      setPins((prev) => addPin(prev, entry));
+    },
+    [],
+  );
+
+  const unpin = React.useCallback((href: string) => {
+    setPins((prev) => removePin(prev, href));
+  }, []);
+
+  const visit = React.useCallback((entry: { href: string; label: string }) => {
+    setRecents((prev) => recordVisit(prev, entry));
+  }, []);
+
+  const clearAll = React.useCallback(() => {
+    setPins([]);
+    setRecents([]);
+    safeRemove(PINS_STORAGE_KEY);
+    safeRemove(RECENT_STORAGE_KEY);
+  }, []);
+
+  // isPinned is recomputed from `pins`; Set membership keeps toggles O(1).
+  const pinnedHrefs = React.useMemo(
+    () => new Set(pins.map((p) => p.href)),
+    [pins],
+  );
+  const isPinned = React.useCallback(
+    (href: string) => pinnedHrefs.has(href),
+    [pinnedHrefs],
+  );
+
+  const value = React.useMemo<NavPrefsValue>(
+    () => ({ pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated }),
+    [pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated],
+  );
+
+  return <NavPrefsCtx.Provider value={value}>{children}</NavPrefsCtx.Provider>;
+}
+
+/**
+ * Read the nav-prefs context. Returns null outside the provider so callers
+ * can gracefully degrade (e.g. server-rendered sub-trees).
+ */
+export function useNavPrefs(): NavPrefsValue | null {
+  return React.useContext(NavPrefsCtx);
+}
+
+/**
+ * Strict form — throws when used outside the provider. Prefer this in
+ * client components that always render inside the AppShell tree.
+ */
+export function useNavPrefsStrict(): NavPrefsValue {
+  const ctx = React.useContext(NavPrefsCtx);
+  if (!ctx) {
+    throw new Error("useNavPrefsStrict must be used inside <NavPrefsProvider>");
+  }
+  return ctx;
+}

--- a/src/components/shell/NavPrefsSections.tsx
+++ b/src/components/shell/NavPrefsSections.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils/cn";
+import { useNavPrefs } from "./NavPrefsContext";
+import { PinButton } from "./PinButton";
+
+/**
+ * Renders the two personalization strips at the top of the sidebar:
+ *
+ *   PINNED — routes the user starred. Empty state shows a subtle hint.
+ *   RECENT — last 5 distinct visited routes. Empty → render nothing.
+ *
+ * Styling deliberately mirrors a labeled NavSection header so the rail
+ * reads as one continuous IA. Items are NOT collapsible (these strips are
+ * always short). A "Manage" action clears both lists.
+ */
+
+function SectionHeader({
+  label,
+  action,
+}: {
+  label: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2">
+      <span className="flex-1 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+        {label}
+      </span>
+      {action}
+    </div>
+  );
+}
+
+function Row({
+  href,
+  label,
+  isActive,
+  showPin,
+}: {
+  href: string;
+  label: string;
+  isActive: boolean;
+  showPin: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "group flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors duration-200 ease-smooth",
+        isActive
+          ? "bg-surface-muted text-text"
+          : "text-text-muted hover:bg-surface-muted hover:text-text",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "h-1 w-1 rounded-full transition-colors",
+          isActive ? "bg-accent" : "bg-border-strong group-hover:bg-accent",
+        )}
+      />
+      <span className="flex-1 truncate">{label}</span>
+      {showPin && <PinButton href={href} label={label} visibility="hover" />}
+    </Link>
+  );
+}
+
+export function NavPrefsSections() {
+  const prefs = useNavPrefs();
+  const pathname = usePathname() ?? "";
+  if (!prefs) return null;
+
+  const { pins, recents, hydrated, clearAll } = prefs;
+
+  const hasAny = pins.length > 0 || recents.length > 0;
+
+  // Pre-hydration render must match the server (empty). The provider flips
+  // `hydrated` in its mount effect; until then render a silent placeholder
+  // so the rail layout doesn't jump.
+  if (!hydrated) {
+    return <div aria-hidden="true" className="space-y-3" />;
+  }
+
+  const manageAction = hasAny ? (
+    <button
+      type="button"
+      onClick={clearAll}
+      className="text-[10px] uppercase tracking-wider text-text-subtle hover:text-text transition-colors"
+      aria-label="Clear pinned and recent"
+      title="Clear pinned and recent"
+    >
+      Manage
+    </button>
+  ) : null;
+
+  return (
+    <div className="space-y-3 mb-3">
+      {/* PINNED */}
+      <div>
+        <SectionHeader label="Pinned" action={manageAction} />
+        {pins.length === 0 ? (
+          <p className="px-3 pb-1 text-[11px] leading-snug text-text-subtle italic">
+            ⌘K + star any page to pin it
+          </p>
+        ) : (
+          <ul className="space-y-0.5 pl-1">
+            {pins.map((p) => (
+              <li key={p.href}>
+                <Row
+                  href={p.href}
+                  label={p.label}
+                  isActive={
+                    pathname === p.href || pathname.startsWith(p.href + "/")
+                  }
+                  showPin
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* RECENT — silent when empty. */}
+      {recents.length > 0 && (
+        <div className="pt-3 border-t border-border/40">
+          <SectionHeader label="Recent" />
+          <ul className="space-y-0.5 pl-1">
+            {recents.map((r) => (
+              <li key={r.href}>
+                <Row
+                  href={r.href}
+                  label={r.label}
+                  isActive={
+                    pathname === r.href || pathname.startsWith(r.href + "/")
+                  }
+                  showPin
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/NavVisitTracker.tsx
+++ b/src/components/shell/NavVisitTracker.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { flattenSectionItems, itemMatchesPath, type NavSection } from "./nav-sections";
+import { useNavPrefs } from "./NavPrefsContext";
+
+/**
+ * Invisible side-effect component that records every distinct route change
+ * into NavPrefsContext recents. Sits inside the provider tree in AppShell.
+ *
+ * Label resolution walks the flattened section list looking for the
+ * longest-prefix match. If no section item matches (e.g. the user is on a
+ * dynamic route not in the nav), we skip the visit — recents would otherwise
+ * fill with raw pathnames which read poorly.
+ */
+
+export interface NavVisitTrackerProps {
+  sections: NavSection[];
+}
+
+function resolveLabel(sections: NavSection[], pathname: string): { href: string; label: string } | null {
+  const items = flattenSectionItems(sections);
+  // Prefer an exact match, else the longest-prefix match.
+  let exact: { href: string; label: string } | null = null;
+  let prefix: { href: string; label: string; len: number } | null = null;
+  for (const item of items) {
+    if (item.href === pathname) {
+      exact = { href: item.href, label: item.label };
+      break;
+    }
+    if (itemMatchesPath(item.href, pathname)) {
+      if (!prefix || item.href.length > prefix.len) {
+        prefix = { href: item.href, label: item.label, len: item.href.length };
+      }
+    }
+  }
+  if (exact) return exact;
+  if (prefix) return { href: prefix.href, label: prefix.label };
+  return null;
+}
+
+export function NavVisitTracker({ sections }: NavVisitTrackerProps) {
+  const prefs = useNavPrefs();
+  const pathname = usePathname() ?? "";
+
+  React.useEffect(() => {
+    if (!prefs || !prefs.hydrated) return;
+    if (!pathname) return;
+    const resolved = resolveLabel(sections, pathname);
+    if (!resolved) return;
+    prefs.visit(resolved);
+    // `visit` is stable via useCallback; pathname + sections drive this.
+  }, [pathname, sections, prefs]);
+
+  return null;
+}

--- a/src/components/shell/PinButton.tsx
+++ b/src/components/shell/PinButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { useNavPrefs } from "./NavPrefsContext";
+
+/**
+ * Small star toggle that any NavItem row can render. Filled = pinned,
+ * outline = pinnable. Click toggles via the NavPrefsContext.
+ *
+ * The button suppresses link activation (stopPropagation + preventDefault)
+ * so clicking the star inside a <Link> row only toggles the pin — it does
+ * not navigate.
+ */
+
+export interface PinButtonProps {
+  href: string;
+  label: string;
+  /** Optional visual density knob. `rail` = always visible, `hover` = opacity-on-hover. */
+  visibility?: "rail" | "hover";
+  className?: string;
+}
+
+export function PinButton({
+  href,
+  label,
+  visibility = "hover",
+  className,
+}: PinButtonProps) {
+  const prefs = useNavPrefs();
+  if (!prefs) return null;
+
+  const pinned = prefs.isPinned(href);
+
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (pinned) prefs.unpin(href);
+    else prefs.pin({ href, label });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={pinned}
+      aria-label={pinned ? `Unpin ${label}` : `Pin ${label}`}
+      title={pinned ? `Unpin ${label}` : `Pin ${label}`}
+      className={cn(
+        "inline-flex items-center justify-center h-6 w-6 rounded-md text-text-subtle",
+        "transition-all duration-150 ease-smooth",
+        "hover:bg-surface-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        visibility === "hover" && !pinned
+          ? "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          : "opacity-100",
+        pinned && "text-amber-500",
+        className,
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill={pinned ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+      </svg>
+    </button>
+  );
+}

--- a/src/lib/domain/nav-prefs.test.ts
+++ b/src/lib/domain/nav-prefs.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  PINS_MAX,
+  PINS_STORAGE_KEY,
+  RECENT_MAX,
+  RECENT_STORAGE_KEY,
+  addPin,
+  parsePins,
+  parseRecents,
+  recordVisit,
+  removePin,
+  type PinnedEntry,
+  type RecentEntry,
+} from "./nav-prefs";
+
+describe("addPin", () => {
+  it("adds a new pin at the top", () => {
+    const next = addPin([], { href: "/clinic/queue", label: "Queue" }, 1000);
+    expect(next).toEqual([
+      { href: "/clinic/queue", label: "Queue", pinnedAt: 1000 },
+    ]);
+  });
+
+  it("dedupes by href and bumps the existing entry to the top with a fresh timestamp", () => {
+    const start: PinnedEntry[] = [
+      { href: "/a", label: "A", pinnedAt: 100 },
+      { href: "/b", label: "B", pinnedAt: 200 },
+    ];
+    const next = addPin(start, { href: "/a", label: "A renamed" }, 500);
+    expect(next).toEqual([
+      { href: "/a", label: "A renamed", pinnedAt: 500 },
+      { href: "/b", label: "B", pinnedAt: 200 },
+    ]);
+  });
+
+  it("caps the list at PINS_MAX", () => {
+    let pins: PinnedEntry[] = [];
+    for (let i = 0; i < PINS_MAX + 3; i++) {
+      pins = addPin(pins, { href: `/p/${i}`, label: `P${i}` }, i);
+    }
+    expect(pins).toHaveLength(PINS_MAX);
+    // Most recent pin is at the head
+    expect(pins[0].href).toBe(`/p/${PINS_MAX + 2}`);
+    // Earliest additions have fallen off
+    expect(pins.some((p) => p.href === "/p/0")).toBe(false);
+  });
+
+  it("preserves insertion order (newest first) when adding distinct pins", () => {
+    let pins: PinnedEntry[] = [];
+    pins = addPin(pins, { href: "/a", label: "A" }, 1);
+    pins = addPin(pins, { href: "/b", label: "B" }, 2);
+    pins = addPin(pins, { href: "/c", label: "C" }, 3);
+    expect(pins.map((p) => p.href)).toEqual(["/c", "/b", "/a"]);
+  });
+});
+
+describe("removePin", () => {
+  it("removes a pin matched by href", () => {
+    const pins: PinnedEntry[] = [
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ];
+    const next = removePin(pins, "/a");
+    expect(next).toEqual([{ href: "/b", label: "B", pinnedAt: 2 }]);
+  });
+
+  it("is a no-op (same reference) when href is not present", () => {
+    const pins: PinnedEntry[] = [{ href: "/a", label: "A", pinnedAt: 1 }];
+    const next = removePin(pins, "/missing");
+    expect(next).toBe(pins);
+  });
+
+  it("removes from an empty array as a no-op", () => {
+    const pins: PinnedEntry[] = [];
+    const next = removePin(pins, "/nope");
+    expect(next).toBe(pins);
+  });
+});
+
+describe("recordVisit", () => {
+  it("adds a new recent at the top", () => {
+    const next = recordVisit([], { href: "/x", label: "X" }, 1000);
+    expect(next).toEqual([{ href: "/x", label: "X", visitedAt: 1000 }]);
+  });
+
+  it("dedupes by href — repeat visits bump the entry to the top", () => {
+    const start: RecentEntry[] = [
+      { href: "/a", label: "A", visitedAt: 100 },
+      { href: "/b", label: "B", visitedAt: 200 },
+      { href: "/c", label: "C", visitedAt: 300 },
+    ];
+    const next = recordVisit(start, { href: "/a", label: "A" }, 999);
+    expect(next).toEqual([
+      { href: "/a", label: "A", visitedAt: 999 },
+      { href: "/b", label: "B", visitedAt: 200 },
+      { href: "/c", label: "C", visitedAt: 300 },
+    ]);
+  });
+
+  it("caps at RECENT_MAX", () => {
+    let recents: RecentEntry[] = [];
+    for (let i = 0; i < RECENT_MAX + 4; i++) {
+      recents = recordVisit(recents, { href: `/r/${i}`, label: `R${i}` }, i);
+    }
+    expect(recents).toHaveLength(RECENT_MAX);
+    expect(recents[0].href).toBe(`/r/${RECENT_MAX + 3}`);
+    expect(recents.at(-1)?.href).toBe(`/r/${RECENT_MAX + 3 - (RECENT_MAX - 1)}`);
+  });
+
+  it("keeps ordering newest-first across distinct hrefs", () => {
+    let recents: RecentEntry[] = [];
+    recents = recordVisit(recents, { href: "/a", label: "A" }, 1);
+    recents = recordVisit(recents, { href: "/b", label: "B" }, 2);
+    recents = recordVisit(recents, { href: "/c", label: "C" }, 3);
+    expect(recents.map((r) => r.href)).toEqual(["/c", "/b", "/a"]);
+  });
+});
+
+describe("parsePins", () => {
+  it("returns [] for null, empty, or malformed JSON", () => {
+    expect(parsePins(null)).toEqual([]);
+    expect(parsePins("")).toEqual([]);
+    expect(parsePins("{not json")).toEqual([]);
+    expect(parsePins("\"just a string\"")).toEqual([]);
+    expect(parsePins("42")).toEqual([]);
+  });
+
+  it("strips individual malformed entries but preserves valid siblings", () => {
+    const raw = JSON.stringify([
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: 42, label: "bad" },
+      null,
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ]);
+    expect(parsePins(raw)).toEqual([
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ]);
+  });
+
+  it("clamps to PINS_MAX on read", () => {
+    const payload = Array.from({ length: PINS_MAX + 5 }, (_, i) => ({
+      href: `/p/${i}`,
+      label: `P${i}`,
+      pinnedAt: i,
+    }));
+    expect(parsePins(JSON.stringify(payload))).toHaveLength(PINS_MAX);
+  });
+});
+
+describe("parseRecents", () => {
+  it("returns [] for null / malformed JSON / wrong shape", () => {
+    expect(parseRecents(null)).toEqual([]);
+    expect(parseRecents("nope")).toEqual([]);
+    expect(parseRecents(JSON.stringify({ not: "array" }))).toEqual([]);
+  });
+
+  it("clamps to RECENT_MAX on read", () => {
+    const payload = Array.from({ length: RECENT_MAX + 3 }, (_, i) => ({
+      href: `/r/${i}`,
+      label: `R${i}`,
+      visitedAt: i,
+    }));
+    expect(parseRecents(JSON.stringify(payload))).toHaveLength(RECENT_MAX);
+  });
+});
+
+describe("storage keys", () => {
+  it("are versioned so future migrations can coexist", () => {
+    expect(PINS_STORAGE_KEY).toBe("nav:pins:v1");
+    expect(RECENT_STORAGE_KEY).toBe("nav:recent:v1");
+  });
+});

--- a/src/lib/domain/nav-prefs.ts
+++ b/src/lib/domain/nav-prefs.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure helpers for the sidebar's Pinned + Recent personalization strips.
+ *
+ * Both collections are persisted to localStorage (see keys below). These
+ * helpers are framework-free so they can be exercised by the node-only
+ * vitest suite; the React provider (`NavPrefsContext`) composes them with
+ * SSR-safe hydration + debounced writes.
+ *
+ *   PinnedEntry    — route the user explicitly starred. Dedup by href, bump
+ *                    to top on re-pin, cap at 8.
+ *   RecentEntry    — last N visited distinct routes, newest first, cap at 5.
+ *
+ * Caps are low intentionally: the Pinned + Recent surfaces sit above the
+ * pillar nav and should not become a wall of links. Pins grow to 8; recents
+ * stay at 5.
+ */
+
+export interface PinnedEntry {
+  href: string;
+  label: string;
+  pinnedAt: number;
+}
+
+export interface RecentEntry {
+  href: string;
+  label: string;
+  visitedAt: number;
+}
+
+export const PINS_STORAGE_KEY = "nav:pins:v1";
+export const RECENT_STORAGE_KEY = "nav:recent:v1";
+
+export const PINS_MAX = 8;
+export const RECENT_MAX = 5;
+
+/**
+ * Add a pin, deduping by href. If the href is already pinned, the entry is
+ * bumped to the top with a refreshed `pinnedAt` timestamp. Capped at
+ * `PINS_MAX` — oldest entries fall off the tail.
+ */
+export function addPin(
+  current: PinnedEntry[],
+  entry: Omit<PinnedEntry, "pinnedAt">,
+  now: number = Date.now(),
+): PinnedEntry[] {
+  const next: PinnedEntry = {
+    href: entry.href,
+    label: entry.label,
+    pinnedAt: now,
+  };
+  const filtered = current.filter((p) => p.href !== entry.href);
+  return [next, ...filtered].slice(0, PINS_MAX);
+}
+
+/**
+ * Remove a pin by href. No-op when the href is not present — returns the
+ * same reference so React consumers can skip re-renders cheaply.
+ */
+export function removePin(current: PinnedEntry[], href: string): PinnedEntry[] {
+  const hit = current.some((p) => p.href === href);
+  if (!hit) return current;
+  return current.filter((p) => p.href !== href);
+}
+
+/**
+ * Record a route visit in the recents list. Dedups by href and keeps the
+ * newest visit first. Capped at `RECENT_MAX`.
+ */
+export function recordVisit(
+  current: RecentEntry[],
+  entry: Omit<RecentEntry, "visitedAt">,
+  now: number = Date.now(),
+): RecentEntry[] {
+  const next: RecentEntry = {
+    href: entry.href,
+    label: entry.label,
+    visitedAt: now,
+  };
+  const filtered = current.filter((r) => r.href !== entry.href);
+  return [next, ...filtered].slice(0, RECENT_MAX);
+}
+
+/**
+ * Parse a localStorage string payload into a typed PinnedEntry[]. Silently
+ * returns [] on any parse error or shape mismatch. Per-entry invalid items
+ * are stripped but valid siblings are preserved.
+ */
+export function parsePins(raw: string | null): PinnedEntry[] {
+  if (!raw) return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(decoded)) return [];
+  const out: PinnedEntry[] = [];
+  for (const v of decoded) {
+    if (
+      v &&
+      typeof v === "object" &&
+      typeof (v as PinnedEntry).href === "string" &&
+      typeof (v as PinnedEntry).label === "string" &&
+      typeof (v as PinnedEntry).pinnedAt === "number"
+    ) {
+      out.push({
+        href: (v as PinnedEntry).href,
+        label: (v as PinnedEntry).label,
+        pinnedAt: (v as PinnedEntry).pinnedAt,
+      });
+    }
+  }
+  return out.slice(0, PINS_MAX);
+}
+
+/**
+ * Parse a localStorage string payload into a typed RecentEntry[]. Same
+ * contract as `parsePins` — silent strip on failure.
+ */
+export function parseRecents(raw: string | null): RecentEntry[] {
+  if (!raw) return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(decoded)) return [];
+  const out: RecentEntry[] = [];
+  for (const v of decoded) {
+    if (
+      v &&
+      typeof v === "object" &&
+      typeof (v as RecentEntry).href === "string" &&
+      typeof (v as RecentEntry).label === "string" &&
+      typeof (v as RecentEntry).visitedAt === "number"
+    ) {
+      out.push({
+        href: (v as RecentEntry).href,
+        label: (v as RecentEntry).label,
+        visitedAt: (v as RecentEntry).visitedAt,
+      });
+    }
+  }
+  return out.slice(0, RECENT_MAX);
+}


### PR DESCRIPTION
## Summary
- Two new sidebar sections at the top: **Pinned** (star-toggle, cap 8) and **Recent** (auto-tracked last 5 routes).
- Persists to `localStorage` — `nav:pins:v1` and `nav:recent:v1`.
- Pure helpers in `src/lib/domain/nav-prefs.ts` (dedupe, cap, ordering, JSON-parse safety) — fully unit-tested.
- `NavPrefsContext` with SSR-safe read-once on mount + 250ms debounced writes.
- `NavVisitTracker` resolves pathname → label via longest-prefix match on flattened nav sections.
- AppShell wrap is surgical (+7 lines of diff).

## Test plan
- [x] `npx vitest run src/lib/domain/nav-prefs.test.ts` — 17/17
- [x] Full suite 259/259
- [x] `npx tsc --noEmit` clean
- [ ] Manual: pin a route, reload, confirm it persists; clear via Manage

Merges second in the 3-PR nav fleet (PR above sets up the shared nav-sections field space).

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C