### PR TITLE
feat(agents): research & insights fleet (10 agents + cohortBuilder POC, EMR-269)

### DIFF
--- a/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
@@ -29,7 +29,7 @@ const DEFAULT_MODEL_ID = getDefaultConfig().modelId;
 type FleetState = Record<string, { enabled: boolean; modelId: string | null }>;
 
 const TIER_ORDER: ModelTier[] = ["budget", "balanced", "premium", "open-source"];
-const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations", "commerce"];
+const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations", "commerce", "research"];
 
 const TIER_SWATCH: Record<ModelTier, string> = {
   "budget": "bg-emerald-500",
@@ -45,6 +45,7 @@ const CATEGORY_EMOJI: Record<AgentCategory, string> = {
   billing: "💳",
   operations: "⚙️",
   commerce: "🛒",
+  research: "🔬",
 };
 
 export function AgentFleetPanel() {
@@ -225,6 +226,8 @@ export function AgentFleetPanel() {
                   ? "Supporting staff — budget models are usually enough."
                   : category === "commerce"
                   ? "Marketplace fleet. Compliance + fraud benefit from premium models; catalog hygiene is fine on budget."
+                  : category === "research"
+                  ? "Research + insights fleet. RWE and protocol recommendations benefit from premium models; cohort math is fine on budget."
                   : "Core clinical agents that shape the physician's daily workflow."}
               </CardDescription>
             </CardHeader>

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -82,6 +82,17 @@ import { cannabisComplianceGateAgent } from "./commerce/cannabis-compliance-gate
 import { cannabisTaxCalculatorAgent } from "./commerce/cannabis-tax-calculator-agent";
 import { shippingRouterAgent } from "./commerce/shipping-router-agent";
 import { vendorPerformanceScorerAgent } from "./commerce/vendor-performance-scorer-agent";
+// Research & Insights Fleet — EMR-269 (10 agents, 2026-04-23)
+import { cohortBuilderAgent } from "./research/cohort-builder-agent";
+import { efficacyComparatorAgent } from "./research/efficacy-comparator-agent";
+import { outcomeDigesterAgent } from "./research/outcome-digester-agent";
+import { rweBundlerAgent } from "./research/rwe-bundler-agent";
+import { deidentifierAgent } from "./research/deidentifier-agent";
+import { adverseEventScannerAgent } from "./research/adverse-event-scanner-agent";
+import { protocolRecommenderAgent } from "./research/protocol-recommender-agent";
+import { insuranceEvidenceBundlerAgent } from "./research/insurance-evidence-bundler-agent";
+import { publicationReadinessScorerAgent } from "./research/publication-readiness-scorer-agent";
+import { researchPartnerMatcherAgent } from "./research/research-partner-matcher-agent";
 
 /**
  * Registry of all agents. Adding an agent = new file + one line here +
@@ -173,6 +184,17 @@ export const agentRegistry = {
   cannabisTaxCalculator: cannabisTaxCalculatorAgent,
   shippingRouter: shippingRouterAgent,
   vendorPerformanceScorer: vendorPerformanceScorerAgent,
+  // Research & Insights Fleet — EMR-269 (10 agents, 2026-04-23)
+  cohortBuilder: cohortBuilderAgent,
+  efficacyComparator: efficacyComparatorAgent,
+  outcomeDigester: outcomeDigesterAgent,
+  rweBundler: rweBundlerAgent,
+  deidentifier: deidentifierAgent,
+  adverseEventScanner: adverseEventScannerAgent,
+  protocolRecommender: protocolRecommenderAgent,
+  insuranceEvidenceBundler: insuranceEvidenceBundlerAgent,
+  publicationReadinessScorer: publicationReadinessScorerAgent,
+  researchPartnerMatcher: researchPartnerMatcherAgent,
 } satisfies Record<string, Agent<any, any>>;
 
 /** Agents tagged as "commerce" — used by the marketplace ops console. */
@@ -197,6 +219,20 @@ export const COMMERCE_AGENT_NAMES: AgentName[] = [
   "cannabisTaxCalculator",
   "shippingRouter",
   "vendorPerformanceScorer",
+];
+
+/** Agents tagged as "research" — used by the research portal + insights console. */
+export const RESEARCH_AGENT_NAMES: AgentName[] = [
+  "cohortBuilder",
+  "efficacyComparator",
+  "outcomeDigester",
+  "rweBundler",
+  "deidentifier",
+  "adverseEventScanner",
+  "protocolRecommender",
+  "insuranceEvidenceBundler",
+  "publicationReadinessScorer",
+  "researchPartnerMatcher",
 ];
 
 export type AgentName = keyof typeof agentRegistry;

--- a/src/lib/agents/research/adverse-event-scanner-agent.ts
+++ b/src/lib/agents/research/adverse-event-scanner-agent.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  productId: z.string().optional(),
+  cohortPatientIds: z.array(z.string()).optional(),
+  windowDays: z.number().int().positive().max(365),
+});
+
+const output = z.object({
+  windowDays: z.number(),
+  cohortSize: z.number(),
+  flags: z.array(
+    z.object({
+      severity: z.enum(["info", "notable", "concern", "urgent"]),
+      pattern: z.string(),
+      affectedPatientIds: z.array(z.string()),
+      firstObservedAt: z.string().nullable(),
+    }),
+  ),
+});
+
+/**
+ * Adverse Event Scanner Agent
+ * ---------------------------
+ * Sweeps `ClinicalObservation` rows tagged `side_effect` or `red_flag`
+ * across a cohort or product and flags unusual clustering (e.g. same
+ * side effect reported by >5% of a cohort within 14 days).
+ *
+ * Status: stub (EMR-269 / Research fleet). Empty flag list today; real
+ * heuristic clustering is TODO.
+ */
+export const adverseEventScannerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "adverseEventScanner",
+  version: "0.1.0",
+  description: "Flags unusual adverse-event clusters across a cohort or product.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ windowDays, cohortPatientIds }, ctx) {
+    ctx.log("info", "adverseEventScanner stub", {
+      windowDays,
+      cohortSize: cohortPatientIds?.length ?? 0,
+    });
+    return {
+      windowDays,
+      cohortSize: cohortPatientIds?.length ?? 0,
+      flags: [],
+    };
+  },
+};

