### PR TITLE
feat(nav): rank pinned items with up/down arrows

### DIFF
--- a/src/components/shell/NavPrefsContext.tsx
+++ b/src/components/shell/NavPrefsContext.tsx
@@ -9,8 +9,10 @@ import {
   parseRecents,
   recordVisit,
   removePin,
+  reorderPin,
   type PinnedEntry,
   type RecentEntry,
+  type ReorderDirection,
 } from "@/lib/domain/nav-prefs";
 
 /**
@@ -18,12 +20,13 @@ import {
  * no server round-trip, no cookies. SSR-safe: initial render is always
  * empty, then the first client effect hydrates from storage.
  *
- *   pins      — pinned routes, newest first, cap 8.
- *   recents   — last 5 distinct visited routes, newest first.
- *   pin/unpin — mutate pins by href.
- *   isPinned  — cheap lookup for star-toggle state.
- *   visit     — record a route visit (used by NavVisitTracker).
- *   clearAll  — nuke both lists + their storage keys (Manage action).
+ *   pins        — pinned routes, user-ordered (new pins land at top), cap 8.
+ *   recents     — last 5 distinct visited routes, newest first.
+ *   pin/unpin   — mutate pins by href.
+ *   movePin     — shift a pin one slot up or down.
+ *   isPinned    — cheap lookup for star-toggle state.
+ *   visit       — record a route visit (used by NavVisitTracker).
+ *   clearAll    — nuke both lists + their storage keys (Manage action).
  *
  * Writes are debounced 250ms so rapid toggles don't hammer localStorage.
  */
@@ -33,6 +36,7 @@ export interface NavPrefsValue {
   recents: RecentEntry[];
   pin: (entry: { href: string; label: string }) => void;
   unpin: (href: string) => void;
+  movePin: (href: string, direction: ReorderDirection) => void;
   isPinned: (href: string) => boolean;
   visit: (entry: { href: string; label: string }) => void;
   clearAll: () => void;
@@ -119,6 +123,13 @@ export function NavPrefsProvider({ children }: { children: React.ReactNode }) {
     setPins((prev) => removePin(prev, href));
   }, []);
 
+  const movePin = React.useCallback(
+    (href: string, direction: ReorderDirection) => {
+      setPins((prev) => reorderPin(prev, href, direction));
+    },
+    [],
+  );
+
   const visit = React.useCallback((entry: { href: string; label: string }) => {
     setRecents((prev) => recordVisit(prev, entry));
   }, []);
@@ -141,8 +152,18 @@ export function NavPrefsProvider({ children }: { children: React.ReactNode }) {
   );
 
   const value = React.useMemo<NavPrefsValue>(
-    () => ({ pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated }),
-    [pins, recents, pin, unpin, isPinned, visit, clearAll, hydrated],
+    () => ({
+      pins,
+      recents,
+      pin,
+      unpin,
+      movePin,
+      isPinned,
+      visit,
+      clearAll,
+      hydrated,
+    }),
+    [pins, recents, pin, unpin, movePin, isPinned, visit, clearAll, hydrated],
   );
 
   return <NavPrefsCtx.Provider value={value}>{children}</NavPrefsCtx.Provider>;

--- a/src/components/shell/NavPrefsSections.tsx
+++ b/src/components/shell/NavPrefsSections.tsx
@@ -11,6 +11,8 @@ import { PinButton } from "./PinButton";
  * Renders the two personalization strips at the top of the sidebar:
  *
  *   PINNED — routes the user starred. Empty state shows a subtle hint.
+ *            Each pinned row exposes up/down arrows on hover so the user
+ *            can rank them; arrows are hidden when only one pin exists.
  *   RECENT — last 5 distinct visited routes. Empty → render nothing.
  *
  * Styling deliberately mirrors a labeled NavSection header so the rail
@@ -35,16 +37,127 @@ function SectionHeader({
   );
 }
 
