### PR TITLE
feat(nav): icon rail + contextual drawer

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -1,6 +1,12 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
+import {
+  IconHome,
+  IconClipboardCheck,
+  IconBookOpen,
+  IconSettings,
+} from "@/components/shell/nav-icons";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { BreathingBreak } from "@/components/ui/breathing-break";
@@ -107,6 +113,9 @@ export default async function ClinicianLayout({
   //   Tier 3 (⌘K palette)     — everything else, discoverable via search.
   const sections: NavSection[] = [
     {
+      label: "Today",
+      pillar: "today",
+      icon: IconHome,
       items: [
         { label: "Today", href: "/clinic" },
         { label: "Command Center", href: "/clinic/command" },
@@ -116,6 +125,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Review",
+      icon: IconClipboardCheck,
       items: [
         {
           label: "Approvals",
@@ -142,6 +152,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Reference",
+      icon: IconBookOpen,
       items: [
         { label: "Providers", href: "/clinic/providers" },
         { label: "Research", href: "/clinic/research" },
@@ -151,6 +162,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Admin",
+      icon: IconSettings,
       items: [
         { label: "Audit", href: "/clinic/audit-trail" },
         { label: "Brief", href: "/clinic/morning-brief" },

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -18,6 +18,10 @@ import {
   computeLabsBadge,
   computeRefillsBadge,
 } from "@/lib/domain/nav-badges";
+import {
+  getActiveAgentActivity,
+  indexActivityByHref,
+} from "@/lib/domain/nav-agent-activity";
 
 export default async function ClinicianLayout({
   children,
@@ -44,6 +48,15 @@ export default async function ClinicianLayout({
       return 0;
     }
   };
+
+  // Ambient agent-activity indicators (emerald/sky pulsing dot on the rail).
+  // Loaded in parallel with the count queries; failures return [] silently so
+  // they can never block login.
+  const activityIndex = indexActivityByHref(
+    user.organizationId
+      ? await getActiveAgentActivity(user.organizationId)
+      : [],
+  );
 
   const [
     pendingCount,
@@ -170,6 +183,15 @@ export default async function ClinicianLayout({
       defaultCollapsed: true,
     },
   ];
+
+  // Decorate any nav item whose href has a currently-running agent job. Pure
+  // in-place pass over the section tree we just built.
+  for (const section of sections) {
+    for (const item of section.items) {
+      const hit = activityIndex[item.href];
+      if (hit) item.activity = hit;
+    }
+  }
 
   return (
     <AppShell

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -16,6 +16,10 @@ import {
   computeAgingBadge,
   computeDenialsBadge,
 } from "@/lib/domain/nav-badges";
+import {
+  getActiveAgentActivity,
+  indexActivityByHref,
+} from "@/lib/domain/nav-agent-activity";
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const MS_PER_HOUR = 1000 * 60 * 60;
@@ -135,6 +139,12 @@ export default async function OperatorLayout({
   const denialsBadge = computeDenialsBadge(denialsState);
   const agingBadge = computeAgingBadge(agingState);
 
+  // Ambient agent-activity index — "an AI is working on this row right now".
+  // Failures return [] so the rail silently degrades to no-dot.
+  const activityIndex = indexActivityByHref(
+    await getActiveAgentActivity(orgId),
+  );
+
   // 3-tier IA for the operator console.
   //
   //   Tier 1 (always visible) — 5 daily-use items plus the Command Center
@@ -225,6 +235,14 @@ export default async function OperatorLayout({
       defaultCollapsed: true,
     },
   ];
+
+  // Decorate nav items where an agent job is currently running for that href.
+  for (const section of sections) {
+    for (const item of section.items) {
+      const hit = activityIndex[item.href];
+      if (hit) item.activity = hit;
+    }
+  }
 
   return (
     <AppShell

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -1,6 +1,14 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
+import {
+  IconLayoutGrid,
+  IconDollar,
+  IconUsers,
+  IconBuilding,
+  IconChart,
+  IconServer,
+} from "@/components/shell/nav-icons";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { prisma } from "@/lib/db/prisma";
@@ -140,6 +148,9 @@ export default async function OperatorLayout({
   // thinks "I'm clearing denials" rather than "I'm in the Billing tab".
   const sections: NavSection[] = [
     {
+      label: "Overview",
+      pillar: "overview",
+      icon: IconLayoutGrid,
       items: [
         { label: "Overview", href: "/ops" },
         { label: "Mission Control", href: "/ops/mission-control" },
@@ -150,6 +161,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Billing",
+      icon: IconDollar,
       items: [
         { label: "Billing", href: "/ops/billing" },
         { label: "Scrub", href: "/ops/scrub" },
@@ -163,6 +175,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Operations",
+      icon: IconUsers,
       items: [
         { label: "Staff schedule", href: "/ops/staff-schedule" },
         { label: "Time clock", href: "/ops/time-clock" },
@@ -179,6 +192,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Practice Setup",
+      icon: IconBuilding,
       items: [
         { label: "Onboarding", href: "/ops/onboarding" },
         { label: "Practice launch", href: "/ops/launch" },
@@ -189,6 +203,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Intelligence",
+      icon: IconChart,
       items: [
         { label: "Analytics", href: "/ops/analytics" },
         { label: "Analytics Lab", href: "/ops/analytics-lab" },
@@ -198,6 +213,7 @@ export default async function OperatorLayout({
     },
     {
       label: "System",
+      icon: IconServer,
       items: [
         { label: "AI Config", href: "/ops/settings/ai-config" },
         { label: "Webhooks", href: "/ops/webhooks" },

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -1,25 +1,57 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
+import {
+  IconHome,
+  IconPill,
+  IconCalendar,
+  IconMessage,
+  IconUser,
+} from "@/components/shell/nav-icons";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { CommandPalette } from "@/components/ui/command-palette";
 
-// Patient nav stays flat — 8 items is short enough that grouping would add
-// noise, not reduce it. The ⌘K palette still surfaces here so patients can
-// jump anywhere with a keyboard shortcut.
+// Patient nav is 5 pillar icons. Each pillar groups 1–3 related routes
+// that open in the contextual drawer. Account is overflow — it lives in
+// its own pillar rather than cluttering the top level.
 const PATIENT_SECTIONS: NavSection[] = [
   {
+    label: "Home",
+    pillar: "home",
+    icon: IconHome,
+    items: [{ label: "Home", href: "/portal" }],
+  },
+  {
+    label: "Health",
+    pillar: "health",
+    icon: IconPill,
     items: [
-      { label: "Home", href: "/portal" },
       { label: "Log Dose", href: "/portal/log-dose" },
       { label: "My Health", href: "/portal/records" },
       { label: "My Journey", href: "/portal/lifestyle" },
-      { label: "Schedule", href: "/portal/schedule" },
+    ],
+  },
+  {
+    label: "Schedule",
+    pillar: "schedule",
+    icon: IconCalendar,
+    items: [{ label: "Schedule", href: "/portal/schedule" }],
+  },
+  {
+    label: "Messages",
+    pillar: "messages",
+    icon: IconMessage,
+    items: [
       { label: "Messages", href: "/portal/messages" },
       { label: "Q&A", href: "/portal/qa" },
-      { label: "Account", href: "/portal/profile" },
     ],
+  },
+  {
+    label: "Account",
+    pillar: "account",
+    icon: IconUser,
+    items: [{ label: "Account", href: "/portal/profile" }],
   },
 ];
 

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -9,6 +9,9 @@ import { ROLE_HOME } from "@/lib/rbac/roles";
 import { MobileNav } from "./MobileNav";
 import { NavSections } from "./NavSections";
 import { PillarNav } from "./PillarNav";
+import { NavPrefsProvider } from "./NavPrefsContext";
+import { NavPrefsSections } from "./NavPrefsSections";
+import { NavVisitTracker } from "./NavVisitTracker";
 import { hasPillarIcons, type NavItem, type NavSection } from "./nav-sections";
 
 // Re-export so existing consumers (each layout) can keep importing the
@@ -57,119 +60,123 @@ export function AppShell({
   const useRail = hasPillarIcons(resolved);
 
   return (
-    <div className="min-h-screen bg-bg flex">
-      {useRail ? (
-        // ── Icon rail + contextual drawer ────────────────────────────────
-        // 64px rail (logo, pillar icons, account) + optional 240px drawer.
-        // iOS-sidebar vibe: minimal, vertical, big touch targets.
-        <div className="hidden md:block">
-          <PillarNav
-            sections={resolved}
-            header={
-              <Link
-                href={homeHref}
-                aria-label="Home"
-                className="flex h-14 w-14 items-center justify-center"
-              >
-                <Wordmark size="sm" />
-              </Link>
-            }
-            footer={
-              <div className="flex flex-col items-center gap-2 pb-3">
-                <form action={logoutAction}>
-                  <button
-                    type="submit"
-                    aria-label="Sign out"
-                    title="Sign out"
-                    className="flex h-10 w-10 items-center justify-center rounded-md text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
-                  >
-                    <svg
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.75"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
+    <NavPrefsProvider>
+      <NavVisitTracker sections={resolved} />
+      <div className="min-h-screen bg-bg flex">
+        {useRail ? (
+          // ── Icon rail + contextual drawer ────────────────────────
+          // 64px rail (logo, pillar icons, account) + optional 240px drawer.
+          // iOS-sidebar vibe: minimal, vertical, big touch targets.
+          <div className="hidden md:block">
+            <PillarNav
+              sections={resolved}
+              header={
+                <Link
+                  href={homeHref}
+                  aria-label="Home"
+                  className="flex h-14 w-14 items-center justify-center"
+                >
+                  <Wordmark size="sm" />
+                </Link>
+              }
+              footer={
+                <div className="flex flex-col items-center gap-2 pb-3">
+                  <form action={logoutAction}>
+                    <button
+                      type="submit"
+                      aria-label="Sign out"
+                      title="Sign out"
+                      className="flex h-10 w-10 items-center justify-center rounded-md text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
                     >
-                      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-                      <polyline points="16 17 21 12 16 7" />
-                      <line x1="21" y1="12" x2="9" y2="12" />
-                    </svg>
-                  </button>
-                </form>
-                <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
-              </div>
-            }
-          />
-        </div>
-      ) : (
-        // ── Legacy stacked sidebar (unchanged) ───────────────────────────
-        <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-surface relative">
-          {/* Subtle radial glow at the top of the rail for warmth */}
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-0 h-40 opacity-70"
-            style={{
-              background:
-                "radial-gradient(ellipse 80% 60% at 20% 0%, var(--highlight-soft), transparent 70%)",
-            }}
-          />
-
-          <div className="relative px-5 pt-6 pb-5">
-            <Link href={homeHref} className="block">
-              <Wordmark size="md" />
-            </Link>
-            <p className="mt-3 text-[11px] uppercase tracking-[0.14em] text-text-subtle">
-              {roleLabel}
-            </p>
-          </div>
-
-          <nav aria-label="Main navigation" className="relative px-3 flex-1 mt-2 overflow-y-auto">
-            <NavSections sections={resolved} />
-          </nav>
-
-          <div className="relative p-3 border-t border-border/80">
-            <div className="flex items-center gap-2.5 px-2 py-2 rounded-md bg-surface-muted/50">
-              <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium text-text truncate">
-                  {user.firstName} {user.lastName}
+                      <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.75"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                        <polyline points="16 17 21 12 16 7" />
+                        <line x1="21" y1="12" x2="9" y2="12" />
+                      </svg>
+                    </button>
+                  </form>
+                  <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
                 </div>
-                <div className="text-xs text-text-subtle truncate">{user.email}</div>
-              </div>
-            </div>
-            <form action={logoutAction} className="mt-2">
-              <button
-                type="submit"
-                className="w-full text-left text-xs text-text-subtle hover:text-text px-3 py-1.5 transition-colors"
-              >
-                Sign out →
-              </button>
-            </form>
-            <p className="text-[9px] text-text-subtle italic leading-tight mt-3 px-2 line-clamp-2">
-              Cannabis should be considered a medicine — please use it carefully
-              and judiciously. Respect the plant and its healing properties.
-            </p>
+              }
+            />
           </div>
-        </aside>
-      )}
+        ) : (
+          // ── Legacy stacked sidebar (unchanged) ───────────────────────
+          <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-surface relative">
+            {/* Subtle radial glow at the top of the rail for warmth */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 top-0 h-40 opacity-70"
+              style={{
+                background:
+                  "radial-gradient(ellipse 80% 60% at 20% 0%, var(--highlight-soft), transparent 70%)",
+              }}
+            />
 
-      {/* Main column */}
-      <div className="flex-1 flex flex-col min-w-0">
-        <header className="md:hidden flex items-center justify-between px-4 h-16 border-b border-border bg-surface">
-          <Link href={homeHref} className="flex items-center gap-2">
-            <Wordmark size="sm" />
-          </Link>
-          <div className="flex items-center gap-2">
-            <MobileNav sections={resolved} />
-            <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
-          </div>
-        </header>
-        <main id="main-content" className="flex-1 min-w-0">{children}</main>
+            <div className="relative px-5 pt-6 pb-5">
+              <Link href={homeHref} className="block">
+                <Wordmark size="md" />
+              </Link>
+              <p className="mt-3 text-[11px] uppercase tracking-[0.14em] text-text-subtle">
+                {roleLabel}
+              </p>
+            </div>
+
+            <nav aria-label="Main navigation" className="relative px-3 flex-1 mt-2 overflow-y-auto">
+              <NavPrefsSections />
+              <NavSections sections={resolved} />
+            </nav>
+
+            <div className="relative p-3 border-t border-border/80">
+              <div className="flex items-center gap-2.5 px-2 py-2 rounded-md bg-surface-muted/50">
+                <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-text truncate">
+                    {user.firstName} {user.lastName}
+                  </div>
+                  <div className="text-xs text-text-subtle truncate">{user.email}</div>
+                </div>
+              </div>
+              <form action={logoutAction} className="mt-2">
+                <button
+                  type="submit"
+                  className="w-full text-left text-xs text-text-subtle hover:text-text px-3 py-1.5 transition-colors"
+                >
+                  Sign out →
+                </button>
+              </form>
+              <p className="text-[9px] text-text-subtle italic leading-tight mt-3 px-2 line-clamp-2">
+                Cannabis should be considered a medicine — please use it carefully
+                and judiciously. Respect the plant and its healing properties.
+              </p>
+            </div>
+          </aside>
+        )}
+
+        {/* Main column */}
+        <div className="flex-1 flex flex-col min-w-0">
+          <header className="md:hidden flex items-center justify-between px-4 h-16 border-b border-border bg-surface">
+            <Link href={homeHref} className="flex items-center gap-2">
+              <Wordmark size="sm" />
+            </Link>
+            <div className="flex items-center gap-2">
+              <MobileNav sections={resolved} />
+              <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
+            </div>
+          </header>
+          <main id="main-content" className="flex-1 min-w-0">{children}</main>
+        </div>
       </div>
-    </div>
+    </NavPrefsProvider>
   );
 }

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -8,7 +8,8 @@ import type { Role } from "@prisma/client";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { MobileNav } from "./MobileNav";
 import { NavSections } from "./NavSections";
-import type { NavItem, NavSection } from "./nav-sections";
+import { PillarNav } from "./PillarNav";
+import { hasPillarIcons, type NavItem, type NavSection } from "./nav-sections";
 
 // Re-export so existing consumers (each layout) can keep importing the
 // NavItem / NavSection types from this module.
@@ -53,58 +54,108 @@ export function AppShell({
   // This prevents the "logo click = logged out" UX bug.
   const homeHref = ROLE_HOME[activeRole] ?? "/";
   const resolved = normalizeSections(sections, nav);
+  const useRail = hasPillarIcons(resolved);
 
   return (
     <div className="min-h-screen bg-bg flex">
-      {/* Side nav */}
-      <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-surface relative">
-        {/* Subtle radial glow at the top of the rail for warmth */}
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 h-40 opacity-70"
-          style={{
-            background:
-              "radial-gradient(ellipse 80% 60% at 20% 0%, var(--highlight-soft), transparent 70%)",
-          }}
-        />
-
-        <div className="relative px-5 pt-6 pb-5">
-          <Link href={homeHref} className="block">
-            <Wordmark size="md" />
-          </Link>
-          <p className="mt-3 text-[11px] uppercase tracking-[0.14em] text-text-subtle">
-            {roleLabel}
-          </p>
-        </div>
-
-        <nav aria-label="Main navigation" className="relative px-3 flex-1 mt-2 overflow-y-auto">
-          <NavSections sections={resolved} />
-        </nav>
-
-        <div className="relative p-3 border-t border-border/80">
-          <div className="flex items-center gap-2.5 px-2 py-2 rounded-md bg-surface-muted/50">
-            <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
-            <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium text-text truncate">
-                {user.firstName} {user.lastName}
+      {useRail ? (
+        // ── Icon rail + contextual drawer ────────────────────────────────
+        // 64px rail (logo, pillar icons, account) + optional 240px drawer.
+        // iOS-sidebar vibe: minimal, vertical, big touch targets.
+        <div className="hidden md:block">
+          <PillarNav
+            sections={resolved}
+            header={
+              <Link
+                href={homeHref}
+                aria-label="Home"
+                className="flex h-14 w-14 items-center justify-center"
+              >
+                <Wordmark size="sm" />
+              </Link>
+            }
+            footer={
+              <div className="flex flex-col items-center gap-2 pb-3">
+                <form action={logoutAction}>
+                  <button
+                    type="submit"
+                    aria-label="Sign out"
+                    title="Sign out"
+                    className="flex h-10 w-10 items-center justify-center rounded-md text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
+                  >
+                    <svg
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.75"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                      <polyline points="16 17 21 12 16 7" />
+                      <line x1="21" y1="12" x2="9" y2="12" />
+                    </svg>
+                  </button>
+                </form>
+                <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
               </div>
-              <div className="text-xs text-text-subtle truncate">{user.email}</div>
-            </div>
-          </div>
-          <form action={logoutAction} className="mt-2">
-            <button
-              type="submit"
-              className="w-full text-left text-xs text-text-subtle hover:text-text px-3 py-1.5 transition-colors"
-            >
-              Sign out →
-            </button>
-          </form>
-          <p className="text-[9px] text-text-subtle italic leading-tight mt-3 px-2 line-clamp-2">
-            Cannabis should be considered a medicine — please use it carefully
-            and judiciously. Respect the plant and its healing properties.
-          </p>
+            }
+          />
         </div>
-      </aside>
+      ) : (
+        // ── Legacy stacked sidebar (unchanged) ───────────────────────────
+        <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-surface relative">
+          {/* Subtle radial glow at the top of the rail for warmth */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 top-0 h-40 opacity-70"
+            style={{
+              background:
+                "radial-gradient(ellipse 80% 60% at 20% 0%, var(--highlight-soft), transparent 70%)",
+            }}
+          />
+
+          <div className="relative px-5 pt-6 pb-5">
+            <Link href={homeHref} className="block">
+              <Wordmark size="md" />
+            </Link>
+            <p className="mt-3 text-[11px] uppercase tracking-[0.14em] text-text-subtle">
+              {roleLabel}
+            </p>
+          </div>
+
+          <nav aria-label="Main navigation" className="relative px-3 flex-1 mt-2 overflow-y-auto">
+            <NavSections sections={resolved} />
+          </nav>
+
+          <div className="relative p-3 border-t border-border/80">
+            <div className="flex items-center gap-2.5 px-2 py-2 rounded-md bg-surface-muted/50">
+              <Avatar firstName={user.firstName} lastName={user.lastName} size="sm" />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-text truncate">
+                  {user.firstName} {user.lastName}
+                </div>
+                <div className="text-xs text-text-subtle truncate">{user.email}</div>
+              </div>
+            </div>
+            <form action={logoutAction} className="mt-2">
+              <button
+                type="submit"
+                className="w-full text-left text-xs text-text-subtle hover:text-text px-3 py-1.5 transition-colors"
+              >
+                Sign out →
+              </button>
+            </form>
+            <p className="text-[9px] text-text-subtle italic leading-tight mt-3 px-2 line-clamp-2">
+              Cannabis should be considered a medicine — please use it carefully
+              and judiciously. Respect the plant and its healing properties.
+            </p>
+          </div>
+        </aside>
+      )}
 
       {/* Main column */}
       <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/shell/ContextDrawer.tsx
+++ b/src/components/shell/ContextDrawer.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { NavItemBadge, navItemAriaLabel } from "./NavSections";
+import { itemMatchesPath, type NavSection } from "./nav-sections";
+
+export interface ContextDrawerProps {
+  /** The pillar section whose items are shown. Null hides the drawer. */
+  section: NavSection | null;
+  pathname: string;
+  /** Called when the drawer should close (outside click, Esc, route change). */
+  onClose: () => void;
+}
+
+/**
+ * 240px drawer that slides out next to the icon rail. Coexists with page
+ * content (no overlay). Closes on:
+ *   - outside click (pointerdown outside the drawer or rail)
+ *   - Escape key
+ *   - route change (parent clears section via pathname effect)
+ *
+ * Renders its own list rather than delegating to `NavSections` because the
+ * drawer is a single-section surface — we want a tighter header + bigger
+ * touch targets than the stacked accordion provides.
+ */
+export function ContextDrawer({ section, pathname, onClose }: ContextDrawerProps) {
+  const open = section !== null;
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click. Only active while open.
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (ref.current && ref.current.contains(target)) return;
+      // Rail buttons live outside the drawer; the rail handles its own
+      // toggle. Ignore clicks inside anything marked data-nav-rail so the
+      // rail can re-open a different pillar without flickering.
+      const el = target as HTMLElement;
+      if (el.closest?.("[data-nav-rail]")) return;
+      onClose();
+    };
+    document.addEventListener("pointerdown", handler);
+    return () => document.removeEventListener("pointerdown", handler);
+  }, [open, onClose]);
+
+  // Close on Escape.
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  return (
+    <div
+      ref={ref}
+      role="region"
+      aria-label={section?.label ?? "Navigation"}
+      aria-hidden={!open}
+      className={cn(
+        "hidden md:flex flex-col w-60 shrink-0 border-r border-border bg-surface",
+        "transition-all duration-200 ease-smooth",
+        open ? "opacity-100" : "pointer-events-none w-0 border-r-0 opacity-0",
+      )}
+    >
+      {section && (
+        <>
+          <div className="px-4 pt-6 pb-3">
+            <p className="text-[11px] uppercase tracking-[0.14em] text-text-subtle">
+              {section.label ?? "Menu"}
+            </p>
+          </div>
+          <nav
+            aria-label={`${section.label ?? "Pillar"} navigation`}
+            className="flex-1 overflow-y-auto px-2 pb-4"
+          >
+            <ul className="space-y-0.5">
+              {section.items.map((item) => {
+                const isActive = itemMatchesPath(item.href, pathname);
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      aria-label={navItemAriaLabel(item)}
+                      aria-current={isActive ? "page" : undefined}
+                      className={cn(
+                        "group flex items-center gap-2.5 px-3 py-2.5 rounded-md text-sm",
+                        "transition-colors duration-200 ease-smooth",
+                        isActive
+                          ? "bg-surface-muted text-text"
+                          : "text-text-muted hover:bg-surface-muted hover:text-text",
+                      )}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          "h-1 w-1 rounded-full transition-colors",
+                          isActive
+                            ? "bg-accent"
+                            : "bg-border-strong group-hover:bg-accent",
+                        )}
+                      />
+                      <span className="flex-1">{item.label}</span>
+                      <NavItemBadge item={item} />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/IconRail.tsx
+++ b/src/components/shell/IconRail.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import {
+  getSectionBadge,
+  pillarId,
+  sectionContainsPath,
+  type NavSection,
+} from "./nav-sections";
+
+export interface IconRailProps {
+  sections: NavSection[];
+  /** Currently focused pillar id (drawer open). May be null if nothing open. */
+  activePillar: string | null;
+  /** Pillar id matching the current pathname (if any) — gets an accent bar. */
+  pathPillar: string | null;
+  /** Toggle a pillar. Same id → closes; different id → opens. */
+  onSelect: (id: string) => void;
+  pathname: string;
+}
+
+/**
+ * 64px vertical strip. One button per pillar. Clicking a button focuses its
+ * drawer via the parent shell. Route-active pillar gets a left accent bar,
+ * drawer-focused pillar gets a subtle surface wash — the two states can
+ * coexist (you can have Approvals open but be looking at Today).
+ *
+ * A `data-pulse` hook is reserved on each button for Agent K's live-signal
+ * pass (e.g., critical denial count pulsing the Billing icon).
+ */
+export function IconRail({
+  sections,
+  activePillar,
+  pathPillar,
+  onSelect,
+  pathname,
+}: IconRailProps) {
+  return (
+    <ul className="flex flex-col gap-1 px-2 py-3">
+      {sections.map((section, idx) => {
+        const Icon = section.icon;
+        if (!Icon) return null;
+        const id = pillarId(section, idx);
+        const badge = getSectionBadge(section);
+        const isFocused = activePillar === id;
+        const isOnPath = pathPillar === id || sectionContainsPath(section, pathname);
+        const label = section.label ?? id;
+        const pulse =
+          badge && (badge.severity === "critical" || badge.severity === "warn");
+        return (
+          <li key={id}>
+            <button
+              type="button"
+              aria-label={label}
+              aria-pressed={isFocused}
+              data-pulse={pulse ? "true" : undefined}
+              onClick={() => onSelect(id)}
+              className={cn(
+                "group relative flex h-12 w-12 items-center justify-center rounded-xl",
+                "text-text-muted transition-colors duration-200 ease-smooth",
+                "hover:bg-surface-muted hover:text-text",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                isFocused && "bg-surface-muted text-text",
+                !isFocused && isOnPath && "text-text",
+              )}
+            >
+              {/* Left accent bar: signals route-active pillar. */}
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute left-0 top-1/2 h-6 w-0.5 -translate-y-1/2 rounded-r-full bg-accent",
+                  "transition-opacity duration-200",
+                  isOnPath ? "opacity-100" : "opacity-0",
+                )}
+              />
+              <Icon width={22} height={22} />
+              {/* Badge dot — matches NavSections severity palette. */}
+              {badge && badge.severity !== "ok" && (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "absolute right-1.5 top-1.5 h-2 w-2 rounded-full ring-2 ring-surface",
+                    badge.severity === "critical" && "bg-red-600",
+                    badge.severity === "warn" && "bg-amber-500",
+                    badge.severity === "info" && "bg-accent",
+                  )}
+                />
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/shell/NavActivityDot.tsx
+++ b/src/components/shell/NavActivityDot.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * A 6px pulsing dot rendered on nav rows where an AI agent is currently
+ * working. Additive-only — lives next to the existing count/semantic badge
+ * without replacing either.
+ *
+ *   "active" — emerald-400 — an agent is producing something that will want
+ *              human attention when it lands (e.g. a draft message for sign-off).
+ *   "info"   — sky-400     — a passive observer is scanning in the background;
+ *              no action pending.
+ *
+ * Tailwind's `animate-pulse` keeps the visual language consistent with the
+ * existing danger-count pill (which also pulses via the same utility).
+ */
+export type NavActivityTone = "info" | "active";
+
+const TONE_CLASS: Record<NavActivityTone, string> = {
+  active: "bg-emerald-400",
+  info: "bg-sky-400",
+};
+
+export function NavActivityDot({ tone }: { tone: NavActivityTone }) {
+  return (
+    <span
+      role="status"
+      aria-label="AI agent working here"
+      className={cn(
+        "inline-block h-1.5 w-1.5 rounded-full animate-pulse",
+        TONE_CLASS[tone],
+      )}
+    />
+  );
+}

--- a/src/components/shell/NavPrefsContext.tsx
+++ b/src/components/shell/NavPrefsContext.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import * as React from "react";
+import {
+  PINS_STORAGE_KEY,
+  RECENT_STORAGE_KEY,
+  addPin,
+  parsePins,
+  parseRecents,
+  recordVisit,
+  removePin,
+  type PinnedEntry,
+  type RecentEntry,
+} from "@/lib/domain/nav-prefs";
+
+/**
+ * Client-side nav personalization state. Lives entirely in localStorage —
+ * no server round-trip, no cookies. SSR-safe: initial render is always
+ * empty, then the first client effect hydrates from storage.
+ *
+ *   pins      — pinned routes, newest first, cap 8.
+ *   recents   — last 5 distinct visited routes, newest first.
+ *   pin/unpin — mutate pins by href.
+ *   isPinned  — cheap lookup for star-toggle state.
+ *   visit     — record a route visit (used by NavVisitTracker).
+ *   clearAll  — nuke both lists + their storage keys (Manage action).
+ *
+ * Writes are debounced 250ms so rapid toggles don't hammer localStorage.
+ */
+
+export interface NavPrefsValue {
+  pins: PinnedEntry[];
+  recents: RecentEntry[];
+  pin: (entry: { href: string; label: string }) => void;
+  unpin: (href: string) => void;
+  isPinned: (href: string) => boolean;
+  visit: (entry: { href: string; label: string }) => void;
+  clearAll: () => void;
+  hydrated: boolean;
+}
+
+const NavPrefsCtx = React.createContext<NavPrefsValue | null>(null);
+
+const WRITE_DEBOUNCE_MS = 250;
+
+function safeGet(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* private mode / quota — non-fatal */
+  }
+}
+
+function safeRemove(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export function NavPrefsProvider({ children }: { children: React.ReactNode }) {
+  const [pins, setPins] = React.useState<PinnedEntry[]>([]);
+  const [recents, setRecents] = React.useState<RecentEntry[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  // Read-once on mount. Malformed / missing payloads become [].
+  React.useEffect(() => {
+    setPins(parsePins(safeGet(PINS_STORAGE_KEY)));
+    setRecents(parseRecents(safeGet(RECENT_STORAGE_KEY)));
+    setHydrated(true);
+  }, []);
+
+  // Debounced writes — one timer per key, reset on each change.
+  const pinsTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const recentsTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (pinsTimer.current) clearTimeout(pinsTimer.current);
+    pinsTimer.current = setTimeout(() => {
+      safeSet(PINS_STORAGE_KEY, JSON.stringify(pins));
+    }, WRITE_DEBOUNCE_MS);
+    return () => {
+      if (pinsTimer.current) clearTimeout(pinsTimer.current);
+    };
+  }, [pins, hydrated]);
+
+  React.useEffect(() => {
+    if (!hydrated) return;
+    if (recentsTimer.current) clearTimeout(recentsTimer.current);
+    recentsTimer.current = setTimeout(() => {
+      safeSet(RECENT_STORAGE_KEY, JSON.stringify(recents));
+    }, WRITE_DEBOUNCE_MS);
+    return () => {
+      if (recentsTimer.current) clearTimeout(recentsTimer.current);
+    };
+  }, [recents, hydrated]);
+
+  const pin = React.useCallback(
+    (entry: { href: string; label: string }) => {
+      setPins((prev) => addPin(prev, entry));
+    },
+    [],
+  );
+
+  const unpin = React.useCallback((href: string) => {
+    setPins((prev) => removePin(prev, href));
+  }, []);
+
+  const visit = React.useCallback((entry: { href: string; label: string }) => {
+    setRecents((prev) => recordVisit(prev, entry));
+  }, []);
+
+  const clearAll = React.useCallback(() => {
+    setPins([]);
+    setRecents([]);
+    safeRemove(PINS_STORAGE_KEY);
+    safeRemove(RECENT_STORAGE_KEY);
+  }, []);
+
+  // isPinned is recomputed from `pins`; Set membership keeps toggles O(1).
+  const pinnedHrefs = React.useMemo(
+    () => new Set(pins.map((p) => p.href)),
+    [pins],
+  );
+  const isPinned = React.useCallback(
+    (href: string) => pinnedHrefs.has(href),
+    [pinnedHrefs],
+  );
+
+  const value = React.useMemo<NavPrefsValue>(
+    () => ({ pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated }),
+    [pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated],
+  );
+
+  return <NavPrefsCtx.Provider value={value}>{children}</NavPrefsCtx.Provider>;
+}
+
+/**
+ * Read the nav-prefs context. Returns null outside the provider so callers
+ * can gracefully degrade (e.g. server-rendered sub-trees).
+ */
+export function useNavPrefs(): NavPrefsValue | null {
+  return React.useContext(NavPrefsCtx);
+}
+
+/**
+ * Strict form — throws when used outside the provider. Prefer this in
+ * client components that always render inside the AppShell tree.
+ */
+export function useNavPrefsStrict(): NavPrefsValue {
+  const ctx = React.useContext(NavPrefsCtx);
+  if (!ctx) {
+    throw new Error("useNavPrefsStrict must be used inside <NavPrefsProvider>");
+  }
+  return ctx;
+}

--- a/src/components/shell/NavPrefsSections.tsx
+++ b/src/components/shell/NavPrefsSections.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils/cn";
+import { useNavPrefs } from "./NavPrefsContext";
+import { PinButton } from "./PinButton";
+
+/**
+ * Renders the two personalization strips at the top of the sidebar:
+ *
+ *   PINNED — routes the user starred. Empty state shows a subtle hint.
+ *   RECENT — last 5 distinct visited routes. Empty → render nothing.
+ *
+ * Styling deliberately mirrors a labeled NavSection header so the rail
+ * reads as one continuous IA. Items are NOT collapsible (these strips are
+ * always short). A "Manage" action clears both lists.
+ */
+
+function SectionHeader({
+  label,
+  action,
+}: {
+  label: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2">
+      <span className="flex-1 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+        {label}
+      </span>
+      {action}
+    </div>
+  );
+}
+
+function Row({
+  href,
+  label,
+  isActive,
+  showPin,
+}: {
+  href: string;
+  label: string;
+  isActive: boolean;
+  showPin: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "group flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors duration-200 ease-smooth",
+        isActive
+          ? "bg-surface-muted text-text"
+          : "text-text-muted hover:bg-surface-muted hover:text-text",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "h-1 w-1 rounded-full transition-colors",
+          isActive ? "bg-accent" : "bg-border-strong group-hover:bg-accent",
+        )}
+      />
+      <span className="flex-1 truncate">{label}</span>
+      {showPin && <PinButton href={href} label={label} visibility="hover" />}
+    </Link>
+  );
+}
+
+export function NavPrefsSections() {
+  const prefs = useNavPrefs();
+  const pathname = usePathname() ?? "";
+  if (!prefs) return null;
+
+  const { pins, recents, hydrated, clearAll } = prefs;
+
+  const hasAny = pins.length > 0 || recents.length > 0;
+
+  // Pre-hydration render must match the server (empty). The provider flips
+  // `hydrated` in its mount effect; until then render a silent placeholder
+  // so the rail layout doesn't jump.
+  if (!hydrated) {
+    return <div aria-hidden="true" className="space-y-3" />;
+  }
+
+  const manageAction = hasAny ? (
+    <button
+      type="button"
+      onClick={clearAll}
+      className="text-[10px] uppercase tracking-wider text-text-subtle hover:text-text transition-colors"
+      aria-label="Clear pinned and recent"
+      title="Clear pinned and recent"
+    >
+      Manage
+    </button>
+  ) : null;
+
+  return (
+    <div className="space-y-3 mb-3">
+      {/* PINNED */}
+      <div>
+        <SectionHeader label="Pinned" action={manageAction} />
+        {pins.length === 0 ? (
+          <p className="px-3 pb-1 text-[11px] leading-snug text-text-subtle italic">
+            ⌘K + star any page to pin it
+          </p>
+        ) : (
+          <ul className="space-y-0.5 pl-1">
+            {pins.map((p) => (
+              <li key={p.href}>
+                <Row
+                  href={p.href}
+                  label={p.label}
+                  isActive={
+                    pathname === p.href || pathname.startsWith(p.href + "/")
+                  }
+                  showPin
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* RECENT — silent when empty. */}
+      {recents.length > 0 && (
+        <div className="pt-3 border-t border-border/40">
+          <SectionHeader label="Recent" />
+          <ul className="space-y-0.5 pl-1">
+            {recents.map((r) => (
+              <li key={r.href}>
+                <Row
+                  href={r.href}
+                  label={r.label}
+                  isActive={
+                    pathname === r.href || pathname.startsWith(r.href + "/")
+                  }
+                  showPin
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/NavSections.tsx
+++ b/src/components/shell/NavSections.tsx
@@ -16,6 +16,7 @@ import {
   type NavSection,
 } from "./nav-sections";
 import type { BadgeSeverity, NavBadge } from "@/lib/domain/nav-badges";
+import { NavActivityDot } from "./NavActivityDot";
 
 /**
  * Rail renderer for the 3-tier IA.
@@ -51,9 +52,9 @@ function CountBadge({ count, tone }: { count: number; tone: CountTone }) {
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // Semantic badge presentation
-// ─────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────────
 // `ok` severity renders nothing — the section is silent-green. The dot color
 // signals severity at a glance; the label gives the punchline; `context`
 // becomes a native title-attribute tooltip.
@@ -150,6 +151,7 @@ function ItemLink({
         )}
       />
       <span className="flex-1">{item.label}</span>
+      {item.activity && <NavActivityDot tone={item.activity.tone} />}
       <NavItemBadge item={item} />
     </Link>
   );

--- a/src/components/shell/NavVisitTracker.tsx
+++ b/src/components/shell/NavVisitTracker.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { flattenSectionItems, itemMatchesPath, type NavSection } from "./nav-sections";
+import { useNavPrefs } from "./NavPrefsContext";
+
+/**
+ * Invisible side-effect component that records every distinct route change
+ * into NavPrefsContext recents. Sits inside the provider tree in AppShell.
+ *
+ * Label resolution walks the flattened section list looking for the
+ * longest-prefix match. If no section item matches (e.g. the user is on a
+ * dynamic route not in the nav), we skip the visit — recents would otherwise
+ * fill with raw pathnames which read poorly.
+ */
+
+export interface NavVisitTrackerProps {
+  sections: NavSection[];
+}
+
+function resolveLabel(sections: NavSection[], pathname: string): { href: string; label: string } | null {
+  const items = flattenSectionItems(sections);
+  // Prefer an exact match, else the longest-prefix match.
+  let exact: { href: string; label: string } | null = null;
+  let prefix: { href: string; label: string; len: number } | null = null;
+  for (const item of items) {
+    if (item.href === pathname) {
+      exact = { href: item.href, label: item.label };
+      break;
+    }
+    if (itemMatchesPath(item.href, pathname)) {
+      if (!prefix || item.href.length > prefix.len) {
+        prefix = { href: item.href, label: item.label, len: item.href.length };
+      }
+    }
+  }
+  if (exact) return exact;
+  if (prefix) return { href: prefix.href, label: prefix.label };
+  return null;
+}
+
+export function NavVisitTracker({ sections }: NavVisitTrackerProps) {
+  const prefs = useNavPrefs();
+  const pathname = usePathname() ?? "";
+
+  React.useEffect(() => {
+    if (!prefs || !prefs.hydrated) return;
+    if (!pathname) return;
+    const resolved = resolveLabel(sections, pathname);
+    if (!resolved) return;
+    prefs.visit(resolved);
+    // `visit` is stable via useCallback; pathname + sections drive this.
+  }, [pathname, sections, prefs]);
+
+  return null;
+}

--- a/src/components/shell/PillarNav.tsx
+++ b/src/components/shell/PillarNav.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { IconRail } from "./IconRail";
+import { ContextDrawer } from "./ContextDrawer";
+import { pillarId, sectionContainsPath, type NavSection } from "./nav-sections";
+
+const LAST_PILLAR_KEY = "nav:lastPillar:v1";
+
+export interface PillarNavProps {
+  sections: NavSection[];
+  /** Slotted content above the rail icons — typically a logo link. */
+  header?: React.ReactNode;
+  /** Slotted content below the rail icons — typically account controls. */
+  footer?: React.ReactNode;
+}
+
+/**
+ * Client wrapper that owns the "which drawer is open" state for the icon
+ * rail layout. Server-rendered `AppShell` delegates the interactive bits
+ * here so it can stay a server component.
+ *
+ * Layout: a 64px rail column (header slot, icons, footer slot) plus a
+ * 240px drawer that slides in when a pillar is focused. Both live inside
+ * a single `data-nav-rail` wrapper so `ContextDrawer` can distinguish
+ * rail clicks from true outside clicks.
+ *
+ * Behavior:
+ *   - On mount, restore last-opened pillar from localStorage (if still
+ *     present in `sections`).
+ *   - If the current pathname lives inside a pillar, that wins on first
+ *     render — user sees their current context, not a stale one.
+ *   - Clicking a rail icon toggles its drawer. Same id → close. Different
+ *     id → switch.
+ */
+export function PillarNav({ sections, header, footer }: PillarNavProps) {
+  const pathname = usePathname() ?? "";
+
+  const pathPillar = React.useMemo(() => {
+    for (let i = 0; i < sections.length; i++) {
+      const s = sections[i];
+      if (!s.icon) continue;
+      if (sectionContainsPath(s, pathname)) return pillarId(s, i);
+    }
+    return null;
+  }, [sections, pathname]);
+
+  const [activePillar, setActivePillar] = React.useState<string | null>(
+    pathPillar,
+  );
+
+  // Hydrate from localStorage once per route change; route context wins.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (pathPillar) {
+      setActivePillar(pathPillar);
+      return;
+    }
+    try {
+      const stored = window.localStorage.getItem(LAST_PILLAR_KEY);
+      if (!stored) return;
+      const exists = sections.some(
+        (s, i) => s.icon && pillarId(s, i) === stored,
+      );
+      if (exists) setActivePillar(stored);
+    } catch {
+      /* private mode — non-fatal */
+    }
+  }, [pathPillar, sections]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (activePillar) {
+        window.localStorage.setItem(LAST_PILLAR_KEY, activePillar);
+      }
+    } catch {
+      /* non-fatal */
+    }
+  }, [activePillar]);
+
+  const onSelect = (id: string) => {
+    setActivePillar((prev) => (prev === id ? null : id));
+  };
+
+  const activeSection = React.useMemo(() => {
+    if (!activePillar) return null;
+    for (let i = 0; i < sections.length; i++) {
+      const s = sections[i];
+      if (!s.icon) continue;
+      if (pillarId(s, i) === activePillar) return s;
+    }
+    return null;
+  }, [sections, activePillar]);
+
+  return (
+    <div className="flex" data-nav-rail>
+      <aside className="flex w-16 shrink-0 flex-col items-center border-r border-border bg-surface">
+        {header}
+        <div className="flex-1 w-full">
+          <IconRail
+            sections={sections}
+            activePillar={activePillar}
+            pathPillar={pathPillar}
+            onSelect={onSelect}
+            pathname={pathname}
+          />
+        </div>
+        {footer}
+      </aside>
+      <ContextDrawer
+        section={activeSection}
+        pathname={pathname}
+        onClose={() => setActivePillar(null)}
+      />
+    </div>
+  );
+}

--- a/src/components/shell/PinButton.tsx
+++ b/src/components/shell/PinButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { useNavPrefs } from "./NavPrefsContext";
+
+/**
+ * Small star toggle that any NavItem row can render. Filled = pinned,
+ * outline = pinnable. Click toggles via the NavPrefsContext.
+ *
+ * The button suppresses link activation (stopPropagation + preventDefault)
+ * so clicking the star inside a <Link> row only toggles the pin — it does
+ * not navigate.
+ */
+
+export interface PinButtonProps {
+  href: string;
+  label: string;
+  /** Optional visual density knob. `rail` = always visible, `hover` = opacity-on-hover. */
+  visibility?: "rail" | "hover";
+  className?: string;
+}
+
+export function PinButton({
+  href,
+  label,
+  visibility = "hover",
+  className,
+}: PinButtonProps) {
+  const prefs = useNavPrefs();
+  if (!prefs) return null;
+
+  const pinned = prefs.isPinned(href);
+
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (pinned) prefs.unpin(href);
+    else prefs.pin({ href, label });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={pinned}
+      aria-label={pinned ? `Unpin ${label}` : `Pin ${label}`}
+      title={pinned ? `Unpin ${label}` : `Pin ${label}`}
+      className={cn(
+        "inline-flex items-center justify-center h-6 w-6 rounded-md text-text-subtle",
+        "transition-all duration-150 ease-smooth",
+        "hover:bg-surface-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        visibility === "hover" && !pinned
+          ? "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          : "opacity-100",
+        pinned && "text-amber-500",
+        className,
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill={pinned ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/shell/nav-icons.tsx
+++ b/src/components/shell/nav-icons.tsx
@@ -1,0 +1,166 @@
+/**
+ * Lightweight stroke-icon set for the pillar rail. Shapes are hand-picked to
+ * read well at 20–22px. Each icon is a plain function component over
+ * `SVGProps<SVGSVGElement>` so it slots into `NavIcon` (lucide-compatible).
+ *
+ * Why not lucide-react? It isn't a repo dependency yet, and adding one is out
+ * of scope for this agent. Swapping any of these for a lucide icon later is a
+ * one-line change in the layout files — the `NavIcon` shape is identical.
+ */
+import * as React from "react";
+
+type SvgProps = React.SVGProps<SVGSVGElement>;
+
+function base(props: SvgProps): SvgProps {
+  const { width, height, strokeWidth, ...rest } = props;
+  return {
+    width: width ?? 20,
+    height: height ?? 20,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: (strokeWidth as number | undefined) ?? 1.75,
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+    "aria-hidden": true,
+    ...rest,
+  };
+}
+
+export const IconHome: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M3 11 12 3l9 8" />
+    <path d="M5 10v10h14V10" />
+    <path d="M10 20v-6h4v6" />
+  </svg>
+);
+
+export const IconStethoscope: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M6 3v6a4 4 0 0 0 8 0V3" />
+    <path d="M6 3H4" />
+    <path d="M14 3h2" />
+    <path d="M10 13v4a5 5 0 0 0 10 0v-2" />
+    <circle cx="20" cy="13" r="2" />
+  </svg>
+);
+
+export const IconClipboardCheck: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="5" y="4" width="14" height="17" rx="2" />
+    <path d="M9 4V3a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1" />
+    <path d="m9 13 2 2 4-4" />
+  </svg>
+);
+
+export const IconBookOpen: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M3 5h7a3 3 0 0 1 3 3v12" />
+    <path d="M21 5h-7a3 3 0 0 0-3 3v12" />
+    <path d="M3 5v14h7" />
+    <path d="M21 5v14h-7" />
+  </svg>
+);
+
+export const IconSettings: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
+  </svg>
+);
+
+export const IconLayoutGrid: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+export const IconDollar: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <line x1="12" y1="2" x2="12" y2="22" />
+    <path d="M17 6H10a3 3 0 0 0 0 6h4a3 3 0 0 1 0 6H7" />
+  </svg>
+);
+
+export const IconUsers: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+
+export const IconBuilding: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="4" y="3" width="16" height="18" rx="1" />
+    <line x1="9" y1="7" x2="9" y2="7" />
+    <line x1="15" y1="7" x2="15" y2="7" />
+    <line x1="9" y1="11" x2="9" y2="11" />
+    <line x1="15" y1="11" x2="15" y2="11" />
+    <line x1="9" y1="15" x2="9" y2="15" />
+    <line x1="15" y1="15" x2="15" y2="15" />
+    <path d="M10 21v-4h4v4" />
+  </svg>
+);
+
+export const IconChart: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M3 3v18h18" />
+    <path d="M7 15l4-4 3 3 5-6" />
+  </svg>
+);
+
+export const IconServer: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="3" y="4" width="18" height="7" rx="1" />
+    <rect x="3" y="13" width="18" height="7" rx="1" />
+    <line x1="7" y1="7.5" x2="7.01" y2="7.5" />
+    <line x1="7" y1="16.5" x2="7.01" y2="16.5" />
+  </svg>
+);
+
+export const IconPill: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="2" y="9" width="20" height="6" rx="3" transform="rotate(-45 12 12)" />
+    <line x1="8.5" y1="8.5" x2="15.5" y2="15.5" />
+  </svg>
+);
+
+export const IconHeart: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.7l-1-1.1a5.5 5.5 0 0 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8Z" />
+  </svg>
+);
+
+export const IconCalendar: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <rect x="3" y="5" width="18" height="16" rx="2" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+    <line x1="8" y1="3" x2="8" y2="7" />
+    <line x1="16" y1="3" x2="16" y2="7" />
+  </svg>
+);
+
+export const IconMessage: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" />
+  </svg>
+);
+
+export const IconUser: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+export const IconInbox: React.FC<SvgProps> = (props) => (
+  <svg {...base(props)}>
+    <path d="M22 12h-6l-2 3h-4l-2-3H2" />
+    <path d="M5 3h14l3 9v7a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-7Z" />
+  </svg>
+);

--- a/src/components/shell/nav-sections.ts
+++ b/src/components/shell/nav-sections.ts
@@ -12,6 +12,7 @@
  */
 
 import { aggregateBadge, type NavBadge } from "@/lib/domain/nav-badges";
+import type { NavAgentActivity } from "@/lib/domain/nav-agent-activity";
 import type * as React from "react";
 
 export type { NavBadge } from "@/lib/domain/nav-badges";
@@ -34,6 +35,13 @@ export interface NavItem {
   countTone?: CountTone;
   /** Semantic badge — preferred. Takes precedence over count/countTone. */
   badge?: NavBadge | null;
+  /**
+   * Ambient "an AI agent is actively working here" indicator. Additive —
+   * renders alongside the existing count / semantic badge, not in place of it.
+   * Populated by the layout by calling `getActiveAgentActivity()`; null/undef
+   * means no agent is currently running for this nav entry.
+   */
+  activity?: NavAgentActivity | null;
 }
 
 export interface NavSection {

--- a/src/components/shell/nav-sections.ts
+++ b/src/components/shell/nav-sections.ts
@@ -12,10 +12,18 @@
  */
 
 import { aggregateBadge, type NavBadge } from "@/lib/domain/nav-badges";
+import type * as React from "react";
 
 export type { NavBadge } from "@/lib/domain/nav-badges";
 
 export type CountTone = "highlight" | "danger" | "accent";
+
+/**
+ * Lucide-compatible icon component. Lives as a plain function component over
+ * `SVGProps` so it accepts any lucide-react icon without adding a new dep.
+ * If/when lucide-react is installed, `LucideIcon` satisfies this shape.
+ */
+export type NavIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 
 export interface NavItem {
   label: string;
@@ -46,6 +54,33 @@ export interface NavSection {
    * aggregate of the child items' `badge` fields is used.
    */
   badge?: NavBadge | null;
+  /**
+   * Icon for the pillar rail. When set on any section in an array, the shell
+   * switches from the stacked nav to the icon-rail + context-drawer layout.
+   * When unset, the section renders in the legacy stacked mode.
+   */
+  icon?: NavIcon;
+  /**
+   * Stable identifier used to key the active pillar (localStorage, URL state,
+   * etc.). Defaults to `label` when omitted but icon is set; only needed
+   * explicitly for unlabeled icon sections.
+   */
+  pillar?: string;
+}
+
+/**
+ * Stable id for a pillar section — prefers explicit `pillar`, then `label`,
+ * falling back to a deterministic index-based key for anonymous sections.
+ */
+export function pillarId(section: NavSection, idx: number): string {
+  return section.pillar ?? section.label ?? `pillar-${idx}`;
+}
+
+/**
+ * True when any section in the array has an icon — triggers the rail layout.
+ */
+export function hasPillarIcons(sections: NavSection[]): boolean {
+  return sections.some((s) => s.icon !== undefined);
 }
 
 /**

--- a/src/lib/domain/nav-agent-activity.test.ts
+++ b/src/lib/domain/nav-agent-activity.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock prisma before importing the module under test so the loader sees the
+// mock instead of a real PrismaClient. vi.mock is hoisted; vi.hoisted keeps
+// the mock object reachable from the factory.
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    agentJob: {
+      findMany: vi.fn(),
+    },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  getActiveAgentActivity,
+  indexActivityByHref,
+} from "./nav-agent-activity";
+
+beforeEach(() => {
+  hoisted.mockPrisma.agentJob.findMany.mockReset();
+});
+
+describe("getActiveAgentActivity", () => {
+  it("returns [] when organizationId is empty without hitting the DB", async () => {
+    const out = await getActiveAgentActivity("");
+    expect(out).toEqual([]);
+    expect(hoisted.mockPrisma.agentJob.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when there are no running jobs (empty-result safety)", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([]);
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toEqual([]);
+  });
+
+  it("maps a running prescription-safety job to the Approvals href with active tone", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([
+      { agentName: "prescription-safety" },
+    ]);
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toEqual([
+      {
+        href: "/clinic/approvals",
+        agentKey: "prescription-safety",
+        tone: "active",
+      },
+    ]);
+  });
+
+  it("scopes the prisma query to status=running + organizationId and caps at 50", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([]);
+    await getActiveAgentActivity("org_42");
+    expect(hoisted.mockPrisma.agentJob.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: "running", organizationId: "org_42" },
+        take: 50,
+      }),
+    );
+  });
+
+  it("skips unmapped agent names instead of throwing", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([
+      { agentName: "unknown-agent-that-has-no-nav" },
+      { agentName: "denial-triage" },
+      { agentName: "also-unknown" },
+    ]);
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      href: "/ops/denials",
+      agentKey: "denial-triage",
+    });
+  });
+
+  it("dedupes multiple running jobs that map to the same href", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([
+      { agentName: "prescription-safety" },
+      { agentName: "prescription-safety" },
+      { agentName: "prescription-safety" },
+    ]);
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toHaveLength(1);
+    expect(out[0].href).toBe("/clinic/approvals");
+  });
+
+  it("collapses two different agents that share a nav href into one entry", async () => {
+    // adherence-drift-detector + visit-discovery-whisperer both target
+    // /clinic/command — a single dot should light up, not two.
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([
+      { agentName: "adherence-drift-detector" },
+      { agentName: "visit-discovery-whisperer" },
+    ]);
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toHaveLength(1);
+    expect(out[0].href).toBe("/clinic/command");
+    // First mapped agent wins tone (info, in this case).
+    expect(out[0].tone).toBe("info");
+  });
+
+  it("returns multiple entries when jobs map to distinct hrefs", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockResolvedValueOnce([
+      { agentName: "prescription-safety" },
+      { agentName: "denial-triage" },
+      { agentName: "clearinghouse-submission" },
+    ]);
+    const out = await getActiveAgentActivity("org_1");
+    const hrefs = out.map((a) => a.href).sort();
+    expect(hrefs).toEqual(["/clinic/approvals", "/ops/denials", "/ops/scrub"]);
+  });
+
+  it("swallows prisma failures and returns [] so the nav never crashes", async () => {
+    hoisted.mockPrisma.agentJob.findMany.mockRejectedValueOnce(
+      new Error("P2021: table AgentJob does not exist"),
+    );
+    // Silence the console.error call in the test output — we assert the
+    // loader handled the error, not that it logged silently.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = await getActiveAgentActivity("org_1");
+    expect(out).toEqual([]);
+    errSpy.mockRestore();
+  });
+});
+
+describe("indexActivityByHref", () => {
+  it("returns an empty object for an empty list", () => {
+    expect(indexActivityByHref([])).toEqual({});
+  });
+
+  it("indexes activity entries by href for O(1) nav decoration", () => {
+    const idx = indexActivityByHref([
+      { href: "/clinic/approvals", agentKey: "prescription-safety", tone: "active" },
+      { href: "/ops/denials", agentKey: "denial-triage", tone: "active" },
+    ]);
+    expect(idx["/clinic/approvals"].tone).toBe("active");
+    expect(idx["/ops/denials"].agentKey).toBe("denial-triage");
+    expect(idx["/nowhere"]).toBeUndefined();
+  });
+});

--- a/src/lib/domain/nav-agent-activity.ts
+++ b/src/lib/domain/nav-agent-activity.ts
@@ -1,0 +1,113 @@
+/**
+ * Ambient agent activity indicators for the sidebar nav.
+ *
+ * The clinician + operator layouts call `getActiveAgentActivity` once per
+ * render and decorate `NavItem.activity` so the rail can show a subtle pulsing
+ * dot next to any section currently being worked on by an AI agent.
+ *
+ * Data source: the `AgentJob` table (Prisma). We look for rows where the
+ * status is "running" and scope to the caller's organization.
+ *
+ * The mapping from an agent's name (stored as `agentName` on AgentJob) to a
+ * nav href is a small static table — if we add a new agent that doesn't map
+ * to a visible nav entry we skip it rather than crashing. Multiple running
+ * jobs against the same href dedupe down to a single dot so a burst of
+ * message-urgency-observer runs doesn't light the rail up like a Christmas
+ * tree.
+ *
+ * Failures never block login: the try/catch mirrors the `safeCount` pattern
+ * in the clinician layout.
+ */
+import { prisma } from "@/lib/db/prisma";
+
+/**
+ * One piece of ambient activity surfaced on a nav row.
+ *   href     — must match the NavItem's href (not a prefix, exact match).
+ *   agentKey — the agent's registry name (AgentJob.agentName), retained for
+ *              debuggability / aria. Not rendered to the user.
+ *   tone     — "active" is emerald (an AI is writing a draft); "info" is sky
+ *              (a passive observer is scanning, nothing awaits you yet).
+ */
+export type NavAgentActivity = {
+  href: string;
+  agentKey: string;
+  tone: "info" | "active";
+};
+
+/**
+ * Static mapping from `AgentJob.agentName` → nav href + visual tone.
+ *
+ * Kept as a plain object (not exhaustive over AgentKind) so that adding a
+ * new agent that has no nav surface is a no-op instead of a type error.
+ * Unmapped agents are silently skipped in `getActiveAgentActivity`.
+ */
+const AGENT_TO_NAV: Record<string, { href: string; tone: "info" | "active" }> = {
+  // Drafts messages for clinician sign-off — shows up on Approvals.
+  "prescription-safety": { href: "/clinic/approvals", tone: "active" },
+  // Classifies + routes new denials — lights up the Denials row.
+  "denial-triage": { href: "/ops/denials", tone: "active" },
+  // Scrubs outgoing claims before submission — the Scrub row.
+  "clearinghouse-submission": { href: "/ops/scrub", tone: "active" },
+  // Passive scan for patients drifting off their regimen — Command Center.
+  "adherence-drift-detector": { href: "/clinic/command", tone: "info" },
+  // Triages inbound patient messages for urgency — Inbox.
+  "message-urgency-observer": { href: "/clinic/messages", tone: "info" },
+  // Looks for missed follow-ups / care-gap visits — Command Center.
+  "visit-discovery-whisperer": { href: "/clinic/command", tone: "info" },
+};
+
+/**
+ * Query currently-running agent jobs for an org and fold them down to one
+ * entry per nav href. Safe to call from server components / layouts.
+ *
+ * Returns [] on any failure (missing table, transient DB error, etc.) so the
+ * nav never blocks the page.
+ */
+export async function getActiveAgentActivity(
+  organizationId: string,
+): Promise<NavAgentActivity[]> {
+  if (!organizationId) return [];
+  try {
+    const jobs = await prisma.agentJob.findMany({
+      where: {
+        status: "running",
+        organizationId,
+      },
+      select: { agentName: true },
+      take: 50,
+    });
+
+    // Dedupe: first-hit wins per href. If two different agents both map to
+    // the same href, the earlier entry in the query result keeps the tone —
+    // this is deterministic enough for a decorative indicator.
+    const seen = new Map<string, NavAgentActivity>();
+    for (const job of jobs) {
+      const mapping = AGENT_TO_NAV[job.agentName];
+      if (!mapping) continue;
+      if (seen.has(mapping.href)) continue;
+      seen.set(mapping.href, {
+        href: mapping.href,
+        agentKey: job.agentName,
+        tone: mapping.tone,
+      });
+    }
+    return Array.from(seen.values());
+  } catch (err) {
+    console.error("[nav-agent-activity] query failed, returning []:", err);
+    return [];
+  }
+}
+
+/**
+ * Build a lookup index so layouts can decorate NavItems in O(1). Pure helper
+ * kept beside the loader so tests can exercise it without touching prisma.
+ */
+export function indexActivityByHref(
+  activity: NavAgentActivity[],
+): Record<string, NavAgentActivity> {
+  const out: Record<string, NavAgentActivity> = {};
+  for (const a of activity) {
+    out[a.href] = a;
+  }
+  return out;
+}

--- a/src/lib/domain/nav-prefs.test.ts
+++ b/src/lib/domain/nav-prefs.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  PINS_MAX,
+  PINS_STORAGE_KEY,
+  RECENT_MAX,
+  RECENT_STORAGE_KEY,
+  addPin,
+  parsePins,
+  parseRecents,
+  recordVisit,
+  removePin,
+  type PinnedEntry,
+  type RecentEntry,
+} from "./nav-prefs";
+
+describe("addPin", () => {
+  it("adds a new pin at the top", () => {
+    const next = addPin([], { href: "/clinic/queue", label: "Queue" }, 1000);
+    expect(next).toEqual([
+      { href: "/clinic/queue", label: "Queue", pinnedAt: 1000 },
+    ]);
+  });
+
+  it("dedupes by href and bumps the existing entry to the top with a fresh timestamp", () => {
+    const start: PinnedEntry[] = [
+      { href: "/a", label: "A", pinnedAt: 100 },
+      { href: "/b", label: "B", pinnedAt: 200 },
+    ];
+    const next = addPin(start, { href: "/a", label: "A renamed" }, 500);
+    expect(next).toEqual([
+      { href: "/a", label: "A renamed", pinnedAt: 500 },
+      { href: "/b", label: "B", pinnedAt: 200 },
+    ]);
+  });
+
+  it("caps the list at PINS_MAX", () => {
+    let pins: PinnedEntry[] = [];
+    for (let i = 0; i < PINS_MAX + 3; i++) {
+      pins = addPin(pins, { href: `/p/${i}`, label: `P${i}` }, i);
+    }
+    expect(pins).toHaveLength(PINS_MAX);
+    // Most recent pin is at the head
+    expect(pins[0].href).toBe(`/p/${PINS_MAX + 2}`);
+    // Earliest additions have fallen off
+    expect(pins.some((p) => p.href === "/p/0")).toBe(false);
+  });
+
+  it("preserves insertion order (newest first) when adding distinct pins", () => {
+    let pins: PinnedEntry[] = [];
+    pins = addPin(pins, { href: "/a", label: "A" }, 1);
+    pins = addPin(pins, { href: "/b", label: "B" }, 2);
+    pins = addPin(pins, { href: "/c", label: "C" }, 3);
+    expect(pins.map((p) => p.href)).toEqual(["/c", "/b", "/a"]);
+  });
+});
+
+describe("removePin", () => {
+  it("removes a pin matched by href", () => {
+    const pins: PinnedEntry[] = [
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ];
+    const next = removePin(pins, "/a");
+    expect(next).toEqual([{ href: "/b", label: "B", pinnedAt: 2 }]);
+  });
+
+  it("is a no-op (same reference) when href is not present", () => {
+    const pins: PinnedEntry[] = [{ href: "/a", label: "A", pinnedAt: 1 }];
+    const next = removePin(pins, "/missing");
+    expect(next).toBe(pins);
+  });
+
+  it("removes from an empty array as a no-op", () => {
+    const pins: PinnedEntry[] = [];
+    const next = removePin(pins, "/nope");
+    expect(next).toBe(pins);
+  });
+});
+
+describe("recordVisit", () => {
+  it("adds a new recent at the top", () => {
+    const next = recordVisit([], { href: "/x", label: "X" }, 1000);
+    expect(next).toEqual([{ href: "/x", label: "X", visitedAt: 1000 }]);
+  });
+
+  it("dedupes by href — repeat visits bump the entry to the top", () => {
+    const start: RecentEntry[] = [
+      { href: "/a", label: "A", visitedAt: 100 },
+      { href: "/b", label: "B", visitedAt: 200 },
+      { href: "/c", label: "C", visitedAt: 300 },
+    ];
+    const next = recordVisit(start, { href: "/a", label: "A" }, 999);
+    expect(next).toEqual([
+      { href: "/a", label: "A", visitedAt: 999 },
+      { href: "/b", label: "B", visitedAt: 200 },
+      { href: "/c", label: "C", visitedAt: 300 },
+    ]);
+  });
+
+  it("caps at RECENT_MAX", () => {
+    let recents: RecentEntry[] = [];
+    for (let i = 0; i < RECENT_MAX + 4; i++) {
+      recents = recordVisit(recents, { href: `/r/${i}`, label: `R${i}` }, i);
+    }
+    expect(recents).toHaveLength(RECENT_MAX);
+    expect(recents[0].href).toBe(`/r/${RECENT_MAX + 3}`);
+    expect(recents.at(-1)?.href).toBe(`/r/${RECENT_MAX + 3 - (RECENT_MAX - 1)}`);
+  });
+
+  it("keeps ordering newest-first across distinct hrefs", () => {
+    let recents: RecentEntry[] = [];
+    recents = recordVisit(recents, { href: "/a", label: "A" }, 1);
+    recents = recordVisit(recents, { href: "/b", label: "B" }, 2);
+    recents = recordVisit(recents, { href: "/c", label: "C" }, 3);
+    expect(recents.map((r) => r.href)).toEqual(["/c", "/b", "/a"]);
+  });
+});
+
+describe("parsePins", () => {
+  it("returns [] for null, empty, or malformed JSON", () => {
+    expect(parsePins(null)).toEqual([]);
+    expect(parsePins("")).toEqual([]);
+    expect(parsePins("{not json")).toEqual([]);
+    expect(parsePins("\"just a string\"")).toEqual([]);
+    expect(parsePins("42")).toEqual([]);
+  });
+
+  it("strips individual malformed entries but preserves valid siblings", () => {
+    const raw = JSON.stringify([
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: 42, label: "bad" },
+      null,
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ]);
+    expect(parsePins(raw)).toEqual([
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ]);
+  });
+
+  it("clamps to PINS_MAX on read", () => {
+    const payload = Array.from({ length: PINS_MAX + 5 }, (_, i) => ({
+      href: `/p/${i}`,
+      label: `P${i}`,
+      pinnedAt: i,
+    }));
+    expect(parsePins(JSON.stringify(payload))).toHaveLength(PINS_MAX);
+  });
+});
+
+describe("parseRecents", () => {
+  it("returns [] for null / malformed JSON / wrong shape", () => {
+    expect(parseRecents(null)).toEqual([]);
+    expect(parseRecents("nope")).toEqual([]);
+    expect(parseRecents(JSON.stringify({ not: "array" }))).toEqual([]);
+  });
+
+  it("clamps to RECENT_MAX on read", () => {
+    const payload = Array.from({ length: RECENT_MAX + 3 }, (_, i) => ({
+      href: `/r/${i}`,
+      label: `R${i}`,
+      visitedAt: i,
+    }));
+    expect(parseRecents(JSON.stringify(payload))).toHaveLength(RECENT_MAX);
+  });
+});
+
+describe("storage keys", () => {
+  it("are versioned so future migrations can coexist", () => {
+    expect(PINS_STORAGE_KEY).toBe("nav:pins:v1");
+    expect(RECENT_STORAGE_KEY).toBe("nav:recent:v1");
+  });
+});

--- a/src/lib/domain/nav-prefs.ts
+++ b/src/lib/domain/nav-prefs.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure helpers for the sidebar's Pinned + Recent personalization strips.
+ *
+ * Both collections are persisted to localStorage (see keys below). These
+ * helpers are framework-free so they can be exercised by the node-only
+ * vitest suite; the React provider (`NavPrefsContext`) composes them with
+ * SSR-safe hydration + debounced writes.
+ *
+ *   PinnedEntry    — route the user explicitly starred. Dedup by href, bump
+ *                    to top on re-pin, cap at 8.
+ *   RecentEntry    — last N visited distinct routes, newest first, cap at 5.
+ *
+ * Caps are low intentionally: the Pinned + Recent surfaces sit above the
+ * pillar nav and should not become a wall of links. Pins grow to 8; recents
+ * stay at 5.
+ */
+
+export interface PinnedEntry {
+  href: string;
+  label: string;
+  pinnedAt: number;
+}
+
+export interface RecentEntry {
+  href: string;
+  label: string;
+  visitedAt: number;
+}
+
+export const PINS_STORAGE_KEY = "nav:pins:v1";
+export const RECENT_STORAGE_KEY = "nav:recent:v1";
+
+export const PINS_MAX = 8;
+export const RECENT_MAX = 5;
+
+/**
+ * Add a pin, deduping by href. If the href is already pinned, the entry is
+ * bumped to the top with a refreshed `pinnedAt` timestamp. Capped at
+ * `PINS_MAX` — oldest entries fall off the tail.
+ */
+export function addPin(
+  current: PinnedEntry[],
+  entry: Omit<PinnedEntry, "pinnedAt">,
+  now: number = Date.now(),
+): PinnedEntry[] {
+  const next: PinnedEntry = {
+    href: entry.href,
+    label: entry.label,
+    pinnedAt: now,
+  };
+  const filtered = current.filter((p) => p.href !== entry.href);
+  return [next, ...filtered].slice(0, PINS_MAX);
+}
+
+/**
+ * Remove a pin by href. No-op when the href is not present — returns the
+ * same reference so React consumers can skip re-renders cheaply.
+ */
+export function removePin(current: PinnedEntry[], href: string): PinnedEntry[] {
+  const hit = current.some((p) => p.href === href);
+  if (!hit) return current;
+  return current.filter((p) => p.href !== href);
+}
+
+/**
+ * Record a route visit in the recents list. Dedups by href and keeps the
+ * newest visit first. Capped at `RECENT_MAX`.
+ */
+export function recordVisit(
+  current: RecentEntry[],
+  entry: Omit<RecentEntry, "visitedAt">,
+  now: number = Date.now(),
+): RecentEntry[] {
+  const next: RecentEntry = {
+    href: entry.href,
+    label: entry.label,
+    visitedAt: now,
+  };
+  const filtered = current.filter((r) => r.href !== entry.href);
+  return [next, ...filtered].slice(0, RECENT_MAX);
+}
+
+/**
+ * Parse a localStorage string payload into a typed PinnedEntry[]. Silently
+ * returns [] on any parse error or shape mismatch. Per-entry invalid items
+ * are stripped but valid siblings are preserved.
+ */
+export function parsePins(raw: string | null): PinnedEntry[] {
+  if (!raw) return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(decoded)) return [];
+  const out: PinnedEntry[] = [];
+  for (const v of decoded) {
+    if (
+      v &&
+      typeof v === "object" &&
+      typeof (v as PinnedEntry).href === "string" &&
+      typeof (v as PinnedEntry).label === "string" &&
+      typeof (v as PinnedEntry).pinnedAt === "number"
+    ) {
+      out.push({
+        href: (v as PinnedEntry).href,
+        label: (v as PinnedEntry).label,
+        pinnedAt: (v as PinnedEntry).pinnedAt,
+      });
+    }
+  }
+  return out.slice(0, PINS_MAX);
+}
+
+/**
+ * Parse a localStorage string payload into a typed RecentEntry[]. Same
+ * contract as `parsePins` — silent strip on failure.
+ */
+export function parseRecents(raw: string | null): RecentEntry[] {
+  if (!raw) return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(decoded)) return [];
+  const out: RecentEntry[] = [];
+  for (const v of decoded) {
+    if (
+      v &&
+      typeof v === "object" &&
+      typeof (v as RecentEntry).href === "string" &&
+      typeof (v as RecentEntry).label === "string" &&
+      typeof (v as RecentEntry).visitedAt === "number"
+    ) {
+      out.push({
+        href: (v as RecentEntry).href,
+        label: (v as RecentEntry).label,
+        visitedAt: (v as RecentEntry).visitedAt,
+      });
+    }
+  }
+  return out.slice(0, RECENT_MAX);
+}


### PR DESCRIPTION
## Summary
- Replaces text-wall sidebar with a 64px icon rail + 240px contextual drawer per pillar.
- New components: `IconRail`, `ContextDrawer`, `PillarNav`, `nav-icons` (17 hand-drawn stroke icons).
- `NavSection` gets optional `icon` + `pillar` fields; helpers `pillarId()` and `hasPillarIcons()`.
- AppShell conditionally swaps stacked sidebar for `PillarNav` when any section has an icon — legacy path preserved.
- Clinician (4 pillars), operator (6 pillars), patient (5 pillars) layouts updated.
- Last-opened pillar persisted to `nav:lastPillar:v1`.
- Drawer closes on outside click / Esc / route change; `pointerdown` detection + `data-nav-rail` escape hatch prevent flicker when switching pillars.

## Test plan
- [x] `npx vitest run src/components/shell/nav-sections.test.ts` — 21/21
- [x] `npx tsc --noEmit` clean
- [ ] Manual: each pillar opens its drawer; active-route pillar gets accent bar; mobile still works via existing `MobileNav`

## Follow-ups (not in this PR)
- Port ambient dots (from the first nav PR) into `ContextDrawer` item render so agent-active indicator shows in drawer view.
- MobileNav port to rail (current MobileNav compiles and still works).
- Drop `lucide-react` stub icons once lucide is a repo dep.

Merges last in the 3-PR nav fleet — conflicts with both earlier PRs expected (nav-sections.ts, AppShell.tsx, clinician/operator layouts).

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C