### PR TITLE
feat(marketplace): DB-backed catalog + persistent cart (EMR-231)

### DIFF
--- a/prisma/migrations/20260423042500_add_persistent_cart/migration.sql
+++ b/prisma/migrations/20260423042500_add_persistent_cart/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "Cart" (
+    "id" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Cart_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CartItem" (
+    "id" TEXT NOT NULL,
+    "cartId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "variantId" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CartItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Cart_patientId_key" ON "Cart"("patientId");
+
+-- CreateIndex
+CREATE INDEX "CartItem_cartId_idx" ON "CartItem"("cartId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CartItem_cartId_productId_variantId_key" ON "CartItem"("cartId", "productId", "variantId");
+
+-- AddForeignKey
+ALTER TABLE "Cart" ADD CONSTRAINT "Cart_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_cartId_fkey" FOREIGN KEY ("cartId") REFERENCES "Cart"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "ProductVariant"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,17 +74,17 @@ model User {
   updatedAt    DateTime  @updatedAt
   lastLoginAt  DateTime?
 
-  memberships     Membership[]
-  patientProfile  Patient?     @relation("PatientUser")
-  providerProfile Provider?    @relation("ProviderUser")
-  sentMessages    Message[]    @relation("MessageSender")
-  auditLogs       AuditLog[]
-  approvedJobs    AgentJob[]   @relation("JobApprovedBy")
-  notifications   Notification[]
+  memberships             Membership[]
+  patientProfile          Patient?                 @relation("PatientUser")
+  providerProfile         Provider?                @relation("ProviderUser")
+  sentMessages            Message[]                @relation("MessageSender")
+  auditLogs               AuditLog[]
+  approvedJobs            AgentJob[]               @relation("JobApprovedBy")
+  notifications           Notification[]
   communicationPreference CommunicationPreference?
-  signedLabResults     LabResult[]     @relation("LabResultSigner")
-  approvedLabOutreach  LabOutreach[]   @relation("LabOutreachApprover")
-  signedRefills        RefillRequest[] @relation("RefillSigner")
+  signedLabResults        LabResult[]              @relation("LabResultSigner")
+  approvedLabOutreach     LabOutreach[]            @relation("LabOutreachApprover")
+  signedRefills           RefillRequest[]          @relation("RefillSigner")
 }
 
 model Membership {
@@ -142,8 +142,8 @@ model Patient {
   presentingConcerns     String?
   treatmentGoals         String?
   // Clinical safety fields (EMR-113)
-  allergies              String[] @default([]) // e.g. ["Penicillin", "Sulfa", "Latex"]
-  contraindications      String[] @default([]) // e.g. ["MAOIs", "Blood thinners"]
+  allergies              String[]            @default([]) // e.g. ["Penicillin", "Sulfa", "Latex"]
+  contraindications      String[]            @default([]) // e.g. ["MAOIs", "Blood thinners"]
   qualificationStatus    QualificationStatus @default(unknown)
   qualificationExpiresAt DateTime?
   // Soft delete
@@ -185,6 +185,7 @@ model Patient {
   // Marketplace
   orders               Order[]
   productReviews       ProductReview[]
+  cart                 Cart?
 
   @@index([organizationId, status])
   @@index([lastName, firstName])
@@ -295,9 +296,9 @@ model Encounter {
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  provider     Provider?    @relation(fields: [providerId], references: [id], onDelete: SetNull)
+  organization      Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  patient           Patient            @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  provider          Provider?          @relation(fields: [providerId], references: [id], onDelete: SetNull)
   notes             Note[]
   documents         Document[]
   claims            Claim[]
@@ -1578,66 +1579,67 @@ enum ProductStatus {
 }
 
 model Product {
-  id                String        @id @default(cuid())
-  organizationId    String
-  name              String
-  slug              String        @unique
-  brand             String
-  description       String
-  shortDescription  String?
-  price             Float
-  compareAtPrice    Float?
-  status            ProductStatus @default(draft)
-  format            String        // tincture, flower, edible, topical, capsule, vape
-  imageUrl          String?
-  images            String[]      @default([])
+  id               String        @id @default(cuid())
+  organizationId   String
+  name             String
+  slug             String        @unique
+  brand            String
+  description      String
+  shortDescription String?
+  price            Float
+  compareAtPrice   Float?
+  status           ProductStatus @default(draft)
+  format           String // tincture, flower, edible, topical, capsule, vape
+  imageUrl         String?
+  images           String[]      @default([])
 
   // Cannabinoid profile
-  thcContent        Float?
-  cbdContent        Float?
-  cbnContent        Float?
-  thcvContent       Float?
-  terpeneProfile    Json?
-  strainType        String?       // indica, sativa, hybrid, n/a
+  thcContent     Float?
+  cbdContent     Float?
+  cbnContent     Float?
+  thcvContent    Float?
+  terpeneProfile Json?
+  strainType     String? // indica, sativa, hybrid, n/a
 
   // Use-case metadata
-  symptoms          String[]      @default([])
-  goals             String[]      @default([])
-  useCases          String[]      @default([])
-  onsetTime         String?
-  duration          String?
+  symptoms  String[] @default([])
+  goals     String[] @default([])
+  useCases  String[] @default([])
+  onsetTime String?
+  duration  String?
 
   // Dosage
-  dosageGuidance    String?
-  beginnerFriendly  Boolean       @default(false)
+  dosageGuidance   String?
+  beginnerFriendly Boolean @default(false)
 
   // Trust
-  labVerified       Boolean       @default(false)
-  coaUrl            String?
-  clinicianPick     Boolean       @default(false)
-  clinicianNote     String?
+  labVerified   Boolean @default(false)
+  coaUrl        String?
+  clinicianPick Boolean @default(false)
+  clinicianNote String?
 
   // Inventory
-  inStock           Boolean       @default(true)
-  inventoryCount    Int           @default(0)
+  inStock        Boolean @default(true)
+  inventoryCount Int     @default(0)
 
   // Ratings
-  averageRating     Float         @default(0)
-  reviewCount       Int           @default(0)
+  averageRating Float @default(0)
+  reviewCount   Int   @default(0)
 
   // Ordering + features
-  sortOrder         Int           @default(0)
-  featured          Boolean       @default(false)
+  sortOrder Int     @default(0)
+  featured  Boolean @default(false)
 
-  deletedAt         DateTime?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
-  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  variants          ProductVariant[]
-  reviews           ProductReview[]
-  orderItems        OrderItem[]
-  categoryMappings  ProductCategory[]
+  organization     Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  variants         ProductVariant[]
+  reviews          ProductReview[]
+  orderItems       OrderItem[]
+  cartItems        CartItem[]
+  categoryMappings ProductCategory[]
 
   @@index([organizationId, status])
   @@index([clinicianPick])
@@ -1645,67 +1647,68 @@ model Product {
 }
 
 model ProductVariant {
-  id              String    @id @default(cuid())
-  productId       String
-  name            String
-  upc             String?          // Universal Product Code for product itemization
-  price           Float
-  compareAtPrice  Float?
-  inStock         Boolean   @default(true)
-  inventoryCount  Int       @default(0)
-  sortOrder       Int       @default(0)
-  createdAt       DateTime  @default(now())
+  id             String   @id @default(cuid())
+  productId      String
+  name           String
+  upc            String? // Universal Product Code for product itemization
+  price          Float
+  compareAtPrice Float?
+  inStock        Boolean  @default(true)
+  inventoryCount Int      @default(0)
+  sortOrder      Int      @default(0)
+  createdAt      DateTime @default(now())
 
-  product         Product   @relation(fields: [productId], references: [id], onDelete: Cascade)
-  orderItems      OrderItem[]
+  product    Product     @relation(fields: [productId], references: [id], onDelete: Cascade)
+  orderItems OrderItem[]
+  cartItems  CartItem[]
 
   @@index([productId])
 }
 
 model MarketplaceCategory {
-  id          String    @id @default(cuid())
+  id          String   @id @default(cuid())
   name        String
-  slug        String    @unique
+  slug        String   @unique
   description String?
-  type        String    @default("standard") // standard, symptom, goal, format
+  type        String   @default("standard") // standard, symptom, goal, format
   imageUrl    String?
   icon        String?
-  sortOrder   Int       @default(0)
+  sortOrder   Int      @default(0)
   parentId    String?
-  createdAt   DateTime  @default(now())
+  createdAt   DateTime @default(now())
 
-  parent      MarketplaceCategory?  @relation("CategoryChildren", fields: [parentId], references: [id])
-  children    MarketplaceCategory[] @relation("CategoryChildren")
-  products    ProductCategory[]
+  parent   MarketplaceCategory?  @relation("CategoryChildren", fields: [parentId], references: [id])
+  children MarketplaceCategory[] @relation("CategoryChildren")
+  products ProductCategory[]
 
   @@index([type])
   @@index([parentId])
 }
 
 model ProductCategory {
-  id          String @id @default(cuid())
-  productId   String
-  categoryId  String
+  id         String @id @default(cuid())
+  productId  String
+  categoryId String
 
-  product     Product             @relation(fields: [productId], references: [id], onDelete: Cascade)
-  category    MarketplaceCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  product  Product             @relation(fields: [productId], references: [id], onDelete: Cascade)
+  category MarketplaceCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
 
   @@unique([productId, categoryId])
 }
 
 model ProductReview {
-  id          String    @id @default(cuid())
-  productId   String
-  patientId   String?
-  authorName  String
-  rating      Int
-  title       String?
-  body        String?
-  verified    Boolean   @default(false)
-  createdAt   DateTime  @default(now())
+  id         String   @id @default(cuid())
+  productId  String
+  patientId  String?
+  authorName String
+  rating     Int
+  title      String?
+  body       String?
+  verified   Boolean  @default(false)
+  createdAt  DateTime @default(now())
 
-  product     Product   @relation(fields: [productId], references: [id], onDelete: Cascade)
-  patient     Patient?  @relation(fields: [patientId], references: [id])
+  product Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  patient Patient? @relation(fields: [patientId], references: [id])
 
   @@index([productId, createdAt])
 }
@@ -1733,29 +1736,57 @@ model Order {
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  patient         Patient      @relation(fields: [patientId], references: [id])
-  items           OrderItem[]
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  patient      Patient      @relation(fields: [patientId], references: [id])
+  items        OrderItem[]
 
   @@index([patientId, createdAt])
   @@index([organizationId, status])
 }
 
 model OrderItem {
-  id          String          @id @default(cuid())
-  orderId     String
-  productId   String
-  variantId   String?
-  quantity    Int
-  unitPrice   Float
-  totalPrice  Float
-  createdAt   DateTime        @default(now())
+  id         String   @id @default(cuid())
+  orderId    String
+  productId  String
+  variantId  String?
+  quantity   Int
+  unitPrice  Float
+  totalPrice Float
+  createdAt  DateTime @default(now())
 
-  order       Order           @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  product     Product         @relation(fields: [productId], references: [id])
-  variant     ProductVariant? @relation(fields: [variantId], references: [id])
+  order   Order           @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  product Product         @relation(fields: [productId], references: [id])
+  variant ProductVariant? @relation(fields: [variantId], references: [id])
 
   @@index([orderId])
+}
+
+// One cart per patient. Items survive browser reload; checkout converts to Order.
+model Cart {
+  id        String   @id @default(cuid())
+  patientId String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  patient Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  items   CartItem[]
+}
+
+model CartItem {
+  id        String   @id @default(cuid())
+  cartId    String
+  productId String
+  variantId String?
+  quantity  Int      @default(1)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  cart    Cart            @relation(fields: [cartId], references: [id], onDelete: Cascade)
+  product Product         @relation(fields: [productId], references: [id], onDelete: Cascade)
+  variant ProductVariant? @relation(fields: [variantId], references: [id], onDelete: SetNull)
+
+  @@unique([cartId, productId, variantId])
+  @@index([cartId])
 }
 
 // --------------------------------------------------------------
@@ -1763,17 +1794,17 @@ model OrderItem {
 // --------------------------------------------------------------
 
 model Notification {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   userId    String
-  type      String   // appointment_reminder, message_received, lab_results, etc.
-  priority  String   @default("normal") // urgent, normal, low
+  type      String // appointment_reminder, message_received, lab_results, etc.
+  priority  String    @default("normal") // urgent, normal, low
   title     String
   body      String
   href      String? // deep link to relevant page
-  read      Boolean  @default(false)
+  read      Boolean   @default(false)
   readAt    DateTime?
   metadata  Json?
-  createdAt DateTime @default(now())
+  createdAt DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -1785,12 +1816,12 @@ model Notification {
 // --------------------------------------------------------------
 
 model Referral {
-  id                     String   @id @default(cuid())
+  id                     String    @id @default(cuid())
   organizationId         String
   patientId              String
-  direction              String   // outbound | inbound
-  status                 String   @default("draft") // draft, sent, received, scheduled, completed, cancelled, declined
-  priority               String   @default("routine") // stat, urgent, routine
+  direction              String // outbound | inbound
+  status                 String    @default("draft") // draft, sent, received, scheduled, completed, cancelled, declined
+  priority               String    @default("routine") // stat, urgent, routine
   referringProviderName  String
   referringPracticeName  String
   referredToProviderName String
@@ -1799,16 +1830,16 @@ model Referral {
   referredToPhone        String?
   referredToFax          String?
   reason                 String
-  diagnosisCodes         Json     @default("[]")
+  diagnosisCodes         Json      @default("[]")
   clinicalNotes          String?
-  attachedDocumentIds    Json     @default("[]")
+  attachedDocumentIds    Json      @default("[]")
   sentAt                 DateTime?
   receivedAt             DateTime?
   scheduledDate          DateTime?
   completedAt            DateTime?
   completionNotes        String?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
@@ -1843,20 +1874,20 @@ model SignedConsent {
 // --------------------------------------------------------------
 
 model StateComplianceForm {
-  id           String   @id @default(cuid())
+  id             String    @id @default(cuid())
   organizationId String
-  patientId    String
-  encounterId  String?
-  stateCode    String
+  patientId      String
+  encounterId    String?
+  stateCode      String
   formTemplateId String
-  formName     String
-  fields       Json
-  status       String   @default("draft") // draft, complete, submitted
-  signedBy     String?
-  signedAt     DateTime?
-  submittedAt  DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  formName       String
+  fields         Json
+  status         String    @default("draft") // draft, complete, submitted
+  signedBy       String?
+  signedAt       DateTime?
+  submittedAt    DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
@@ -1870,15 +1901,15 @@ model StateComplianceForm {
 // --------------------------------------------------------------
 
 model CaregiverInvite {
-  id              String   @id @default(cuid())
+  id              String    @id @default(cuid())
   patientId       String
   caregiverEmail  String
   caregiverName   String
   relationship    String
-  accessLevel     String   @default("read_only") // read_only, full, emergency_only
-  status          String   @default("invited") // invited, active, revoked, expired
-  caregiverUserId String?  // set when accepted
-  invitedAt       DateTime @default(now())
+  accessLevel     String    @default("read_only") // read_only, full, emergency_only
+  status          String    @default("invited") // invited, active, revoked, expired
+  caregiverUserId String? // set when accepted
+  invitedAt       DateTime  @default(now())
   acceptedAt      DateTime?
   revokedAt       DateTime?
   expiresAt       DateTime?
@@ -1898,7 +1929,7 @@ model SurveySubmission {
   patientId   String
   encounterId String?
   surveyType  String   @default("post_visit")
-  responses   Json     // Array of { questionId, value }
+  responses   Json // Array of { questionId, value }
   npsScore    Int?
   submittedAt DateTime @default(now())
 
@@ -1917,8 +1948,8 @@ model IntakeFormTemplate {
   organizationId String
   name           String
   description    String?
-  sections       Json     // Array of { id, title, description }
-  fields         Json     // Array of IntakeField objects
+  sections       Json // Array of { id, title, description }
+  fields         Json // Array of IntakeField objects
   version        Int      @default(1)
   isDefault      Boolean  @default(false)
   active         Boolean  @default(true)
@@ -1935,13 +1966,13 @@ model IntakeFormTemplate {
 // --------------------------------------------------------------
 
 model CommunicationPreference {
-  id              String  @id @default(cuid())
-  userId          String  @unique
-  smsOptIn        Boolean @default(false)
-  emailFrequency  String  @default("instant") // instant, daily, weekly, off
+  id              String   @id @default(cuid())
+  userId          String   @unique
+  smsOptIn        Boolean  @default(false)
+  emailFrequency  String   @default("instant") // instant, daily, weekly, off
   quietHoursStart String? // "22:00"
   quietHoursEnd   String? // "07:00"
-  preferences     Json    @default("{}") // per-category: { appointments: { email: true, sms: false }, ... }
+  preferences     Json     @default("{}") // per-category: { appointments: { email: true, sms: false }, ... }
   updatedAt       DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1973,11 +2004,11 @@ model LabResult {
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  patient        Patient         @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  signedBy       User?           @relation("LabResultSigner", fields: [signedById], references: [id])
-  outreach       LabOutreach?
-  monitoringFor  RefillRequest[] @relation("RefillMonitoringLab")
+  patient       Patient         @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  organization  Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  signedBy      User?           @relation("LabResultSigner", fields: [signedById], references: [id])
+  outreach      LabOutreach?
+  monitoringFor RefillRequest[] @relation("RefillMonitoringLab")
 
   @@index([organizationId, signedAt])
   @@index([patientId, receivedAt])
@@ -2016,37 +2047,37 @@ model LabOutreach {
 // --------------------------------------------------------------
 
 model RefillRequest {
-  id              String    @id @default(cuid())
-  organizationId  String
-  patientId       String
-  medicationId    String
-  requestedQty    Int
-  requestedDays   Int?
+  id                String    @id @default(cuid())
+  organizationId    String
+  patientId         String
+  medicationId      String
+  requestedQty      Int
+  requestedDays     Int?
   // Pharmacy (denormalized for Phase 1)
-  pharmacyName    String
-  pharmacyPhone   String?
-  pharmacyAddress String?
+  pharmacyName      String
+  pharmacyPhone     String?
+  pharmacyAddress   String?
   // Copilot context
   lastRelevantLabId String? // optional link to the lab the copilot thinks matters
   // Copilot outputs
   copilotSuggestion String? // "approve" | "deny" | "review"
-  safetyFlags     Json      @default("[]") // string[] of flag codes
-  rationale       String? // one-liner from the copilot
+  safetyFlags       Json      @default("[]") // string[] of flag codes
+  rationale         String? // one-liner from the copilot
   // Lifecycle
-  receivedAt      DateTime  @default(now())
-  status          String    @default("new") // "new" | "flagged" | "approved" | "sent" | "denied"
-  signedById      String?
-  signedAt        DateTime?
-  deniedReason    String?
-  faxPdfUrl       String? // populated by Phase 1 fax-PDF stub on sign
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  receivedAt        DateTime  @default(now())
+  status            String    @default("new") // "new" | "flagged" | "approved" | "sent" | "denied"
+  signedById        String?
+  signedAt          DateTime?
+  deniedReason      String?
+  faxPdfUrl         String? // populated by Phase 1 fax-PDF stub on sign
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
-  patient         Patient            @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  organization    Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  medication      PatientMedication  @relation(fields: [medicationId], references: [id], onDelete: Cascade)
-  signedBy        User?              @relation("RefillSigner", fields: [signedById], references: [id])
-  lastRelevantLab LabResult?         @relation("RefillMonitoringLab", fields: [lastRelevantLabId], references: [id])
+  patient         Patient           @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  organization    Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  medication      PatientMedication @relation(fields: [medicationId], references: [id], onDelete: Cascade)
+  signedBy        User?             @relation("RefillSigner", fields: [signedById], references: [id])
+  lastRelevantLab LabResult?        @relation("RefillMonitoringLab", fields: [lastRelevantLabId], references: [id])
 
   @@index([organizationId, status])
   @@index([patientId, receivedAt])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,7 @@ import {
   TaskStatus,
   AgentJobStatus,
   ProductType,
+  ProductStatus,
   DeliveryRoute,
   MedicationType,
   AppointmentStatus,
@@ -29,6 +30,7 @@ import {
   EligibilityStatus,
 } from "@prisma/client";
 import bcrypt from "bcryptjs";
+import { CATEGORIES, PRODUCTS } from "../src/lib/marketplace/data";
 
 const prisma = new PrismaClient();
 
@@ -139,6 +141,129 @@ async function cleanIdempotent() {
   await prisma.feeScheduleEntry.deleteMany({
     where: { organizationId: org.id },
   });
+
+  // ── Marketplace ────────────────────────────────────────────────
+  // Cart cascades to CartItem; Order cascades to OrderItem; Product
+  // cascades to ProductVariant, ProductReview, ProductCategory,
+  // CartItem. Delete Orders before Products because OrderItem.product
+  // is restrict-on-delete.
+  await prisma.cart.deleteMany({
+    where: { patient: { organizationId: org.id } },
+  });
+  await prisma.order.deleteMany({ where: { organizationId: org.id } });
+  await prisma.product.deleteMany({ where: { organizationId: org.id } });
+  // MarketplaceCategory is global (not org-scoped); only delete seed slugs.
+  await prisma.marketplaceCategory.deleteMany({
+    where: { slug: { in: CATEGORIES.map((c) => c.slug) } },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace seed
+// ---------------------------------------------------------------------------
+
+const PRODUCT_STATUS_MAP: Record<string, ProductStatus> = {
+  draft: ProductStatus.draft,
+  active: ProductStatus.active,
+  archived: ProductStatus.archived,
+  out_of_stock: ProductStatus.out_of_stock,
+};
+
+async function seedMarketplace(organizationId: string) {
+  // Categories first — products reference them via ProductCategory joins.
+  const categoryIdBySlug = new Map<string, string>();
+  for (const cat of CATEGORIES) {
+    const row = await prisma.marketplaceCategory.create({
+      data: {
+        name: cat.name,
+        slug: cat.slug,
+        description: cat.description ?? null,
+        type: cat.type,
+        icon: cat.icon ?? null,
+      },
+    });
+    categoryIdBySlug.set(cat.slug, row.id);
+  }
+
+  // Static CATEGORIES use synthetic ids like "cat-sleep"; map those to
+  // the real cuids we just created so the product join rows resolve.
+  const seedCategoryIdToRealId = new Map<string, string>();
+  for (const cat of CATEGORIES) {
+    const realId = categoryIdBySlug.get(cat.slug);
+    if (realId) seedCategoryIdToRealId.set(cat.id, realId);
+  }
+
+  for (const p of PRODUCTS) {
+    const product = await prisma.product.create({
+      data: {
+        organizationId,
+        name: p.name,
+        slug: p.slug,
+        brand: p.brand,
+        description: p.description,
+        shortDescription: p.shortDescription ?? null,
+        price: p.price,
+        compareAtPrice: p.compareAtPrice ?? null,
+        status: PRODUCT_STATUS_MAP[p.status] ?? ProductStatus.active,
+        format: p.format,
+        imageUrl: p.imageUrl ?? null,
+        images: p.images,
+        thcContent: p.thcContent ?? null,
+        cbdContent: p.cbdContent ?? null,
+        cbnContent: p.cbnContent ?? null,
+        terpeneProfile: (p.terpeneProfile ?? {}) as Prisma.InputJsonValue,
+        strainType: p.strainType ?? null,
+        symptoms: p.symptoms,
+        goals: p.goals,
+        useCases: p.useCases,
+        onsetTime: p.onsetTime ?? null,
+        duration: p.duration ?? null,
+        dosageGuidance: p.dosageGuidance ?? null,
+        beginnerFriendly: p.beginnerFriendly,
+        labVerified: p.labVerified,
+        coaUrl: p.coaUrl ?? null,
+        clinicianPick: p.clinicianPick,
+        clinicianNote: p.clinicianNote ?? null,
+        inStock: p.inStock,
+        averageRating: p.averageRating,
+        reviewCount: p.reviewCount,
+        featured: p.featured,
+        variants: {
+          create: p.variants.map((v, i) => ({
+            name: v.name,
+            upc: v.upc ?? null,
+            price: v.price,
+            compareAtPrice: v.compareAtPrice ?? null,
+            inStock: v.inStock,
+            sortOrder: i,
+          })),
+        },
+        reviews: {
+          create: p.reviews.map((r) => ({
+            authorName: r.authorName,
+            rating: r.rating,
+            title: r.title ?? null,
+            body: r.body ?? null,
+            verified: r.verified,
+            createdAt: new Date(r.createdAt),
+          })),
+        },
+      },
+    });
+
+    // Join-table rows for product ↔ category
+    for (const seedCatId of p.categoryIds) {
+      const realCatId = seedCategoryIdToRealId.get(seedCatId);
+      if (!realCatId) continue;
+      await prisma.productCategory.create({
+        data: { productId: product.id, categoryId: realCatId },
+      });
+    }
+  }
+
+  console.log(
+    `  Marketplace: ${CATEGORIES.length} categories, ${PRODUCTS.length} products seeded.`,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -3122,6 +3247,12 @@ async function main() {
   console.log(
     "  Command Center: allergies + meds + regimens + pain logs + observations + finalized notes for Maya/James/Sarah."
   );
+
+  // ------------------------------------------------------------------
+  // Marketplace catalog
+  // ------------------------------------------------------------------
+  console.log("Seeding marketplace catalog...");
+  await seedMarketplace(org.id);
 
   // ------------------------------------------------------------------
   // Done

--- a/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
@@ -29,7 +29,7 @@ const DEFAULT_MODEL_ID = getDefaultConfig().modelId;
 type FleetState = Record<string, { enabled: boolean; modelId: string | null }>;
 
 const TIER_ORDER: ModelTier[] = ["budget", "balanced", "premium", "open-source"];
-const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations"];
+const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations", "commerce"];
 
 const TIER_SWATCH: Record<ModelTier, string> = {
   "budget": "bg-emerald-500",
@@ -44,6 +44,7 @@ const CATEGORY_EMOJI: Record<AgentCategory, string> = {
   patient: "🌱",
   billing: "💳",
   operations: "⚙️",
+  commerce: "🛒",
 };
 
 export function AgentFleetPanel() {
@@ -222,6 +223,8 @@ export function AgentFleetPanel() {
                   ? "Voice-sensitive agents. Nurse Nora and Wellness Coach meaningfully improve on balanced+ models."
                   : category === "operations"
                   ? "Supporting staff — budget models are usually enough."
+                  : category === "commerce"
+                  ? "Marketplace fleet. Compliance + fraud benefit from premium models; catalog hygiene is fine on budget."
                   : "Core clinical agents that shape the physician's daily workflow."}
               </CardDescription>
             </CardHeader>

--- a/src/app/(patient)/portal/shop/cart/actions.ts
+++ b/src/app/(patient)/portal/shop/cart/actions.ts
@@ -1,0 +1,132 @@
+"use server";
+
+import { prisma } from "@/lib/db/prisma";
+import { getCurrentUser } from "@/lib/auth/session";
+
+export interface ServerCartItem {
+  productId: string;
+  variantId: string | null;
+  quantity: number;
+  price: number;
+  name: string;
+}
+
+// Resolve the patient row for the current user. Returns null for non-patient
+// sessions (e.g. clinicians browsing the portal) — caller treats as "no cart".
+async function resolvePatientId(): Promise<string | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, organizationId: user.organizationId ?? "" },
+    select: { id: true },
+  });
+  return patient?.id ?? null;
+}
+
+async function getOrCreateCart(patientId: string) {
+  return prisma.cart.upsert({
+    where: { patientId },
+    update: {},
+    create: { patientId },
+    select: { id: true },
+  });
+}
+
+function hydrate(
+  item: {
+    productId: string;
+    variantId: string | null;
+    quantity: number;
+    product: { name: string; price: number };
+    variant: { price: number } | null;
+  },
+): ServerCartItem {
+  return {
+    productId: item.productId,
+    variantId: item.variantId,
+    quantity: item.quantity,
+    price: item.variant?.price ?? item.product.price,
+    name: item.product.name,
+  };
+}
+
+export async function getServerCart(): Promise<ServerCartItem[]> {
+  const patientId = await resolvePatientId();
+  if (!patientId) return [];
+  const cart = await prisma.cart.findUnique({
+    where: { patientId },
+    include: {
+      items: {
+        include: {
+          product: { select: { name: true, price: true } },
+          variant: { select: { price: true } },
+        },
+      },
+    },
+  });
+  if (!cart) return [];
+  return cart.items.map(hydrate);
+}
+
+export async function setCartItemQuantity(
+  productId: string,
+  variantId: string | null,
+  quantity: number,
+): Promise<ServerCartItem[]> {
+  const patientId = await resolvePatientId();
+  if (!patientId) return [];
+
+  if (quantity <= 0) {
+    return removeCartItem(productId, variantId);
+  }
+
+  const cart = await getOrCreateCart(patientId);
+
+  // Prisma's compound-key `where` clause on `cartId_productId_variantId`
+  // rejects null for `variantId` at the type level, so we do the upsert by
+  // hand: find existing row, update its quantity; otherwise create.
+  const existing = await prisma.cartItem.findFirst({
+    where: { cartId: cart.id, productId, variantId },
+    select: { id: true },
+  });
+  if (existing) {
+    await prisma.cartItem.update({
+      where: { id: existing.id },
+      data: { quantity },
+    });
+  } else {
+    await prisma.cartItem.create({
+      data: { cartId: cart.id, productId, variantId, quantity },
+    });
+  }
+
+  return getServerCart();
+}
+
+export async function removeCartItem(
+  productId: string,
+  variantId: string | null,
+): Promise<ServerCartItem[]> {
+  const patientId = await resolvePatientId();
+  if (!patientId) return [];
+  const cart = await prisma.cart.findUnique({
+    where: { patientId },
+    select: { id: true },
+  });
+  if (!cart) return [];
+  await prisma.cartItem.deleteMany({
+    where: { cartId: cart.id, productId, variantId },
+  });
+  return getServerCart();
+}
+
+export async function clearServerCart(): Promise<void> {
+  const patientId = await resolvePatientId();
+  if (!patientId) return;
+  const cart = await prisma.cart.findUnique({
+    where: { patientId },
+    select: { id: true },
+  });
+  if (!cart) return;
+  await prisma.cartItem.deleteMany({ where: { cartId: cart.id } });
+}

--- a/src/app/(patient)/portal/shop/category/[slug]/page.tsx
+++ b/src/app/(patient)/portal/shop/category/[slug]/page.tsx
@@ -6,8 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import {
   getCategoryBySlug,
   getProductsByCategory,
-  PRODUCTS,
-} from "@/lib/marketplace/data";
+} from "@/lib/marketplace/queries";
 
 // ---------------------------------------------------------------------------
 // Metadata
@@ -21,22 +20,9 @@ export async function generateMetadata({
   params,
 }: CategoryPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const category = getCategoryBySlug(slug);
+  const category = await getCategoryBySlug(slug);
   return { title: category?.name ?? "Category" };
 }
-
-// ---------------------------------------------------------------------------
-// Collection slug helpers
-// ---------------------------------------------------------------------------
-
-const COLLECTION_FILTERS: Record<
-  string,
-  (p: (typeof PRODUCTS)[number]) => boolean
-> = {
-  "clinician-picks": (p) => p.clinicianPick,
-  "best-sellers": (p) => p.featured,
-  "beginner-friendly": (p) => p.beginnerFriendly,
-};
 
 // ---------------------------------------------------------------------------
 // Page
@@ -44,7 +30,7 @@ const COLLECTION_FILTERS: Record<
 
 export default async function CategoryPage({ params }: CategoryPageProps) {
   const { slug } = await params;
-  const category = getCategoryBySlug(slug);
+  const category = await getCategoryBySlug(slug);
 
   if (!category) {
     return (
@@ -73,11 +59,9 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     );
   }
 
-  // Determine products — special handling for collection slugs
-  const collectionFilter = COLLECTION_FILTERS[slug];
-  const products = collectionFilter
-    ? PRODUCTS.filter(collectionFilter)
-    : getProductsByCategory(slug);
+  // Category rows (including collections) are seeded in the DB, so a single
+  // join-query by slug handles symptom, goal, format, and collection pages.
+  const products = await getProductsByCategory(slug);
 
   return (
     <PageShell maxWidth="max-w-[1100px]">

--- a/src/app/(patient)/portal/shop/page.tsx
+++ b/src/app/(patient)/portal/shop/page.tsx
@@ -9,7 +9,7 @@ import {
   getFeaturedProducts,
   getClinicianPicks,
   getCategories,
-} from "@/lib/marketplace/data";
+} from "@/lib/marketplace/queries";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Shop" };
@@ -22,11 +22,14 @@ const QUICK_BROWSE = [
   { label: "Energy", slug: "energy" },
 ] as const;
 
-export default function ShopPage() {
-  const featured = getFeaturedProducts();
-  const clinicianPicks = getClinicianPicks();
-  const symptomCategories = getCategories("symptom");
-  const goalCategories = getCategories("goal");
+export default async function ShopPage() {
+  const [featured, clinicianPicks, symptomCategories, goalCategories] =
+    await Promise.all([
+      getFeaturedProducts(),
+      getClinicianPicks(),
+      getCategories("symptom"),
+      getCategories("goal"),
+    ]);
 
   return (
     <PageShell maxWidth="max-w-[1100px]">

--- a/src/app/(patient)/portal/shop/products/[slug]/page.tsx
+++ b/src/app/(patient)/portal/shop/products/[slug]/page.tsx
@@ -7,7 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { RatingStars } from "@/components/marketplace/RatingStars";
 import { ProductGrid } from "@/components/marketplace/ProductGrid";
-import { getProductBySlug, getRelatedProducts } from "@/lib/marketplace/data";
+import {
+  getProductBySlug,
+  getRelatedProducts,
+} from "@/lib/marketplace/queries";
 import { FORMAT_LABELS } from "@/lib/marketplace/types";
 
 // ---------------------------------------------------------------------------
@@ -22,7 +25,7 @@ export async function generateMetadata({
   params,
 }: SlugPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const product = getProductBySlug(slug);
+  const product = await getProductBySlug(slug);
   if (!product) return { title: "Product Not Found" };
   return {
     title: product.name,
@@ -36,10 +39,10 @@ export async function generateMetadata({
 
 export default async function ProductDetailPage({ params }: SlugPageProps) {
   const { slug } = await params;
-  const product = getProductBySlug(slug);
+  const product = await getProductBySlug(slug);
   if (!product) notFound();
 
-  const relatedProducts = getRelatedProducts(product.id);
+  const relatedProducts = await getRelatedProducts(product.id);
   const formatLabel = FORMAT_LABELS[product.format] ?? product.format;
   const strainLabel =
     product.strainType && product.strainType !== "n/a"

--- a/src/app/(patient)/portal/shop/products/page.tsx
+++ b/src/app/(patient)/portal/shop/products/page.tsx
@@ -3,7 +3,11 @@ import Link from "next/link";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { ProductGrid } from "@/components/marketplace/ProductGrid";
 import { SearchBar } from "@/components/marketplace/SearchBar";
-import { searchProducts, PRODUCTS, CATEGORIES } from "@/lib/marketplace/data";
+import {
+  searchProducts,
+  getAllProducts,
+  getCategories,
+} from "@/lib/marketplace/queries";
 import type { ProductFormat } from "@/lib/marketplace/types";
 import { FORMAT_LABELS } from "@/lib/marketplace/types";
 
@@ -25,14 +29,14 @@ export default async function ProductsPage({ searchParams }: ProductsPageProps) 
   const format = params.format as ProductFormat | undefined;
 
   // Build filtered product list
-  let products = PRODUCTS;
-
-  if (q) {
-    products = searchProducts(q);
-  }
+  const [baseProducts, categories] = await Promise.all([
+    q ? searchProducts(q) : getAllProducts(),
+    getCategories(),
+  ]);
+  let products = baseProducts;
 
   if (category) {
-    const cat = CATEGORIES.find(
+    const cat = categories.find(
       (c) => c.slug === category || c.id === category
     );
     if (cat) {
@@ -49,7 +53,7 @@ export default async function ProductsPage({ searchParams }: ProductsPageProps) 
 
   // Active filter labels for display
   const activeCategory = category
-    ? CATEGORIES.find((c) => c.slug === category || c.id === category)
+    ? categories.find((c) => c.slug === category || c.id === category)
     : undefined;
   const activeFormatLabel = format ? FORMAT_LABELS[format] : undefined;
 

--- a/src/components/marketplace/CartProvider.tsx
+++ b/src/components/marketplace/CartProvider.tsx
@@ -9,6 +9,13 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import {
+  getServerCart,
+  setCartItemQuantity,
+  removeCartItem as removeServerCartItem,
+  clearServerCart,
+  type ServerCartItem,
+} from "@/app/(patient)/portal/shop/cart/actions";
 
 // ── Cart item shape ─────────────────────────────────────────────────────
 interface CartItemEntry {
@@ -17,6 +24,16 @@ interface CartItemEntry {
   quantity: number;
   price: number;
   name: string;
+}
+
+function entryFromServer(item: ServerCartItem): CartItemEntry {
+  return {
+    productId: item.productId,
+    variantId: item.variantId ?? undefined,
+    quantity: item.quantity,
+    price: item.price,
+    name: item.name,
+  };
 }
 
 interface CartContextValue {
@@ -83,19 +100,74 @@ function writeStorage(items: CartItemEntry[]) {
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItemEntry[]>([]);
   const hydrated = useRef(false);
+  // Authenticated patient session — server is the source of truth. Falls back
+  // to localStorage-only for anon/clinician browsing.
+  const persistsToServer = useRef(false);
 
-  // Hydrate from localStorage on mount
+  // Hydrate: prefer server cart (authed patient); else localStorage. If the
+  // server cart is empty and localStorage has items, push them up so cross-
+  // device continuity survives the first server hit.
   useEffect(() => {
-    setItems(readStorage());
-    hydrated.current = true;
+    let cancelled = false;
+    (async () => {
+      try {
+        const server = await getServerCart();
+        if (cancelled) return;
+        persistsToServer.current = true;
+        if (server.length > 0) {
+          setItems(server.map(entryFromServer));
+        } else {
+          const local = readStorage();
+          if (local.length > 0) {
+            setItems(local);
+            await Promise.all(
+              local.map((l) =>
+                setCartItemQuantity(l.productId, l.variantId ?? null, l.quantity),
+              ),
+            );
+          }
+        }
+      } catch {
+        // Unauth or server error — stay in localStorage-only mode.
+        setItems(readStorage());
+      } finally {
+        hydrated.current = true;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  // Persist to localStorage whenever items change (skip the initial default)
+  // Persist to localStorage whenever items change (skip the initial default).
+  // Server sync happens per-mutation below.
   useEffect(() => {
     if (hydrated.current) {
       writeStorage(items);
     }
   }, [items]);
+
+  // Fire-and-forget server sync. Failures are logged but don't revert local
+  // state — localStorage still has the truth and the next hydrate will
+  // reconcile.
+  const syncSet = useCallback(
+    (productId: string, variantId: string | undefined, quantity: number) => {
+      if (!persistsToServer.current) return;
+      setCartItemQuantity(productId, variantId ?? null, quantity).catch((e) =>
+        console.warn("[cart] server sync failed", e),
+      );
+    },
+    [],
+  );
+  const syncRemove = useCallback(
+    (productId: string, variantId: string | undefined) => {
+      if (!persistsToServer.current) return;
+      removeServerCartItem(productId, variantId ?? null).catch((e) =>
+        console.warn("[cart] server remove failed", e),
+      );
+    },
+    [],
+  );
 
   const addItem = useCallback(
     (
@@ -104,16 +176,15 @@ export function CartProvider({ children }: { children: ReactNode }) {
       price: number,
       name: string
     ) => {
+      let nextQty = 1;
       setItems((prev) => {
         const idx = prev.findIndex((entry) =>
           matchesItem(entry, productId, variantId)
         );
         if (idx >= 0) {
           const updated = [...prev];
-          updated[idx] = {
-            ...updated[idx],
-            quantity: updated[idx].quantity + 1,
-          };
+          nextQty = updated[idx].quantity + 1;
+          updated[idx] = { ...updated[idx], quantity: nextQty };
           return updated;
         }
         return [
@@ -121,8 +192,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
           { productId, variantId, quantity: 1, price, name },
         ];
       });
+      syncSet(productId, variantId, nextQty);
     },
-    []
+    [syncSet]
   );
 
   const removeItem = useCallback(
@@ -130,8 +202,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
       setItems((prev) =>
         prev.filter((entry) => !matchesItem(entry, productId, variantId))
       );
+      syncRemove(productId, variantId);
     },
-    []
+    [syncRemove]
   );
 
   const updateQuantity = useCallback(
@@ -140,6 +213,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         setItems((prev) =>
           prev.filter((entry) => !matchesItem(entry, productId, variantId))
         );
+        syncRemove(productId, variantId);
         return;
       }
       setItems((prev) =>
@@ -149,12 +223,18 @@ export function CartProvider({ children }: { children: ReactNode }) {
             : entry
         )
       );
+      syncSet(productId, variantId, quantity);
     },
-    []
+    [syncSet, syncRemove]
   );
 
   const clearCart = useCallback(() => {
     setItems([]);
+    if (persistsToServer.current) {
+      clearServerCart().catch((e) =>
+        console.warn("[cart] server clear failed", e),
+      );
+    }
   }, []);
 
   const itemCount = items.reduce((sum, entry) => sum + entry.quantity, 0);

--- a/src/lib/agents/commerce/abandoned-cart-rescuer-agent.ts
+++ b/src/lib/agents/commerce/abandoned-cart-rescuer-agent.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  staleHours: z.number().int().positive().max(720),
+});
+
+const output = z.object({
+  candidates: z.array(
+    z.object({
+      cartId: z.string(),
+      patientId: z.string(),
+      itemCount: z.number(),
+      ageHours: z.number(),
+    }),
+  ),
+});
+
+/**
+ * Abandoned Cart Rescuer Agent
+ * ----------------------------
+ * Finds carts untouched for `staleHours` and surfaces them for a follow-up
+ * nudge (message, email, in-app banner). Writes nothing — downstream
+ * messaging agent drafts the outreach.
+ *
+ * Status: stub (EMR-17 / Agent-night). Query wired against the Cart model
+ * shipped in EMR-231.
+ */
+export const abandonedCartRescuerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "abandonedCartRescuer",
+  version: "0.1.0",
+  description: "Surfaces carts idle beyond the staleness threshold for follow-up.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ organizationId, staleHours }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const cutoff = new Date(Date.now() - staleHours * 3600 * 1000);
+    const carts = await prisma.cart.findMany({
+      where: {
+        updatedAt: { lt: cutoff },
+        patient: { organizationId },
+        items: { some: {} },
+      },
+      select: {
+        id: true,
+        patientId: true,
+        updatedAt: true,
+        _count: { select: { items: true } },
+      },
+    });
+    const now = Date.now();
+    const candidates = carts.map((c) => ({
+      cartId: c.id,
+      patientId: c.patientId,
+      itemCount: c._count.items,
+      ageHours: Math.round((now - c.updatedAt.getTime()) / 3600000),
+    }));
+    ctx.log("info", "abandonedCartRescuer swept", { count: candidates.length });
+    return { candidates };
+  },
+};

--- a/src/lib/agents/commerce/bundle-suggester-agent.ts
+++ b/src/lib/agents/commerce/bundle-suggester-agent.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string().optional(),
+  anchorProductId: z.string().optional(),
+  limit: z.number().int().positive().max(10),
+});
+
+const output = z.object({
+  bundles: z.array(
+    z.object({
+      label: z.string(),
+      productIds: z.array(z.string()),
+      rationale: z.string(),
+    }),
+  ),
+});
+
+/**
+ * Bundle Suggester Agent
+ * ----------------------
+ * Proposes 2-3 product bundles (e.g. "Sleep stack", "Post-workout recovery")
+ * from co-consumption patterns in `OrderItem` + clinician-pick overlap on
+ * `symptoms`/`goals`.
+ *
+ * Status: stub (EMR-17 / Agent-night). Full implementation requires order
+ * volume we don't yet have; returns an empty bundle list until then.
+ */
+export const bundleSuggesterAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "bundleSuggester",
+  version: "0.1.0",
+  description: "Suggests themed product bundles from co-consumption data.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run(_input, ctx) {
+    ctx.log("info", "bundleSuggester stub — awaiting order volume for co-purchase signal");
+    return { bundles: [] };
+  },
+};

--- a/src/lib/agents/commerce/cannabis-compliance-gate-agent.ts
+++ b/src/lib/agents/commerce/cannabis-compliance-gate-agent.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  orderId: z.string(),
+});
+
+const output = z.object({
+  orderId: z.string(),
+  allowed: z.boolean(),
+  blockers: z.array(
+    z.enum([
+      "missing_medical_auth",
+      "state_purchase_limit_exceeded",
+      "unlicensed_shipping_state",
+      "missing_age_verification",
+      "thc_dosage_exceeds_state_cap",
+    ]),
+  ),
+  notes: z.string().optional(),
+});
+
+/**
+ * Cannabis Compliance Gate Agent
+ * ------------------------------
+ * Hard gate before fulfillment. Verifies medical authorization,
+ * state-level purchase and THC caps, and age verification. A single
+ * blocker returns `allowed: false`.
+ *
+ * Status: stub (EMR-17 / Agent-night). Permissive default — always
+ * allows until the state-rules data lands. MUST be tightened before
+ * any real fulfillment flow.
+ */
+export const cannabisComplianceGateAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "cannabisComplianceGate",
+  version: "0.1.0",
+  description: "Compliance gate verifying medical auth, state caps, and age before fulfillment.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ orderId }, ctx) {
+    ctx.log("warn", "cannabisComplianceGate stub — permissive default, MUST harden before fulfillment", {
+      orderId,
+    });
+    return { orderId, allowed: true, blockers: [], notes: "Stub — no rules enforced yet." };
+  },
+};

--- a/src/lib/agents/commerce/cannabis-tax-calculator-agent.ts
+++ b/src/lib/agents/commerce/cannabis-tax-calculator-agent.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  orderId: z.string(),
+  destinationState: z.string().length(2),
+});
+
+const output = z.object({
+  orderId: z.string(),
+  destinationState: z.string(),
+  breakdown: z.array(
+    z.object({
+      label: z.string(),
+      amount: z.number(),
+    }),
+  ),
+  totalTax: z.number(),
+});
+
+/**
+ * Cannabis Tax Calculator Agent
+ * -----------------------------
+ * Computes state + local cannabis excise + retail sales tax per order.
+ * Rules vary wildly by state; this is the single source of truth the
+ * checkout flow must call before charge.
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns zero tax until the
+ * state-rules table ships. Fulfillment MUST NOT rely on this to be
+ * correct yet.
+ */
+export const cannabisTaxCalculatorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "cannabisTaxCalculator",
+  version: "0.1.0",
+  description: "Computes cannabis excise + retail tax per order destination.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ orderId, destinationState }, ctx) {
+    ctx.log("warn", "cannabisTaxCalculator stub — returns 0; must not be used in production", {
+      orderId,
+      destinationState,
+    });
+    return { orderId, destinationState, breakdown: [], totalTax: 0 };
+  },
+};

--- a/src/lib/agents/commerce/category-curator-agent.ts
+++ b/src/lib/agents/commerce/category-curator-agent.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ productId: z.string() });
+
+const output = z.object({
+  productId: z.string(),
+  currentCategoryIds: z.array(z.string()),
+  suggestedAddCategoryIds: z.array(z.string()),
+  suggestedRemoveCategoryIds: z.array(z.string()),
+  rationale: z.string().optional(),
+});
+
+/**
+ * Category Curator Agent
+ * ----------------------
+ * Suggests category additions and removals per product based on its
+ * `symptoms`, `goals`, `format`, and `clinicianPick` flags.
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns empty suggestions; full
+ * mapping matrix is TODO.
+ */
+export const categoryCuratorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "categoryCurator",
+  version: "0.1.0",
+  description: "Suggests marketplace category additions and removals per product.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ productId }, ctx) {
+    ctx.log("info", "categoryCurator stub", { productId });
+    return {
+      productId,
+      currentCategoryIds: [],
+      suggestedAddCategoryIds: [],
+      suggestedRemoveCategoryIds: [],
+    };
+  },
+};

--- a/src/lib/agents/commerce/cross-sell-ranker-agent.ts
+++ b/src/lib/agents/commerce/cross-sell-ranker-agent.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  productId: z.string(),
+  limit: z.number().int().positive().max(20),
+});
+
+const output = z.object({
+  anchorProductId: z.string(),
+  crossSells: z.array(
+    z.object({
+      productId: z.string(),
+      liftScore: z.number(),
+      reason: z.string(),
+    }),
+  ),
+});
+
+/**
+ * Cross-Sell Ranker Agent
+ * -----------------------
+ * Produces the "frequently bought with" list for a product detail page.
+ * Mines co-occurrence from `OrderItem` within a rolling window.
+ *
+ * Status: stub (EMR-17 / Agent-night). Empty list until order volume is
+ * sufficient; downstream UI should hide the section on empty.
+ */
+export const crossSellRankerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "crossSellRanker",
+  version: "0.1.0",
+  description: "'Frequently bought with' ranking from OrderItem co-occurrence.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ productId }, ctx) {
+    ctx.log("info", "crossSellRanker stub invoked", { productId });
+    return { anchorProductId: productId, crossSells: [] };
+  },
+};

--- a/src/lib/agents/commerce/order-fraud-detector-agent.ts
+++ b/src/lib/agents/commerce/order-fraud-detector-agent.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ orderId: z.string() });
+
+const output = z.object({
+  orderId: z.string(),
+  riskScore: z.number().min(0).max(100),
+  signals: z.array(z.string()),
+  action: z.enum(["allow", "review", "block"]),
+});
+
+/**
+ * Order Fraud Detector Agent
+ * --------------------------
+ * Scores a new order for fraud risk. Signals: unusual total vs. patient
+ * baseline, shipping/billing address mismatch, high-velocity new account,
+ * known-fraudster lookup.
+ *
+ * Status: stub (EMR-17 / Agent-night). Conservative default — always
+ * "allow" with score 0 until signal library lands.
+ */
+export const orderFraudDetectorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "orderFraudDetector",
+  version: "0.1.0",
+  description: "Scores new orders for fraud risk before fulfillment.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ orderId }, ctx) {
+    ctx.log("info", "orderFraudDetector stub", { orderId });
+    return { orderId, riskScore: 0, signals: [], action: "allow" as const };
+  },
+};

--- a/src/lib/agents/commerce/pricing-anomaly-agent.ts
+++ b/src/lib/agents/commerce/pricing-anomaly-agent.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ organizationId: z.string() });
+
+const output = z.object({
+  anomalies: z.array(
+    z.object({
+      productId: z.string(),
+      kind: z.enum([
+        "compare_at_lower_than_price",
+        "price_zero",
+        "price_excessive_markdown",
+        "variant_price_below_cost",
+        "variant_price_above_base",
+      ]),
+      severity: z.enum(["low", "medium", "high"]),
+      detail: z.string(),
+    }),
+  ),
+});
+
+/**
+ * Pricing Anomaly Agent
+ * ---------------------
+ * Sweeps marketplace `Product` + `ProductVariant` rows for likely pricing
+ * errors: `compareAtPrice < price`, zero price, implausibly deep markdowns.
+ *
+ * Status: stub (EMR-17 / Agent-night). Runs two high-signal checks today
+ * so the catalog ops surface has something to flag.
+ */
+export const pricingAnomalyAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "pricingAnomaly",
+  version: "0.1.0",
+  description: "Flags marketplace pricing anomalies (inverted compareAt, zero, etc).",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ organizationId }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const products = await prisma.product.findMany({
+      where: { organizationId, deletedAt: null },
+      select: { id: true, price: true, compareAtPrice: true },
+    });
+    const anomalies: z.infer<typeof output>["anomalies"] = [];
+    for (const p of products) {
+      if (p.price === 0) anomalies.push({ productId: p.id, kind: "price_zero", severity: "high", detail: "price is 0" });
+      if (p.compareAtPrice != null && p.compareAtPrice < p.price)
+        anomalies.push({
+          productId: p.id,
+          kind: "compare_at_lower_than_price",
+          severity: "medium",
+          detail: `compareAt ${p.compareAtPrice} < price ${p.price}`,
+        });
+    }
+    ctx.log("info", "pricingAnomaly swept catalog", { count: anomalies.length });
+    return { anomalies };
+  },
+};

--- a/src/lib/agents/commerce/pricing-optimizer-agent.ts
+++ b/src/lib/agents/commerce/pricing-optimizer-agent.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ productId: z.string() });
+
+const output = z.object({
+  productId: z.string(),
+  currentPrice: z.number(),
+  suggestedPrice: z.number().nullable(),
+  direction: z.enum(["hold", "raise", "lower"]),
+  rationale: z.string(),
+});
+
+/**
+ * Pricing Optimizer Agent
+ * -----------------------
+ * Suggests price adjustments based on conversion rate, inventory depth,
+ * competitor pricing (future), and stock velocity.
+ *
+ * Status: stub (EMR-17 / Agent-night). Always returns "hold" — pricing
+ * moves are gated behind human approval per marketplace policy.
+ */
+export const pricingOptimizerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "pricingOptimizer",
+  version: "0.1.0",
+  description: "Suggests product price adjustments from demand + inventory signals.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ productId }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const p = await prisma.product.findUnique({ where: { id: productId }, select: { price: true } });
+    const currentPrice = p?.price ?? 0;
+    ctx.log("info", "pricingOptimizer stub", { productId });
+    return {
+      productId,
+      currentPrice,
+      suggestedPrice: null,
+      direction: "hold" as const,
+      rationale: "Stub: insufficient signal volume — holding price.",
+    };
+  },
+};

--- a/src/lib/agents/commerce/product-qc-agent.ts
+++ b/src/lib/agents/commerce/product-qc-agent.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ productId: z.string() });
+
+const output = z.object({
+  productId: z.string(),
+  issues: z.array(
+    z.object({
+      code: z.enum([
+        "missing_coa",
+        "stale_coa",
+        "missing_cannabinoid_profile",
+        "missing_dosage_guidance",
+        "missing_images",
+        "status_inconsistent",
+      ]),
+      severity: z.enum(["low", "medium", "high"]),
+      message: z.string(),
+    }),
+  ),
+  qualityScore: z.number().min(0).max(100),
+});
+
+/**
+ * Product QC Agent
+ * ----------------
+ * Audits marketplace `Product` rows for catalog hygiene: missing COA,
+ * stale lab results, missing cannabinoid disclosure, missing dosage
+ * guidance, status inconsistencies (inStock + status=archived etc).
+ *
+ * Status: stub (EMR-17 / Agent-night). Emits basic checks today so the
+ * catalog QC surface can start rendering real issues.
+ */
+export const productQCAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "productQC",
+  version: "0.1.0",
+  description: "Audits product catalog rows for missing or stale metadata.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ productId }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const p = await prisma.product.findUnique({ where: { id: productId } });
+    if (!p) return { productId, issues: [], qualityScore: 0 };
+
+    const issues: z.infer<typeof output>["issues"] = [];
+    if (!p.coaUrl) issues.push({ code: "missing_coa", severity: "high", message: "No COA URL on record." });
+    if (p.thcContent == null && p.cbdContent == null)
+      issues.push({ code: "missing_cannabinoid_profile", severity: "medium", message: "No THC/CBD content disclosed." });
+    if (!p.dosageGuidance)
+      issues.push({ code: "missing_dosage_guidance", severity: "medium", message: "No dosage guidance for patients." });
+    if (p.images.length === 0 && !p.imageUrl)
+      issues.push({ code: "missing_images", severity: "low", message: "No product images uploaded." });
+
+    const qualityScore = Math.max(0, 100 - issues.reduce((s, i) => s + (i.severity === "high" ? 40 : i.severity === "medium" ? 20 : 10), 0));
+    ctx.log("info", "productQC scanned", { productId, issueCount: issues.length, qualityScore });
+    return { productId, issues, qualityScore };
+  },
+};

--- a/src/lib/agents/commerce/product-recommender-agent.ts
+++ b/src/lib/agents/commerce/product-recommender-agent.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  limit: z.number().int().positive().max(50),
+});
+
+const output = z.object({
+  recommendations: z.array(
+    z.object({
+      productId: z.string(),
+      slug: z.string(),
+      score: z.number(),
+      reasons: z.array(z.string()),
+    }),
+  ),
+  generatedAt: z.string(),
+});
+
+/**
+ * Product Recommender Agent
+ * -------------------------
+ * Per-patient marketplace recommendations. Delegates the scoring to the
+ * outcome-weighted ranking engine (EMR-230) so the moat logic stays in one
+ * place and is independently testable.
+ *
+ * Status: stub (EMR-17 / Agent-night 2026-04-23). Wired to the ranking
+ * engine; will gain personalization layers (collaborative filtering,
+ * cohort-based nudges) as data accumulates.
+ */
+export const productRecommenderAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "productRecommender",
+  version: "0.1.0",
+  description: "Per-patient marketplace recommendations, outcome-weighted.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ patientId, limit }, ctx) {
+    const { rankProductsForPatient } = await import(
+      "@/lib/marketplace/ranking"
+    );
+    const ranked = await rankProductsForPatient(patientId, { limit });
+    ctx.log("info", "productRecommender produced ranking", {
+      count: ranked.length,
+    });
+    return {
+      recommendations: ranked.map((r) => ({
+        productId: r.product.id,
+        slug: r.product.slug,
+        score: r.score,
+        reasons: r.reasons,
+      })),
+      generatedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/src/lib/agents/commerce/promo-generator-agent.ts
+++ b/src/lib/agents/commerce/promo-generator-agent.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  intent: z.enum(["retention", "reactivation", "first_purchase", "restock"]),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  offer: z
+    .object({
+      label: z.string(),
+      productIds: z.array(z.string()),
+      discountPct: z.number().min(0).max(50),
+      expiresAt: z.string(),
+    })
+    .nullable(),
+});
+
+/**
+ * Promo Generator Agent
+ * ---------------------
+ * Generates targeted promos per patient cohort/intent. Respects
+ * cannabis-marketing constraints — no medical claims, no outcome
+ * promises.
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns `offer: null` by default;
+ * future version will pull cohort + product data.
+ */
+export const promoGeneratorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "promoGenerator",
+  version: "0.1.0",
+  description: "Generates targeted marketplace promos per patient intent.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientId }, ctx) {
+    ctx.log("info", "promoGenerator stub", { patientId });
+    return { patientId, offer: null };
+  },
+};

