### PR TITLE
hotfix(EMR-205): make NavSection.icon serializable across RSC boundary

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -1,12 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
-import {
-  IconHome,
-  IconClipboardCheck,
-  IconBookOpen,
-  IconSettings,
-} from "@/components/shell/nav-icons";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { BreathingBreak } from "@/components/ui/breathing-break";
@@ -107,7 +101,7 @@ export default async function ClinicianLayout({
     {
       label: "Today",
       pillar: "today",
-      icon: IconHome,
+      icon: "home",
       items: [
         { label: "Today", href: "/clinic" },
         { label: "Command Center", href: "/clinic/command" },
@@ -117,7 +111,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Review",
-      icon: IconClipboardCheck,
+      icon: "clipboard-check",
       items: [
         {
           label: "Approvals",
@@ -141,7 +135,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Reference",
-      icon: IconBookOpen,
+      icon: "book-open",
       items: [
         { label: "Providers", href: "/clinic/providers" },
         { label: "Research", href: "/clinic/research" },
@@ -151,7 +145,7 @@ export default async function ClinicianLayout({
     },
     {
       label: "Admin",
-      icon: IconSettings,
+      icon: "settings",
       items: [
         { label: "Audit", href: "/clinic/audit-trail" },
         { label: "Brief", href: "/clinic/morning-brief" },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -1,14 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
-import {
-  IconLayoutGrid,
-  IconDollar,
-  IconUsers,
-  IconBuilding,
-  IconChart,
-  IconServer,
-} from "@/components/shell/nav-icons";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { prisma } from "@/lib/db/prisma";
@@ -133,7 +125,7 @@ export default async function OperatorLayout({
     {
       label: "Overview",
       pillar: "overview",
-      icon: IconLayoutGrid,
+      icon: "layout-grid",
       items: [
         { label: "Overview", href: "/ops" },
         { label: "Mission Control", href: "/ops/mission-control" },
@@ -144,7 +136,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Billing",
-      icon: IconDollar,
+      icon: "dollar",
       items: [
         { label: "Billing", href: "/ops/billing" },
         { label: "Scrub", href: "/ops/scrub" },
@@ -157,7 +149,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Operations",
-      icon: IconUsers,
+      icon: "users",
       items: [
         { label: "Staff schedule", href: "/ops/staff-schedule" },
         { label: "Time clock", href: "/ops/time-clock" },
@@ -174,7 +166,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Practice Setup",
-      icon: IconBuilding,
+      icon: "building",
       items: [
         { label: "Onboarding", href: "/ops/onboarding" },
         { label: "Practice launch", href: "/ops/launch" },
@@ -185,7 +177,7 @@ export default async function OperatorLayout({
     },
     {
       label: "Intelligence",
-      icon: IconChart,
+      icon: "chart",
       items: [
         { label: "Analytics", href: "/ops/analytics" },
         { label: "Analytics Lab", href: "/ops/analytics-lab" },
@@ -195,7 +187,7 @@ export default async function OperatorLayout({
     },
     {
       label: "System",
-      icon: IconServer,
+      icon: "server",
       items: [
         { label: "AI Config", href: "/ops/settings/ai-config" },
         { label: "Webhooks", href: "/ops/webhooks" },

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -1,13 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
-import {
-  IconHome,
-  IconPill,
-  IconCalendar,
-  IconMessage,
-  IconUser,
-} from "@/components/shell/nav-icons";
 import { ROLE_HOME } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { CommandPalette } from "@/components/ui/command-palette";
@@ -16,13 +9,13 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Home",
     pillar: "home",
-    icon: IconHome,
+    icon: "home",
     items: [{ label: "Home", href: "/portal" }],
   },
   {
     label: "Health",
     pillar: "health",
-    icon: IconPill,
+    icon: "pill",
     items: [
       { label: "Log Dose", href: "/portal/log-dose" },
       { label: "My Health", href: "/portal/records" },
@@ -32,13 +25,13 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Schedule",
     pillar: "schedule",
-    icon: IconCalendar,
+    icon: "calendar",
     items: [{ label: "Schedule", href: "/portal/schedule" }],
   },
   {
     label: "Messages",
     pillar: "messages",
-    icon: IconMessage,
+    icon: "message",
     items: [
       { label: "Messages", href: "/portal/messages" },
       { label: "Q&A", href: "/portal/qa" },
@@ -47,7 +40,7 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Account",
     pillar: "account",
-    icon: IconUser,
+    icon: "user",
     items: [{ label: "Account", href: "/portal/profile" }],
   },
 ];

--- a/src/components/shell/IconRail.tsx
+++ b/src/components/shell/IconRail.tsx
@@ -8,6 +8,7 @@ import {
   sectionContainsPath,
   type NavSection,
 } from "./nav-sections";
+import { resolveNavIcon } from "./icon-registry";
 
 export interface IconRailProps {
   sections: NavSection[];
@@ -27,7 +28,7 @@ export function IconRail({
   return (
     <ul className="flex flex-col gap-1 px-2 py-3">
       {sections.map((section, idx) => {
-        const Icon = section.icon;
+        const Icon = resolveNavIcon(section.icon);
         if (!Icon) return null;
         const id = pillarId(section, idx);
         const badge = getSectionBadge(section);

--- a/src/components/shell/icon-registry.tsx
+++ b/src/components/shell/icon-registry.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// Client-side lookup from a serializable NavIconKey to the actual SVG
+// component. NavSection carries only the string key across the RSC
+// boundary (see nav-sections.ts); the component is resolved here.
+
+import * as React from "react";
+import {
+  IconHome,
+  IconPill,
+  IconCalendar,
+  IconMessage,
+  IconUser,
+  IconStethoscope,
+  IconClipboardCheck,
+  IconBookOpen,
+  IconSettings,
+  IconLayoutGrid,
+  IconDollar,
+  IconUsers,
+  IconBuilding,
+  IconChart,
+  IconServer,
+  IconHeart,
+  IconInbox,
+} from "./nav-icons";
+import type { NavIconKey } from "./nav-sections";
+
+type NavIconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+const REGISTRY: Record<NavIconKey, NavIconComponent> = {
+  home: IconHome,
+  pill: IconPill,
+  calendar: IconCalendar,
+  message: IconMessage,
+  user: IconUser,
+  stethoscope: IconStethoscope,
+  "clipboard-check": IconClipboardCheck,
+  "book-open": IconBookOpen,
+  settings: IconSettings,
+  "layout-grid": IconLayoutGrid,
+  dollar: IconDollar,
+  users: IconUsers,
+  building: IconBuilding,
+  chart: IconChart,
+  server: IconServer,
+  heart: IconHeart,
+  inbox: IconInbox,
+};
+
+export function resolveNavIcon(
+  key: NavIconKey | undefined,
+): NavIconComponent | null {
+  if (!key) return null;
+  return REGISTRY[key] ?? null;
+}

--- a/src/components/shell/nav-sections.ts
+++ b/src/components/shell/nav-sections.ts
@@ -4,13 +4,34 @@
 
 import { aggregateBadge, type NavBadge } from "@/lib/domain/nav-badges";
 import type { NavAgentActivity } from "@/lib/domain/nav-agent-activity";
-import type * as React from "react";
 
 export type { NavBadge } from "@/lib/domain/nav-badges";
 
 export type CountTone = "highlight" | "danger" | "accent";
 
-export type NavIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+// Icon references on NavSection cross the server→client RSC boundary, so they
+// MUST be serializable. We pass a string key here and resolve to a component
+// inside the client icon registry (./icon-registry). Passing a function/
+// component reference directly triggers "Functions cannot be passed directly
+// to Client Components" at render time.
+export type NavIconKey =
+  | "home"
+  | "pill"
+  | "calendar"
+  | "message"
+  | "user"
+  | "stethoscope"
+  | "clipboard-check"
+  | "book-open"
+  | "settings"
+  | "layout-grid"
+  | "dollar"
+  | "users"
+  | "building"
+  | "chart"
+  | "server"
+  | "heart"
+  | "inbox";
 
 export interface NavItem {
   label: string;
@@ -27,7 +48,7 @@ export interface NavSection {
   items: NavItem[];
   defaultCollapsed?: boolean;
   badge?: NavBadge | null;
-  icon?: NavIcon;
+  icon?: NavIconKey;
   pillar?: string;
 }
 


### PR DESCRIPTION
## Root cause

The `/login` "Something went wrong" crash (error digest `35578989`) is caused by React Server Components refusing to serialize function references across the server→client boundary:

```
Error: Functions cannot be passed directly to Client Components unless you
explicitly expose it by marking it with "use server". Or maybe you meant to
call this function rather than return it.
  {label: "Home", pillar: "home", icon: function i, items: ...}
                                        ^^^^^^^^^^
  digest: '35578989'
```

The `(patient|clinician|operator)/layout.tsx` files are server components that build a `NavSection[]` with `icon: IconHome` (a React function component) and pass it into `AppShell`, which hands it to client components (`PillarNav`, `NavVisitTracker`, `IconRail`, `MobileNav`). RSC serialization fails on the function reference, so any page that mounts `AppShell` — including the POST response for `/login` after auth redirects to `/portal` — throws.

Introduced in the IconRail/PillarNav refactor (commits `91731d2`, `0f6dcbb`, `26a7152`, `dab377e`).

## Fix

- `NavSection.icon` is now a `NavIconKey` string literal (`"home" | "pill" | "calendar" | ...`) instead of a `ComponentType`.
- New `src/components/shell/icon-registry.tsx` is a `"use client"` module that maps the key back to the actual SVG component.
- `IconRail` resolves the component via `resolveNavIcon(section.icon)`.
- Patient, clinician, and operator layouts updated to pass string keys.

Only plain strings/primitives now cross the RSC boundary for nav sections.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `npm run build` succeeds
- [ ] Deploy: `/login` loads without "Something went wrong"
- [ ] Deploy: signing in redirects to `/portal` and renders (not skeleton)
- [ ] Deploy: icons visible in patient/clinician/operator pillar rails

## Related

- EMR-205 (critical demo outage)
- Follow-up to merged PRs #61, #63

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7