### PR TITLE
Add Linear integration: client, API route, docs, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,8 @@ OPENAI_API_KEY=
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
 STORAGE_BUCKET=documents
+
+# ---- Linear integration ----
+# Personal API key from Linear (Settings -> API -> Personal API keys).
+# Used by internal tooling to fetch issue specs + pinned briefing comments.
+LINEAR_API_KEY=

--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Direct pushes to `main` are blocked by a branch-protection ruleset. All changes 
 If CI fails, fix it on the branch — don't bypass the check. The rules that protect `main` also protect future-you from debugging a silent production outage at 3 AM.
 
 
+## Linear integration (tickets + pinned brief retrieval)
+
+Set `LINEAR_API_KEY` in `.env` (Personal API key from Linear).
+
+Then query the internal API endpoint:
+
+```bash
+curl http://localhost:3000/api/integrations/linear/issues/EMR-17
+```
+
+Response includes the issue payload and a `codexAgentBrief` field when a comment body contains 'Codex Agent Brief'. The endpoint is restricted to authenticated internal roles (`operator`, `practice_owner`, `system`).
+
 ## Security posture
 
 - RBAC enforced in layouts **and** every server action

--- a/src/app/api/integrations/linear/issues/[identifier]/route.ts
+++ b/src/app/api/integrations/linear/issues/[identifier]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+
+import { requireUser } from "@/lib/auth/session";
+import { findCodexAgentBriefComment, getLinearIssue } from "@/lib/integrations/linear";
+
+interface RouteContext {
+  params: { identifier: string };
+}
+
+function toHttpError(error: unknown): { status: number; message: string } {
+  if (error instanceof Error) {
+    if (error.message === "UNAUTHORIZED") {
+      return { status: 401, message: "unauthorized" };
+    }
+    if (error.message === "FORBIDDEN") {
+      return { status: 403, message: "forbidden" };
+    }
+    return { status: 500, message: error.message };
+  }
+
+  return { status: 500, message: "Linear integration error" };
+}
+
+async function requireLinearIntegrationAccess() {
+  const user = await requireUser();
+  const canAccess = user.roles.some((role) =>
+    role === "operator" || role === "practice_owner" || role === "system",
+  );
+
+  if (!canAccess) {
+    throw new Error("FORBIDDEN");
+  }
+}
+
+export async function GET(_req: Request, { params }: RouteContext) {
+  try {
+    await requireLinearIntegrationAccess();
+
+    const issue = await getLinearIssue(params.identifier);
+
+    if (!issue) {
+      return NextResponse.json(
+        { ok: false, error: `Issue ${params.identifier} not found` },
+        { status: 404 },
+      );
+    }
+
+    const codexAgentBrief = findCodexAgentBriefComment(issue);
+
+    return NextResponse.json({
+      ok: true,
+      issue,
+      codexAgentBrief,
+    });
+  } catch (error) {
+    const { status, message } = toHttpError(error);
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/src/lib/integrations/linear.test.ts
+++ b/src/lib/integrations/linear.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { findCodexAgentBriefComment, type LinearIssue } from "./linear";
+
+function makeIssue(comments: Array<{ id: string; body: string }>): LinearIssue {
+  return {
+    id: "issue-1",
+    identifier: "EMR-17",
+    title: "Codex setup",
+    description: null,
+    url: "https://linear.app/leafjourney/issue/EMR-17",
+    state: null,
+    project: null,
+    comments: {
+      nodes: comments.map((comment) => ({
+        ...comment,
+        createdAt: "2026-04-23T00:00:00.000Z",
+        user: null,
+      })),
+    },
+  };
+}
+
+describe("findCodexAgentBriefComment", () => {
+  it("returns the pinned brief comment when text is present", () => {
+    const issue = makeIssue([
+      { id: "c1", body: "General planning notes" },
+      { id: "c2", body: "Codex Agent Brief: full implementation spec here." },
+    ]);
+
+    const result = findCodexAgentBriefComment(issue);
+
+    expect(result?.id).toBe("c2");
+  });
+
+  it("supports markdown heading-only variants", () => {
+    const issue = makeIssue([
+      { id: "c1", body: "# Agent Brief\nMarketplace implementation details." },
+    ]);
+
+    const result = findCodexAgentBriefComment(issue);
+
+    expect(result?.id).toBe("c1");
+  });
+
+  it("returns null when no matching comment exists", () => {
+    const issue = makeIssue([{ id: "c1", body: "No brief in this thread." }]);
+
+    const result = findCodexAgentBriefComment(issue);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/integrations/linear.ts
+++ b/src/lib/integrations/linear.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+
+const LINEAR_API_URL = "https://api.linear.app/graphql";
+
+const linearCommentSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  createdAt: z.string(),
+  user: z.object({
+    id: z.string(),
+    name: z.string().nullable().optional(),
+  }).nullable().optional(),
+});
+
+const linearIssueSchema = z.object({
+  id: z.string(),
+  identifier: z.string(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  url: z.string().optional(),
+  state: z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string(),
+  }).nullable().optional(),
+  project: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).nullable().optional(),
+  comments: z.object({
+    nodes: z.array(linearCommentSchema),
+  }).optional(),
+});
+
+const linearIssueResponseSchema = z.object({
+  issue: linearIssueSchema.nullable(),
+});
+
+export type LinearIssue = z.infer<typeof linearIssueSchema>;
+export type LinearComment = z.infer<typeof linearCommentSchema>;
+
+interface LinearGraphQLError {
+  message: string;
+}
+
+interface LinearGraphQLResponse<T> {
+  data?: T;
+  errors?: LinearGraphQLError[];
+}
+
+function getLinearApiKey(): string {
+  const apiKey = process.env.LINEAR_API_KEY;
+  if (!apiKey) {
+    throw new Error("LINEAR_API_KEY is not configured");
+  }
+  return apiKey;
+}
+
+async function linearGraphQL<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const apiKey = getLinearApiKey();
+
+  const response = await fetch(LINEAR_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ query, variables }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear API request failed (${response.status})`);
+  }
+
+  const json = (await response.json()) as LinearGraphQLResponse<T>;
+
+  if (json.errors?.length) {
+    throw new Error(`Linear API error: ${json.errors.map((e) => e.message).join("; ")}`);
+  }
+
+  if (!json.data) {
+    throw new Error("Linear API returned no data");
+  }
+
+  return json.data;
+}
+
+const ISSUE_BY_IDENTIFIER_QUERY = `
+  query IssueByIdentifier($identifier: String!) {
+    issue(id: $identifier) {
+      id
+      identifier
+      title
+      description
+      url
+      state {
+        id
+        name
+        type
+      }
+      project {
+        id
+        name
+      }
+      comments(first: 100) {
+        nodes {
+          id
+          body
+          createdAt
+          user {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function getLinearIssue(identifier: string): Promise<LinearIssue | null> {
+  const data = await linearGraphQL<unknown>(ISSUE_BY_IDENTIFIER_QUERY, { identifier });
+  const parsed = linearIssueResponseSchema.parse(data);
+  return parsed.issue;
+}
+
+export function findCodexAgentBriefComment(issue: LinearIssue): LinearComment | null {
+  const comments = issue.comments?.nodes ?? [];
+  const match = comments.find((comment) => {
+    const body = comment.body.trim();
+    return /codex\s+agent\s+brief/i.test(body) || /^#\s*agent\s+brief/im.test(body);
+  });
+
+  return match ?? null;
+}


### PR DESCRIPTION
### Motivation

- Add a Linear integration to fetch issue payloads and extract a pinned "Codex Agent Brief" comment for internal tooling. 
- Restrict the new endpoint to internal roles so only operators and owners can fetch issue briefs. 
- Surface configuration and usage details in the repository docs and `.env.example` so local/dev environments can be wired with a `LINEAR_API_KEY`.

### Description

- Introduce a GraphQL client in `src/lib/integrations/linear.ts` that queries the Linear API and exposes `getLinearIssue` and `findCodexAgentBriefComment` functions. 
- Add a server API route at `src/app/api/integrations/linear/issues/[identifier]/route.ts` that enforces role checks and returns `{ issue, codexAgentBrief }` for the requested identifier. 
- Add unit tests in `src/lib/integrations/linear.test.ts` covering the `findCodexAgentBriefComment` behavior including heading-only markdown variants. 
- Update `.env.example` with `LINEAR_API_KEY` and extend `README.md` with usage instructions and a `curl` example for the new endpoint.

### Testing

- Ran the new unit tests with `vitest` for `src/lib/integrations/linear.test.ts`, which exercise `findCodexAgentBriefComment`, and they passed. 
- The added code includes Zod schemas used at runtime to validate GraphQL responses and will raise clear errors when `LINEAR_API_KEY` is not configured. 
- The new endpoint behavior is covered by the tests indirectly via the comment extraction logic used by the API route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea278a631883238058b24d1b41468a)