### PR TITLE
feat(infra): switch web boot to prisma migrate deploy via Supabase direct URL

### DIFF
--- a/prisma/migrations/20260419155934_add_charting_completed_at/migration.sql
+++ b/prisma/migrations/20260419155934_add_charting_completed_at/migration.sql
@@ -1,2 +1,5 @@
 -- AlterTable
-ALTER TABLE "Encounter" ADD COLUMN "chartingCompletedAt" TIMESTAMP(3);
+-- `IF NOT EXISTS` so this migration can baseline against prod DBs where
+-- the column was added manually via `db push` or SQL Editor before we
+-- switched to `migrate deploy`. Safe no-op on up-to-date databases.
+ALTER TABLE "Encounter" ADD COLUMN IF NOT EXISTS "chartingCompletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,8 +12,14 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  // Runtime query URL — points at Supabase's PgBouncer pooler (port 6543).
+  url       = env("DATABASE_URL")
+  // Schema-change URL — direct connection (port 5432). Prisma uses this
+  // for `migrate deploy` / `db push` / `introspect` because those need
+  // advisory locks that PgBouncer drops. Falls back to `url` if unset
+  // locally; prod MUST have this set.
+  directUrl = env("DIRECT_URL")
 }
 
 // --------------------------------------------------------------

--- a/render.yaml
+++ b/render.yaml
@@ -4,9 +4,11 @@
 # Rules of the road:
 #   1. `main` is the only branch that deploys. Open PRs into main; never
 #      point a Render service at a feature branch.
-#   2. Schema sync happens in `startCommand`, right before the app starts
-#      serving traffic. No reliance on preDeployCommand (it's a no-op on
-#      Starter and failed silently for weeks).
+#   2. Schema sync happens in `startCommand` via `prisma migrate deploy`
+#      — versioned migrations applied through Supabase's DIRECT (5432)
+#      connection. The pooler (6543) can't hold the advisory locks
+#      migrations need, which is how schema drift silently bit us before.
+#      Runtime queries still go through the pooler via DATABASE_URL.
 #   3. Seeding is a one-off, not part of every deploy. Run `npm run db:seed`
 #      manually from a Render shell when spinning up a fresh database.
 
@@ -18,7 +20,7 @@ services:
     plan: starter
     branch: main
     buildCommand: npm ci && npx prisma generate && npm run build
-    startCommand: npx prisma db push --accept-data-loss --skip-generate && npm run start
+    startCommand: npx prisma migrate deploy && npm run start
     healthCheckPath: /api/health
     envVars:
       - key: NODE_ENV
@@ -27,6 +29,12 @@ services:
         fromDatabase:
           name: emr-postgres
           property: connectionString
+      # Direct (non-pooled) Supabase URL for schema migrations. Must be
+      # set manually in the Render dashboard — it's the port-5432
+      # connection string from Supabase → Project Settings → Database →
+      # Connection string → "Direct connection".
+      - key: DIRECT_URL
+        sync: false
       - key: SESSION_SECRET
         generateValue: true
       - key: AGENT_MODEL_CLIENT


### PR DESCRIPTION
## Why

Schema changes were silently failing for weeks. Root cause: `prisma db push` was running through the Supabase **pooler** (port 6543), and PgBouncer drops the advisory locks Prisma uses for schema operations. The `Encounter.chartingCompletedAt` demo outage earlier today was that silent failure finally biting.

## What changes

1. **`prisma/schema.prisma`** — add `directUrl = env("DIRECT_URL")`. Prisma uses this for every schema operation (migrate / push / introspect). Runtime queries still use the pooler via `url`, so the connection economy is unchanged.

2. **`render.yaml`** — web `startCommand` swapped:
   ```diff
   - startCommand: npx prisma db push --accept-data-loss --skip-generate && npm run start
   + startCommand: npx prisma migrate deploy && npm run start
   ```
   Versioned migrations, applied in order, failures surface loudly. Added `DIRECT_URL` as a `sync: false` env var so Render prompts us to set it manually.

3. **`prisma/migrations/20260419155934_add_charting_completed_at/migration.sql`** — `ADD COLUMN IF NOT EXISTS` so this migration can baseline against the current prod DB (where the column was added manually via the Supabase SQL Editor this morning). Safe no-op on DBs that already have it.

## ⚠️ Before merging

You must set `DIRECT_URL` in the **emr-web** Render service env vars:

1. Supabase dashboard → Project Settings → Database → Connection string
2. Select **"Direct connection"** (port 5432, not the pooled 6543)
3. Copy the full URL (includes password)
4. Render → emr-web → Environment → Add `DIRECT_URL` → paste → Save

If you skip this, the deploy will fail fast with `Environment variable not found: DIRECT_URL` — no data risk, just a red deploy.

## What happens on first deploy after merge

1. `prisma migrate deploy` runs against the direct URL
2. Prisma creates `_prisma_migrations` table (didn't exist before — we were using `db push`)
3. Applies `20260419155934_add_charting_completed_at` — SQL is now idempotent, so the pre-existing column is a no-op
4. Migration is recorded as applied; future migrations ride on top normally

## Why this matters going forward

- Schema drift becomes impossible to miss — deploys fail loudly
- Migration history is committed to the repo; rollbacks and audits are clean
- New migrations just work: `npx prisma migrate dev --name foo` locally → commit → merge → Render applies on next deploy

## Test plan

- [x] `npx prisma validate` passes with `DIRECT_URL` set
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `DIRECT_URL` set in Render dashboard
- [ ] Merge → deploy completes → `chartingCompletedAt` migration logged in `_prisma_migrations`
- [ ] `/portal` and `/clinic` still render (no regression from the runtime query URL)

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7