### PR TITLE
feat(marketplace): Recommended-for-You patient surface + CannabisProduct FK (EMR-268)

### DIFF
--- a/prisma/migrations/20260423170000_add_cannabis_product_marketplace_fk/migration.sql
+++ b/prisma/migrations/20260423170000_add_cannabis_product_marketplace_fk/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "CannabisProduct" ADD COLUMN "marketplaceProductId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "CannabisProduct_marketplaceProductId_idx" ON "CannabisProduct"("marketplaceProductId");
+
+-- AddForeignKey
+ALTER TABLE "CannabisProduct" ADD CONSTRAINT "CannabisProduct_marketplaceProductId_fkey" FOREIGN KEY ("marketplaceProductId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1404,32 +1404,37 @@ enum DeliveryRoute {
 }
 
 model CannabisProduct {
-  id                String        @id @default(cuid())
-  organizationId    String
-  name              String // e.g. "THC Infused Oil 10mg/mL"
-  brand             String? // e.g. "Green Path Organics"
-  productType       ProductType
-  route             DeliveryRoute
+  id                   String        @id @default(cuid())
+  organizationId       String
+  name                 String // e.g. "THC Infused Oil 10mg/mL"
+  brand                String? // e.g. "Green Path Organics"
+  productType          ProductType
+  route                DeliveryRoute
   // Cannabinoid concentrations (mg per mL, mg per unit, or % for flower)
-  thcConcentration  Float? // mg/mL for liquids, mg/unit for capsules, % for flower
-  cbdConcentration  Float?
-  cbnConcentration  Float?
-  cbgConcentration  Float?
-  thcCbdRatio       String? // e.g. "1:1", "20:1", "1:20"
+  thcConcentration     Float? // mg/mL for liquids, mg/unit for capsules, % for flower
+  cbdConcentration     Float?
+  cbnConcentration     Float?
+  cbgConcentration     Float?
+  thcCbdRatio          String? // e.g. "1:1", "20:1", "1:20"
   // Terpene profile (optional, structured)
-  terpeneProfile    Json? // { myrcene: 0.5, limonene: 0.3, ... } in %
+  terpeneProfile       Json? // { myrcene: 0.5, limonene: 0.3, ... } in %
   // Units
-  concentrationUnit String        @default("mg/mL") // "mg/mL", "mg/unit", "%", "mg/g"
-  unitSize          Float? // mL per bottle, units per pack, grams per container
+  concentrationUnit    String        @default("mg/mL") // "mg/mL", "mg/unit", "%", "mg/g"
+  unitSize             Float? // mL per bottle, units per pack, grams per container
+  // Link to the marketplace listing. Null when no storefront product exists yet;
+  // authoritative when set (supersedes the name-match bridge in ranking.ts).
+  marketplaceProductId String?
   // Metadata
-  description       String?
-  active            Boolean       @default(true)
-  createdAt         DateTime      @default(now())
+  description          String?
+  active               Boolean       @default(true)
+  createdAt            DateTime      @default(now())
 
-  organization Organization    @relation(fields: [organizationId], references: [id])
-  regimens     DosingRegimen[]
+  organization       Organization    @relation(fields: [organizationId], references: [id])
+  regimens           DosingRegimen[]
+  marketplaceProduct Product?        @relation("CannabisProductMarketplace", fields: [marketplaceProductId], references: [id], onDelete: SetNull)
 
   @@index([organizationId, active])
+  @@index([marketplaceProductId])
 }
 
 model DosingRegimen {
@@ -1640,6 +1645,7 @@ model Product {
   orderItems       OrderItem[]
   cartItems        CartItem[]
   categoryMappings ProductCategory[]
+  cannabisProducts CannabisProduct[] @relation("CannabisProductMarketplace")
 
   @@index([organizationId, status])
   @@index([clinicianPick])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -261,8 +261,73 @@ async function seedMarketplace(organizationId: string) {
     }
   }
 
+  // ── Bridge: CannabisProduct → marketplace Product (EMR-268) ───────
+  // Authoritative FK when set; ranking engine prefers it over the
+  // name-match fallback. Two-phase backfill:
+  //   1. Generic: normalized-name + optional-brand match. Production
+  //      vendor onboarding is what actually populates this in real use.
+  //   2. Demo overrides: hardcoded pairs for the 3 clinical products the
+  //      seed creates for Maya / James / Sarah. Names don't overlap with
+  //      branded marketplace listings, so the generic pass matches 0
+  //      rows — without these overrides the demo "Recommended for You"
+  //      section can't show product-efficacy boosts.
+  const marketplaceByKey = new Map<string, string>(); // normalized "name|brand" → productId
+  const marketplaceByName = new Map<string, string>(); // normalized "name" → productId (ambiguity last-write-wins)
+  {
+    const rows = await prisma.product.findMany({
+      where: { organizationId, deletedAt: null },
+      select: { id: true, name: true, brand: true },
+    });
+    for (const r of rows) {
+      const k = `${r.name.trim().toLowerCase()}|${r.brand.trim().toLowerCase()}`;
+      marketplaceByKey.set(k, r.id);
+      marketplaceByName.set(r.name.trim().toLowerCase(), r.id);
+    }
+  }
+
+  const clinicalRows = await prisma.cannabisProduct.findMany({
+    where: { organizationId, marketplaceProductId: null },
+    select: { id: true, name: true, brand: true },
+  });
+
+  let bridged = 0;
+  for (const c of clinicalRows) {
+    const keyed = marketplaceByKey.get(
+      `${c.name.trim().toLowerCase()}|${(c.brand ?? "").trim().toLowerCase()}`,
+    );
+    const named = keyed ?? marketplaceByName.get(c.name.trim().toLowerCase());
+    if (!named) continue;
+    await prisma.cannabisProduct.update({
+      where: { id: c.id },
+      data: { marketplaceProductId: named },
+    });
+    bridged++;
+  }
+
+  // Demo overrides — map clinical seed products to their closest marketplace
+  // twin by clinical intent. Matched on CannabisProduct.name (seeded by this
+  // repo's seed.ts) and product slug (seeded by seedMarketplace above).
+  const DEMO_BRIDGES: Record<string, string> = {
+    "Balanced THC:CBD Tincture": "solace-calm-drops",
+    "CBD Isolate Capsules 25mg": "canopy-clinical-balance-capsules",
+    "High-CBD Sleep Tincture": "solace-nightfall-tincture",
+    "Night Capsule 10:5 THC:CBN": "botanica-rest-gummies",
+  };
+  for (const [cannabisName, marketplaceSlug] of Object.entries(DEMO_BRIDGES)) {
+    const target = await prisma.product.findUnique({
+      where: { slug: marketplaceSlug },
+      select: { id: true },
+    });
+    if (!target) continue;
+    const updated = await prisma.cannabisProduct.updateMany({
+      where: { organizationId, name: cannabisName, marketplaceProductId: null },
+      data: { marketplaceProductId: target.id },
+    });
+    bridged += updated.count;
+  }
+
   console.log(
-    `  Marketplace: ${CATEGORIES.length} categories, ${PRODUCTS.length} products seeded.`,
+    `  Marketplace: ${CATEGORIES.length} categories, ${PRODUCTS.length} products seeded. Bridged ${bridged} CannabisProduct → Product.`,
   );
 }
 

