### PR TITLE
hotfix(EMR-205): session.ts iron-session fallback (missed by PR #61)

### DIFF
--- a/src/app/(auth)/sign-in/[[...sign-in]]/clerk-signin-box.tsx
+++ b/src/app/(auth)/sign-in/[[...sign-in]]/clerk-signin-box.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+// Client-only Clerk sign-in widget. Isolated into its own module so the
+// `@clerk/nextjs` import only loads when AUTH_PROVIDER=clerk AND the
+// user actually navigates here — never during boot of the (auth) group.
+
+import { SignIn } from "@clerk/nextjs";
+
+export default function ClerkSignInBox() {
+  return (
+    <SignIn
+      signUpUrl="/sign-up"
+      appearance={{
+        elements: {
+          rootBox: "w-full",
+          card: "bg-transparent shadow-none border-0 p-0",
+          headerTitle: "hidden",
+          headerSubtitle: "hidden",
+          formButtonPrimary:
+            "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
+          socialButtonsBlockButton:
+            "border border-border hover:bg-surface-muted rounded-md",
+          formFieldInput:
+            "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
+          footerActionLink: "text-accent hover:text-accent/80",
+        },
+        layout: {
+          socialButtonsPlacement: "top",
+          socialButtonsVariant: "blockButton",
+        },
+      }}
+    />
+  );
+}

--- a/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,10 +1,19 @@
-// Clerk Sign-In page — used when AUTH_PROVIDER=clerk
-// Falls back to a message when Clerk is not configured.
+// Clerk Sign-In page — gated behind AUTH_PROVIDER=clerk.
+//
+// EMR-205: the top-level `import { SignIn } from "@clerk/nextjs"` used to
+// run at module load and crashed the whole (auth) route group when Clerk
+// env vars weren't set — including /login, which shares this group.
+// Dynamic-importing inside the render path keeps @clerk/nextjs out of
+// the hot boot path until Clerk is actually wired.
 
-import { SignIn } from "@clerk/nextjs";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 
 export const metadata = { title: "Sign in — Leafjourney" };
+
+const ClerkSignInBox = dynamic(() => import("./clerk-signin-box"), {
+  ssr: false,
+});
 
 export default function SignInPage() {
   const clerkEnabled = process.env.AUTH_PROVIDER === "clerk";
@@ -33,29 +42,7 @@ export default function SignInPage() {
       <p className="text-sm text-text-muted mb-8 text-center">
         Sign in to your Leafjourney account
       </p>
-
-      <SignIn
-        signUpUrl="/sign-up"
-        appearance={{
-          elements: {
-            rootBox: "w-full",
-            card: "bg-transparent shadow-none border-0 p-0",
-            headerTitle: "hidden",
-            headerSubtitle: "hidden",
-            formButtonPrimary:
-              "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
-            socialButtonsBlockButton:
-              "border border-border hover:bg-surface-muted rounded-md",
-            formFieldInput:
-              "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
-            footerActionLink: "text-accent hover:text-accent/80",
-          },
-          layout: {
-            socialButtonsPlacement: "top",
-            socialButtonsVariant: "blockButton",
-          },
-        }}
-      />
+      <ClerkSignInBox />
     </div>
   );
 }

--- a/src/app/(auth)/sign-up/[[...sign-up]]/clerk-signup-box.tsx
+++ b/src/app/(auth)/sign-up/[[...sign-up]]/clerk-signup-box.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+// Client-only Clerk sign-up widget. Isolated into its own module so the
+// `@clerk/nextjs` import only loads when AUTH_PROVIDER=clerk AND the
+// user actually navigates here — never during boot of the (auth) group.
+
+import { SignUp } from "@clerk/nextjs";
+
+export default function ClerkSignUpBox() {
+  return (
+    <SignUp
+      signInUrl="/sign-in"
+      appearance={{
+        elements: {
+          rootBox: "w-full",
+          card: "bg-transparent shadow-none border-0 p-0",
+          headerTitle: "hidden",
+          headerSubtitle: "hidden",
+          formButtonPrimary:
+            "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
+          socialButtonsBlockButton:
+            "border border-border hover:bg-surface-muted rounded-md",
+          formFieldInput:
+            "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
+          footerActionLink: "text-accent hover:text-accent/80",
+        },
+        layout: {
+          socialButtonsPlacement: "top",
+          socialButtonsVariant: "blockButton",
+        },
+      }}
+    />
+  );
+}

--- a/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,10 +1,17 @@
-// Clerk Sign-Up page — used when AUTH_PROVIDER=clerk
-// Falls back to a message when Clerk is not configured.
+// Clerk Sign-Up page — gated behind AUTH_PROVIDER=clerk.
+//
+// EMR-205: see the sibling /sign-in/page.tsx comment. Moving the
+// @clerk/nextjs import into a client-only dynamic component so a missing
+// Clerk config can't crash the (auth) route group.
 
-import { SignUp } from "@clerk/nextjs";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 
 export const metadata = { title: "Sign up — Leafjourney" };
+
+const ClerkSignUpBox = dynamic(() => import("./clerk-signup-box"), {
+  ssr: false,
+});
 
 export default function SignUpPage() {
   const clerkEnabled = process.env.AUTH_PROVIDER === "clerk";
@@ -33,29 +40,7 @@ export default function SignUpPage() {
       <p className="text-sm text-text-muted mb-8 text-center">
         Create your account
       </p>
-
-      <SignUp
-        signInUrl="/sign-in"
-        appearance={{
-          elements: {
-            rootBox: "w-full",
-            card: "bg-transparent shadow-none border-0 p-0",
-            headerTitle: "hidden",
-            headerSubtitle: "hidden",
-            formButtonPrimary:
-              "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
-            socialButtonsBlockButton:
-              "border border-border hover:bg-surface-muted rounded-md",
-            formFieldInput:
-              "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
-            footerActionLink: "text-accent hover:text-accent/80",
-          },
-          layout: {
-            socialButtonsPlacement: "top",
-            socialButtonsVariant: "blockButton",
-          },
-        }}
-      />
+      <ClerkSignUpBox />
     </div>
   );
 }

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -62,13 +62,22 @@ export interface AuthedUser {
  * this function don't need to change.
  */
 export const getCurrentUser = cache(async (): Promise<AuthedUser | null> => {
-  // Delegate to Clerk when the feature flag is on
+  // EMR-205: when AUTH_PROVIDER=clerk is set but the legacy iron-session
+  // login action still writes its own cookie, Clerk returns null for
+  // iron-session users and the whole app 401s. Fall through to
+  // iron-session so both auth paths keep working until we finish the
+  // Clerk migration.
   if (process.env.AUTH_PROVIDER === "clerk") {
-    const { getCurrentUserFromClerk } = await import("./clerk-session");
-    return getCurrentUserFromClerk();
+    try {
+      const { getCurrentUserFromClerk } = await import("./clerk-session");
+      const clerkUser = await getCurrentUserFromClerk();
+      if (clerkUser) return clerkUser;
+    } catch (err) {
+      console.warn("[auth] Clerk session lookup failed, falling back:", err);
+    }
   }
 
-  // Legacy iron-session path (default)
+  // Legacy iron-session path (default, and fallback when Clerk has no session)
   const session = await getSession();
   if (!session.userId) return null;
 


### PR DESCRIPTION
## Summary

Follow-up to PR #61. This commit was originally `8c60e12` on the hotfix branch but the PR was merged before it hit the PR head, so `main` never received the `session.ts` change. Re-applying cleanly.

## What it fixes

`getCurrentUser()` currently returns `null` immediately when `AUTH_PROVIDER=clerk` is set — even if Clerk has no session for the user. Since the legacy `loginAction` still writes iron-session cookies, iron-session users get a 401 on every request. That's what caused the demo crash.

With this patch, the Clerk branch:
1. Tries to get a Clerk session
2. If Clerk returns `null` (no session), falls through to iron-session
3. If Clerk throws (misconfig, missing keys), logs the warning and falls through to iron-session

So the two auth paths can coexist until the login flow is fully migrated.

## Test plan

- [ ] CI typecheck + lint + build pass
- [ ] Deploy with `AUTH_PROVIDER` unset → iron-session works (baseline unchanged)
- [ ] Deploy with `AUTH_PROVIDER=clerk` and no Clerk keys → iron-session users still log in (regression fixed)
- [ ] Deploy with `AUTH_PROVIDER=clerk` and valid Clerk keys → Clerk users get their session (future state)

## Related

- EMR-205 ticket on `claude/review-ticket-priorities-muFuD`
- Follow-up to merged PR #61

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7