### PR TITLE
fix(nav): break NavVisitTracker infinite render loop (UI freeze hotfix)

### DIFF
--- a/src/components/shell/NavVisitTracker.tsx
+++ b/src/components/shell/NavVisitTracker.tsx
@@ -13,6 +13,17 @@ import { useNavPrefs } from "./NavPrefsContext";
  * longest-prefix match. If no section item matches (e.g. the user is on a
  * dynamic route not in the nav), we skip the visit — recents would otherwise
  * fill with raw pathnames which read poorly.
+ *
+ * IMPORTANT: the effect deps intentionally exclude the full `prefs` object.
+ * `prefs` is a `useMemo` that re-creates on every state change in
+ * NavPrefsProvider — including the very `recents` list this component writes
+ * to. Depending on it creates an infinite render loop:
+ *   visit() → setRecents → prefs memo rebuilds → new prefs reference →
+ *   effect re-fires → visit() …
+ * Instead we pluck the two stable bits we actually need — `visit` (wrapped
+ * in useCallback([]) in the provider, so its identity never changes) and
+ * `hydrated` (a primitive bool). Both only change in ways that make the
+ * effect *want* to re-run.
  */
 
 export interface NavVisitTrackerProps {
@@ -43,15 +54,19 @@ function resolveLabel(sections: NavSection[], pathname: string): { href: string;
 export function NavVisitTracker({ sections }: NavVisitTrackerProps) {
   const prefs = useNavPrefs();
   const pathname = usePathname() ?? "";
+  const visit = prefs?.visit;
+  const hydrated = prefs?.hydrated ?? false;
 
   React.useEffect(() => {
-    if (!prefs || !prefs.hydrated) return;
+    if (!visit || !hydrated) return;
     if (!pathname) return;
     const resolved = resolveLabel(sections, pathname);
     if (!resolved) return;
-    prefs.visit(resolved);
-    // `visit` is stable via useCallback; pathname + sections drive this.
-  }, [pathname, sections, prefs]);
+    visit(resolved);
+    // Deps: pathname + sections drive which route is recorded; visit + hydrated
+    // are stable references from the provider. Excluding `prefs` is load-bearing
+    // — see the comment at the top of the file.
+  }, [pathname, sections, visit, hydrated]);
 
   return null;
 }


### PR DESCRIPTION
## 🔴 Hotfix: UI freezes, clicks do nothing

## Summary
`NavVisitTracker` (from PR #58) had an infinite render loop: the effect depended on the memoized `prefs` object, which re-creates on every state change in the provider — including the `recents` list this component writes to.

```
visit() → setRecents → prefs memo rebuilds → new prefs reference →
effect re-fires → visit() → …
```

React saturates, the event loop starves, and clicks on nav links never fire their handlers.

## Fix
Depend only on the stable `visit` callback (wrapped in `useCallback([])` in the provider) and the `hydrated` primitive, not the full `prefs` identity. Effect now runs exactly once per route change.

## Test plan
- [ ] Pull the branch, `npm run dev`, log in as clinician
- [ ] Click around the nav (Today, Command Center, Roster, Inbox, Approvals…) — all should navigate
- [ ] Check `localStorage` for `nav:recent:v1` — should record the last 5 distinct routes, no infinite growth

## Blast radius
Single file, 1 hook change. Recommend merging as soon as CI passes.

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C