--- a/src/lib/agents/commerce/restock-predictor-agent.ts
+++ b/src/lib/agents/commerce/restock-predictor-agent.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  variantId: z.string(),
+  horizonDays: z.number().int().positive().max(90),
+});
+
+const output = z.object({
+  variantId: z.string(),
+  horizonDays: z.number(),
+  dailyVelocity: z.number(),
+  projectedStockOutAt: z.string().nullable(),
+  confidence: z.enum(["low", "medium", "high"]),
+});
+
+/**
+ * Restock Predictor Agent
+ * -----------------------
+ * Forecasts per-variant stock-out dates from recent `OrderItem` velocity.
+ * Pairs with `waitlistNotifier` and `inventoryAlert` (existing).
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns zero velocity until order
+ * volume accumulates; downstream UI should render "insufficient data" on
+ * `confidence: low`.
+ */
+export const restockPredictorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "restockPredictor",
+  version: "0.1.0",
+  description: "Forecasts per-variant stock-out dates from order velocity.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ variantId, horizonDays }, ctx) {
+    ctx.log("info", "restockPredictor stub", { variantId, horizonDays });
+    return {
+      variantId,
+      horizonDays,
+      dailyVelocity: 0,
+      projectedStockOutAt: null,
+      confidence: "low" as const,
+    };
+  },
+};

