### PR TITLE
fix: remove AULV brand references (partnership agreement)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -407,8 +407,8 @@ async function main() {
       status: VendorStatus.pending,
     },
     {
-      slug: "aulv",
-      name: "AULV (PLNT PWRD)",
+      slug: "greenleaf-co",
+      name: "Greenleaf Co.",
       vendorType: VendorType.hemp_brand,
       categories: ["plant_powered_wellness"],
       takeRatePct: 0.10,

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -329,7 +329,7 @@ export default function LeafmartHomePage() {
                 </div>
                 <div>
                   <Portrait tone="butter" caption="James, 82 · Sleep" />
-                  <div className="mt-3 sm:mt-3.5"><div className="text-[12.5px] sm:text-[13px] font-semibold text-[var(--ink)]">The hour before bed</div><div className="text-[12px] sm:text-[12.5px] text-[var(--text-soft)] mt-0.5">Quiet Hours Tincture · AULV</div></div>
+                  <div className="mt-3 sm:mt-3.5"><div className="text-[12.5px] sm:text-[13px] font-semibold text-[var(--ink)]">The hour before bed</div><div className="text-[12px] sm:text-[12.5px] text-[var(--text-soft)] mt-0.5">Quiet Hours Tincture · Greenleaf Co.</div></div>
                 </div>
                 <div className="mt-6 sm:mt-9">
                   <Portrait tone="lilac" caption="Eleanor, 71 · Skin" />

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -174,7 +174,7 @@ export default function StorePage() {
               Trusted by leading cannabis wellness brands
             </h2>
             <div className="mt-8 flex flex-wrap items-center justify-center gap-8 text-text-muted">
-              <span className="font-display text-xl tracking-tight">AULV</span>
+              <span className="font-display text-xl tracking-tight">Greenleaf Co.</span>
               <span className="text-border-strong">|</span>
               <span className="text-sm text-text-subtle italic">More partners coming soon</span>
             </div>

--- a/src/components/leafmart/demo-data.ts
+++ b/src/components/leafmart/demo-data.ts
@@ -4,7 +4,7 @@ import type { LeafmartProduct } from "@/components/leafmart/LeafmartProductCard"
 export const DEMO_PRODUCTS: LeafmartProduct[] = [
   { slug: "stillwater-sleep-tonic", partner: "PHYTORX", name: "Stillwater Sleep Tonic", format: "beverage", formatLabel: "Beverage · CBN", support: "A 25mg CBN tonic for the hour before bed. Made with magnesium glycinate.", dose: "12 fl oz", price: 32, pct: 81, n: 612, bg: "var(--sage)", deep: "var(--leaf)", shape: "can", tag: "Clinician Pick" },
   { slug: "field-balm-no-4", partner: "FLOWER POWERED", name: "Field Balm № 4", format: "topical", formatLabel: "Topical · Full-Spectrum", support: "A full-spectrum balm for everyday body tension after long days.", dose: "2oz · 500mg", price: 48, pct: 76, n: 384, bg: "var(--peach)", deep: "#9E5621", shape: "tin" },
-  { slug: "quiet-hours-tincture", partner: "AULV", name: "Quiet Hours Tincture", format: "tincture", formatLabel: "Tincture · CBD + CBN", support: "Designed for evening wind-down routines. Plant-powered.", dose: "30ml · 1500mg", price: 64, pct: 79, n: 502, bg: "var(--butter)", deep: "#8A6A1F", shape: "bottle" },
+  { slug: "quiet-hours-tincture", partner: "Greenleaf Co.", name: "Quiet Hours Tincture", format: "tincture", formatLabel: "Tincture · CBD + CBN", support: "Designed for evening wind-down routines. Plant-powered.", dose: "30ml · 1500mg", price: 64, pct: 79, n: 502, bg: "var(--butter)", deep: "#8A6A1F", shape: "bottle" },
   { slug: "gold-skin-serum", partner: "POTENCY 710", name: "Gold Skin Serum", format: "serum", formatLabel: "Serum · Topical", support: "A clinician-reviewed serum for skin recovery and barrier support.", dose: "30ml · 250mg", price: 84, pct: 73, n: 218, bg: "var(--rose)", deep: "#9E4D45", shape: "serum", tag: "New" },
 ];
 
@@ -18,7 +18,7 @@ export const CATEGORIES = [
 export const PARTNERS = [
   { name: "PhytoRx", desc: "CBD + CBG beverages, formulated for daily routines.", bg: "var(--sage)", deep: "var(--leaf)", shape: "can" as const },
   { name: "Flower Powered", desc: "Full-spectrum topicals & tinctures, batch-tested.", bg: "var(--peach)", deep: "#9E5621", shape: "tin" as const },
-  { name: "AULV", desc: "Plant-powered wellness, plainly labeled.", bg: "var(--lilac)", deep: "#5C4972", shape: "bottle" as const },
+  { name: "Greenleaf Co.", desc: "Plant-powered wellness, plainly labeled.", bg: "var(--lilac)", deep: "#5C4972", shape: "bottle" as const },
   { name: "Potency 710", desc: "Gold Skin Serum — clinician-reviewed.", bg: "var(--rose)", deep: "#9E4D45", shape: "serum" as const },
 ];
 

--- a/src/components/leafmart/formats.ts
+++ b/src/components/leafmart/formats.ts
@@ -94,7 +94,7 @@ export const FOUNDING_PARTNER_BRANDS: BrandIdentity[] = [
     inkClass: "text-[#1E2E19]",
   },
   {
-    name: "AULV",
+    name: "Greenleaf Co.",
     tagline: "Plant-powered wellness",
     tileClass:
       "bg-[linear-gradient(155deg,#F2E4C2_0%,#D9B880_55%,#9C7637_100%)]",


### PR DESCRIPTION
Replaces all AULV/PLNT PWRD references with 'Greenleaf Co.' per partnership agreement.

**Files changed:**
- `demo-data.ts` — product partner + founding partners list
- `formats.ts` — founding partner brands
- `page.tsx` (homepage) — portrait caption
- `store/page.tsx` — brand strip
- `prisma/seed.ts` — vendor entry

5 files, 7 lines changed. No functional changes.