### PR TITLE
fix(leafmart): dark mode button contrast

### DIFF
--- a/src/app/leafmart/about/page.tsx
+++ b/src/app/leafmart/about/page.tsx
@@ -66,7 +66,7 @@ export default function AboutPage() {
           <div className="mt-6 sm:mt-8">
             <Link
               href="/leafmart/shop"
-              className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] transition-colors px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] w-full sm:w-auto"
+              className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] transition-colors px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] w-full sm:w-auto"
             >
               Browse the shelf →
             </Link>

--- a/src/app/leafmart/account/addresses/page.tsx
+++ b/src/app/leafmart/account/addresses/page.tsx
@@ -169,7 +169,7 @@ export default function AddressesPage() {
           <button
             type="button"
             onClick={startCreate}
-            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
+            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
           >
             Add address
           </button>
@@ -189,7 +189,7 @@ export default function AddressesPage() {
               </p>
               <Link
                 href="/leafmart/login?next=/leafmart/account/addresses"
-                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors mt-3"
+                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors mt-3"
               >
                 Sign in
               </Link>
@@ -308,7 +308,7 @@ export default function AddressesPage() {
                 <button
                   type="submit"
                   disabled={saving}
-                  className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-50"
+                  className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-50"
                 >
                   {saving ? "Saving…" : editing ? "Save changes" : "Add address"}
                 </button>
@@ -334,7 +334,7 @@ export default function AddressesPage() {
               <button
                 type="button"
                 onClick={startCreate}
-                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
+                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
               >
                 Add your first address
               </button>

--- a/src/app/leafmart/account/orders/[id]/page.tsx
+++ b/src/app/leafmart/account/orders/[id]/page.tsx
@@ -151,13 +151,13 @@ export default async function OrderDetailPage({
             <div className="flex flex-col gap-2">
               <Link
                 href="/leafmart/account/outcomes"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--leaf)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--ink)] transition-colors"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--leaf)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--ink)] transition-colors"
               >
                 Log an outcome
               </Link>
               <Link
                 href="/leafmart/account/orders"
-                className="inline-flex items-center justify-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors"
+                className="inline-flex items-center justify-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors"
               >
                 Back to orders
               </Link>

--- a/src/app/leafmart/account/orders/page.tsx
+++ b/src/app/leafmart/account/orders/page.tsx
@@ -124,7 +124,7 @@ export default async function OrderHistoryPage() {
               </p>
               <Link
                 href="/leafmart/shop"
-                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
+                className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
               >
                 Browse the shop
               </Link>
@@ -189,7 +189,7 @@ export default async function OrderHistoryPage() {
                 <div className="flex flex-wrap gap-3">
                   <button
                     type="button"
-                    className="inline-flex items-center rounded-full font-medium border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors"
+                    className="inline-flex items-center rounded-full font-medium border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors"
                     style={{ padding: "10px 20px", fontSize: 13.5 }}
                   >
                     Reorder

--- a/src/app/leafmart/account/outcomes/page.tsx
+++ b/src/app/leafmart/account/outcomes/page.tsx
@@ -190,7 +190,7 @@ export default function OutcomesPage() {
                           type="button"
                           onClick={() => submit(product.slug)}
                           disabled={d.rating === 0}
-                          className="inline-flex items-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[#FFF8E8] hover:bg-[var(--ink)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="inline-flex items-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[var(--bg)] hover:bg-[var(--ink)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                           style={{ padding: "10px 20px", fontSize: 13.5 }}
                         >
                           Log outcome

--- a/src/app/leafmart/account/page.tsx
+++ b/src/app/leafmart/account/page.tsx
@@ -165,7 +165,7 @@ export default async function AccountDashboardPage() {
             <div className="flex flex-col gap-3">
               <Link
                 href="/leafmart/consult"
-                className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[#FFF8E8] hover:bg-[var(--ink)] transition-colors"
+                className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[var(--bg)] hover:bg-[var(--ink)] transition-colors"
                 style={{ padding: "14px 28px", fontSize: 15 }}
               >
                 Connect to Leafjourney

--- a/src/app/leafmart/cart/page.tsx
+++ b/src/app/leafmart/cart/page.tsx
@@ -74,13 +74,13 @@ export default function CartPage() {
         <div className="flex flex-wrap gap-3">
           <Link
             href="/leafmart/shop"
-            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
           >
             Browse the shop
           </Link>
           <Link
             href="/leafmart/quiz"
-            className="inline-flex items-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors"
+            className="inline-flex items-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors"
           >
             Take the quiz
           </Link>
@@ -270,7 +270,7 @@ export default function CartPage() {
           </div>
           <Link
             href="/leafmart/checkout"
-            className="mt-6 block w-full text-center rounded-full bg-[var(--ink)] text-[#FFF8E8] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            className="mt-6 block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
           >
             Continue to checkout
           </Link>

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -145,9 +145,9 @@ function StepIndicator({ active }: { active: StepIndex }) {
               <span
                 className={`w-7 h-7 rounded-full flex items-center justify-center text-[12px] font-semibold tabular-nums transition-all duration-300 relative z-10 ${
                   isActive
-                    ? "bg-[var(--ink)] text-[#FFF8E8] scale-110 shadow-[0_0_0_4px_var(--bg)]"
+                    ? "bg-[var(--ink)] text-[var(--bg)] scale-110 shadow-[0_0_0_4px_var(--bg)]"
                     : isDone
-                      ? "bg-[var(--leaf)] text-[#FFF8E8] shadow-[0_0_0_4px_var(--bg)]"
+                      ? "bg-[var(--leaf)] text-[var(--bg)] shadow-[0_0_0_4px_var(--bg)]"
                       : "bg-[var(--surface-muted)] text-[var(--muted)] shadow-[0_0_0_4px_var(--bg)]"
                 }`}
               >
@@ -422,7 +422,7 @@ export default function CheckoutPage() {
         </p>
         <Link
           href="/leafmart/shop"
-          className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+          className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
         >
           Browse the shop
         </Link>
@@ -512,13 +512,13 @@ export default function CheckoutPage() {
         <div className="mt-10 flex flex-wrap gap-3">
           <Link
             href="/leafmart/shop"
-            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            className="inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
           >
             Keep shopping
           </Link>
           <Link
             href="/leafmart"
-            className="inline-flex items-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors"
+            className="inline-flex items-center rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-7 py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors"
           >
             Back to home
           </Link>
@@ -833,8 +833,8 @@ export default function CheckoutPage() {
               disabled={isProcessing}
               className={`inline-flex items-center gap-2 rounded-full px-7 py-3.5 text-[14px] font-medium tracking-wide transition-all duration-300 ${
                 isProcessing
-                  ? "bg-[var(--leaf)] text-[#FFF8E8] cursor-wait"
-                  : "bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)]"
+                  ? "bg-[var(--leaf)] text-[var(--bg)] cursor-wait"
+                  : "bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)]"
               }`}
             >
               {isProcessing ? (
@@ -859,7 +859,7 @@ export default function CheckoutPage() {
               <li key={product.slug} className="py-3 flex items-center gap-3">
                 <div className="w-12 h-12 rounded-xl flex-shrink-0 overflow-hidden relative">
                   <ProductSilhouette shape={product.shape} bg={product.bg} deep={product.deep} height={48} />
-                  <span className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[#FFF8E8] text-[10px] font-semibold rounded-full w-5 h-5 flex items-center justify-center tabular-nums">
+                  <span className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[var(--bg)] text-[10px] font-semibold rounded-full w-5 h-5 flex items-center justify-center tabular-nums">
                     {quantity}
                   </span>
                 </div>

--- a/src/app/leafmart/consult/page.tsx
+++ b/src/app/leafmart/consult/page.tsx
@@ -72,14 +72,14 @@ export default function ConsultPage() {
             <div className="flex flex-wrap items-center gap-3 mb-8">
               <Link
                 href="/portal/schedule"
-                className="inline-flex items-center rounded-full font-medium tracking-wide bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] transition-colors"
+                className="inline-flex items-center rounded-full font-medium tracking-wide bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] transition-colors"
                 style={{ padding: "16px 28px", fontSize: 15 }}
               >
                 Book a consultation
               </Link>
               <Link
                 href="#how-it-works"
-                className="inline-flex items-center rounded-full font-medium border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors"
+                className="inline-flex items-center rounded-full font-medium border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors"
                 style={{ padding: "16px 28px", fontSize: 15 }}
               >
                 How it works
@@ -156,7 +156,7 @@ export default function ConsultPage() {
           </div>
           <Link
             href="/portal/schedule"
-            className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[#FFF8E8] hover:bg-[var(--ink)] transition-colors whitespace-nowrap"
+            className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[var(--bg)] hover:bg-[var(--ink)] transition-colors whitespace-nowrap"
             style={{ padding: "16px 32px", fontSize: 15 }}
           >
             Book a consultation

--- a/src/app/leafmart/dosing-guide/[slug]/page.tsx
+++ b/src/app/leafmart/dosing-guide/[slug]/page.tsx
@@ -210,7 +210,7 @@ export default function DosingGuidePage({ params }: { params: { slug: string } }
           </div>
           <Link
             href="/leafmart/account/outcomes"
-            className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[#FFF8E8] hover:bg-[var(--ink)] transition-colors whitespace-nowrap px-7 sm:px-8 py-4 text-[14.5px] sm:text-[15px] w-full lg:w-auto"
+            className="inline-flex items-center justify-center rounded-full font-medium tracking-wide bg-[var(--leaf)] text-[var(--bg)] hover:bg-[var(--ink)] transition-colors whitespace-nowrap px-7 sm:px-8 py-4 text-[14.5px] sm:text-[15px] w-full lg:w-auto"
           >
             Log your outcome
           </Link>

--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -47,8 +47,8 @@ function Pill({
       href={href}
       className={`inline-flex items-center justify-center rounded-full font-medium tracking-wide transition-colors px-6 sm:px-7 py-3.5 sm:py-4 text-[14.5px] sm:text-[15px] ${
         primary
-          ? "bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)]"
-          : "border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[#FFF8E8]"
+          ? "bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] hover:text-[var(--bg)]"
+          : "border-[1.5px] border-[var(--ink)] text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--bg)]"
       } ${className}`}
     >
       {children}

--- a/src/app/leafmart/quiz/page.tsx
+++ b/src/app/leafmart/quiz/page.tsx
@@ -73,13 +73,13 @@ export default function QuizPage() {
         <div className="mt-10 sm:mt-12 flex flex-col sm:flex-row sm:flex-wrap sm:justify-center gap-3 sm:gap-3.5">
           <button
             onClick={() => { setStep(0); setAnswers([]); }}
-            className="rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] font-medium hover:bg-[var(--ink)] hover:text-[#FFF8E8] transition-colors w-full sm:w-auto"
+            className="rounded-full border-[1.5px] border-[var(--ink)] text-[var(--ink)] px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] font-medium hover:bg-[var(--ink)] hover:text-[var(--bg)] transition-colors w-full sm:w-auto"
           >
             Retake the quiz
           </button>
           <Link
             href="/leafmart/products"
-            className="rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] font-medium hover:bg-[var(--leaf)] transition-colors w-full sm:w-auto inline-flex items-center justify-center"
+            className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px] font-medium hover:bg-[var(--leaf)] transition-colors w-full sm:w-auto inline-flex items-center justify-center"
           >
             Browse all products →
           </Link>
@@ -131,7 +131,7 @@ export default function QuizPage() {
         {step > 0 && (
           <button
             onClick={() => { setStep(step - 1); setAnswers(answers.slice(0, -1)); }}
-            className="mt-5 sm:mt-6 text-sm text-[rgba(255,248,232,0.6)] hover:text-[#FFF8E8] transition-colors"
+            className="mt-5 sm:mt-6 text-sm text-[rgba(255,248,232,0.6)] hover:text-[var(--bg)] transition-colors"
           >
             ← Go back
           </button>

--- a/src/app/leafmart/search/search-client.tsx
+++ b/src/app/leafmart/search/search-client.tsx
@@ -52,7 +52,7 @@ function MultiFilterRow<T extends { slug: string; name: string }>({
               className={
                 "rounded-full px-4 py-1.5 text-[12.5px] font-medium border transition-colors " +
                 (selected
-                  ? "bg-[var(--ink)] text-[#FFF8E8] border-[var(--ink)]"
+                  ? "bg-[var(--ink)] text-[var(--bg)] border-[var(--ink)]"
                   : "bg-[var(--surface)] text-[var(--ink)] border-[var(--border)] hover:border-[var(--leaf)]")
               }
             >
@@ -78,7 +78,7 @@ function NoResults({ onReset }: { onReset: () => void }) {
         <button
           type="button"
           onClick={onReset}
-          className="inline-flex items-center rounded-full font-medium bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] transition-colors px-5 py-3 text-[14px]"
+          className="inline-flex items-center rounded-full font-medium bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] transition-colors px-5 py-3 text-[14px]"
         >
           Clear filters
         </button>

--- a/src/app/leafmart/shop/page.tsx
+++ b/src/app/leafmart/shop/page.tsx
@@ -67,7 +67,7 @@ export default async function ShopPage() {
         <div className="mt-8 sm:mt-10 text-center">
           <Link
             href="/leafmart/products"
-            className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] transition-colors w-full sm:w-auto px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px]"
+            className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] transition-colors w-full sm:w-auto px-6 py-3.5 sm:py-3 text-[14.5px] sm:text-[15px]"
           >
             Browse all products →
           </Link>

--- a/src/components/leafmart/AccountAuthFallback.tsx
+++ b/src/components/leafmart/AccountAuthFallback.tsx
@@ -10,7 +10,7 @@ export function AccountAuthFallback({ mode }: { mode: "signin" | "signup" }) {
       </p>
       <Link
         href={mode === "signin" ? "/login" : "/sign-up"}
-        className="inline-flex items-center justify-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
+        className="inline-flex items-center justify-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[14px] font-medium hover:bg-[var(--leaf)] transition-colors"
       >
         Continue to legacy {mode === "signin" ? "sign-in" : "sign-up"}
       </Link>

--- a/src/components/leafmart/CartDrawer.tsx
+++ b/src/components/leafmart/CartDrawer.tsx
@@ -179,7 +179,7 @@ export function CartDrawer() {
               <Link
                 href="/leafmart/shop"
                 onClick={closeCart}
-                className="mt-2 inline-flex items-center rounded-full bg-[var(--ink)] text-[#FFF8E8] px-6 py-3 text-[13px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+                className="mt-2 inline-flex items-center rounded-full bg-[var(--ink)] text-[var(--bg)] px-6 py-3 text-[13px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
               >
                 Browse the shop
               </Link>
@@ -202,7 +202,7 @@ export function CartDrawer() {
                       {quantity > 1 && (
                         <span
                           key={`badge-${product.slug}-${tk}`}
-                          className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[#FFF8E8] text-[10px] font-bold rounded-full w-[18px] h-[18px] flex items-center justify-center tabular-nums shadow-sm lm-count-tick"
+                          className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[var(--bg)] text-[10px] font-bold rounded-full w-[18px] h-[18px] flex items-center justify-center tabular-nums shadow-sm lm-count-tick"
                         >
                           {quantity}
                         </span>
@@ -279,7 +279,7 @@ export function CartDrawer() {
             <Link
               href="/leafmart/checkout"
               onClick={closeCart}
-              className="block w-full text-center rounded-full bg-[var(--ink)] text-[#FFF8E8] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+              className="block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
             >
               Checkout · {formatUSD(subtotal)}
             </Link>

--- a/src/components/leafmart/LeafmartFooter.tsx
+++ b/src/components/leafmart/LeafmartFooter.tsx
@@ -124,7 +124,7 @@ function NewsletterSignup() {
         <button
           type="submit"
           disabled={status === "submitting"}
-          className="rounded-full bg-[var(--ink)] text-[#FFF8E8] px-5 py-2.5 text-[13px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-5 py-2.5 text-[13px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
         >
           {status === "submitting" ? "Joining…" : "Join"}
         </button>

--- a/src/components/leafmart/LeafmartHeader.tsx
+++ b/src/components/leafmart/LeafmartHeader.tsx
@@ -46,7 +46,7 @@ function CartBadgeButton({
           Cart
         </span>
         {itemCount > 0 && (
-          <span className="bg-[var(--leaf)] text-[#FFF8E8] text-[11px] font-bold rounded-full w-[22px] h-[22px] flex items-center justify-center tabular-nums">
+          <span className="bg-[var(--leaf)] text-[var(--bg)] text-[11px] font-bold rounded-full w-[22px] h-[22px] flex items-center justify-center tabular-nums">
             {itemCount > 99 ? "99+" : itemCount}
           </span>
         )}
@@ -64,7 +64,7 @@ function CartBadgeButton({
       {itemCount > 0 && (
         <span
           aria-hidden="true"
-          className="absolute -top-0.5 -right-0.5 bg-[var(--leaf)] text-[#FFF8E8] text-[10px] font-bold rounded-full min-w-[18px] h-[18px] px-1 flex items-center justify-center tabular-nums"
+          className="absolute -top-0.5 -right-0.5 bg-[var(--leaf)] text-[var(--bg)] text-[10px] font-bold rounded-full min-w-[18px] h-[18px] px-1 flex items-center justify-center tabular-nums"
           style={{ animation: "lmFadeInUp 280ms cubic-bezier(0.2, 0, 0, 1)" }}
         >
           {itemCount > 99 ? "99+" : itemCount}
@@ -183,7 +183,7 @@ export function LeafmartHeader() {
           <CartBadgeButton />
           <Link
             href="/leafmart/quiz"
-            className="bg-[var(--ink)] text-[#FFF8E8] rounded-full px-[18px] py-[10px] text-[13px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            className="bg-[var(--ink)] text-[var(--bg)] rounded-full px-[18px] py-[10px] text-[13px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
           >
             Take the quiz
           </Link>
@@ -296,7 +296,7 @@ export function LeafmartHeader() {
           <Link
             href="/leafmart/quiz"
             onClick={() => setOpen(false)}
-            className="mt-6 inline-flex items-center justify-center bg-[var(--ink)] text-[#FFF8E8] rounded-full px-6 py-4 text-[15px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors lm-fade-in"
+            className="mt-6 inline-flex items-center justify-center bg-[var(--ink)] text-[var(--bg)] rounded-full px-6 py-4 text-[15px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors lm-fade-in"
             style={{ animationDelay: open ? "360ms" : "0ms" }}
           >
             Take the quiz →

--- a/src/components/leafmart/LeafmartProductCard.tsx
+++ b/src/components/leafmart/LeafmartProductCard.tsx
@@ -107,8 +107,8 @@ export function LeafmartProductCard({ product }: { product: LeafmartProduct }) {
               aria-label={`Add ${p.name} to cart`}
               className={`group relative rounded-full w-[42px] h-[42px] flex items-center justify-center transition-all duration-300 ${
                 justAdded
-                  ? "bg-[var(--leaf)] text-[#FFF8E8] scale-110"
-                  : "bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] hover:scale-105"
+                  ? "bg-[var(--leaf)] text-[var(--bg)] scale-110"
+                  : "bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] hover:scale-105"
               }`}
             >
               {justAdded ? (

--- a/src/components/leafmart/ProductDetailClient.tsx
+++ b/src/components/leafmart/ProductDetailClient.tsx
@@ -199,8 +199,8 @@ export function ProductDetailClient({ product, related }: Props) {
                     !inStock
                       ? "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
                       : added
-                        ? "bg-[var(--leaf)] text-[#FFF8E8] scale-[1.02]"
-                        : "bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)]"
+                        ? "bg-[var(--leaf)] text-[var(--bg)] scale-[1.02]"
+                        : "bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)]"
                   }`}
                 >
                   {!inStock ? (

--- a/src/components/leafmart/ProductReviews.tsx
+++ b/src/components/leafmart/ProductReviews.tsx
@@ -124,7 +124,7 @@ export function ProductReviews({ reviews, averageRating, reviewCount }: Props) {
                   onClick={() => setSort(s.id)}
                   className={`px-3 py-1.5 rounded-full text-[11.5px] font-medium transition-colors ${
                     sort === s.id
-                      ? "bg-[var(--ink)] text-[#FFF8E8]"
+                      ? "bg-[var(--ink)] text-[var(--bg)]"
                       : "text-[var(--text-soft)] hover:text-[var(--ink)]"
                   }`}
                 >

--- a/src/components/leafmart/VariantSelector.tsx
+++ b/src/components/leafmart/VariantSelector.tsx
@@ -31,7 +31,7 @@ export function VariantSelector({ variants, selectedId, onSelect }: Props) {
                 disabled
                   ? "border-[var(--border)] text-[var(--muted)] line-through cursor-not-allowed"
                   : selected
-                    ? "bg-[var(--ink)] text-[#FFF8E8] border-[var(--ink)] scale-[1.02]"
+                    ? "bg-[var(--ink)] text-[var(--bg)] border-[var(--ink)] scale-[1.02]"
                     : "bg-[var(--surface)] text-[var(--text)] border-[var(--border)] hover:border-[var(--ink)]"
               }`}
             >

--- a/src/components/leafmart/VendorApplicationForm.tsx
+++ b/src/components/leafmart/VendorApplicationForm.tsx
@@ -247,7 +247,7 @@ export function VendorApplicationForm() {
                 className={
                   "inline-flex items-center gap-2 cursor-pointer rounded-full px-4 py-2 text-[13px] font-medium border transition-colors " +
                   (checked
-                    ? "bg-[var(--ink)] text-[#FFF8E8] border-[var(--ink)]"
+                    ? "bg-[var(--ink)] text-[var(--bg)] border-[var(--ink)]"
                     : "bg-[var(--surface)] text-[var(--ink)] border-[var(--border)] hover:border-[var(--leaf)]")
                 }
               >
@@ -280,7 +280,7 @@ export function VendorApplicationForm() {
                 className={
                   "inline-flex items-center gap-2 cursor-pointer rounded-full px-5 py-2.5 text-[13.5px] font-medium border transition-colors " +
                   (selected
-                    ? "bg-[var(--leaf)] text-[#FFF8E8] border-[var(--leaf)]"
+                    ? "bg-[var(--leaf)] text-[var(--bg)] border-[var(--leaf)]"
                     : "bg-[var(--surface)] text-[var(--ink)] border-[var(--border)] hover:border-[var(--leaf)]")
                 }
               >
@@ -320,7 +320,7 @@ export function VendorApplicationForm() {
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[#FFF8E8] hover:bg-[var(--leaf)] transition-colors px-6 sm:px-7 py-3.5 sm:py-4 text-[14.5px] sm:text-[15px] disabled:opacity-60 disabled:cursor-not-allowed w-full sm:w-auto"
+          className="inline-flex items-center justify-center rounded-full font-medium bg-[var(--ink)] text-[var(--bg)] hover:bg-[var(--leaf)] transition-colors px-6 sm:px-7 py-3.5 sm:py-4 text-[14.5px] sm:text-[15px] disabled:opacity-60 disabled:cursor-not-allowed w-full sm:w-auto"
         >
           {submitting ? (
             <>


### PR DESCRIPTION
## Problem
In dark mode, `--ink` flips to near-white (`#F1EFE8`). Buttons using `bg-[var(--ink)] text-[#FFF8E8]` became white-on-white — **completely invisible**.

## Fix
Replaced all `text-[#FFF8E8]` with `text-[var(--bg)]` on ink-background buttons. `--bg` auto-inverts with the theme (`#FFFCF7` light → `#0F1210` dark), guaranteeing contrast.

**23 files, 52 swaps, zero functional changes.**

Remaining 9 instances are intentional (quiz on green bg, Clerk theme strings).