--- a/src/lib/agents/commerce/return-risk-scorer-agent.ts
+++ b/src/lib/agents/commerce/return-risk-scorer-agent.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ orderId: z.string() });
+
+const output = z.object({
+  orderId: z.string(),
+  returnProbability: z.number().min(0).max(1),
+  drivers: z.array(z.string()),
+});
+
+/**
+ * Return Risk Scorer Agent
+ * ------------------------
+ * Predicts probability of return/refund for an order pre-ship. Signals:
+ * product category base rate, size/variant changes, prior return history,
+ * review sentiment on the specific product.
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns uniform 0.1 prior until
+ * historical data populates the model.
+ */
+export const returnRiskScorerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "returnRiskScorer",
+  version: "0.1.0",
+  description: "Predicts return probability for an order before fulfillment.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ orderId }, ctx) {
+    ctx.log("info", "returnRiskScorer stub", { orderId });
+    return { orderId, returnProbability: 0.1, drivers: [] };
+  },
+};

--- a/src/lib/agents/commerce/review-moderator-agent.ts
+++ b/src/lib/agents/commerce/review-moderator-agent.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ reviewId: z.string() });
+
+const output = z.object({
+  reviewId: z.string(),
+  flag: z.enum(["ok", "spam", "fake", "off_topic", "harmful"]),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().optional(),
+});
+
+/**
+ * Review Moderator Agent
+ * ----------------------
+ * Scans `ProductReview.body` for spam, astroturfing, and harmful claims
+ * (e.g. medical advice beyond wellness positioning). Flags rather than
+ * deletes — moderation workflow is human-gated.
+ *
+ * Status: stub (EMR-17 / Agent-night). Returns `ok` for all inputs; full
+ * heuristic + LLM scoring is TODO.
+ */
+export const reviewModeratorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "reviewModerator",
+  version: "0.1.0",
+  description: "Flags product reviews for spam, fake content, or harmful claims.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ reviewId }, ctx) {
+    ctx.log("info", "reviewModerator stub", { reviewId });
+    return { reviewId, flag: "ok" as const, confidence: 0.1 };
+  },
+};

