### PR TITLE
fix(deploy): install devDependencies on Render so ESLint is available

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -23,6 +23,8 @@ services:
     startCommand: npx prisma migrate deploy && npm run start
     healthCheckPath: /api/health
     envVars:
+      - key: NPM_CONFIG_PRODUCTION
+        value: "false"
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL


### PR DESCRIPTION
Render sets NODE_ENV=production → npm ci skips devDependencies → next build fails because ESLint is missing.

Adds NPM_CONFIG_PRODUCTION=false to render.yaml so devDeps install during build.

**This is why every deploy since PR #90 has failed.**