### PR TITLE
design(leafmart): Comprehensive visual polish — silhouettes, cart, checkout, typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -221,6 +221,32 @@
     from { opacity: 0; transform: scale(0.4); }
     to   { opacity: 1; transform: scale(1); }
   }
+  @keyframes draw-check {
+    to { stroke-dashoffset: 0; }
+  }
+  @keyframes gentle-bounce {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.15); }
+  }
+  @keyframes slide-out-right {
+    from { opacity: 1; transform: translateX(0); }
+    to   { opacity: 0; transform: translateX(40px); }
+  }
+
+  /* ── Design utility classes ─────────────────────────────── */
+  .text-balance { text-wrap: balance; }
+
+  .price {
+    font-family: var(--font-display);
+    font-feature-settings: "tnum", "kern";
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+  }
+
+  .product-thumb {
+    overflow: hidden;
+    flex-shrink: 0;
+  }
 
   @media (prefers-reduced-motion: reduce) {
     .lm-fade-in,
@@ -254,7 +280,8 @@
   }
   .card-lift:hover {
     transform: translateY(-4px);
-    box-shadow: 0 20px 50px rgba(28, 40, 32, 0.10);
+    box-shadow: 0 20px 50px rgba(28, 40, 32, 0.10),
+               0 4px 16px rgba(184, 120, 47, 0.06);
   }
 
   /* Trust chip — rounded pill with Leaf Soft bg */
@@ -274,7 +301,7 @@
   .eyebrow {
     font-size: 11.5px;
     font-weight: 600;
-    letter-spacing: 1.6px;
+    letter-spacing: 2px;
     text-transform: uppercase;
   }
 