--- a/src/lib/agents/commerce/search-personalizer-agent.ts
+++ b/src/lib/agents/commerce/search-personalizer-agent.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string().optional(),
+  query: z.string(),
+  candidateProductIds: z.array(z.string()),
+});
+
+const output = z.object({
+  rankedProductIds: z.array(z.string()),
+  reasoning: z.string().optional(),
+});
+
+/**
+ * Search Personalizer Agent
+ * -------------------------
+ * Reranks marketplace search results using the patient's active regimen,
+ * recent outcome logs, and memory tags. Falls through to input order if no
+ * patient context is available.
+ *
+ * Status: stub (EMR-17 / Agent-night). Pass-through today; real reranker
+ * will consume the EMR-230 ranking engine.
+ */
+export const searchPersonalizerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "searchPersonalizer",
+  version: "0.1.0",
+  description: "Reranks marketplace search results against patient context.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ candidateProductIds }, ctx) {
+    ctx.log("info", "searchPersonalizer stub — pass-through ordering");
+    return { rankedProductIds: candidateProductIds };
+  },
+};

--- a/src/lib/agents/commerce/seo-metadata-agent.ts
+++ b/src/lib/agents/commerce/seo-metadata-agent.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ productId: z.string() });
+
+const output = z.object({
+  productId: z.string(),
+  metaTitle: z.string(),
+  metaDescription: z.string(),
+  imageAltTexts: z.array(z.string()),
+});
+
+/**
+ * SEO Metadata Agent
+ * ------------------
+ * Generates meta-title, meta-description, and image alt-text per product.
+ * Output is pasted into the Product record (future field) or returned for
+ * SSR head tags.
+ *
+ * Status: stub (EMR-17 / Agent-night). Emits deterministic defaults from
+ * product fields; LLM-generated copy is TODO.
+ */
+export const seoMetadataAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "seoMetadata",
+  version: "0.1.0",
+  description: "Generates SEO meta-title, description, and alt text per product.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ productId }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const p = await prisma.product.findUnique({ where: { id: productId } });
+    if (!p) return { productId, metaTitle: "", metaDescription: "", imageAltTexts: [] };
+
+    const metaTitle = `${p.name} — ${p.brand} | Leafjourney`;
+    const metaDescription = p.shortDescription ?? p.description.slice(0, 155);
+    const imageAltTexts = p.images.length
+      ? p.images.map(() => `${p.name} by ${p.brand}`)
+      : [`${p.name} by ${p.brand}`];
+
+    ctx.log("info", "seoMetadata generated defaults", { productId });
+    return { productId, metaTitle, metaDescription, imageAltTexts };
+  },
+};

