### PR TITLE
hotfix(EMR-205): fix withTimeout rejection-path + narrow /portal encounters query

### DIFF
--- a/src/app/(patient)/portal/page.tsx
+++ b/src/app/(patient)/portal/page.tsx
@@ -20,9 +20,10 @@ import { QuickSymptomFab } from "@/components/ui/quick-symptom-fab";
 import { withTimeout } from "@/lib/utils/with-timeout";
 
 // EMR-205: guard the home-page queries so a hung downstream call can
-// never wedge the Suspense boundary again.
-const PATIENT_QUERY_TIMEOUT_MS = 8_000;
-const PLANT_HEALTH_TIMEOUT_MS = 3_000;
+// never wedge the Suspense boundary again. Tight timeouts give the user
+// fast feedback (retry UI) instead of an endless skeleton.
+const PATIENT_QUERY_TIMEOUT_MS = 5_000;
+const PLANT_HEALTH_TIMEOUT_MS = 2_000;
 
 const DEFAULT_PLANT_HEALTH: PlantHealth = {
   score: 40,
@@ -146,6 +147,11 @@ export default async function PatientHome() {
   // genuinely missing patient record, so we don't mis-route to intake.
   // `any` here because the TIMEOUT sentinel widens the resolved type and
   // the surrounding code already handles null vs. not-null.
+  // EMR-205: `encounters` uses a narrow `select` to avoid pulling
+  // Encounter.* (which references `chartingCompletedAt` — a column that
+  // may be missing from prod DBs where the migration hasn't run yet).
+  // Keeping the field list minimal also makes this query less likely
+  // to time out on slow connections.
   const patient: any = await withTimeout<any>(
     prisma.patient.findUnique({
       where: { userId: user.id },
@@ -155,6 +161,13 @@ export default async function PatientHome() {
         encounters: {
           orderBy: { scheduledFor: "desc" },
           take: 3,
+          select: {
+            id: true,
+            status: true,
+            scheduledFor: true,
+            modality: true,
+            completedAt: true,
+          },
         },
         tasks: {
           where: { status: "open" },

--- a/src/lib/utils/with-timeout.ts
+++ b/src/lib/utils/with-timeout.ts
@@ -2,12 +2,13 @@
  * Race a promise against a wall-clock timeout.
  *
  * If `promise` has not settled within `ms`, resolve with `fallback` instead.
- * The original promise is allowed to finish in the background — any late
- * rejection is swallowed (logged) so it doesn't crash the Node process.
+ * If `promise` rejects before the timeout, resolve with `fallback` too — the
+ * rejection is swallowed (logged). Any late rejection after a timeout is also
+ * swallowed so it doesn't crash the Node process.
  *
- * Intended for Server Components where a hung downstream call (DB, cache,
- * upstream API) would otherwise wedge the Suspense boundary forever,
- * blocking hydration and making the whole route feel broken.
+ * Intended for Server Components where a hung or failing downstream call
+ * (DB, cache, upstream API) would otherwise wedge the Suspense boundary
+ * forever, blocking hydration and making the whole route feel broken.
  */
 export async function withTimeout<T>(
   promise: Promise<T>,
@@ -25,7 +26,14 @@ export async function withTimeout<T>(
     }, ms);
   });
 
-  const result = await Promise.race([promise, timeoutPromise]);
+  // Swallow rejections on the wrapped promise so Promise.race never rejects —
+  // a slow-or-broken downstream should never surface as an unhandled error.
+  const safePromise = Promise.resolve(promise).catch((err) => {
+    console.warn(`[${label}] rejected — serving fallback:`, err);
+    return fallback;
+  });
+
+  const result = await Promise.race([safePromise, timeoutPromise]);
   if (timer) clearTimeout(timer);
 
   if (timedOut) {


### PR DESCRIPTION
## Problem

`/portal` loads the layout + pillar nav fine (PR #64 fixed that) but the main content area stays stuck on the loading skeleton forever — the server component `PatientHome` never resolves, so Suspense never streams past `loading.tsx`.

## Two root causes

1. **`withTimeout` bug**: when the wrapped promise *rejects* before the timer fires, `Promise.race` rejects and the fallback is never returned. The caller throws, Next.js streams nothing useful, and the client is left on the skeleton. Only the *timeout* path (setTimeout winning) served the fallback.

2. **Schema drift exposure**: the `encounters` relation in the patient dashboard query pulled `Encounter.*`. If prod is missing `Encounter.chartingCompletedAt` (migration hasn't run), the entire patient query rejects with a column-does-not-exist error, which — thanks to #1 — propagated instead of falling back.

## Fix

- `withTimeout` now wraps the input promise with `.catch(fallback)` before racing, so rejection AND timeout both serve the fallback cleanly.
- `/portal`'s `encounters` include uses a narrow `select` of only the fields the page actually reads (`id, status, scheduledFor, modality, completedAt`), so the query is immune to the missing column.
- Timeouts tightened (8s → 5s, 3s → 2s) so users see the retry UI faster if the DB is genuinely slow.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Deploy: `/portal` renders content (or retry UI) within 5s, never stuck on skeleton
- [ ] Logs: any `[portal.home.patient.findUnique] rejected — serving fallback:` warnings identify remaining DB issues

## Related

- Follow-up to #61, #63, #64
- EMR-205 demo outage

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7