--- a/src/lib/agents/research/cohort-builder-agent.test.ts
+++ b/src/lib/agents/research/cohort-builder-agent.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findMany: vi.fn() },
+    outcomeLog: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import { cohortBuilderAgent } from "./cohort-builder-agent";
+
+// Minimal AgentContext shim — the agent only calls ctx.log, so a spy suffices.
+const makeCtx = () =>
+  ({
+    log: vi.fn(),
+  }) as unknown as Parameters<typeof cohortBuilderAgent.run>[1];
+
+function reset() {
+  hoisted.mockPrisma.patient.findMany.mockReset();
+  hoisted.mockPrisma.outcomeLog.findMany.mockReset();
+}
+beforeEach(reset);
+
+describe("cohortBuilder", () => {
+  it("returns an empty cohort when no patients match", async () => {
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([]);
+    const result = await cohortBuilderAgent.run(
+      { organizationId: "org_1" },
+      makeCtx(),
+    );
+    expect(result.size).toBe(0);
+    expect(result.patientIds).toEqual([]);
+    expect(result.medianAgeDays).toBeNull();
+    expect(result.metricBaselines).toEqual({});
+    // outcomeLog.findMany should NOT be called if there are no patients.
+    expect(hoisted.mockPrisma.outcomeLog.findMany).not.toHaveBeenCalled();
+  });
+
+  it("filters out patients below the minOutcomeLogs threshold", async () => {
+    const now = Date.now();
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([
+      { id: "p1", dateOfBirth: new Date(now - 30 * 365 * 86_400_000) },
+      { id: "p2", dateOfBirth: new Date(now - 40 * 365 * 86_400_000) },
+      { id: "p3", dateOfBirth: null },
+    ]);
+    hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([
+      // p1: 2 logs → below threshold of 3
+      { patientId: "p1", metric: "pain", value: 7 },
+      { patientId: "p1", metric: "sleep", value: 3 },
+      // p2: 4 logs → passes
+      { patientId: "p2", metric: "pain", value: 5 },
+      { patientId: "p2", metric: "pain", value: 4 },
+      { patientId: "p2", metric: "sleep", value: 6 },
+      { patientId: "p2", metric: "mood", value: 7 },
+      // p3: 3 logs → passes
+      { patientId: "p3", metric: "pain", value: 8 },
+      { patientId: "p3", metric: "pain", value: 6 },
+      { patientId: "p3", metric: "sleep", value: 5 },
+    ]);
+
+    const result = await cohortBuilderAgent.run(
+      { organizationId: "org_1", minOutcomeLogs: 3 },
+      makeCtx(),
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.patientIds.sort()).toEqual(["p2", "p3"]);
+    // Baselines are computed across ALL cohort candidates (pre-filter),
+    // since this is a research snapshot of the condition at intake.
+    expect(result.metricBaselines.pain).toEqual({
+      mean: Number(((7 + 5 + 4 + 8 + 6) / 5).toFixed(3)),
+      sampleSize: 5,
+    });
+    expect(result.metricBaselines.sleep.sampleSize).toBe(3);
+    expect(result.metricBaselines.mood).toEqual({ mean: 7, sampleSize: 1 });
+  });
+
+  it("computes median age in days across patients with known DOB only", async () => {
+    const now = Date.now();
+    const dob = (years: number) => new Date(now - years * 365 * 86_400_000);
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([
+      { id: "p1", dateOfBirth: dob(25) }, // 9_125 days
+      { id: "p2", dateOfBirth: dob(40) }, // 14_600 days → median of 3 sorted
+      { id: "p3", dateOfBirth: dob(60) }, // 21_900 days
+      { id: "p4", dateOfBirth: null },
+    ]);
+    hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([]);
+
+    const result = await cohortBuilderAgent.run(
+      { organizationId: "org_1", minOutcomeLogs: 0 },
+      makeCtx(),
+    );
+
+    expect(result.size).toBe(4);
+    // Median of [9125, 14600, 21900] = 14600 (index 1 = floor(3/2))
+    expect(result.medianAgeDays).toBe(40 * 365);
+  });
+
+  it("honors the criteria echo on the result", async () => {
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([]);
+    const result = await cohortBuilderAgent.run(
+      {
+        organizationId: "org_1",
+        memoryTag: "sleep",
+        activeRegimenOnly: true,
+        minOutcomeLogs: 5,
+        lookbackDays: 180,
+      },
+      makeCtx(),
+    );
+    expect(result.criteria).toEqual({
+      memoryTag: "sleep",
+      activeRegimenOnly: true,
+      minOutcomeLogs: 5,
+      lookbackDays: 180,
+    });
+  });
+
+  it("threads memoryTag + activeRegimenOnly into the patient query", async () => {
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([]);
+    await cohortBuilderAgent.run(
+      {
+        organizationId: "org_1",
+        memoryTag: "pain",
+        activeRegimenOnly: true,
+      },
+      makeCtx(),
+    );
+    const where = hoisted.mockPrisma.patient.findMany.mock.calls[0][0].where;
+    expect(where.organizationId).toBe("org_1");
+    expect(where.patientMemories).toBeDefined();
+    expect(where.patientMemories.some.tags).toEqual({ has: "pain" });
+    expect(where.dosingRegimens).toEqual({ some: { active: true } });
+  });
+});