--- a/src/lib/agents/commerce/shipping-router-agent.ts
+++ b/src/lib/agents/commerce/shipping-router-agent.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  orderId: z.string(),
+  destinationZip: z.string(),
+});
+
+const output = z.object({
+  orderId: z.string(),
+  carrier: z.enum(["usps", "ups", "fedex", "local_courier", "unassigned"]),
+  estimatedDays: z.number().int().positive(),
+  rationale: z.string(),
+});
+
+/**
+ * Shipping Router Agent
+ * ---------------------
+ * Picks a fulfillment partner per order based on destination, product
+ * type (cold-chain, hazmat, cannabinoid content), and partner SLAs.
+ *
+ * Status: stub (EMR-17 / Agent-night). Always returns `unassigned`
+ * today — partner integration matrix is TODO.
+ */
+export const shippingRouterAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "shippingRouter",
+  version: "0.1.0",
+  description: "Picks a fulfillment carrier per order destination + product profile.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ orderId }, ctx) {
+    ctx.log("info", "shippingRouter stub", { orderId });
+    return {
+      orderId,
+      carrier: "unassigned" as const,
+      estimatedDays: 5,
+      rationale: "Stub — carrier matrix pending.",
+    };
+  },
+};

--- a/src/lib/agents/commerce/vendor-performance-scorer-agent.ts
+++ b/src/lib/agents/commerce/vendor-performance-scorer-agent.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  brand: z.string(),
+  lookbackDays: z.number().int().positive().max(365),
+});
+
+const output = z.object({
+  brand: z.string(),
+  lookbackDays: z.number(),
+  score: z.number().min(0).max(100),
+  metrics: z.object({
+    onTimeShipmentRate: z.number().min(0).max(1).nullable(),
+    returnRate: z.number().min(0).max(1).nullable(),
+    complaintRate: z.number().min(0).max(1).nullable(),
+    avgReviewRating: z.number().min(0).max(5).nullable(),
+  }),
+});
+
+/**
+ * Vendor Performance Scorer Agent
+ * -------------------------------
+ * Scores product brands on fulfillment quality, return rate, complaint
+ * rate, and aggregate review rating. Feeds the vendor portal dashboard.
+ *
+ * Status: stub (EMR-17 / Agent-night). Emits null metrics until we have
+ * shipment + complaint tables; avg review rating is queryable today.
+ */
+export const vendorPerformanceScorerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "vendorPerformanceScorer",
+  version: "0.1.0",
+  description: "Scores marketplace brands on fulfillment + review performance.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ brand, lookbackDays }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const products = await prisma.product.findMany({
+      where: { brand, deletedAt: null },
+      select: { averageRating: true, reviewCount: true },
+    });
+    const totalReviews = products.reduce((s, p) => s + p.reviewCount, 0);
+    const avg =
+      totalReviews > 0
+        ? products.reduce((s, p) => s + p.averageRating * p.reviewCount, 0) / totalReviews
+        : null;
+    ctx.log("info", "vendorPerformanceScorer stub scored brand", { brand });
+    return {
+      brand,
+      lookbackDays,
+      score: avg != null ? Math.round(avg * 20) : 0,
+      metrics: {
+        onTimeShipmentRate: null,
+        returnRate: null,
+        complaintRate: null,
+        avgReviewRating: avg,
+      },
+    };
+  },
+};

--- a/src/lib/agents/commerce/waitlist-notifier-agent.ts
+++ b/src/lib/agents/commerce/waitlist-notifier-agent.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({ variantId: z.string() });
+
+const output = z.object({
+  variantId: z.string(),
+  notifiedPatientIds: z.array(z.string()),
+  skippedReason: z.string().optional(),
+});
+
+/**
+ * Waitlist Notifier Agent
+ * -----------------------
+ * When a variant transitions from out-of-stock to in-stock, notifies
+ * patients who opted into the restock waitlist for that variant.
+ *
+ * Status: stub (EMR-17 / Agent-night). Waitlist model + opt-in flow are
+ * TODO; returns empty list today.
+ */
+export const waitlistNotifierAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "waitlistNotifier",
+  version: "0.1.0",
+  description: "Notifies patients waitlisted on a variant once it's back in stock.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ variantId }, ctx) {
+    ctx.log("info", "waitlistNotifier stub — waitlist model not yet built", { variantId });
+    return { variantId, notifiedPatientIds: [], skippedReason: "waitlist model pending" };
+  },
+};

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -61,6 +61,27 @@ import { qualityImprovementAgent } from "./quality-improvement-agent";
 // Mission Control — Phase 1 (MALLIK-006 + MALLIK-007)
 import { labSummarizerAgent } from "./lab-summarizer-agent";
 import { refillCopilotAgent } from "./refill-copilot-agent";
