### PR TITLE
hotfix(nav): revert to legacy wide sidebar — drop icon keys from layouts

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -101,7 +101,6 @@ export default async function ClinicianLayout({
     {
       label: "Today",
       pillar: "today",
-      icon: "home",
       items: [
         { label: "Today", href: "/clinic" },
         { label: "Command Center", href: "/clinic/command" },
@@ -111,7 +110,6 @@ export default async function ClinicianLayout({
     },
     {
       label: "Review",
-      icon: "clipboard-check",
       items: [
         {
           label: "Approvals",
@@ -135,7 +133,6 @@ export default async function ClinicianLayout({
     },
     {
       label: "Reference",
-      icon: "book-open",
       items: [
         { label: "Providers", href: "/clinic/providers" },
         { label: "Research", href: "/clinic/research" },
@@ -145,7 +142,6 @@ export default async function ClinicianLayout({
     },
     {
       label: "Admin",
-      icon: "settings",
       items: [
         { label: "Audit", href: "/clinic/audit-trail" },
         { label: "Brief", href: "/clinic/morning-brief" },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -125,7 +125,6 @@ export default async function OperatorLayout({
     {
       label: "Overview",
       pillar: "overview",
-      icon: "layout-grid",
       items: [
         { label: "Overview", href: "/ops" },
         { label: "Mission Control", href: "/ops/mission-control" },
@@ -136,7 +135,6 @@ export default async function OperatorLayout({
     },
     {
       label: "Billing",
-      icon: "dollar",
       items: [
         { label: "Billing", href: "/ops/billing" },
         { label: "Scrub", href: "/ops/scrub" },
@@ -149,7 +147,6 @@ export default async function OperatorLayout({
     },
     {
       label: "Operations",
-      icon: "users",
       items: [
         { label: "Staff schedule", href: "/ops/staff-schedule" },
         { label: "Time clock", href: "/ops/time-clock" },
@@ -166,7 +163,6 @@ export default async function OperatorLayout({
     },
     {
       label: "Practice Setup",
-      icon: "building",
       items: [
         { label: "Onboarding", href: "/ops/onboarding" },
         { label: "Practice launch", href: "/ops/launch" },
@@ -177,7 +173,6 @@ export default async function OperatorLayout({
     },
     {
       label: "Intelligence",
-      icon: "chart",
       items: [
         { label: "Analytics", href: "/ops/analytics" },
         { label: "Analytics Lab", href: "/ops/analytics-lab" },
@@ -187,7 +182,6 @@ export default async function OperatorLayout({
     },
     {
       label: "System",
-      icon: "server",
       items: [
         { label: "AI Config", href: "/ops/settings/ai-config" },
         { label: "Webhooks", href: "/ops/webhooks" },

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -9,13 +9,11 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Home",
     pillar: "home",
-    icon: "home",
     items: [{ label: "Home", href: "/portal" }],
   },
   {
     label: "Health",
     pillar: "health",
-    icon: "pill",
     items: [
       { label: "Log Dose", href: "/portal/log-dose" },
       { label: "My Health", href: "/portal/records" },
@@ -25,13 +23,11 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Schedule",
     pillar: "schedule",
-    icon: "calendar",
     items: [{ label: "Schedule", href: "/portal/schedule" }],
   },
   {
     label: "Messages",
     pillar: "messages",
-    icon: "message",
     items: [
       { label: "Messages", href: "/portal/messages" },
       { label: "Q&A", href: "/portal/qa" },
@@ -40,7 +36,6 @@ const PATIENT_SECTIONS: NavSection[] = [
   {
     label: "Account",
     pillar: "account",
-    icon: "user",
     items: [{ label: "Account", href: "/portal/profile" }],
   },
 ];


### PR DESCRIPTION
## Why

The pillar-rail + slide-out drawer ships a two-step interaction — click a pillar icon, then click the item in the drawer — which made the clinic nav feel *locked*: items weren't visible until the user figured out to click a pillar first. That's a regression from the old wide sidebar where every group and its items were always visible and always clickable.

Restoring the familiar sidebar tonight so the demo is usable. The new nav stays in the tree for a cleaner re-introduction later.

## How

`AppShell` already has the fallback wired in — when no `NavSection` has an `icon` set, `hasPillarIcons` returns false and it renders the legacy `<aside>` with `NavSections`. Only change is removing the `icon: "..."` keys from the three role layouts. No component changes, no tree shake.

```diff
 {
   label: "Home",
   pillar: "home",
-  icon: "home",
   items: [{ label: "Home", href: "/portal" }],
 },
```

PillarNav / IconRail / ContextDrawer / icon-registry remain in the repo, just unused at runtime.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Deploy: `/portal`, `/clinic`, `/ops` render the wide sidebar with every group visible and every link clickable
- [ ] Click any nav item — URL changes, page loads

## Related

- Unblocks the demo after the pillar-nav rollout (PR #64 / commits `91731d2`, `0f6dcbb`, `26a7152`, `dab377e`)

https://claude.ai/code/session_01G4UbPt9pSALEmfoQtbXmC7