### PR TITLE
Add Codex PRD and implement task intake/execution planner with tests

### DIFF
--- a/docs/codex-prd.md
+++ b/docs/codex-prd.md
@@ -1,0 +1,291 @@
+# Product Requirements Document: Codex
+
+## Document status
+
+Draft v1
+
+## Product summary
+
+Codex is an AI coding agent and command center that helps users write, review, test, ship, and automate software work across local and cloud environments. It supports paired coding in local tools and delegated work in cloud sandboxes, and is designed for parallel, multi-agent workflows with configurable approvals, worktrees, and automations. This PRD frames Codex as the operating layer for modern software execution rather than a single chat-based coding assistant.[^1][^2][^3][^4][^5]
+
+## Background and context
+
+Software teams are constrained less by raw code generation than by coordination overhead, context switching, repetitive engineering work, and long tails of maintenance. Codex addresses this by turning software tasks into delegable units of work that can be executed in parallel by agents across a repository, with human review retained at meaningful checkpoints. OpenAI positions Codex as available across ChatGPT, the Codex app, terminal workflows, IDE integrations, and cloud execution, with support for background work and automations.[^1][^2][^4][^5][^7][^8]
+
+## Problem statement
+
+Engineering teams lose time and momentum in five recurring ways:
+
+1. Small but necessary tasks fragment attention, including test writing, refactors, bug fixes, renames, and documentation upkeep.
+2. Codebase understanding is slow, especially when engineers must navigate unfamiliar systems or cross-functional contributors need answers without blocking developers.
+3. Long-running work is difficult to parallelize safely across branches, environments, and reviewers.
+4. Automation is fragmented across scripts, CI jobs, issue queues, and human triage.
+5. Existing AI coding tools are often optimized for snippets or interactive edits rather than accountable, end-to-end task execution.
+
+## Product vision
+
+Codex becomes the default execution layer for software teams: a trusted agentic system that can take in a spec, inspect a codebase, plan work, make changes, run commands, execute tests, surface tradeoffs, and hand back reviewable results. Over time, Codex should feel less like autocomplete and more like a disciplined colleague that can take on bounded work independently while keeping humans in control.[^1][^4][^5][^6]
+
+## Goals
+
+### Primary goals
+
+* Reduce developer time spent on repetitive and well-scoped engineering tasks.
+* Increase throughput by enabling parallel execution across multiple agents and worktrees.
+* Improve software delivery quality through integrated testing, clearer change summaries, and better repo understanding.
+* Make coding automation accessible to both engineers and adjacent technical collaborators.
+* Create a secure and configurable operating model for agentic software work.
+
+### Secondary goals
+
+* Increase adoption across local terminal, IDE, desktop app, and ChatGPT surfaces.
+* Expand Codex from reactive task execution into proactive background work through automations.
+* Improve trust through transparent actions, reviewability, and configurable permissions.
+
+## Non-goals
+
+* Codex is not intended to replace human code review or engineering leadership.
+* Codex is not a general-purpose office assistant; this PRD focuses on software work.
+* Codex is not a one-click production deployment system.
+* Codex is not optimized first for pixel-perfect design generation or visual frontend prototyping from image-heavy inputs.
+* Codex is not a full project management platform, though it may integrate with issue trackers and alerts.
+
+## Target users
+
+### Core users
+
+**Software engineers**
+Use Codex to write features, fix bugs, refactor code, run tests, and understand unfamiliar parts of a codebase.[^1][^8]
+
+**Engineering managers and tech leads**
+Use Codex to offload backlog tasks, triage issues, supervise agent workflows, and accelerate team throughput.
+
+**Product-minded technical collaborators**
+Use Codex for lightweight code changes, documentation updates, or codebase Q&A without requiring full engineering intervention.[^1]
+
+### Secondary users
+
+**DevOps and platform teams**
+Use Codex automations for alert monitoring, CI/CD support, routine maintenance, and operational triage.[^2]
+
+**Security and compliance stakeholders**
+Require visibility, configurable permissions, sandboxing controls, and auditability around agent actions.[^5]
+
+## User needs
+
+* I need to hand off a coding task without losing confidence in the result.
+* I need Codex to understand my repo, not just my prompt.
+* I need to run multiple tasks in parallel without branch chaos.
+* I need to control what Codex can read, modify, run, and access.
+* I need outputs that are reviewable, test-backed, and aligned with team conventions.
+* I need background automations for routine work that does not deserve a human calendar slot.
+
+## Core product principles
+
+1. **Execution over suggestion**: Codex should complete real tasks end to end, not just propose next steps.[^1][^2]
+2. **Parallel by design**: The product should support multi-agent workflows and concurrent work as a first-class behavior.[^2][^5]
+3. **Human control at the right layer**: Approval modes, permissions, and review flows must be configurable without strangling usefulness.[^5][^8]
+4. **Grounded in the repo**: Code understanding, file navigation, tests, and command execution should be central.
+5. **Trust through transparency**: Users need to see what Codex did, why it did it, and what remains uncertain.
+6. **Ambient utility**: The highest-leverage work includes always-on maintenance and background execution.[^2]
+
+## Key use cases
+
+### 1. Paired coding in terminal or IDE
+
+A developer invokes Codex locally to inspect files, modify code, run tests, and iterate on a feature or bug fix with approvals based on chosen mode.[^7][^8]
+
+### 2. Delegated cloud task execution
+
+A user submits a coding task to Codex in ChatGPT or the Codex app. Codex runs the task in a cloud sandbox preloaded with the repository, performs edits, executes tests, and returns a change summary and artifacts for review.[^1][^5]
+
+### 3. Multi-agent project execution
+
+A user supervises multiple agents handling different tasks or workstreams in parallel, such as migrations, refactors, test backfills, or issue triage, coordinated through worktrees and cloud environments.[^2][^5]
+
+### 4. Codebase Q&A and orientation
+
+A user asks questions about a repository, architecture, or implementation decisions and receives grounded answers with relevant files, context, and past changes surfaced.
+
+### 5. Background automations
+
+A team configures Codex to perform recurring software work such as issue triage, alert monitoring, dependency checks, CI failure investigation, or routine maintenance without requiring a fresh prompt each time.[^2]
+
+## Functional requirements
+
+### A. Task intake and routing
+
+* Users can create tasks from ChatGPT, Codex app, terminal, or IDE.
+* Users can classify work as ask, code, automate, or review.
+* Codex should support natural language specs and optional structured constraints.
+* Codex should determine whether work is best handled locally, in the cloud, or as an automation.
+
+### B. Repository understanding
+
+* Codex can inspect repository structure, relevant files, configs, tests, and docs.
+* Codex can explain unfamiliar code paths and surface rationale where possible.
+* Codex can identify relevant dependencies and build systems.
+* Codex can preserve team conventions and coding style where detectable.[^1]
+
+### C. Code editing and execution
+
+* Codex can create, modify, and delete files as needed for a task.
+* Codex can run commands, scripts, and tests within permission boundaries.[^1][^8]
+* Codex should iterate until tests pass or clearly explain blockers.[^1]
+* Codex should generate a concise summary of changes, affected files, risks, and follow-up recommendations.
+
+### D. Parallel work management
+
+* Users can launch multiple tasks concurrently.
+* Each task runs in its own isolated environment or worktree.[^1][^2][^5]
+* Users can inspect progress per task and compare results.
+* Users can merge, discard, or revise results independently.
+
+### E. Approval and permissions
+
+* Codex supports configurable approval modes for reading, writing, and command execution.[^8]
+* Users can define internet access, environment access, and repository access when available.[^1][^5]
+* Enterprises can apply policy controls and permission boundaries.
+* Sensitive or destructive operations should require stronger confirmation.
+
+### F. Automations
+
+* Users can create recurring or trigger-based coding workflows.[^2]
+* Automations can monitor issue queues, alerts, CI failures, or predefined tasks.
+* Automations should produce logs, artifacts, summaries, and escalation paths.
+* Users can pause, disable, and audit automations.
+
+### G. Review and collaboration
+
+* Codex outputs should be reviewable as diffs, summaries, command logs, and test results.
+* Users can course-correct tasks during execution where supported by the product surface.[^4]
+* Codex should support pull-request-ready handoff behavior.
+* Teams can share agent outputs and collaborate asynchronously.
+
+## User experience requirements
+
+### Core UX requirements
+
+* Starting a task should feel lightweight and fast.
+* The system should make progress visible without overwhelming the user.
+* Work in progress should be inspectable at any point.
+* Reviews should focus on changed intent, changed code, and verification status.
+* Users should understand whether Codex is pairing locally, running remotely, or executing automatically.
+
+### UX objects
+
+* Task composer
+* Agent status view
+* Diff and test review panel
+* Worktree/environment manager
+* Automation builder and run history
+* Permission and approval controls
+
+## Safety, security, and trust requirements
+
+* Codex must default to sandboxed execution for cloud tasks.[^1][^5]
+* Access controls must be explicit, inspectable, and configurable.
+* Logs should record commands run, files modified, and execution outcomes.
+* The product should communicate uncertainty and failures clearly.
+* Enterprises should have clear policy boundaries around repositories, secrets, internet access, and destructive actions.
+* Codex must make it difficult to silently perform sensitive actions without user awareness.
+
+## Success metrics
+
+### Adoption metrics
+
+* Weekly active Codex users
+* Tasks created per active user
+* Multi-surface usage across app, terminal, IDE, ChatGPT
+* Automation creation rate
+
+### Productivity metrics
+
+* Median time saved per task
+* Completion rate for delegated tasks
+* Parallel task throughput per user/team
+* Reduction in developer time on repetitive work
+
+### Quality metrics
+
+* Test pass rate on completed coding tasks
+* Reviewer acceptance rate
+* Rework rate after Codex-generated changes
+* Accuracy/helpfulness rating for codebase Q&A
+
+### Trust metrics
+
+* Approval override frequency
+* Incident rate from unsafe or undesired actions
+* User confidence score after task completion
+* Automation disable rate due to low trust or noise
+
+## MVP scope
+
+### In scope for MVP
+
+* Task creation from at least one primary surface and one local surface
+* Repository inspection and codebase Q&A
+* Code editing with command execution and test running
+* Isolated task environments
+* Change summaries plus test result reporting
+* Basic approval modes
+* Initial automation support for routine coding workflows
+
+### Out of scope for MVP
+
+* Full visual design-to-code workflows based on image input
+* Deep non-engineering workflow support
+* Fully autonomous production deployments
+* Rich org-wide analytics and deep project management features
+
+## Competitive framing
+
+Codex should be differentiated less by raw model output and more by end-to-end software execution, multi-agent coordination, secure environment handling, and background automations. The product is strongest when it behaves like an accountable execution layer rather than a fancy autocomplete surface.[^1][^2][^5]
+
+## Risks and constraints
+
+* Users may overtrust agent output and under-review important changes.
+* Long-running delegated tasks may feel slower than local interactive editing.[^1]
+* Repo-specific conventions and hidden context may still require human steering.
+* Permission friction can reduce usability if defaults are too restrictive.
+* Automation noise can erode trust if low-value tasks are surfaced too often.
+* Security posture must keep pace with expanding agent capabilities and integrations.
+
+## Open questions
+
+1. What is the ideal boundary between interactive local pairing and cloud delegation?
+2. Which automation triggers produce meaningful value without becoming spam?
+3. How should users supervise many concurrent agents without UI overload?
+4. What review artifact format builds the most trust: diff-first, intent-first, or test-first?
+5. Which enterprise controls are mandatory for broad organizational adoption?
+6. How far should Codex go in proactive work before users feel loss of control?
+
+## Launch recommendation
+
+Position Codex around four promises:
+
+* real work completed end to end
+* parallel agents that unblock throughput
+* secure, configurable execution
+* background automation for the software work no one wants to babysit
+
+That message is consistent with OpenAI’s current public Codex positioning across the product page, launch posts, app launch materials, and help documentation.[^1][^2][^3][^4][^5][^7][^8]
+
+## Sources
+
+[^1]: OpenAI, “Introducing Codex,” published May 16, 2025. [https://openai.com/index/introducing-codex/](https://openai.com/index/introducing-codex/)
+
+[^2]: OpenAI, “Codex,” product page. [https://openai.com/codex](https://openai.com/codex)
+
+[^3]: OpenAI Academy, “Codex.” [https://openai.com/academy/codex/](https://openai.com/academy/codex/)
+
+[^4]: OpenAI, “Introducing GPT-5.3-Codex,” published February 5, 2026. [https://openai.com/index/introducing-gpt-5-3-codex/](https://openai.com/index/introducing-gpt-5-3-codex/)
+
+[^5]: OpenAI, “Introducing the Codex app,” published February 2, 2026, updated March 4, 2026. [https://openai.com/index/introducing-the-codex-app//](https://openai.com/index/introducing-the-codex-app//)
+
+[^6]: OpenAI, “Introducing upgrades to Codex,” published September 15, 2025. [https://openai.com/index/introducing-upgrades-to-codex/](https://openai.com/index/introducing-upgrades-to-codex/)
+
+[^7]: OpenAI Help Center, “Using Codex with your ChatGPT plan,” updated recently. [https://help.openai.com/en/articles/11369540-codex-in-chatgpt](https://help.openai.com/en/articles/11369540-codex-in-chatgpt)
+
+[^8]: OpenAI Help Center, “OpenAI Codex CLI – Getting Started,” updated recently. [https://help.openai.com/en/articles/11096431-openai-codex-ci-getting-started](https://help.openai.com/en/articles/11096431-openai-codex-ci-getting-started)

--- a/src/lib/codex/task-intake.test.ts
+++ b/src/lib/codex/task-intake.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { buildExecutionPlan } from "./task-intake";
+
+describe("buildExecutionPlan", () => {
+  it("routes repository Q&A to local with no approval", () => {
+    const plan = buildExecutionPlan({
+      title: "Explain claim routing",
+      description: "Help me understand where claim denials are generated in the codebase.",
+      kind: "ask",
+      requiresRepositoryWrite: false,
+      estimatedChangedFiles: 0,
+      requiresInternet: false,
+      longRunning: false,
+      triggerType: "manual",
+      allowBackgroundRun: false,
+    });
+
+    expect(plan.surface).toBe("local");
+    expect(plan.approval).toBe("none");
+    expect(plan.suggestedParallelism).toBe(1);
+  });
+
+  it("routes complex code work to cloud with execution approval", () => {
+    const plan = buildExecutionPlan({
+      title: "Refactor medication timeline",
+      description: "Split timeline renderer and write tests for edge cases in dosage transitions.",
+      kind: "code",
+      requiresRepositoryWrite: true,
+      estimatedChangedFiles: 11,
+      requiresInternet: false,
+      longRunning: true,
+      triggerType: "manual",
+      allowBackgroundRun: false,
+    });
+
+    expect(plan.surface).toBe("cloud");
+    expect(plan.approval).toBe("before_execute");
+    expect(plan.requiresIsolation).toBe(true);
+    expect(plan.suggestedParallelism).toBeGreaterThan(1);
+  });
+
+  it("routes scheduled tasks to automation", () => {
+    const plan = buildExecutionPlan({
+      title: "Nightly flaky test triage",
+      description: "Inspect failing tests every night and open drafts with hypotheses.",
+      kind: "automate",
+      requiresRepositoryWrite: true,
+      estimatedChangedFiles: 8,
+      requiresInternet: true,
+      longRunning: true,
+      triggerType: "schedule",
+      allowBackgroundRun: true,
+    });
+
+    expect(plan.surface).toBe("automation");
+    expect(plan.approval).toBe("before_merge");
+    expect(plan.suggestedParallelism).toBeGreaterThanOrEqual(2);
+  });
+
+  it("respects explicit surface requests when valid", () => {
+    const plan = buildExecutionPlan({
+      title: "Local hotfix",
+      description: "Apply a one-line fix and run a focused test command only.",
+      kind: "code",
+      requiresRepositoryWrite: true,
+      estimatedChangedFiles: 1,
+      longRunning: false,
+      requiresInternet: false,
+      triggerType: "manual",
+      allowBackgroundRun: false,
+      requestedSurface: "local",
+    });
+
+    expect(plan.surface).toBe("local");
+    expect(plan.reasoning.join(" ")).toContain("Requested surface accepted");
+  });
+
+  it("downgrades invalid automation request without background permission", () => {
+    const plan = buildExecutionPlan({
+      title: "One-off scripting",
+      description: "Run this one-time script manually right now.",
+      kind: "code",
+      requiresRepositoryWrite: true,
+      estimatedChangedFiles: 2,
+      longRunning: false,
+      requiresInternet: false,
+      triggerType: "manual",
+      allowBackgroundRun: false,
+      requestedSurface: "automation",
+    });
+
+    expect(plan.surface).not.toBe("automation");
+    expect(plan.reasoning.join(" ")).toContain("downgraded");
+  });
+});

--- a/src/lib/codex/task-intake.ts
+++ b/src/lib/codex/task-intake.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+export const codexTaskKindSchema = z.enum(["ask", "code", "automate", "review"]);
+export type CodexTaskKind = z.infer<typeof codexTaskKindSchema>;
+
+export const executionSurfaceSchema = z.enum(["local", "cloud", "automation"]);
+export type ExecutionSurface = z.infer<typeof executionSurfaceSchema>;
+
+export const codexTaskInputSchema = z.object({
+  title: z.string().trim().min(3),
+  description: z.string().trim().min(10),
+  kind: codexTaskKindSchema,
+  requiresRepositoryWrite: z.boolean().default(false),
+  requiresInternet: z.boolean().default(false),
+  longRunning: z.boolean().default(false),
+  estimatedChangedFiles: z.number().int().nonnegative().default(0),
+  triggerType: z.enum(["manual", "schedule", "event"]).default("manual"),
+  allowBackgroundRun: z.boolean().default(false),
+  requestedSurface: executionSurfaceSchema.optional(),
+});
+
+export type CodexTaskInput = z.infer<typeof codexTaskInputSchema>;
+
+export type ApprovalRequirement = "none" | "before_write" | "before_execute" | "before_merge";
+
+export type CodexExecutionPlan = {
+  surface: ExecutionSurface;
+  confidence: number;
+  reasoning: string[];
+  approval: ApprovalRequirement;
+  requiresIsolation: boolean;
+  suggestedParallelism: number;
+};
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function scoreComplexity(input: CodexTaskInput): number {
+  const fileWeight = Math.min(input.estimatedChangedFiles, 20) / 20;
+  const longRunWeight = input.longRunning ? 0.25 : 0;
+  const writeWeight = input.requiresRepositoryWrite ? 0.2 : 0;
+  const netWeight = input.requiresInternet ? 0.1 : 0;
+  return clamp01(fileWeight * 0.45 + longRunWeight + writeWeight + netWeight);
+}
+
+export function buildExecutionPlan(rawInput: CodexTaskInput): CodexExecutionPlan {
+  const input = codexTaskInputSchema.parse(rawInput);
+  const reasoning: string[] = [];
+
+  if (input.triggerType !== "manual") {
+    reasoning.push("Non-manual trigger detected, favoring automation surface.");
+  }
+
+  if (input.requestedSurface) {
+    reasoning.push(`User requested ${input.requestedSurface} execution surface.`);
+  }
+
+  const complexity = scoreComplexity(input);
+  const requiresIsolation = input.longRunning || input.estimatedChangedFiles >= 6 || input.kind === "automate";
+
+  let surface: ExecutionSurface = "local";
+
+  if (input.triggerType !== "manual" || input.kind === "automate" || input.allowBackgroundRun) {
+    surface = "automation";
+    reasoning.push("Task is recurring/triggered or allows background run, so automation is preferred.");
+  } else if (input.kind === "ask" && !input.requiresRepositoryWrite) {
+    surface = "local";
+    reasoning.push("Q&A task with no writes is best handled in a local paired flow.");
+  } else if (complexity >= 0.45 || input.longRunning) {
+    surface = "cloud";
+    reasoning.push("Task complexity suggests isolated delegated execution in cloud sandbox.");
+  }
+
+  if (input.requestedSurface) {
+    if (input.requestedSurface === "automation" && input.triggerType === "manual" && !input.allowBackgroundRun) {
+      reasoning.push("Requested automation was downgraded because task is manual without background permission.");
+    } else {
+      surface = input.requestedSurface;
+      reasoning.push("Requested surface accepted.");
+    }
+  }
+
+  let approval: ApprovalRequirement = "none";
+  if (input.requiresRepositoryWrite && surface === "local") approval = "before_write";
+  if (surface === "cloud") approval = "before_execute";
+  if (surface === "automation" && input.requiresRepositoryWrite) approval = "before_merge";
+
+  const suggestedParallelism =
+    surface === "automation"
+      ? Math.max(1, Math.min(6, Math.ceil((input.estimatedChangedFiles || 1) / 3)))
+      : surface === "cloud"
+        ? Math.max(1, Math.min(4, Math.ceil((input.estimatedChangedFiles || 1) / 4)))
+        : 1;
+
+  const confidence = clamp01(0.55 + (input.requestedSurface ? 0.2 : 0) + (complexity < 0.5 ? 0.1 : -0.05));
+
+  return {
+    surface,
+    confidence,
+    reasoning,
+    approval,
+    requiresIsolation,
+    suggestedParallelism,
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide a formal Product Requirements Document for the Codex product to capture vision, goals, use cases, and launch guidance.
- Introduce a deterministic task intake and routing component to decide execution surface, approvals, isolation, and parallelism for Codex tasks.

### Description

- Add `docs/codex-prd.md` as the Codex Product Requirements Document with vision, goals, use cases, requirements, risks, and launch recommendations.
- Implement task intake logic in `src/lib/codex/task-intake.ts` including Zod schemas (`codexTaskInputSchema`, `codexTaskKindSchema`, `executionSurfaceSchema`), the `buildExecutionPlan` function, and supporting helpers (`scoreComplexity`, `clamp01`).
- `buildExecutionPlan` computes `surface`, `confidence`, `reasoning`, `approval`, `requiresIsolation`, and `suggestedParallelism` based on inputs such as `estimatedChangedFiles`, `longRunning`, `requiresRepositoryWrite`, `triggerType`, and `requestedSurface`.
- Add unit tests `src/lib/codex/task-intake.test.ts` covering routing decisions, requested-surface handling, automation downgrades, and parallelism suggestions for `buildExecutionPlan`.

### Testing

- Added 5 unit tests for `buildExecutionPlan` in `src/lib/codex/task-intake.test.ts` and executed them with `vitest`. All tests passed.
- Type validation is exercised via the Zod schemas during test runs and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e997ab8e108323b629838aab576dea)