### PR TITLE
fix(db): migration for Codex Vendor + requires21Plus + ageVerifiedAt (missed in PR #82)

### DIFF
--- a/prisma/migrations/20260424123000_add_codex_marketplace_foundation/migration.sql
+++ b/prisma/migrations/20260424123000_add_codex_marketplace_foundation/migration.sql
@@ -1,0 +1,79 @@
+-- EMR-233 / EMR-245 follow-up: ships the schema additions introduced in
+-- PR #82 (codex) that didn't come with a migration file. Adds Vendor +
+-- VendorDocument tables, VendorType / VendorStatus / VendorDocumentType /
+-- VendorDocumentStatus enums, Patient.ageVerifiedAt, and Product.requires21Plus.
+
+-- CreateEnum
+CREATE TYPE "VendorType" AS ENUM ('hemp_brand', 'licensed_dispensary');
+
+-- CreateEnum
+CREATE TYPE "VendorStatus" AS ENUM ('pending', 'active', 'suspended', 'offboarded');
+
+-- CreateEnum
+CREATE TYPE "VendorDocumentType" AS ENUM ('insurance', 'w9', 'coa');
+
+-- CreateEnum
+CREATE TYPE "VendorDocumentStatus" AS ENUM ('missing', 'submitted', 'approved', 'rejected');
+
+-- AlterTable
+ALTER TABLE "Patient" ADD COLUMN "ageVerifiedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN "requires21Plus" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "Vendor" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "vendorType" "VendorType" NOT NULL,
+    "categories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "productLines" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "takeRatePct" DOUBLE PRECISION NOT NULL DEFAULT 0.10,
+    "foundingPartnerFlag" BOOLEAN NOT NULL DEFAULT false,
+    "foundingPartnerExpiresAt" TIMESTAMP(3),
+    "payoutSchedule" TEXT NOT NULL DEFAULT 'weekly',
+    "reservePct" DOUBLE PRECISION DEFAULT 0.10,
+    "reserveDays" INTEGER DEFAULT 14,
+    "status" "VendorStatus" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Vendor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VendorDocument" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "vendorId" TEXT NOT NULL,
+    "documentType" "VendorDocumentType" NOT NULL,
+    "fileUrl" TEXT,
+    "status" "VendorDocumentStatus" NOT NULL DEFAULT 'missing',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "VendorDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Vendor_slug_key" ON "Vendor"("slug");
+
+-- CreateIndex
+CREATE INDEX "Vendor_organizationId_status_idx" ON "Vendor"("organizationId", "status");
+
+-- CreateIndex
+CREATE INDEX "VendorDocument_organizationId_status_idx" ON "VendorDocument"("organizationId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VendorDocument_vendorId_documentType_key" ON "VendorDocument"("vendorId", "documentType");
+
+-- AddForeignKey
+ALTER TABLE "Vendor" ADD CONSTRAINT "Vendor_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "VendorDocument" ADD CONSTRAINT "VendorDocument_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "VendorDocument" ADD CONSTRAINT "VendorDocument_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary

**Fixes the runtime error on `/leafmart`** and any other route that touches `Product` or `Vendor` after PR #82 merged.

PR #82 added `Vendor`, `VendorDocument`, `Product.requires21Plus`, and `Patient.ageVerifiedAt` to `schema.prisma` but **did not ship a migration file**. Result: any Prisma query that selects from `Product` fails with `column "requires21Plus" does not exist` the moment the code runs against a live DB.

This PR ships the migration that should have been in #82.

## What's in the migration

- **Enums:** `VendorType`, `VendorStatus`, `VendorDocumentType`, `VendorDocumentStatus`
- **Table:** `Vendor` — slug unique, org+status index, FK to `Organization` with cascade delete
- **Table:** `VendorDocument` — FK cascade to `Organization` + `Vendor`, unique on `vendorId+documentType`
- **Column:** `Patient.ageVerifiedAt` (nullable timestamp)
- **Column:** `Product.requires21Plus` (boolean, default `false`)

SQL generated via `prisma migrate diff --from-empty --to-schema-datamodel` and extracted to match what `prisma migrate dev --name add_codex_marketplace_foundation` would have produced. Format matches every other migration already in this repo.

## Root cause

PR #82's description claims `npm run build` passed locally — but `build` runs `prisma generate` (client only), not `prisma migrate dev` (which creates migrations). The `prisma generate` step silently tolerates schema drift; the missing migration only surfaces when a request hits a real DB. Classic foot-gun.

## Deploy

```bash
npm run db:migrate    # applies add_codex_marketplace_foundation
```

**For DBs that were hotfixed** (someone ran `prisma db push` to unblock locally): you'll need
```bash
npx prisma migrate resolve --applied 20260424123000_add_codex_marketplace_foundation
```
so Prisma doesn't try to re-apply an already-applied delta.

## Test plan

- [ ] Pull this branch, run `npm run db:migrate`, visit `/leafmart` — renders without 500
- [ ] `/leafmart/shop` renders the category directory with live counts
- [ ] `/leafmart/products/solace-nightfall-tincture` renders the PDP
- [ ] Authenticated `/portal/shop` still works (regression check — was working before migration existed because `prisma generate` didn't fail; now extra-safe)

## Priority

**Merge this before any of the Leafmart PRs (#84-87)** so they deploy to a DB that has the columns they reference.

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_