--- a/src/lib/agents/research/cohort-builder-agent.ts
+++ b/src/lib/agents/research/cohort-builder-agent.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  memoryTag: z.string().optional(),
+  activeRegimenOnly: z.boolean().optional(),
+  minOutcomeLogs: z.number().int().min(0).optional(),
+  lookbackDays: z.number().int().positive().max(3650).optional(),
+  limit: z.number().int().positive().max(10_000).optional(),
+});
+
+const output = z.object({
+  patientIds: z.array(z.string()),
+  size: z.number(),
+  medianAgeDays: z.number().nullable(),
+  metricBaselines: z.record(
+    z.object({
+      mean: z.number(),
+      sampleSize: z.number(),
+    }),
+  ),
+  criteria: z.object({
+    memoryTag: z.string().optional(),
+    activeRegimenOnly: z.boolean(),
+    minOutcomeLogs: z.number(),
+    lookbackDays: z.number(),
+  }),
+});
+
+type CohortOutput = z.infer<typeof output>;
+
+/**
+ * Cohort Builder Agent
+ * --------------------
+ * Filters patients by research cohort criteria. First piece of the
+ * research fleet with real Prisma logic — the other agents scaffold shapes
+ * only until the use case is proven.
+ *
+ * Criteria today:
+ *  - Memory tag (e.g. "sleep", "pain") via `PatientMemory.tags[]`
+ *  - Active regimen requirement (DosingRegimen.active)
+ *  - Minimum outcome-log count in the lookback window
+ *  - Org-scoped, soft-delete respected
+ *
+ * Returns the cohort shape used by every downstream research agent:
+ * `{ patientIds, size, medianAgeDays, metricBaselines }`.
+ */
+export const cohortBuilderAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "cohortBuilder",
+  version: "0.1.0",
+  description:
+    "Filters patients by condition / regimen / outcome-log criteria and returns a cohort spec + metric baselines.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run(payload, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+
+    const activeRegimenOnly = payload.activeRegimenOnly ?? false;
+    const minOutcomeLogs = payload.minOutcomeLogs ?? 0;
+    const lookbackDays = payload.lookbackDays ?? 90;
+    const limit = payload.limit ?? 500;
+    const since = new Date(Date.now() - lookbackDays * 86_400_000);
+
+    // Start with the org-scoped patient list. We filter in app code rather
+    // than building one giant `where` clause so the criteria stay legible.
+    const patients = await prisma.patient.findMany({
+      where: {
+        organizationId: payload.organizationId,
+        deletedAt: null,
+        ...(payload.memoryTag
+          ? {
+              patientMemories: {
+                some: {
+                  tags: { has: payload.memoryTag },
+                  OR: [
+                    { validUntil: null },
+                    { validUntil: { gt: new Date() } },
+                  ],
+                },
+              },
+            }
+          : {}),
+        ...(activeRegimenOnly
+          ? { dosingRegimens: { some: { active: true } } }
+          : {}),
+      },
+      select: {
+        id: true,
+        dateOfBirth: true,
+      },
+      take: limit * 2, // room to drop after min-log filter
+    });
+
+    if (patients.length === 0) {
+      return emptyCohort(payload, activeRegimenOnly, minOutcomeLogs, lookbackDays);
+    }
+
+    const patientIds = patients.map((p) => p.id);
+
+    // Pull outcome logs across the cohort in one query, group by patient +
+    // metric so we can both enforce minOutcomeLogs and compute baselines.
+    const logs = await prisma.outcomeLog.findMany({
+      where: {
+        patientId: { in: patientIds },
+        loggedAt: { gte: since },
+      },
+      select: {
+        patientId: true,
+        metric: true,
+        value: true,
+      },
+    });
+
+    const logsByPatient = new Map<string, number>();
+    const valuesByMetric = new Map<string, number[]>();
+    for (const log of logs) {
+      logsByPatient.set(log.patientId, (logsByPatient.get(log.patientId) ?? 0) + 1);
+      const arr = valuesByMetric.get(log.metric) ?? [];
+      arr.push(log.value);
+      valuesByMetric.set(log.metric, arr);
+    }
+
+    const filtered = patients.filter(
+      (p) => (logsByPatient.get(p.id) ?? 0) >= minOutcomeLogs,
+    );
+    const capped = filtered.slice(0, limit);
+
+    // Median age in days.
+    const now = Date.now();
+    const ages = capped
+      .map((p) => (p.dateOfBirth ? now - p.dateOfBirth.getTime() : null))
+      .filter((d): d is number => d != null)
+      .map((ms) => Math.floor(ms / 86_400_000))
+      .sort((a, b) => a - b);
+    const medianAgeDays = ages.length === 0
+      ? null
+      : ages[Math.floor(ages.length / 2)];
+
+    // Metric baselines — mean of values in the window (by all cohort patients;
+    // limit doesn't affect this since we slice after computing).
+    const metricBaselines: Record<string, { mean: number; sampleSize: number }> = {};
+    for (const [metric, values] of valuesByMetric) {
+      const sum = values.reduce((a, b) => a + b, 0);
+      metricBaselines[metric] = {
+        mean: Number((sum / values.length).toFixed(3)),
+        sampleSize: values.length,
+      };
+    }
+
+    ctx.log("info", "cohortBuilder assembled cohort", {
+      candidatePatients: patients.length,
+      filteredSize: capped.length,
+      metricCount: Object.keys(metricBaselines).length,
+    });
+
+    return {
+      patientIds: capped.map((p) => p.id),
+      size: capped.length,
+      medianAgeDays,
+      metricBaselines,
+      criteria: {
+        memoryTag: payload.memoryTag,
+        activeRegimenOnly,
+        minOutcomeLogs,
+        lookbackDays,
+      },
+    };
+  },
+};
+
+function emptyCohort(
+  payload: z.infer<typeof input>,
+  activeRegimenOnly: boolean,
+  minOutcomeLogs: number,
+  lookbackDays: number,
+): CohortOutput {
+  return {
+    patientIds: [],
+    size: 0,
+    medianAgeDays: null,
+    metricBaselines: {},
+    criteria: {
+      memoryTag: payload.memoryTag,
+      activeRegimenOnly,
+      minOutcomeLogs,
+      lookbackDays,
+    },
+  };
+}

