### PR TITLE
feat(agents): Cannabis Pharmacology Fleet — 12 agents + terpeneProfileMatcher POC (EMR-272)

### DIFF
--- a/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
@@ -29,7 +29,7 @@ const DEFAULT_MODEL_ID = getDefaultConfig().modelId;
 type FleetState = Record<string, { enabled: boolean; modelId: string | null }>;
 
 const TIER_ORDER: ModelTier[] = ["budget", "balanced", "premium", "open-source"];
-const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations", "commerce", "research"];
+const CATEGORY_ORDER: AgentCategory[] = ["clinical", "safety", "patient", "billing", "operations", "commerce", "research", "pharmacology"];
 
 const TIER_SWATCH: Record<ModelTier, string> = {
   "budget": "bg-emerald-500",
@@ -46,6 +46,7 @@ const CATEGORY_EMOJI: Record<AgentCategory, string> = {
   operations: "⚙️",
   commerce: "🛒",
   research: "🔬",
+  pharmacology: "💊",
 };
 
 export function AgentFleetPanel() {
@@ -228,6 +229,8 @@ export function AgentFleetPanel() {
                   ? "Marketplace fleet. Compliance + fraud benefit from premium models; catalog hygiene is fine on budget."
                   : category === "research"
                   ? "Research + insights fleet. RWE and protocol recommendations benefit from premium models; cohort math is fine on budget."
+                  : category === "pharmacology"
+                  ? "Cannabis pharmacology fleet. Interaction checkers + perinatal framing want premium models; route + terpene work is fine on balanced."
                   : "Core clinical agents that shape the physician's daily workflow."}
               </CardDescription>
             </CardHeader>

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -93,6 +93,19 @@ import { protocolRecommenderAgent } from "./research/protocol-recommender-agent"
 import { insuranceEvidenceBundlerAgent } from "./research/insurance-evidence-bundler-agent";
 import { publicationReadinessScorerAgent } from "./research/publication-readiness-scorer-agent";
 import { researchPartnerMatcherAgent } from "./research/research-partner-matcher-agent";
+// Cannabis Pharmacology Fleet — EMR-272 (12 agents, 2026-04-23)
+import { terpeneProfileMatcherAgent } from "./pharmacology/terpene-profile-matcher-agent";
+import { cannabinoidInteractionCheckerAgent } from "./pharmacology/cannabinoid-interaction-checker-agent";
+import { routeOfAdministrationAdvisorAgent } from "./pharmacology/route-of-administration-advisor-agent";
+import { pkPdCalculatorAgent } from "./pharmacology/pk-pd-calculator-agent";
+import { titrationSchedulerAgent } from "./pharmacology/titration-scheduler-agent";
+import { entourageAnalystAgent } from "./pharmacology/entourage-analyst-agent";
+import { drugCannabisInteractionCheckerAgent } from "./pharmacology/drug-cannabis-interaction-checker-agent";
+import { toleranceTrackerAgent } from "./pharmacology/tolerance-tracker-agent";
+import { washoutPlannerAgent } from "./pharmacology/washout-planner-agent";
+import { contraindicationSweeperAgent } from "./pharmacology/contraindication-sweeper-agent";
+import { bioequivalenceMapperAgent } from "./pharmacology/bioequivalence-mapper-agent";
+import { pregnancyLactationAdvisorAgent } from "./pharmacology/pregnancy-lactation-advisor-agent";
 
 /**
  * Registry of all agents. Adding an agent = new file + one line here +
@@ -195,6 +208,19 @@ export const agentRegistry = {
   insuranceEvidenceBundler: insuranceEvidenceBundlerAgent,
   publicationReadinessScorer: publicationReadinessScorerAgent,
   researchPartnerMatcher: researchPartnerMatcherAgent,
+  // Cannabis Pharmacology Fleet — EMR-272 (12 agents, 2026-04-23)
+  terpeneProfileMatcher: terpeneProfileMatcherAgent,
+  cannabinoidInteractionChecker: cannabinoidInteractionCheckerAgent,
+  routeOfAdministrationAdvisor: routeOfAdministrationAdvisorAgent,
+  pkPdCalculator: pkPdCalculatorAgent,
+  titrationScheduler: titrationSchedulerAgent,
+  entourageAnalyst: entourageAnalystAgent,
+  drugCannabisInteractionChecker: drugCannabisInteractionCheckerAgent,
+  toleranceTracker: toleranceTrackerAgent,
+  washoutPlanner: washoutPlannerAgent,
+  contraindicationSweeper: contraindicationSweeperAgent,
+  bioequivalenceMapper: bioequivalenceMapperAgent,
+  pregnancyLactationAdvisor: pregnancyLactationAdvisorAgent,
 } satisfies Record<string, Agent<any, any>>;
 
 /** Agents tagged as "commerce" — used by the marketplace ops console. */
@@ -233,6 +259,22 @@ export const RESEARCH_AGENT_NAMES: AgentName[] = [
   "insuranceEvidenceBundler",
   "publicationReadinessScorer",
   "researchPartnerMatcher",
+];
+
+/** Agents tagged as "pharmacology" — used by the prescribe / titrate surfaces. */
+export const PHARMACOLOGY_AGENT_NAMES: AgentName[] = [
+  "terpeneProfileMatcher",
+  "cannabinoidInteractionChecker",
+  "routeOfAdministrationAdvisor",
+  "pkPdCalculator",
+  "titrationScheduler",
+  "entourageAnalyst",
+  "drugCannabisInteractionChecker",
+  "toleranceTracker",
+  "washoutPlanner",
+  "contraindicationSweeper",
+  "bioequivalenceMapper",
+  "pregnancyLactationAdvisor",
 ];
 
 export type AgentName = keyof typeof agentRegistry;

--- a/src/lib/agents/pharmacology/bioequivalence-mapper-agent.ts
+++ b/src/lib/agents/pharmacology/bioequivalence-mapper-agent.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  cannabinoid: z.enum(["THC", "CBD", "CBN", "CBG"]),
+  mgDose: z.number().positive(),
+  fromRoute: z.enum(["sublingual", "oral", "inhaled", "topical", "transdermal"]),
+  toRoute: z.enum(["sublingual", "oral", "inhaled", "topical", "transdermal"]),
+});
+
+const output = z.object({
+  convertedMg: z.number().nullable(),
+  conversionFactor: z.number().nullable(),
+  caveat: z.string(),
+});
+
+/**
+ * Bioequivalence Mapper
+ * ---------------------
+ * Status: stub (EMR-272). Dose-equivalence across routes requires the
+ * EMR-146 PK tables; returns null conversion today with a clear caveat.
+ */
+export const bioequivalenceMapperAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "bioequivalenceMapper",
+  version: "0.1.0",
+  description:
+    "Converts a cannabinoid dose between routes of administration.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cannabinoid, fromRoute, toRoute }, ctx) {
+    ctx.log("info", "bioequivalenceMapper stub", { cannabinoid, fromRoute, toRoute });
+    return {
+      convertedMg: null,
+      conversionFactor: null,
+      caveat: "Stub — route-to-route conversion table pending EMR-146.",
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/cannabinoid-interaction-checker-agent.ts
+++ b/src/lib/agents/pharmacology/cannabinoid-interaction-checker-agent.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  cannabinoids: z.array(
+    z.object({
+      name: z.enum(["THC", "CBD", "CBN", "CBG", "CBC", "THCV", "THCA", "CBDA"]),
+      mgPerDose: z.number().min(0),
+    }),
+  ),
+});
+
+const output = z.object({
+  flags: z.array(
+    z.object({
+      severity: z.enum(["info", "caution", "warning"]),
+      summary: z.string(),
+      involvedCannabinoids: z.array(z.string()),
+    }),
+  ),
+});
+
+/**
+ * Cannabinoid Interaction Checker
+ * -------------------------------
+ * Status: stub (EMR-272 / Pharmacology fleet). Real matrix lands with the
+ * Health Canada ingest in EMR-146. Today returns an empty flag list.
+ */
+export const cannabinoidInteractionCheckerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "cannabinoidInteractionChecker",
+  version: "0.1.0",
+  description:
+    "Flags interactions within a multi-cannabinoid formulation at clinical dose.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ cannabinoids }, ctx) {
+    ctx.log("info", "cannabinoidInteractionChecker stub", {
+      cannabinoidCount: cannabinoids.length,
+    });
+    return { flags: [] };
+  },
+};

