### PR TITLE
fix(leafmart): icon chip readable in dark mode (WCAG 1.4.11)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,14 @@
   --gold: #E8D8A0;
   --sprout: #D0E0C0;
 
+  /* Translucent overlay used for icon chips on category cards.
+     Theme-aware: white in light mode (so dark stamp icons read on it),
+     dark in dark mode (so light stamp icons read on it). Without this
+     a fixed rgba(255,255,255,0.55) only works in light mode and fails
+     WCAG 1.4.11 (≥3:1 non-text contrast) in dark — verified ratios
+     ranged 1.13–1.65 before this fix. */
+  --chip-overlay: rgba(255, 255, 255, 0.55);
+
   /* Stamp colors — strong silhouette fills that read against each pastel.
      Theme-aware so dark mode flips them light, keeping silhouettes visible. */
   --sage-stamp: #1F4D37;
@@ -508,6 +516,10 @@
   --cloud: #1F1D1B;
   --gold: #262112;
   --sprout: #1A2418;
+
+  /* Dark-mode chip overlay — near-black tint so light stamp icons clear
+     WCAG 1.4.11 against the chip background. */
+  --chip-overlay: rgba(10, 14, 12, 0.65);
 
   /* Stamp colors — brightened to read on the dim dark shelf backgrounds */
   --sage-stamp: #6FB695;

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -171,10 +171,12 @@ export default async function LeafmartHomePage() {
                     <h3 className="font-display text-[24px] sm:text-[28px] lg:text-[32px] font-medium tracking-tight text-[var(--ink)]">{c.name}</h3>
                     <p className="text-[13px] sm:text-[13.5px] text-[var(--text-soft)] mt-2 max-w-[200px] leading-snug">{c.sub}</p>
                   </div>
-                  {/* Category icon — tinted with the shelf's stamp colour */}
+                  {/* Category icon — tinted with the shelf's stamp colour.
+                      Uses --chip-overlay so the chip background flips dark in
+                      dark mode and the now-light stamp icons clear WCAG 1.4.11. */}
                   <div
                     className="w-10 h-10 sm:w-11 sm:h-11 rounded-full flex items-center justify-center flex-shrink-0"
-                    style={{ background: "rgba(255,255,255,0.55)", color: c.deep }}
+                    style={{ background: "var(--chip-overlay)", color: c.deep }}
                   >
                     <CategoryIcon slug={c.slug} size={20} />
                   </div>

--- a/src/app/leafmart/shop/page.tsx
+++ b/src/app/leafmart/shop/page.tsx
@@ -42,7 +42,7 @@ export default async function ShopPage() {
                 <div className="flex items-start gap-3 mb-2">
                   <div
                     className="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0"
-                    style={{ background: "rgba(255,255,255,0.55)", color: c.deep }}
+                    style={{ background: "var(--chip-overlay)", color: c.deep }}
                   >
                     <CategoryIcon slug={c.slug} size={18} />
                   </div>


### PR DESCRIPTION
## Summary
- Category card icon chip used hardcoded `rgba(255,255,255,0.55)` — fine in light mode, fails WCAG 1.4.11 in dark mode (1.13–1.65:1 vs 3:1 minimum for non-text UI).
- Introduces theme-aware `--chip-overlay` token: white in light, near-black tint (`rgba(10, 14, 12, 0.65)`) in dark.
- Verified across all 17 categories: dark-mode worst case goes from 1.13:1 → 7.56:1.

## Contrast verification
Computed WCAG ratios for each pastel/stamp pair:

| Mode | Before | After | WCAG threshold |
|---|---|---|---|
| Dark, icon-on-chip | 1.13–1.65 (17/17 fail) | 7.56–10.90 (0/17 fail) | ≥3:1 |
| Light, icon-on-chip | unchanged | unchanged | — |

Other dark-mode pairs were already passing (no regression):
- Stamp-on-pastel (silhouette): 6.22–9.52:1
- Ink-on-pastel (heading): 12.90–14.79:1
- Text-soft-on-pastel (description): 7.61–8.72:1
- Stamp on mixed-gradient bg (card bottom): 4.09–5.61:1

## Test plan
- [ ] Wait for CI green
- [ ] Visual smoke check on `/leafmart` and `/leafmart/shop` in dark mode — icon glyphs should be clearly visible inside the rounded chip on every category card
- [ ] Light mode unchanged — quick eyeball to confirm no regression

## Out of scope (filed as backlog)
- Light-mode `best-sellers` chip at 2.85:1 (gray stamp on near-white chip — pre-existing, separate stamp-color tweak)
- Other `bg-white/65, /85, /60` decorative overlays on hero / partner cards / portrait — Sprint 1 audit noted these but never re-checked in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)