+// Commerce Fleet — EMR-17 (20 agents, stub-shipped 2026-04-23)
+import { productRecommenderAgent } from "./commerce/product-recommender-agent";
+import { bundleSuggesterAgent } from "./commerce/bundle-suggester-agent";
+import { crossSellRankerAgent } from "./commerce/cross-sell-ranker-agent";
+import { searchPersonalizerAgent } from "./commerce/search-personalizer-agent";
+import { reviewModeratorAgent } from "./commerce/review-moderator-agent";
+import { productQCAgent } from "./commerce/product-qc-agent";
+import { seoMetadataAgent } from "./commerce/seo-metadata-agent";
+import { categoryCuratorAgent } from "./commerce/category-curator-agent";
+import { pricingAnomalyAgent } from "./commerce/pricing-anomaly-agent";
+import { restockPredictorAgent } from "./commerce/restock-predictor-agent";
+import { waitlistNotifierAgent } from "./commerce/waitlist-notifier-agent";
+import { abandonedCartRescuerAgent } from "./commerce/abandoned-cart-rescuer-agent";
+import { orderFraudDetectorAgent } from "./commerce/order-fraud-detector-agent";
+import { returnRiskScorerAgent } from "./commerce/return-risk-scorer-agent";
+import { pricingOptimizerAgent } from "./commerce/pricing-optimizer-agent";
+import { promoGeneratorAgent } from "./commerce/promo-generator-agent";
+import { cannabisComplianceGateAgent } from "./commerce/cannabis-compliance-gate-agent";
+import { cannabisTaxCalculatorAgent } from "./commerce/cannabis-tax-calculator-agent";
+import { shippingRouterAgent } from "./commerce/shipping-router-agent";
+import { vendorPerformanceScorerAgent } from "./commerce/vendor-performance-scorer-agent";
 
 /**
  * Registry of all agents. Adding an agent = new file + one line here +
@@ -131,7 +152,52 @@ export const agentRegistry = {
   // Mission Control — Phase 1 (MALLIK-006 + MALLIK-007)
   labSummarizer: labSummarizerAgent,
   refillCopilot: refillCopilotAgent,
+  // Commerce Fleet — EMR-17 (20 agents stub-shipped 2026-04-23)
+  productRecommender: productRecommenderAgent,
+  bundleSuggester: bundleSuggesterAgent,
+  crossSellRanker: crossSellRankerAgent,
+  searchPersonalizer: searchPersonalizerAgent,
+  reviewModerator: reviewModeratorAgent,
+  productQC: productQCAgent,
+  seoMetadata: seoMetadataAgent,
+  categoryCurator: categoryCuratorAgent,
+  pricingAnomaly: pricingAnomalyAgent,
+  restockPredictor: restockPredictorAgent,
+  waitlistNotifier: waitlistNotifierAgent,
+  abandonedCartRescuer: abandonedCartRescuerAgent,
+  orderFraudDetector: orderFraudDetectorAgent,
+  returnRiskScorer: returnRiskScorerAgent,
+  pricingOptimizer: pricingOptimizerAgent,
+  promoGenerator: promoGeneratorAgent,
+  cannabisComplianceGate: cannabisComplianceGateAgent,
+  cannabisTaxCalculator: cannabisTaxCalculatorAgent,
+  shippingRouter: shippingRouterAgent,
+  vendorPerformanceScorer: vendorPerformanceScorerAgent,
 } satisfies Record<string, Agent<any, any>>;
+
+/** Agents tagged as "commerce" — used by the marketplace ops console. */
+export const COMMERCE_AGENT_NAMES: AgentName[] = [
+  "productRecommender",
+  "bundleSuggester",
+  "crossSellRanker",
+  "searchPersonalizer",
+  "reviewModerator",
+  "productQC",
+  "seoMetadata",
+  "categoryCurator",
+  "pricingAnomaly",
+  "restockPredictor",
+  "waitlistNotifier",
+  "abandonedCartRescuer",
+  "orderFraudDetector",
+  "returnRiskScorer",
+  "pricingOptimizer",
+  "promoGenerator",
+  "cannabisComplianceGate",
+  "cannabisTaxCalculator",
+  "shippingRouter",
+  "vendorPerformanceScorer",
+];
 
 export type AgentName = keyof typeof agentRegistry;
 

--- a/src/lib/domain/byok.ts
+++ b/src/lib/domain/byok.ts
@@ -160,7 +160,13 @@ export function leafjourneyPriceBasis(rawMonthlyCostUsd: number): "floor" | "key
 // tier drives the sensible starting assignment when a practice hasn't set
 // an override. Token estimates are calibrated from observed traffic.
 
-export type AgentCategory = "clinical" | "patient" | "billing" | "operations" | "safety";
+export type AgentCategory =
+  | "clinical"
+  | "patient"
+  | "billing"
+  | "operations"
+  | "safety"
+  | "commerce";
 
 export interface AgentCatalogEntry {
   /** Must match a key in agentRegistry (src/lib/agents/index.ts). */
@@ -242,6 +248,29 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   { id: "contentCreation", displayName: "Content Creation", description: "Marketing + education content drafts.", category: "operations", defaultTier: "balanced", estimatedTokensPerMonth: 80_000 },
   { id: "inventoryAlert", displayName: "Inventory Alert", description: "Supplies + consumables low-stock.", category: "operations", defaultTier: "budget", estimatedTokensPerMonth: 20_000 },
   { id: "qualityImprovement", displayName: "Quality Improvement", description: "QI projects + MIPS readiness.", category: "operations", defaultTier: "balanced", estimatedTokensPerMonth: 80_000 },
+
+  // Commerce (EMR-17 marketplace fleet — 20 agents shipped as stubs on
+  // 2026-04-23; full logic rolls out ticket-by-ticket)
+  { id: "productRecommender", displayName: "Product Recommender", description: "Per-patient marketplace recommendations, outcome-weighted (EMR-230).", category: "commerce", defaultTier: "balanced", estimatedTokensPerMonth: 180_000, qualitySensitive: true },
+  { id: "bundleSuggester", displayName: "Bundle Suggester", description: "Suggests themed product bundles from co-consumption.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 60_000 },
+  { id: "crossSellRanker", displayName: "Cross-Sell Ranker", description: "Frequently-bought-with ranking from OrderItem co-occurrence.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 50_000 },
+  { id: "searchPersonalizer", displayName: "Search Personalizer", description: "Reranks search results against patient context.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 90_000 },
+  { id: "reviewModerator", displayName: "Review Moderator", description: "Flags product reviews for spam, fake content, or harmful claims.", category: "commerce", defaultTier: "balanced", estimatedTokensPerMonth: 60_000, qualitySensitive: true },
+  { id: "productQC", displayName: "Product QC", description: "Audits product catalog rows for missing or stale metadata.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+  { id: "seoMetadata", displayName: "SEO Metadata", description: "Generates meta-title, meta-description, and alt text per product.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 80_000 },
+  { id: "categoryCurator", displayName: "Category Curator", description: "Suggests marketplace category additions and removals.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+  { id: "pricingAnomaly", displayName: "Pricing Anomaly", description: "Flags inverted compareAt, zero price, deep-markdown outliers.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 30_000 },
+  { id: "restockPredictor", displayName: "Restock Predictor", description: "Forecasts per-variant stock-out dates from velocity.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+  { id: "waitlistNotifier", displayName: "Waitlist Notifier", description: "Notifies patients waitlisted on a variant when it returns to stock.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 30_000 },
+  { id: "abandonedCartRescuer", displayName: "Abandoned Cart Rescuer", description: "Surfaces idle carts for follow-up outreach.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 50_000 },
+  { id: "orderFraudDetector", displayName: "Order Fraud Detector", description: "Scores new orders for fraud risk before fulfillment.", category: "commerce", defaultTier: "balanced", estimatedTokensPerMonth: 70_000, qualitySensitive: true },
+  { id: "returnRiskScorer", displayName: "Return Risk Scorer", description: "Predicts return probability for an order before fulfillment.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+  { id: "pricingOptimizer", displayName: "Pricing Optimizer", description: "Suggests price adjustments from demand + inventory signals.", category: "commerce", defaultTier: "balanced", estimatedTokensPerMonth: 80_000 },
+  { id: "promoGenerator", displayName: "Promo Generator", description: "Generates targeted marketplace promos per patient intent.", category: "commerce", defaultTier: "balanced", estimatedTokensPerMonth: 70_000 },
+  { id: "cannabisComplianceGate", displayName: "Cannabis Compliance Gate", description: "Verifies medical auth, state caps, and age before fulfillment.", category: "commerce", defaultTier: "premium", estimatedTokensPerMonth: 100_000, qualitySensitive: true },
+  { id: "cannabisTaxCalculator", displayName: "Cannabis Tax Calculator", description: "Computes cannabis excise + retail tax per order destination.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 50_000 },
+  { id: "shippingRouter", displayName: "Shipping Router", description: "Picks a fulfillment carrier per order destination + product profile.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+  { id: "vendorPerformanceScorer", displayName: "Vendor Performance Scorer", description: "Scores marketplace brands on fulfillment + review performance.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
 ];
 
 /** Per-agent override. Undefined modelId → use the practice default. */
@@ -281,4 +310,5 @@ export const CATEGORY_LABELS: Record<AgentCategory, string> = {
   safety: "Safety & guardrails",
   billing: "Revenue cycle",
   operations: "Operations",
+  commerce: "Marketplace",
 };

--- a/src/lib/marketplace/queries.ts
+++ b/src/lib/marketplace/queries.ts
@@ -1,0 +1,292 @@
+// DB-backed marketplace query layer. Mirrors the function signatures from
+// `./data.ts` (the in-memory mock) so portal shop routes can swap the import
+// and become async. Scoped to the current user's organization.
+
+import { cache } from "react";
+import { prisma } from "@/lib/db/prisma";
+import { getCurrentUser } from "@/lib/auth/session";
+import { ProductStatus } from "@prisma/client";
+import type {
+  MarketplaceProduct,
+  MarketplaceCategory,
+  ProductVariant,
+  ProductReview,
+  ProductFormat,
+} from "./types";
+
+const productInclude = {
+  variants: { orderBy: { sortOrder: "asc" } },
+  reviews: { orderBy: { createdAt: "desc" } },
+  categoryMappings: { include: { category: true } },
+} as const;
+
+type ProductRow = Awaited<
+  ReturnType<typeof prisma.product.findFirstOrThrow<{ include: typeof productInclude }>>
+>;
+
+function mapVariant(v: ProductRow["variants"][number]): ProductVariant {
+  return {
+    id: v.id,
+    name: v.name,
+    upc: v.upc ?? undefined,
+    price: v.price,
+    compareAtPrice: v.compareAtPrice ?? undefined,
+    inStock: v.inStock,
+  };
+}
+
+function mapReview(r: ProductRow["reviews"][number]): ProductReview {
+  return {
+    id: r.id,
+    authorName: r.authorName,
+    rating: r.rating,
+    title: r.title ?? undefined,
+    body: r.body ?? undefined,
+    verified: r.verified,
+    createdAt: r.createdAt.toISOString().slice(0, 10),
+  };
+}
+
+function mapProduct(p: ProductRow): MarketplaceProduct {
+  const terpene = (p.terpeneProfile ?? {}) as Record<string, number>;
+  return {
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    brand: p.brand,
+    description: p.description,
+    shortDescription: p.shortDescription ?? "",
+    price: p.price,
+    compareAtPrice: p.compareAtPrice ?? undefined,
+    status: p.status,
+    format: p.format as ProductFormat,
+    imageUrl: p.imageUrl ?? undefined,
+    images: p.images,
+    thcContent: p.thcContent ?? undefined,
+    cbdContent: p.cbdContent ?? undefined,
+    cbnContent: p.cbnContent ?? undefined,
+    terpeneProfile: terpene,
+    strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+    symptoms: p.symptoms,
+    goals: p.goals,
+    useCases: p.useCases,
+    onsetTime: p.onsetTime ?? undefined,
+    duration: p.duration ?? undefined,
+    dosageGuidance: p.dosageGuidance ?? undefined,
+    beginnerFriendly: p.beginnerFriendly,
+    labVerified: p.labVerified,
+    coaUrl: p.coaUrl ?? undefined,
+    clinicianPick: p.clinicianPick,
+    clinicianNote: p.clinicianNote ?? undefined,
+    inStock: p.inStock,
+    averageRating: p.averageRating,
+    reviewCount: p.reviewCount,
+    featured: p.featured,
+    categoryIds: p.categoryMappings.map((m) => m.categoryId),
+    variants: p.variants.map(mapVariant),
+    reviews: p.reviews.map(mapReview),
+  };
+}
+
+// Resolve the caller's org. Requests without a session or membership yield
+// null — callers treat that as an empty catalog.
+const resolveOrgId = cache(async (): Promise<string | null> => {
+  const user = await getCurrentUser();
+  return user?.organizationId ?? null;
+});
+
+// ---------------------------------------------------------------------------
+// Queries (mirror data.ts signatures, async)
+// ---------------------------------------------------------------------------
+
+export async function getProductBySlug(
+  slug: string,
+): Promise<MarketplaceProduct | undefined> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return undefined;
+  const row = await prisma.product.findFirst({
+    where: { slug, organizationId: orgId, deletedAt: null },
+    include: productInclude,
+  });
+  return row ? mapProduct(row) : undefined;
+}
+
+export async function getProductsByCategory(
+  categorySlug: string,
+): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const rows = await prisma.product.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      categoryMappings: { some: { category: { slug: categorySlug } } },
+    },
+    include: productInclude,
+    orderBy: [{ featured: "desc" }, { averageRating: "desc" }],
+  });
+  return rows.map(mapProduct);
+}
+
+export async function getFeaturedProducts(): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const rows = await prisma.product.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      featured: true,
+      status: ProductStatus.active,
+    },
+    include: productInclude,
+    orderBy: [{ sortOrder: "asc" }, { averageRating: "desc" }],
+  });
+  return rows.map(mapProduct);
+}
+
+export async function getClinicianPicks(): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const rows = await prisma.product.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      clinicianPick: true,
+      status: ProductStatus.active,
+    },
+    include: productInclude,
+    orderBy: { averageRating: "desc" },
+  });
+  return rows.map(mapProduct);
+}
+
+export async function getAllProducts(): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const rows = await prisma.product.findMany({
+    where: { organizationId: orgId, deletedAt: null },
+    include: productInclude,
+    orderBy: [{ featured: "desc" }, { sortOrder: "asc" }, { name: "asc" }],
+  });
+  return rows.map(mapProduct);
+}
+
+export async function searchProducts(
+  query: string,
+): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const q = query.trim();
+  const rows = await prisma.product.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      ...(q
+        ? {
+            OR: [
+              { name: { contains: q, mode: "insensitive" } },
+              { brand: { contains: q, mode: "insensitive" } },
+              { description: { contains: q, mode: "insensitive" } },
+              { symptoms: { has: q } },
+              { goals: { has: q } },
+              { format: { equals: q, mode: "insensitive" } },
+            ],
+          }
+        : {}),
+    },
+    include: productInclude,
+    orderBy: [{ featured: "desc" }, { averageRating: "desc" }],
+  });
+  return rows.map(mapProduct);
+}
+
+export async function getRelatedProducts(
+  productId: string,
+  limit = 4,
+): Promise<MarketplaceProduct[]> {
+  const orgId = await resolveOrgId();
+  if (!orgId) return [];
+  const source = await prisma.product.findFirst({
+    where: { id: productId, organizationId: orgId, deletedAt: null },
+    select: { symptoms: true, goals: true },
+  });
+  if (!source) return [];
+  const pool = await prisma.product.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      id: { not: productId },
+      OR: [
+        { symptoms: { hasSome: source.symptoms } },
+        { goals: { hasSome: source.goals } },
+      ],
+    },
+    include: productInclude,
+    take: limit * 4,
+  });
+  const targets = new Set<string>([...source.symptoms, ...source.goals]);
+  return pool
+    .map((p) => ({
+      product: mapProduct(p),
+      score: [...p.symptoms, ...p.goals].filter((t) => targets.has(t)).length,
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((r) => r.product);
+}
+
+export async function getCategoryBySlug(
+  slug: string,
+): Promise<MarketplaceCategory | undefined> {
+  const orgId = await resolveOrgId();
+  const row = await prisma.marketplaceCategory.findUnique({
+    where: { slug },
+    include: {
+      _count: {
+        select: {
+          products: orgId
+            ? { where: { product: { organizationId: orgId, deletedAt: null } } }
+            : true,
+        },
+      },
+    },
+  });
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? undefined,
+    type: row.type as MarketplaceCategory["type"],
+    icon: row.icon ?? undefined,
+    productCount: row._count.products,
+  };
+}
+
+export async function getCategories(
+  type?: string,
+): Promise<MarketplaceCategory[]> {
+  const orgId = await resolveOrgId();
+  const rows = await prisma.marketplaceCategory.findMany({
+    where: type ? { type } : {},
+    orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+    include: {
+      _count: {
+        select: {
+          products: orgId
+            ? { where: { product: { organizationId: orgId, deletedAt: null } } }
+            : true,
+        },
+      },
+    },
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? undefined,
+    type: row.type as MarketplaceCategory["type"],
+    icon: row.icon ?? undefined,
+    productCount: row._count.products,
+  }));
+}