-function Row({
+function ReorderButton({
+  direction,
+  disabled,
+  onClick,
+  label,
+}: {
+  direction: "up" | "down";
+  disabled: boolean;
+  onClick: (e: React.MouseEvent) => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex h-6 w-6 items-center justify-center rounded-md text-text-subtle",
+        "transition-all duration-150 ease-smooth",
+        "hover:bg-surface-muted hover:text-text",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        "disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-subtle",
+        // Hidden by default, revealed on row hover/focus. The pin button uses
+        // the same pattern so the controls appear as a single hover cluster.
+        "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {direction === "up" ? (
+          <polyline points="18 15 12 9 6 15" />
+        ) : (
+          <polyline points="6 9 12 15 18 9" />
+        )}
+      </svg>
+    </button>
+  );
+}
+
+function PinnedRow({
   href,
   label,
   isActive,
-  showPin,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
 }: {
   href: string;
   label: string;
   isActive: boolean;
-  showPin: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}) {
+  const stopAndRun = (fn: () => void) => (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    fn();
+  };
+
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "group flex items-center gap-1 px-3 py-2 rounded-md text-sm transition-colors duration-200 ease-smooth",
+        isActive
+          ? "bg-surface-muted text-text"
+          : "text-text-muted hover:bg-surface-muted hover:text-text",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "h-1 w-1 rounded-full transition-colors mr-1.5",
+          isActive ? "bg-accent" : "bg-border-strong group-hover:bg-accent",
+        )}
+      />
+      <span className="flex-1 truncate">{label}</span>
+      {(canMoveUp || canMoveDown) && (
+        <>
+          <ReorderButton
+            direction="up"
+            disabled={!canMoveUp}
+            onClick={stopAndRun(onMoveUp)}
+            label={`Move ${label} up`}
+          />
+          <ReorderButton
+            direction="down"
+            disabled={!canMoveDown}
+            onClick={stopAndRun(onMoveDown)}
+            label={`Move ${label} down`}
+          />
+        </>
+      )}
+      <PinButton href={href} label={label} visibility="hover" />
+    </Link>
+  );
+}
+
+function RecentRow({
+  href,
+  label,
+  isActive,
+}: {
+  href: string;
+  label: string;
+  isActive: boolean;
 }) {
   return (
     <Link
@@ -65,7 +178,7 @@ function Row({
         )}
       />
       <span className="flex-1 truncate">{label}</span>
-      {showPin && <PinButton href={href} label={label} visibility="hover" />}
+      <PinButton href={href} label={label} visibility="hover" />
     </Link>
   );
 }
