### PR TITLE
feat(leafmart): brand shell + public landing at /leafmart (EMR-273)

### DIFF
--- a/src/app/leafmart/layout.tsx
+++ b/src/app/leafmart/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { LeafmartHeader } from "@/components/leafmart/LeafmartHeader";
+import { LeafmartFooter } from "@/components/leafmart/LeafmartFooter";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Leafmart — Physician-curated cannabis wellness",
+    template: "%s | Leafmart",
+  },
+  description:
+    "The marketplace for physician-curated cannabis wellness products. Every product reviewed for quality, lab verification, and real patient outcomes.",
+};
+
+export default function LeafmartLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-bg flex flex-col">
+      <LeafmartHeader />
+      <main className="flex-1">{children}</main>
+      <LeafmartFooter />
+    </div>
+  );
+}

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -1,0 +1,380 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { LeafSprig } from "@/components/ui/ornament";
+import { RatingStars } from "@/components/marketplace/RatingStars";
+import {
+  getPublicFeaturedProducts,
+  getPublicClinicianPicks,
+} from "@/lib/marketplace/public-queries";
+import { FORMAT_LABELS } from "@/lib/marketplace/types";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Leafmart — Physician-curated cannabis wellness",
+};
+
+const VALUE_PROPS = [
+  {
+    title: "Physician curated",
+    body: "Every brand we list is reviewed by our clinical team for quality, ingredients, and real-world patient response.",
+  },
+  {
+    title: "Lab verified",
+    body: "Third-party Certificate of Analysis available for every product. If we can't verify it, we don't list it.",
+  },
+  {
+    title: "Outcome informed",
+    body: "Our recommendations are shaped by thousands of real patient outcomes across the Leafjourney network.",
+  },
+] as const;
+
+const HOW_IT_WORKS = [
+  {
+    step: "01",
+    title: "Browse curated",
+    body: "Shop products physicians actually recommend — sorted by evidence, not ad spend.",
+  },
+  {
+    step: "02",
+    title: "See the fit",
+    body: "Each product shows its cannabinoid profile, typical use cases, and clinician notes.",
+  },
+  {
+    step: "03",
+    title: "Track what works",
+    body: "Sign up to log outcomes — we'll tailor recommendations as you learn what your body responds to.",
+  },
+] as const;
+
+const FOUNDING_PARTNERS = [
+  { name: "PhytoRx", tagline: "CBD + CBG beverages" },
+  { name: "Flower Powered", tagline: "Full-spectrum topicals + tinctures" },
+  { name: "AULV", tagline: "Plant-powered wellness" },
+  { name: "Potency 710", tagline: "Gold Skin Serum" },
+] as const;
+
+export default async function LeafmartHomePage() {
+  const [featured, clinicianPicks] = await Promise.all([
+    getPublicFeaturedProducts(4),
+    getPublicClinicianPicks(3),
+  ]);
+
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="relative overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10"
+          style={{
+            background:
+              "radial-gradient(ellipse 70% 50% at 85% 5%, var(--highlight-soft), transparent 65%)," +
+              "radial-gradient(ellipse 50% 60% at 5% 85%, var(--accent-soft), transparent 60%)",
+          }}
+        />
+        <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-24 md:py-28">
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+              <LeafSprig size={14} className="text-accent" />
+              <span className="text-[11px] uppercase tracking-wider text-text-muted">
+                Physician-curated cannabis marketplace
+              </span>
+            </div>
+            <h1 className="font-display text-[42px] sm:text-5xl md:text-6xl lg:text-[68px] leading-[0.98] tracking-tight text-text">
+              The cannabis store{" "}
+              <span className="text-accent italic">your doctor</span>
+              <br />
+              would send you to.
+            </h1>
+            <p className="mt-6 text-lg text-text-muted max-w-xl leading-relaxed">
+              Leafmart is the marketplace side of Leafjourney. Every product is
+              clinician-reviewed, lab-verified, and shaped by real patient
+              outcomes — so the thing you buy is the thing that actually
+              helps.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/leafmart/products">
+                <Button size="lg" variant="primary">
+                  Browse products
+                </Button>
+              </Link>
+              <Link href="/leafmart/about">
+                <Button size="lg" variant="secondary">
+                  How it works
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Value props ────────────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {VALUE_PROPS.map((v) => (
+            <Card key={v.title} tone="ambient">
+              <CardContent className="py-7">
+                <LeafSprig size={18} className="text-accent mb-4" />
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {v.title}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {v.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Featured products ──────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-10">
+        <div className="flex items-end justify-between mb-8">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-text">
+              Featured
+            </h2>
+            <p className="text-sm text-text-muted mt-1">
+              Products we&apos;re particularly excited about right now.
+            </p>
+          </div>
+          <Link
+            href="/leafmart/products"
+            className="text-sm text-accent hover:underline hidden sm:inline"
+          >
+            See all →
+          </Link>
+        </div>
+
+        {featured.length === 0 ? (
+          <p className="text-sm text-text-muted">
+            No featured products are available right now. Check back soon.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+            {featured.map((p) => (
+              <PublicProductPreview
+                key={p.id}
+                slug={p.slug}
+                name={p.name}
+                brand={p.brand}
+                price={p.price}
+                compareAtPrice={p.compareAtPrice}
+                format={p.format}
+                averageRating={p.averageRating}
+                reviewCount={p.reviewCount}
+                clinicianPick={p.clinicianPick}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── How it works ───────────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-20">
+        <div className="max-w-2xl mb-10">
+          <h2 className="text-2xl font-semibold tracking-tight text-text">
+            How Leafmart works
+          </h2>
+          <p className="text-sm text-text-muted mt-2">
+            A cannabis store with the rigor of a medical platform behind it.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {HOW_IT_WORKS.map((s) => (
+            <div
+              key={s.step}
+              className="rounded-lg border border-border bg-surface p-6"
+            >
+              <p className="font-display text-sm text-accent tracking-[0.2em] mb-3">
+                {s.step}
+              </p>
+              <h3 className="text-base font-semibold text-text mb-2">
+                {s.title}
+              </h3>
+              <p className="text-sm text-text-muted leading-relaxed">
+                {s.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Clinician picks strip ──────────────────────────── */}
+      {clinicianPicks.length > 0 && (
+        <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-10">
+          <div className="flex items-end justify-between mb-6">
+            <div>
+              <h2 className="text-2xl font-semibold tracking-tight text-text">
+                Clinician picks
+              </h2>
+              <p className="text-sm text-text-muted mt-1">
+                What our care team reaches for first.
+              </p>
+            </div>
+            <Link
+              href="/leafmart/category/clinician-picks"
+              className="text-sm text-accent hover:underline hidden sm:inline"
+            >
+              See all picks →
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {clinicianPicks.map((p) => (
+              <PublicProductPreview
+                key={p.id}
+                slug={p.slug}
+                name={p.name}
+                brand={p.brand}
+                price={p.price}
+                compareAtPrice={p.compareAtPrice}
+                format={p.format}
+                averageRating={p.averageRating}
+                reviewCount={p.reviewCount}
+                clinicianPick={p.clinicianPick}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Founding partner spotlight ─────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-20">
+        <div className="rounded-2xl border border-border bg-accent-soft/40 p-8 md:p-12">
+          <div className="max-w-2xl mb-8">
+            <p className="text-[11px] uppercase tracking-wider text-accent mb-2">
+              Founding partners
+            </p>
+            <h2 className="text-2xl font-semibold tracking-tight text-text">
+              Brands we&apos;re building with
+            </h2>
+            <p className="text-sm text-text-muted mt-2">
+              Each founding partner is locked in at 10% take-rate for 24
+              months. A thank-you for trusting an unproven platform with
+              their product.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {FOUNDING_PARTNERS.map((p) => (
+              <div
+                key={p.name}
+                className="rounded-lg border border-border bg-surface p-4"
+              >
+                <p className="font-display text-base text-text">{p.name}</p>
+                <p className="text-xs text-text-muted mt-1">{p.tagline}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-8">
+            <Link href="/leafmart/vendors">
+              <Button size="md" variant="secondary">
+                Sell on Leafmart →
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Final CTA ──────────────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
+        <div className="text-center max-w-2xl mx-auto">
+          <h2 className="font-display text-3xl md:text-4xl tracking-tight text-text mb-4">
+            Buy what your doctor would pick.
+          </h2>
+          <p className="text-sm text-text-muted mb-6">
+            Leafmart is free to browse. Sign up to track outcomes and get
+            personalized recommendations as you go.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link href="/leafmart/products">
+              <Button size="lg" variant="primary">
+                Browse products
+              </Button>
+            </Link>
+            <Link href="/signup">
+              <Button size="lg" variant="secondary">
+                Create account
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+interface PublicProductPreviewProps {
+  slug: string;
+  name: string;
+  brand: string;
+  price: number;
+  compareAtPrice?: number;
+  format: string;
+  averageRating: number;
+  reviewCount: number;
+  clinicianPick: boolean;
+}
+
+function PublicProductPreview({
+  slug,
+  name,
+  brand,
+  price,
+  compareAtPrice,
+  format,
+  averageRating,
+  reviewCount,
+  clinicianPick,
+}: PublicProductPreviewProps) {
+  const formatLabel =
+    FORMAT_LABELS[format as keyof typeof FORMAT_LABELS] ?? format;
+  return (
+    <Link
+      href={`/leafmart/products/${slug}`}
+      className="group rounded-lg border border-border bg-surface overflow-hidden transition-all duration-200 hover:shadow-sm hover:-translate-y-0.5"
+    >
+      <div className="aspect-[4/3] bg-surface-muted flex items-center justify-center">
+        <span className="text-sm font-medium text-text-subtle tracking-wide capitalize">
+          {formatLabel}
+        </span>
+      </div>
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-2 mb-1">
+          <p className="text-xs uppercase tracking-wider text-text-subtle truncate">
+            {brand}
+          </p>
+          {clinicianPick && (
+            <Badge tone="accent" className="shrink-0 text-[10px]">
+              Pick
+            </Badge>
+          )}
+        </div>
+        <p className="text-sm font-semibold text-text group-hover:text-accent transition-colors line-clamp-2 min-h-[2.5rem]">
+          {name}
+        </p>
+        <div className="flex items-center gap-2 mt-3">
+          <span className="text-sm font-semibold text-text">
+            ${price.toFixed(2)}
+          </span>
+          {compareAtPrice != null && compareAtPrice > price && (
+            <span className="text-xs text-text-subtle line-through">
+              ${compareAtPrice.toFixed(2)}
+            </span>
+          )}
+        </div>
+        {reviewCount > 0 && (
+          <div className="mt-2">
+            <RatingStars rating={averageRating} count={reviewCount} />
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,10 +47,10 @@ export default function HomePage() {
             Education
           </Link>
           <Link
-            href="/store"
+            href="/leafmart"
             className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
           >
-            Store
+            Leafmart
           </Link>
           <Link
             href="/login"

--- a/src/components/leafmart/LeafmartFooter.tsx
+++ b/src/components/leafmart/LeafmartFooter.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export function LeafmartFooter() {
+  return (
+    <footer className="mt-24 border-t border-border bg-surface-muted/40">
+      <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-10">
+          <div className="col-span-2 md:col-span-1">
+            <div className="flex items-center gap-2 mb-3">
+              <LeafSprig size={18} className="text-accent" />
+              <span className="font-display text-lg tracking-tight text-text">
+                Leafmart
+              </span>
+            </div>
+            <p className="text-xs text-text-muted leading-relaxed">
+              Physician-curated cannabis wellness products. Every product on
+              Leafmart is reviewed by our care team for quality, lab
+              verification, and real-world patient outcomes.
+            </p>
+          </div>
+
+          <FooterColumn title="Shop">
+            <FooterLink href="/leafmart/products">All products</FooterLink>
+            <FooterLink href="/leafmart/category/sleep">Sleep</FooterLink>
+            <FooterLink href="/leafmart/category/calm">Calm</FooterLink>
+            <FooterLink href="/leafmart/category/focus">Focus</FooterLink>
+            <FooterLink href="/leafmart/category/recovery">Recovery</FooterLink>
+          </FooterColumn>
+
+          <FooterColumn title="Leafmart">
+            <FooterLink href="/leafmart/about">About us</FooterLink>
+            <FooterLink href="/leafmart/vendors">Partner with us</FooterLink>
+            <FooterLink href="/leafmart/faq">FAQ</FooterLink>
+            <FooterLink href="/education">Education</FooterLink>
+          </FooterColumn>
+
+          <FooterColumn title="Trust">
+            <FooterLink href="/security">Security</FooterLink>
+            <FooterLink href="/leafmart/faq#lab-testing">Lab testing</FooterLink>
+            <FooterLink href="/leafmart/faq#clinician-review">
+              Clinician review
+            </FooterLink>
+            <FooterLink href="/login">Sign in</FooterLink>
+          </FooterColumn>
+        </div>
+
+        <div className="pt-6 border-t border-border flex flex-col md:flex-row justify-between gap-3 text-[11px] text-text-subtle">
+          <p>
+            &copy; {new Date().getFullYear()} Leafjourney Health. Leafmart is
+            Leafjourney&apos;s public marketplace.
+          </p>
+          <p className="uppercase tracking-wider">
+            Products may contain cannabinoids. 21+ where required by law.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterColumn({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wider text-text mb-3">
+        {title}
+      </p>
+      <ul className="space-y-2">{children}</ul>
+    </div>
+  );
+}
+
+function FooterLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className="text-xs text-text-muted hover:text-text transition-colors"
+      >
+        {children}
+      </Link>
+    </li>
+  );
+}

--- a/src/components/leafmart/LeafmartHeader.tsx
+++ b/src/components/leafmart/LeafmartHeader.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { LeafSprig } from "@/components/ui/ornament";
+
+/**
+ * Public Leafmart header. Intentionally lighter than the EMR-branded
+ * site chrome — Leafmart is the consumer storefront and should feel
+ * like a marketplace, not a medical tool.
+ */
+export function LeafmartHeader() {
+  return (
+    <header className="sticky top-0 z-30 bg-bg/90 backdrop-blur border-b border-border">
+      <div className="max-w-[1280px] mx-auto flex items-center justify-between px-6 lg:px-12 h-16">
+        <Link
+          href="/leafmart"
+          className="flex items-center gap-2 group"
+          aria-label="Leafmart home"
+        >
+          <LeafSprig size={20} className="text-accent" />
+          <span className="font-display text-xl tracking-tight text-text group-hover:text-accent transition-colors">
+            Leafmart
+          </span>
+        </Link>
+
+        <nav className="flex items-center gap-0.5 md:gap-1">
+          <Link
+            href="/leafmart/products"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+          >
+            Shop
+          </Link>
+          <Link
+            href="/leafmart/about"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+          >
+            About
+          </Link>
+          <Link
+            href="/leafmart/vendors"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+          >
+            Partner with us
+          </Link>
+          <Link
+            href="/education"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+          >
+            Education
+          </Link>
+          <Link
+            href="/login"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+          >
+            Sign in
+          </Link>
+          <Link href="/portal/shop" className="ml-1">
+            <Button size="sm" variant="primary">
+              Shop
+            </Button>
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/marketplace/public-queries.test.ts
+++ b/src/lib/marketplace/public-queries.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    product: { findMany: vi.fn(), findFirst: vi.fn() },
+    marketplaceCategory: { findMany: vi.fn(), findUnique: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  getPublicFeaturedProducts,
+  getPublicProductBySlug,
+  getAllPublicProducts,
+  getPublicProductsByCategory,
+  searchPublicProducts,
+  getPublicCategories,
+} from "./public-queries";
+
+function productRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "p1",
+    slug: "p1",
+    name: "Demo Product",
+    brand: "Demo Brand",
+    description: "A description",
+    shortDescription: "short",
+    price: 42,
+    compareAtPrice: null,
+    status: "active",
+    format: "tincture",
+    imageUrl: null,
+    images: [],
+    thcContent: 5,
+    cbdContent: 20,
+    cbnContent: null,
+    terpeneProfile: { myrcene: 0.4 },
+    strainType: "indica",
+    symptoms: ["Sleep"],
+    goals: ["Calm"],
+    useCases: ["evening"],
+    onsetTime: "20-40 min",
+    duration: "6-8 hr",
+    dosageGuidance: "INTERNAL guidance do not leak",
+    beginnerFriendly: true,
+    labVerified: true,
+    coaUrl: "https://example.com/coa",
+    clinicianPick: true,
+    clinicianNote: "INTERNAL NOTE DO NOT LEAK",
+    inStock: true,
+    inventoryCount: 5,
+    averageRating: 4.5,
+    reviewCount: 12,
+    sortOrder: 0,
+    featured: true,
+    organizationId: "org_1",
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    variants: [],
+    reviews: [],
+    categoryMappings: [],
+    ...overrides,
+  };
+}
+
+function reset() {
+  hoisted.mockPrisma.product.findMany.mockReset();
+  hoisted.mockPrisma.product.findFirst.mockReset();
+  hoisted.mockPrisma.marketplaceCategory.findMany.mockReset();
+  hoisted.mockPrisma.marketplaceCategory.findUnique.mockReset();
+}
+beforeEach(reset);
+
+describe("public-queries: field stripping", () => {
+  it("strips clinicianNote and dosageGuidance from the public surface", async () => {
+    hoisted.mockPrisma.product.findFirst.mockResolvedValue(productRow());
+    const result = await getPublicProductBySlug("p1");
+    expect(result).toBeDefined();
+    expect(result?.clinicianNote).toBeUndefined();
+    expect(result?.dosageGuidance).toBeUndefined();
+  });
+
+  it("preserves patient-safe fields on the public surface", async () => {
+    hoisted.mockPrisma.product.findFirst.mockResolvedValue(productRow());
+    const result = await getPublicProductBySlug("p1");
+    expect(result?.name).toBe("Demo Product");
+    expect(result?.brand).toBe("Demo Brand");
+    expect(result?.symptoms).toEqual(["Sleep"]);
+    expect(result?.coaUrl).toBe("https://example.com/coa");
+    expect(result?.thcContent).toBe(5);
+    expect(result?.cbdContent).toBe(20);
+    expect(result?.terpeneProfile).toEqual({ myrcene: 0.4 });
+  });
+});
+
+describe("public-queries: filter criteria", () => {
+  it("enforces status=active + deletedAt=null on all list queries", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await getAllPublicProducts();
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe("active");
+    expect(where.deletedAt).toBeNull();
+    // NOT org-scoped — Leafmart is platform-wide.
+    expect(where.organizationId).toBeUndefined();
+  });
+
+  it("featured query filters to featured=true", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await getPublicFeaturedProducts(4);
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.featured).toBe(true);
+    expect(
+      hoisted.mockPrisma.product.findMany.mock.calls[0][0].take,
+    ).toBe(4);
+  });
+
+  it("category query joins through ProductCategory → MarketplaceCategory slug", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await getPublicProductsByCategory("sleep");
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.categoryMappings.some.category.slug).toBe("sleep");
+  });
+
+  it("search with empty query returns all active products (no OR clause)", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await searchPublicProducts("");
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+    expect(where.status).toBe("active");
+  });
+
+  it("search with query OR's across name/brand/description/symptoms/goals/format", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await searchPublicProducts("sleep");
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.OR).toHaveLength(6);
+  });
+});
+
+describe("public-queries: categories", () => {
+  it("getPublicCategories with no type returns all (no where filter)", async () => {
+    hoisted.mockPrisma.marketplaceCategory.findMany.mockResolvedValue([]);
+    await getPublicCategories();
+    const where =
+      hoisted.mockPrisma.marketplaceCategory.findMany.mock.calls[0][0].where;
+    expect(where).toEqual({});
+  });
+
+  it("getPublicCategories with type filter applies where.type", async () => {
+    hoisted.mockPrisma.marketplaceCategory.findMany.mockResolvedValue([]);
+    await getPublicCategories("symptom");
+    const where =
+      hoisted.mockPrisma.marketplaceCategory.findMany.mock.calls[0][0].where;
+    expect(where.type).toBe("symptom");
+  });
+
+  it("categories hydrate product counts scoped to active + non-deleted products", async () => {
+    hoisted.mockPrisma.marketplaceCategory.findMany.mockResolvedValue([
+      {
+        id: "c1",
+        name: "Sleep",
+        slug: "sleep",
+        description: null,
+        type: "symptom",
+        icon: null,
+        _count: { products: 3 },
+      },
+    ]);
+    const result = await getPublicCategories("symptom");
+    expect(result[0].productCount).toBe(3);
+    const productsFilter =
+      hoisted.mockPrisma.marketplaceCategory.findMany.mock.calls[0][0].include
+        ._count.select.products;
+    expect(productsFilter.where.product.status).toBe("active");
+    expect(productsFilter.where.product.deletedAt).toBeNull();
+  });
+});

--- a/src/lib/marketplace/public-queries.test.ts
+++ b/src/lib/marketplace/public-queries.test.ts
@@ -59,6 +59,7 @@ function productRow(overrides: Record<string, unknown> = {}) {
     featured: true,
     organizationId: "org_1",
     deletedAt: null,
+    requires21Plus: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     variants: [],
@@ -99,14 +100,23 @@ describe("public-queries: field stripping", () => {
 });
 
 describe("public-queries: filter criteria", () => {
-  it("enforces status=active + deletedAt=null on all list queries", async () => {
+  it("enforces status=active + deletedAt=null + requires21Plus=false on all list queries", async () => {
     hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
     await getAllPublicProducts();
     const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
     expect(where.status).toBe("active");
     expect(where.deletedAt).toBeNull();
+    // EMR-245: 21+ products hidden from unauthenticated public surface.
+    expect(where.requires21Plus).toBe(false);
     // NOT org-scoped — Leafmart is platform-wide.
     expect(where.organizationId).toBeUndefined();
+  });
+
+  it("hides 21+ products from the public search query (EMR-245 age gate)", async () => {
+    hoisted.mockPrisma.product.findMany.mockResolvedValue([]);
+    await searchPublicProducts("sleep");
+    const where = hoisted.mockPrisma.product.findMany.mock.calls[0][0].where;
+    expect(where.requires21Plus).toBe(false);
   });
 
   it("featured query filters to featured=true", async () => {

--- a/src/lib/marketplace/public-queries.ts
+++ b/src/lib/marketplace/public-queries.ts
@@ -98,6 +98,7 @@ function mapPublicProduct(p: PublicProductRow): MarketplaceProduct {
     clinicianPick: p.clinicianPick,
     // Clinician note stripped on the public surface — clinician-internal.
     clinicianNote: undefined,
+    requires21Plus: p.requires21Plus,
     inStock: p.inStock,
     averageRating: p.averageRating,
     reviewCount: p.reviewCount,
@@ -111,6 +112,11 @@ function mapPublicProduct(p: PublicProductRow): MarketplaceProduct {
 const PUBLIC_PRODUCT_WHERE = {
   status: ProductStatus.active,
   deletedAt: null,
+  // EMR-245: age-gated products (>0.3% delta-9 THC) are hidden from the
+  // unauthenticated public surface entirely. Visitors see them only after
+  // sign-in where the age-gate flow (src/server/marketplace/age-gate.ts)
+  // runs and verifies DOB.
+  requires21Plus: false,
 } as const;
 
 export async function getPublicFeaturedProducts(

--- a/src/lib/marketplace/public-queries.ts
+++ b/src/lib/marketplace/public-queries.ts
@@ -1,0 +1,255 @@
+// EMR-273 — Public-facing marketplace query layer for Leafmart.com.
+//
+// Unlike `./queries.ts` (which scopes to the authenticated patient's org),
+// this module is platform-wide and session-less. It's the source of truth
+// for the public Leafmart storefront and any unauthenticated crawler /
+// preview.
+//
+// Safety rules for this module:
+//   1. NEVER reference `getCurrentUser` or any session primitive.
+//   2. NEVER return `clinicianNote` — that's clinician-internal context.
+//   3. Only `status=active` + `deletedAt=null` products.
+//   4. No patient / order / cart references in the returned shape.
+
+import { ProductStatus } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import type {
+  MarketplaceProduct,
+  MarketplaceCategory,
+  ProductFormat,
+  ProductVariant,
+  ProductReview,
+} from "./types";
+
+const publicProductInclude = {
+  variants: { orderBy: { sortOrder: "asc" } },
+  reviews: { orderBy: { createdAt: "desc" } },
+  categoryMappings: { include: { category: true } },
+} as const;
+
+type PublicProductRow = Awaited<
+  ReturnType<
+    typeof prisma.product.findFirstOrThrow<{
+      include: typeof publicProductInclude;
+    }>
+  >
+>;
+
+function mapPublicVariant(v: PublicProductRow["variants"][number]): ProductVariant {
+  return {
+    id: v.id,
+    name: v.name,
+    upc: v.upc ?? undefined,
+    price: v.price,
+    compareAtPrice: v.compareAtPrice ?? undefined,
+    inStock: v.inStock,
+  };
+}
+
+function mapPublicReview(r: PublicProductRow["reviews"][number]): ProductReview {
+  return {
+    id: r.id,
+    authorName: r.authorName,
+    rating: r.rating,
+    title: r.title ?? undefined,
+    body: r.body ?? undefined,
+    verified: r.verified,
+    createdAt: r.createdAt.toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Public product mapper. Identical to the authenticated mapper EXCEPT:
+ *  - `clinicianNote` is stripped (internal clinician context)
+ *  - `dosageGuidance` is stripped (requires clinical consultation framing
+ *     the public storefront doesn't provide)
+ */
+function mapPublicProduct(p: PublicProductRow): MarketplaceProduct {
+  const terpene = (p.terpeneProfile ?? {}) as Record<string, number>;
+  return {
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    brand: p.brand,
+    description: p.description,
+    shortDescription: p.shortDescription ?? "",
+    price: p.price,
+    compareAtPrice: p.compareAtPrice ?? undefined,
+    status: p.status,
+    format: p.format as ProductFormat,
+    imageUrl: p.imageUrl ?? undefined,
+    images: p.images,
+    thcContent: p.thcContent ?? undefined,
+    cbdContent: p.cbdContent ?? undefined,
+    cbnContent: p.cbnContent ?? undefined,
+    terpeneProfile: terpene,
+    strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+    symptoms: p.symptoms,
+    goals: p.goals,
+    useCases: p.useCases,
+    onsetTime: p.onsetTime ?? undefined,
+    duration: p.duration ?? undefined,
+    // Dosage guidance intentionally stripped on the public surface —
+    // surface it only in authenticated portal contexts.
+    dosageGuidance: undefined,
+    beginnerFriendly: p.beginnerFriendly,
+    labVerified: p.labVerified,
+    coaUrl: p.coaUrl ?? undefined,
+    clinicianPick: p.clinicianPick,
+    // Clinician note stripped on the public surface — clinician-internal.
+    clinicianNote: undefined,
+    inStock: p.inStock,
+    averageRating: p.averageRating,
+    reviewCount: p.reviewCount,
+    featured: p.featured,
+    categoryIds: p.categoryMappings.map((m) => m.categoryId),
+    variants: p.variants.map(mapPublicVariant),
+    reviews: p.reviews.map(mapPublicReview),
+  };
+}
+
+const PUBLIC_PRODUCT_WHERE = {
+  status: ProductStatus.active,
+  deletedAt: null,
+} as const;
+
+export async function getPublicFeaturedProducts(
+  limit = 4,
+): Promise<MarketplaceProduct[]> {
+  const rows = await prisma.product.findMany({
+    where: { ...PUBLIC_PRODUCT_WHERE, featured: true },
+    include: publicProductInclude,
+    orderBy: [{ sortOrder: "asc" }, { averageRating: "desc" }],
+    take: limit,
+  });
+  return rows.map(mapPublicProduct);
+}
+
+export async function getPublicClinicianPicks(
+  limit = 6,
+): Promise<MarketplaceProduct[]> {
+  const rows = await prisma.product.findMany({
+    where: { ...PUBLIC_PRODUCT_WHERE, clinicianPick: true },
+    include: publicProductInclude,
+    orderBy: { averageRating: "desc" },
+    take: limit,
+  });
+  return rows.map(mapPublicProduct);
+}
+
+export async function getPublicProductBySlug(
+  slug: string,
+): Promise<MarketplaceProduct | undefined> {
+  const row = await prisma.product.findFirst({
+    where: { ...PUBLIC_PRODUCT_WHERE, slug },
+    include: publicProductInclude,
+  });
+  return row ? mapPublicProduct(row) : undefined;
+}
+
+export async function getAllPublicProducts(): Promise<MarketplaceProduct[]> {
+  const rows = await prisma.product.findMany({
+    where: PUBLIC_PRODUCT_WHERE,
+    include: publicProductInclude,
+    orderBy: [{ featured: "desc" }, { sortOrder: "asc" }, { name: "asc" }],
+  });
+  return rows.map(mapPublicProduct);
+}
+
+export async function getPublicProductsByCategory(
+  categorySlug: string,
+): Promise<MarketplaceProduct[]> {
+  const rows = await prisma.product.findMany({
+    where: {
+      ...PUBLIC_PRODUCT_WHERE,
+      categoryMappings: { some: { category: { slug: categorySlug } } },
+    },
+    include: publicProductInclude,
+    orderBy: [{ featured: "desc" }, { averageRating: "desc" }],
+  });
+  return rows.map(mapPublicProduct);
+}
+
+export async function getPublicCategoryBySlug(
+  slug: string,
+): Promise<MarketplaceCategory | undefined> {
+  const row = await prisma.marketplaceCategory.findUnique({
+    where: { slug },
+    include: {
+      _count: {
+        select: {
+          products: {
+            where: {
+              product: { status: ProductStatus.active, deletedAt: null },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? undefined,
+    type: row.type as MarketplaceCategory["type"],
+    icon: row.icon ?? undefined,
+    productCount: row._count.products,
+  };
+}
+
+export async function getPublicCategories(
+  type?: string,
+): Promise<MarketplaceCategory[]> {
+  const rows = await prisma.marketplaceCategory.findMany({
+    where: type ? { type } : {},
+    orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+    include: {
+      _count: {
+        select: {
+          products: {
+            where: {
+              product: { status: ProductStatus.active, deletedAt: null },
+            },
+          },
+        },
+      },
+    },
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description ?? undefined,
+    type: row.type as MarketplaceCategory["type"],
+    icon: row.icon ?? undefined,
+    productCount: row._count.products,
+  }));
+}
+
+export async function searchPublicProducts(
+  query: string,
+): Promise<MarketplaceProduct[]> {
+  const q = query.trim();
+  const rows = await prisma.product.findMany({
+    where: {
+      ...PUBLIC_PRODUCT_WHERE,
+      ...(q
+        ? {
+            OR: [
+              { name: { contains: q, mode: "insensitive" } },
+              { brand: { contains: q, mode: "insensitive" } },
+              { description: { contains: q, mode: "insensitive" } },
+              { symptoms: { has: q } },
+              { goals: { has: q } },
+              { format: { equals: q, mode: "insensitive" } },
+            ],
+          }
+        : {}),
+    },
+    include: publicProductInclude,
+    orderBy: [{ featured: "desc" }, { averageRating: "desc" }],
+  });
+  return rows.map(mapPublicProduct);
+}


### PR DESCRIPTION
## Summary

Stands up **Leafmart** as the public face of the marketplace. Unauthenticated visitors can now browse Leafjourney's product catalog with clinician framing, trust signals, and the founding-partner story — while authenticated checkout stays on `/portal/shop` where EMR-231/268/270 already shipped.

Linear: **EMR-273** (child of EMR-17)

## What's in this PR (7 files, +910)

### Public query layer — `src/lib/marketplace/public-queries.ts`
Session-less, platform-wide query module for Leafmart and any other public surface.

**Safety rules enforced in the module:**
- Never references `getCurrentUser` or any session primitive
- Never returns `clinicianNote` or `dosageGuidance` (internal context that needs clinician framing)
- Only `status=active` + `deletedAt=null` products
- No patient / order / cart references

Exports: `getPublicFeaturedProducts`, `getPublicClinicianPicks`, `getPublicProductBySlug`, `getAllPublicProducts`, `getPublicProductsByCategory`, `getPublicCategoryBySlug`, `getPublicCategories`, `searchPublicProducts`.

### Brand shell
- `src/components/leafmart/LeafmartHeader.tsx` — 🌿 wordmark, Shop / About / Partner / Education / Sign in / primary Shop button
- `src/components/leafmart/LeafmartFooter.tsx` — three-column site map, trust column, brand promise, 21+ disclaimer
- `src/app/leafmart/layout.tsx` — brand chrome wrapper with metadata template

### Landing page — `src/app/leafmart/page.tsx`
- **Hero:** "The cannabis store your doctor would send you to"
- **Value-prop strip:** physician-curated / lab-verified / outcome-informed
- **Featured products** — 4 cards via `getPublicFeaturedProducts`
- **"How Leafmart works"** — 3-step explainer
- **Clinician picks** — top 3 picks strip
- **Founding-partner spotlight** — PhytoRx / Flower Powered / AULV / Potency 710 with 10% take-rate / 24-month lock-in messaging
- **Final CTA** — "Buy what your doctor would pick"

All CTAs route to `/leafmart/products` or `/signup` / `/login`. Nothing touches checkout, age gate, or FDA screening (those stay in Lucca/Codex lanes).

### Main landing nav
- `/` now points "Leafmart" (renamed from "Store") at `/leafmart`. The existing `/store` partner-link page (EMR-111) remains intact for any bookmarked traffic.

## Tests — 10 new vitest cases

- Field stripping: `clinicianNote` + `dosageGuidance` absent on returned public products
- Field preservation: name / brand / symptoms / coaUrl / cannabinoid content all pass through
- Filter shape: `status=active` + `deletedAt=null` + NOT org-scoped
- Featured / category / search query shapes
- Category product-count hydration scoped to active + non-deleted

**335/335 tests pass. `npm run typecheck` clean.**

## Leafmart PR chain (filed overnight)

| # | Ticket | Title | State |
|---|---|---|---|
| **this** | **EMR-273** | **Brand shell + landing** | **this PR** |
| next | EMR-274 | Catalog browse + PDP + category | next |
| next | EMR-275 | About + vendors + FAQ | later |

## Out of scope (deliberately — not mine)

- Checkout (Lucca, EMR-232)
- Age gate (Codex, EMR-245)
- FDA claim screening (Codex, EMR-243)
- State shipping matrix (Codex, EMR-244)
- Vendor portal (EMR-228)
- Schema changes

## Test plan

- [x] `npm test` (335/335)
- [x] `npm run typecheck`
- [ ] Unauthenticated visitor loads `/leafmart` → hero + value props + featured strip + clinician picks + vendor spotlight all render
- [ ] Main landing `/` → "Leafmart" nav link points to `/leafmart`
- [ ] `/leafmart` header → clicking "Shop" routes to `/leafmart/products` (404 until EMR-274 ships)
- [ ] Clicking any product card routes to `/leafmart/products/[slug]` (404 until EMR-274 ships)

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_