--- a/src/lib/marketplace/ranking.test.ts
+++ b/src/lib/marketplace/ranking.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prisma mock — hoisted so vi.mock's factory can reach it.
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findUnique: vi.fn() },
+    product: { findMany: vi.fn() },
+    outcomeLog: { findMany: vi.fn() },
+    patientMemory: { findMany: vi.fn() },
+    dosingRegimen: { findMany: vi.fn() },
+    orderItem: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  rankProductsForPatient,
+  WEIGHT_CONDITION_PER_HIT,
+  WEIGHT_CLINICIAN_PICK,
+  WEIGHT_IN_STOCK_AND_RATED,
+  WEIGHT_IN_STOCK_ONLY,
+  WEIGHT_BEGINNER_SAFETY,
+  WEIGHT_PRODUCT_EFFICACY,
+} from "./ranking";
+
+// Build a Product row that satisfies the fields the mapper reads.
+function productRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "p1",
+    slug: "p1",
+    name: "Demo Product",
+    brand: "Demo Brand",
+    description: "",
+    shortDescription: null,
+    price: 40,
+    compareAtPrice: null,
+    status: "active",
+    format: "tincture",
+    imageUrl: null,
+    images: [],
+    thcContent: null,
+    cbdContent: null,
+    cbnContent: null,
+    thcvContent: null,
+    terpeneProfile: null,
+    strainType: null,
+    symptoms: [],
+    goals: [],
+    useCases: [],
+    onsetTime: null,
+    duration: null,
+    dosageGuidance: null,
+    beginnerFriendly: false,
+    labVerified: false,
+    coaUrl: null,
+    clinicianPick: false,
+    clinicianNote: null,
+    inStock: false,
+    inventoryCount: 0,
+    averageRating: 0,
+    reviewCount: 0,
+    sortOrder: 0,
+    featured: false,
+    organizationId: "org_1",
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    variants: [],
+    reviews: [],
+    categoryMappings: [],
+    ...overrides,
+  };
+}
+
+function resetMocks() {
+  hoisted.mockPrisma.patient.findUnique.mockReset();
+  hoisted.mockPrisma.product.findMany.mockReset();
+  hoisted.mockPrisma.outcomeLog.findMany.mockReset();
+  hoisted.mockPrisma.patientMemory.findMany.mockReset();
+  hoisted.mockPrisma.dosingRegimen.findMany.mockReset();
+  hoisted.mockPrisma.orderItem.findMany.mockReset();
+}
+
+// Sensible empty defaults — tests override only what they care about.
+function primeEmpty(patientOrg = "org_1") {
+  hoisted.mockPrisma.patient.findUnique.mockResolvedValue({
+    id: "pat_1",
+    organizationId: patientOrg,
+  });
+  hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([]);
+  hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([]);
+  hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([]);
+  hoisted.mockPrisma.orderItem.findMany.mockResolvedValue([]);
+}
+
+beforeEach(resetMocks);
+
+describe("rankProductsForPatient", () => {
+  it("returns [] when the patient does not exist", async () => {
+    hoisted.mockPrisma.patient.findUnique.mockResolvedValue(null);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    const result = await rankProductsForPatient("nope");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when there are no products (empty DB, no crash)", async () => {
+    primeEmpty();
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    const result = await rankProductsForPatient("pat_1");
+    expect(result).toEqual([]);
+  });
+
+  it("boosts a Sleep product when the patient has a recent low sleep score", async () => {
+    primeEmpty();
+    hoisted.mockPrisma.outcomeLog.findMany.mockImplementation(
+      async (args: { where?: { loggedAt?: unknown } }) => {
+        // The recent-window query is the one with `loggedAt: { gte }`.
+        if (args?.where?.loggedAt) {
+          return [{ metric: "sleep", value: 2, loggedAt: new Date() }];
+        }
+        return [];
+      },
+    );
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "sleep-1",
+        slug: "sleep-1",
+        name: "Sleep Tincture",
+        goals: ["Sleep"],
+        inStock: true,
+        averageRating: 4.0,
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result).toHaveLength(1);
+    expect(result[0].product.id).toBe("sleep-1");
+    // condition match (Sleep) + in-stock-only
+    expect(result[0].score).toBe(
+      WEIGHT_CONDITION_PER_HIT + WEIGHT_IN_STOCK_ONLY,
+    );
+    expect(result[0].reasons.some((r) => r.includes("Sleep"))).toBe(true);
+  });
+
+  it("awards clinician pick + in-stock-and-rated correctly", async () => {
+    primeEmpty();
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "pick-1",
+        slug: "pick-1",
+        clinicianPick: true,
+        inStock: true,
+        averageRating: 4.7,
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result).toHaveLength(1);
+    // Patient has no prior regimens and product isn't beginnerFriendly, so
+    // just the two signals fire.
+    expect(result[0].score).toBe(
+      WEIGHT_CLINICIAN_PICK + WEIGHT_IN_STOCK_AND_RATED,
+    );
+    expect(result[0].reasons).toContain("clinician pick");
+  });
+
+  it("drops products the patient has already ordered", async () => {
+    primeEmpty();
+    hoisted.mockPrisma.orderItem.findMany.mockResolvedValue([
+      { productId: "owned" },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "owned",
+        slug: "owned",
+        clinicianPick: true,
+        inStock: true,
+        averageRating: 4.9,
+      }),
+      productRow({
+        id: "fresh",
+        slug: "fresh",
+        clinicianPick: true,
+        inStock: true,
+        averageRating: 4.9,
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result.map((r) => r.product.id)).toEqual(["fresh"]);
+  });
+
+  it("produces a deterministic, correctly-summed score for a composed scenario", async () => {
+    hoisted.mockPrisma.patient.findUnique.mockResolvedValue({
+      id: "pat_1",
+      organizationId: "org_1",
+    });
+    // Recent outcomes: high pain + low sleep.
+    hoisted.mockPrisma.outcomeLog.findMany.mockImplementation(
+      async (args: { where?: { loggedAt?: unknown } }) => {
+        if (args?.where?.loggedAt) {
+          return [
+            { metric: "pain", value: 8, loggedAt: new Date() },
+            { metric: "sleep", value: 2, loggedAt: new Date() },
+          ];
+        }
+        // All-time logs — before + after regimen window for efficacy signal.
+        return [
+          {
+            metric: "pain",
+            value: 8,
+            loggedAt: new Date("2026-03-01T00:00:00Z"),
+          },
+          {
+            metric: "pain",
+            value: 3,
+            loggedAt: new Date("2026-03-20T00:00:00Z"),
+          },
+        ];
+      },
+    );
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([]);
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      {
+        startDate: new Date("2026-03-01T00:00:00Z"),
+        endDate: new Date("2026-03-25T00:00:00Z"),
+        product: { name: "Relief Oil", brand: "Demo Brand" },
+      },
+    ]);
+    hoisted.mockPrisma.orderItem.findMany.mockResolvedValue([]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "relief",
+        slug: "relief",
+        name: "Relief Oil", // matches the regimen (normalizeName)
+        brand: "Demo Brand",
+        symptoms: ["Pain"],
+        goals: ["Sleep"],
+        clinicianPick: true,
+        inStock: true,
+        averageRating: 4.8,
+        beginnerFriendly: true,
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result).toHaveLength(1);
+    const r = result[0];
+
+    // 2 condition hits (Pain + Sleep) = 20
+    // efficacy bridge match (pain 8→3) = 30
+    // clinician pick = 15
+    // in-stock + rating 4.8 = 15
+    // has prior regimens → beginner safety NOT awarded
+    const expected =
+      WEIGHT_CONDITION_PER_HIT * 2 +
+      WEIGHT_PRODUCT_EFFICACY +
+      WEIGHT_CLINICIAN_PICK +
+      WEIGHT_IN_STOCK_AND_RATED;
+    expect(r.score).toBe(expected);
+    expect(r.reasons.some((s) => s.includes("pain 8→3"))).toBe(true);
+    expect(r.reasons.some((s) => s.includes("clinician pick"))).toBe(true);
+  });
+
+  it("awards beginner safety only when patient has no prior regimens", async () => {
+    primeEmpty();
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "starter",
+        slug: "starter",
+        beginnerFriendly: true,
+        inStock: true,
+        averageRating: 4.2,
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result[0].score).toBe(WEIGHT_BEGINNER_SAFETY + WEIGHT_IN_STOCK_ONLY);
+    expect(
+      result[0].reasons.some((s) => s.toLowerCase().includes("beginner")),
+    ).toBe(true);
+  });
+});

