### PR TITLE
feat(leafmart): brand identity polish — product tiles + trust seal + founding-partner chips

### DIFF
--- a/src/app/leafmart/about/page.tsx
+++ b/src/app/leafmart/about/page.tsx
@@ -1,0 +1,212 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "About Leafmart",
+  description:
+    "Leafmart is the public marketplace for Leafjourney — the AI-native cannabis wellness platform. Every product is physician-curated, lab-verified, and shaped by real patient outcomes.",
+};
+
+const PILLARS = [
+  {
+    title: "Physician curated",
+    body: "A practicing clinician reviews every product before it's listed. If we wouldn't recommend it to a patient in clinic, it doesn't end up on Leafmart.",
+  },
+  {
+    title: "Lab verified",
+    body: "Third-party Certificate of Analysis is a hard requirement for every listing. Cannabinoid content, terpene profile, and contaminant screening — all on record.",
+  },
+  {
+    title: "Outcome informed",
+    body: "Products that help real patients move up in our rankings. Products that don't, quietly move down. The marketplace learns from the clinic.",
+  },
+] as const;
+
+export default function LeafmartAboutPage() {
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-10">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">About</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            About Leafmart
+          </span>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-3xl">
+          A cannabis store with{" "}
+          <span className="text-accent italic">a clinic</span> behind it.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          Leafmart is the public-facing marketplace for Leafjourney. Leafjourney
+          is the AI-native cannabis wellness platform used by clinicians to
+          recommend, dose, and track cannabis-assisted therapies. What you buy
+          on Leafmart is what those clinicians use in practice.
+        </p>
+      </section>
+
+      {/* ── The three pillars ──────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          How we decide what makes the shelf
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {PILLARS.map((p) => (
+            <Card key={p.title}>
+              <CardContent className="pt-6">
+                <LeafSprig size={16} className="text-accent mb-4" />
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {p.title}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {p.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* ── The founding-partner pledge ────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <div className="rounded-2xl border border-border bg-accent-soft/40 p-8 md:p-12">
+          <p className="text-[11px] uppercase tracking-wider text-accent mb-2">
+            The founding-partner pledge
+          </p>
+          <h2 className="text-2xl md:text-3xl font-semibold tracking-tight text-text">
+            10% take rate. 24 months. Weekly payouts.
+          </h2>
+          <p className="mt-4 text-sm text-text-muted max-w-2xl leading-relaxed">
+            Amazon charges 30–40% all-in. Etsy 10%+. We&apos;ve locked our
+            first four partners at 10% for 24 months — a promise we keep
+            because we&apos;re asking them to trust a platform that doesn&apos;t
+            have proof yet. They get every new feature, every new patient, and
+            a seat at the table as we shape what Leafmart becomes.
+          </p>
+
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <PledgeStat label="Take rate" value="10%" sub="locked 24 months" />
+            <PledgeStat
+              label="Payout cadence"
+              value="Weekly"
+              sub="7-day hold, then paid"
+            />
+            <PledgeStat
+              label="First partners"
+              value="4"
+              sub="PhytoRx, Flower Powered, AULV, Potency 710"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ── The clinic behind the store ────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_1.3fr] gap-8 md:gap-12 items-start">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-text mb-4">
+              The clinic behind the store
+            </h2>
+            <p className="text-sm text-text-muted leading-relaxed">
+              Leafjourney is an EMR — the chart, the prescribing tool, the
+              outcome tracker. When a patient logs how they felt after a
+              dose, that signal feeds back into what Leafmart recommends next.
+            </p>
+          </div>
+          <ul className="space-y-4 text-sm">
+            <ClinicPoint title="Charts are charts.">
+              Your clinical data stays with your clinician. Leafmart surfaces
+              aggregate outcome signals, never individual records.
+            </ClinicPoint>
+            <ClinicPoint title="Recommendations are ranked, not sold.">
+              Products rise in ranking because patients improve, not because
+              a brand paid for placement. We do not sell sponsored slots.
+            </ClinicPoint>
+            <ClinicPoint title="Vendors see their own numbers, never yours.">
+              Brands on Leafmart see their sales, payouts, and reviews.
+              They never see your chart, your outcomes, or your identity.
+            </ClinicPoint>
+          </ul>
+        </div>
+      </section>
+
+      {/* ── CTA ────────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Browse what a clinician would pick.
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Free to browse. Sign up to track outcomes and get recommendations
+          tailored to what works for you.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link href="/leafmart/products">
+            <Button size="lg" variant="primary">
+              Browse products
+            </Button>
+          </Link>
+          <Link href="/leafmart/vendors">
+            <Button size="lg" variant="secondary">
+              Sell on Leafmart
+            </Button>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function PledgeStat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-1">
+        {label}
+      </p>
+      <p className="text-2xl font-display text-text tabular-nums">{value}</p>
+      <p className="text-[11px] text-text-subtle mt-1">{sub}</p>
+    </div>
+  );
+}
+
+function ClinicPoint({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li className="flex gap-3">
+      <span
+        className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-accent-soft text-accent shrink-0 mt-0.5"
+        aria-hidden="true"
+      >
+        ✓
+      </span>
+      <div>
+        <p className="text-sm font-semibold text-text mb-1">{title}</p>
+        <p className="text-sm text-text-muted leading-relaxed">{children}</p>
+      </div>
+    </li>
+  );
+}

--- a/src/app/leafmart/category/[slug]/page.tsx
+++ b/src/app/leafmart/category/[slug]/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import {
+  getPublicCategoryBySlug,
+  getPublicProductsByCategory,
+} from "@/lib/marketplace/public-queries";
+
+interface CategoryPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: CategoryPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const category = await getPublicCategoryBySlug(slug);
+  return { title: category?.name ?? "Category" };
+}
+
+export default async function LeafmartCategoryPage({
+  params,
+}: CategoryPageProps) {
+  const { slug } = await params;
+  const category = await getPublicCategoryBySlug(slug);
+
+  if (!category) {
+    return (
+      <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">Not found</span>
+        </div>
+        <EmptyState
+          title="Category not found"
+          description="This category doesn't exist or may have been renamed."
+          action={
+            <Link
+              href="/leafmart/products"
+              className="text-sm text-accent hover:underline"
+            >
+              Browse all products →
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  const products = await getPublicProductsByCategory(slug);
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+      <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+        <Link href="/leafmart" className="hover:text-text transition-colors">
+          Leafmart
+        </Link>
+        <span aria-hidden="true">/</span>
+        <Link
+          href="/leafmart/products"
+          className="hover:text-text transition-colors"
+        >
+          Shop
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-text">{category.name}</span>
+      </div>
+
+      <header className="mb-10 max-w-2xl">
+        {category.icon && (
+          <span
+            className="block text-3xl text-accent mb-3"
+            aria-hidden="true"
+          >
+            {category.icon}
+          </span>
+        )}
+        <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+          {category.name}
+        </h1>
+        {category.description && (
+          <p className="text-sm text-text-muted mt-2 leading-relaxed">
+            {category.description}
+          </p>
+        )}
+        <p className="text-xs text-text-subtle mt-3">
+          {products.length} {products.length === 1 ? "product" : "products"}
+        </p>
+      </header>
+
+      {products.length === 0 ? (
+        <EmptyState
+          title="No products yet"
+          description="We haven't curated anything for this category yet. Check back soon."
+        />
+      ) : (
+        <PublicProductGrid products={products} columns={4} />
+      )}
+    </div>
+  );
+}

--- a/src/app/leafmart/faq/page.tsx
+++ b/src/app/leafmart/faq/page.tsx
@@ -1,0 +1,300 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "Leafmart FAQ",
+  description:
+    "Answers to common questions about Leafmart — lab testing, clinician review, shipping, age verification, returns, and privacy.",
+};
+
+interface FaqItem {
+  id: string;
+  q: string;
+  a: React.ReactNode;
+}
+
+const SECTIONS: { title: string; items: FaqItem[] }[] = [
+  {
+    title: "Product + clinical review",
+    items: [
+      {
+        id: "lab-testing",
+        q: "How do you verify lab testing?",
+        a: (
+          <>
+            Every Leafmart product has a third-party Certificate of Analysis
+            (COA) on file — typically an ISO 17025 accredited lab. COAs
+            cover cannabinoid content, terpene profile, and contaminant
+            screening (pesticides, heavy metals, microbial, solvents). We
+            refuse listings without a current COA. You can click through to
+            the COA on every PDP that has one.
+          </>
+        ),
+      },
+      {
+        id: "clinician-review",
+        q: "What does 'physician curated' mean exactly?",
+        a: (
+          <>
+            Every brand + product combination is reviewed by a practicing
+            clinician on our care team before it&apos;s listed. The clinician
+            looks at the cannabinoid profile, the lab result, the brand&apos;s
+            consistency record, and (when available) outcome signals from
+            patients who have used it. If the clinician wouldn&apos;t
+            recommend it in an encounter, it doesn&apos;t make the shelf.
+          </>
+        ),
+      },
+      {
+        id: "ranking",
+        q: "How are products ranked in search + recommendations?",
+        a: (
+          <>
+            A combination of clinician-pick status, in-stock + rating,
+            structure/function match against your goals, and — when data
+            exists — a per-product efficacy signal from de-identified
+            outcome data. We do not sell sponsored placements. Brands cannot
+            pay to move up.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Shipping + age",
+    items: [
+      {
+        id: "shipping",
+        q: "Where do you ship?",
+        a: (
+          <>
+            Hemp-derived products (≤ 0.3% delta-9 THC) ship to most states —
+            a handful have zero-THC or smokable-flower restrictions that our
+            checkout enforces automatically. Licensed-cannabis products (over
+            the hemp threshold) ship intrastate only. Every cart-to-state
+            combination is validated before checkout confirms.
+          </>
+        ),
+      },
+      {
+        id: "age-verification",
+        q: "Do I need to verify my age?",
+        a: (
+          <>
+            Any product containing more than 0.3% delta-9 THC requires 21+
+            age verification. We check date of birth on file (from your
+            patient chart, if you have one) or prompt you at first
+            interaction. Once verified, we don&apos;t re-prompt per product
+            or per session.
+          </>
+        ),
+      },
+      {
+        id: "partner-fulfillment",
+        q: "Who actually ships the product?",
+        a: (
+          <>
+            The brand. Leafmart is a marketplace — each vendor fulfills
+            their own orders under their own license. We route orders to the
+            right vendor, handle payment, and surface tracking numbers once
+            they&apos;re uploaded. Multi-vendor orders may arrive in
+            separate packages.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Payments + returns",
+    items: [
+      {
+        id: "payments",
+        q: "How do payments work?",
+        a: (
+          <>
+            Payabli-backed processing. Credit / debit + ACH supported. Your
+            card is charged on order confirmation. We hold funds briefly
+            before disbursing to vendors — if there&apos;s a dispute, it
+            resolves before money moves.
+          </>
+        ),
+      },
+      {
+        id: "returns",
+        q: "Can I return a product?",
+        a: (
+          <>
+            Within 30 days, yes — we&apos;re the customer-service first
+            line, not the vendor. Reach out through your order page or
+            email support@leafjourney.com. We review vendor-fault vs
+            buyer-remorse cases and issue partial or full refunds via the
+            original payment method. Opened consumables may be partial-refund
+            only, depending on the product type.
+          </>
+        ),
+      },
+      {
+        id: "disputes",
+        q: "What if something's wrong and the vendor isn't responding?",
+        a: (
+          <>
+            Open a dispute on your order page. We step in. Leafmart is on
+            the hook to resolve — not you chasing a brand.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Privacy",
+    items: [
+      {
+        id: "privacy",
+        q: "What happens to my health data?",
+        a: (
+          <>
+            Your chart is your chart. If you sign in to Leafmart with your
+            Leafjourney patient account, we use your outcome data to tailor
+            recommendations — but that data never leaves our platform and is
+            never shared with vendors. Vendors see aggregate, de-identified,
+            cohort-level signal only (and only with consent).
+          </>
+        ),
+      },
+      {
+        id: "tracking",
+        q: "Do you sell my browsing data?",
+        a: (
+          <>
+            No. We don&apos;t run third-party ad pixels on Leafmart.
+            Analytics stays first-party. Your email never goes to a mailing
+            broker.
+          </>
+        ),
+      },
+      {
+        id: "account",
+        q: "How do I delete my account?",
+        a: (
+          <>
+            Email support@leafjourney.com with &ldquo;Delete my
+            account.&rdquo; We comply within 30 days (faster where state law
+            requires). Clinical records have retention requirements but can
+            be isolated and anonymized on request.
+          </>
+        ),
+      },
+    ],
+  },
+];
+
+export default function LeafmartFaqPage() {
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-8">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">FAQ</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            Frequently asked
+          </span>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-2xl">
+          The short list of{" "}
+          <span className="text-accent italic">what people ask</span>.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          If something&apos;s missing, email{" "}
+          <a
+            href="mailto:support@leafjourney.com"
+            className="underline hover:text-text transition-colors"
+          >
+            support@leafjourney.com
+          </a>{" "}
+          and we&apos;ll add it.
+        </p>
+      </section>
+
+      {/* ── Jump-to table of contents ──────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-6">
+        <div className="rounded-lg border border-border bg-surface-muted/50 p-5">
+          <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-3">
+            Jump to
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {SECTIONS.flatMap((s) => s.items).map((item) => (
+              <Link
+                key={item.id}
+                href={`#${item.id}`}
+                className="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1 text-xs text-text-muted hover:text-text transition-colors"
+              >
+                {item.q}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Sections ───────────────────────────────────────── */}
+      {SECTIONS.map((section) => (
+        <section
+          key={section.title}
+          className="max-w-[1080px] mx-auto px-6 lg:px-12 py-10"
+        >
+          <h2 className="text-xl font-semibold tracking-tight text-text mb-6">
+            {section.title}
+          </h2>
+          <div className="space-y-8">
+            {section.items.map((item) => (
+              <article
+                key={item.id}
+                id={item.id}
+                className="scroll-mt-24 border-l-2 border-accent/40 pl-5"
+              >
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {item.q}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {item.a}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {/* ── CTA ────────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Still curious?
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Good questions make the FAQ better. Reach out.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href="mailto:support@leafjourney.com">
+            <Button size="lg" variant="primary">
+              Email support
+            </Button>
+          </a>
+          <Link href="/leafmart/products">
+            <Button size="lg" variant="secondary">
+              Browse products
+            </Button>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -1,15 +1,16 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { LeafSprig } from "@/components/ui/ornament";
-import { RatingStars } from "@/components/marketplace/RatingStars";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import { BotanicalAccent } from "@/components/leafmart/BotanicalAccent";
+import { TrustSeal } from "@/components/leafmart/TrustSeal";
+import { BrandChip } from "@/components/leafmart/BrandChip";
+import { FOUNDING_PARTNER_BRANDS } from "@/components/leafmart/formats";
 import {
   getPublicFeaturedProducts,
   getPublicClinicianPicks,
 } from "@/lib/marketplace/public-queries";
-import { FORMAT_LABELS } from "@/lib/marketplace/types";
 
 export const dynamic = "force-dynamic";
 
@@ -50,13 +51,6 @@ const HOW_IT_WORKS = [
   },
 ] as const;
 
-const FOUNDING_PARTNERS = [
-  { name: "PhytoRx", tagline: "CBD + CBG beverages" },
-  { name: "Flower Powered", tagline: "Full-spectrum topicals + tinctures" },
-  { name: "AULV", tagline: "Plant-powered wellness" },
-  { name: "Potency 710", tagline: "Gold Skin Serum" },
-] as const;
-
 export default async function LeafmartHomePage() {
   const [featured, clinicianPicks] = await Promise.all([
     getPublicFeaturedProducts(4),
@@ -65,86 +59,178 @@ export default async function LeafmartHomePage() {
 
   return (
     <>
-      {/* ── Hero ───────────────────────────────────────────── */}
-      <section className="relative overflow-hidden">
+      {/* ── Hero ────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden border-b border-border">
+        {/* Layered ambient wash */}
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 -z-10"
           style={{
             background:
-              "radial-gradient(ellipse 70% 50% at 85% 5%, var(--highlight-soft), transparent 65%)," +
-              "radial-gradient(ellipse 50% 60% at 5% 85%, var(--accent-soft), transparent 60%)",
+              "radial-gradient(ellipse 60% 55% at 18% 30%, var(--highlight-soft), transparent 60%)," +
+              "radial-gradient(ellipse 55% 60% at 82% 80%, var(--accent-soft), transparent 60%)",
           }}
         />
-        <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-24 md:py-28">
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+        {/* Subtle paper grain */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-[0.04] -z-10"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 20% 20%, rgba(31,77,55,.5) 0, transparent 25%), radial-gradient(circle at 75% 60%, rgba(184,120,47,.5) 0, transparent 25%)",
+          }}
+        />
+        <BotanicalAccent
+          variant="hero"
+          className="hidden md:block absolute -right-12 -top-8 w-[560px] h-[560px] -z-10"
+        />
+
+        <div className="max-w-[1280px] mx-auto px-6 lg:px-12 pt-20 pb-24 md:pt-28 md:pb-32 grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-center">
+          <div className="lg:col-span-7">
+            <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface/70 backdrop-blur px-3 py-1 mb-7 shadow-sm">
               <LeafSprig size={14} className="text-accent" />
-              <span className="text-[11px] uppercase tracking-wider text-text-muted">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-text-muted">
                 Physician-curated cannabis marketplace
               </span>
             </div>
-            <h1 className="font-display text-[42px] sm:text-5xl md:text-6xl lg:text-[68px] leading-[0.98] tracking-tight text-text">
+            <h1 className="font-display text-[44px] sm:text-6xl md:text-[72px] leading-[0.96] tracking-tight text-text">
               The cannabis store{" "}
-              <span className="text-accent italic">your doctor</span>
-              <br />
-              would send you to.
+              <span className="text-accent italic">your doctor</span> would send
+              you to.
             </h1>
-            <p className="mt-6 text-lg text-text-muted max-w-xl leading-relaxed">
+            <p className="mt-7 text-lg text-text-muted max-w-xl leading-relaxed">
               Leafmart is the marketplace side of Leafjourney. Every product is
               clinician-reviewed, lab-verified, and shaped by real patient
               outcomes — so the thing you buy is the thing that actually
               helps.
             </p>
-            <div className="mt-8 flex flex-wrap gap-3">
-              <Link href="/leafmart/products">
+            <div className="mt-9 flex flex-wrap items-center gap-3">
+              <Link href="/leafmart/shop">
                 <Button size="lg" variant="primary">
-                  Browse products
+                  Shop by what you need
                 </Button>
               </Link>
-              <Link href="/leafmart/about">
+              <Link href="/leafmart/products">
                 <Button size="lg" variant="secondary">
-                  How it works
+                  See all products
                 </Button>
               </Link>
             </div>
+
+            {/* Quiet trust markers */}
+            <dl className="mt-12 grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-4 max-w-lg">
+              <div>
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">Lab-verified</dt>
+                <dd className="font-display text-2xl text-accent mt-0.5">100%</dd>
+              </div>
+              <div>
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">Founding partners</dt>
+                <dd className="font-display text-2xl text-accent mt-0.5">4</dd>
+              </div>
+              <div>
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">Reviewed by</dt>
+                <dd className="font-display text-2xl text-accent mt-0.5">MD</dd>
+              </div>
+              <div>
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">Take rate</dt>
+                <dd className="font-display text-2xl text-accent mt-0.5">10%</dd>
+              </div>
+            </dl>
+          </div>
+
+          {/* Right: trust seal medallion — carries the editorial weight */}
+          <div className="lg:col-span-5 flex justify-center lg:justify-end">
+            <div className="relative">
+              <div className="absolute inset-0 rounded-full blur-3xl bg-highlight-soft opacity-60" />
+              <TrustSeal size={240} className="relative" />
+            </div>
           </div>
         </div>
-      </section>
 
-      {/* ── Value props ────────────────────────────────────── */}
-      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {VALUE_PROPS.map((v) => (
-            <Card key={v.title} tone="ambient">
-              <CardContent className="py-7">
-                <LeafSprig size={18} className="text-accent mb-4" />
-                <h3 className="text-base font-semibold text-text mb-2">
-                  {v.title}
-                </h3>
-                <p className="text-sm text-text-muted leading-relaxed">
-                  {v.body}
-                </p>
-              </CardContent>
-            </Card>
+        {/* Quick-browse chip row — anchored to hero bottom */}
+        <div className="max-w-[1280px] mx-auto px-6 lg:px-12 pb-10 flex flex-wrap items-center gap-2">
+          <span className="text-[11px] uppercase tracking-[0.16em] text-text-subtle mr-1">
+            Quick browse
+          </span>
+          {[
+            { label: "Sleep", slug: "sleep" },
+            { label: "Pain support", slug: "pain-support" },
+            { label: "Calm", slug: "calm" },
+            { label: "Focus", slug: "focus" },
+            { label: "Recovery", slug: "recovery" },
+            { label: "Energy", slug: "energy" },
+          ].map((c) => (
+            <Link
+              key={c.slug}
+              href={`/leafmart/category/${c.slug}`}
+              className="inline-flex items-center rounded-full border border-border bg-surface/80 backdrop-blur px-3 py-1 text-xs font-medium text-text-muted hover:text-text hover:bg-surface hover:border-border-strong transition-colors"
+            >
+              {c.label}
+            </Link>
           ))}
         </div>
       </section>
 
-      {/* ── Featured products ──────────────────────────────── */}
+      {/* ── Value props ─────────────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {VALUE_PROPS.map((v) => (
+            <div
+              key={v.title}
+              className="relative rounded-lg border border-border bg-surface p-7 shadow-sm hover:shadow-md transition-shadow"
+            >
+              <LeafSprig size={18} className="text-accent mb-4" />
+              <h3 className="font-display text-xl tracking-tight text-text mb-2">
+                {v.title}
+              </h3>
+              <p className="text-sm text-text-muted leading-relaxed">{v.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Editorial clinician note ────────────────────────── */}
       <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-10">
-        <div className="flex items-end justify-between mb-8">
-          <div>
-            <h2 className="text-2xl font-semibold tracking-tight text-text">
-              Featured
-            </h2>
-            <p className="text-sm text-text-muted mt-1">
-              Products we&apos;re particularly excited about right now.
+        <figure className="relative rounded-2xl border border-border bg-surface-muted/50 p-10 md:p-14 overflow-hidden">
+          <span
+            aria-hidden="true"
+            className="absolute -top-16 -right-4 font-display text-[220px] leading-none text-accent-soft select-none"
+          >
+            &ldquo;
+          </span>
+          <p className="relative text-[11px] uppercase tracking-[0.2em] text-accent mb-5">
+            A note from our care team
+          </p>
+          <blockquote className="relative">
+            <p className="font-display text-2xl md:text-[32px] leading-[1.2] tracking-tight text-text max-w-3xl">
+              A good cannabis store doesn&apos;t sell you what&apos;s popular
+              — it sells you what&apos;s{" "}
+              <em className="text-accent">right</em>. Every product on Leafmart
+              is here because one of us would reach for it in clinic. Nothing
+              here is paid placement. Nothing here is untested.
             </p>
+            <figcaption className="relative mt-6 text-sm text-text-muted flex items-center gap-3">
+              <span className="h-px w-10 bg-border-strong" aria-hidden="true" />
+              The Leafjourney clinical team
+            </figcaption>
+          </blockquote>
+        </figure>
+      </section>
+
+      {/* ── Featured products ───────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+        <div className="flex items-end justify-between mb-10">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em] text-accent mb-2">
+              This week
+            </p>
+            <h2 className="font-display text-3xl tracking-tight text-text">
+              Featured on Leafmart
+            </h2>
           </div>
           <Link
             href="/leafmart/products"
-            className="text-sm text-accent hover:underline hidden sm:inline"
+            className="hidden sm:inline text-sm text-accent hover:underline"
           >
             See all →
           </Link>
@@ -155,46 +241,31 @@ export default async function LeafmartHomePage() {
             No featured products are available right now. Check back soon.
           </p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
-            {featured.map((p) => (
-              <PublicProductPreview
-                key={p.id}
-                slug={p.slug}
-                name={p.name}
-                brand={p.brand}
-                price={p.price}
-                compareAtPrice={p.compareAtPrice}
-                format={p.format}
-                averageRating={p.averageRating}
-                reviewCount={p.reviewCount}
-                clinicianPick={p.clinicianPick}
-              />
-            ))}
-          </div>
+          <PublicProductGrid products={featured} columns={4} />
         )}
       </section>
 
-      {/* ── How it works ───────────────────────────────────── */}
+      {/* ── How it works ────────────────────────────────────── */}
       <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-20">
-        <div className="max-w-2xl mb-10">
-          <h2 className="text-2xl font-semibold tracking-tight text-text">
-            How Leafmart works
-          </h2>
-          <p className="text-sm text-text-muted mt-2">
-            A cannabis store with the rigor of a medical platform behind it.
+        <div className="max-w-2xl mb-12">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-accent mb-2">
+            How it works
           </p>
+          <h2 className="font-display text-3xl tracking-tight text-text">
+            A cannabis store with the rigor of a medical platform behind it.
+          </h2>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {HOW_IT_WORKS.map((s) => (
             <div
               key={s.step}
-              className="rounded-lg border border-border bg-surface p-6"
+              className="relative rounded-lg border border-border bg-surface p-7 shadow-sm"
             >
-              <p className="font-display text-sm text-accent tracking-[0.2em] mb-3">
+              <p className="font-display text-4xl text-accent/70 mb-4 tabular-nums">
                 {s.step}
               </p>
-              <h3 className="text-base font-semibold text-text mb-2">
+              <h3 className="font-display text-lg tracking-tight text-text mb-2">
                 {s.title}
               </h3>
               <p className="text-sm text-text-muted leading-relaxed">
@@ -205,74 +276,57 @@ export default async function LeafmartHomePage() {
         </div>
       </section>
 
-      {/* ── Clinician picks strip ──────────────────────────── */}
+      {/* ── Clinician picks ────────────────────────────────── */}
       {clinicianPicks.length > 0 && (
-        <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-10">
-          <div className="flex items-end justify-between mb-6">
+        <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+          <div className="flex items-end justify-between mb-10">
             <div>
-              <h2 className="text-2xl font-semibold tracking-tight text-text">
+              <p className="text-[11px] uppercase tracking-[0.2em] text-accent mb-2">
+                What our team reaches for
+              </p>
+              <h2 className="font-display text-3xl tracking-tight text-text">
                 Clinician picks
               </h2>
-              <p className="text-sm text-text-muted mt-1">
-                What our care team reaches for first.
-              </p>
             </div>
             <Link
               href="/leafmart/category/clinician-picks"
-              className="text-sm text-accent hover:underline hidden sm:inline"
+              className="hidden sm:inline text-sm text-accent hover:underline"
             >
               See all picks →
             </Link>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-            {clinicianPicks.map((p) => (
-              <PublicProductPreview
-                key={p.id}
-                slug={p.slug}
-                name={p.name}
-                brand={p.brand}
-                price={p.price}
-                compareAtPrice={p.compareAtPrice}
-                format={p.format}
-                averageRating={p.averageRating}
-                reviewCount={p.reviewCount}
-                clinicianPick={p.clinicianPick}
-              />
-            ))}
-          </div>
+          <PublicProductGrid products={clinicianPicks} columns={3} />
         </section>
       )}
 
-      {/* ── Founding partner spotlight ─────────────────────── */}
+      {/* ── Founding partner spotlight ──────────────────────── */}
       <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-20">
-        <div className="rounded-2xl border border-border bg-accent-soft/40 p-8 md:p-12">
-          <div className="max-w-2xl mb-8">
-            <p className="text-[11px] uppercase tracking-wider text-accent mb-2">
+        <div className="rounded-2xl border border-border bg-surface p-8 md:p-14 shadow-sm relative overflow-hidden">
+          <BotanicalAccent
+            variant="corner"
+            className="absolute bottom-0 right-0 w-56 h-56 opacity-50"
+          />
+          <div className="relative max-w-2xl mb-10">
+            <p className="text-[11px] uppercase tracking-[0.2em] text-highlight mb-2">
               Founding partners
             </p>
-            <h2 className="text-2xl font-semibold tracking-tight text-text">
+            <h2 className="font-display text-3xl tracking-tight text-text">
               Brands we&apos;re building with
             </h2>
-            <p className="text-sm text-text-muted mt-2">
-              Each founding partner is locked in at 10% take-rate for 24
-              months. A thank-you for trusting an unproven platform with
-              their product.
+            <p className="text-sm text-text-muted mt-3 leading-relaxed">
+              Each founding partner is locked in at 10% take rate for 24
+              months. A thank-you for trusting an unproven platform with their
+              product.
             </p>
           </div>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {FOUNDING_PARTNERS.map((p) => (
-              <div
-                key={p.name}
-                className="rounded-lg border border-border bg-surface p-4"
-              >
-                <p className="font-display text-base text-text">{p.name}</p>
-                <p className="text-xs text-text-muted mt-1">{p.tagline}</p>
-              </div>
+          <div className="relative grid grid-cols-2 md:grid-cols-4 gap-4">
+            {FOUNDING_PARTNER_BRANDS.map((b) => (
+              <BrandChip key={b.name} brand={b} />
             ))}
           </div>
 
-          <div className="mt-8">
+          <div className="relative mt-10">
             <Link href="/leafmart/vendors">
               <Button size="md" variant="secondary">
                 Sell on Leafmart →
@@ -282,99 +336,29 @@ export default async function LeafmartHomePage() {
         </div>
       </section>
 
-      {/* ── Final CTA ──────────────────────────────────────── */}
-      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-16">
-        <div className="text-center max-w-2xl mx-auto">
-          <h2 className="font-display text-3xl md:text-4xl tracking-tight text-text mb-4">
-            Buy what your doctor would pick.
-          </h2>
-          <p className="text-sm text-text-muted mb-6">
-            Leafmart is free to browse. Sign up to track outcomes and get
-            personalized recommendations as you go.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link href="/leafmart/products">
-              <Button size="lg" variant="primary">
-                Browse products
-              </Button>
-            </Link>
-            <Link href="/signup">
-              <Button size="lg" variant="secondary">
-                Create account
-              </Button>
-            </Link>
-          </div>
+      {/* ── Final CTA ───────────────────────────────────────── */}
+      <section className="max-w-[1280px] mx-auto px-6 lg:px-12 py-20 text-center">
+        <TrustSeal size={80} className="mx-auto mb-6" />
+        <h2 className="font-display text-4xl md:text-5xl tracking-tight text-text mb-4">
+          Buy what your doctor would pick.
+        </h2>
+        <p className="text-base text-text-muted mb-8 max-w-xl mx-auto leading-relaxed">
+          Leafmart is free to browse. Sign up to track outcomes and get
+          personalized recommendations as you go.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link href="/leafmart/shop">
+            <Button size="lg" variant="primary">
+              Shop by what you need
+            </Button>
+          </Link>
+          <Link href="/signup">
+            <Button size="lg" variant="secondary">
+              Create account
+            </Button>
+          </Link>
         </div>
       </section>
     </>
-  );
-}
-
-interface PublicProductPreviewProps {
-  slug: string;
-  name: string;
-  brand: string;
-  price: number;
-  compareAtPrice?: number;
-  format: string;
-  averageRating: number;
-  reviewCount: number;
-  clinicianPick: boolean;
-}
-
-function PublicProductPreview({
-  slug,
-  name,
-  brand,
-  price,
-  compareAtPrice,
-  format,
-  averageRating,
-  reviewCount,
-  clinicianPick,
-}: PublicProductPreviewProps) {
-  const formatLabel =
-    FORMAT_LABELS[format as keyof typeof FORMAT_LABELS] ?? format;
-  return (
-    <Link
-      href={`/leafmart/products/${slug}`}
-      className="group rounded-lg border border-border bg-surface overflow-hidden transition-all duration-200 hover:shadow-sm hover:-translate-y-0.5"
-    >
-      <div className="aspect-[4/3] bg-surface-muted flex items-center justify-center">
-        <span className="text-sm font-medium text-text-subtle tracking-wide capitalize">
-          {formatLabel}
-        </span>
-      </div>
-      <div className="p-4">
-        <div className="flex items-start justify-between gap-2 mb-1">
-          <p className="text-xs uppercase tracking-wider text-text-subtle truncate">
-            {brand}
-          </p>
-          {clinicianPick && (
-            <Badge tone="accent" className="shrink-0 text-[10px]">
-              Pick
-            </Badge>
-          )}
-        </div>
-        <p className="text-sm font-semibold text-text group-hover:text-accent transition-colors line-clamp-2 min-h-[2.5rem]">
-          {name}
-        </p>
-        <div className="flex items-center gap-2 mt-3">
-          <span className="text-sm font-semibold text-text">
-            ${price.toFixed(2)}
-          </span>
-          {compareAtPrice != null && compareAtPrice > price && (
-            <span className="text-xs text-text-subtle line-through">
-              ${compareAtPrice.toFixed(2)}
-            </span>
-          )}
-        </div>
-        {reviewCount > 0 && (
-          <div className="mt-2">
-            <RatingStars rating={averageRating} count={reviewCount} />
-          </div>
-        )}
-      </div>
-    </Link>
   );
 }

--- a/src/app/leafmart/products/[slug]/page.tsx
+++ b/src/app/leafmart/products/[slug]/page.tsx
@@ -1,0 +1,392 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { RatingStars } from "@/components/marketplace/RatingStars";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import { ProductTile } from "@/components/leafmart/ProductTile";
+import {
+  getPublicProductBySlug,
+  getAllPublicProducts,
+} from "@/lib/marketplace/public-queries";
+import { FORMAT_LABELS } from "@/lib/marketplace/types";
+
+interface PDPProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PDPProps): Promise<Metadata> {
+  const { slug } = await params;
+  const product = await getPublicProductBySlug(slug);
+  if (!product) return { title: "Product not found" };
+  return {
+    title: `${product.name} — ${product.brand}`,
+    description: product.shortDescription || product.description.slice(0, 160),
+  };
+}
+
+export default async function LeafmartProductDetailPage({ params }: PDPProps) {
+  const { slug } = await params;
+  const product = await getPublicProductBySlug(slug);
+  if (!product) notFound();
+
+  const formatLabel = FORMAT_LABELS[product.format] ?? product.format;
+  const strainLabel =
+    product.strainType && product.strainType !== "n/a"
+      ? product.strainType.charAt(0).toUpperCase() + product.strainType.slice(1)
+      : null;
+
+  // Lightweight "you may also like" — share symptoms/goals with the current
+  // product, bounded to 4 items. Public-safe (no personalization).
+  const related = await getRelatedPublic(product);
+
+  return (
+    <div className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+      {/* ── Breadcrumb ─────────────────────────────────────── */}
+      <nav aria-label="Breadcrumb" className="mb-8">
+        <ol className="flex flex-wrap items-center gap-1.5 text-xs text-text-subtle">
+          <li>
+            <Link
+              href="/leafmart"
+              className="hover:text-text transition-colors"
+            >
+              Leafmart
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link
+              href="/leafmart/products"
+              className="hover:text-text transition-colors"
+            >
+              Shop
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="text-text font-medium truncate max-w-[240px]">
+            {product.name}
+          </li>
+        </ol>
+      </nav>
+
+      {/* ── Hero — image + buy card ────────────────────────── */}
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-14">
+        <ProductTile
+          format={product.format}
+          brand={product.brand}
+          name={product.name}
+          variant="hero"
+          className="shadow-sm"
+        />
+        {/* legacy format label kept for screen readers */}
+        <span className="sr-only">{formatLabel}</span>
+
+        <div className="flex flex-col gap-4">
+          <p className="text-xs uppercase tracking-wider text-text-subtle">
+            {product.brand}
+          </p>
+          <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+            {product.name}
+          </h1>
+          {product.reviewCount > 0 && (
+            <RatingStars
+              rating={product.averageRating}
+              count={product.reviewCount}
+            />
+          )}
+
+          <div className="flex items-baseline gap-3">
+            <span className="text-2xl font-semibold text-text tabular-nums">
+              ${product.price.toFixed(2)}
+            </span>
+            {product.compareAtPrice != null &&
+              product.compareAtPrice > product.price && (
+                <span className="text-base text-text-subtle line-through">
+                  ${product.compareAtPrice.toFixed(2)}
+                </span>
+              )}
+          </div>
+
+          {product.clinicianPick && (
+            <div className="rounded-lg bg-accent-soft/60 p-4">
+              <Badge tone="accent">Clinician pick</Badge>
+              <p className="text-sm text-text leading-relaxed mt-2">
+                Our care team selected this product for its quality,
+                cannabinoid profile, and documented outcomes. (Clinician
+                commentary shown after sign-in.)
+              </p>
+            </div>
+          )}
+
+          {/* Variant pills (display-only on public surface) */}
+          {product.variants.length > 1 && (
+            <div className="space-y-2">
+              <p className="text-[11px] uppercase tracking-wider text-text-subtle">
+                Sizes
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {product.variants.map((v, idx) => (
+                  <span
+                    key={v.id}
+                    className={`inline-flex items-center rounded-md border px-3 py-1.5 text-xs font-medium ${
+                      idx === 0
+                        ? "border-accent bg-accent-soft text-accent"
+                        : "border-border bg-surface text-text"
+                    }`}
+                  >
+                    {v.name}
+                    {v.price !== product.variants[0]?.price && (
+                      <span className="ml-1.5 text-text-subtle">
+                        ${v.price.toFixed(2)}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Auth handoff — public surface never wires checkout directly */}
+          <div className="mt-2">
+            <Link href={`/login?next=${encodeURIComponent(`/portal/shop/products/${product.slug}`)}`}>
+              <Button variant="primary" size="lg" className="w-full">
+                {product.inStock ? "Sign in to buy" : "Out of stock"}
+              </Button>
+            </Link>
+            <p className="text-[11px] text-text-subtle mt-2 text-center">
+              Checkout opens after you sign in — keeps dosing and outcome
+              tracking tied to your chart.
+            </p>
+          </div>
+
+          {/* Trust signals */}
+          <ul className="flex flex-col gap-1.5 mt-3">
+            {product.labVerified && (
+              <TrustLine>Third-party lab verified — COA available.</TrustLine>
+            )}
+            {product.clinicianPick && (
+              <TrustLine>Physician reviewed before listing.</TrustLine>
+            )}
+            {product.beginnerFriendly && (
+              <TrustLine>Beginner-friendly formulation.</TrustLine>
+            )}
+          </ul>
+        </div>
+      </section>
+
+      {/* ── Description ─────────────────────────────────── */}
+      <section className="space-y-10 mb-14">
+        <div>
+          <h2 className="text-lg font-semibold text-text mb-3">
+            About this product
+          </h2>
+          <p className="text-sm text-text-muted leading-relaxed whitespace-pre-line">
+            {product.description}
+          </p>
+        </div>
+
+        {/* Cannabinoid profile */}
+        {(product.thcContent != null ||
+          product.cbdContent != null ||
+          product.cbnContent != null ||
+          strainLabel) && (
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-sm font-semibold text-text mb-4">
+                Cannabinoid profile
+              </h3>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                {product.thcContent != null && (
+                  <Stat label="THC" value={`${product.thcContent}%`} />
+                )}
+                {product.cbdContent != null && (
+                  <Stat label="CBD" value={`${product.cbdContent}%`} />
+                )}
+                {product.cbnContent != null && (
+                  <Stat label="CBN" value={`${product.cbnContent}%`} />
+                )}
+                {strainLabel && <Stat label="Strain" value={strainLabel} />}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Onset & duration */}
+        {(product.onsetTime || product.duration) && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {product.onsetTime && (
+              <InfoBox title="Onset">{product.onsetTime}</InfoBox>
+            )}
+            {product.duration && (
+              <InfoBox title="Duration">{product.duration}</InfoBox>
+            )}
+          </div>
+        )}
+
+        {/* Use cases */}
+        {(product.symptoms.length > 0 || product.goals.length > 0) && (
+          <div>
+            <h3 className="text-sm font-semibold text-text mb-3">
+              May support
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {product.symptoms.map((s) => (
+                <Badge key={`s-${s}`} tone="neutral">
+                  {s}
+                </Badge>
+              ))}
+              {product.goals.map((g) => (
+                <Badge key={`g-${g}`} tone="accent">
+                  {g}
+                </Badge>
+              ))}
+            </div>
+            <p className="text-[11px] text-text-subtle mt-3">
+              Structure/function terms only — not a claim to treat, cure, or
+              prevent any disease.
+            </p>
+          </div>
+        )}
+
+        {product.beginnerFriendly && (
+          <Badge tone="success" className="text-sm px-3 py-1">
+            Beginner-friendly
+          </Badge>
+        )}
+
+        {product.coaUrl && product.coaUrl !== "#" && (
+          <div>
+            <Link
+              href={product.coaUrl}
+              className="text-sm text-accent hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Download Certificate of Analysis →
+            </Link>
+          </div>
+        )}
+      </section>
+
+      {/* ── Reviews ─────────────────────────────────────── */}
+      {product.reviews.length > 0 && (
+        <section className="mb-14">
+          <div className="flex items-center gap-3 mb-6">
+            <h2 className="text-lg font-semibold text-text">Reviews</h2>
+            <RatingStars rating={product.averageRating} />
+            <span className="text-sm text-text-muted">
+              {product.averageRating.toFixed(1)} ({product.reviewCount})
+            </span>
+          </div>
+          <div className="space-y-6">
+            {product.reviews.map((r) => (
+              <div
+                key={r.id}
+                className="border-b border-border pb-6 last:border-b-0 last:pb-0"
+              >
+                <div className="flex flex-wrap items-center gap-3 mb-2">
+                  <span className="text-sm font-medium text-text">
+                    {r.authorName}
+                  </span>
+                  <RatingStars rating={r.rating} />
+                  {r.verified && (
+                    <Badge tone="success" className="text-[11px]">
+                      Verified purchase
+                    </Badge>
+                  )}
+                  <span className="text-xs text-text-subtle ml-auto">
+                    {new Date(r.createdAt).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+                {r.title && (
+                  <p className="text-sm font-semibold text-text mb-1">
+                    {r.title}
+                  </p>
+                )}
+                {r.body && (
+                  <p className="text-sm text-text-muted leading-relaxed">
+                    {r.body}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Related ─────────────────────────────────────── */}
+      {related.length > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold text-text mb-6">
+            You may also like
+          </h2>
+          <PublicProductGrid products={related} columns={4} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+async function getRelatedPublic(product: {
+  id: string;
+  symptoms: string[];
+  goals: string[];
+}) {
+  const all = await getAllPublicProducts();
+  const targets = new Set([...product.symptoms, ...product.goals]);
+  return all
+    .filter((p) => p.id !== product.id)
+    .map((p) => {
+      const shared = [...p.symptoms, ...p.goals].filter((t) => targets.has(t));
+      return { p, score: shared.length };
+    })
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4)
+    .map((r) => r.p);
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="text-center">
+      <p className="text-2xl font-semibold text-text tabular-nums">{value}</p>
+      <p className="text-xs text-text-subtle mt-1">{label}</p>
+    </div>
+  );
+}
+
+function InfoBox({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4">
+      <p className="text-xs uppercase tracking-wider text-text-subtle mb-1">
+        {title}
+      </p>
+      <p className="text-sm font-medium text-text">{children}</p>
+    </div>
+  );
+}
+
+function TrustLine({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-center gap-2 text-sm text-text-muted">
+      <span className="text-success" aria-hidden="true">
+        ✓
+      </span>
+      {children}
+    </li>
+  );
+}

--- a/src/app/leafmart/products/page.tsx
+++ b/src/app/leafmart/products/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SearchBar } from "@/components/marketplace/SearchBar";
+import { PublicProductGrid } from "@/components/leafmart/PublicProductCard";
+import {
+  getAllPublicProducts,
+  searchPublicProducts,
+  getPublicCategories,
+} from "@/lib/marketplace/public-queries";
+import { FORMAT_LABELS, type ProductFormat } from "@/lib/marketplace/types";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Shop all products" };
+
+interface ProductsPageProps {
+  searchParams: Promise<{
+    q?: string;
+    category?: string;
+    format?: string;
+  }>;
+}
+
+export default async function LeafmartProductsPage({
+  searchParams,
+}: ProductsPageProps) {
+  const { q, category, format } = await searchParams;
+  const formatFilter = format as ProductFormat | undefined;
+
+  const [base, categories] = await Promise.all([
+    q ? searchPublicProducts(q) : getAllPublicProducts(),
+    getPublicCategories(),
+  ]);
+
+  let products = base;
+  if (category) {
+    const cat = categories.find(
+      (c) => c.slug === category || c.id === category,
+    );
+    if (cat) products = products.filter((p) => p.categoryIds.includes(cat.id));
+  }
+  if (formatFilter) {
+    products = products.filter((p) => p.format === formatFilter);
+  }
+
+  const activeCategory = category
+    ? categories.find((c) => c.slug === category || c.id === category)
+    : undefined;
+  const activeFormatLabel = formatFilter
+    ? FORMAT_LABELS[formatFilter]
+    : undefined;
+  const title = q ? `Results for "${q}"` : "All products";
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+      <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+        <Link href="/leafmart" className="hover:text-text transition-colors">
+          Leafmart
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-text">Shop</span>
+      </div>
+
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+            {title}
+          </h1>
+          <p className="text-sm text-text-muted mt-1">
+            {products.length}{" "}
+            {products.length === 1 ? "product" : "products"}
+          </p>
+        </div>
+        <SearchBar defaultValue={q} className="w-full md:w-[360px]" />
+      </div>
+
+      {/* Format filter chips */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        <span className="text-xs font-medium uppercase tracking-wider text-text-subtle mr-1">
+          Format
+        </span>
+        <FormatChip
+          label="All"
+          active={!formatFilter}
+          href={{ pathname: "/leafmart/products", query: queryWithout({ q, category }, "format") }}
+        />
+        {(Object.keys(FORMAT_LABELS) as ProductFormat[]).map((f) => (
+          <FormatChip
+            key={f}
+            label={FORMAT_LABELS[f]}
+            active={formatFilter === f}
+            href={{
+              pathname: "/leafmart/products",
+              query: queryWith({ q, category, format: f }),
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Active filter pills */}
+      {(activeCategory || activeFormatLabel) && (
+        <div className="flex flex-wrap items-center gap-2 mb-6">
+          <span className="text-[11px] uppercase tracking-wider text-text-subtle">
+            Filters:
+          </span>
+          {activeCategory && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted border border-border px-3 py-1 text-xs font-medium text-text-muted">
+              {activeCategory.name}
+              <Link
+                href={{
+                  pathname: "/leafmart/products",
+                  query: queryWithout({ q, format }, "category"),
+                }}
+                className="ml-0.5 text-text-subtle hover:text-text"
+                aria-label={`Remove ${activeCategory.name} filter`}
+              >
+                ×
+              </Link>
+            </span>
+          )}
+          {activeFormatLabel && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted border border-border px-3 py-1 text-xs font-medium text-text-muted">
+              {activeFormatLabel}
+              <Link
+                href={{
+                  pathname: "/leafmart/products",
+                  query: queryWithout({ q, category }, "format"),
+                }}
+                className="ml-0.5 text-text-subtle hover:text-text"
+                aria-label={`Remove ${activeFormatLabel} filter`}
+              >
+                ×
+              </Link>
+            </span>
+          )}
+        </div>
+      )}
+
+      {products.length === 0 ? (
+        <EmptyState
+          title="No products match"
+          description="Try adjusting your filters or removing your search."
+        />
+      ) : (
+        <PublicProductGrid products={products} columns={4} />
+      )}
+    </div>
+  );
+}
+
+function queryWith(parts: Record<string, string | undefined>) {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parts)) {
+    if (v) out[k] = v;
+  }
+  return out;
+}
+
+function queryWithout(
+  parts: Record<string, string | undefined>,
+  drop: string,
+) {
+  const { [drop]: _dropped, ...rest } = parts;
+  return queryWith(rest);
+}
+
+function FormatChip({
+  label,
+  active,
+  href,
+}: {
+  label: string;
+  active: boolean;
+  href: Parameters<typeof Link>[0]["href"];
+}) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "border-accent bg-accent-soft text-accent"
+          : "border-border bg-surface text-text-muted hover:text-text"
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/app/leafmart/shop/page.tsx
+++ b/src/app/leafmart/shop/page.tsx
@@ -1,0 +1,242 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LeafSprig } from "@/components/ui/ornament";
+import { getPublicCategories } from "@/lib/marketplace/public-queries";
+import type { MarketplaceCategory } from "@/lib/marketplace/types";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  title: "Shop by what you need",
+  description:
+    "Browse Leafmart by condition, goal, format, or curated collection. Every category is physician-reviewed.",
+};
+
+interface CategoryGroup {
+  id: "symptom" | "goal" | "format" | "collection" | "other";
+  title: string;
+  description: string;
+}
+
+const GROUPS: CategoryGroup[] = [
+  {
+    id: "symptom",
+    title: "By what's bothering you",
+    description:
+      "Categories oriented around the concerns patients bring to us most often.",
+  },
+  {
+    id: "goal",
+    title: "By what you're aiming for",
+    description:
+      "A positive framing — where do you want your day (or night) to land?",
+  },
+  {
+    id: "format",
+    title: "By how you take it",
+    description:
+      "Tinctures feel different from edibles. Start where you're comfortable.",
+  },
+  {
+    id: "collection",
+    title: "Curated picks",
+    description:
+      "Our care team's picks + customer favorites + beginner-friendly shelves.",
+  },
+];
+
+function classify(type: string): CategoryGroup["id"] {
+  if (type === "symptom" || type === "goal" || type === "format" || type === "collection") {
+    return type;
+  }
+  return "other";
+}
+
+export default async function LeafmartShopDirectoryPage() {
+  const allCategories = await getPublicCategories();
+
+  const grouped = new Map<CategoryGroup["id"], MarketplaceCategory[]>();
+  for (const cat of allCategories) {
+    const g = classify(cat.type);
+    const arr = grouped.get(g) ?? [];
+    arr.push(cat);
+    grouped.set(g, arr);
+  }
+  for (const arr of grouped.values()) {
+    arr.sort(
+      (a, b) => b.productCount - a.productCount || a.name.localeCompare(b.name),
+    );
+  }
+
+  const totalProducts = allCategories.reduce((sum, c) => sum + c.productCount, 0);
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 lg:px-12 py-12">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-xs text-text-subtle mb-6">
+        <Link href="/leafmart" className="hover:text-text transition-colors">
+          Leafmart
+        </Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-text">Shop</span>
+      </div>
+
+      <div className="max-w-3xl mb-10">
+        <h1 className="font-display text-3xl md:text-4xl tracking-tight text-text">
+          Shop by what you need.
+        </h1>
+        <p className="mt-3 text-sm text-text-muted leading-relaxed">
+          Every category here has been physician-reviewed. Browse by the
+          concern on your mind, the mood you&apos;re aiming for, or the
+          format you already know works for you.
+        </p>
+        <div className="mt-4 flex gap-3">
+          <Link href="/leafmart/products">
+            <Button size="sm" variant="primary">
+              See all products →
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* ── Condition / intent quick chips ─────────────────── */}
+      <QuickChips categories={allCategories} />
+
+      {/* ── Grouped directory ──────────────────────────────── */}
+      {allCategories.length === 0 ? (
+        <EmptyState
+          title="Catalog building"
+          description="Check back soon — we&apos;re curating the shelves."
+        />
+      ) : (
+        <div className="space-y-14 mt-12">
+          {GROUPS.map((group) => {
+            const categories = grouped.get(group.id);
+            if (!categories || categories.length === 0) return null;
+            return (
+              <section key={group.id}>
+                <div className="mb-5">
+                  <h2 className="text-xl font-semibold tracking-tight text-text">
+                    {group.title}
+                  </h2>
+                  <p className="text-sm text-text-muted mt-1 max-w-2xl">
+                    {group.description}
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                  {categories.map((cat) => (
+                    <CategoryTile key={cat.id} category={cat} />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── Stats / trust strip ────────────────────────────── */}
+      <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatTile label="Categories" value={allCategories.length.toString()} />
+        <StatTile label="Products" value={totalProducts.toString()} />
+        <StatTile
+          label="Clinician-picked"
+          value={allCategories
+            .filter((c) => c.slug === "clinician-picks")
+            .reduce((sum, c) => sum + c.productCount, 0)
+            .toString()}
+        />
+        <StatTile
+          label="Beginner-friendly"
+          value={allCategories
+            .filter((c) => c.slug === "beginner-friendly")
+            .reduce((sum, c) => sum + c.productCount, 0)
+            .toString()}
+        />
+      </div>
+    </div>
+  );
+}
+
+function QuickChips({ categories }: { categories: MarketplaceCategory[] }) {
+  const QUICK_SLUGS = [
+    "sleep",
+    "pain-support",
+    "anxiety",
+    "calm",
+    "focus",
+    "recovery",
+    "energy",
+  ];
+  const chips = QUICK_SLUGS.map((slug) =>
+    categories.find((c) => c.slug === slug),
+  ).filter((c): c is MarketplaceCategory => Boolean(c));
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-3">
+        Quick browse
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {chips.map((c) => (
+          <Link
+            key={c.id}
+            href={`/leafmart/category/${c.slug}`}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-1.5 text-sm font-medium text-text transition-colors hover:bg-surface-muted"
+          >
+            {c.icon && (
+              <span aria-hidden="true" className="text-accent">
+                {c.icon}
+              </span>
+            )}
+            {c.name}
+            <span className="text-xs text-text-subtle">{c.productCount}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CategoryTile({ category }: { category: MarketplaceCategory }) {
+  return (
+    <Link
+      href={`/leafmart/category/${category.slug}`}
+      className="group block h-full"
+    >
+      <div className="relative h-full rounded-lg border border-border bg-surface p-5 shadow-sm transition-all duration-300 group-hover:shadow-md group-hover:-translate-y-0.5 group-hover:border-border-strong overflow-hidden">
+        {/* Accent gradient wash — only on hover */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-soft/0 to-accent-soft/40 opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+        />
+        <div className="relative flex items-start justify-between mb-4">
+          <LeafSprig size={20} className="text-accent/80" />
+          <span className="text-[11px] uppercase tracking-[0.16em] text-text-subtle tabular-nums">
+            {category.productCount}
+          </span>
+        </div>
+        <p className="relative font-display text-lg tracking-tight text-text group-hover:text-accent transition-colors">
+          {category.name}
+        </p>
+        {category.description && (
+          <p className="relative text-xs text-text-muted mt-1.5 line-clamp-2 leading-relaxed">
+            {category.description}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-4 text-center">
+      <p className="text-2xl font-display text-text tabular-nums">{value}</p>
+      <p className="text-[11px] uppercase tracking-wider text-text-subtle mt-1">
+        {label}
+      </p>
+    </div>
+  );
+}

--- a/src/app/leafmart/vendors/page.tsx
+++ b/src/app/leafmart/vendors/page.tsx
@@ -1,0 +1,313 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { LeafSprig } from "@/components/ui/ornament";
+
+export const metadata: Metadata = {
+  title: "Partner with Leafmart",
+  description:
+    "Sell your cannabis wellness products on Leafmart. 10% take rate, 24-month founding-partner lock-in, weekly payouts, clinician-reviewed listings.",
+};
+
+const ECONOMICS = [
+  { label: "Take rate", value: "10%", sub: "locked 24 months" },
+  { label: "Payout cadence", value: "Weekly", sub: "7-day hold" },
+  { label: "Reserve", value: "10%", sub: "14-day rolling reserve" },
+  { label: "Onboarding", value: "~7 days", sub: "vetting + listing" },
+] as const;
+
+const WHAT_YOU_GET = [
+  {
+    title: "Clinical distribution",
+    body: "Your product is recommended inside patient charts, not just browsed in a store. Leafjourney clinicians can suggest your product during an encounter.",
+  },
+  {
+    title: "Outcome ranking",
+    body: "As patients log outcomes, products that actually help move up in our ranking engine. A working product doesn't need to buy ads — it wins on evidence.",
+  },
+  {
+    title: "Real-world evidence",
+    body: "Aggregated outcome data feeds back to you quarterly. Where your product helps, where it doesn't, and which cohorts respond best.",
+  },
+  {
+    title: "Payment spine + compliance",
+    body: "Payabli-backed processing, 1099-K reporting, state shipping matrix, age gating, and FDA claim screening — all handled for you.",
+  },
+] as const;
+
+const ONBOARDING_STEPS = [
+  {
+    step: "01",
+    title: "Apply",
+    body: "Email hello@leafjourney.com with your brand, product lines, and COA links. We respond within 72 hours.",
+  },
+  {
+    step: "02",
+    title: "Vet + paperwork",
+    body: "We verify insurance, W-9, state licenses, and lab results. You set up your Payabli Pay Point with our help.",
+  },
+  {
+    step: "03",
+    title: "List + launch",
+    body: "We ingest your catalog, run listings past our clinical reviewer, and go live. Founding partners get a feature slot in the launch week.",
+  },
+] as const;
+
+const FAQ_SNIPPETS = [
+  {
+    q: "Do you carry products with delta-9 THC above 0.3%?",
+    a: "Only in states where licensed distribution is legal. Hemp-derived (≤ 0.3% delta-9) listings ship broadly; licensed cannabis listings ship intrastate only. Our state matrix enforces this at checkout.",
+  },
+  {
+    q: "Who reviews my listing copy?",
+    a: "A practicing clinician plus our FDA-claim screener (regex + clinical review). We'll flag anything that crosses structure/function language and suggest rewrites — we won't silently edit your copy.",
+  },
+  {
+    q: "How are outcomes attributed to my product?",
+    a: "When a clinician links a DosingRegimen to your product, subsequent OutcomeLog entries inside that regimen's window count toward your product's efficacy signal. De-identified, cohort-level, consented.",
+  },
+  {
+    q: "Can I leave?",
+    a: "Yes. 30-day notice for founding partners, standard partners any time. Reserve disburses on the existing schedule. No clawbacks, no lock-in penalties — we keep you because the platform works.",
+  },
+] as const;
+
+const APPLY_EMAIL = "hello@leafjourney.com";
+
+export default function LeafmartVendorsPage() {
+  const applyHref = `mailto:${APPLY_EMAIL}?subject=${encodeURIComponent(
+    "Leafmart partner application",
+  )}&body=${encodeURIComponent(
+    "Brand name:\nWebsite:\nProduct categories:\nStates you currently ship to:\nCOA sample link:\nAnything else we should know:",
+  )}`;
+
+  return (
+    <>
+      {/* ── Hero ───────────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 pt-16 pb-10">
+        <div className="flex items-center gap-2 text-xs text-text-subtle mb-8">
+          <Link href="/leafmart" className="hover:text-text transition-colors">
+            Leafmart
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-text">Partner with us</span>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 mb-6">
+          <LeafSprig size={14} className="text-accent" />
+          <span className="text-[11px] uppercase tracking-wider text-text-muted">
+            For brands
+          </span>
+          <Badge tone="accent" className="ml-1 text-[10px]">
+            Now accepting founding partners
+          </Badge>
+        </div>
+
+        <h1 className="font-display text-[42px] sm:text-5xl md:text-[60px] leading-[1.02] tracking-tight text-text max-w-3xl">
+          Sell cannabis products where they&apos;re{" "}
+          <span className="text-accent italic">actually prescribed</span>.
+        </h1>
+        <p className="mt-6 text-lg text-text-muted max-w-2xl leading-relaxed">
+          Leafmart is the marketplace side of an AI-native clinical platform.
+          Your product sits inside clinician workflow — not just a search
+          result on a store page. And our economics are keystone-fair from day
+          one.
+        </p>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <a href={applyHref}>
+            <Button size="lg" variant="primary">
+              Apply to partner
+            </Button>
+          </a>
+          <Link href="#economics">
+            <Button size="lg" variant="secondary">
+              See the economics
+            </Button>
+          </Link>
+        </div>
+      </section>
+
+      {/* ── Economics tiles ────────────────────────────────── */}
+      <section id="economics" className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-2">
+          Founding-partner economics
+        </h2>
+        <p className="text-sm text-text-muted mb-8 max-w-2xl">
+          These terms lock for 24 months from your go-live date. After that,
+          you stay on whatever our standard terms are — which will never be
+          worse than Shopify and never as punishing as Amazon.
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {ECONOMICS.map((e) => (
+            <div
+              key={e.label}
+              className="rounded-lg border border-border bg-surface p-4"
+            >
+              <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-1">
+                {e.label}
+              </p>
+              <p className="text-2xl font-display text-text tabular-nums">
+                {e.value}
+              </p>
+              <p className="text-[11px] text-text-subtle mt-1">{e.sub}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Benchmark */}
+        <div className="mt-8 rounded-lg border border-border bg-surface-muted/50 p-5">
+          <p className="text-[11px] uppercase tracking-wider text-text-subtle mb-3">
+            Compared to
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
+            <Benchmark name="Amazon" rate="30-40%" />
+            <Benchmark name="Etsy" rate="~10% + ads" />
+            <Benchmark name="Shopify" rate="3-5%" />
+            <Benchmark name="Leafmart" rate="10% locked" highlight />
+          </div>
+        </div>
+      </section>
+
+      {/* ── What you get ───────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          What you get
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {WHAT_YOU_GET.map((b) => (
+            <Card key={b.title}>
+              <CardContent className="pt-6">
+                <h3 className="text-base font-semibold text-text mb-2">
+                  {b.title}
+                </h3>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  {b.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Onboarding ─────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          Onboarding in three steps
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {ONBOARDING_STEPS.map((s) => (
+            <div
+              key={s.step}
+              className="rounded-lg border border-border bg-surface p-6"
+            >
+              <p className="font-display text-sm text-accent tracking-[0.2em] mb-3">
+                {s.step}
+              </p>
+              <h3 className="text-base font-semibold text-text mb-2">
+                {s.title}
+              </h3>
+              <p className="text-sm text-text-muted leading-relaxed">
+                {s.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── FAQ snippets ───────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-12">
+        <h2 className="text-2xl font-semibold tracking-tight text-text mb-6">
+          Common questions
+        </h2>
+        <div className="divide-y divide-border border-y border-border">
+          {FAQ_SNIPPETS.map((item) => (
+            <details
+              key={item.q}
+              className="group py-5 [&_summary]:cursor-pointer"
+            >
+              <summary className="flex items-center justify-between gap-4 list-none">
+                <h3 className="text-sm font-semibold text-text">{item.q}</h3>
+                <span
+                  className="text-xs text-text-subtle group-open:rotate-45 transition-transform"
+                  aria-hidden="true"
+                >
+                  +
+                </span>
+              </summary>
+              <p className="mt-3 text-sm text-text-muted leading-relaxed">
+                {item.a}
+              </p>
+            </details>
+          ))}
+        </div>
+        <p className="text-xs text-text-subtle mt-4">
+          More on{" "}
+          <Link
+            href="/leafmart/faq"
+            className="underline hover:text-text transition-colors"
+          >
+            the full FAQ
+          </Link>
+          .
+        </p>
+      </section>
+
+      {/* ── Final CTA ──────────────────────────────────────── */}
+      <section className="max-w-[1080px] mx-auto px-6 lg:px-12 py-16 text-center">
+        <h2 className="font-display text-3xl tracking-tight text-text mb-3">
+          Ready to list?
+        </h2>
+        <p className="text-sm text-text-muted mb-6">
+          Reply within 72 hours. Onboarding is ~7 days end-to-end.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a href={applyHref}>
+            <Button size="lg" variant="primary">
+              Apply to partner
+            </Button>
+          </a>
+          <Link href="/leafmart/about">
+            <Button size="lg" variant="secondary">
+              About Leafmart
+            </Button>
+          </Link>
+        </div>
+        <p className="text-[11px] text-text-subtle mt-6">
+          Questions?{" "}
+          <a
+            href={`mailto:${APPLY_EMAIL}`}
+            className="underline hover:text-text transition-colors"
+          >
+            {APPLY_EMAIL}
+          </a>
+        </p>
+      </section>
+    </>
+  );
+}
+
+function Benchmark({
+  name,
+  rate,
+  highlight,
+}: {
+  name: string;
+  rate: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md px-3 py-2 ${
+        highlight
+          ? "bg-accent-soft text-accent font-semibold"
+          : "bg-surface text-text-muted"
+      }`}
+    >
+      <p className="text-[11px] uppercase tracking-wider">{name}</p>
+      <p className="text-sm tabular-nums">{rate}</p>
+    </div>
+  );
+}

--- a/src/components/leafmart/BotanicalAccent.tsx
+++ b/src/components/leafmart/BotanicalAccent.tsx
@@ -1,0 +1,83 @@
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Decorative botanical composition rendered behind the Leafmart hero.
+ * Pure SVG, single-color, scale-independent. Adds visual weight without
+ * photography and stays on-brand with the LeafSprig ornament system.
+ */
+export function BotanicalAccent({
+  className,
+  variant = "hero",
+}: {
+  className?: string;
+  variant?: "hero" | "corner";
+}) {
+  if (variant === "corner") {
+    return (
+      <svg
+        viewBox="0 0 160 160"
+        fill="none"
+        aria-hidden="true"
+        className={cn("text-accent/15", className)}
+      >
+        <g stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 140 Q 80 90 140 40" />
+          <path d="M40 130 Q 80 100 120 60" />
+          <path d="M60 135 Q 85 110 110 80" />
+          <path d="M36 131 l -4 -5 m 0 0 l 6 -2" />
+          <path d="M56 121 l -4 -5 m 0 0 l 6 -2" />
+          <path d="M76 111 l -4 -5 m 0 0 l 6 -2" />
+          <path d="M96 96 l -4 -5 m 0 0 l 6 -2" />
+          <path d="M116 81 l -4 -5 m 0 0 l 6 -2" />
+        </g>
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      viewBox="0 0 480 480"
+      fill="none"
+      aria-hidden="true"
+      className={cn("text-accent/20", className)}
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {/* Main stem — from bottom-right rising up-and-left */}
+        <path d="M430 470 C 380 400 340 320 320 240 C 310 180 320 130 350 70" />
+
+        {/* Secondary stem, mirrored */}
+        <path d="M430 470 C 400 420 380 360 380 300" />
+
+        {/* Leaf clusters on main stem — three pairs */}
+        <path d="M340 180 C 320 178 300 170 282 155 C 302 152 322 158 340 172 Z" />
+        <path d="M340 180 C 360 178 380 170 398 155 C 378 152 358 158 340 172 Z" />
+
+        <path d="M328 244 C 308 242 288 234 270 219 C 290 216 310 222 328 236 Z" />
+        <path d="M328 244 C 348 242 368 234 386 219 C 366 216 346 222 328 236 Z" />
+
+        <path d="M322 320 C 302 318 282 310 264 295 C 284 292 304 298 322 312 Z" />
+        <path d="M322 320 C 342 318 362 310 380 295 C 360 292 340 298 322 312 Z" />
+
+        {/* Small buds */}
+        <circle cx="350" cy="70" r="3" fill="currentColor" stroke="none" />
+        <circle cx="360" cy="90" r="2" fill="currentColor" stroke="none" />
+        <circle cx="345" cy="95" r="1.6" fill="currentColor" stroke="none" />
+
+        {/* Soft radial wash — very low opacity */}
+        <circle
+          cx="360"
+          cy="160"
+          r="140"
+          fill="currentColor"
+          stroke="none"
+          opacity="0.06"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/leafmart/BrandChip.tsx
+++ b/src/components/leafmart/BrandChip.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils/cn";
+import type { BrandIdentity } from "./formats";
+
+/**
+ * Founding-partner brand tile. Tonal block with the partner's name set
+ * in display serif + tagline underneath. Hover reveals a gold rule that
+ * slides in from the left, reinforcing the "curated shelf" metaphor.
+ */
+export function BrandChip({
+  brand,
+  className,
+}: {
+  brand: BrandIdentity;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "group relative overflow-hidden rounded-lg p-5 h-full min-h-[136px] flex flex-col justify-end transition-transform duration-300 hover:-translate-y-0.5",
+        brand.tileClass,
+        brand.inkClass,
+        className,
+      )}
+    >
+      {/* Grain */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.08] mix-blend-overlay"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 15% 15%, rgba(255,255,255,.4) 0, transparent 40%), radial-gradient(circle at 85% 85%, rgba(0,0,0,.2) 0, transparent 40%)",
+        }}
+      />
+      {/* Slide-in rule on hover */}
+      <span
+        aria-hidden="true"
+        className="absolute top-5 left-5 right-5 h-px bg-current opacity-30 origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-500"
+      />
+      <p className="relative font-display text-xl tracking-tight">{brand.name}</p>
+      <p className="relative text-xs mt-1 opacity-80">{brand.tagline}</p>
+    </div>
+  );
+}

--- a/src/components/leafmart/FormatIcon.tsx
+++ b/src/components/leafmart/FormatIcon.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/lib/utils/cn";
+import type { ProductFormat } from "@/lib/marketplace/types";
+
+interface FormatIconProps {
+  format: ProductFormat;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Per-format inline SVG iconography for Leafmart.
+ *
+ * Every icon is drawn at 24x24 on a 2px grid with a consistent stroke
+ * weight (1.25) and no fill, so they read as a family. Intent is
+ * editorial / pharmacy-window, not pictogram clipart.
+ */
+export function FormatIcon({ format, size = 24, className }: FormatIconProps) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.25,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+    className: cn("shrink-0", className),
+  };
+
+  switch (format) {
+    case "tincture":
+      // Dropper bottle with dropper bulb
+      return (
+        <svg {...common}>
+          <path d="M9 3.5h6M10 3.5v2.5l-1.2 1.4a3 3 0 0 0-.8 2v8.3a2.3 2.3 0 0 0 2.3 2.3h3.4a2.3 2.3 0 0 0 2.3-2.3V9.4a3 3 0 0 0-.8-2L14 6V3.5" />
+          <path d="M9.5 13.5h5" />
+          <circle cx="12" cy="9.5" r="0.6" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case "topical":
+      // Jar with flat lid + salve dome
+      return (
+        <svg {...common}>
+          <path d="M5.5 6.5h13v2.3a1.2 1.2 0 0 1-1.2 1.2H6.7A1.2 1.2 0 0 1 5.5 8.8V6.5Z" />
+          <path d="M7 10h10v8a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-8Z" />
+          <path d="M9 14.5c0-1.4 1.4-2 3-2s3 .6 3 2" />
+        </svg>
+      );
+    case "edible":
+      // Gummy / lozenge
+      return (
+        <svg {...common}>
+          <path d="M4.5 12a7.5 7.5 0 0 1 15 0 7.5 7.5 0 0 1-15 0Z" />
+          <path d="M8 12a4 4 0 0 1 8 0" />
+          <circle cx="10" cy="10" r="0.5" fill="currentColor" stroke="none" />
+          <circle cx="14" cy="14" r="0.5" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case "capsule":
+      // Two-tone capsule on diagonal
+      return (
+        <svg {...common}>
+          <path d="m7.5 16.5 9-9a4 4 0 1 1 5.6 5.6l-9 9A4 4 0 1 1 7.5 16.5Z" transform="translate(-3 -1.2) scale(0.7)" />
+          <path d="M9.5 14.5 14.5 9.5" />
+        </svg>
+      );
+    case "vape":
+      // Pen with airflow dots
+      return (
+        <svg {...common}>
+          <path d="M5 10.5h11l2 1.5-2 1.5H5a1 1 0 0 1-1-1v-1a1 1 0 0 1 1-1Z" />
+          <path d="M17 12h2" />
+          <path d="M7 10.5v-2M10 10.5v-2" />
+          <circle cx="21" cy="12" r="0.5" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case "concentrate":
+      // Faceted crystal / shatter
+      return (
+        <svg {...common}>
+          <path d="M12 4 18 8 16 16 12 20 8 16 6 8 Z" />
+          <path d="M8 8h8M12 4v16M6 8l6 8M18 8l-6 8" />
+        </svg>
+      );
+    case "patch":
+      // Square patch with rounded corners + stitching
+      return (
+        <svg {...common}>
+          <rect x="4.5" y="4.5" width="15" height="15" rx="2" />
+          <path d="M4.5 8.5h15M4.5 15.5h15M8.5 4.5v15M15.5 4.5v15" strokeDasharray="1.5 2" />
+        </svg>
+      );
+    case "flower":
+      // Cannabis leaf — single, clean, no clichés
+      return (
+        <svg {...common}>
+          <path d="M12 3v18M12 7 C10 9 7.5 9.5 5 9 c 1 2 2 3 4.5 3.5 M12 7 c 2 2 4.5 2.5 7 2 -1 2 -2 3 -4.5 3.5 M12 11 c -1.5 2 -4 2.5 -6.5 2.5 1 1.8 2.5 2.8 4.5 3 M12 11 c 1.5 2 4 2.5 6.5 2.5 -1 1.8 -2.5 2.8 -4.5 3" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="7" />
+        </svg>
+      );
+  }
+}

--- a/src/components/leafmart/LeafmartHeader.tsx
+++ b/src/components/leafmart/LeafmartHeader.tsx
@@ -24,10 +24,16 @@ export function LeafmartHeader() {
 
         <nav className="flex items-center gap-0.5 md:gap-1">
           <Link
-            href="/leafmart/products"
+            href="/leafmart/shop"
             className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
           >
             Shop
+          </Link>
+          <Link
+            href="/leafmart/products"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors hidden md:inline"
+          >
+            All products
           </Link>
           <Link
             href="/leafmart/about"
@@ -42,10 +48,10 @@ export function LeafmartHeader() {
             Partner with us
           </Link>
           <Link
-            href="/education"
-            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors"
+            href="/leafmart/faq"
+            className="text-xs md:text-sm text-text-muted hover:text-text px-2 md:px-3 py-2 transition-colors hidden md:inline"
           >
-            Education
+            FAQ
           </Link>
           <Link
             href="/login"
@@ -53,9 +59,9 @@ export function LeafmartHeader() {
           >
             Sign in
           </Link>
-          <Link href="/portal/shop" className="ml-1">
+          <Link href="/leafmart/shop" className="ml-1">
             <Button size="sm" variant="primary">
-              Shop
+              Start browsing
             </Button>
           </Link>
         </nav>

--- a/src/components/leafmart/ProductTile.tsx
+++ b/src/components/leafmart/ProductTile.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils/cn";
+import { FormatIcon } from "./FormatIcon";
+import { FORMAT_VISUALS } from "./formats";
+import type { ProductFormat } from "@/lib/marketplace/types";
+
+interface ProductTileProps {
+  format: ProductFormat;
+  brand?: string;
+  name?: string;
+  /** Show the big editorial layout (PDP). Default is the compact card layout. */
+  variant?: "card" | "hero";
+  className?: string;
+}
+
+/**
+ * The "product image" on Leafmart — a brand-coded tonal tile that stands
+ * in for real photography. Gradient + format icon + wordmark line give
+ * every card a unique visual identity without needing a CDN pipeline.
+ *
+ * Two variants:
+ *   - card → used on grids; compact format icon + subtle brand line
+ *   - hero → used on PDPs; oversized icon, editorial typography
+ */
+export function ProductTile({
+  format,
+  brand,
+  name,
+  variant = "card",
+  className,
+}: ProductTileProps) {
+  const visual = FORMAT_VISUALS[format] ?? FORMAT_VISUALS.tincture;
+  const isHero = variant === "hero";
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden",
+        visual.tileClass,
+        visual.inkClass,
+        isHero ? "aspect-square rounded-lg" : "aspect-[4/3]",
+        className,
+      )}
+      aria-hidden="true"
+    >
+      {/* Paper-grain noise overlay */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.08] mix-blend-overlay"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 20% 20%, rgba(255,255,255,.35) 0, transparent 35%), radial-gradient(circle at 80% 80%, rgba(0,0,0,.25) 0, transparent 35%)",
+        }}
+      />
+
+      {/* Corner wordmark — tiny and editorial */}
+      {brand && !isHero && (
+        <p
+          className={cn(
+            "absolute top-3 left-3 text-[9px] uppercase tracking-[0.2em] opacity-80",
+          )}
+        >
+          {brand}
+        </p>
+      )}
+
+      {/* Centered format icon */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <FormatIcon
+          format={format}
+          size={isHero ? 80 : 44}
+          className={cn("opacity-90", isHero && "drop-shadow-sm")}
+        />
+      </div>
+
+      {/* Format label footer — bottom-left editorial line */}
+      <p
+        className={cn(
+          "absolute bottom-3 left-3 uppercase tracking-[0.2em] opacity-80",
+          isHero ? "text-xs" : "text-[10px]",
+        )}
+      >
+        {visual.label}
+      </p>
+
+      {/* Hero variant additionally prints the product name in a display serif */}
+      {isHero && name && (
+        <p className="absolute bottom-10 left-6 right-6 font-display text-xl leading-tight tracking-tight opacity-95">
+          {name}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/leafmart/PublicProductCard.tsx
+++ b/src/components/leafmart/PublicProductCard.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { Badge } from "@/components/ui/badge";
+import { RatingStars } from "@/components/marketplace/RatingStars";
+import { ProductTile } from "./ProductTile";
+import type { MarketplaceProduct } from "@/lib/marketplace/types";
+
+/**
+ * Leafmart's public product card. No add-to-cart affordance (public
+ * surface doesn't wire checkout). All CTAs route to the PDP.
+ *
+ * Visual contract: every card is a two-block stack — a brand-coded
+ * ProductTile at the top and an editorial info block below. Resting
+ * shadow is hairline `shadow-sm`; hover gains depth + subtle lift.
+ */
+export function PublicProductCard({
+  product,
+  className,
+}: {
+  product: MarketplaceProduct;
+  className?: string;
+}) {
+  return (
+    <Link
+      href={`/leafmart/products/${product.slug}`}
+      className={cn(
+        "group flex flex-col rounded-lg border border-border bg-surface overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-1 hover:border-border-strong",
+        className,
+      )}
+    >
+      <ProductTile
+        format={product.format}
+        brand={product.brand}
+        className="transition-transform duration-500 group-hover:scale-[1.02]"
+      />
+
+      <div className="p-5 flex flex-col gap-1.5 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-[10px] uppercase tracking-[0.16em] text-text-subtle truncate">
+            {product.brand}
+          </p>
+          {product.clinicianPick && (
+            <Badge tone="accent" className="shrink-0 text-[10px]">
+              Pick
+            </Badge>
+          )}
+        </div>
+
+        <p className="font-display text-lg leading-snug tracking-tight text-text group-hover:text-accent transition-colors line-clamp-2 min-h-[2.75rem]">
+          {product.name}
+        </p>
+
+        {/* Cannabinoid micro-badges */}
+        {(product.thcContent != null || product.cbdContent != null) && (
+          <div className="flex gap-1.5 mt-1">
+            {product.thcContent != null && (
+              <span className="inline-flex items-center rounded bg-surface-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-text-muted tabular-nums">
+                THC {product.thcContent}%
+              </span>
+            )}
+            {product.cbdContent != null && (
+              <span className="inline-flex items-center rounded bg-surface-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-text-muted tabular-nums">
+                CBD {product.cbdContent}%
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-baseline gap-2 mt-auto pt-2">
+          <span className="text-base font-semibold text-text tabular-nums">
+            ${product.price.toFixed(2)}
+          </span>
+          {product.compareAtPrice != null &&
+            product.compareAtPrice > product.price && (
+              <span className="text-xs text-text-subtle line-through tabular-nums">
+                ${product.compareAtPrice.toFixed(2)}
+              </span>
+            )}
+          {product.reviewCount > 0 && (
+            <span className="ml-auto">
+              <RatingStars
+                rating={product.averageRating}
+                count={product.reviewCount}
+              />
+            </span>
+          )}
+        </div>
+
+        {!product.inStock && (
+          <p className="text-xs text-text-subtle">Out of stock</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export function PublicProductGrid({
+  products,
+  columns = 3,
+  className,
+}: {
+  products: MarketplaceProduct[];
+  columns?: 2 | 3 | 4;
+  className?: string;
+}) {
+  const cols: Record<number, string> = {
+    2: "grid-cols-1 sm:grid-cols-2",
+    3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+    4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+  };
+  return (
+    <div className={cn("grid gap-6", cols[columns], className)}>
+      {products.map((p) => (
+        <PublicProductCard key={p.id} product={p} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/leafmart/TrustSeal.tsx
+++ b/src/components/leafmart/TrustSeal.tsx
@@ -1,0 +1,95 @@
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * The Leafmart Promise seal — used on the trust strip, checkout
+ * confirmation, and any surface where "this is physician-curated"
+ * needs a visual anchor. Modeled as a wax-seal medallion with a leaf
+ * sprig inside.
+ *
+ * Paired with `shadow-seal` from tailwind.config.ts for the pressed-in
+ * feel.
+ */
+export function TrustSeal({
+  size = 56,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 80 80"
+      fill="none"
+      aria-label="The Leafmart Promise"
+      className={cn("drop-shadow-sm", className)}
+    >
+      <defs>
+        <radialGradient id="leafmart-seal-grad" cx="50%" cy="40%" r="60%">
+          <stop offset="0%" stopColor="#2F6B4C" />
+          <stop offset="55%" stopColor="#1F4D37" />
+          <stop offset="100%" stopColor="#0E3225" />
+        </radialGradient>
+      </defs>
+      {/* Deckled outer ring */}
+      <circle
+        cx="40"
+        cy="40"
+        r="36"
+        fill="url(#leafmart-seal-grad)"
+        stroke="#0E3225"
+        strokeWidth="1.5"
+      />
+      {/* Inner deckle */}
+      <circle
+        cx="40"
+        cy="40"
+        r="30"
+        fill="none"
+        stroke="#D4B254"
+        strokeWidth="0.8"
+        strokeDasharray="1.5 2"
+        opacity="0.5"
+      />
+      {/* Inner solid ring */}
+      <circle
+        cx="40"
+        cy="40"
+        r="28"
+        fill="none"
+        stroke="#D4B254"
+        strokeWidth="1"
+        opacity="0.6"
+      />
+      {/* Arc text — Leafmart curved above */}
+      <path
+        id="leafmart-seal-top"
+        d="M 18 38 A 22 22 0 0 1 62 38"
+        fill="none"
+      />
+      <text fill="#F4E7CA" fontSize="7" letterSpacing="3" fontWeight="500">
+        <textPath href="#leafmart-seal-top" startOffset="14%">
+          LEAFMART
+        </textPath>
+      </text>
+      {/* Center leaf mark */}
+      <g transform="translate(40 44)" fill="none" stroke="#F4E7CA" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M 0 -7 C 5 -3, 5 4, 0 10 C -5 4, -5 -3, 0 -7 Z" />
+        <path d="M 0 -5 L 0 9" />
+        <path d="M 0 -2 L -2.8 -3 M 0 -2 L 2.8 -3 M 0 2 L -3 1 M 0 2 L 3 1 M 0 5 L -3 4 M 0 5 L 3 4" />
+      </g>
+      {/* Arc text — PROMISE curved below */}
+      <path
+        id="leafmart-seal-bottom"
+        d="M 18 48 A 22 22 0 0 0 62 48"
+        fill="none"
+      />
+      <text fill="#F4E7CA" fontSize="6" letterSpacing="4" fontWeight="500">
+        <textPath href="#leafmart-seal-bottom" startOffset="20%">
+          PHYSICIAN CURATED
+        </textPath>
+      </text>
+    </svg>
+  );
+}

--- a/src/components/leafmart/formats.ts
+++ b/src/components/leafmart/formats.ts
@@ -1,0 +1,110 @@
+// Leafmart format design tokens — one visual treatment per product format.
+//
+// Each format has a tonal gradient, a paired ink color for icon + text
+// overlays, and a canonical label. The gradients are tuned to the
+// existing globals.css palette (cream / moss / amber / gold) so the
+// whole surface reads as a warm editorial magazine, not a rainbow.
+
+import type { ProductFormat } from "@/lib/marketplace/types";
+
+export interface FormatVisual {
+  /** Tailwind classes applied to the tile background */
+  tileClass: string;
+  /** Tailwind class for the icon + label color on the tile */
+  inkClass: string;
+  /** Short human label (singular) */
+  label: string;
+}
+
+export const FORMAT_VISUALS: Record<ProductFormat, FormatVisual> = {
+  tincture: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#F4E3BC_0%,#E6C98A_55%,#D4A757_100%)]",
+    inkClass: "text-[#5B3A10]",
+    label: "Tincture",
+  },
+  flower: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#C9D7B2_0%,#8AA878_55%,#4F6A47_100%)]",
+    inkClass: "text-[#1F3222]",
+    label: "Flower",
+  },
+  edible: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#F0D1C6_0%,#D99A7F_55%,#A0593E_100%)]",
+    inkClass: "text-[#4A1E0F]",
+    label: "Edible",
+  },
+  topical: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#E8E4D0_0%,#BDC6A5_55%,#7C8D6B_100%)]",
+    inkClass: "text-[#2B3423]",
+    label: "Topical",
+  },
+  capsule: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#EFE3CF_0%,#C6A982_55%,#8C6B43_100%)]",
+    inkClass: "text-[#3E2812]",
+    label: "Capsule",
+  },
+  vape: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#4A463E_0%,#2E2B26_55%,#1A1814_100%)]",
+    inkClass: "text-[#E6CE9A]",
+    label: "Vaporizer",
+  },
+  concentrate: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#F6E7B9_0%,#E0BF6A_55%,#B58830_100%)]",
+    inkClass: "text-[#3E2A0A]",
+    label: "Concentrate",
+  },
+  patch: {
+    tileClass:
+      "bg-[linear-gradient(135deg,#F2EAD7_0%,#DECDA5_55%,#B19966_100%)]",
+    inkClass: "text-[#3E2F17]",
+    label: "Patch",
+  },
+};
+
+// Founding-partner brand identities. Kept in the warm / editorial
+// palette — each brand gets a tonal block (not a saturated logo color)
+// so the spotlight reads as a curated shelf, not an ad banner.
+export interface BrandIdentity {
+  /** Exact brand name as seeded on the Product rows */
+  name: string;
+  tagline: string;
+  tileClass: string;
+  inkClass: string;
+}
+
+export const FOUNDING_PARTNER_BRANDS: BrandIdentity[] = [
+  {
+    name: "PhytoRx",
+    tagline: "CBD + CBG beverages",
+    tileClass:
+      "bg-[linear-gradient(155deg,#E4ECE8_0%,#B5CCC4_55%,#4E6F67_100%)]",
+    inkClass: "text-[#1F332F]",
+  },
+  {
+    name: "Flower Powered",
+    tagline: "Full-spectrum topicals + tinctures",
+    tileClass:
+      "bg-[linear-gradient(155deg,#DDE4C9_0%,#9BB184_55%,#47663E_100%)]",
+    inkClass: "text-[#1E2E19]",
+  },
+  {
+    name: "AULV",
+    tagline: "Plant-powered wellness",
+    tileClass:
+      "bg-[linear-gradient(155deg,#F2E4C2_0%,#D9B880_55%,#9C7637_100%)]",
+    inkClass: "text-[#402B0C]",
+  },
+  {
+    name: "Potency 710",
+    tagline: "Gold Skin Serum",
+    tileClass:
+      "bg-[linear-gradient(155deg,#F7ECC5_0%,#DFC277_55%,#A98229_100%)]",
+    inkClass: "text-[#3E2E0A]",
+  },
+];


### PR DESCRIPTION
## Summary

**Option B visual polish pass.** Takes Leafmart from a catalog admin tool to a curated editorial marketplace — no real product photography required. Also forward-ports the Leafmart content routes (about / vendors / faq / PDP / category / shop directory) that were stuck on stacked branches after last night's merges.

## ⚠️ Two things in one PR

1. **Brand polish** (the headline) — product tiles, trust seal, founding-partner chips, editorial hero, branded category tiles, display-serif typography passes
2. **Forward-port fix** — PR #85/#86/#87's merges went into their stacked parent branches, not into `main`, so only `/leafmart` worked on the deployed site. This PR brings those routes back onto main.

## Why it looked like shit before

- Every product card showed a gray box with "Tincture" / "Topical" text as a placeholder (no imagery)
- Category icons were unicode glyphs (`☽`, `✚`, `♡`) rendering as tiny flat symbols
- Cards were flat rectangles with no hover lift or shadow transitions
- Hero was text-only, no visual weight
- Founding-partner spotlight was plain cards, no brand differentiation
- Editorial quote block had generic border + background, no typographic drama

## New components — `src/components/leafmart/`

| File | Purpose |
|---|---|
| `formats.ts` | Per-format visual tokens (tonal gradients + ink colors + labels) + `FOUNDING_PARTNER_BRANDS` identity config |
| `FormatIcon.tsx` | 8 hand-drawn 24x24 SVG icons (tincture dropper, topical jar, capsule, vape pen, concentrate crystal, patch w/ stitching, cannabis leaf, gummy). Consistent 1.25 stroke, no fill. Editorial pharmacy-window vibe, not pictogram clipart. |
| `ProductTile.tsx` | Brand-coded tile that replaces the gray format-label placeholder. Two variants — `card` (grid, 4:3) + `hero` (PDP, 1:1 w/ name in display serif). Paper-grain overlay. |
| `BotanicalAccent.tsx` | SVG cannabis-leaf composition (hero + corner variants) for editorial background washes |
| `TrustSeal.tsx` | **"LEAFMART · PHYSICIAN CURATED"** wax-seal medallion w/ arc text + centered LeafSprig. Anchors the hero's right column + final CTA. |
| `BrandChip.tsx` | Founding-partner tile w/ brand-tonal gradient + hover slide-in gold rule |

## Updated components

### `PublicProductCard.tsx`
- Uses `ProductTile` instead of gray placeholder
- Group hover: tile scales 1.02, card lifts, `shadow-sm` → `shadow-md`, border darkens, name goes to accent
- Cannabinoid micro-badges now use `surface-muted/60` for softer tonality
- Rating moved inline with price row (editorial density vs. stacked)
- Display serif on product name

### `/leafmart/page.tsx` (landing — the big one)
- Hero redesign: eyebrow chip + 72px display headline + 4-stat trust strip (lab-verified / founding partners / reviewed-by-MD / take rate) left; **240px TrustSeal w/ soft radial glow** right. BotanicalAccent washed behind.
- Quick-browse condition chips anchored to hero bottom
- Value-prop strip cards gain display-serif titles + `shadow-sm` resting
- **Editorial clinician note** — oversized open-quote ornament, 32px display serif, clinical-team attribution rule
- "How it works" steps get oversized display-serif step numbers
- **Founding partner spotlight** — four `BrandChip` tiles (PhytoRx cool blue-green, Flower Powered moss, AULV amber, Potency 710 gold) + BotanicalAccent corner
- Final CTA gets centered 80px TrustSeal above headline

### `/leafmart/shop/page.tsx` (shop directory)
- `CategoryTile` redesigned: `LeafSprig` ornament (no more unicode glyphs), display-serif name, accent-soft gradient wash on hover, card lift + border-strong on hover

### `/leafmart/products/[slug]/page.tsx` (PDP)
- Hero image swap: `ProductTile variant="hero"` replaces the flat `surface-muted` placeholder. Full brand-coded gradient + 80px format icon + name typeset in display serif.

## Framing discipline preserved

- **Within the existing design system** — no new tokens added to `globals.css`, all colors are Tailwind arbitrary values tuned to the cream / moss / amber / gold palette
- **Never more than two colors per screen** — each format tile + brand chip is tonal (one hue gradient), never rainbow
- **Restrained motion** — 300-500ms, smooth easing, no bounce, respects `prefers-reduced-motion`
- **Consumer-retail register** (warmer, more display-serif weight) while staying clinical in messaging

## Tests + typecheck

- `npm run typecheck` clean
- **346/346 tests pass** (unchanged — all visual changes, no new helpers)

## Deploy

No DB changes. Just `git pull` + restart dev server.

## Test plan

- [x] `npm test`
- [x] `npm run typecheck`
- [ ] `/leafmart` — hero shows big TrustSeal medallion on right, 72px display headline + trust-strip on left, BotanicalAccent behind
- [ ] Featured product cards show brand-coded gradient tiles (tincture = warm amber, topical = sage, capsule = clay, vape = charcoal/gold)
- [ ] Hover a product card → tile scales subtly, card lifts, shadow deepens, name turns accent color
- [ ] `/leafmart/shop` — category tiles have LeafSprig ornament (no unicode glyphs) + hover gradient wash
- [ ] `/leafmart/products/solace-nightfall-tincture` — PDP hero now shows the amber tincture tile with name in display serif
- [ ] Founding-partner spotlight on landing — four tonal brand blocks, hover reveals sliding gold rule
- [ ] Editorial clinician note block — oversized open-quote ornament visible in accent-soft
- [ ] `/leafmart/about`, `/leafmart/vendors`, `/leafmart/faq` all render (regression check — these were not on main before this PR)

https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVEos9nJTXwju8ydddXYiP)_