### PR TITLE
feat(leafmart): about + vendors pitch + FAQ pages (EMR-275)

### DIFF
--- a/src/app/leafmart/about/page.tsx
+++ b/src/app/leafmart/about/page.tsx
@@ -1,0 +1,212 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "About Leafmart",
+  description:
+    "Leafmart is the public marketplace for Leafjourney — the AI-native cannabis wellness platform. Every product is physician-curated, lab-verified, and shaped by real patient outcomes.",
+};
+
+const PILLARS = [
+  {
+    title: "Physician curated",
+    body: "A practicing clinician reviews every product before it's listed. If we wouldn't recommend it to a patient in clinic, it doesn't end up on Leafmart.",
+  },
+  {
+    title: "Lab verified",
+    body: "Third-party Certificate of Analysis is a hard requirement for every listing. Cannabinoid content, terpene profile, and contaminant screening — all on record.",
+  },
+  {
+    title: "Outcome informed",
+    body: "Products that help real patients move up in our rankings. Products that don't, quietly move down. The marketplace learns from the clinic.",
+  },
+] as const;
+
+export default function LeafmartAboutPage() {
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-10">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">About</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            About Leafmart
+          </span>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-3xl">
+          A cannabis store with{" "}
+          <span className="text-accent italic">a clinic</span> behind it.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          Leafmart is the public-facing marketplace for Leafjourney. Leafjourney
+          is the AI-native cannabis wellness platform used by clinicians to
+          recommend, dose, and track cannabis-assisted therapies. What you buy
+          on Leafmart is what those clinicians use in practice.
+        </p>
+      </section>
+
+      {/* ── The three pillars ──────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          How we decide what makes the shelf
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {PILLARS.map((p) => (
+            <Card key={p.title}>
+              <CardContent className="pt-6">
+                <LeafSprig size={16} className="text-accent mb-4" />
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {p.title}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {p.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* ── The founding-partner pledge ────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <div className="rounded-2xl border border-border bg-accent-soft/40 p-8 md:p-12">
+          <p className="text-[11px] uppercase tracking-wider text-accent mb-2">
+            The founding-partner pledge
+          </p>
+          <h2 className="text-2xl md:text-3xl font-semibold tracking-tight text-text">
+            10% take rate. 24 months. Weekly payouts.
+          </h2>
+          <p className="mt-4 text-sm text-text-muted max-w-2xl leading-relaxed">
+            Amazon charges 30–40% all-in. Etsy 10%+. We&apos;ve locked our
+            first four partners at 10% for 24 months — a promise we keep
+            because we&apos;re asking them to trust a platform that doesn&apos;t
+            have proof yet. They get every new feature, every new patient, and
+            a seat at the table as we shape what Leafmart becomes.
+          </p>
+
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <PledgeStat label="Take rate" value="10%" sub="locked 24 months" />
+            <PledgeStat
+              label="Payout cadence"
+              value="Weekly"
+              sub="7-day hold, then paid"
+            />
+            <PledgeStat
+              label="First partners"
+              value="4"
+              sub="PhytoRx, Flower Powered, AULV, Potency 710"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ── The clinic behind the store ────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_1.3fr] gap-8 md:gap-12 items-start">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-text mb-4">
+              The clinic behind the store
+            </h2>
+            <p className="text-sm text-text-muted leading-relaxed">
+              Leafjourney is an EMR — the chart, the prescribing tool, the
+              outcome tracker. When a patient logs how they felt after a
+              dose, that signal feeds back into what Leafmart recommends next.
+            </p>
+          </div>
+          <ul className="space-y-4 text-sm">
+            <ClinicPoint title="Charts are charts.">
+              Your clinical data stays with your clinician. Leafmart surfaces
+              aggregate outcome signals, never individual records.
+            </ClinicPoint>
+            <ClinicPoint title="Recommendations are ranked, not sold.">
+              Products rise in ranking because patients improve, not because
+              a brand paid for placement. We do not sell sponsored slots.
+            </ClinicPoint>
+            <ClinicPoint title="Vendors see their own numbers, never yours.">
+              Brands on Leafmart see their sales, payouts, and reviews.
+              They never see your chart, your outcomes, or your identity.
+            </ClinicPoint>
+          </ul>
+        </div>
+      </section>
+
+      {/* ── CTA ────────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Browse what a clinician would pick.
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Free to browse. Sign up to track outcomes and get recommendations
+          tailored to what works for you.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link href="/leafmart/products">
+            <Button size="lg" variant="primary">
+              Browse products
+            </Button>
+          </Link>
+          <Link href="/leafmart/vendors">
+            <Button size="lg" variant="secondary">
+              Sell on Leafmart
+            </Button>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function PledgeStat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-1">
+        {label}
+      </p>
+      <p className="text-2xl font-display text-text tabular-nums">{value}</p>
+      <p className="text-[11px] text-text-subtle mt-1">{sub}</p>
+    </div>
+  );
+}
+
+function ClinicPoint({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li className="flex gap-3">
+      <span
+        className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-accent-soft text-accent shrink-0 mt-0.5"
+        aria-hidden="true"
+      >
+        ✓
+      </span>
+      <div>
+        <p className="text-sm font-semibold text-text mb-1">{title}</p>
+        <p className="text-sm text-text-muted leading-relaxed">{children}</p>
+      </div>
+    </li>
+  );
+}

--- a/src/app/leafmart/faq/page.tsx
+++ b/src/app/leafmart/faq/page.tsx
@@ -1,0 +1,300 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "Leafmart FAQ",
+  description:
+    "Answers to common questions about Leafmart — lab testing, clinician review, shipping, age verification, returns, and privacy.",
+};
+
+interface FaqItem {
+  id: string;
+  q: string;
+  a: React.ReactNode;
+}
+
+const SECTIONS: { title: string; items: FaqItem[] }[] = [
+  {
+    title: "Product + clinical review",
+    items: [
+      {
+        id: "lab-testing",
+        q: "How do you verify lab testing?",
+        a: (
+          <>
+            Every Leafmart product has a third-party Certificate of Analysis
+            (COA) on file — typically an ISO 17025 accredited lab. COAs
+            cover cannabinoid content, terpene profile, and contaminant
+            screening (pesticides, heavy metals, microbial, solvents). We
+            refuse listings without a current COA. You can click through to
+            the COA on every PDP that has one.
+          </>
+        ),
+      },
+      {
+        id: "clinician-review",
+        q: "What does 'physician curated' mean exactly?",
+        a: (
+          <>
+            Every brand + product combination is reviewed by a practicing
+            clinician on our care team before it&apos;s listed. The clinician
+            looks at the cannabinoid profile, the lab result, the brand&apos;s
+            consistency record, and (when available) outcome signals from
+            patients who have used it. If the clinician wouldn&apos;t
+            recommend it in an encounter, it doesn&apos;t make the shelf.
+          </>
+        ),
+      },
+      {
+        id: "ranking",
+        q: "How are products ranked in search + recommendations?",
+        a: (
+          <>
+            A combination of clinician-pick status, in-stock + rating,
+            structure/function match against your goals, and — when data
+            exists — a per-product efficacy signal from de-identified
+            outcome data. We do not sell sponsored placements. Brands cannot
+            pay to move up.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Shipping + age",
+    items: [
+      {
+        id: "shipping",
+        q: "Where do you ship?",
+        a: (
+          <>
+            Hemp-derived products (≤ 0.3% delta-9 THC) ship to most states —
+            a handful have zero-THC or smokable-flower restrictions that our
+            checkout enforces automatically. Licensed-cannabis products (over
+            the hemp threshold) ship intrastate only. Every cart-to-state
+            combination is validated before checkout confirms.
+          </>
+        ),
+      },
+      {
+        id: "age-verification",
+        q: "Do I need to verify my age?",
+        a: (
+          <>
+            Any product containing more than 0.3% delta-9 THC requires 21+
+            age verification. We check date of birth on file (from your
+            patient chart, if you have one) or prompt you at first
+            interaction. Once verified, we don&apos;t re-prompt per product
+            or per session.
+          </>
+        ),
+      },
+      {
+        id: "partner-fulfillment",
+        q: "Who actually ships the product?",
+        a: (
+          <>
+            The brand. Leafmart is a marketplace — each vendor fulfills
+            their own orders under their own license. We route orders to the
+            right vendor, handle payment, and surface tracking numbers once
+            they&apos;re uploaded. Multi-vendor orders may arrive in
+            separate packages.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Payments + returns",
+    items: [
+      {
+        id: "payments",
+        q: "How do payments work?",
+        a: (
+          <>
+            Payabli-backed processing. Credit / debit + ACH supported. Your
+            card is charged on order confirmation. We hold funds briefly
+            before disbursing to vendors — if there&apos;s a dispute, it
+            resolves before money moves.
+          </>
+        ),
+      },
+      {
+        id: "returns",
+        q: "Can I return a product?",
+        a: (
+          <>
+            Within 30 days, yes — we&apos;re the customer-service first
+            line, not the vendor. Reach out through your order page or
+            email support@leafjourney.com. We review vendor-fault vs
+            buyer-remorse cases and issue partial or full refunds via the
+            original payment method. Opened consumables may be partial-refund
+            only, depending on the product type.
+          </>
+        ),
+      },
+      {
+        id: "disputes",
+        q: "What if something's wrong and the vendor isn't responding?",
+        a: (
+          <>
+            Open a dispute on your order page. We step in. Leafmart is on
+            the hook to resolve — not you chasing a brand.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Privacy",
+    items: [
+      {
+        id: "privacy",
+        q: "What happens to my health data?",
+        a: (
+          <>
+            Your chart is your chart. If you sign in to Leafmart with your
+            Leafjourney patient account, we use your outcome data to tailor
+            recommendations — but that data never leaves our platform and is
+            never shared with vendors. Vendors see aggregate, de-identified,
+            cohort-level signal only (and only with consent).
+          </>
+        ),
+      },
+      {
+        id: "tracking",
+        q: "Do you sell my browsing data?",
+        a: (
+          <>
+            No. We don&apos;t run third-party ad pixels on Leafmart.
+            Analytics stays first-party. Your email never goes to a mailing
+            broker.
+          </>
+        ),
+      },
+      {
+        id: "account",
+        q: "How do I delete my account?",
+        a: (
+          <>
+            Email support@leafjourney.com with &ldquo;Delete my
+            account.&rdquo; We comply within 30 days (faster where state law
+            requires). Clinical records have retention requirements but can
+            be isolated and anonymized on request.
+          </>
+        ),
+      },
+    ],
+  },
+];
+
+export default function LeafmartFaqPage() {
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-8">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">FAQ</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            Frequently asked
+          </span>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-2xl">
+          The short list of{" "}
+          <span className="text-accent italic">what people ask</span>.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          If something&apos;s missing, email{" "}
+          <a
+            href="mailto:support@leafjourney.com"
+            className="underline hover:text-text transition-colors"
+          >
+            support@leafjourney.com
+          </a>{" "}
+          and we&apos;ll add it.
+        </p>
+      </section>
+
+      {/* ── Jump-to table of contents ──────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-6">
+        <div className="rounded-lg border border-border bg-surface-muted/50 p-5">
+          <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-3">
+            Jump to
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {SECTIONS.flatMap((s) => s.items).map((item) => (
+              <Link
+                key={item.id}
+                href={`#${item.id}`}
+                className="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1 text-xs text-text-muted hover:text-text transition-colors"
+              >
+                {item.q}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Sections ───────────────────────────────────────── */}
+      {SECTIONS.map((section) => (
+        <section
+          key={section.title}
+          className="max-w-[1080px] mx-auto px-6 lg:px-12 py-10"
+        >
+          <h2 className="text-xl font-semibold tracking-tight text-text mb-6">
+            {section.title}
+          </h2>
+          <div className="space-y-8">
+            {section.items.map((item) => (
+              <article
+                key={item.id}
+                id={item.id}
+                className="scroll-mt-24 border-l-2 border-accent/40 pl-5"
+              >
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {item.q}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {item.a}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {/* ── CTA ────────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Still curious?
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Good questions make the FAQ better. Reach out.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="mailto:support@leafjourney.com">
+            <Button size="lg" variant="primary">
+              Email support
+            </Button>
+          </a>
+          <Link href="/leafmart/products">
+            <Button size="lg" variant="secondary">
+              Browse products
+            </Button>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/leafmart/vendors/page.tsx
+++ b/src/app/leafmart/vendors/page.tsx
@@ -1,0 +1,313 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "Partner with Leafmart",
+  description:
+    "Sell your cannabis wellness products on Leafmart. 10% take rate, 24-month founding-partner lock-in, weekly payouts, clinician-reviewed listings.",
+};
+
+const ECONOMICS = [
+  { label: "Take rate", value: "10%", sub: "locked 24 months" },
+  { label: "Payout cadence", value: "Weekly", sub: "7-day hold" },
+  { label: "Reserve", value: "10%", sub: "14-day rolling reserve" },
+  { label: "Onboarding", value: "~7 days", sub: "vetting + listing" },
+] as const;
+
+const WHAT_YOU_GET = [
+  {
+    title: "Clinical distribution",
+    body: "Your product is recommended inside patient charts, not just browsed in a store. Leafjourney clinicians can suggest your product during an encounter.",
+  },
+  {
+    title: "Outcome ranking",
+    body: "As patients log outcomes, products that actually help move up in our ranking engine. A working product doesn't need to buy ads — it wins on evidence.",
+  },
+  {
+    title: "Real-world evidence",
+    body: "Aggregated outcome data feeds back to you quarterly. Where your product helps, where it doesn't, and which cohorts respond best.",
+  },
+  {
+    title: "Payment spine + compliance",
+    body: "Payabli-backed processing, 1099-K reporting, state shipping matrix, age gating, and FDA claim screening — all handled for you.",
+  },
+] as const;
+
+const ONBOARDING_STEPS = [
+  {
+    step: "01",
+    title: "Apply",
+    body: "Email hello@leafjourney.com with your brand, product lines, and COA links. We respond within 72 hours.",
+  },
+  {
+    step: "02",
+    title: "Vet + paperwork",
+    body: "We verify insurance, W-9, state licenses, and lab results. You set up your Payabli Pay Point with our help.",
+  },
+  {
+    step: "03",
+    title: "List + launch",
+    body: "We ingest your catalog, run listings past our clinical reviewer, and go live. Founding partners get a feature slot in the launch week.",
+  },
+] as const;
+
+const FAQ_SNIPPETS = [
+  {
+    q: "Do you carry products with delta-9 THC above 0.3%?",
+    a: "Only in states where licensed distribution is legal. Hemp-derived (≤ 0.3% delta-9) listings ship broadly; licensed cannabis listings ship intrastate only. Our state matrix enforces this at checkout.",
+  },
+  {
+    q: "Who reviews my listing copy?",
+    a: "A practicing clinician plus our FDA-claim screener (regex + clinical review). We'll flag anything that crosses structure/function language and suggest rewrites — we won't silently edit your copy.",
+  },
+  {
+    q: "How are outcomes attributed to my product?",
+    a: "When a clinician links a DosingRegimen to your product, subsequent OutcomeLog entries inside that regimen's window count toward your product's efficacy signal. De-identified, cohort-level, consented.",
+  },
+  {
+    q: "Can I leave?",
+    a: "Yes. 30-day notice for founding partners, standard partners any time. Reserve disburses on the existing schedule. No clawbacks, no lock-in penalties — we keep you because the platform works.",
+  },
+] as const;
+
+const APPLY_EMAIL = "hello@leafjourney.com";
+
+export default function LeafmartVendorsPage() {
+  const applyHref = `mailto:${APPLY_EMAIL}?subject=${encodeURIComponent(
+    "Leafmart partner application",
+  )}&body=${encodeURIComponent(
+    "Brand name:\nWebsite:\nProduct categories:\nStates you currently ship to:\nCOA sample link:\nAnything else we should know:",
+  )}`;
+
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-10">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">Partner with us</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            For brands
+          </span>
+          <Badge tone="accent" className="ml-1 text-[10px]">
+            Now accepting founding partners
+          </Badge>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-3xl">
+          Sell cannabis products where they&apos;re{" "}
+          <span className="text-accent italic">actually prescribed</span>.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          Leafmart is the marketplace side of an AI-native clinical platform.
+          Your product sits inside clinician workflow — not just a search
+          result on a store page. And our economics are keystone-fair from day
+          one.
+        </p>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <a href={applyHref}>
+            <Button size="lg" variant="primary">
+              Apply to partner
+            </Button>
+          </a>
+          <Link href="#economics">
+            <Button size="lg" variant="secondary">
+              See the economics
+            </Button>
+          </Link>
+        </div>
+      </section>
+
+      {/* ── Economics tiles ────────────────────────────────── */}
+      <section id="economics" className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-2">
+          Founding-partner economics
+        </h2>
+        <p className="text-sm text-text-muted mb-8 max-w-2xl">
+          These terms lock for 24 months from your go-live date. After that,
+          you stay on whatever our standard terms are — which will never be
+          worse than Shopify and never as punishing as Amazon.
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {ECONOMICS.map((e) => (
+            <div
+              key={e.label}
+              className="rounded-lg border border-border bg-surface p-4"
+            >
+              <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-1">
+                {e.label}
+              </p>
+              <p className="text-2xl font-display text-text tabular-nums">
+                {e.value}
+              </p>
+              <p className="text-[11px] text-text-subtle mt-1">{e.sub}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Benchmark */}
+        <div className="mt-8 rounded-lg border border-border bg-surface-muted/50 p-5">
+          <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-3">
+            Compared to
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
+            <Benchmark name="Amazon" rate="30-40%" />
+            <Benchmark name="Etsy" rate="~10% + ads" />
+            <Benchmark name="Shopify" rate="3-5%" />
+            <Benchmark name="Leafmart" rate="10% locked" highlight />
+          </div>
+        </div>
+      </section>
+
+      {/* ── What you get ───────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          What you get
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {WHAT_YOU_GET.map((b) => (
+            <Card key={b.title}>
+              <CardContent className="pt-6">
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {b.title}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {b.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Onboarding ─────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          Onboarding in three steps
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {ONBOARDING_STEPS.map((s) => (
+            <div
+              key={s.step}
+              className="rounded-lg border border-border bg-surface p-6"
+            >
+              <p className="font-display text-sm text-accent tracking-[0.2em] mb-3">
+                {s.step}
+              </p>
+              <h3 className="text-base font-semibold text-text mb-2">
+                {s.title}
+              </h3>
+              <p className="text-sm text-text-muted leading-relaxed">
+                {s.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── FAQ snippets ───────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          Common questions
+        </h2>
+        <div className="divide-y divide-border border-y border-border">
+          {FAQ_SNIPPETS.map((item) => (
+            <details
+              key={item.q}
+              className="group py-5 [&_summary]:cursor-pointer"
+            >
+              <summary className="flex items-center justify-between gap-4 list-none">
+                <h3 className="text-sm font-semibold text-text">{item.q}</h3>
+                <span
+                  className="text-xs text-text-subtle group-open:rotate-45 transition-transform"
+                  aria-hidden="true"
+                >
+                  +
+                </span>
+              </summary>
+              <p className="mt-3 text-sm text-text-muted leading-relaxed">
+                {item.a}
+              </p>
+            </details>
+          ))}
+        </div>
+        <p className="text-xs text-text-subtle mt-4">
+          More on{" "}
+          <Link
+            href="/leafmart/faq"
+            className="underline hover:text-text transition-colors"
+          >
+            the full FAQ
+          </Link>
+          .
+        </p>
+      </section>
+
+      {/* ── Final CTA ──────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Ready to list?
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Reply within 72 hours. Onboarding is ~7 days end-to-end.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href={applyHref}>
+            <Button size="lg" variant="primary">
+              Apply to partner
+            </Button>
+          </a>
+          <Link href="/leafmart/about">
+            <Button size="lg" variant="secondary">
+              About Leafmart
+            </Button>
+          </Link>
+        </div>
+        <p className="text-[11px] text-text-subtle mt-6">
+          Questions?{" "}
+          <a
+            href={`mailto:${APPLY_EMAIL}`}
+            className="underline hover:text-text transition-colors"
+          >
+            {APPLY_EMAIL}
+          </a>
+        </p>
+      </section>
+    </>
+  );
+}
+
+function Benchmark({
+  name,
+  rate,
+  highlight,
+}: {
+  name: string;
+  rate: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md px-3 py-2 ${
+        highlight
+          ? "bg-accent-soft text-accent font-semibold"
+          : "bg-surface text-text-muted"
+      }`}
+    >
+      <p className="text-[11px] uppercase tracking-wider">{name}</p>
+      <p className="text-sm tabular-nums">{rate}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Third Leafmart PR. Rounds out the public brand presence — the static content pages a real marketplace needs so the footer + header have no dead links.

Linear: **EMR-275** (child of EMR-17, relates to EMR-273 / EMR-274)

## ⚠️ Stacked on PR #85 → PR #84

Base: `scwayman/leafmart-catalog`. The stack is:
- PR #84 (EMR-273 foundation) → main
- PR #85 (EMR-274 catalog) → #84
- **this PR (EMR-275 brand pages)** → #85

Rebase each onto main as the parent merges.

## What's in this PR (3 files, +825)

### `/leafmart/about`
- Hero: "A cannabis store with a clinic behind it"
- Three pillars (physician-curated / lab-verified / outcome-informed)
- Founding-partner pledge: 10% take rate locked 24 months, weekly payouts, first 4 partners spotlighted
- "The clinic behind the store" — three principles explicitly stating PHI isolation, ranking transparency (no paid placement), vendor blindness

### `/leafmart/vendors` — "Sell on Leafmart" pitch
- "Now accepting founding partners" badge
- Economics tiles — 10% take rate / weekly payouts / 10% reserve / ~7-day onboarding
- Benchmark strip: Amazon 30–40% / Etsy ~10% + ads / Shopify 3–5% / **Leafmart 10% locked**
- What you get: clinical distribution / outcome ranking / RWE feedback / payment spine + compliance
- 3-step onboarding (apply → vet → list+launch)
- FAQ snippets: delta-9 ≤ 0.3% rule, listing review process, outcome attribution contract, exit terms
- **"Apply to partner"** CTA is a `mailto:` to `hello@leafjourney.com` with a pre-filled body template

### `/leafmart/faq`
- 4 sections with anchor-linkable items:
  - **Product + clinical review** — lab testing, "physician curated" definition, ranking mechanism
  - **Shipping + age** — state-matrix, 21+ verification, multi-vendor fulfillment
  - **Payments + returns** — Payabli flow, 30-day return window, dispute escalation
  - **Privacy** — chart-is-yours, no ad pixels, deletion process
- Jump-to chip row up top for quick skim

## Framing discipline preserved

- **Structure/function only** — no disease-cure language anywhere on the public surface
- Clinician commentary always gated behind sign-in
- Vendor attribution language matches the EMR-268 ranking engine contract: de-identified, cohort-level, consented
- Exit terms explicit — no lock-in ambiguity

## Tests

- **335/335 pass** (unchanged — routes are static server components, no new helpers)
- `npm run typecheck` clean

## Out of scope (deliberately — not mine)

- Vendor portal / real application form (Codex, EMR-228)
- Full ToS / Privacy legal text (Codex, EMR-258)
- CMS backing — content lives in the page files for now
- Age-verification wiring (Codex, EMR-245)

## Test plan

- [x] `npm test` (335/335)
- [x] `npm run typecheck`
- [ ] `/leafmart/about` renders with hero, pillars, founding-partner pledge, clinic-behind-the-store section
- [ ] `/leafmart/vendors` shows economics tiles, benchmark strip, apply CTA launches `mailto:`
- [ ] `/leafmart/faq#lab-testing` scrolls to the lab-testing answer
- [ ] Every link in `LeafmartFooter` and `LeafmartHeader` resolves to a real page

## Leafmart chain

| PR | Ticket | Title | State |
|---|---|---|---|
| #84 | EMR-273 | Brand shell + landing | open |
| #85 | EMR-274 | Catalog browse + PDP + category | open |
| **this** | **EMR-275** | **About + vendors + FAQ** | **this PR** |
| next | EMR-276 | ChatCB teaser on Leafmart | coming |

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_