--- a/src/app/leafmart/cart/page.tsx
+++ b/src/app/leafmart/cart/page.tsx
@@ -164,7 +164,10 @@ export default function CartPage() {
             </div>
             <div className="flex justify-between">
               <dt className="text-[var(--text-soft)]">Shipping</dt>
-              <dd className="text-[var(--leaf)] font-medium">Free</dd>
+              <dd className="text-[var(--leaf)] font-medium flex items-center gap-1.5">
+                <svg width="12" height="12" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5" fill="none" stroke="currentColor" strokeWidth="1.4" /><path d="M3.5 6.2L5.2 7.8L8.5 4.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                Free
+              </dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-[var(--text-soft)]">Estimated tax</dt>

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -212,7 +212,7 @@ export default function CheckoutPage() {
   // ── Confirmation step ──────────────────────────────────────────
   if (step === 3 && orderNumber && confirmedSnapshot) {
     return (
-      <section className="max-w-[720px] mx-auto px-6 lg:px-10 py-20 lg:py-24">
+      <section className="max-w-[720px] mx-auto px-6 lg:px-10 py-20 lg:py-24 lm-fade-in">
         <div
           className="w-16 h-16 rounded-full flex items-center justify-center mb-7"
           style={{ background: "var(--sage)" }}
@@ -225,6 +225,9 @@ export default function CheckoutPage() {
               strokeWidth="2.2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              strokeDasharray="28"
+              strokeDashoffset="28"
+              className="animate-[draw-check_0.6s_ease-out_0.3s_forwards]"
             />
           </svg>
         </div>

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -74,7 +74,7 @@ export default function LeafmartHomePage() {
               Join 12,000+ Leafmart members
             </div>
 
-            <h1 className="font-display text-[40px] sm:text-[56px] md:text-[64px] lg:text-[76px] leading-[1.02] sm:leading-[1.0] font-normal tracking-[-1.5px] sm:tracking-[-2px] text-[var(--ink)] mb-0">
+            <h1 className="font-display text-[40px] sm:text-[56px] md:text-[64px] lg:text-[76px] leading-[1.02] sm:leading-[1.0] font-normal tracking-[-1.5px] sm:tracking-[-2px] text-[var(--ink)] mb-0 text-balance">
               Cannabis wellness,<br />
               <em className="font-accent not-italic text-[var(--leaf)]">doctor-guided.</em>
             </h1>
@@ -152,12 +152,12 @@ export default function LeafmartHomePage() {
               className="card-lift rounded-[24px] sm:rounded-[28px] p-5 sm:p-6 pb-0 flex flex-col overflow-hidden cursor-pointer min-h-[280px] sm:min-h-[340px] lg:min-h-[380px]"
               style={{ background: c.bg }}
             >
-              <div className="flex justify-between items-start">
+                <div className="flex justify-between items-start">
                 <div>
                   <h3 className="font-display text-[24px] sm:text-[28px] lg:text-[32px] font-medium tracking-tight text-[var(--ink)]">{c.name}</h3>
                   <p className="text-[13px] sm:text-[13.5px] text-[var(--text-soft)] mt-2 max-w-[200px] leading-snug">{c.sub}</p>
                 </div>
-                <div className="bg-white/60 text-[var(--ink)] rounded-full px-2.5 py-1 text-xs font-semibold">{c.count}</div>
+                <div className="bg-white/60 text-[var(--ink)] rounded-full px-2.5 py-1 text-[11px] font-semibold tabular-nums">{c.count} products</div>
               </div>
               <div className="flex-1 flex items-end mt-2.5 justify-center">
                 <div className="w-3/4 h-[160px] sm:h-[200px]">
@@ -194,7 +194,7 @@ export default function LeafmartHomePage() {
       <section className="px-4 sm:px-6 lg:px-14 py-12 sm:py-16 max-w-[1440px] mx-auto">
         <div className="text-center mb-10 sm:mb-12">
           <p className="eyebrow text-[var(--leaf)]">The Method</p>
-          <h2 className="font-display text-[32px] sm:text-[44px] lg:text-[56px] font-normal tracking-[-1.2px] sm:tracking-[-1.4px] leading-[1.05] sm:leading-[1.0] mt-3 max-w-3xl mx-auto">
+          <h2 className="font-display text-[32px] sm:text-[44px] lg:text-[56px] font-normal tracking-[-1.2px] sm:tracking-[-1.4px] leading-[1.05] sm:leading-[1.0] mt-3 max-w-3xl mx-auto text-balance">
             Three layers of editing, <em className="font-accent not-italic text-[var(--leaf)]">before</em><br className="hidden sm:block" />
             a single product reaches your cart.
           </h2>
@@ -270,8 +270,8 @@ export default function LeafmartHomePage() {
               className="rounded-[24px] sm:rounded-[28px] p-6 sm:p-8 flex flex-col min-h-[240px] sm:min-h-[260px] flex-shrink-0 w-[82%] md:w-auto snap-start"
               style={{ background: r.bg }}
             >
-              <div className="font-display text-[36px] text-[var(--leaf)] leading-none mb-2">&ldquo;</div>
-              <p className="font-display text-[17px] sm:text-[19px] leading-[1.4] font-normal text-[var(--ink)] flex-1">{r.quote}</p>
+              <div className="font-display text-[48px] sm:text-[56px] text-[var(--leaf)] leading-none mb-0 -mt-2 opacity-40 select-none" aria-hidden="true">&ldquo;</div>
+              <p className="font-display text-[17px] sm:text-[19px] leading-[1.4] font-normal text-[var(--ink)] flex-1 -mt-3">{r.quote}</p>
               <div className="flex items-center gap-3 mt-5 sm:mt-6">
                 <div className="w-9 h-9 rounded-full bg-white/70 flex items-center justify-center font-display font-medium">
                   {r.name[0]}

--- a/src/components/leafmart/CartDrawer.tsx
+++ b/src/components/leafmart/CartDrawer.tsx
@@ -5,8 +5,13 @@ import { useEffect } from "react";
 import { useCart, formatUSD } from "@/lib/leafmart/cart-store";
 import { ProductSilhouette } from "./ProductSilhouette";
 
+const FREE_SHIPPING_THRESHOLD = 75;
+
 export function CartDrawer() {
-  const { items, isOpen, closeCart, removeItem, updateQuantity, subtotal } = useCart();
+  const { items, isOpen, closeCart, removeItem, updateQuantity, subtotal, itemCount } = useCart();
+
+  const shippingProgress = Math.min(1, subtotal / FREE_SHIPPING_THRESHOLD);
+  const shippingRemaining = Math.max(0, FREE_SHIPPING_THRESHOLD - subtotal);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -34,47 +39,63 @@ export function CartDrawer() {
         role="dialog"
         aria-modal="true"
         aria-label="Shopping cart"
-        className={`fixed top-0 right-0 z-50 h-full w-full sm:w-[440px] bg-[var(--bg)] border-l border-[var(--border)] shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
+        className={`fixed top-0 right-0 z-50 h-full w-full sm:w-[420px] bg-[var(--bg)] border-l border-[var(--border)] shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
-        <header className="flex items-center justify-between px-6 py-5 border-b border-[var(--border)]">
+        {/* Header */}
+        <header className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)]">
           <div>
             <p className="eyebrow text-[var(--text-soft)]">Your cart</p>
-            <h2 className="font-display text-[24px] font-medium tracking-tight text-[var(--ink)]">
-              {items.length === 0 ? "Empty" : `${items.length} item${items.length === 1 ? "" : "s"}`}
+            <h2 className="font-display text-[22px] font-medium tracking-tight text-[var(--ink)] leading-tight">
+              {items.length === 0 ? "Empty" : `${itemCount} item${itemCount === 1 ? "" : "s"}`}
             </h2>
           </div>
           <button
             onClick={closeCart}
             aria-label="Close cart"
-            className="rounded-full w-9 h-9 flex items-center justify-center border border-[var(--border)] text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors"
+            className="rounded-full w-8 h-8 flex items-center justify-center border border-[var(--border)] text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors"
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
-              <path d="M2 2L12 12M12 2L2 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+            <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+              <path d="M2 2L10 10M10 2L2 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
             </svg>
           </button>
         </header>
 
+        {/* Shipping progress */}
+        {items.length > 0 && (
+          <div className="px-5 py-3 border-b border-[var(--border)] bg-[var(--surface-muted)]/50">
+            {shippingRemaining > 0 ? (
+              <p className="text-[12px] text-[var(--text-soft)] mb-2">
+                <span className="font-medium text-[var(--leaf)]">{formatUSD(shippingRemaining)}</span> away from free shipping
+              </p>
+            ) : (
+              <p className="text-[12px] font-medium text-[var(--leaf)] mb-2 flex items-center gap-1.5">
+                <svg width="12" height="12" viewBox="0 0 12 12"><circle cx="6" cy="6" r="5" fill="none" stroke="currentColor" strokeWidth="1.4" /><path d="M3.5 6.2L5.2 7.8L8.5 4.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                Free shipping unlocked
+              </p>
+            )}
+            <div className="h-1 bg-[var(--border)] rounded-full overflow-hidden">
+              <div
+                className="h-full bg-[var(--leaf)] rounded-full transition-all duration-500 ease-out"
+                style={{ width: `${shippingProgress * 100}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Items */}
         <div className="flex-1 overflow-y-auto">
           {items.length === 0 ? (
             <div className="h-full flex flex-col items-center justify-center px-8 text-center gap-4">
-              <div
-                className="w-20 h-20 rounded-full flex items-center justify-center"
-                style={{ background: "var(--sage)" }}
-              >
+              <div className="w-20 h-20 rounded-full flex items-center justify-center" style={{ background: "var(--sage)" }}>
                 <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
-                  <path
-                    d="M6 9h20l-2 14a3 3 0 0 1-3 2.6H11A3 3 0 0 1 8 23L6 9z"
-                    fill="none" stroke="var(--leaf)" strokeWidth="1.6" strokeLinejoin="round"
-                  />
+                  <path d="M6 9h20l-2 14a3 3 0 0 1-3 2.6H11A3 3 0 0 1 8 23L6 9z" fill="none" stroke="var(--leaf)" strokeWidth="1.6" strokeLinejoin="round" />
                   <path d="M11 9V7a5 5 0 0 1 10 0v2" fill="none" stroke="var(--leaf)" strokeWidth="1.6" strokeLinecap="round" />
                 </svg>
               </div>
-              <p className="font-display text-[22px] font-medium text-[var(--ink)]">
-                Your cart is empty
-              </p>
-              <p className="text-[14px] text-[var(--text-soft)] leading-relaxed max-w-[260px]">
+              <p className="font-display text-[22px] font-medium text-[var(--ink)]">Your cart is empty</p>
+              <p className="text-[13px] text-[var(--text-soft)] leading-relaxed max-w-[240px]">
                 Browse physician-curated formulas, lab-verified and ranked by real outcomes.
               </p>
               <Link
@@ -88,52 +109,61 @@ export function CartDrawer() {
           ) : (
             <ul className="divide-y divide-[var(--border)]">
               {items.map(({ product, quantity }) => (
-                <li key={product.slug} className="px-6 py-5 flex gap-4 animate-[fade-in_0.3s_ease-out]">
-                  {/* Product silhouette thumbnail */}
-                  <div className="w-[72px] h-[72px] rounded-2xl flex-shrink-0 overflow-hidden">
-                    <ProductSilhouette
-                      shape={product.shape}
-                      bg={product.bg}
-                      deep={product.deep}
-                      height={72}
-                    />
+                <li key={product.slug} className="px-5 py-4 flex gap-3.5 animate-[fade-in_0.3s_ease-out]">
+                  {/* Compact silhouette with quantity badge */}
+                  <div className="relative flex-shrink-0">
+                    <div className="w-[64px] h-[64px] rounded-2xl overflow-hidden">
+                      <ProductSilhouette shape={product.shape} bg={product.bg} deep={product.deep} height={64} />
+                    </div>
+                    {quantity > 1 && (
+                      <span className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[#FFF8E8] text-[10px] font-bold rounded-full w-[18px] h-[18px] flex items-center justify-center tabular-nums shadow-sm">
+                        {quantity}
+                      </span>
+                    )}
                   </div>
+
+                  {/* Product info */}
                   <div className="flex-1 min-w-0">
-                    <p className="eyebrow text-[var(--text-soft)] mb-1">{product.partner}</p>
-                    <p className="font-display text-[16px] font-medium text-[var(--ink)] leading-tight truncate">
+                    <p className="text-[10.5px] font-semibold tracking-[1.4px] uppercase text-[var(--text-soft)] mb-0.5">{product.partner}</p>
+                    <p className="font-display text-[15px] font-medium text-[var(--ink)] leading-tight truncate">
                       {product.name}
                     </p>
-                    <p className="text-[12px] text-[var(--muted)] mt-0.5">{product.dose}</p>
-                    <div className="flex items-center justify-between mt-3">
+                    <p className="text-[11.5px] text-[var(--muted)] mt-0.5">{product.dose}</p>
+
+                    <div className="flex items-center justify-between mt-2.5">
                       <div className="inline-flex items-center border border-[var(--border)] rounded-full overflow-hidden">
                         <button
                           onClick={() => updateQuantity(product.slug, quantity - 1)}
                           aria-label={`Decrease ${product.name} quantity`}
-                          className="w-8 h-8 flex items-center justify-center text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors"
+                          className="w-7 h-7 flex items-center justify-center text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors text-[13px]"
                         >
                           −
                         </button>
-                        <span className="w-7 text-center text-[13px] font-medium tabular-nums">
-                          {quantity}
-                        </span>
+                        <span className="w-6 text-center text-[12px] font-medium tabular-nums">{quantity}</span>
                         <button
                           onClick={() => updateQuantity(product.slug, quantity + 1)}
                           aria-label={`Increase ${product.name} quantity`}
-                          className="w-8 h-8 flex items-center justify-center text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors"
+                          className="w-7 h-7 flex items-center justify-center text-[var(--ink)] hover:bg-[var(--surface-muted)] transition-colors text-[13px]"
                         >
                           +
                         </button>
                       </div>
-                      <span className="font-display text-[17px] font-medium text-[var(--ink)] tabular-nums">
-                        {formatUSD(product.price * quantity)}
-                      </span>
+
+                      <div className="flex items-center gap-3">
+                        <button
+                          onClick={() => removeItem(product.slug)}
+                          aria-label={`Remove ${product.name}`}
+                          className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-[var(--surface-muted)] text-[var(--muted)] hover:text-[var(--danger)] transition-colors"
+                        >
+                          <svg width="13" height="13" viewBox="0 0 13 13" aria-hidden="true">
+                            <path d="M3 4.5h7M5 4.5V3.5a1 1 0 0 1 1-1h1a1 1 0 0 1 1 1v1M4.5 4.5l.4 6a1 1 0 0 0 1 .9h1.2a1 1 0 0 0 1-.9l.4-6" fill="none" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        </button>
+                        <span className="font-display text-[16px] font-medium text-[var(--ink)] tabular-nums">
+                          {formatUSD(product.price * quantity)}
+                        </span>
+                      </div>
                     </div>
-                    <button
-                      onClick={() => removeItem(product.slug)}
-                      className="mt-2 text-[12px] text-[var(--muted)] hover:text-[var(--danger)] transition-colors"
-                    >
-                      Remove
-                    </button>
                   </div>
                 </li>
               ))}
@@ -141,28 +171,29 @@ export function CartDrawer() {
           )}
         </div>
 
+        {/* Footer */}
         {items.length > 0 && (
-          <footer className="border-t border-[var(--border)] px-6 py-5 bg-[var(--bg)]">
-            <div className="flex items-center justify-between mb-4">
-              <span className="eyebrow text-[var(--text-soft)]">Subtotal</span>
-              <span className="font-display text-[24px] font-medium text-[var(--ink)] tabular-nums">
+          <footer className="border-t border-[var(--border)] px-5 py-4 bg-[var(--bg)]">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-[12px] font-semibold tracking-[1.4px] uppercase text-[var(--text-soft)]">Subtotal</span>
+              <span className="font-display text-[22px] font-medium text-[var(--ink)] tabular-nums">
                 {formatUSD(subtotal)}
               </span>
             </div>
-            <p className="text-[12px] text-[var(--muted)] mb-4 leading-relaxed">
+            <p className="text-[11.5px] text-[var(--muted)] mb-3.5 leading-relaxed">
               Shipping &amp; tax calculated at checkout.
             </p>
             <Link
               href="/leafmart/checkout"
               onClick={closeCart}
-              className="block w-full text-center rounded-full bg-[var(--ink)] text-[#FFF8E8] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+              className="block w-full text-center rounded-full bg-[var(--ink)] text-[#FFF8E8] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
             >
-              Checkout
+              Checkout · {formatUSD(subtotal)}
             </Link>
             <Link
               href="/leafmart/cart"
               onClick={closeCart}
-              className="block w-full text-center mt-2 py-3 text-[13px] font-medium text-[var(--ink)] hover:text-[var(--leaf)] transition-colors"
+              className="block w-full text-center mt-2 py-2.5 text-[12.5px] font-medium text-[var(--ink)] hover:text-[var(--leaf)] transition-colors"
             >
               View full cart
             </Link>

--- a/src/components/leafmart/LeafmartProductCard.tsx
+++ b/src/components/leafmart/LeafmartProductCard.tsx
@@ -59,18 +59,18 @@ export function LeafmartProductCard({ product }: { product: LeafmartProduct }) {
         <p className="text-[13.5px] text-[var(--text-soft)] leading-relaxed flex-1">{p.support}</p>
         <div className="flex justify-between items-center mt-4 pt-3.5 border-t border-[var(--border)]">
           <div>
-            <div className="text-xs text-[var(--muted)] mb-0.5">{p.dose}</div>
-            <div className="text-xs text-[var(--leaf)] font-semibold flex items-center gap-1.5">
+            <div className="text-[11.5px] text-[var(--muted)] mb-0.5">{p.dose}</div>
+            <div className="text-[11.5px] text-[var(--leaf)] font-semibold flex items-center gap-1.5">
               <span className="w-1 h-1 rounded-full bg-[var(--leaf)]" />
               {p.pct}% helped · n={p.n}
             </div>
           </div>
-          <div className="flex items-center gap-3">
-            <span className="font-display text-[22px] font-medium text-[var(--ink)]">${p.price}</span>
+          <div className="flex items-center gap-2.5">
+            <span className="font-display text-[22px] font-medium text-[var(--ink)] tabular-nums">${p.price}</span>
             <button
               onClick={handleQuickAdd}
               aria-label={`Add ${p.name} to cart`}
-              className={`rounded-full w-[38px] h-[38px] flex items-center justify-center text-lg transition-all duration-300 ${
+              className={`group relative rounded-full w-[42px] h-[42px] flex items-center justify-center transition-all duration-300 ${
                 justAdded
                   ? "bg-[var(--leaf)] text-[#FFF8E8] scale-110"
                   : "bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] hover:scale-105"
@@ -81,7 +81,11 @@ export function LeafmartProductCard({ product }: { product: LeafmartProduct }) {
                   <path d="M3 8.5L6.5 12L13 4.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               ) : (
-                "+"
+                <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                  <path d="M3 3h1.5l.8 4m0 0L6.5 13h8l1.5-6H5.3z" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                  <circle cx="7.5" cy="15.5" r="1" fill="currentColor" />
+                  <circle cx="13" cy="15.5" r="1" fill="currentColor" />
+                </svg>
               )}
             </button>
           </div>

--- a/src/components/leafmart/ProductSilhouette.tsx
+++ b/src/components/leafmart/ProductSilhouette.tsx
@@ -2,9 +2,16 @@
 
 /**
  * SVG product silhouettes — the visual stand-in for product photography.
+ *
+ * TWO rendering modes:
+ *   • **full** (height ≥ 120px) — detailed shapes with labels, white info
+ *     panels, and fine detail lines. Used on product cards and PDP.
+ *   • **compact** (height < 120px) — bold simplified shapes stripped of
+ *     text, detail lines, and inner panels. Crisp at 48–72px for cart
+ *     drawer, checkout sidebar, and thumbnails.
+ *
  * Each shape is an abstracted, tactile bottle/can/jar/tin/serum/box that
- * reads at any size and sits on a pastel background. Based on the design
- * system field guide (leafmart-medvi.jsx L13-93).
+ * reads at any size and sits on a pastel background.
  */
 
 type Shape = "bottle" | "can" | "jar" | "tin" | "serum" | "box";
@@ -19,6 +26,175 @@ interface ProductSilhouetteProps {
   className?: string;
 }
 
+/* ─────────────────────────────────────────────────────────────────────────
+   Compact SVGs — bold shapes, no text, no detail lines.
+   ViewBox is 80×80 so every pixel counts at small sizes.
+   ───────────────────────────────────────────────────────────────────────── */
+
+function CompactBottle({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <rect x="32" y="8" width="16" height="8" rx="2" fill={deep} opacity="0.8" />
+      <rect x="35" y="4" width="10" height="6" rx="2" fill={deep} opacity="0.6" />
+      <path d="M26 20 Q26 16 30 16 H50 Q54 16 54 20 V68 Q54 74 48 74 H32 Q26 74 26 68 Z" fill={deep} />
+      <rect x="30" y="36" width="20" height="24" rx="2" fill="rgba(255,255,255,0.85)" />
+    </svg>
+  );
+}
+
+function CompactCan({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <ellipse cx="40" cy="12" rx="18" ry="4" fill={deep} opacity="0.6" />
+      <rect x="22" y="12" width="36" height="56" fill={deep} />
+      <ellipse cx="40" cy="68" rx="18" ry="4" fill={deep} opacity="0.8" />
+      <rect x="28" y="26" width="24" height="30" rx="2" fill="rgba(255,255,255,0.85)" />
+    </svg>
+  );
+}
+
+function CompactJar({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <rect x="22" y="20" width="36" height="10" rx="3" fill={deep} />
+      <rect x="20" y="28" width="40" height="44" rx="4" fill={deep} />
+      <rect x="26" y="38" width="28" height="24" rx="2" fill="rgba(255,255,255,0.85)" />
+      <circle cx="40" cy="62" r="4" fill="none" stroke={deep} strokeWidth="1.5" opacity="0.5" />
+    </svg>
+  );
+}
+
+function CompactTin({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <ellipse cx="40" cy="42" rx="28" ry="10" fill={deep} opacity="0.5" />
+      <rect x="12" y="42" width="56" height="22" fill={deep} />
+      <ellipse cx="40" cy="64" rx="28" ry="10" fill={deep} />
+      <ellipse cx="40" cy="42" rx="22" ry="7" fill="rgba(255,255,255,0.88)" />
+    </svg>
+  );
+}
+
+function CompactSerum({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <rect x="35" y="6" width="10" height="14" rx="2" fill={deep} opacity="0.75" />
+      <rect x="33" y="18" width="14" height="6" rx="1.5" fill={deep} />
+      <rect x="28" y="24" width="24" height="50" rx="4" fill={deep} />
+      <rect x="32" y="36" width="16" height="28" rx="2" fill="rgba(255,255,255,0.85)" />
+    </svg>
+  );
+}
+
+function CompactBox({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 80 80" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+      <rect x="16" y="18" width="48" height="54" rx="4" fill={deep} />
+      <rect x="22" y="28" width="36" height="34" rx="2" fill="rgba(255,255,255,0.88)" />
+      <circle cx="40" cy="58" r="4" fill={deep} opacity="0.35" />
+    </svg>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Full SVGs — detailed shapes with labels and fine detail lines.
+   Used at 120px+ on product cards, PDP, and category cards.
+   ───────────────────────────────────────────────────────────────────────── */
+
+function FullBottle({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <rect x="78" y="32" width="44" height="20" rx="3" fill={deep} />
+      <rect x="84" y="20" width="32" height="14" rx="3" fill={deep} opacity="0.85" />
+      <path d="M62 60 Q62 52 70 52 H130 Q138 52 138 60 V250 Q138 262 126 262 H74 Q62 262 62 250 Z" fill={deep} />
+      <rect x="74" y="120" width="52" height="92" rx="3" fill="rgba(255,255,255,0.85)" />
+      <rect x="80" y="132" width="40" height="2" fill={deep} opacity="0.5" />
+      <rect x="80" y="142" width="28" height="2" fill={deep} opacity="0.4" />
+      <rect x="80" y="180" width="20" height="6" fill={deep} opacity="0.6" />
+    </svg>
+  );
+}
+
+function FullCan({ deep, label }: { deep: string; label: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <ellipse cx="100" cy="44" rx="42" ry="8" fill={deep} opacity="0.7" />
+      <rect x="58" y="44" width="84" height="216" fill={deep} />
+      <ellipse cx="100" cy="260" rx="42" ry="8" fill={deep} opacity="0.85" />
+      <rect x="68" y="100" width="64" height="120" rx="3" fill="rgba(255,255,255,0.88)" />
+      <text x="100" y="148" textAnchor="middle" fontFamily="Fraunces" fontSize="20" fontWeight="500" fill={deep}>
+        {label || "still"}
+      </text>
+      <rect x="80" y="170" width="40" height="2" fill={deep} opacity="0.4" />
+      <rect x="86" y="180" width="28" height="2" fill={deep} opacity="0.3" />
+      <rect x="84" y="200" width="32" height="8" rx="2" fill={deep} opacity="0.55" />
+    </svg>
+  );
+}
+
+function FullJar({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <rect x="50" y="80" width="100" height="22" rx="4" fill={deep} />
+      <rect x="46" y="100" width="108" height="160" rx="6" fill={deep} />
+      <rect x="58" y="130" width="84" height="100" rx="3" fill="rgba(255,255,255,0.85)" />
+      <rect x="68" y="146" width="64" height="3" fill={deep} opacity="0.55" />
+      <rect x="68" y="158" width="48" height="3" fill={deep} opacity="0.4" />
+      <circle cx="100" cy="200" r="14" fill="none" stroke={deep} strokeWidth="2" opacity="0.6" />
+    </svg>
+  );
+}
+
+function FullTin({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <ellipse cx="100" cy="170" rx="80" ry="22" fill={deep} opacity="0.6" />
+      <rect x="20" y="170" width="160" height="60" fill={deep} />
+      <ellipse cx="100" cy="230" rx="80" ry="22" fill={deep} />
+      <ellipse cx="100" cy="170" rx="68" ry="16" fill="rgba(255,255,255,0.9)" />
+      <text x="100" y="175" textAnchor="middle" fontFamily="Fraunces" fontSize="14" fontWeight="500" fill={deep}>
+        field balm № 4
+      </text>
+    </svg>
+  );
+}
+
+function FullSerum({ deep }: { deep: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <rect x="86" y="20" width="28" height="40" rx="3" fill={deep} opacity="0.85" />
+      <rect x="82" y="56" width="36" height="14" rx="2" fill={deep} />
+      <rect x="68" y="70" width="64" height="190" rx="6" fill={deep} />
+      <rect x="78" y="120" width="44" height="110" rx="3" fill="rgba(255,255,255,0.88)" />
+      <text x="100" y="160" textAnchor="middle" fontFamily="Fraunces" fontSize="14" fontWeight="500" fill={deep}>
+        gold
+      </text>
+      <text x="100" y="178" textAnchor="middle" fontFamily="Fraunces" fontSize="11" fill={deep} opacity="0.7">
+        serum
+      </text>
+    </svg>
+  );
+}
+
+function FullBox({ deep, label }: { deep: string; label: string }) {
+  return (
+    <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
+      <rect x="40" y="80" width="120" height="170" rx="6" fill={deep} />
+      <rect x="52" y="110" width="96" height="120" rx="3" fill="rgba(255,255,255,0.9)" />
+      <text x="100" y="150" textAnchor="middle" fontFamily="Fraunces" fontSize="13" fontWeight="500" fill={deep}>
+        {label || "edibles"}
+      </text>
+      <rect x="68" y="170" width="64" height="2" fill={deep} opacity="0.45" />
+      <rect x="76" y="180" width="48" height="2" fill={deep} opacity="0.35" />
+      <circle cx="100" cy="210" r="8" fill={deep} opacity="0.4" />
+    </svg>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Main component — auto-switches between compact and full at 120px.
+   ───────────────────────────────────────────────────────────────────────── */
+
 export function ProductSilhouette({
   shape = "bottle",
   bg = "var(--sage)",
@@ -28,94 +204,33 @@ export function ProductSilhouette({
   big = false,
   className = "",
 }: ProductSilhouetteProps) {
+  const isCompact = height < 120;
+  const radius = isCompact ? Math.min(16, Math.round(height * 0.2)) : 28;
+  const pad = isCompact ? 6 : 24;
+  const innerWidth = isCompact ? "85%" : big ? "70%" : "62%";
+
   let svg: React.ReactNode;
-  switch (shape) {
-    case "bottle":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <rect x="78" y="32" width="44" height="20" rx="3" fill={deep} />
-          <rect x="84" y="20" width="32" height="14" rx="3" fill={deep} opacity="0.85" />
-          <path d="M62 60 Q62 52 70 52 H130 Q138 52 138 60 V250 Q138 262 126 262 H74 Q62 262 62 250 Z" fill={deep} />
-          <rect x="74" y="120" width="52" height="92" rx="3" fill="rgba(255,255,255,0.85)" />
-          <rect x="80" y="132" width="40" height="2" fill={deep} opacity="0.5" />
-          <rect x="80" y="142" width="28" height="2" fill={deep} opacity="0.4" />
-          <rect x="80" y="180" width="20" height="6" fill={deep} opacity="0.6" />
-        </svg>
-      );
-      break;
-    case "jar":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <rect x="50" y="80" width="100" height="22" rx="4" fill={deep} />
-          <rect x="46" y="100" width="108" height="160" rx="6" fill={deep} />
-          <rect x="58" y="130" width="84" height="100" rx="3" fill="rgba(255,255,255,0.85)" />
-          <rect x="68" y="146" width="64" height="3" fill={deep} opacity="0.55" />
-          <rect x="68" y="158" width="48" height="3" fill={deep} opacity="0.4" />
-          <circle cx="100" cy="200" r="14" fill="none" stroke={deep} strokeWidth="2" opacity="0.6" />
-        </svg>
-      );
-      break;
-    case "can":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <ellipse cx="100" cy="44" rx="42" ry="8" fill={deep} opacity="0.7" />
-          <rect x="58" y="44" width="84" height="216" fill={deep} />
-          <ellipse cx="100" cy="260" rx="42" ry="8" fill={deep} opacity="0.85" />
-          <rect x="68" y="100" width="64" height="120" rx="3" fill="rgba(255,255,255,0.88)" />
-          <text x="100" y="148" textAnchor="middle" fontFamily="Fraunces" fontSize="20" fontWeight="500" fill={deep}>
-            {label || "still"}
-          </text>
-          <rect x="80" y="170" width="40" height="2" fill={deep} opacity="0.4" />
-          <rect x="86" y="180" width="28" height="2" fill={deep} opacity="0.3" />
-          <rect x="84" y="200" width="32" height="8" rx="2" fill={deep} opacity="0.55" />
-        </svg>
-      );
-      break;
-    case "serum":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <rect x="86" y="20" width="28" height="40" rx="3" fill={deep} opacity="0.85" />
-          <rect x="82" y="56" width="36" height="14" rx="2" fill={deep} />
-          <rect x="68" y="70" width="64" height="190" rx="6" fill={deep} />
-          <rect x="78" y="120" width="44" height="110" rx="3" fill="rgba(255,255,255,0.88)" />
-          <text x="100" y="160" textAnchor="middle" fontFamily="Fraunces" fontSize="14" fontWeight="500" fill={deep}>
-            gold
-          </text>
-          <text x="100" y="178" textAnchor="middle" fontFamily="Fraunces" fontSize="11" fill={deep} opacity="0.7">
-            serum
-          </text>
-        </svg>
-      );
-      break;
-    case "tin":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <ellipse cx="100" cy="170" rx="80" ry="22" fill={deep} opacity="0.6" />
-          <rect x="20" y="170" width="160" height="60" fill={deep} />
-          <ellipse cx="100" cy="230" rx="80" ry="22" fill={deep} />
-          <ellipse cx="100" cy="170" rx="68" ry="16" fill="rgba(255,255,255,0.9)" />
-          <text x="100" y="175" textAnchor="middle" fontFamily="Fraunces" fontSize="14" fontWeight="500" fill={deep}>
-            field balm № 4
-          </text>
-        </svg>
-      );
-      break;
-    case "box":
-      svg = (
-        <svg viewBox="0 0 200 280" width="100%" height="100%" preserveAspectRatio="xMidYMax meet">
-          <rect x="40" y="80" width="120" height="170" rx="6" fill={deep} />
-          <rect x="52" y="110" width="96" height="120" rx="3" fill="rgba(255,255,255,0.9)" />
-          <text x="100" y="150" textAnchor="middle" fontFamily="Fraunces" fontSize="13" fontWeight="500" fill={deep}>
-            {label || "edibles"}
-          </text>
-          <rect x="68" y="170" width="64" height="2" fill={deep} opacity="0.45" />
-          <rect x="76" y="180" width="48" height="2" fill={deep} opacity="0.35" />
-          <circle cx="100" cy="210" r="8" fill={deep} opacity="0.4" />
-        </svg>
-      );
-      break;
-    default:
-      svg = <svg viewBox="0 0 200 280" />;
+
+  if (isCompact) {
+    switch (shape) {
+      case "bottle": svg = <CompactBottle deep={deep} />; break;
+      case "can":    svg = <CompactCan deep={deep} />;    break;
+      case "jar":    svg = <CompactJar deep={deep} />;    break;
+      case "tin":    svg = <CompactTin deep={deep} />;    break;
+      case "serum":  svg = <CompactSerum deep={deep} />;  break;
+      case "box":    svg = <CompactBox deep={deep} />;    break;
+      default:       svg = <svg viewBox="0 0 80 80" />;
+    }
+  } else {
+    switch (shape) {
+      case "bottle": svg = <FullBottle deep={deep} />;             break;
+      case "can":    svg = <FullCan deep={deep} label={label} />;  break;
+      case "jar":    svg = <FullJar deep={deep} />;                break;
+      case "tin":    svg = <FullTin deep={deep} />;                break;
+      case "serum":  svg = <FullSerum deep={deep} />;              break;
+      case "box":    svg = <FullBox deep={deep} label={label} />;  break;
+      default:       svg = <svg viewBox="0 0 200 280" />;
+    }
   }
 
   return (
@@ -123,22 +238,22 @@ export function ProductSilhouette({
       className={className}
       style={{
         background: bg,
-        borderRadius: 28,
+        borderRadius: radius,
         position: "relative",
         overflow: "hidden",
         height,
         display: "flex",
-        alignItems: "flex-end",
+        alignItems: isCompact ? "center" : "flex-end",
         justifyContent: "center",
-        padding: "0 24px",
+        padding: `0 ${pad}px`,
       }}
     >
       <div
         style={{
-          width: big ? "70%" : "62%",
-          height: "100%",
+          width: innerWidth,
+          height: isCompact ? "75%" : "100%",
           display: "flex",
-          alignItems: "flex-end",
+          alignItems: isCompact ? "center" : "flex-end",
           justifyContent: "center",
         }}
       >


### PR DESCRIPTION
## Visual Polish Sprint

### Root Fix: ProductSilhouette dual-mode rendering
The core issue: SVGs designed for 280px+ had fine details (2px lines, text labels) that collapsed into blobs at 48-72px thumbnail sizes.

**Solution:** Auto-switching between `compact` (80×80 viewBox, bold shapes, no text) and `full` (200×280 viewBox, detailed) at the 120px threshold. This single change fixes cart drawer, checkout sidebar, and confirmation receipt.

### Cart Drawer
- Compact silhouettes at 64px (crisp, not blobby)
- Free shipping progress bar
- Trash icon for remove action
- Quantity badges on thumbnails
- Subtotal in checkout button

### Checkout
- Animated SVG checkmark draws itself on confirmation
- Compact silhouettes in sidebar and receipt

### Product Cards
- 42px quick-add with cart icon SVG (was 38px `+`)
- tabular-nums on prices

### Homepage
- `text-balance` on headlines
- Category badges show '18 products'
- Larger decorative quotation marks (48-56px)

### CSS
- `draw-check`, `gentle-bounce`, `slide-out-right` keyframes
- `.text-balance`, `.price`, `.product-thumb` utilities
- Warm-tinted card shadows
- Wider eyebrow letter-spacing (2px)