--- a/src/lib/agents/research/deidentifier-agent.ts
+++ b/src/lib/agents/research/deidentifier-agent.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  patientIds: z.array(z.string()),
+  includeFields: z.array(
+    z.enum(["demographics", "outcomes", "regimens", "memory_tags", "observations"]),
+  ),
+});
+
+const output = z.object({
+  rowCount: z.number(),
+  columnCount: z.number(),
+  kAnonymity: z.number(),
+  redactedFields: z.array(z.string()),
+  exportRef: z.string().nullable(),
+});
+
+/**
+ * De-identifier Agent
+ * -------------------
+ * Produces a HIPAA Safe-Harbor-compliant dataset ref for an export.
+ * Strips direct identifiers (name, address, contact, DOB→year-only,
+ * chart IDs → synthetic IDs). Computes k-anonymity on the released
+ * quasi-identifiers as a guardrail.
+ *
+ * Status: stub (EMR-269 / Research fleet). Returns zeros and a null
+ * exportRef — the actual de-identification pipeline will live under
+ * `src/server/research/` once EMR-228/vendor-portal + research-portal
+ * stack is in place. NEVER invoke this on patient data in production
+ * until the pipeline is real.
+ */
+export const deidentifierAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "deidentifier",
+  version: "0.1.0",
+  description: "Produces a HIPAA Safe-Harbor de-identified dataset reference for a cohort.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientIds }, ctx) {
+    ctx.log("warn", "deidentifier stub — NOT de-identification-grade", {
+      cohortSize: patientIds.length,
+    });
+    return {
+      rowCount: 0,
+      columnCount: 0,
+      kAnonymity: 0,
+      redactedFields: [],
+      exportRef: null,
+    };
+  },
+};