--- a/src/lib/marketplace/ranking.ts
+++ b/src/lib/marketplace/ranking.ts
@@ -1,0 +1,387 @@
+// EMR-230 — Outcome-weighted product ranking engine.
+//
+// Per-patient marketplace product recommendations from real clinical and
+// outcome data. The scoring model is intentionally legible + auditable — not
+// an ML black box. Each returned ranking carries a `reasons[]` explaining why
+// the product was boosted, so clinicians and patients can trust it.
+//
+// The Prisma schema currently does NOT FK the marketplace `Product` to the
+// clinical `CannabisProduct` — regimens reference `CannabisProduct` only.
+// Until that bridge exists, we best-effort match by lowercased+trimmed name
+// (and brand when available). If no bridge, product-specific outcome signal
+// is skipped and we fall back to condition-match only.
+
+import { prisma } from "@/lib/db/prisma";
+import { ProductStatus, type OutcomeMetric } from "@prisma/client";
+import type { MarketplaceProduct } from "./types";
+
+// Scoring weights — tweak here.
+export const WEIGHT_CONDITION_MATCH = 40; // cumulative cap
+export const WEIGHT_CONDITION_PER_HIT = 10;
+export const WEIGHT_PRODUCT_EFFICACY = 30;
+export const WEIGHT_CLINICIAN_PICK = 15;
+export const WEIGHT_IN_STOCK_AND_RATED = 15;
+export const WEIGHT_IN_STOCK_ONLY = 7;
+export const WEIGHT_BEGINNER_SAFETY = 10;
+
+// Outcome analysis window + thresholds.
+const OUTCOME_LOOKBACK_DAYS = 30;
+const OUTCOME_HIGH_THRESHOLD = 5; // value > 5 = symptom present (pain/anxiety/nausea)
+const OUTCOME_LOW_THRESHOLD = 5; // value < 5 = deficit (sleep/mood/energy)
+const REGIMEN_IMPROVEMENT_POINTS = 2; // ≥2 point improvement across a regimen window
+
+// Which metrics are "high = bad" vs "low = bad". Maps to symptom/goal labels
+// our marketplace uses (see SYMPTOM_OPTIONS / GOAL_OPTIONS in types.ts).
+const METRIC_TO_TARGETS: Record<
+  OutcomeMetric,
+  { direction: "high-bad" | "low-bad"; labels: string[] }
+> = {
+  pain: { direction: "high-bad", labels: ["Pain", "Pain support"] },
+  anxiety: { direction: "high-bad", labels: ["Anxiety", "Calm"] },
+  nausea: { direction: "high-bad", labels: ["Nausea"] },
+  side_effects: { direction: "high-bad", labels: [] },
+  sleep: { direction: "low-bad", labels: ["Sleep"] },
+  mood: { direction: "low-bad", labels: ["Calm", "Everyday wellness"] },
+  energy: { direction: "low-bad", labels: ["Energy", "Focus"] },
+  appetite: { direction: "low-bad", labels: ["Appetite"] },
+  adherence: { direction: "low-bad", labels: [] },
+};
+
+export interface RankedProduct {
+  product: MarketplaceProduct;
+  score: number;
+  reasons: string[];
+}
+
+export interface RankOptions {
+  limit?: number;
+  organizationId?: string;
+}
+
+// Cannabis product identifier, normalized for a best-effort bridge match.
+function normalizeName(s: string | null | undefined): string {
+  return (s ?? "").trim().toLowerCase();
+}
+
+// Given a patient's memory + recent outcome signals, return which
+// symptom/goal labels the patient currently needs help with.
+interface ConditionSignal {
+  label: string;
+  reason: string;
+}
+
+function collectConditionSignals(
+  memoryTags: string[],
+  recentLogs: { metric: OutcomeMetric; value: number }[],
+): ConditionSignal[] {
+  const signals: ConditionSignal[] = [];
+  const seenLabel = new Set<string>();
+
+  // Memory tags — treat the tag itself as a symptom/goal hint.
+  for (const raw of memoryTags) {
+    const tag = raw.trim();
+    if (!tag) continue;
+    // Title-case first letter to match marketplace symptom/goal options.
+    const label = tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
+    if (seenLabel.has(label)) continue;
+    seenLabel.add(label);
+    signals.push({ label, reason: `matches a tracked concern: ${label}` });
+  }
+
+  // Outcome logs — group by metric, use latest value to decide.
+  const byMetric = new Map<OutcomeMetric, number>();
+  for (const log of recentLogs) {
+    // Keep the most recent value per metric (logs are ordered desc below).
+    if (!byMetric.has(log.metric)) byMetric.set(log.metric, log.value);
+  }
+  for (const [metric, value] of byMetric) {
+    const spec = METRIC_TO_TARGETS[metric];
+    if (!spec) continue;
+    const flagged =
+      (spec.direction === "high-bad" && value > OUTCOME_HIGH_THRESHOLD) ||
+      (spec.direction === "low-bad" && value < OUTCOME_LOW_THRESHOLD);
+    if (!flagged) continue;
+    for (const label of spec.labels) {
+      if (seenLabel.has(label)) continue;
+      seenLabel.add(label);
+      signals.push({
+        label,
+        reason: `matches your goal: ${label} (recent ${metric}=${value})`,
+      });
+    }
+  }
+
+  return signals;
+}
+
+// For each past regimen, compute the outcome delta across its window and
+// return the product identifier (normalized name[+brand]) if the patient
+// improved by ≥REGIMEN_IMPROVEMENT_POINTS on any tracked metric.
+interface EfficacySignal {
+  key: string; // normalized name
+  brand: string; // normalized brand ("" if none)
+  metric: OutcomeMetric;
+  before: number;
+  after: number;
+}
+
+function computeEfficacySignals(
+  regimens: {
+    startDate: Date;
+    endDate: Date | null;
+    product: { name: string; brand: string | null };
+  }[],
+  allLogs: { metric: OutcomeMetric; value: number; loggedAt: Date }[],
+): EfficacySignal[] {
+  const out: EfficacySignal[] = [];
+  for (const r of regimens) {
+    const start = r.startDate;
+    const end = r.endDate ?? new Date();
+    const windowLogs = allLogs.filter(
+      (l) => l.loggedAt >= start && l.loggedAt <= end,
+    );
+    if (windowLogs.length < 2) continue;
+
+    const byMetric = new Map<OutcomeMetric, { metric: OutcomeMetric; value: number; loggedAt: Date }[]>();
+    for (const l of windowLogs) {
+      const arr = byMetric.get(l.metric) ?? [];
+      arr.push(l);
+      byMetric.set(l.metric, arr);
+    }
+    for (const [metric, entries] of byMetric) {
+      if (entries.length < 2) continue;
+      const sorted = [...entries].sort(
+        (a, b) => a.loggedAt.getTime() - b.loggedAt.getTime(),
+      );
+      const first = sorted[0].value;
+      const last = sorted[sorted.length - 1].value;
+      const spec = METRIC_TO_TARGETS[metric];
+      if (!spec) continue;
+      const improvement =
+        spec.direction === "high-bad" ? first - last : last - first;
+      if (improvement >= REGIMEN_IMPROVEMENT_POINTS) {
+        out.push({
+          key: normalizeName(r.product.name),
+          brand: normalizeName(r.product.brand),
+          metric,
+          before: first,
+          after: last,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+export async function rankProductsForPatient(
+  patientId: string,
+  options: RankOptions = {},
+): Promise<RankedProduct[]> {
+  if (!patientId) return [];
+  const limit = options.limit ?? 10;
+
+  const patient = await prisma.patient.findUnique({
+    where: { id: patientId },
+    select: { id: true, organizationId: true },
+  });
+  if (!patient) return [];
+
+  const organizationId = options.organizationId ?? patient.organizationId;
+  const sinceOutcomes = new Date(
+    Date.now() - OUTCOME_LOOKBACK_DAYS * 86_400_000,
+  );
+
+  const [
+    productRows,
+    recentOutcomes,
+    allOutcomes,
+    memories,
+    regimens,
+    orderedItems,
+  ] = await Promise.all([
+    prisma.product.findMany({
+      where: {
+        organizationId,
+        deletedAt: null,
+        status: ProductStatus.active,
+      },
+      include: {
+        variants: { orderBy: { sortOrder: "asc" } },
+        reviews: { orderBy: { createdAt: "desc" } },
+        categoryMappings: { include: { category: true } },
+      },
+    }),
+    prisma.outcomeLog.findMany({
+      where: { patientId, loggedAt: { gte: sinceOutcomes } },
+      orderBy: { loggedAt: "desc" },
+      select: { metric: true, value: true, loggedAt: true },
+    }),
+    prisma.outcomeLog.findMany({
+      where: { patientId },
+      orderBy: { loggedAt: "asc" },
+      select: { metric: true, value: true, loggedAt: true },
+    }),
+    prisma.patientMemory.findMany({
+      where: {
+        patientId,
+        OR: [{ validUntil: null }, { validUntil: { gt: new Date() } }],
+      },
+      select: { tags: true },
+    }),
+    prisma.dosingRegimen.findMany({
+      where: { patientId },
+      select: {
+        startDate: true,
+        endDate: true,
+        product: { select: { name: true, brand: true } },
+      },
+    }),
+    prisma.orderItem.findMany({
+      where: { order: { patientId } },
+      select: { productId: true },
+    }),
+  ]);
+
+  const alreadyOrdered = new Set(orderedItems.map((i) => i.productId));
+  const memoryTags = memories.flatMap((m) => m.tags);
+  const signals = collectConditionSignals(memoryTags, recentOutcomes);
+  const efficacy = computeEfficacySignals(regimens, allOutcomes);
+  const hasPriorRegimens = regimens.length > 0;
+
+  const ranked: RankedProduct[] = [];
+  for (const row of productRows) {
+    if (alreadyOrdered.has(row.id)) continue;
+
+    let score = 0;
+    const reasons: string[] = [];
+
+    // 1. Condition match — up to WEIGHT_CONDITION_MATCH.
+    const matchable = new Set<string>([...row.symptoms, ...row.goals]);
+    let conditionScore = 0;
+    for (const sig of signals) {
+      if (matchable.has(sig.label)) {
+        conditionScore += WEIGHT_CONDITION_PER_HIT;
+        reasons.push(sig.reason);
+      }
+    }
+    if (conditionScore > WEIGHT_CONDITION_MATCH) {
+      conditionScore = WEIGHT_CONDITION_MATCH;
+    }
+    score += conditionScore;
+
+    // 2. Product efficacy — exact bridge match by normalized name (brand too
+    // when both sides expose it).
+    const rowKey = normalizeName(row.name);
+    const rowBrand = normalizeName(row.brand);
+    for (const eff of efficacy) {
+      const nameMatch = eff.key && eff.key === rowKey;
+      // Brand match is required only when both sides have a brand.
+      const brandMatch = !eff.brand || !rowBrand || eff.brand === rowBrand;
+      if (nameMatch && brandMatch) {
+        score += WEIGHT_PRODUCT_EFFICACY;
+        reasons.push(
+          `similar to regimen that improved ${eff.metric} ${eff.before}→${eff.after}`,
+        );
+        break;
+      }
+    }
+
+    // 3. Clinician pick.
+    if (row.clinicianPick) {
+      score += WEIGHT_CLINICIAN_PICK;
+      reasons.push("clinician pick");
+    }
+
+    // 4. In-stock + rating.
+    if (row.inStock && row.averageRating >= 4.5) {
+      score += WEIGHT_IN_STOCK_AND_RATED;
+      reasons.push(`in stock, highly rated (${row.averageRating.toFixed(1)}★)`);
+    } else if (row.inStock) {
+      score += WEIGHT_IN_STOCK_ONLY;
+    }
+
+    // 5. Beginner safety.
+    if (!hasPriorRegimens && row.beginnerFriendly) {
+      score += WEIGHT_BEGINNER_SAFETY;
+      reasons.push("beginner-friendly — a gentle starting point");
+    }
+
+    if (score <= 0) continue;
+
+    ranked.push({
+      product: mapProductRow(row),
+      score,
+      reasons,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score || a.product.name.localeCompare(b.product.name));
+  return ranked.slice(0, limit);
+}
+
+// Local copy of the queries.ts mapper — duplicated to keep this module
+// independent (the queries.ts version pulls in next/cache via getCurrentUser).
+type ProductRow = Awaited<
+  ReturnType<typeof prisma.product.findFirstOrThrow<{
+    include: {
+      variants: { orderBy: { sortOrder: "asc" } };
+      reviews: { orderBy: { createdAt: "desc" } };
+      categoryMappings: { include: { category: true } };
+    };
+  }>>
+>;
+
+function mapProductRow(p: ProductRow): MarketplaceProduct {
+  return {
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    brand: p.brand,
+    description: p.description,
+    shortDescription: p.shortDescription ?? "",
+    price: p.price,
+    compareAtPrice: p.compareAtPrice ?? undefined,
+    status: p.status,
+    format: p.format as MarketplaceProduct["format"],
+    imageUrl: p.imageUrl ?? undefined,
+    images: p.images,
+    thcContent: p.thcContent ?? undefined,
+    cbdContent: p.cbdContent ?? undefined,
+    cbnContent: p.cbnContent ?? undefined,
+    terpeneProfile: (p.terpeneProfile ?? {}) as Record<string, number>,
+    strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+    symptoms: p.symptoms,
+    goals: p.goals,
+    useCases: p.useCases,
+    onsetTime: p.onsetTime ?? undefined,
+    duration: p.duration ?? undefined,
+    dosageGuidance: p.dosageGuidance ?? undefined,
+    beginnerFriendly: p.beginnerFriendly,
+    labVerified: p.labVerified,
+    coaUrl: p.coaUrl ?? undefined,
+    clinicianPick: p.clinicianPick,
+    clinicianNote: p.clinicianNote ?? undefined,
+    inStock: p.inStock,
+    averageRating: p.averageRating,
+    reviewCount: p.reviewCount,
+    featured: p.featured,
+    categoryIds: p.categoryMappings.map((m) => m.categoryId),
+    variants: p.variants.map((v) => ({
+      id: v.id,
+      name: v.name,
+      upc: v.upc ?? undefined,
+      price: v.price,
+      compareAtPrice: v.compareAtPrice ?? undefined,
+      inStock: v.inStock,
+    })),
+    reviews: p.reviews.map((r) => ({
+      id: r.id,
+      authorName: r.authorName,
+      rating: r.rating,
+      title: r.title ?? undefined,
+      body: r.body ?? undefined,
+      verified: r.verified,
+      createdAt: r.createdAt.toISOString().slice(0, 10),
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Foundation night for the Leafjourney marketplace (EMR-231, child of EMR-17). Replaces the in-memory `src/lib/marketplace/data.ts` mock with a Prisma-backed read layer and adds patient-scoped persistent cart. Unblocks EMR-225 (take rate), EMR-230 (outcome ranking), and EMR-53 (AI recommendations).

## What's in this PR

- **Schema:** new `Cart` (unique per Patient) + `CartItem` (unique by cart/product/variant) with back-refs on `Product` / `ProductVariant`. Migration `prisma/migrations/20260423042500_add_persistent_cart/`.
- **Seed:** `prisma/seed.ts` now upserts 16 categories + 12 products (variants, reviews, category joins) via a new `seedMarketplace(orgId)` helper. Idempotent cleanup added to `cleanIdempotent()`.
- **Query layer:** `src/lib/marketplace/queries.ts` — async Prisma-backed mirror of `data.ts` signatures, org-scoped via `getCurrentUser()`.
- **Route swap:** the 4 portal-shop routes import from `queries` instead of `data`. Category page drops bespoke `COLLECTION_FILTERS` — collection slugs are seeded as `MarketplaceCategory` rows, so a single join query handles them.
- **Cart persistence:** server actions in `src/app/(patient)/portal/shop/cart/actions.ts` (`getServerCart`, `setCartItemQuantity`, `removeCartItem`, `clearServerCart`). `CartProvider` hydrates from server on mount, pushes localStorage into DB if server cart is empty, and fire-and-forgets every subsequent mutation. Non-patient sessions fall back to localStorage-only.

## Out of scope (deliberately)

- Payabli end-to-end checkout wiring (schema + gateway exist; hookup is a separate ticket)
- Product / vendor admin UI — belongs to EMR-225 vendor-portal scope
- Outcome-weighted ranking — EMR-230 (coming in follow-up commit on this branch)

## Test plan

- [x] `npm test` — 283/283 passing
- [x] `npm run typecheck` — clean
- [ ] Run `npm run db:migrate` in staging and verify the new migration applies cleanly
- [ ] Run `npm run db:seed` and verify 16 categories + 12 products land in DB
- [ ] Load `/portal/shop` as an authenticated patient — featured + clinician-pick grids render from DB
- [ ] Add items to cart; reload page; items persist
- [ ] Sign out, browse as clinician — cart falls back to localStorage silently (no 500)
- [ ] `/portal/shop/category/clinician-picks` renders (collection slug via DB, not COLLECTION_FILTERS)

## Deploy

```bash
npm run db:migrate   # applies add_persistent_cart
npm run db:seed      # idempotent
```

## Branch name

Kept as `claude/review-recent-changes-KaBlz` per harness instruction even though it doesn't match the scope. Cherry-pick to a cleaner branch before landing if desired.

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_