--- a/src/lib/agents/pharmacology/contraindication-sweeper-agent.ts
+++ b/src/lib/agents/pharmacology/contraindication-sweeper-agent.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  contraindications: z.array(z.string()),
+  riskyProducts: z.array(
+    z.object({
+      productId: z.string(),
+      reasons: z.array(z.string()),
+    }),
+  ),
+  swept: z.boolean(),
+});
+
+/**
+ * Contraindication Sweeper
+ * ------------------------
+ * Status: stub (EMR-272). Will cross-reference `Patient.contraindications`
+ * + `allergies` against the marketplace catalog to flag risky listings.
+ * Returns an empty risky list today but echoes the patient's known
+ * contraindications so callers can render context.
+ */
+export const contraindicationSweeperAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "contraindicationSweeper",
+  version: "0.1.0",
+  description:
+    "Sweeps the catalog for products that conflict with a patient's contraindications.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ patientId }, ctx) {
+    const { prisma } = await import("@/lib/db/prisma");
+    const patient = await prisma.patient.findUnique({
+      where: { id: patientId },
+      select: { contraindications: true },
+    });
+    ctx.log("info", "contraindicationSweeper stub", { patientId });
+    return {
+      patientId,
+      contraindications: patient?.contraindications ?? [],
+      riskyProducts: [],
+      swept: Boolean(patient),
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/drug-cannabis-interaction-checker-agent.ts
+++ b/src/lib/agents/pharmacology/drug-cannabis-interaction-checker-agent.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientMedications: z.array(z.string()),
+  cannabinoids: z.array(
+    z.object({
+      name: z.enum(["THC", "CBD", "CBN", "CBG"]),
+      mgPerDay: z.number().min(0),
+    }),
+  ),
+});
+
+const output = z.object({
+  flags: z.array(
+    z.object({
+      severity: z.enum(["info", "caution", "warning", "contraindicated"]),
+      medication: z.string(),
+      cannabinoid: z.string(),
+      mechanism: z.string(),
+      recommendation: z.string(),
+    }),
+  ),
+});
+
+/**
+ * Drug × Cannabis Interaction Checker
+ * -----------------------------------
+ * Status: stub (EMR-272). The high-value interactions (warfarin, SSRIs,
+ * CYP3A4 inhibitors, immunosuppressants, certain antiepileptics) will be
+ * encoded against the EMR-146 Health Canada + Epidiolex reference once
+ * ingested. Returns empty flags today. Approval-gated.
+ */
+export const drugCannabisInteractionCheckerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "drugCannabisInteractionChecker",
+  version: "0.1.0",
+  description:
+    "Flags interactions between patient medications and cannabinoid therapy.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientMedications, cannabinoids }, ctx) {
+    ctx.log("info", "drugCannabisInteractionChecker stub", {
+      medCount: patientMedications.length,
+      cannabinoidCount: cannabinoids.length,
+    });
+    return { flags: [] };
+  },
+};