--- a/src/lib/agents/research/efficacy-comparator-agent.ts
+++ b/src/lib/agents/research/efficacy-comparator-agent.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const cohortRef = z.object({
+  memoryTag: z.string().optional(),
+  label: z.string(),
+});
+
+const input = z.object({
+  organizationId: z.string(),
+  cohortA: cohortRef,
+  cohortB: cohortRef,
+  metric: z.enum([
+    "pain",
+    "sleep",
+    "anxiety",
+    "mood",
+    "nausea",
+    "appetite",
+    "energy",
+    "adherence",
+    "side_effects",
+  ]),
+  lookbackDays: z.number().int().positive().max(3650),
+});
+
+const output = z.object({
+  metric: z.string(),
+  a: z.object({ label: z.string(), mean: z.number().nullable(), n: z.number() }),
+  b: z.object({ label: z.string(), mean: z.number().nullable(), n: z.number() }),
+  delta: z.number().nullable(),
+  pValueEstimate: z.number().nullable(),
+  interpretation: z.string(),
+});
+
+/**
+ * Efficacy Comparator Agent
+ * -------------------------
+ * Head-to-head outcome comparison between two cohorts on a single metric.
+ * Pairs with `cohortBuilder` — you build two cohorts, then compare them.
+ *
+ * Status: stub (EMR-269 / Research fleet). Returns empty shape until the
+ * statistical plumbing is wired; downstream UIs should hide the section
+ * when `pValueEstimate` is null.
+ */
+export const efficacyComparatorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "efficacyComparator",
+  version: "0.1.0",
+  description:
+    "Head-to-head comparison of two cohorts on a single outcome metric.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cohortA, cohortB, metric }, ctx) {
+    ctx.log("info", "efficacyComparator stub", { metric });
+    return {
+      metric,
+      a: { label: cohortA.label, mean: null, n: 0 },
+      b: { label: cohortB.label, mean: null, n: 0 },
+      delta: null,
+      pValueEstimate: null,
+      interpretation: "Stub — statistical comparison not yet implemented.",
+    };
+  },
+};

--- a/src/lib/agents/research/insurance-evidence-bundler-agent.ts
+++ b/src/lib/agents/research/insurance-evidence-bundler-agent.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  claimId: z.string().optional(),
+  purpose: z.enum([
+    "prior_auth",
+    "medical_necessity",
+    "appeal",
+    "reimbursement",
+  ]),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  purpose: z.string(),
+  evidenceCount: z.number(),
+  packetSections: z.array(
+    z.object({
+      title: z.string(),
+      itemCount: z.number(),
+    }),
+  ),
+  downloadRef: z.string().nullable(),
+});
+
+/**
+ * Insurance Evidence Bundler Agent
+ * --------------------------------
+ * Assembles patient-specific evidence for insurance submissions: outcome
+ * trajectories, regimen history, provider documentation, COAs. Supports
+ * prior-auth, medical-necessity, appeals, and reimbursement workflows.
+ *
+ * Status: stub (EMR-269 / Research fleet). Export format pending; returns
+ * shape-only. Gated behind approval because this touches claims flow.
+ */
+export const insuranceEvidenceBundlerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "insuranceEvidenceBundler",
+  version: "0.1.0",
+  description: "Assembles patient evidence packets for insurance submissions.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientId, purpose }, ctx) {
+    ctx.log("info", "insuranceEvidenceBundler stub", { patientId, purpose });
+    return {
+      patientId,
+      purpose,
+      evidenceCount: 0,
+      packetSections: [],
+      downloadRef: null,
+    };
+  },
+};

