### PR TITLE
feat(leafmart): catalog browse + PDP + category (EMR-274)

### DIFF
--- a/src/app/leafmart/category/[slug]/page.tsx
+++ b/src/app/leafmart/category/[slug]/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import {
+  getPublicCategoryBySlug,
+  getPublicProductsByCategory,
+} from "@/lib/marketplace/public-queries";
+
+interface CategoryPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: CategoryPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const category = await getPublicCategoryBySlug(slug);
+  return { title: category?.name ?? "Category" };
+}
+
+export default async function LeafmartCategoryPage({
+  params,
+}: CategoryPageProps) {
+  const { slug } = await params;
+  const category = await getPublicCategoryBySlug(slug);
+
+  if (!category) {
+    return (
+      <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">Not found</span>
+        </div>
+        <EmptyState
+          title="Category not found"
+          description="This category doesn't exist or may have been renamed."
+          action={
+            <Link
+              href="/leafmart/products"
+              className="text-sm text-accent hover:underline"
+            >
+              Browse all products →
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  const products = await getPublicProductsByCategory(slug);
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+      <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+        <Link href="/leafmart" className="hover:text-text transition-colors">
+          Leafmart
+        </Link>
+        <span aria-hidden="true">/</span>
+        <Link
+          href="/leafmart/products"
+          className="hover:text-text transition-colors"
+        >
+          Shop
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-text">{category.name}</span>
+      </div>
+
+      <header className="mb-10 max-w-2xl">
+        {category.icon && (
+          <span
+            className="block text-3xl text-accent mb-3"
+            aria-hidden="true"
+          >
+            {category.icon}
+          </span>
+        )}
+        <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+          {category.name}
+        </h1>
+        {category.description && (
+          <p className="text-sm text-text-muted mt-2 leading-relaxed">
+            {category.description}
+          </p>
+        )}
+        <p className="text-xs text-text-subtle mt-3">
+          {products.length} {products.length === 1 ? "product" : "products"}
+        </p>
+      </header>
+
+      {products.length === 0 ? (
+        <EmptyState
+          title="No products yet"
+          description="We haven't curated anything for this category yet. Check back soon."
+        />
+      ) : (
+        <PublicProductGrid products={products} columns={4} />
+      )}
+    </div>
+  );
+}

--- a/src/app/leafmart/products/[slug]/page.tsx
+++ b/src/app/leafmart/products/[slug]/page.tsx
@@ -1,0 +1,387 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { RatingStars } from "@/components/marketplace/RatingStars";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import {
+  getPublicProductBySlug,
+  getAllPublicProducts,
+} from "@/lib/marketplace/public-queries";
+import { FORMAT_LABELS } from "@/lib/marketplace/types";
+
+interface PDPProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PDPProps): Promise<Metadata> {
+  const { slug } = await params;
+  const product = await getPublicProductBySlug(slug);
+  if (!product) return { title: "Product not found" };
+  return {
+    title: `${product.name} — ${product.brand}`,
+    description: product.shortDescription || product.description.slice(0, 160),
+  };
+}
+
+export default async function LeafmartProductDetailPage({ params }: PDPProps) {
+  const { slug } = await params;
+  const product = await getPublicProductBySlug(slug);
+  if (!product) notFound();
+
+  const formatLabel = FORMAT_LABELS[product.format] ?? product.format;
+  const strainLabel =
+    product.strainType && product.strainType !== "n/a"
+      ? product.strainType.charAt(0).toUpperCase() + product.strainType.slice(1)
+      : null;
+
+  // Lightweight "you may also like" — share symptoms/goals with the current
+  // product, bounded to 4 items. Public-safe (no personalization).
+  const related = await getRelatedPublic(product);
+
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+      {/* ── Breadcrumb ─────────────────────────────────────── */}
+      <nav aria-label="Breadcrumb" className="mb-8">
+        <ol className="flex flex-wrap items-center gap-1.5 text-xs text-text-subtle">
+          <li>
+            <Link
+              href="/leafmart"
+              className="hover:text-text transition-colors"
+            >
+              Leafmart
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link
+              href="/leafmart/products"
+              className="hover:text-text transition-colors"
+            >
+              Shop
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="text-text font-medium truncate max-w-[240px]">
+            {product.name}
+          </li>
+        </ol>
+      </nav>
+
+      {/* ── Hero — image + buy card ────────────────────────── */}
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-14">
+        <div className="bg-surface-muted rounded-lg aspect-square flex items-center justify-center">
+          <span className="text-lg font-medium text-text-subtle tracking-wide capitalize">
+            {formatLabel}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <p className="text-xs uppercase tracking-wider text-text-subtle">
+            {product.brand}
+          </p>
+          <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+            {product.name}
+          </h1>
+          {product.reviewCount > 0 && (
+            <RatingStars
+              rating={product.averageRating}
+              count={product.reviewCount}
+            />
+          )}
+
+          <div className="flex items-baseline gap-3">
+            <span className="text-2xl font-semibold text-text tabular-nums">
+              ${product.price.toFixed(2)}
+            </span>
+            {product.compareAtPrice != null &&
+              product.compareAtPrice > product.price && (
+                <span className="text-base text-text-subtle line-through">
+                  ${product.compareAtPrice.toFixed(2)}
+                </span>
+              )}
+          </div>
+
+          {product.clinicianPick && (
+            <div className="rounded-lg bg-accent-soft/60 p-4">
+              <Badge tone="accent">Clinician pick</Badge>
+              <p className="text-sm text-text leading-relaxed mt-2">
+                Our care team selected this product for its quality,
+                cannabinoid profile, and documented outcomes. (Clinician
+                commentary shown after sign-in.)
+              </p>
+            </div>
+          )}
+
+          {/* Variant pills (display-only on public surface) */}
+          {product.variants.length > 1 && (
+            <div className="space-y-2">
+              <p className="text-[11px] uppercase tracking-wider text-text-subtle">
+                Sizes
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {product.variants.map((v, idx) => (
+                  <span
+                    key={v.id}
+                    className={`inline-flex items-center rounded-md border px-3 py-1.5 text-xs font-medium ${
+                      idx === 0
+                        ? "border-accent bg-accent-soft text-accent"
+                        : "border-border bg-surface text-text"
+                    }`}
+                  >
+                    {v.name}
+                    {v.price !== product.variants[0]?.price && (
+                      <span className="ml-1.5 text-text-subtle">
+                        ${v.price.toFixed(2)}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Auth handoff — public surface never wires checkout directly */}
+          <div className="mt-2">
+            <Link href={`/login?next=${encodeURIComponent(`/portal/shop/products/${product.slug}`)}`}>
+              <Button variant="primary" size="lg" className="w-full">
+                {product.inStock ? "Sign in to buy" : "Out of stock"}
+              </Button>
+            </Link>
+            <p className="text-[11px] text-text-subtle mt-2 text-center">
+              Checkout opens after you sign in — keeps dosing and outcome
+              tracking tied to your chart.
+            </p>
+          </div>
+
+          {/* Trust signals */}
+          <ul className="flex flex-col gap-1.5 mt-3">
+            {product.labVerified && (
+              <TrustLine>Third-party lab verified — COA available.</TrustLine>
+            )}
+            {product.clinicianPick && (
+              <TrustLine>Physician reviewed before listing.</TrustLine>
+            )}
+            {product.beginnerFriendly && (
+              <TrustLine>Beginner-friendly formulation.</TrustLine>
+            )}
+          </ul>
+        </div>
+      </section>
+
+      {/* ── Description ─────────────────────────────────── */}
+      <section className="space-y-10 mb-14">
+        <div>
+          <h2 className="text-lg font-semibold text-text mb-3">
+            About this product
+          </h2>
+          <p className="text-sm text-text-muted leading-relaxed whitespace-pre-line">
+            {product.description}
+          </p>
+        </div>
+
+        {/* Cannabinoid profile */}
+        {(product.thcContent != null ||
+          product.cbdContent != null ||
+          product.cbnContent != null ||
+          strainLabel) && (
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-sm font-semibold text-text mb-4">
+                Cannabinoid profile
+              </h3>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                {product.thcContent != null && (
+                  <Stat label="THC" value={`${product.thcContent}%`} />
+                )}
+                {product.cbdContent != null && (
+                  <Stat label="CBD" value={`${product.cbdContent}%`} />
+                )}
+                {product.cbnContent != null && (
+                  <Stat label="CBN" value={`${product.cbnContent}%`} />
+                )}
+                {strainLabel && <Stat label="Strain" value={strainLabel} />}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Onset & duration */}
+        {(product.onsetTime || product.duration) && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {product.onsetTime && (
+              <InfoBox title="Onset">{product.onsetTime}</InfoBox>
+            )}
+            {product.duration && (
+              <InfoBox title="Duration">{product.duration}</InfoBox>
+            )}
+          </div>
+        )}
+
+        {/* Use cases */}
+        {(product.symptoms.length > 0 || product.goals.length > 0) && (
+          <div>
+            <h3 className="text-sm font-semibold text-text mb-3">
+              May support
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {product.symptoms.map((s) => (
+                <Badge key={`s-${s}`} tone="neutral">
+                  {s}
+                </Badge>
+              ))}
+              {product.goals.map((g) => (
+                <Badge key={`g-${g}`} tone="accent">
+                  {g}
+                </Badge>
+              ))}
+            </div>
+            <p className="text-[11px] text-text-subtle mt-3">
+              Structure/function terms only — not a claim to treat, cure, or
+              prevent any disease.
+            </p>
+          </div>
+        )}
+
+        {product.beginnerFriendly && (
+          <Badge tone="success" className="text-sm px-3 py-1">
+            Beginner-friendly
+          </Badge>
+        )}
+
+        {product.coaUrl && product.coaUrl !== "#" && (
+          <div>
+            <Link
+              href={product.coaUrl}
+              className="text-sm text-accent hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Download Certificate of Analysis →
+            </Link>
+          </div>
+        )}
+      </section>
+
+      {/* ── Reviews ─────────────────────────────────────── */}
+      {product.reviews.length > 0 && (
+        <section className="mb-14">
+          <div className="flex items-center gap-3 mb-6">
+            <h2 className="text-lg font-semibold text-text">Reviews</h2>
+            <RatingStars rating={product.averageRating} />
+            <span className="text-sm text-text-muted">
+              {product.averageRating.toFixed(1)} ({product.reviewCount})
+            </span>
+          </div>
+          <div className="space-y-6">
+            {product.reviews.map((r) => (
+              <div
+                key={r.id}
+                className="border-b border-border pb-6 last:border-b-0 last:pb-0"
+              >
+                <div className="flex flex-wrap items-center gap-3 mb-2">
+                  <span className="text-sm font-medium text-text">
+                    {r.authorName}
+                  </span>
+                  <RatingStars rating={r.rating} />
+                  {r.verified && (
+                    <Badge tone="success" className="text-[11px]">
+                      Verified purchase
+                    </Badge>
+                  )}
+                  <span className="text-xs text-text-subtle ml-auto">
+                    {new Date(r.createdAt).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+                {r.title && (
+                  <p className="text-sm font-semibold text-text mb-1">
+                    {r.title}
+                  </p>
+                )}
+                {r.body && (
+                  <p className="text-sm text-text-muted leading-relaxed">
+                    {r.body}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Related ─────────────────────────────────────── */}
+      {related.length > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold text-text mb-6">
+            You may also like
+          </h2>
+          <PublicProductGrid products={related} columns={4} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+async function getRelatedPublic(product: {
+  id: string;
+  symptoms: string[];
+  goals: string[];
+}) {
+  const all = await getAllPublicProducts();
+  const targets = new Set([...product.symptoms, ...product.goals]);
+  return all
+    .filter((p) => p.id !== product.id)
+    .map((p) => {
+      const shared = [...p.symptoms, ...p.goals].filter((t) => targets.has(t));
+      return { p, score: shared.length };
+    })
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4)
+    .map((r) => r.p);
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="text-center">
+      <p className="text-2xl font-semibold text-text tabular-nums">{value}</p>
+      <p className="text-xs text-text-subtle mt-1">{label}</p>
+    </div>
+  );
+}
+
+function InfoBox({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <p className="text-xs uppercase tracking-wider text-text-subtle mb-1">
+        {title}
+      </p>
+      <p className="text-sm font-medium text-text">{children}</p>
+    </div>
+  );
+}
+
+function TrustLine({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-center gap-2 text-sm text-text-muted">
+      <span className="text-success" aria-hidden="true">
+        ✓
+      </span>
+      {children}
+    </li>
+  );
+}

--- a/src/app/leafmart/products/page.tsx
+++ b/src/app/leafmart/products/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SearchBar } from "@/components/marketplace/SearchBar";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import {
+  getAllPublicProducts,
+  searchPublicProducts,
+  getPublicCategories,
+} from "@/lib/marketplace/public-queries";
+import { FORMAT_LABELS, type ProductFormat } from "@/lib/marketplace/types";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Shop all products" };
+
+interface ProductsPageProps {
+  searchParams: Promise<{
+    q?: string;
+    category?: string;
+    format?: string;
+  }>;
+}
+
+export default async function LeafmartProductsPage({
+  searchParams,
+}: ProductsPageProps) {
+  const { q, category, format } = await searchParams;
+  const formatFilter = format as ProductFormat | undefined;
+
+  const [base, categories] = await Promise.all([
+    q ? searchPublicProducts(q) : getAllPublicProducts(),
+    getPublicCategories(),
+  ]);
+
+  let products = base;
+  if (category) {
+    const cat = categories.find(
+      (c) => c.slug === category || c.id === category,
+    );
+    if (cat) products = products.filter((p) => p.categoryIds.includes(cat.id));
+  }
+  if (formatFilter) {
+    products = products.filter((p) => p.format === formatFilter);
+  }
+
+  const activeCategory = category
+    ? categories.find((c) => c.slug === category || c.id === category)
+    : undefined;
+  const activeFormatLabel = formatFilter
+    ? FORMAT_LABELS[formatFilter]
+    : undefined;
+  const title = q ? `Results for "${q}"` : "All products";
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+      <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+        <Link href="/leafmart" className="hover:text-text transition-colors">
+          Leafmart
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-text">Shop</span>
+      </div>
+
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+            {title}
+          </h1>
+          <p className="text-sm text-text-muted mt-1">
+            {products.length}{" "}
+            {products.length === 1 ? "product" : "products"}
+          </p>
+        </div>
+        <SearchBar defaultValue={q} className="w-full md:w-[360px]" />
+      </div>
+
+      {/* Format filter chips */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        <span className="text-xs font-medium uppercase tracking-wider text-text-subtle mr-1">
+          Format
+        </span>
+        <FormatChip
+          label="All"
+          active={!formatFilter}
+          href={{ pathname: "/leafmart/products", query: queryWithout({ q, category }, "format") }}
+        />
+        {(Object.keys(FORMAT_LABELS) as ProductFormat[]).map((f) => (
+          <FormatChip
+            key={f}
+            label={FORMAT_LABELS[f]}
+            active={formatFilter === f}
+            href={{
+              pathname: "/leafmart/products",
+              query: queryWith({ q, category, format: f }),
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Active filter pills */}
+      {(activeCategory || activeFormatLabel) && (
+        <div className="flex flex-wrap items-center gap-2 mb-6">
+          <span className="text-[11px] uppercase tracking-wider text-text-subtle">
+            Filters:
+          </span>
+          {activeCategory && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted border border-border px-3 py-1 text-xs font-medium text-text-muted">
+              {activeCategory.name}
+              <Link
+                href={{
+                  pathname: "/leafmart/products",
+                  query: queryWithout({ q, format }, "category"),
+                }}
+                className="ml-0.5 text-text-subtle hover:text-text"
+                aria-label={`Remove ${activeCategory.name} filter`}
+              >
+                ×
+              </Link>
+            </span>
+          )}
+          {activeFormatLabel && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted border border-border px-3 py-1 text-xs font-medium text-text-muted">
+              {activeFormatLabel}
+              <Link
+                href={{
+                  pathname: "/leafmart/products",
+                  query: queryWithout({ q, category }, "format"),
+                }}
+                className="ml-0.5 text-text-subtle hover:text-text"
+                aria-label={`Remove ${activeFormatLabel} filter`}
+              >
+                ×
+              </Link>
+            </span>
+          )}
+        </div>
+      )}
+
+      {products.length === 0 ? (
+        <EmptyState
+          title="No products match"
+          description="Try adjusting your filters or removing your search."
+        />
+      ) : (
+        <PublicProductGrid products={products} columns={4} />
+      )}
+    </div>
+  );
+}
+
+function queryWith(parts: Record<string, string | undefined>) {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parts)) {
+    if (v) out[k] = v;
+  }
+  return out;
+}
+
+function queryWithout(
+  parts: Record<string, string | undefined>,
+  drop: string,
+) {
+  const { [drop]: _dropped, ...rest } = parts;
+  return queryWith(rest);
+}
+
+function FormatChip({
+  label,
+  active,
+  href,
+}: {
+  label: string;
+  active: boolean;
+  href: Parameters<typeof Link>[0]["href"];
+}) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "border-accent bg-accent-soft text-accent"
+          : "border-border bg-surface text-text-muted hover:text-text"
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/components/leafmart/PublicProductCard.tsx
+++ b/src/components/leafmart/PublicProductCard.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { Badge } from "@/components/ui/badge";
+import { RatingStars } from "@/components/marketplace/RatingStars";
+import type { MarketplaceProduct } from "@/lib/marketplace/types";
+import { FORMAT_LABELS } from "@/lib/marketplace/types";
+
+/**
+ * Public product card for Leafmart. Differs from the portal ProductCard
+ * in that it has no add-to-cart affordance — all CTAs route to the PDP,
+ * and the "buy" action only appears inside the authenticated portal.
+ */
+export function PublicProductCard({
+  product,
+  className,
+}: {
+  product: MarketplaceProduct;
+  className?: string;
+}) {
+  const formatLabel = FORMAT_LABELS[product.format] ?? product.format;
+
+  return (
+    <Link
+      href={`/leafmart/products/${product.slug}`}
+      className={cn(
+        "group rounded-lg border border-border bg-surface overflow-hidden transition-all duration-200 hover:shadow-sm hover:-translate-y-0.5",
+        className,
+      )}
+    >
+      <div className="aspect-[4/3] bg-surface-muted flex items-center justify-center">
+        <span className="text-sm font-medium text-text-subtle tracking-wide capitalize">
+          {formatLabel}
+        </span>
+      </div>
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-2 mb-1">
+          <p className="text-xs uppercase tracking-wider text-text-subtle truncate">
+            {product.brand}
+          </p>
+          {product.clinicianPick && (
+            <Badge tone="accent" className="shrink-0 text-[10px]">
+              Pick
+            </Badge>
+          )}
+        </div>
+        <p className="text-sm font-semibold text-text group-hover:text-accent transition-colors line-clamp-2 min-h-[2.5rem]">
+          {product.name}
+        </p>
+
+        {/* Cannabinoid micro-badges */}
+        {(product.thcContent != null || product.cbdContent != null) && (
+          <div className="flex gap-1.5 mt-2">
+            {product.thcContent != null && (
+              <span className="inline-flex items-center rounded bg-surface-muted px-1.5 py-0.5 text-[10px] font-medium text-text-muted tabular-nums">
+                THC {product.thcContent}%
+              </span>
+            )}
+            {product.cbdContent != null && (
+              <span className="inline-flex items-center rounded bg-surface-muted px-1.5 py-0.5 text-[10px] font-medium text-text-muted tabular-nums">
+                CBD {product.cbdContent}%
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 mt-3">
+          <span className="text-sm font-semibold text-text">
+            ${product.price.toFixed(2)}
+          </span>
+          {product.compareAtPrice != null &&
+            product.compareAtPrice > product.price && (
+              <span className="text-xs text-text-subtle line-through">
+                ${product.compareAtPrice.toFixed(2)}
+              </span>
+            )}
+        </div>
+
+        {product.reviewCount > 0 && (
+          <div className="mt-2">
+            <RatingStars
+              rating={product.averageRating}
+              count={product.reviewCount}
+            />
+          </div>
+        )}
+
+        {!product.inStock && (
+          <p className="text-xs text-text-subtle mt-2">Out of stock</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export function PublicProductGrid({
+  products,
+  columns = 3,
+  className,
+}: {
+  products: MarketplaceProduct[];
+  columns?: 2 | 3 | 4;
+  className?: string;
+}) {
+  const cols: Record<number, string> = {
+    2: "grid-cols-1 sm:grid-cols-2",
+    3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+    4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+  };
+  return (
+    <div className={cn("grid gap-5", cols[columns], className)}>
+      {products.map((p) => (
+        <PublicProductCard key={p.id} product={p} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Second PR in the **Leafmart** chain. Ships the public catalog browse + product detail + category pages on top of the brand shell from PR #84.

Linear: **EMR-274** (child of EMR-17, relates to EMR-273)

## ⚠️ Stacked on PR #84

Base: `scwayman/leafmart-foundation`. After PR #84 merges, rebase this onto `main` and the diff shrinks to just the 4 new files.

## What's in this PR (4 files, +~720)

### Catalog route — `/leafmart/products`
- Browse all active products (hydrated via `public-queries.getAllPublicProducts` from PR #84)
- Search (shared `SearchBar` with `searchPublicProducts`)
- Format filter chips (tincture / edible / topical / capsule / vape / patch / ...)
- URL-param-driven active filter pills with one-click remove
- Empty state when nothing matches

### PDP — `/leafmart/products/[slug]`
- Image hero + brand + name + rating
- Price + compareAt
- Clinician-pick callout with "commentary shown after sign-in" framing
- Variant pills (display-only on public surface)
- **"Sign in to buy" CTA** → `/login?next=/portal/shop/products/[slug]` — authenticated checkout stays on the EMR-231/268/270 portal. No checkout wiring here.
- Trust signals: lab-verified / physician-reviewed / beginner-friendly
- Cannabinoid profile grid (THC / CBD / CBN / strain)
- Onset + duration info boxes
- **"May support"** symptoms/goals with explicit structure/function framing + "not a claim to treat, cure, or prevent any disease" disclaimer
- COA download link when present
- Reviews section
- "You may also like" related-products strip (shares symptoms/goals, bounded to 4)

### Category — `/leafmart/category/[slug]`
- Hero with icon + description + product count
- Grid via `getPublicProductsByCategory`
- 404-safe with helpful redirect link

### Components — `src/components/leafmart/PublicProductCard.tsx`
- Card + grid. No add-to-cart affordance on the public surface.
- THC/CBD micro-badges, clinician-pick badge, out-of-stock label, rating stars.

## Framing discipline

Public surface walks the structure/function line carefully — aligns with Codex's EMR-243 FDA screening work:

- Symptoms/goals rendered under **"May support"** header
- Explicit disclaimer: *"Structure/function terms only — not a claim to treat, cure, or prevent any disease"*
- `clinicianNote` + `dosageGuidance` already stripped in `public-queries` (from PR #84)
- Clinician commentary always gated behind sign-in

## Tests

- **335/335 pass** (unchanged — pages are RSCs exercised by the Next.js build; core logic tested in EMR-273's public-queries.test.ts)
- `npm run typecheck` clean

## Out of scope (deliberately — not mine)

- Checkout / add-to-cart on public surface (Lucca, EMR-232)
- Age gate (Codex, EMR-245)
- Filters beyond format — sort / price range / symptom chips follow in a later ticket
- Image upload pipeline (separate ticket)

## Test plan

- [x] `npm test` (335/335)
- [x] `npm run typecheck`
- [ ] Unauthenticated `/leafmart/products` lists all 12 seeded products
- [ ] `?q=sleep` narrows to sleep-related products
- [ ] `?format=tincture` filter chip activates
- [ ] `/leafmart/products/solace-nightfall-tincture` renders full PDP with "Sign in to buy" CTA
- [ ] Clicking "Sign in to buy" lands at `/login?next=/portal/shop/products/solace-nightfall-tincture`
- [ ] `/leafmart/category/sleep` renders sleep-category grid
- [ ] `/leafmart/category/does-not-exist` renders 404-safe empty state

## Leafmart chain

| PR | Ticket | Title | State |
|---|---|---|---|
| #84 | EMR-273 | Brand shell + landing | open |
| **this** | **EMR-274** | **Catalog browse + PDP + category** | **this PR** |
| next | EMR-275 | About + vendors + FAQ | coming |

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_