@@ -75,7 +188,7 @@ export function NavPrefsSections() {
   const pathname = usePathname() ?? "";
   if (!prefs) return null;
 
-  const { pins, recents, hydrated, clearAll } = prefs;
+  const { pins, recents, hydrated, clearAll, movePin } = prefs;
 
   const hasAny = pins.length > 0 || recents.length > 0;
 
@@ -109,15 +222,18 @@ export function NavPrefsSections() {
           </p>
         ) : (
           <ul className="space-y-0.5 pl-1">
-            {pins.map((p) => (
+            {pins.map((p, idx) => (
               <li key={p.href}>
-                <Row
+                <PinnedRow
                   href={p.href}
                   label={p.label}
                   isActive={
                     pathname === p.href || pathname.startsWith(p.href + "/")
                   }
-                  showPin
+                  canMoveUp={idx > 0}
+                  canMoveDown={idx < pins.length - 1}
+                  onMoveUp={() => movePin(p.href, "up")}
+                  onMoveDown={() => movePin(p.href, "down")}
                 />
               </li>
             ))}
@@ -132,13 +248,12 @@ export function NavPrefsSections() {
           <ul className="space-y-0.5 pl-1">
             {recents.map((r) => (
               <li key={r.href}>
-                <Row
+                <RecentRow
                   href={r.href}
                   label={r.label}
                   isActive={
                     pathname === r.href || pathname.startsWith(r.href + "/")
                   }
-                  showPin
                 />
               </li>
             ))}

--- a/src/lib/domain/nav-prefs.test.ts
+++ b/src/lib/domain/nav-prefs.test.ts
@@ -9,6 +9,7 @@ import {
   parseRecents,
   recordVisit,
   removePin,
+  reorderPin,
   type PinnedEntry,
   type RecentEntry,
 } from "./nav-prefs";
@@ -74,6 +75,60 @@ describe("removePin", () => {
     const pins: PinnedEntry[] = [];
     const next = removePin(pins, "/nope");
     expect(next).toBe(pins);
+  });
+});
+
+describe("reorderPin", () => {
+  const start: PinnedEntry[] = [
+    { href: "/a", label: "A", pinnedAt: 1 },
+    { href: "/b", label: "B", pinnedAt: 2 },
+    { href: "/c", label: "C", pinnedAt: 3 },
+  ];
+
+  it("moves a middle pin up by one position", () => {
+    const next = reorderPin(start, "/b", "up");
+    expect(next.map((p) => p.href)).toEqual(["/b", "/a", "/c"]);
+  });
+
+  it("moves a middle pin down by one position", () => {
+    const next = reorderPin(start, "/b", "down");
+    expect(next.map((p) => p.href)).toEqual(["/a", "/c", "/b"]);
+  });
+
+  it("is a no-op (same reference) when moving the first pin up", () => {
+    const next = reorderPin(start, "/a", "up");
+    expect(next).toBe(start);
+  });
+
+  it("is a no-op (same reference) when moving the last pin down", () => {
+    const next = reorderPin(start, "/c", "down");
+    expect(next).toBe(start);
+  });
+
+  it("is a no-op when the href is not in the list", () => {
+    const next = reorderPin(start, "/missing", "up");
+    expect(next).toBe(start);
+  });
+
+  it("preserves pinnedAt timestamps on both swapped entries", () => {
+    const next = reorderPin(start, "/c", "up");
+    expect(next).toEqual([
+      { href: "/a", label: "A", pinnedAt: 1 },
+      { href: "/c", label: "C", pinnedAt: 3 },
+      { href: "/b", label: "B", pinnedAt: 2 },
+    ]);
+  });
+
+  it("is pure — the input array is not mutated", () => {
+    const snapshot = start.map((p) => ({ ...p }));
+    reorderPin(start, "/b", "up");
+    expect(start).toEqual(snapshot);
+  });
+
+  it("handles a single-element list as a no-op in either direction", () => {
+    const one: PinnedEntry[] = [{ href: "/a", label: "A", pinnedAt: 1 }];
+    expect(reorderPin(one, "/a", "up")).toBe(one);
+    expect(reorderPin(one, "/a", "down")).toBe(one);
   });
 });
 

--- a/src/lib/domain/nav-prefs.ts
+++ b/src/lib/domain/nav-prefs.ts
@@ -7,7 +7,9 @@
  * SSR-safe hydration + debounced writes.
  *
  *   PinnedEntry    — route the user explicitly starred. Dedup by href, bump
- *                    to top on re-pin, cap at 8.
+ *                    to top on re-pin, cap at 8. Order is user-controlled:
+ *                    new pins land at the top; the user can reorder via
+ *                    `reorderPin`.
  *   RecentEntry    — last N visited distinct routes, newest first, cap at 5.
  *
  * Caps are low intentionally: the Pinned + Recent surfaces sit above the
@@ -60,6 +62,29 @@ export function removePin(current: PinnedEntry[], href: string): PinnedEntry[] {
   const hit = current.some((p) => p.href === href);
   if (!hit) return current;
   return current.filter((p) => p.href !== href);
+}
+
+export type ReorderDirection = "up" | "down";
+
+/**
+ * Swap a pinned entry one position up or down. No-op (same reference) when:
+ *   • href is not present in the list
+ *   • direction would push past an edge (up-at-top, down-at-bottom)
+ * Preserves `pinnedAt` timestamps — reordering is an explicit user action,
+ * not a re-pin, so history stays intact.
+ */
+export function reorderPin(
+  current: PinnedEntry[],
+  href: string,
+  direction: ReorderDirection,
+): PinnedEntry[] {
+  const idx = current.findIndex((p) => p.href === href);
+  if (idx === -1) return current;
+  const swapWith = direction === "up" ? idx - 1 : idx + 1;
+  if (swapWith < 0 || swapWith >= current.length) return current;
+  const next = current.slice();
+  [next[idx], next[swapWith]] = [next[swapWith], next[idx]];
+  return next;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds up/down arrow buttons to each pinned row so the user can rank them. Arrows appear on hover (same pattern as the pin/unpin star button) and only when there's more than one pin.

## What changed
- `reorderPin(pins, href, "up" | "down")` pure helper in `nav-prefs.ts`
  - No-op (same reference) when href missing, or swap would push past an edge
  - Preserves `pinnedAt` timestamps — reordering is not a re-pin
- `NavPrefsContext.movePin(href, direction)` wires it into the provider
- `NavPrefsSections` splits the pinned row renderer from the recent row renderer; pinned rows now show ⬆️/⬇️ arrow buttons (disabled at edges) alongside the star
- Aria-labels: `Move Approvals up` / `Move Approvals down` for screen readers
- Arrow buttons stop event propagation so clicking them reorders without navigating

## Why not drag-and-drop?
Zero new deps, works on touch without gesture handling, and stays inside the same hover-reveal pattern the star button already uses. Drag-and-drop is a future upgrade.

## Storage compatibility
Pin format in `localStorage` is unchanged — this just changes the order of entries. No migration needed.

## Test plan
- [x] 8 new tests for `reorderPin` (middle up/down, edge no-ops, missing href, single-element, timestamp preservation, purity)
- [x] Full pure-helper suite still passes
- [ ] Manual: pin 3+ routes, hover each, click ⬆️/⬇️ to rank; reload to confirm persistence

https://claude.ai/code/session_01CADVvBTuHmstTvX4McKe4C