--- a/src/lib/agents/research/outcome-digester-agent.ts
+++ b/src/lib/agents/research/outcome-digester-agent.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  cohortLabel: z.string(),
+  patientIds: z.array(z.string()),
+  periodDays: z.number().int().positive().max(3650),
+});
+
+const output = z.object({
+  cohortLabel: z.string(),
+  size: z.number(),
+  periodDays: z.number(),
+  narrative: z.string(),
+  highlightMetrics: z.array(
+    z.object({
+      metric: z.string(),
+      mean: z.number(),
+      changeVsBaseline: z.number().nullable(),
+    }),
+  ),
+});
+
+/**
+ * Outcome Digester Agent
+ * ----------------------
+ * Narrative rollup of a cohort's outcomes over a period. Feeds monthly
+ * digests, investor updates, and partner-performance reviews.
+ *
+ * Status: stub (EMR-269 / Research fleet). Emits a placeholder narrative
+ * today; LLM-written summaries are TODO. Structured `highlightMetrics`
+ * shape is stable so downstream dashboards can wire now.
+ */
+export const outcomeDigesterAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "outcomeDigester",
+  version: "0.1.0",
+  description: "Narrative summary of cohort outcomes across a time window.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cohortLabel, patientIds, periodDays }, ctx) {
+    ctx.log("info", "outcomeDigester stub", { cohortLabel, size: patientIds.length });
+    return {
+      cohortLabel,
+      size: patientIds.length,
+      periodDays,
+      narrative: `Stub digest for cohort ${cohortLabel} over the last ${periodDays} days. Full narrative pending LLM wiring.`,
+      highlightMetrics: [],
+    };
+  },
+};

--- a/src/lib/agents/research/protocol-recommender-agent.ts
+++ b/src/lib/agents/research/protocol-recommender-agent.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  conditionLabel: z.string(),
+  lookbackDays: z.number().int().positive().max(1825),
+});
+
+const output = z.object({
+  conditionLabel: z.string(),
+  suggestedProtocols: z.array(
+    z.object({
+      name: z.string(),
+      thcCbdRatio: z.string().nullable(),
+      route: z.string().nullable(),
+      evidenceCohortSize: z.number(),
+      medianImprovement: z.number().nullable(),
+      caveat: z.string().optional(),
+    }),
+  ),
+});
+
+/**
+ * Protocol Recommender Agent
+ * --------------------------
+ * Data-driven protocol suggestions from outcome clusters. Mines the top
+ * regimens (by patient count + median improvement) for a given condition
+ * and returns them as ranked candidates.
+ *
+ * Status: stub (EMR-269 / Research fleet). Clustering pending; returns
+ * empty list today. Output shape stable so UI can wire.
+ */
+export const protocolRecommenderAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "protocolRecommender",
+  version: "0.1.0",
+  description: "Recommends regimen protocols per condition from outcome clusters.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ conditionLabel }, ctx) {
+    ctx.log("info", "protocolRecommender stub", { conditionLabel });
+    return { conditionLabel, suggestedProtocols: [] };
+  },
+};

--- a/src/lib/agents/research/publication-readiness-scorer-agent.ts
+++ b/src/lib/agents/research/publication-readiness-scorer-agent.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  cohortPatientIds: z.array(z.string()),
+  targetJournal: z.string().optional(),
+});
+
+const output = z.object({
+  score: z.number().min(0).max(100),
+  passedChecks: z.array(z.string()),
+  gaps: z.array(
+    z.object({
+      check: z.string(),
+      severity: z.enum(["blocker", "warning", "advisory"]),
+      detail: z.string(),
+    }),
+  ),
+  readinessLevel: z.enum(["case_report", "observational", "journal", "not_ready"]),
+});
+
+/**
+ * Publication Readiness Scorer Agent
+ * ----------------------------------
+ * Scores a cohort for publication readiness. Checks sample size,
+ * follow-up duration, control group presence, outcome measure
+ * validity (e.g. PROMIS), missing-data rates, consent coverage.
+ *
+ * Status: stub (EMR-269 / Research fleet). Emits `not_ready` + empty
+ * checks today. Real heuristic bundle follows the MCL (Medical Cannabis
+ * Library) publication criteria.
+ */
+export const publicationReadinessScorerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "publicationReadinessScorer",
+  version: "0.1.0",
+  description: "Scores a cohort's readiness for academic publication.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cohortPatientIds }, ctx) {
+    ctx.log("info", "publicationReadinessScorer stub", {
+      size: cohortPatientIds.length,
+    });
+    return {
+      score: 0,
+      passedChecks: [],
+      gaps: [],
+      readinessLevel: "not_ready" as const,
+    };
+  },
+};

