### PR TITLE
hotfix(EMR-205): unwedge /portal + /clinic — timeout + fallback on home queries

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -17,6 +17,40 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { formatRelative } from "@/lib/utils/format";
 import { RecentPatients } from "@/components/shell/recent-patients";
+import { withTimeout } from "@/lib/utils/with-timeout";
+
+// EMR-205: guard the mission-control fan-out so a single hung query
+// can never wedge the Suspense boundary and strand clinicians on the
+// loading skeleton.
+const MISSION_CONTROL_TIMEOUT_MS = 8_000;
+
+// Empty-shape fallback for the 19-way Promise.all below. If the DB
+// fan-out times out (or any individual query rejects), we render the
+// page with zeros/empty lists instead of stranding the user. Typed as
+// `any` intentionally — the destructured tuple has deep Prisma types
+// and we just need the shape.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MISSION_CONTROL_FALLBACK: any = [
+  [],  //  1 todaysEncounters
+  0,   //  2 openNotes
+  [],  //  3 needsReviewNotes
+  0,   //  4 approvalJobs
+  0,   //  5 activeThreads
+  0,   //  6 activePatientCount
+  0,   //  7 weekVisits
+  0,   //  8 weekFinalizedNotes
+  [],  //  9 recentEncounters
+  [],  // 10 recentFinalizedNotes
+  [],  // 11 recentAssessments
+  [],  // 12 recentMessages
+  [],  // 13 recentDocuments
+  [],  // 14 allChartSummaries
+  [0, 0, 0, 0, 0, 0, 0], // 15 dailyEncounterCounts
+  0,   // 16 needsReviewCount
+  [],  // 17 recentAgentJobs
+  [],  // 18 pendingDrafts
+  [],  // 19 recentObservations
+];
 
 export const metadata = { title: "Mission Control" };
 
@@ -210,7 +244,8 @@ export default async function ClinicHomePage() {
     recentAgentJobs,
     pendingDrafts,
     recentObservations,
-  ] = await Promise.all([
+  ] = await withTimeout(
+    Promise.all([
     // 1. Today's encounters
     //    Exclude encounters whose patient has been soft-deleted — otherwise
     //    the card would render with a ghost patient and the Prepare button
@@ -402,7 +437,14 @@ export default async function ClinicHomePage() {
       orderBy: { createdAt: "desc" },
       take: 6,
     }),
-  ]);
+  ]).catch((err) => {
+    console.warn("[clinic.home] mission-control fan-out rejected:", err);
+    return MISSION_CONTROL_FALLBACK;
+  }),
+    MISSION_CONTROL_TIMEOUT_MS,
+    MISSION_CONTROL_FALLBACK,
+    "clinic.home",
+  );
 
   /* ---- Derived values ---- */
   const notesToSign = openNotes + needsReviewCount;

--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -29,7 +29,6 @@ const MISSION_CONTROL_TIMEOUT_MS = 8_000;
 // page with zeros/empty lists instead of stranding the user. Typed as
 // `any` intentionally — the destructured tuple has deep Prisma types
 // and we just need the shape.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const MISSION_CONTROL_FALLBACK: any = [
   [],  //  1 todaysEncounters
   0,   //  2 openNotes