--- a/src/lib/agents/pharmacology/entourage-analyst-agent.ts
+++ b/src/lib/agents/pharmacology/entourage-analyst-agent.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  indication: z.string(),
+  preferFullSpectrum: z.boolean().optional(),
+});
+
+const output = z.object({
+  preference: z.enum(["full_spectrum", "broad_spectrum", "isolate", "no_preference"]),
+  rationale: z.string(),
+  caveats: z.array(z.string()),
+});
+
+/**
+ * Entourage Analyst
+ * -----------------
+ * Status: stub (EMR-272). Returns `no_preference` until the full-spectrum
+ * vs isolate decision table lands with EMR-146.
+ */
+export const entourageAnalystAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "entourageAnalyst",
+  version: "0.1.0",
+  description:
+    "Advises full-spectrum vs broad-spectrum vs isolate for a given indication.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ indication }, ctx) {
+    ctx.log("info", "entourageAnalyst stub", { indication });
+    return {
+      preference: "no_preference" as const,
+      rationale:
+        "Stub — full/broad/isolate decision table pending EMR-146 ingest.",
+      caveats: [],
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/pk-pd-calculator-agent.ts
+++ b/src/lib/agents/pharmacology/pk-pd-calculator-agent.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  cannabinoid: z.enum(["THC", "CBD", "CBN", "CBG"]),
+  mgDose: z.number().positive(),
+  route: z.enum(["sublingual", "oral", "inhaled", "topical", "transdermal"]),
+  patientWeightKg: z.number().positive().optional(),
+});
+
+const output = z.object({
+  estimatedBioavailabilityPct: z.number().nullable(),
+  estimatedCmaxNgPerMl: z.number().nullable(),
+  estimatedTmaxMinutes: z.number().nullable(),
+  estimatedHalfLifeHours: z.number().nullable(),
+  caveat: z.string(),
+});
+
+/**
+ * PK/PD Calculator
+ * ----------------
+ * Status: stub (EMR-272). Returns null values with caveat; the real
+ * parameter tables land with EMR-146.
+ */
+export const pkPdCalculatorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "pkPdCalculator",
+  version: "0.1.0",
+  description: "Estimates PK/PD parameters for a cannabinoid + route + dose.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ cannabinoid, route, mgDose }, ctx) {
+    ctx.log("info", "pkPdCalculator stub", { cannabinoid, route, mgDose });
+    return {
+      estimatedBioavailabilityPct: null,
+      estimatedCmaxNgPerMl: null,
+      estimatedTmaxMinutes: null,
+      estimatedHalfLifeHours: null,
+      caveat: "Stub — PK/PD tables pending EMR-146.",
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/pregnancy-lactation-advisor-agent.ts
+++ b/src/lib/agents/pharmacology/pregnancy-lactation-advisor-agent.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  stage: z.enum([
+    "preconception",
+    "pregnancy_t1",
+    "pregnancy_t2",
+    "pregnancy_t3",
+    "lactation",
+    "none",
+  ]),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  stage: z.string(),
+  guidance: z.string(),
+  caveats: z.array(z.string()),
+});
+
+/**
+ * Pregnancy / Lactation Advisor
+ * -----------------------------
+ * Status: stub (EMR-272). Returns a conservative default advisory —
+ * detailed stage-specific guidance lands with EMR-146. Approval-gated
+ * because perinatal framing is high-stakes.
+ */
+export const pregnancyLactationAdvisorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "pregnancyLactationAdvisor",
+  version: "0.1.0",
+  description:
+    "Cautious framing for cannabinoid use across pregnancy and lactation.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientId, stage }, ctx) {
+    ctx.log("info", "pregnancyLactationAdvisor stub", { patientId, stage });
+    return {
+      patientId,
+      stage,
+      guidance:
+        "Stub — consult current Health Canada and ACOG guidance. Default is conservative avoidance.",
+      caveats: [
+        "Detailed stage-specific framing lands with EMR-146 ingest.",
+      ],
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/route-of-administration-advisor-agent.ts
+++ b/src/lib/agents/pharmacology/route-of-administration-advisor-agent.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  indication: z.string(),
+  onsetNeed: z.enum(["immediate", "minutes", "hours"]),
+  durationNeed: z.enum(["short", "moderate", "extended"]),
+  patientPreference: z
+    .enum(["sublingual", "oral", "inhaled", "topical", "transdermal"])
+    .optional(),
+});
+
+const output = z.object({
+  recommendation: z.enum([
+    "sublingual",
+    "oral",
+    "inhaled",
+    "topical",
+    "transdermal",
+    "unspecified",
+  ]),
+  rationale: z.string(),
+  alternatives: z.array(z.string()),
+});
+
+/**
+ * Route of Administration Advisor
+ * -------------------------------
+ * Status: stub (EMR-272). Decision matrix pending EMR-146 ingest; returns
+ * `unspecified` today with a clear rationale note.
+ */
+export const routeOfAdministrationAdvisorAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "routeOfAdministrationAdvisor",
+  version: "0.1.0",
+  description:
+    "Recommends a route of administration given indication + onset + duration needs.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ indication }, ctx) {
+    ctx.log("info", "routeOfAdministrationAdvisor stub", { indication });
+    return {
+      recommendation: "unspecified" as const,
+      rationale: "Stub — decision matrix lands with EMR-146 Health Canada ingest.",
+      alternatives: [],
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/terpene-profile-matcher-agent.test.ts
+++ b/src/lib/agents/pharmacology/terpene-profile-matcher-agent.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    product: { findUnique: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import { terpeneProfileMatcherAgent } from "./terpene-profile-matcher-agent";
+
+const makeCtx = () =>
+  ({ log: vi.fn() }) as unknown as Parameters<
+    typeof terpeneProfileMatcherAgent.run
+  >[1];
+
+beforeEach(() => {
+  hoisted.mockPrisma.product.findUnique.mockReset();
+});
+
+describe("terpeneProfileMatcher", () => {
+  it("returns empty hints when the profile is empty", async () => {
+    const result = await terpeneProfileMatcherAgent.run(
+      { terpeneProfile: {} },
+      makeCtx(),
+    );
+    expect(result.dominantTerpenes).toEqual([]);
+    expect(result.therapeuticHints).toEqual([]);
+  });
+
+  it("ranks dominant terpenes desc by concentration + aggregates hints", async () => {
+    const result = await terpeneProfileMatcherAgent.run(
+      {
+        terpeneProfile: {
+          myrcene: 0.9,
+          linalool: 0.4,
+          limonene: 0.1,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(result.dominantTerpenes.map((t) => t.terpene)).toEqual([
+      "myrcene",
+      "linalool",
+      "limonene",
+    ]);
+    // myrcene + linalool both contribute "supports restful sleep" — aggregated
+    // to one hint with both supporting terpenes, sorted.
+    const sleepHint = result.therapeuticHints.find(
+      (h) => h.hint === "supports restful sleep",
+    );
+    expect(sleepHint?.supportingTerpenes).toEqual(["linalool", "myrcene"]);
+    expect(sleepHint?.evidenceLevel).toBe("preclinical");
+  });
+
+  it("filters unknown terpenes without crashing", async () => {
+    const result = await terpeneProfileMatcherAgent.run(
+      {
+        terpeneProfile: {
+          madeUpTerpene: 0.7,
+          myrcene: 0.5,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(result.dominantTerpenes).toHaveLength(2);
+    // Only myrcene contributes to hints
+    expect(
+      result.therapeuticHints.every((h) =>
+        h.supportingTerpenes.every((t) => t === "myrcene"),
+      ),
+    ).toBe(true);
+  });
+
+  it("maps unicode/hyphen/underscore terpene names (β-caryophyllene, beta_caryophyllene)", async () => {
+    const unicode = await terpeneProfileMatcherAgent.run(
+      { terpeneProfile: { "β-caryophyllene": 0.6 } },
+      makeCtx(),
+    );
+    expect(unicode.therapeuticHints.length).toBeGreaterThan(0);
+
+    const underscore = await terpeneProfileMatcherAgent.run(
+      { terpeneProfile: { beta_caryophyllene: 0.6 } },
+      makeCtx(),
+    );
+    expect(underscore.therapeuticHints.length).toBeGreaterThan(0);
+  });
+
+  it("fetches the product when only a productId is provided", async () => {
+    hoisted.mockPrisma.product.findUnique.mockResolvedValue({
+      terpeneProfile: { pinene: 0.8 },
+    });
+
+    const result = await terpeneProfileMatcherAgent.run(
+      { productId: "p1" },
+      makeCtx(),
+    );
+
+    expect(result.resolvedFrom).toBe("product_fetch");
+    expect(result.therapeuticHints.some((h) => h.hint.includes("focus"))).toBe(
+      true,
+    );
+  });
+
+  it("sorts hints by evidence level then by top supporting concentration", async () => {
+    const result = await terpeneProfileMatcherAgent.run(
+      {
+        terpeneProfile: {
+          // Two preclinical hits at equal concentration — tiebreak on name
+          myrcene: 0.5,
+          linalool: 0.5,
+          // Anecdotal-only hit ranks below preclinical ones regardless of
+          // concentration.
+          ocimene: 0.99,
+        },
+      },
+      makeCtx(),
+    );
+
+    const first = result.therapeuticHints[0];
+    expect(first.evidenceLevel).toBe("preclinical");
+
+    const anecdotalIdx = result.therapeuticHints.findIndex(
+      (h) => h.hint === "supports alertness",
+    );
+    const lastPreclinicalIdx = [...result.therapeuticHints]
+      .map((h, i) => ({ i, e: h.evidenceLevel }))
+      .filter((x) => x.e === "preclinical")
+      .pop()?.i;
+    expect(anecdotalIdx).toBeGreaterThan(lastPreclinicalIdx ?? -1);
+  });
+});

--- a/src/lib/agents/pharmacology/terpene-profile-matcher-agent.ts
+++ b/src/lib/agents/pharmacology/terpene-profile-matcher-agent.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+// EMR-272 — Terpene Profile Matcher (POC, real logic).
+//
+// Given a marketplace product's terpene profile, returns ranked therapeutic
+// hints drawn from a curated terpene→indication table. The knowledge table
+// is intentionally small and conservative — structure/function framing only,
+// no disease claims (aligns with the FDA screening Codex is building in
+// EMR-243). Expand the table as EMR-146's Health Canada ingest matures.
+
+const input = z.object({
+  productId: z.string().optional(),
+  terpeneProfile: z.record(z.number()).optional(),
+});
+
+const output = z.object({
+  productId: z.string().optional(),
+  dominantTerpenes: z.array(
+    z.object({
+      terpene: z.string(),
+      concentration: z.number(),
+    }),
+  ),
+  therapeuticHints: z.array(
+    z.object({
+      hint: z.string(),
+      supportingTerpenes: z.array(z.string()),
+      evidenceLevel: z.enum(["anecdotal", "preclinical", "clinical"]),
+    }),
+  ),
+  resolvedFrom: z.enum(["input_profile", "product_fetch", "empty"]),
+});
+
+interface TerpeneKnowledge {
+  hint: string;
+  evidence: "anecdotal" | "preclinical" | "clinical";
+}
+
+// Conservative structure/function hints. One terpene can contribute to
+// multiple hints; hints aggregate across matching terpenes.
+const TERPENE_TABLE: Record<string, TerpeneKnowledge[]> = {
+  myrcene: [
+    { hint: "supports restful sleep", evidence: "preclinical" },
+    { hint: "contributes to body-forward, calming effects", evidence: "anecdotal" },
+  ],
+  linalool: [
+    { hint: "supports a calm mood", evidence: "preclinical" },
+    { hint: "supports restful sleep", evidence: "anecdotal" },
+  ],
+  limonene: [
+    { hint: "supports a positive mood", evidence: "preclinical" },
+    { hint: "may encourage alertness", evidence: "anecdotal" },
+  ],
+  pinene: [
+    { hint: "supports mental clarity and focus", evidence: "preclinical" },
+    { hint: "may ease the sensation of body heaviness", evidence: "anecdotal" },
+  ],
+  alphaPinene: [
+    { hint: "supports mental clarity and focus", evidence: "preclinical" },
+  ],
+  betaPinene: [
+    { hint: "supports mental clarity and focus", evidence: "preclinical" },
+  ],
+  caryophyllene: [
+    { hint: "supports recovery after activity", evidence: "preclinical" },
+    { hint: "contributes to a grounded feeling", evidence: "anecdotal" },
+  ],
+  betaCaryophyllene: [
+    { hint: "supports recovery after activity", evidence: "preclinical" },
+  ],
+  humulene: [
+    { hint: "may moderate appetite", evidence: "anecdotal" },
+  ],
+  terpinolene: [
+    { hint: "supports an uplifted, engaged state", evidence: "anecdotal" },
+  ],
+  ocimene: [
+    { hint: "supports alertness", evidence: "anecdotal" },
+  ],
+  eucalyptol: [
+    { hint: "supports easy breathing", evidence: "preclinical" },
+  ],
+};
+
+const EVIDENCE_RANK: Record<"anecdotal" | "preclinical" | "clinical", number> = {
+  clinical: 3,
+  preclinical: 2,
+  anecdotal: 1,
+};
+
+function normalizeKey(raw: string): string {
+  return raw
+    .trim()
+    // Strip common prefix notations so e.g. "β-caryophyllene" and
+    // "beta_caryophyllene" both map to "betaCaryophyllene" → fall back to
+    // "caryophyllene" when not present in the table.
+    .replace(/[\s_\-]+/g, "")
+    .replace(/β/g, "beta")
+    .replace(/α/g, "alpha")
+    .toLowerCase();
+}
+
+function lookupTerpene(raw: string): { key: string; knowledge: TerpeneKnowledge[] } | null {
+  const key = normalizeKey(raw);
+  // Try direct match, then alpha/beta-prefix stripped match.
+  const direct = TERPENE_TABLE[Object.keys(TERPENE_TABLE).find((k) => k.toLowerCase() === key) ?? ""];
+  if (direct) return { key, knowledge: direct };
+  const stripped = key.replace(/^(alpha|beta)/, "");
+  const fallbackKey = Object.keys(TERPENE_TABLE).find(
+    (k) => k.toLowerCase() === stripped,
+  );
+  if (fallbackKey) return { key, knowledge: TERPENE_TABLE[fallbackKey] };
+  return null;
+}
+
+/**
+ * Terpene Profile Matcher (EMR-272 POC)
+ * -------------------------------------
+ * Input: a product ID (looks up `Product.terpeneProfile`) or an inline
+ * terpene profile. Output: dominant terpenes (sorted desc by
+ * concentration) + therapeutic hints aggregated from a curated table.
+ *
+ * Hints are structure/function framed, never disease claims.
+ */
+export const terpeneProfileMatcherAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "terpeneProfileMatcher",
+  version: "0.1.0",
+  description:
+    "Maps a product's terpene profile to structure/function therapeutic hints.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ productId, terpeneProfile }, ctx) {
+    let profile = terpeneProfile;
+    let resolvedFrom: z.infer<typeof output>["resolvedFrom"] = "input_profile";
+
+    if (!profile && productId) {
+      const { prisma } = await import("@/lib/db/prisma");
+      const p = await prisma.product.findUnique({
+        where: { id: productId },
+        select: { terpeneProfile: true },
+      });
+      profile = (p?.terpeneProfile ?? null) as Record<string, number> | null ?? undefined;
+      resolvedFrom = profile ? "product_fetch" : "empty";
+    }
+
+    if (!profile || Object.keys(profile).length === 0) {
+      ctx.log("info", "terpeneProfileMatcher: empty profile", { productId });
+      return {
+        productId,
+        dominantTerpenes: [],
+        therapeuticHints: [],
+        resolvedFrom: profile === undefined ? "empty" : resolvedFrom,
+      };
+    }
+
+    const dominantTerpenes = Object.entries(profile)
+      .filter(([, v]) => typeof v === "number" && v > 0)
+      .map(([terpene, concentration]) => ({ terpene, concentration }))
+      .sort(
+        (a, b) =>
+          b.concentration - a.concentration || a.terpene.localeCompare(b.terpene),
+      );
+
+    // Aggregate hints. Each hint carries supporting terpenes + the highest
+    // evidence level among contributing terpenes.
+    const byHint = new Map<
+      string,
+      {
+        supportingTerpenes: Set<string>;
+        evidence: "anecdotal" | "preclinical" | "clinical";
+        topConcentration: number;
+      }
+    >();
+    for (const { terpene, concentration } of dominantTerpenes) {
+      const looked = lookupTerpene(terpene);
+      if (!looked) continue;
+      for (const entry of looked.knowledge) {
+        const existing = byHint.get(entry.hint);
+        if (existing) {
+          existing.supportingTerpenes.add(terpene);
+          if (EVIDENCE_RANK[entry.evidence] > EVIDENCE_RANK[existing.evidence]) {
+            existing.evidence = entry.evidence;
+          }
+          if (concentration > existing.topConcentration) {
+            existing.topConcentration = concentration;
+          }
+        } else {
+          byHint.set(entry.hint, {
+            supportingTerpenes: new Set([terpene]),
+            evidence: entry.evidence,
+            topConcentration: concentration,
+          });
+        }
+      }
+    }
+
+    const therapeuticHints = [...byHint.entries()]
+      .map(([hint, meta]) => ({
+        hint,
+        supportingTerpenes: [...meta.supportingTerpenes].sort(),
+        evidenceLevel: meta.evidence,
+        _topConcentration: meta.topConcentration,
+      }))
+      .sort(
+        (a, b) =>
+          EVIDENCE_RANK[b.evidenceLevel] - EVIDENCE_RANK[a.evidenceLevel] ||
+          b._topConcentration - a._topConcentration ||
+          a.hint.localeCompare(b.hint),
+      )
+      .map(({ _topConcentration, ...rest }) => rest);
+
+    ctx.log("info", "terpeneProfileMatcher matched hints", {
+      productId,
+      dominantTerpeneCount: dominantTerpenes.length,
+      hintCount: therapeuticHints.length,
+    });
+
+    return {
+      productId,
+      dominantTerpenes,
+      therapeuticHints,
+      resolvedFrom,
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/titration-scheduler-agent.ts
+++ b/src/lib/agents/pharmacology/titration-scheduler-agent.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  startingMgPerDay: z.number().positive(),
+  targetMgPerDay: z.number().positive(),
+  direction: z.enum(["up", "down"]),
+  stepPct: z.number().min(5).max(50).optional(),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  steps: z.array(
+    z.object({
+      weekIndex: z.number(),
+      mgPerDay: z.number(),
+      holdDays: z.number(),
+      note: z.string().optional(),
+    }),
+  ),
+  assumptions: z.array(z.string()),
+});
+
+/**
+ * Titration Scheduler
+ * -------------------
+ * Status: stub (EMR-272). Real scheduler will respect tolerance-tracker
+ * signals + product-specific PK constraints once EMR-146 ingest lands.
+ * Returns an empty ladder today.
+ */
+export const titrationSchedulerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "titrationScheduler",
+  version: "0.1.0",
+  description:
+    "Generates an up/down-titration ladder between starting and target dose.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientId, direction }, ctx) {
+    ctx.log("info", "titrationScheduler stub", { patientId, direction });
+    return {
+      patientId,
+      steps: [],
+      assumptions: [
+        "Stub — real ladder generation pending EMR-146 PK tables.",
+      ],
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/tolerance-tracker-agent.ts
+++ b/src/lib/agents/pharmacology/tolerance-tracker-agent.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  cannabinoid: z.enum(["THC", "CBD", "CBN", "CBG"]),
+  windowDays: z.number().int().positive().max(180),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  toleranceTrend: z.enum(["stable", "rising", "declining", "insufficient_data"]),
+  confidenceLevel: z.enum(["low", "medium", "high"]),
+  recommendation: z.string(),
+});
+
+/**
+ * Tolerance Tracker
+ * -----------------
+ * Status: stub (EMR-272). Rolling-window `DoseLog` analysis against
+ * `OutcomeLog` trend lands next. Returns `insufficient_data` today.
+ */
+export const toleranceTrackerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "toleranceTracker",
+  version: "0.1.0",
+  description:
+    "Detects developing tolerance across a patient's recent DoseLog + OutcomeLog.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: false,
+
+  async run({ patientId, cannabinoid }, ctx) {
+    ctx.log("info", "toleranceTracker stub", { patientId, cannabinoid });
+    return {
+      patientId,
+      toleranceTrend: "insufficient_data" as const,
+      confidenceLevel: "low" as const,
+      recommendation:
+        "Stub — rolling-window tolerance analysis pending.",
+    };
+  },
+};

--- a/src/lib/agents/pharmacology/washout-planner-agent.ts
+++ b/src/lib/agents/pharmacology/washout-planner-agent.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { Agent } from "@/lib/orchestration/types";
+
+const input = z.object({
+  patientId: z.string(),
+  fromProductId: z.string(),
+  toProductId: z.string(),
+});
+
+const output = z.object({
+  patientId: z.string(),
+  recommendedWashoutDays: z.number().int().min(0).nullable(),
+  rationale: z.string(),
+  warnings: z.array(z.string()),
+});
+
+/**
+ * Washout Planner
+ * ---------------
+ * Status: stub (EMR-272). Schedules the cannabinoid washout when a patient
+ * switches formulations; returns null days + caveat today.
+ */
+export const washoutPlannerAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: "washoutPlanner",
+  version: "0.1.0",
+  description:
+    "Plans cannabinoid washout when a patient switches formulations.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: [],
+  requiresApproval: true,
+
+  async run({ patientId, fromProductId, toProductId }, ctx) {
+    ctx.log("info", "washoutPlanner stub", { patientId, fromProductId, toProductId });
+    return {
+      patientId,
+      recommendedWashoutDays: null,
+      rationale: "Stub — washout guidance pending EMR-146.",
+      warnings: [],
+    };
+  },
+};

--- a/src/lib/domain/byok.ts
+++ b/src/lib/domain/byok.ts
@@ -167,7 +167,8 @@ export type AgentCategory =
   | "operations"
   | "safety"
   | "commerce"
-  | "research";
+  | "research"
+  | "pharmacology";
 
 export interface AgentCatalogEntry {
   /** Must match a key in agentRegistry (src/lib/agents/index.ts). */
@@ -285,6 +286,21 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
   { id: "insuranceEvidenceBundler", displayName: "Insurance Evidence Bundler", description: "Assembles patient evidence for insurance submissions.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 50_000 },
   { id: "publicationReadinessScorer", displayName: "Publication Readiness", description: "Scores a cohort for academic publication readiness.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 40_000 },
   { id: "researchPartnerMatcher", displayName: "Research Partner Matcher", description: "Matches cohorts to academic, pharma, and regulator RFPs.", category: "research", defaultTier: "balanced", estimatedTokensPerMonth: 30_000 },
+
+  // Pharmacology (EMR-272 — 12-agent cannabis pharmacology fleet under the
+  // BIG EMR-146 module)
+  { id: "terpeneProfileMatcher", displayName: "Terpene Profile Matcher", description: "Maps a product's terpene profile to structure/function therapeutic hints.", category: "pharmacology", defaultTier: "budget", estimatedTokensPerMonth: 20_000 },
+  { id: "cannabinoidInteractionChecker", displayName: "Cannabinoid Interaction Checker", description: "Flags interactions within a multi-cannabinoid formulation at clinical dose.", category: "pharmacology", defaultTier: "premium", estimatedTokensPerMonth: 60_000, qualitySensitive: true },
+  { id: "routeOfAdministrationAdvisor", displayName: "Route of Administration", description: "Recommends route given indication + onset + duration needs.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 40_000 },
+  { id: "pkPdCalculator", displayName: "PK/PD Calculator", description: "Estimates PK/PD parameters for cannabinoid + route + dose.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 30_000, qualitySensitive: true },
+  { id: "titrationScheduler", displayName: "Titration Scheduler", description: "Generates up/down-titration ladder between starting and target dose.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 50_000, qualitySensitive: true },
+  { id: "entourageAnalyst", displayName: "Entourage Analyst", description: "Advises full-spectrum vs broad-spectrum vs isolate for an indication.", category: "pharmacology", defaultTier: "budget", estimatedTokensPerMonth: 20_000 },
+  { id: "drugCannabisInteractionChecker", displayName: "Drug × Cannabis Interactions", description: "Flags interactions between patient medications and cannabinoid therapy.", category: "pharmacology", defaultTier: "premium", estimatedTokensPerMonth: 80_000, qualitySensitive: true },
+  { id: "toleranceTracker", displayName: "Tolerance Tracker", description: "Detects developing tolerance across recent DoseLog + OutcomeLog.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 40_000 },
+  { id: "washoutPlanner", displayName: "Washout Planner", description: "Plans cannabinoid washout when switching formulations.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 30_000 },
+  { id: "contraindicationSweeper", displayName: "Contraindication Sweeper", description: "Sweeps the catalog for products conflicting with a patient's contraindications.", category: "pharmacology", defaultTier: "balanced", estimatedTokensPerMonth: 40_000, qualitySensitive: true },
+  { id: "bioequivalenceMapper", displayName: "Bioequivalence Mapper", description: "Converts a cannabinoid dose between routes of administration.", category: "pharmacology", defaultTier: "budget", estimatedTokensPerMonth: 20_000 },
+  { id: "pregnancyLactationAdvisor", displayName: "Pregnancy/Lactation Advisor", description: "Cautious framing for cannabinoid use across pregnancy and lactation.", category: "pharmacology", defaultTier: "premium", estimatedTokensPerMonth: 30_000, qualitySensitive: true },
 ];
 
 /** Per-agent override. Undefined modelId → use the practice default. */
@@ -326,4 +342,5 @@ export const CATEGORY_LABELS: Record<AgentCategory, string> = {
   operations: "Operations",
   commerce: "Marketplace",
   research: "Research & insights",
+  pharmacology: "Pharmacology",
 };


### PR DESCRIPTION
## Summary

Ships the **Cannabis Pharmacology Fleet** — 12 agents that populate the clinical-pharmacology substrate the EMR needs. Implements the agent layer for the BIG Cannabis Pharmacology module (EMR-146). Founding-partner demo artifact for clinical rigor.

Linear: **EMR-272** (child of EMR-146, relates to EMR-17 + EMR-269)

## Fleet — 12 agents under `src/lib/agents/pharmacology/`

| Agent | Role | State |
|---|---|---|
| `terpeneProfileMatcher` | Terpene → structure/function hints | **Real logic + 6 tests** |
| `cannabinoidInteractionChecker` | Multi-cannabinoid formulation flags | Stub (approval-gated) |
| `routeOfAdministrationAdvisor` | Route per indication + onset | Stub |
| `pkPdCalculator` | PK/PD estimates per route | Stub |
| `titrationScheduler` | Up/down-titration ladder | Stub (approval-gated) |
| `entourageAnalyst` | Full-spectrum vs broad vs isolate | Stub |
| `drugCannabisInteractionChecker` | Warfarin / SSRI / CYP450 / etc | Stub (approval-gated) |
| `toleranceTracker` | DoseLog rolling-window tolerance | Stub |
| `washoutPlanner` | Formulation-switch washout | Stub (approval-gated) |
| `contraindicationSweeper` | Patient.contraindications × catalog | Stub with real patient-fetch |
| `bioequivalenceMapper` | Dose conversion across routes | Stub |
| `pregnancyLactationAdvisor` | Perinatal caution framing | Stub (approval-gated) |

## `terpeneProfileMatcher` — POC

Reads `Product.terpeneProfile` JSON (or accepts an inline profile), ranks dominant terpenes by concentration, aggregates therapeutic hints from a curated structure/function table.

**Framing is explicitly structure/function, never disease claims** — aligns with the FDA screening Codex is building in EMR-243. Expand the table as EMR-146 Health Canada ingest matures.

Table highlights (shipping today):
- myrcene / linalool → sleep + calm *(preclinical)*
- limonene → mood *(preclinical)*
- pinene → focus *(preclinical)*
- caryophyllene → recovery *(preclinical)*
- humulene / ocimene / terpinolene → *(anecdotal)*

**Key-normalization** handles `β-caryophyllene`, `beta_caryophyllene`, `beta-caryophyllene` → `caryophyllene`. Unknown terpenes filter silently. Hints sorted `clinical > preclinical > anecdotal`, tiebreak on top supporting concentration then name.

## Plumbing

- New `pharmacology` AgentCategory in `byok.ts`
- `CATEGORY_LABELS` → "Pharmacology"
- `CATEGORY_EMOJI` → 💊 in `agent-fleet.tsx`
- `CATEGORY_ORDER` appends `pharmacology`
- Category description: "Cannabis pharmacology fleet. Interaction checkers + perinatal framing want premium models; route + terpene work is fine on balanced."
- `PHARMACOLOGY_AGENT_NAMES` exported from `src/lib/agents/index.ts`

## Tests — 6 new vitest cases for `terpeneProfileMatcher`

- Empty profile → empty hints
- Dominant-terpene ranking + hint aggregation (myrcene + linalool → shared sleep hint, both supporting)
- Unknown-terpene filter
- Unicode / hyphen / underscore name mapping
- `productId` → Prisma fetch path
- Evidence-level sort with concentration tiebreak

**325/325 tests pass. `npm run typecheck` clean.**

## Out of scope (deliberately)

- UI routes (separate ticket once POC proves value)
- Real LLM-backed narrative output (stubs return structured shells)
- Schema changes
- Actual Health Canada document parsing — EMR-146 parent covers that
- Anything in Lucca's / Codex's / research / commerce lanes

## Test plan

- [x] `npm test` (325/325)
- [x] `npm run typecheck`
- [ ] `/ops/settings/ai-config` — verify new "Pharmacology" section with 💊 icon and all 12 agents
- [ ] Integration check: invoke `terpeneProfileMatcher` against a seeded marketplace product (e.g. Nightfall Sleep Tincture with `{myrcene: 0.8, linalool: 0.6}`) — expect "supports restful sleep" and "supports a calm mood" hints

## Tonight's PR stack

| # | Title | Base | State |
|---|---|---|---|
| 75 | Marketplace foundation + commerce (EMR-231) | main | ✅ merged |
| 77 | Recommended-for-You + FK (EMR-268) | main | ✅ merged |
| 78 | Research fleet (EMR-269) | main | open |
| 79 | Patients-Like-You (EMR-270) | PR #78 | open |
| 80 | Cohort Explorer (EMR-271) | PR #79 | open |
| **81** | **Pharmacology fleet (EMR-272)** | main | open |

This PR is independent — branches off main, no cross-PR dependency.

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_