--- a/src/lib/agents/research/research-partner-matcher-agent.ts
+++ b/src/lib/agents/research/research-partner-matcher-agent.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  cohortLabel: z.string(),
+  cohortSize: z.number(),
+  primaryConditions: z.array(z.string()),
+  primaryProducts: z.array(z.string()).optional(),
+});
+
+const output = z.object({
+  matches: z.array(
+    z.object({
+      partnerKind: z.enum(["academic", "industry", "patient_advocacy", "regulator"]),
+      partnerName: z.string(),
+      fitScore: z.number().min(0).max(100),
+      rfpOrContact: z.string(),
+      rationale: z.string(),
+    }),
+  ),
+  searchedAt: z.string(),
+});
+
+/**
+ * Research Partner Matcher Agent
+ * ------------------------------
+ * Matches cohorts against a curated registry of academic labs,
+ * pharma RFPs, patient-advocacy groups, and regulator observational
+ * programs looking for real-world data. The registry is separate data
+ * (seeded by ops) and updated quarterly.
+ *
+ * Status: stub (EMR-269 / Research fleet). Empty matches until the
+ * registry ships. Output shape stable.
+ */
+export const researchPartnerMatcherAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "researchPartnerMatcher",
+  version: "0.1.0",
+  description: "Matches a cohort profile against academic, pharma, and regulator partner RFPs.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cohortLabel, cohortSize }, ctx) {
+    ctx.log("info", "researchPartnerMatcher stub", { cohortLabel, cohortSize });
+    return {
+      matches: [],
+      searchedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/src/lib/agents/research/rwe-bundler-agent.ts
+++ b/src/lib/agents/research/rwe-bundler-agent.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  organizationId: z.string(),
+  productId: z.string(),
+  cohortPatientIds: z.array(z.string()),
+  bundleType: z.enum(["rwe_summary", "safety_profile", "efficacy_dossier"]),
+});
+
+const output = z.object({
+  productId: z.string(),
+  bundleType: z.string(),
+  citations: z.array(z.string()),
+  downloadUrl: z.string().nullable(),
+  generatedAt: z.string(),
+  notes: z.string(),
+});
+
+/**
+ * RWE (Real-World Evidence) Bundler Agent
+ * ---------------------------------------
+ * Packages cohort outcomes + regimen histories into a pharma-facing
+ * real-world-evidence dossier. Output references structured artifacts
+ * that the export pipeline will render.
+ *
+ * Status: stub (EMR-269 / Research fleet). Returns metadata-only until
+ * the export pipeline exists; `downloadUrl` stays null. No PHI leaves
+ * this function — de-identification runs in `deidentifier` first.
+ */
+export const rweBundlerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "rweBundler",
+  version: "0.1.0",
+  description: "Packages cohort outcomes into a pharma real-world-evidence bundle.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ productId, bundleType }, ctx) {
+    ctx.log("info", "rweBundler stub", { productId, bundleType });
+    return {
+      productId,
+      bundleType,
+      citations: [],
+      downloadUrl: null,
+      generatedAt: new Date().toISOString(),
+      notes: "Stub — export pipeline pending. Will reject if cohort contains fewer than N patients once implemented.",
+    };
+  },
+};

--- a/src/lib/domain/byok.ts
+++ b/src/lib/domain/byok.ts
@@ -166,7 +166,8 @@ export type AgentCategory =
   | "billing"
   | "operations"
   | "safety"