--- a/src/app/(patient)/portal/shop/page.tsx
+++ b/src/app/(patient)/portal/shop/page.tsx
@@ -5,11 +5,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ProductGrid } from "@/components/marketplace/ProductGrid";
 import { TrustStrip } from "@/components/marketplace/TrustStrip";
 import { SearchBar } from "@/components/marketplace/SearchBar";
+import { RecommendedForYou } from "@/components/marketplace/RecommendedForYou";
 import {
   getFeaturedProducts,
   getClinicianPicks,
   getCategories,
 } from "@/lib/marketplace/queries";
+import { getCurrentUser } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Shop" };
@@ -23,8 +25,9 @@ const QUICK_BROWSE = [
 ] as const;
 
 export default async function ShopPage() {
-  const [featured, clinicianPicks, symptomCategories, goalCategories] =
+  const [user, featured, clinicianPicks, symptomCategories, goalCategories] =
     await Promise.all([
+      getCurrentUser(),
       getFeaturedProducts(),
       getClinicianPicks(),
       getCategories("symptom"),
@@ -61,6 +64,14 @@ export default async function ShopPage() {
 
       {/* ── Trust strip ───────────────────────────────────────────────── */}
       <TrustStrip className="rounded-lg mb-12" />
+
+      {/* ── Recommended for You (EMR-230 moat) ────────────────────────── */}
+      {user?.organizationId && (
+        <RecommendedForYou
+          userId={user.id}
+          organizationId={user.organizationId}
+        />
+      )}
 
       {/* ── Featured ──────────────────────────────────────────────────── */}
       <section className="mb-14">

--- a/src/components/marketplace/RecommendedForYou.tsx
+++ b/src/components/marketplace/RecommendedForYou.tsx
@@ -1,0 +1,78 @@
+import { prisma } from "@/lib/db/prisma";
+import { rankProductsForPatient } from "@/lib/marketplace/ranking";
+import { ProductCard } from "@/components/marketplace/ProductCard";
+
+interface RecommendedForYouProps {
+  userId: string;
+  organizationId: string;
+  limit?: number;
+}
+
+/**
+ * Server component. Renders per-patient marketplace recommendations backed by
+ * the EMR-230 ranking engine. Silent no-op if the authenticated user isn't a
+ * patient (e.g. clinician browsing the portal) or if the engine returns no
+ * positive-score products.
+ *
+ * Each card carries the top `reason` from the ranking so the patient
+ * understands *why* this product surfaced — the moat's whole point.
+ */
+export async function RecommendedForYou({
+  userId,
+  organizationId,
+  limit = 4,
+}: RecommendedForYouProps) {
+  const patient = await prisma.patient.findFirst({
+    where: { userId, organizationId },
+    select: { id: true },
+  });
+  if (!patient) return null;
+
+  const ranked = await rankProductsForPatient(patient.id, { limit });
+
+  if (ranked.length === 0) {
+    return (
+      <section className="mb-14">
+        <h2 className="text-xl font-semibold tracking-tight text-text">
+          Recommended for You
+        </h2>
+        <p className="mt-1 mb-6 text-sm text-text-muted">
+          We&apos;ll tailor this once you log a few outcomes.
+        </p>
+        <div className="rounded-lg border border-dashed border-border bg-surface-muted px-6 py-8 text-center">
+          <p className="text-sm text-text-muted">
+            Start logging how you feel after each dose — the more data, the
+            smarter these suggestions get.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-14">
+      <h2 className="text-xl font-semibold tracking-tight text-text">
+        Recommended for You
+      </h2>
+      <p className="mt-1 mb-6 text-sm text-text-muted">
+        Based on your recent outcomes, regimens, and goals.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {ranked.map((r) => (
+          <div key={r.product.id} className="flex flex-col gap-2">
+            <ProductCard product={r.product} />
+            {r.reasons[0] && (
+              <p className="text-xs text-text-muted px-1 line-clamp-2">
+                <span className="text-accent" aria-hidden="true">
+                  ✦{" "}
+                </span>
+                {r.reasons[0]}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/marketplace/ranking.test.ts
+++ b/src/lib/marketplace/ranking.test.ts
@@ -228,7 +228,11 @@ describe("rankProductsForPatient", () => {
       {
         startDate: new Date("2026-03-01T00:00:00Z"),
         endDate: new Date("2026-03-25T00:00:00Z"),
-        product: { name: "Relief Oil", brand: "Demo Brand" },
+        product: {
+          name: "Relief Oil",
+          brand: "Demo Brand",
+          marketplaceProductId: null, // forces fallback to name-match
+        },
       },
     ]);
     hoisted.mockPrisma.orderItem.findMany.mockResolvedValue([]);
@@ -264,6 +268,62 @@ describe("rankProductsForPatient", () => {
     expect(r.score).toBe(expected);
     expect(r.reasons.some((s) => s.includes("pain 8→3"))).toBe(true);
     expect(r.reasons.some((s) => s.includes("clinician pick"))).toBe(true);
+  });
+
+  it("bridges efficacy via marketplaceProductId FK even when names differ (EMR-268)", async () => {
+    hoisted.mockPrisma.patient.findUnique.mockResolvedValue({
+      id: "pat_1",
+      organizationId: "org_1",
+    });
+    hoisted.mockPrisma.outcomeLog.findMany.mockImplementation(
+      async (args: { where?: { loggedAt?: unknown } }) => {
+        if (args?.where?.loggedAt) {
+          return []; // no recent outcomes → no condition match
+        }
+        return [
+          {
+            metric: "pain",
+            value: 8,
+            loggedAt: new Date("2026-03-01T00:00:00Z"),
+          },
+          {
+            metric: "pain",
+            value: 3,
+            loggedAt: new Date("2026-03-20T00:00:00Z"),
+          },
+        ];
+      },
+    );
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([]);
+    hoisted.mockPrisma.orderItem.findMany.mockResolvedValue([]);
+    // Clinical product has a totally different name from the marketplace
+    // product, but the FK ties them together — the ranking engine should
+    // still award the efficacy boost.
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      {
+        startDate: new Date("2026-03-01T00:00:00Z"),
+        endDate: new Date("2026-03-25T00:00:00Z"),
+        product: {
+          name: "Clinical THC Oil 10mg/mL", // doesn't match marketplace name
+          brand: null,
+          marketplaceProductId: "mkt-a", // but the FK does
+        },
+      },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({
+        id: "mkt-a",
+        slug: "calm-drops",
+        name: "Calm & Clarity Drops",
+        brand: "Solace Botanicals",
+      }),
+    ]);
+
+    const result = await rankProductsForPatient("pat_1");
+    expect(result).toHaveLength(1);
+    expect(result[0].product.id).toBe("mkt-a");
+    expect(result[0].score).toBe(WEIGHT_PRODUCT_EFFICACY);
+    expect(result[0].reasons.some((s) => s.includes("pain 8→3"))).toBe(true);
   });
 
   it("awards beginner safety only when patient has no prior regimens", async () => {

--- a/src/lib/marketplace/ranking.ts
+++ b/src/lib/marketplace/ranking.ts
@@ -5,11 +5,11 @@
 // an ML black box. Each returned ranking carries a `reasons[]` explaining why
 // the product was boosted, so clinicians and patients can trust it.
 //
-// The Prisma schema currently does NOT FK the marketplace `Product` to the
-// clinical `CannabisProduct` — regimens reference `CannabisProduct` only.
-// Until that bridge exists, we best-effort match by lowercased+trimmed name
-// (and brand when available). If no bridge, product-specific outcome signal
-// is skipped and we fall back to condition-match only.
+// Clinical ↔ marketplace bridge: `CannabisProduct.marketplaceProductId`
+// (EMR-268) is the authoritative link when set. When null, we fall back to a
+// normalized name (+ brand) match. The fallback exists only until the seed +
+// vendor onboarding backfills every CannabisProduct with its marketplace
+// twin; remove once null-rate on that column is effectively zero.
 
 import { prisma } from "@/lib/db/prisma";
 import { ProductStatus, type OutcomeMetric } from "@prisma/client";
@@ -118,7 +118,8 @@ function collectConditionSignals(
 // return the product identifier (normalized name[+brand]) if the patient
 // improved by ≥REGIMEN_IMPROVEMENT_POINTS on any tracked metric.
 interface EfficacySignal {
-  key: string; // normalized name
+  marketplaceProductId: string | null; // authoritative link when non-null
+  key: string; // normalized name (fallback bridge)
   brand: string; // normalized brand ("" if none)
   metric: OutcomeMetric;
   before: number;
@@ -129,7 +130,11 @@ function computeEfficacySignals(
   regimens: {
     startDate: Date;
     endDate: Date | null;
-    product: { name: string; brand: string | null };
+    product: {
+      name: string;
+      brand: string | null;
+      marketplaceProductId: string | null;
+    };
   }[],
   allLogs: { metric: OutcomeMetric; value: number; loggedAt: Date }[],
 ): EfficacySignal[] {
@@ -161,6 +166,7 @@ function computeEfficacySignals(
         spec.direction === "high-bad" ? first - last : last - first;
       if (improvement >= REGIMEN_IMPROVEMENT_POINTS) {
         out.push({
+          marketplaceProductId: r.product.marketplaceProductId,
           key: normalizeName(r.product.name),
           brand: normalizeName(r.product.brand),
           metric,
@@ -233,7 +239,13 @@ export async function rankProductsForPatient(
       select: {
         startDate: true,
         endDate: true,
-        product: { select: { name: true, brand: true } },
+        product: {
+          select: {
+            name: true,
+            brand: true,
+            marketplaceProductId: true,
+          },
+        },
       },
     }),
     prisma.orderItem.findMany({
@@ -269,15 +281,22 @@ export async function rankProductsForPatient(
     }
     score += conditionScore;
 
-    // 2. Product efficacy — exact bridge match by normalized name (brand too
-    // when both sides expose it).
+    // 2. Product efficacy — prefer the authoritative FK; fall back to
+    // normalized name+brand match while the backfill is rolling out.
     const rowKey = normalizeName(row.name);
     const rowBrand = normalizeName(row.brand);
     for (const eff of efficacy) {
-      const nameMatch = eff.key && eff.key === rowKey;
-      // Brand match is required only when both sides have a brand.
-      const brandMatch = !eff.brand || !rowBrand || eff.brand === rowBrand;
-      if (nameMatch && brandMatch) {
+      const fkMatch =
+        eff.marketplaceProductId != null &&
+        eff.marketplaceProductId === row.id;
+      let nameMatch = false;
+      if (!fkMatch && eff.marketplaceProductId == null) {
+        const nameEq = eff.key && eff.key === rowKey;
+        // Brand match is required only when both sides have a brand.
+        const brandEq = !eff.brand || !rowBrand || eff.brand === rowBrand;
+        nameMatch = Boolean(nameEq && brandEq);
+      }
+      if (fkMatch || nameMatch) {
         score += WEIGHT_PRODUCT_EFFICACY;
         reasons.push(
           `similar to regimen that improved ${eff.metric} ${eff.before}→${eff.after}`,


### PR DESCRIPTION
## Summary

Exposes the EMR-230 ranking engine to patients on `/portal/shop` and replaces the name-match bridge with a proper `CannabisProduct → Product` FK.

Closes gap flagged in PR #75: the ranking engine was shipped but no route rendered its output. Now an authenticated patient landing on `/portal/shop` sees a "Recommended for You" section with the top 4 picks and a per-card rationale explaining *why* each product surfaced.

Linear: **EMR-268** (child of EMR-17, relates to EMR-230 + EMR-53)

## What's in this PR

### Schema (`20260423170000_add_cannabis_product_marketplace_fk`)
- `CannabisProduct.marketplaceProductId String?` — nullable FK to `Product.id`, `ON DELETE SET NULL`
- Index on the new column
- Back-ref `Product.cannabisProducts` via relation name `"CannabisProductMarketplace"`

### Seed (two-phase bridge backfill)
- **Generic pass:** normalized name + optional brand match for any `CannabisProduct` with a null FK
- **Demo overrides:** 4 hardcoded CannabisProduct-name → marketplace-slug pairs so the demo DB has real product-efficacy signals for Maya/James/Sarah's regimens (their clinical product names don't match branded marketplace listings organically)
- Logs the total bridged count on each seed run

### Ranking engine (`src/lib/marketplace/ranking.ts`)
- `computeEfficacySignals` now carries `marketplaceProductId` through from the regimen query to the signal
- Scoring loop prefers the authoritative FK; falls back to name+brand match only when FK is null. Backfill can roll out gradually without regressing existing recommendations.

### UI (`src/components/marketplace/RecommendedForYou.tsx`)
- New async server component. Resolves the current user's patient row, calls `rankProductsForPatient`, renders a 4-column `ProductCard` grid with the top `reason` as a small accent caption per card.
- Empty state: "We'll tailor this once you log a few outcomes."
- Silent no-op for non-patient sessions (clinicians browsing the portal see nothing — no 500)
- Rendered in `/portal/shop/page.tsx` above "Featured"

### Tests
- **New:** `bridges efficacy via marketplaceProductId FK even when names differ (EMR-268)` — clinical product name `"Clinical THC Oil 10mg/mL"` with `marketplaceProductId: "mkt-a"` → marketplace product `"Calm & Clarity Drops"`. FK wins, efficacy boost awarded despite the name gap.
- Existing composed-scenario test updated to pass `marketplaceProductId: null` to exercise the fallback path.
- **299/299 tests pass. `npm run typecheck` clean.**

## Test plan

- [x] `npm test` passes (22 files, 299 tests)
- [x] `npm run typecheck` clean
- [ ] Run `npm run db:migrate` in staging
- [ ] Run `npm run db:seed` and verify bridged count ≥ 4 (demo overrides) in the log
- [ ] As authenticated patient Maya (who has a 30-day regimen): load `/portal/shop` — see "Recommended for You" with product-efficacy reason text mentioning her outcome improvement
- [ ] As a brand-new patient with no outcomes: see the empty-state copy
- [ ] As a clinician (no patient row): section doesn't render

## Out of scope (deliberately)

- Public `/store` recommendations — ranking engine is patient-scoped by design
- Anything in Lucca's payment lane (EMR-232–236) or Codex's (EMR-237–239, 243–245)
- Vendor-onboarding flow that sets `marketplaceProductId` in production — the generic backfill is the current mechanism, `marketplaceProductId` will be set manually by vendor-portal admin once that ships

## Deploy

```bash
npm run db:migrate   # applies add_cannabis_product_marketplace_fk
npm run db:seed      # idempotent; populates the FK for demo data
```

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_