### PR TITLE
Improve multi-step agent execution graph robustness and efficiency

### DIFF
--- a/src/lib/orchestration/runner.ts
+++ b/src/lib/orchestration/runner.ts
@@ -1,7 +1,8 @@
 import type { AgentJob } from "@prisma/client";
 import { createAgentContext } from "./context";
 import { agentRegistry } from "@/lib/agents";
-import type { Agent, ApprovalPolicy, StepResult } from "./types";
+import type { Agent, ApprovalPolicy } from "./types";
+import { StepExecutionGraph } from "./step-graph";
 import {
   claimNextJob,
   markFailed,
@@ -89,19 +90,15 @@ export async function runJob(job: AgentJob, workerId: string): Promise<void> {
       ctx.tools.step("plan-complete", { stepCount: plan.steps.length });
 
       // Phase 2: Execute steps in dependency order
-      const allSteps = [...plan.steps];
-      const completed = new Set<string>();
-      let maxIterations = allSteps.length + 10; // safety cap for dynamic steps
+      const stepGraph = new StepExecutionGraph(plan.steps);
+      let maxIterations = Math.max(20, plan.steps.length * 4); // safety cap for dynamic expansion
 
-      while (completed.size < allSteps.length && maxIterations-- > 0) {
-        // Find steps whose dependencies are all complete
-        const ready = allSteps.filter(
-          (s) => !completed.has(s.id) && (s.dependsOn ?? []).every((d) => completed.has(d)),
-        );
+      while (stepGraph.completedCount < stepGraph.totalSteps && maxIterations-- > 0) {
+        const ready = stepGraph.takeReadyBatch();
 
-        if (ready.length === 0 && completed.size < allSteps.length) {
-          ctx.log("error", "Deadlock: no ready steps but not all complete");
-          break;
+        if (ready.length === 0) {
+          const blocked = stepGraph.findBlockedStepIds();
+          throw new Error(`Step deadlock: no runnable steps; blocked=${blocked.join(",")}`);
         }
 
         // Execute ready steps (could be parallelized in future)
@@ -111,7 +108,7 @@ export async function runJob(job: AgentJob, workerId: string): Promise<void> {
 
           const stepResult = await agent.runStep(step, input, ctx);
           ctx.stepResults.set(step.id, stepResult);
-          completed.add(step.id);
+          stepGraph.markCompleted(step.id);
 
           ctx.tools.step(`step-${step.id}-complete`, {
             confidence: stepResult.confidence,
@@ -120,9 +117,16 @@ export async function runJob(job: AgentJob, workerId: string): Promise<void> {
           // Dynamic step addition
           if (stepResult.nextSteps?.length) {
             ctx.log("info", `Step ${step.name} added ${stepResult.nextSteps.length} new steps`);
-            allSteps.push(...stepResult.nextSteps);
+            stepGraph.addSteps(stepResult.nextSteps);
+            maxIterations += stepResult.nextSteps.length * 2;
           }
         }
+      }
+
+      if (maxIterations <= 0 && stepGraph.completedCount < stepGraph.totalSteps) {
+        throw new Error(
+          `Step iteration limit exceeded: completed=${stepGraph.completedCount} total=${stepGraph.totalSteps}`,
+        );
       }
 
       // Phase 3: Final assembly — call run() with all step results available

--- a/src/lib/orchestration/step-graph.test.ts
+++ b/src/lib/orchestration/step-graph.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { StepExecutionGraph } from "./step-graph";
+import type { AgentStep } from "./types";
+
+describe("StepExecutionGraph", () => {
+  it("executes dependent steps in topological order", () => {
+    const graph = new StepExecutionGraph([
+      { id: "a", name: "A" },
+      { id: "b", name: "B", dependsOn: ["a"] },
+      { id: "c", name: "C", dependsOn: ["b"] },
+    ]);
+
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["a"]);
+    graph.markCompleted("a");
+
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["b"]);
+    graph.markCompleted("b");
+
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["c"]);
+    graph.markCompleted("c");
+
+    expect(graph.completedCount).toBe(3);
+    expect(graph.totalSteps).toBe(3);
+  });
+
+  it("supports dynamic steps added after a parent completes", () => {
+    const graph = new StepExecutionGraph([{ id: "root", name: "Root" }]);
+
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["root"]);
+    graph.markCompleted("root");
+
+    graph.addSteps([
+      { id: "child-1", name: "Child 1", dependsOn: ["root"] },
+      { id: "child-2", name: "Child 2", dependsOn: ["child-1"] },
+    ]);
+
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["child-1"]);
+    graph.markCompleted("child-1");
+    expect(graph.takeReadyBatch().map((s) => s.id)).toEqual(["child-2"]);
+  });
+
+  it("throws on duplicate step ids", () => {
+    expect(
+      () =>
+        new StepExecutionGraph([
+          { id: "dup", name: "One" },
+          { id: "dup", name: "Two" },
+        ]),
+    ).toThrow(/Duplicate step id: dup/);
+  });
+
+  it("throws when dependencies reference unknown steps", () => {
+    expect(
+      () =>
+        new StepExecutionGraph([
+          { id: "a", name: "A", dependsOn: ["missing"] },
+        ]),
+    ).toThrow(/depends on unknown step/);
+  });
+
+  it("surfaces blocked step ids for deadlock diagnostics", () => {
+    const steps: AgentStep[] = [
+      { id: "a", name: "A", dependsOn: ["b"] },
+      { id: "b", name: "B", dependsOn: ["a"] },
+    ];
+
+    const graph = new StepExecutionGraph(steps);
+
+    expect(graph.takeReadyBatch()).toEqual([]);
+    expect(graph.findBlockedStepIds()).toEqual(expect.arrayContaining(["a", "b"]));
+  });
+});

--- a/src/lib/orchestration/step-graph.ts
+++ b/src/lib/orchestration/step-graph.ts
@@ -1,0 +1,120 @@
+import type { AgentStep } from "./types";
+
+interface StepNode {
+  step: AgentStep;
+  unresolvedDeps: number;
+  dependents: Set<string>;
+}
+
+/**
+ * Efficient dependency scheduler for V3 multi-step agent plans.
+ *
+ * Guarantees:
+ * - step IDs are unique
+ * - all dependencies reference known steps
+ * - dependency updates are O(out-degree) on completion
+ */
+export class StepExecutionGraph {
+  private readonly nodes = new Map<string, StepNode>();
+  private readonly readyQueue: string[] = [];
+  private readonly completed = new Set<string>();
+
+  constructor(initialSteps: AgentStep[]) {
+    this.addSteps(initialSteps);
+  }
+
+  addSteps(steps: AgentStep[]): void {
+    // Register new nodes first so intra-batch dependencies can resolve.
+    for (const step of steps) {
+      if (this.nodes.has(step.id)) {
+        throw new Error(`Duplicate step id: ${step.id}`);
+      }
+      this.nodes.set(step.id, {
+        step,
+        unresolvedDeps: 0,
+        dependents: new Set<string>(),
+      });
+    }
+
+    // Wire dependency edges.
+    for (const step of steps) {
+      const node = this.nodes.get(step.id);
+      if (!node) continue;
+
+      const deps = step.dependsOn ?? [];
+      let unresolved = 0;
+
+      for (const depId of deps) {
+        const depNode = this.nodes.get(depId);
+        if (!depNode) {
+          throw new Error(`Step ${step.id} depends on unknown step ${depId}`);
+        }
+        if (!this.completed.has(depId)) {
+          unresolved++;
+        }
+        depNode.dependents.add(step.id);
+      }
+
+      node.unresolvedDeps = unresolved;
+      if (unresolved === 0 && !this.completed.has(step.id)) {
+        this.readyQueue.push(step.id);
+      }
+    }
+  }
+
+  takeReadyBatch(): AgentStep[] {
+    const batch: AgentStep[] = [];
+
+    while (this.readyQueue.length > 0) {
+      const id = this.readyQueue.shift();
+      if (!id || this.completed.has(id)) continue;
+      const node = this.nodes.get(id);
+      if (!node || node.unresolvedDeps > 0) continue;
+      batch.push(node.step);
+    }
+
+    return batch;
+  }
+
+  markCompleted(stepId: string): void {
+    if (this.completed.has(stepId)) {
+      throw new Error(`Step already completed: ${stepId}`);
+    }
+
+    const node = this.nodes.get(stepId);
+    if (!node) {
+      throw new Error(`Unknown completed step: ${stepId}`);
+    }
+
+    this.completed.add(stepId);
+
+    for (const dependentId of node.dependents) {
+      const dependent = this.nodes.get(dependentId);
+      if (!dependent || this.completed.has(dependentId)) continue;
+      dependent.unresolvedDeps = Math.max(0, dependent.unresolvedDeps - 1);
+      if (dependent.unresolvedDeps === 0) {
+        this.readyQueue.push(dependentId);
+      }
+    }
+  }
+
+  get totalSteps(): number {
+    return this.nodes.size;
+  }
+
+  get completedCount(): number {
+    return this.completed.size;
+  }
+
+  findBlockedStepIds(limit = 10): string[] {
+    const blocked: string[] = [];
+    for (const [id, node] of this.nodes.entries()) {
+      if (this.completed.has(id)) continue;
+      if (node.unresolvedDeps > 0) {
+        blocked.push(id);
+      }
+      if (blocked.length >= limit) break;
+    }
+    return blocked;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make V3 multi-step agent execution deterministic and more efficient by replacing the O(N^2) ready-step rescans with a dedicated scheduler.
- Fail fast on malformed plans (duplicate IDs, unknown dependencies) to surface issues early and avoid silent deadlocks.
- Provide clear diagnostics for deadlocks and bounded iteration behavior when plans dynamically expand.

### Description
- Add a new `StepExecutionGraph` scheduler (`src/lib/orchestration/step-graph.ts`) that enforces unique step IDs, validates dependencies, maintains a ready queue, and updates dependents in O(out-degree) on completion.
- Replace the runner's naive ready-step scan with `StepExecutionGraph` in `runJob` (`src/lib/orchestration/runner.ts`) and wire in `takeReadyBatch`, `markCompleted`, and `addSteps` for dynamic expansion.
- Tighten loop safety by using a scalable iteration cap that grows with dynamic additions and by throwing descriptive errors on deadlock or iteration-limit exhaustion instead of silently proceeding.
- Add unit tests (`src/lib/orchestration/step-graph.test.ts`) covering topological ordering, dynamic step insertion, duplicate-ID rejection, unknown-dependency rejection, and blocked-step diagnostics.

### Testing
- Ran the focused unit tests with `npm test -- src/lib/orchestration/step-graph.test.ts`, which passed (5 tests passed).
- Ran the TypeScript check with `npm run typecheck`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9911c6d3483238534b543babd9079)