-  | "commerce";
+  | "commerce"
+  | "research";
 
 export interface AgentCatalogEntry {
   /** Must match a key in agentRegistry (src/lib/agents/index.ts). */
@@ -271,6 +272,19 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   { id: "cannabisTaxCalculator", displayName: "Cannabis Tax Calculator", description: "Computes cannabis excise + retail tax per order destination.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 50_000 },
   { id: "shippingRouter", displayName: "Shipping Router", description: "Picks a fulfillment carrier per order destination + product profile.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
   { id: "vendorPerformanceScorer", displayName: "Vendor Performance Scorer", description: "Scores marketplace brands on fulfillment + review performance.", category: "commerce", defaultTier: "budget", estimatedTokensPerMonth: 40_000 },
+
+  // Research & Insights (EMR-269 — 10-agent fleet mining outcome + regimen
+  // data for cohort analytics, RWE, reimbursement, and publication)
+  { id: "cohortBuilder", displayName: "Cohort Builder", description: "Filters patients into research cohorts with baseline metric summaries.", category: "research", defaultTier: "budget", estimatedTokensPerMonth: 30_000 },
+  { id: "efficacyComparator", displayName: "Efficacy Comparator", description: "Head-to-head outcome comparison across two cohorts.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 40_000, qualitySensitive: true },
+  { id: "outcomeDigester", displayName: "Outcome Digester", description: "Narrative cohort rollup for partner + investor updates.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 90_000, qualitySensitive: true },
+  { id: "rweBundler", displayName: "RWE Bundler", description: "Real-world-evidence dossier for pharma partnerships.", category: "research", defaultTier: "premium", estimatedTokensPerMonth: 80_000, qualitySensitive: true },
+  { id: "deidentifier", displayName: "De-identifier", description: "HIPAA Safe-Harbor de-identified dataset reference.", category: "research", defaultTier: "budget", estimatedTokensPerMonth: 20_000 },
+  { id: "adverseEventScanner", displayName: "Adverse Event Scanner", description: "Flags unusual AE clusters across a cohort or product.", category: "research", defaultTier: "premium", estimatedTokensPerMonth: 60_000, qualitySensitive: true },
+  { id: "protocolRecommender", displayName: "Protocol Recommender", description: "Suggests regimen protocols per condition from outcome clusters.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 70_000, qualitySensitive: true },
+  { id: "insuranceEvidenceBundler", displayName: "Insurance Evidence Bundler", description: "Assembles patient evidence for insurance submissions.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 50_000 },
+  { id: "publicationReadinessScorer", displayName: "Publication Readiness", description: "Scores a cohort for academic publication readiness.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 40_000 },
+  { id: "researchPartnerMatcher", displayName: "Research Partner Matcher", description: "Matches cohorts to academic, pharma, and regulator RFPs.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 30_000 },
 ];
 
 /** Per-agent override. Undefined modelId → use the practice default. */
@@ -311,4 +325,5 @@ export const CATEGORY_LABELS: Record<AgentCategory, string> = {
   billing: "Revenue cycle",
   operations: "Operations",
   commerce: "Marketplace",
+  research: "Research & insights",
 };


### PR DESCRIPTION
## Summary

Ships the **Research & Insights Fleet** — 10 agents that mine patient outcome + regimen data for cohort analytics, real-world evidence, reimbursement documentation, and research packets. Directly leverages the EMR-230 moat and aligns with CLAUDE.md's data-reuse directive (research / product dev / insurance / pharma).

This is the "here's what our data can do" artifact for founding-partner demos.

Linear: **EMR-269** (child of EMR-17, relates to EMR-230)

## Fleet — 10 agents under `src/lib/agents/research/`

| Agent | Role | State |
|---|---|---|
| `cohortBuilder` | Patient filter + baseline metrics | **Real logic + tests** |
| `efficacyComparator` | Head-to-head metric comparison across 2 cohorts | Stub |
| `outcomeDigester` | Narrative cohort rollup | Stub |
| `rweBundler` | Pharma real-world-evidence packet | Stub (approval-gated) |
| `deidentifier` | HIPAA Safe-Harbor dataset ref | Stub (approval-gated) |
| `adverseEventScanner` | AE cluster flagger | Stub (approval-gated) |
| `protocolRecommender` | Data-driven protocol suggestions | Stub (approval-gated) |
| `insuranceEvidenceBundler` | Reimbursement evidence packet | Stub (approval-gated) |
| `publicationReadinessScorer` | Cohort publication-readiness score | Stub |
| `researchPartnerMatcher` | Academic/pharma/regulator RFP matching | Stub |

## cohortBuilder — proof of concept

Real Prisma logic. Filters patients by:
- `memoryTag` (via `PatientMemory.tags[]` array-contains, respecting `validUntil`)
- `activeRegimenOnly` (`DosingRegimen.active`)
- `minOutcomeLogs` within `lookbackDays` (default 90)
- Org-scoped, soft-delete-respecting

Returns:
```ts
{ patientIds, size, medianAgeDays, metricBaselines, criteria }
```
where `metricBaselines` is `{ [metric]: { mean, sampleSize } }` computed across **all candidates pre-filter** — so baselines stay stable as follow-up thresholds tighten.

## Plumbing

- New `research` AgentCategory in `byok.ts`
- `CATEGORY_LABELS` → "Research & insights"
- `CATEGORY_EMOJI` → 🔬 in `agent-fleet.tsx`
- `CATEGORY_ORDER` appends `research`
- Category description wired for the ops AI-fleet panel
- `RESEARCH_AGENT_NAMES` exported from `src/lib/agents/index.ts`

## Tests

- 5 new vitest cases for `cohortBuilder`: empty cohort, minOutcomeLogs filter, median-age-with-nulls, criteria echo, Prisma query threading (memoryTag + activeRegimenOnly)
- **304/304 passing** across 23 files
- `npm run typecheck` clean

## Out of scope

- New UI routes — separate ticket once the fleet has output worth surfacing
- Real LLM wiring for narrative outputs (stubs return structured shells)
- Schema changes — all 10 agents work against existing models
- Anything in Lucca's (EMR-232–236) or Codex's (EMR-237–239, 243–245) lanes

## Test plan

- [x] `npm test` (304/304)
- [x] `npm run typecheck`
- [ ] Open `/ops/settings/ai-config` — verify the new "Research & insights" section with 🔬 icon and all 10 agents listed
- [ ] Verify `cohortBuilder` runs against the demo seed DB with Maya / James / Sarah populated

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_