### PR TITLE
feat(marketplace): Patients-Like-You widget — fuses cohortBuilder + ranking (EMR-270)

### DIFF
--- a/src/app/(patient)/portal/shop/page.tsx
+++ b/src/app/(patient)/portal/shop/page.tsx
@@ -6,6 +6,7 @@ import { ProductGrid } from "@/components/marketplace/ProductGrid";
 import { TrustStrip } from "@/components/marketplace/TrustStrip";
 import { SearchBar } from "@/components/marketplace/SearchBar";
 import { RecommendedForYou } from "@/components/marketplace/RecommendedForYou";
+import { PatientsLikeYou } from "@/components/marketplace/PatientsLikeYou";
 import {
   getFeaturedProducts,
   getClinicianPicks,
@@ -68,6 +69,14 @@ export default async function ShopPage() {
       {/* ── Recommended for You (EMR-230 moat) ────────────────────────── */}
       {user?.organizationId && (
         <RecommendedForYou
+          userId={user.id}
+          organizationId={user.organizationId}
+        />
+      )}
+
+      {/* ── Patients Like You (EMR-270 cohort intelligence) ───────────── */}
+      {user?.organizationId && (
+        <PatientsLikeYou
           userId={user.id}
           organizationId={user.organizationId}
         />

--- a/src/components/marketplace/PatientsLikeYou.tsx
+++ b/src/components/marketplace/PatientsLikeYou.tsx
@@ -1,0 +1,153 @@
+import { prisma } from "@/lib/db/prisma";
+import { ProductCard } from "@/components/marketplace/ProductCard";
+import { cohortBuilderAgent } from "@/lib/agents/research/cohort-builder-agent";
+import { rankProductsForPatient } from "@/lib/marketplace/ranking";
+import {
+  getPopularProductsInCohort,
+  MIN_COHORT_SIZE,
+} from "@/lib/marketplace/cohort-insights";
+
+interface PatientsLikeYouProps {
+  userId: string;
+  organizationId: string;
+  limit?: number;
+}
+
+/**
+ * Server component. Second patient-visible marketplace surface.
+ *
+ * Distinct from <RecommendedForYou /> (EMR-268): that widget answers "what
+ * should YOU try" from your own outcomes. This widget answers "what do
+ * people LIKE YOU actually use" — cohort popularity with a personal-fit
+ * callout.
+ *
+ * Fuses two agents:
+ *   - cohortBuilderAgent (EMR-269)  → finds the cohort
+ *   - rankProductsForPatient (EMR-230) → annotates each cohort-popular
+ *     product with the matching personal-fit reason, if any
+ *
+ * HIPAA min-cell protection: hides per-product counts when cohort size
+ * is below MIN_COHORT_SIZE. Hides the whole section when the current
+ * user has no patient row or no memory tags (nothing to build a cohort
+ * around).
+ */
+export async function PatientsLikeYou({
+  userId,
+  organizationId,
+  limit = 3,
+}: PatientsLikeYouProps) {
+  const patient = await prisma.patient.findFirst({
+    where: { userId, organizationId },
+    select: { id: true },
+  });
+  if (!patient) return null;
+
+  // Pick the latest active memory's first tag as the cohort anchor.
+  const latestMemory = await prisma.patientMemory.findFirst({
+    where: {
+      patientId: patient.id,
+      tags: { isEmpty: false },
+      OR: [{ validUntil: null }, { validUntil: { gt: new Date() } }],
+    },
+    orderBy: { createdAt: "desc" },
+    select: { tags: true },
+  });
+  const memoryTag = latestMemory?.tags[0];
+  if (!memoryTag) return null;
+
+  // Call the cohort-builder agent directly — the agent only uses ctx.log,
+  // so a minimal stub satisfies its contract without spinning up the
+  // orchestration runner.
+  const stubCtx = { log: () => {} } as unknown as Parameters<
+    typeof cohortBuilderAgent.run
+  >[1];
+
+  const [cohort, ranked] = await Promise.all([
+    cohortBuilderAgent.run(
+      {
+        organizationId,
+        memoryTag,
+        activeRegimenOnly: true,
+      },
+      stubCtx,
+    ),
+    rankProductsForPatient(patient.id, { limit: 8, organizationId }),
+  ]);
+
+  // Drop this patient from the cohort — "people like me" shouldn't
+  // include me.
+  const peerIds = cohort.patientIds.filter((id) => id !== patient.id);
+
+  if (peerIds.length < MIN_COHORT_SIZE) {
+    return (
+      <section className="mb-14">
+        <h2 className="text-xl font-semibold tracking-tight text-text">
+          Patients Like You
+        </h2>
+        <p className="mt-1 mb-6 text-sm text-text-muted">
+          Based on patients tracking <em>{memoryTag}</em>, like you.
+        </p>
+        <div className="rounded-lg border border-dashed border-border bg-surface-muted px-6 py-8 text-center">
+          <p className="text-sm text-text-muted">
+            Building cohort data — we need at least {MIN_COHORT_SIZE} patients
+            with the same focus before we can share what&apos;s working for
+            them.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const popular = await getPopularProductsInCohort(peerIds, {
+    organizationId,
+    limit,
+  });
+
+  if (popular.length === 0) return null;
+
+  // Index the personal ranking so we can attach a personal-fit reason
+  // to any cohort-popular product that also made the patient's top 8.
+  const personalByProductId = new Map<string, { score: number; reasons: string[] }>();
+  for (const r of ranked) {
+    personalByProductId.set(r.product.id, { score: r.score, reasons: r.reasons });
+  }
+
+  return (
+    <section className="mb-14">
+      <h2 className="text-xl font-semibold tracking-tight text-text">
+        Patients Like You
+      </h2>
+      <p className="mt-1 mb-6 text-sm text-text-muted">
+        {peerIds.length} patients tracking <em>{memoryTag}</em> — here&apos;s
+        what&apos;s in their active regimens.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {popular.map((row) => {
+          const personal = personalByProductId.get(row.product.id);
+          return (
+            <div key={row.product.id} className="flex flex-col gap-2">
+              <ProductCard product={row.product} />
+              <div className="px-1 space-y-1">
+                <p className="text-xs text-text-muted">
+                  <span className="text-accent" aria-hidden="true">
+                    ◉{" "}
+                  </span>
+                  {row.regimenCount} of {peerIds.length} cohort members use this
+                </p>
+                {personal?.reasons[0] && (
+                  <p className="text-xs text-text-muted line-clamp-2">
+                    <span className="text-accent" aria-hidden="true">
+                      ✦{" "}
+                    </span>
+                    {personal.reasons[0]}
+                  </p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/marketplace/cohort-insights.test.ts
+++ b/src/lib/marketplace/cohort-insights.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    dosingRegimen: { findMany: vi.fn() },
+    product: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  getPopularProductsInCohort,
+  MIN_COHORT_SIZE,
+} from "./cohort-insights";
+
+function productRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "p1",
+    slug: "p1",
+    name: "Demo Product",
+    brand: "Demo Brand",
+    description: "",
+    shortDescription: null,
+    price: 40,
+    compareAtPrice: null,
+    status: "active",
+    format: "tincture",
+    imageUrl: null,
+    images: [],
+    thcContent: null,
+    cbdContent: null,
+    cbnContent: null,
+    thcvContent: null,
+    terpeneProfile: null,
+    strainType: null,
+    symptoms: [],
+    goals: [],
+    useCases: [],
+    onsetTime: null,
+    duration: null,
+    dosageGuidance: null,
+    beginnerFriendly: false,
+    labVerified: false,
+    coaUrl: null,
+    clinicianPick: false,
+    clinicianNote: null,
+    inStock: true,
+    inventoryCount: 0,
+    averageRating: 0,
+    reviewCount: 0,
+    sortOrder: 0,
+    featured: false,
+    organizationId: "org_1",
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    variants: [],
+    reviews: [],
+    categoryMappings: [],
+    ...overrides,
+  };
+}
+
+function reset() {
+  hoisted.mockPrisma.dosingRegimen.findMany.mockReset();
+  hoisted.mockPrisma.product.findMany.mockReset();
+}
+beforeEach(reset);
+
+describe("getPopularProductsInCohort", () => {
+  it("returns [] when the cohort is empty (no queries fire)", async () => {
+    const result = await getPopularProductsInCohort([], {
+      organizationId: "org_1",
+    });
+    expect(result).toEqual([]);
+    expect(hoisted.mockPrisma.dosingRegimen.findMany).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.product.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when no cohort member has a linked active regimen", async () => {
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([]);
+    const result = await getPopularProductsInCohort(["p1", "p2", "p3"], {
+      organizationId: "org_1",
+    });
+    expect(result).toEqual([]);
+    // product.findMany should not fire when there's nothing to hydrate.
+    expect(hoisted.mockPrisma.product.findMany).not.toHaveBeenCalled();
+  });
+
+  it("counts distinct cohort members per marketplace product and sorts desc", async () => {
+    // p1 uses product A (two regimens — still counts once); p2 uses A + B;
+    // p3 uses B only. Expect A=2, B=2 — tie-broken by product name asc.
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      { patientId: "p1", product: { marketplaceProductId: "mkt-a" } },
+      { patientId: "p1", product: { marketplaceProductId: "mkt-a" } },
+      { patientId: "p2", product: { marketplaceProductId: "mkt-a" } },
+      { patientId: "p2", product: { marketplaceProductId: "mkt-b" } },
+      { patientId: "p3", product: { marketplaceProductId: "mkt-b" } },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({ id: "mkt-a", slug: "alpha", name: "Alpha" }),
+      productRow({ id: "mkt-b", slug: "bravo", name: "Bravo" }),
+    ]);
+
+    const result = await getPopularProductsInCohort(["p1", "p2", "p3"], {
+      organizationId: "org_1",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].product.id).toBe("mkt-a"); // A before B on name tiebreak
+    expect(result[0].regimenCount).toBe(2);
+    expect(result[1].product.id).toBe("mkt-b");
+    expect(result[1].regimenCount).toBe(2);
+  });
+
+  it("skips regimens with no marketplace FK (filtered in the Prisma WHERE)", async () => {
+    // Simulate that the Prisma `where` filter already excludes null-FK rows.
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      { patientId: "p1", product: { marketplaceProductId: "mkt-a" } },
+      { patientId: "p2", product: { marketplaceProductId: "mkt-a" } },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({ id: "mkt-a", slug: "alpha", name: "Alpha" }),
+    ]);
+
+    const result = await getPopularProductsInCohort(["p1", "p2"], {
+      organizationId: "org_1",
+    });
+
+    expect(result).toHaveLength(1);
+    const whereArg =
+      hoisted.mockPrisma.dosingRegimen.findMany.mock.calls[0][0].where;
+    expect(whereArg.product.marketplaceProductId).toEqual({ not: null });
+    expect(whereArg.active).toBe(true);
+  });
+
+  it("honors limit + drops products not hydrated by the org-scoped query", async () => {
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      { patientId: "p1", product: { marketplaceProductId: "mkt-a" } },
+      { patientId: "p2", product: { marketplaceProductId: "mkt-b" } },
+      { patientId: "p3", product: { marketplaceProductId: "mkt-c" } },
+      { patientId: "p4", product: { marketplaceProductId: "mkt-d" } },
+    ]);
+    // Only 3 of the 4 IDs hydrate (mkt-d is archived/different-org/deleted).
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({ id: "mkt-a", slug: "alpha", name: "Alpha" }),
+      productRow({ id: "mkt-b", slug: "bravo", name: "Bravo" }),
+      productRow({ id: "mkt-c", slug: "charlie", name: "Charlie" }),
+    ]);
+
+    const result = await getPopularProductsInCohort(
+      ["p1", "p2", "p3", "p4"],
+      { organizationId: "org_1", limit: 2 },
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.product.id !== "mkt-d")).toBe(true);
+  });
+
+  it("scopes the marketplace hydrate query to the caller's org + active status", async () => {
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      { patientId: "p1", product: { marketplaceProductId: "mkt-a" } },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([
+      productRow({ id: "mkt-a", slug: "alpha", name: "Alpha" }),
+    ]);
+
+    await getPopularProductsInCohort(["p1"], { organizationId: "org_xyz" });
+
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.organizationId).toBe("org_xyz");
+    expect(where.deletedAt).toBeNull();
+    expect(where.status).toBe("active");
+    expect(where.id).toEqual({ in: ["mkt-a"] });
+  });
+
+  it("exports a min-cohort-size constant the widget can honor", () => {
+    expect(MIN_COHORT_SIZE).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/lib/marketplace/cohort-insights.ts
+++ b/src/lib/marketplace/cohort-insights.ts
@@ -1,0 +1,172 @@
+// EMR-270 — Cohort-driven marketplace insights.
+//
+// Consumed by the "Patients Like You" widget on /portal/shop. Aggregates
+// active DosingRegimens across a cohort and maps each to its linked
+// marketplace Product via the EMR-268 FK (CannabisProduct.marketplaceProductId).
+// Returns products ranked by cohort popularity — how many cohort members
+// have an active regimen tied to each listing.
+//
+// HIPAA note: the caller is responsible for enforcing a minimum cohort
+// size (MIN_COHORT_SIZE) before displaying any per-product counts. This
+// helper always returns counts regardless — the UI gates the display.
+
+import { prisma } from "@/lib/db/prisma";
+import { ProductStatus } from "@prisma/client";
+import type { MarketplaceProduct } from "./types";
+
+export const MIN_COHORT_SIZE = 3;
+
+export interface CohortPopularProduct {
+  product: MarketplaceProduct;
+  regimenCount: number; // # of cohort members with an active regimen → this marketplace product
+}
+
+export interface CohortInsightOptions {
+  organizationId: string;
+  limit?: number;
+}
+
+export async function getPopularProductsInCohort(
+  patientIds: string[],
+  options: CohortInsightOptions,
+): Promise<CohortPopularProduct[]> {
+  if (patientIds.length === 0) return [];
+  const limit = options.limit ?? 4;
+
+  // Active regimens in the cohort, joined to the cannabis product and
+  // (via EMR-268 FK) the marketplace product.
+  const regimens = await prisma.dosingRegimen.findMany({
+    where: {
+      patientId: { in: patientIds },
+      active: true,
+      product: {
+        marketplaceProductId: { not: null },
+      },
+    },
+    select: {
+      patientId: true,
+      product: {
+        select: {
+          marketplaceProductId: true,
+        },
+      },
+    },
+  });
+
+  // Count DISTINCT patients per marketplace product — a patient with two
+  // regimens on the same product still counts once (this is a "people who
+  // use X" metric, not "active regimens on X").
+  const patientsByProduct = new Map<string, Set<string>>();
+  for (const r of regimens) {
+    const mpId = r.product.marketplaceProductId;
+    if (!mpId) continue;
+    const set = patientsByProduct.get(mpId) ?? new Set<string>();
+    set.add(r.patientId);
+    patientsByProduct.set(mpId, set);
+  }
+
+  if (patientsByProduct.size === 0) return [];
+
+  // Hydrate marketplace rows. Scope by org + active status — don't surface
+  // a draft/archived listing even if the FK points at it.
+  const productIds = [...patientsByProduct.keys()];
+  const rows = await prisma.product.findMany({
+    where: {
+      id: { in: productIds },
+      organizationId: options.organizationId,
+      deletedAt: null,
+      status: ProductStatus.active,
+    },
+    include: {
+      variants: { orderBy: { sortOrder: "asc" } },
+      reviews: { orderBy: { createdAt: "desc" } },
+      categoryMappings: { include: { category: true } },
+    },
+  });
+
+  const ranked = rows
+    .map((row) => ({
+      product: mapProductRow(row),
+      regimenCount: patientsByProduct.get(row.id)?.size ?? 0,
+    }))
+    .filter((r) => r.regimenCount > 0)
+    .sort(
+      (a, b) =>
+        b.regimenCount - a.regimenCount ||
+        a.product.name.localeCompare(b.product.name),
+    )
+    .slice(0, limit);
+
+  return ranked;
+}
+
+// Local mapper — duplicated from queries.ts / ranking.ts on purpose. The
+// other mappers require a user session (queries.ts) or live in a module
+// we don't want to widen the export surface of (ranking.ts is private
+// to the moat).
+type ProductRow = Awaited<
+  ReturnType<
+    typeof prisma.product.findFirstOrThrow<{
+      include: {
+        variants: { orderBy: { sortOrder: "asc" } };
+        reviews: { orderBy: { createdAt: "desc" } };
+        categoryMappings: { include: { category: true } };
+      };
+    }>
+  >
+>;
+
+function mapProductRow(p: ProductRow): MarketplaceProduct {
+  return {
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    brand: p.brand,
+    description: p.description,
+    shortDescription: p.shortDescription ?? "",
+    price: p.price,
+    compareAtPrice: p.compareAtPrice ?? undefined,
+    status: p.status,
+    format: p.format as MarketplaceProduct["format"],
+    imageUrl: p.imageUrl ?? undefined,
+    images: p.images,
+    thcContent: p.thcContent ?? undefined,
+    cbdContent: p.cbdContent ?? undefined,
+    cbnContent: p.cbnContent ?? undefined,
+    terpeneProfile: (p.terpeneProfile ?? {}) as Record<string, number>,
+    strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+    symptoms: p.symptoms,
+    goals: p.goals,
+    useCases: p.useCases,
+    onsetTime: p.onsetTime ?? undefined,
+    duration: p.duration ?? undefined,
+    dosageGuidance: p.dosageGuidance ?? undefined,
+    beginnerFriendly: p.beginnerFriendly,
+    labVerified: p.labVerified,
+    coaUrl: p.coaUrl ?? undefined,
+    clinicianPick: p.clinicianPick,
+    clinicianNote: p.clinicianNote ?? undefined,
+    inStock: p.inStock,
+    averageRating: p.averageRating,
+    reviewCount: p.reviewCount,
+    featured: p.featured,
+    categoryIds: p.categoryMappings.map((m) => m.categoryId),
+    variants: p.variants.map((v) => ({
+      id: v.id,
+      name: v.name,
+      upc: v.upc ?? undefined,
+      price: v.price,
+      compareAtPrice: v.compareAtPrice ?? undefined,
+      inStock: v.inStock,
+    })),
+    reviews: p.reviews.map((r) => ({
+      id: r.id,
+      authorName: r.authorName,
+      rating: r.rating,
+      title: r.title ?? undefined,
+      body: r.body ?? undefined,
+      verified: r.verified,
+      createdAt: r.createdAt.toISOString().slice(0, 10),
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Second patient-visible marketplace surface. Distinct from **Recommended for You** (EMR-268):

| Widget | Question | Data |
|---|---|---|
| Recommended for You | "What should **you** try?" | Your own outcomes, regimens, memories |
| **Patients Like You** *(this PR)* | "What do people **like you** actually use?" | Cohort active-regimen popularity + your personal-fit overlay |

Fuses **both** agents in one server component: `cohortBuilderAgent` (EMR-269) + `rankProductsForPatient` (EMR-230).

Linear: **EMR-270** (child of EMR-17, relates to EMR-230, EMR-268, EMR-269)

## ⚠️ Stacked on PR #78

This PR branches off `scwayman/research-agent-fleet` because it needs `cohortBuilderAgent`. **Base branch is `scwayman/research-agent-fleet`**, not main — GitHub will show the correct incremental diff.

Rebase onto main after PR #78 lands. After that merge, change this PR's base to `main` so the diff shrinks to just the Patients-Like-You files.

## What's in this PR (4 files, +518)

### New helper — `src/lib/marketplace/cohort-insights.ts`
- `getPopularProductsInCohort(patientIds, { organizationId, limit })` — aggregates active `DosingRegimen` rows across a cohort, counts DISTINCT cohort members per marketplace product via `CannabisProduct.marketplaceProductId` (the EMR-268 FK), hydrates org-scoped active Product rows, returns sorted by count desc with deterministic name tiebreak
- `MIN_COHORT_SIZE = 3` — exported so callers gate display consistently (HIPAA min-cell guard)

### New server component — `src/components/marketplace/PatientsLikeYou.tsx`
- Props: `{ userId, organizationId, limit? }`
- Picks anchor tag from `PatientMemory.tags[0]` on the latest active memory. No tag → renders nothing (nothing to cohort against)
- Parallel: `cohortBuilderAgent.run(...)` + `rankProductsForPatient(...)`. Agent called with a minimal `ctx.log` stub — no orchestration runner required for this read-only call
- Drops the current patient from the cohort ("people like me" shouldn't include me)
- `peerSize < MIN_COHORT_SIZE` → placeholder copy, no per-product counts
- Otherwise: top N products with two captions each — "N of M cohort members use this" (cohort signal) + the top `reason` from rankProductsForPatient (personal-fit signal), when the same product is also in the patient's top-8 personal ranking

### Page wire-in — `/portal/shop/page.tsx`
- Rendered below `<RecommendedForYou />`
- Silent no-op for clinicians / non-patient sessions (same pattern as RecommendedForYou)

### Tests — 7 new vitest cases for `getPopularProductsInCohort`
- Empty cohort → `[]` (no Prisma round-trip)
- No active regimens → `[]` (no hydrate round-trip)
- Distinct-member counting + deterministic tiebreak
- Prisma `where` filter shape (active + `marketplaceProductId: { not: null }`)
- Limit honored + unhydrated products dropped
- Org-scoped + active-status hydration
- `MIN_COHORT_SIZE` constant sanity

**311/311 tests pass** (up from 304). `npm run typecheck` clean.

## Out of scope (deliberately)

- Clinician-facing cohort dashboard (EMR-269 will own that surface once the research fleet has output)
- Public `/store` variant — both agents require an authenticated patient
- Schema changes — reuses EMR-268 FK + existing regimen/product rows
- Anything in Lucca's (EMR-232–236) or Codex's (EMR-237–239, 243–245) lanes

## Test plan

- [x] `npm test` (311/311)
- [x] `npm run typecheck`
- [ ] Authenticated patient Maya with ≥3 peers on `sleep` memory tag: loads `/portal/shop`, sees both widgets; cohort-popular products show "N of M cohort members use this" + personal-fit line
- [ ] New patient with no memory tags: Recommended-for-You shows empty-state, Patients-Like-You is absent
- [ ] Patient with a unique tag and <3 peers: sees placeholder "Building cohort data"
- [ ] Clinician browsing the portal: neither widget renders

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_