### PR TITLE
feat(clinical): Cohort Explorer at /clinic/cohorts (EMR-271)

### DIFF
--- a/src/app/(clinician)/clinic/cohorts/page.tsx
+++ b/src/app/(clinician)/clinic/cohorts/page.tsx
@@ -1,0 +1,283 @@
+import Link from "next/link";
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { cn } from "@/lib/utils/cn";
+import {
+  listOrgMemoryTags,
+  getCohortExplorerView,
+  MIN_COHORT_SIZE,
+} from "@/lib/research/cohort-explorer";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Cohorts" };
+
+interface CohortsPageProps {
+  searchParams: Promise<{ tag?: string; window?: string }>;
+}
+
+export default async function CohortsPage({ searchParams }: CohortsPageProps) {
+  const user = await requireUser();
+  const { tag, window } = await searchParams;
+
+  if (!user.organizationId) {
+    return (
+      <PageShell maxWidth="max-w-[1100px]">
+        <PageHeader
+          eyebrow="Cohorts"
+          title="Cohort Explorer"
+          description="Explore aggregate outcomes across your patient population."
+        />
+        <EmptyState
+          title="No organization linked"
+          description="Your account isn't attached to a practice. Ask your practice owner to add you."
+        />
+      </PageShell>
+    );
+  }
+
+  const lookbackDays = parseLookbackParam(window);
+  const tags = await listOrgMemoryTags(user.organizationId);
+
+  const view = tag
+    ? await getCohortExplorerView({
+        organizationId: user.organizationId,
+        memoryTag: tag,
+        lookbackDays,
+      })
+    : null;
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Cohorts"
+        title="Cohort Explorer"
+        description="Aggregate outcomes across your patient population, segmented by the concerns they're tracking."
+      />
+
+      {/* Tag picker */}
+      <Card tone="ambient" className="mb-8">
+        <CardContent className="py-5">
+          {tags.length === 0 ? (
+            <p className="text-sm text-text-muted">
+              No patient-memory tags in this practice yet. As patients log
+              outcomes and the scribe populates memory, cohorts will populate
+              here automatically.
+            </p>
+          ) : (
+            <>
+              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-3">
+                Pick a focus
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {tags.map((t) => {
+                  const active = t.tag === tag;
+                  return (
+                    <Link
+                      key={t.tag}
+                      href={`/clinic/cohorts?tag=${encodeURIComponent(t.tag)}${window ? `&window=${window}` : ""}`}
+                      className={cn(
+                        "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors",
+                        active
+                          ? "border-accent bg-accent-soft text-accent"
+                          : "border-border bg-surface text-text hover:bg-surface-muted",
+                      )}
+                    >
+                      <span className="font-medium">{t.tag}</span>
+                      <span className="text-xs text-text-subtle">
+                        {t.patientCount}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {!view ? (
+        <EmptyState
+          title="Pick a focus to explore"
+          description="Select a tag above to see the cohort summary — size, age distribution, outcome baselines, and the products they're using."
+        />
+      ) : view.belowMinCohort ? (
+        <Card tone="ambient">
+          <CardContent className="py-8 text-center">
+            <p className="text-sm font-medium text-text mb-1">
+              Cohort too small to display
+            </p>
+            <p className="text-sm text-text-muted">
+              Only {view.cohortSize} patient
+              {view.cohortSize === 1 ? "" : "s"} match &quot;{view.tag}&quot;.
+              We keep cohort summaries hidden until at least {MIN_COHORT_SIZE}{" "}
+              patients to protect individual privacy.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <CohortSummary view={view} />
+      )}
+    </PageShell>
+  );
+}
+
+function parseLookbackParam(raw: string | undefined): number {
+  if (!raw) return 90;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0 || n > 3650) return 90;
+  return n;
+}
+
+function CohortSummary({
+  view,
+}: {
+  view: Awaited<ReturnType<typeof getCohortExplorerView>>;
+}) {
+  return (
+    <div className="space-y-8">
+      {/* ── Summary tiles ────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatTile label="Cohort size" value={view.cohortSize.toString()} />
+        <StatTile
+          label="Median age"
+          value={
+            view.medianAgeYears != null
+              ? `${view.medianAgeYears} yr`
+              : "—"
+          }
+        />
+        <StatTile
+          label="Active regimens"
+          value={view.activeRegimenPatientCount.toString()}
+          sub={`of ${view.cohortSize}`}
+        />
+        <StatTile
+          label="On clinician picks"
+          value={
+            view.clinicianPickUsageRate == null
+              ? "—"
+              : `${Math.round(view.clinicianPickUsageRate * 100)}%`
+          }
+          sub="of actively-regimened"
+        />
+      </div>
+
+      {/* ── Metric baselines ──────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-lg font-semibold tracking-tight text-text mb-4">
+          Outcome baselines
+          <span className="text-xs font-normal text-text-subtle ml-2">
+            last {view.lookbackDays} days
+          </span>
+        </h2>
+        {view.metricBaselines.length === 0 ? (
+          <EmptyState
+            title="No outcome logs in the window"
+            description="Cohort members haven't logged outcomes in the selected lookback window."
+          />
+        ) : (
+          <div className="space-y-3">
+            {view.metricBaselines.map((m) => (
+              <MetricBar key={m.metric} metric={m.metric} mean={m.mean} sampleSize={m.sampleSize} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Popular products ──────────────────────────────────────────── */}
+      <section>
+        <h2 className="text-lg font-semibold tracking-tight text-text mb-4">
+          What this cohort uses
+        </h2>
+        {view.popularProducts.length === 0 ? (
+          <EmptyState
+            title="No linked products"
+            description="Cohort members' active regimens aren't yet linked to marketplace products. (CannabisProduct → Product FK bridge, EMR-268.)"
+          />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {view.popularProducts.map((row) => (
+              <Card key={row.product.id}>
+                <CardContent className="py-4">
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-text truncate">
+                        {row.product.name}
+                      </p>
+                      <p className="text-xs text-text-subtle truncate">
+                        {row.product.brand}
+                      </p>
+                    </div>
+                    {row.product.clinicianPick && (
+                      <Badge tone="accent" className="shrink-0">
+                        Pick
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-muted">
+                    <span className="text-accent" aria-hidden="true">
+                      ◉{" "}
+                    </span>
+                    {row.regimenCount} of {view.cohortSize} cohort members
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
+        {label}
+      </p>
+      <p className="text-2xl font-display text-text tabular-nums">{value}</p>
+      {sub && <p className="text-[11px] text-text-subtle mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+function MetricBar({
+  metric,
+  mean,
+  sampleSize,
+}: {
+  metric: string;
+  mean: number;
+  sampleSize: number;
+}) {
+  // Outcome values are 0-10 in the Leafjourney schema; normalize for the bar.
+  const pct = Math.max(0, Math.min(1, mean / 10));
+  return (
+    <div className="grid grid-cols-[8rem_1fr_4rem] items-center gap-3">
+      <span className="text-sm font-medium text-text capitalize">{metric}</span>
+      <div className="h-2 rounded-full bg-surface-muted overflow-hidden">
+        <div
+          className="h-full bg-accent"
+          style={{ width: `${pct * 100}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      <span className="text-xs text-text-muted tabular-nums text-right">
+        {mean.toFixed(1)}{" "}
+        <span className="text-text-subtle">({sampleSize})</span>
+      </span>
+    </div>
+  );
+}

--- a/src/lib/research/cohort-explorer.test.ts
+++ b/src/lib/research/cohort-explorer.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patientMemory: { findMany: vi.fn() },
+    patient: { findMany: vi.fn() },
+    outcomeLog: { findMany: vi.fn() },
+    dosingRegimen: { findMany: vi.fn() },
+    product: { findMany: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  listOrgMemoryTags,
+  getCohortExplorerView,
+  MIN_COHORT_SIZE,
+} from "./cohort-explorer";
+
+function reset() {
+  hoisted.mockPrisma.patientMemory.findMany.mockReset();
+  hoisted.mockPrisma.patient.findMany.mockReset();
+  hoisted.mockPrisma.outcomeLog.findMany.mockReset();
+  hoisted.mockPrisma.dosingRegimen.findMany.mockReset();
+  hoisted.mockPrisma.product.findMany.mockReset();
+}
+beforeEach(reset);
+
+describe("listOrgMemoryTags", () => {
+  it("returns [] when no memories exist", async () => {
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([]);
+    const result = await listOrgMemoryTags("org_1");
+    expect(result).toEqual([]);
+  });
+
+  it("counts distinct patients per tag and sorts desc", async () => {
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([
+      { patientId: "p1", tags: ["sleep", "anxiety"] },
+      { patientId: "p1", tags: ["sleep"] }, // same patient, same tag → still 1
+      { patientId: "p2", tags: ["sleep"] },
+      { patientId: "p3", tags: ["sleep", "pain"] },
+      { patientId: "p4", tags: ["pain"] },
+      { patientId: "p5", tags: ["anxiety"] },
+    ]);
+    const result = await listOrgMemoryTags("org_1");
+    expect(result).toEqual([
+      { tag: "sleep", patientCount: 3 },
+      { tag: "anxiety", patientCount: 2 },
+      { tag: "pain", patientCount: 2 },
+    ]);
+  });
+
+  it("trims whitespace + drops empty-string tags", async () => {
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([
+      { patientId: "p1", tags: ["  sleep  ", "", "pain"] },
+    ]);
+    const result = await listOrgMemoryTags("org_1");
+    expect(result.find((r) => r.tag === "sleep")).toBeDefined();
+    expect(result.find((r) => r.tag === "")).toBeUndefined();
+    expect(result.find((r) => r.tag === "  sleep  ")).toBeUndefined();
+  });
+
+  it("honors the limit parameter", async () => {
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([
+      { patientId: "p1", tags: ["a"] },
+      { patientId: "p2", tags: ["b"] },
+      { patientId: "p3", tags: ["c"] },
+      { patientId: "p4", tags: ["d"] },
+    ]);
+    const result = await listOrgMemoryTags("org_1", 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("scopes the Prisma query to the org + active memories", async () => {
+    hoisted.mockPrisma.patientMemory.findMany.mockResolvedValue([]);
+    await listOrgMemoryTags("org_xyz");
+    const where =
+      hoisted.mockPrisma.patientMemory.findMany.mock.calls[0][0].where;
+    expect(where.patient.organizationId).toBe("org_xyz");
+    expect(where.patient.deletedAt).toBeNull();
+    expect(where.tags).toEqual({ isEmpty: false });
+    expect(where.OR).toBeDefined();
+  });
+});
+
+describe("getCohortExplorerView", () => {
+  it("returns belowMinCohort when fewer than MIN_COHORT_SIZE match", async () => {
+    // cohortBuilderAgent queries patient + outcomeLog internally. Return a
+    // tiny cohort.
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue([
+      { id: "p1", dateOfBirth: null },
+    ]);
+    hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([]);
+
+    const view = await getCohortExplorerView({
+      organizationId: "org_1",
+      memoryTag: "sleep",
+    });
+
+    expect(view.belowMinCohort).toBe(true);
+    expect(view.cohortSize).toBe(1);
+    expect(view.popularProducts).toEqual([]);
+    expect(view.metricBaselines).toEqual([]);
+    expect(view.clinicianPickUsageRate).toBeNull();
+    // Neither of the downstream queries should run on a below-min cohort.
+    expect(hoisted.mockPrisma.dosingRegimen.findMany).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.product.findMany).not.toHaveBeenCalled();
+  });
+
+  it("computes clinicianPickUsageRate from active regimens", async () => {
+    const now = Date.now();
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue(
+      ["p1", "p2", "p3", "p4", "p5"].map((id) => ({
+        id,
+        dateOfBirth: new Date(now - 30 * 365 * 86_400_000),
+      })),
+    );
+    hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([
+      { patientId: "p1", metric: "sleep", value: 4, loggedAt: new Date() },
+      { patientId: "p2", metric: "sleep", value: 6, loggedAt: new Date() },
+    ]);
+    // 4 of 5 have active regimens; 3 of those 4 are on clinician picks.
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([
+      {
+        patientId: "p1",
+        product: { marketplaceProduct: { clinicianPick: true } },
+      },
+      {
+        patientId: "p2",
+        product: { marketplaceProduct: { clinicianPick: true } },
+      },
+      {
+        patientId: "p3",
+        product: { marketplaceProduct: { clinicianPick: true } },
+      },
+      {
+        patientId: "p4",
+        product: { marketplaceProduct: { clinicianPick: false } },
+      },
+    ]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+
+    const view = await getCohortExplorerView({
+      organizationId: "org_1",
+      memoryTag: "sleep",
+    });
+
+    expect(view.belowMinCohort).toBe(false);
+    expect(view.activeRegimenPatientCount).toBe(4);
+    expect(view.clinicianPickUsageRate).toBe(0.75);
+  });
+
+  it("sorts metric baselines by sampleSize desc", async () => {
+    const now = Date.now();
+    hoisted.mockPrisma.patient.findMany.mockResolvedValue(
+      ["p1", "p2", "p3"].map((id) => ({
+        id,
+        dateOfBirth: new Date(now - 35 * 365 * 86_400_000),
+      })),
+    );
+    hoisted.mockPrisma.outcomeLog.findMany.mockResolvedValue([
+      { patientId: "p1", metric: "sleep", value: 6, loggedAt: new Date() },
+      { patientId: "p2", metric: "pain", value: 7, loggedAt: new Date() },
+      { patientId: "p3", metric: "pain", value: 5, loggedAt: new Date() },
+      { patientId: "p1", metric: "pain", value: 8, loggedAt: new Date() },
+    ]);
+    hoisted.mockPrisma.dosingRegimen.findMany.mockResolvedValue([]);
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+
+    const view = await getCohortExplorerView({
+      organizationId: "org_1",
+      memoryTag: "sleep",
+    });
+
+    expect(view.metricBaselines[0].metric).toBe("pain"); // 3 samples
+    expect(view.metricBaselines[0].sampleSize).toBe(3);
+    expect(view.metricBaselines[1].metric).toBe("sleep");
+    expect(view.metricBaselines[1].sampleSize).toBe(1);
+  });
+});

--- a/src/lib/research/cohort-explorer.ts
+++ b/src/lib/research/cohort-explorer.ts
@@ -1,0 +1,189 @@
+// EMR-271 — Clinician cohort explorer data layer.
+//
+// Drives `/clinic/cohorts`. Wraps cohortBuilderAgent + the EMR-270
+// cohort-insights helper + a clinician-pick usage calculation into one
+// view model so the UI can render without chaining queries.
+//
+// The tag discovery path (`listOrgMemoryTags`) flattens `PatientMemory.tags[]`
+// in JS because Prisma doesn't expose a generic SELECT DISTINCT over array
+// elements. Fine at seed scale; at practice scale (10k+ patients) this
+// would move to a raw `unnest` query or a materialized tag-count table.
+
+import { prisma } from "@/lib/db/prisma";
+import { cohortBuilderAgent } from "@/lib/agents/research/cohort-builder-agent";
+import {
+  getPopularProductsInCohort,
+  MIN_COHORT_SIZE,
+  type CohortPopularProduct,
+} from "@/lib/marketplace/cohort-insights";
+
+export { MIN_COHORT_SIZE };
+
+export interface TagUsage {
+  tag: string;
+  patientCount: number;
+}
+
+/**
+ * Distinct non-empty tags from currently-valid PatientMemory rows in the
+ * org, ranked by the number of patients using each tag. Drives the tag
+ * picker on the cohort explorer page.
+ */
+export async function listOrgMemoryTags(
+  organizationId: string,
+  limit = 20,
+): Promise<TagUsage[]> {
+  const memories = await prisma.patientMemory.findMany({
+    where: {
+      patient: { organizationId, deletedAt: null },
+      tags: { isEmpty: false },
+      OR: [{ validUntil: null }, { validUntil: { gt: new Date() } }],
+    },
+    select: { patientId: true, tags: true },
+  });
+
+  // Tag → distinct patient count. A patient with two memories tagged
+  // "sleep" still counts once.
+  const patientsByTag = new Map<string, Set<string>>();
+  for (const m of memories) {
+    for (const raw of m.tags) {
+      const tag = raw.trim();
+      if (!tag) continue;
+      const set = patientsByTag.get(tag) ?? new Set<string>();
+      set.add(m.patientId);
+      patientsByTag.set(tag, set);
+    }
+  }
+
+  return [...patientsByTag.entries()]
+    .map(([tag, patients]) => ({ tag, patientCount: patients.size }))
+    .sort(
+      (a, b) => b.patientCount - a.patientCount || a.tag.localeCompare(b.tag),
+    )
+    .slice(0, limit);
+}
+
+export interface CohortExplorerView {
+  tag: string;
+  lookbackDays: number;
+  cohortSize: number;
+  peerCount: number; // same as cohortSize — named for clarity
+  medianAgeYears: number | null;
+  activeRegimenPatientCount: number;
+  clinicianPickUsageRate: number | null; // 0..1 or null when cohortSize < MIN
+  metricBaselines: Array<{
+    metric: string;
+    mean: number;
+    sampleSize: number;
+  }>;
+  popularProducts: CohortPopularProduct[];
+  belowMinCohort: boolean;
+}
+
+/**
+ * One-shot view model for `/clinic/cohorts?tag=...`. Fans out
+ * cohortBuilder + cohort-insights + clinician-pick usage in parallel;
+ * the route renders straight from this object.
+ */
+export async function getCohortExplorerView(params: {
+  organizationId: string;
+  memoryTag: string;
+  lookbackDays?: number;
+  productLimit?: number;
+}): Promise<CohortExplorerView> {
+  const lookbackDays = params.lookbackDays ?? 90;
+
+  // cohortBuilder only calls ctx.log — stub is safe.
+  const stubCtx = { log: () => {} } as unknown as Parameters<
+    typeof cohortBuilderAgent.run
+  >[1];
+
+  const cohort = await cohortBuilderAgent.run(
+    {
+      organizationId: params.organizationId,
+      memoryTag: params.memoryTag,
+      activeRegimenOnly: false,
+      lookbackDays,
+    },
+    stubCtx,
+  );
+
+  const cohortSize = cohort.size;
+  const belowMinCohort = cohortSize < MIN_COHORT_SIZE;
+
+  if (belowMinCohort) {
+    return {
+      tag: params.memoryTag,
+      lookbackDays,
+      cohortSize,
+      peerCount: cohortSize,
+      medianAgeYears:
+        cohort.medianAgeDays != null
+          ? Math.round(cohort.medianAgeDays / 365)
+          : null,
+      activeRegimenPatientCount: 0,
+      clinicianPickUsageRate: null,
+      metricBaselines: [],
+      popularProducts: [],
+      belowMinCohort: true,
+    };
+  }
+
+  const [activeRegimens, popularProducts] = await Promise.all([
+    prisma.dosingRegimen.findMany({
+      where: {
+        patientId: { in: cohort.patientIds },
+        active: true,
+      },
+      select: {
+        patientId: true,
+        product: {
+          select: {
+            marketplaceProduct: { select: { clinicianPick: true } },
+          },
+        },
+      },
+    }),
+    getPopularProductsInCohort(cohort.patientIds, {
+      organizationId: params.organizationId,
+      limit: params.productLimit ?? 6,
+    }),
+  ]);
+
+  const patientsWithActiveRegimen = new Set(
+    activeRegimens.map((r) => r.patientId),
+  );
+  const patientsOnClinicianPick = new Set(
+    activeRegimens
+      .filter((r) => r.product.marketplaceProduct?.clinicianPick)
+      .map((r) => r.patientId),
+  );
+  const clinicianPickUsageRate =
+    patientsWithActiveRegimen.size === 0
+      ? 0
+      : Number(
+          (
+            patientsOnClinicianPick.size / patientsWithActiveRegimen.size
+          ).toFixed(3),
+        );
+
+  const metricBaselines = Object.entries(cohort.metricBaselines)
+    .map(([metric, stats]) => ({ metric, ...stats }))
+    .sort((a, b) => b.sampleSize - a.sampleSize);
+
+  return {
+    tag: params.memoryTag,
+    lookbackDays,
+    cohortSize,
+    peerCount: cohortSize,
+    medianAgeYears:
+      cohort.medianAgeDays != null
+        ? Math.round(cohort.medianAgeDays / 365)
+        : null,
+    activeRegimenPatientCount: patientsWithActiveRegimen.size,
+    clinicianPickUsageRate,
+    metricBaselines,
+    popularProducts,
+    belowMinCohort: false,
+  };
+}


### PR DESCRIPTION
## Summary

Clinician-facing **Cohort Explorer** at `/clinic/cohorts`. Symmetric to the two patient-facing widgets shipped in EMR-268 (Recommended-for-You) and EMR-270 (Patients-Like-You). Lets clinicians answer "what's happening in my [memory-tag] patient population" in two clicks — demo-ready moat surface for founding partners.

Linear: **EMR-271** (child of EMR-17, relates to EMR-230 / EMR-268 / EMR-269 / EMR-270)

## ⚠️ Stacked on PR #79

Base: `scwayman/patients-like-you-widget` (PR #79). After #78 and #79 merge, rebase this onto main and the diff shrinks to just these 3 files.

## What's in this PR (3 files, +656)

### Data layer — `src/lib/research/cohort-explorer.ts`
- `listOrgMemoryTags(orgId, limit = 20)` — distinct non-empty tags from currently-valid `PatientMemory` rows across the org, ranked by distinct-patient count. Drives the tag picker. Flattens `tags[]` in JS because Prisma doesn't expose `SELECT DISTINCT` over array elements — fine at seed scale, move to raw `unnest` at practice scale.
- `getCohortExplorerView({ organizationId, memoryTag, lookbackDays })` — one-shot view model. Fans out `cohortBuilderAgent` + `getPopularProductsInCohort` (EMR-270) + clinician-pick usage rate in parallel. Short-circuits with `belowMinCohort` when cohort < `MIN_COHORT_SIZE`, mirroring the HIPAA guard on the patient widget.

### Route — `src/app/(clinician)/clinic/cohorts/page.tsx`
- Auth inherited from `(clinician)/layout.tsx` (clinician + practice_owner)
- `?tag=X[&window=N]` URL-param selection
- Tag-picker chip row with per-tag patient counts
- Summary tiles: cohort size, median age (yr), active regimen count, clinician-pick usage rate
- Outcome baseline bars: one row per metric, 0–10 normalized, shows mean + sample size
- "What this cohort uses" grid — reuses `CohortPopularProduct` from EMR-270; clinician-pick badge when applicable

### Empty states handled
- No tags in the org → copy explaining the pipeline
- No tag selected → picker + prompt
- Tag selected, cohort < `MIN_COHORT_SIZE` → "too small to display" + rationale
- No outcome logs in the window → inline empty state
- No linked products → pointer to EMR-268 FK caveat

## Tests — 8 new vitest cases

**`listOrgMemoryTags`** (5):
- Empty org → `[]`
- Distinct-patient-per-tag counting + desc sort
- Whitespace trim + empty-string drop
- Limit honored
- WHERE clause shape (org-scoped + active memories only)

**`getCohortExplorerView`** (3):
- `belowMinCohort` short-circuit — no downstream queries fire
- `clinicianPickUsageRate = on-picks / active-regimened`
- `metricBaselines` sorted by `sampleSize` desc

**319/319 tests pass. `npm run typecheck` clean.**

## Out of scope (deliberately)

- Comparison view (cohort A vs B) — follow-up once `efficacyComparator` upgrades from stub
- LLM-generated cohort narrative — `outcomeDigester` stub owns that when real
- Export / download — separate ticket
- Schema changes
- Anything in Lucca's or Codex's lanes

## PR stack

| # | Title | State |
|---|---|---|
| 78 | Research & Insights fleet (EMR-269) | open |
| 79 | Patients-Like-You widget (EMR-270) | open, stacked on #78 |
| **this** | Cohort Explorer (EMR-271) | open, stacked on #79 |

## Test plan

- [x] `npm test` (319/319)
- [x] `npm run typecheck`
- [ ] As a clinician, load `/clinic/cohorts` — see tag picker populated with the demo memory tags
- [ ] Click "sleep" — summary tiles render, metric baseline bars render, popular-products grid renders
- [ ] Click a rare/unique tag → "cohort too small to display" placeholder
- [ ] Load as a patient → redirected away (layout gates the route)

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_