@@ -452,7 +451,7 @@ export default async function ClinicHomePage() {
   const avgReadiness =
     allChartSummaries.length > 0
       ? Math.round(
-          allChartSummaries.reduce((s, c) => s + c.completenessScore, 0) /
+          allChartSummaries.reduce((s: number, c: { completenessScore: number }) => s + c.completenessScore, 0) /
             allChartSummaries.length
         )
       : 0;
@@ -774,7 +773,7 @@ export default async function ClinicHomePage() {
           </Card>
         ) : (
           <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin">
-            {todaysEncounters.map((enc) => {
+            {todaysEncounters.map((enc: any) => {
               const readiness = enc.patient.chartSummary?.completenessScore ?? null;
               const status = readinessStatus(readiness);
 
@@ -956,7 +955,7 @@ export default async function ClinicHomePage() {
                 </p>
               ) : (
                 <ul className="space-y-1 -mx-2">
-                  {needsReviewNotes.map((note) => (
+                  {needsReviewNotes.map((note: any) => (
                     <li key={note.id}>
                       <Link
                         href={`/clinic/patients/${note.encounter.patient.id}/notes/${note.id}`}

--- a/src/app/(patient)/portal/page.tsx
+++ b/src/app/(patient)/portal/page.tsx
@@ -12,11 +12,27 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, LeafSprig, EditorialRule } from "@/components/ui/ornament";
 import { AmbientOrb } from "@/components/ui/hero-art";
 import { HealthPlant } from "@/components/ui/health-plant";
-import { computePlantHealth, STAGE_LABELS } from "@/lib/domain/plant-health";
+import { computePlantHealth, STAGE_LABELS, type PlantHealth } from "@/lib/domain/plant-health";
 import { formatDate, formatRelative } from "@/lib/utils/format";
 import { OnboardingTour } from "@/components/ui/onboarding-tour";
 import { WellnessTipWidget } from "@/components/ui/wellness-tip-widget";
 import { QuickSymptomFab } from "@/components/ui/quick-symptom-fab";
+import { withTimeout } from "@/lib/utils/with-timeout";
+
+// EMR-205: guard the home-page queries so a hung downstream call can
+// never wedge the Suspense boundary again.
+const PATIENT_QUERY_TIMEOUT_MS = 8_000;
+const PLANT_HEALTH_TIMEOUT_MS = 3_000;
+
+const DEFAULT_PLANT_HEALTH: PlantHealth = {
+  score: 40,
+  stage: "growing",
+  leafColor: "light-green",
+  hasFlowers: false,
+  stemCount: 2,
+  leafCount: 4,
+  healthFactors: [],
+};
 
 export const metadata = { title: "Home" };
 
@@ -126,35 +142,77 @@ function generateHealthTips(data: {
 export default async function PatientHome() {
   const user = await requireRole("patient");
 
-  const patient = await prisma.patient.findUnique({
-    where: { userId: user.id },
-    include: {
-      chartSummary: true,
-      outcomeLogs: { orderBy: { loggedAt: "asc" }, take: 100 },
-      encounters: {
-        orderBy: { scheduledFor: "desc" },
-        take: 3,
+  // Sentinel: the string "TIMEOUT" distinguishes a hung query from a
+  // genuinely missing patient record, so we don't mis-route to intake.
+  // `any` here because the TIMEOUT sentinel widens the resolved type and
+  // the surrounding code already handles null vs. not-null.
+  const patient: any = await withTimeout<any>(
+    prisma.patient.findUnique({
+      where: { userId: user.id },
+      include: {
+        chartSummary: true,
+        outcomeLogs: { orderBy: { loggedAt: "asc" }, take: 100 },
+        encounters: {
+          orderBy: { scheduledFor: "desc" },
+          take: 3,
+        },
+        tasks: {
+          where: { status: "open" },
+          orderBy: { dueAt: "asc" },
+          take: 5,
+        },
+        messageThreads: {
+          orderBy: { lastMessageAt: "desc" },
+          take: 1,
+          include: { messages: { orderBy: { createdAt: "desc" }, take: 1 } },
+        },
+        dosingRegimens: {
+          where: { active: true },
+          include: { product: true },
+        },
       },
-      tasks: {
-        where: { status: "open" },
-        orderBy: { dueAt: "asc" },
-        take: 5,
-      },
-      messageThreads: {
-        orderBy: { lastMessageAt: "desc" },
-        take: 1,
-        include: { messages: { orderBy: { createdAt: "desc" }, take: 1 } },
-      },
-      dosingRegimens: {
-        where: { active: true },
-        include: { product: true },
-      },
-    },
-  });
+    }).catch((err) => {
+      console.warn("[portal.home] patient.findUnique rejected:", err);
+      return "TIMEOUT";
+    }),
+    PATIENT_QUERY_TIMEOUT_MS,
+    "TIMEOUT",
+    "portal.home.patient.findUnique",
+  );
+
+  if (patient === "TIMEOUT") {
+    return (
+      <PageShell maxWidth="max-w-[1040px]">
+        <div className="py-16 text-center">
+          <Eyebrow className="mb-4 justify-center">Taking a moment</Eyebrow>
+          <h1 className="font-display text-2xl md:text-3xl text-text tracking-tight mb-3">
+            Your dashboard is loading slowly.
+          </h1>
+          <p className="text-sm text-text-muted max-w-md mx-auto leading-relaxed mb-8">
+            We couldn&apos;t fetch your chart in time. This is almost always a
+            temporary network hiccup — please retry.
+          </p>
+          <div className="flex justify-center gap-3">
+            <Link href="/portal">
+              <Button size="lg">Retry</Button>
+            </Link>
+            <Link href="/portal/garden">
+              <Button size="lg" variant="secondary">Go to My Garden</Button>
+            </Link>
+          </div>
+        </div>
+      </PageShell>
+    );
+  }
 
   if (!patient) redirect("/portal/intake");
 
-  const plantHealth = await computePlantHealth(patient.id);
+  const plantHealth = await withTimeout(
+    computePlantHealth(patient.id),
+    PLANT_HEALTH_TIMEOUT_MS,
+    DEFAULT_PLANT_HEALTH,
+    "portal.home.computePlantHealth",
+  );
 
   // Build metric series
   const metricSeries: Record<string, number[]> = {};

--- a/src/app/(patient)/portal/page.tsx
+++ b/src/app/(patient)/portal/page.tsx
@@ -232,8 +232,8 @@ export default async function PatientHome() {
   const latestEnergy = latestMetric.energy;
   const latestAdherence = latestMetric.adherence;
 
-  const nextVisit = patient.encounters.find((e) => e.status === "scheduled");
-  const recentVisit = patient.encounters.find((e) => e.status === "complete");
+  const nextVisit = patient.encounters.find((e: any) => e.status === "scheduled");
+  const recentVisit = patient.encounters.find((e: any) => e.status === "complete");
   const intakeComplete = patient.chartSummary?.completenessScore ?? 0;
 
   // Compute overall outcome average (for pain, anxiety — lower is better)
@@ -557,7 +557,7 @@ export default async function PatientHome() {
               <p className="text-sm text-text-muted py-2">You&apos;re all caught up.</p>
             ) : (
               <ul className="divide-y divide-border/70 -mx-4">
-                {patient.tasks.slice(0, 3).map((task) => (
+                {patient.tasks.slice(0, 3).map((task: any) => (
                   <li key={task.id} className="px-4 py-3 flex items-start justify-between gap-3">
                     <div className="flex gap-2 min-w-0">
                       <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-accent shrink-0" />

--- a/src/lib/utils/with-timeout.ts
+++ b/src/lib/utils/with-timeout.ts
@@ -1,0 +1,39 @@
+/**
+ * Race a promise against a wall-clock timeout.
+ *
+ * If `promise` has not settled within `ms`, resolve with `fallback` instead.
+ * The original promise is allowed to finish in the background — any late
+ * rejection is swallowed (logged) so it doesn't crash the Node process.
+ *
+ * Intended for Server Components where a hung downstream call (DB, cache,
+ * upstream API) would otherwise wedge the Suspense boundary forever,
+ * blocking hydration and making the whole route feel broken.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  label = "withTimeout",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve(fallback);
+    }, ms);
+  });
+
+  const result = await Promise.race([promise, timeoutPromise]);
+  if (timer) clearTimeout(timer);
+
+  if (timedOut) {
+    console.warn(`[${label}] timed out after ${ms}ms — serving fallback`);
+    Promise.resolve(promise).catch((err) => {
+      console.warn(`[${label}] late rejection after timeout:`, err);
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Patient portal (`/portal`) and clinician mission control (`/clinic`) were stuck on their `loading.tsx` skeletons in the live demo. The server component never returned → Suspense never resolved → hydration never completed → even the side nav became unclickable.

This is a surgical, no-schema-change fix that guarantees the page renders (with graceful fallback) even if a downstream query hangs.

## What changed

- **`src/lib/utils/with-timeout.ts`** (new) — races any promise against a wall-clock timeout and resolves to a caller-supplied fallback if the promise hasn't settled. Late rejections are swallowed + logged so zombie promises can't crash Node.
- **`src/app/(patient)/portal/page.tsx`** — wraps `prisma.patient.findUnique` (8s) and `computePlantHealth` (3s). A `"TIMEOUT"` sentinel keeps us from mis-routing to `/portal/intake` when the query hangs; instead we render a friendly "loading slowly — retry" state with links to Retry and `/portal/garden`.
- **`src/app/(clinician)/clinic/page.tsx`** — wraps the 19-way mission-control `Promise.all` (8s). Falls back to empty lists / zero counts so the page still renders the full layout.

## What this does NOT do

Does not fix the root cause of the hang — suspected candidates are DB pool exhaustion, Clerk `AUTH_PROVIDER` misconfig, or one of the nested relation includes. Those still need investigation on the deployed build. This PR is the bleeding-stopper.

## Test plan

- [ ] CI typecheck + lint + build pass
- [ ] Deploy to preview, load `/portal` as a demo patient — page renders (even if some cards show empties)
- [ ] Load `/clinic` as a demo clinician — mission control renders
- [ ] Artificially slow a query (or kill DB) in a local dev run and confirm the fallback UI appears instead of a forever-skeleton
- [ ] Confirm nav links clickable on both `/portal` and `/clinic` after load

## Follow-ups

- EMR-205 ticket on `claude/review-ticket-priorities-muFuD` has the full post-demo fix plan (DB pool audit, Clerk env verification, per-query instrumentation, regression test).

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7