### PR TITLE
feat(seo): leafjourney marketing — JSON-LD, meta tags, OG, sitemap

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,12 +1,24 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Wordmark } from "@/components/ui/logo";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { SITE_URL } from "@/lib/seo";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "About — Leafjourney",
   description:
     "Meet the founders behind Leafjourney: visionaries rebuilding healthcare from the ground up.",
+  alternates: { canonical: `${SITE_URL}/about` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "About — Leafjourney",
+    description:
+      "Meet the founders behind Leafjourney: visionaries rebuilding healthcare from the ground up.",
+    url: `${SITE_URL}/about`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
 };
 
 const FOUNDERS = [

--- a/src/app/developer/page.tsx
+++ b/src/app/developer/page.tsx
@@ -3,8 +3,25 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow } from "@/components/ui/ornament";
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/seo";
 
-export const metadata = { title: "Developers — Leafjourney" };
+// /developer is disallowed in robots.txt — keep the layout's noindex
+// default. Still ship rich metadata for direct shares (Slack, email).
+export const metadata: Metadata = {
+  title: "Developers — Leafjourney",
+  description:
+    "API references, integration guides, and SDK docs for building on the Leafjourney platform.",
+  alternates: { canonical: `${SITE_URL}/developer` },
+  openGraph: {
+    title: "Developers — Leafjourney",
+    description:
+      "API references, integration guides, and SDK docs for building on the Leafjourney platform.",
+    url: `${SITE_URL}/developer`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
 
 export default function DeveloperPortalPage() {
   return (

--- a/src/app/education/layout.tsx
+++ b/src/app/education/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * The /education page is a client component (`"use client"`) so it cannot
+ * declare its own `metadata`. This layout supplies it, and Next.js merges
+ * the per-page metadata with the root layout's defaults.
+ */
+export const metadata: Metadata = {
+  title: "Education — Leafjourney",
+  description:
+    "ChatCB, the cannabinoid wheel, drug interaction checker, and curated PubMed research — all in one place. Built for clinicians and patients.",
+  alternates: { canonical: `${SITE_URL}/education` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Education — Leafjourney",
+    description:
+      "Conversational cannabis search engine with PubMed integration, terpene/cannabinoid wheel, and drug interaction checker.",
+    url: `${SITE_URL}/education`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function EducationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -25,11 +25,11 @@ import { askChatCB, searchPubMedArticles, type ChatCBResponse, type PubMedSearch
 type Tab = "chatcb" | "wheel" | "drugmix" | "research" | "learn";
 
 const TABS: { key: Tab; label: string; icon: string }[] = [
-  { key: "chatcb", label: "ChatCB", icon: "AI" },
-  { key: "wheel", label: "Cannabis Wheel", icon: "W" },
-  { key: "drugmix", label: "Drug Mix", icon: "Rx" },
-  { key: "research", label: "Research", icon: "R" },
-  { key: "learn", label: "Learn", icon: "L" },
+  { key: "chatcb", label: "ChatCB", icon: "✦" },
+  { key: "wheel", label: "Cannabis Wheel", icon: "⚛" },
+  { key: "drugmix", label: "Drug Mix", icon: "℞" },
+  { key: "research", label: "Research", icon: "📚" },
+  { key: "learn", label: "Learn", icon: "🎓" },
 ];
 
 const SUGGESTED_QUESTIONS = [
@@ -208,7 +208,7 @@ function ChatCBTab() {
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
                 placeholder="Ask anything about cannabis medicine..."
-                className="w-full h-14 rounded-2xl border border-border-strong bg-white pl-5 pr-14 text-base text-text shadow-sm focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+                className="w-full h-14 rounded-2xl border border-border-strong bg-surface pl-5 pr-14 text-base text-text shadow-sm focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
               />
               <button
                 onClick={() => handleSubmit()}
@@ -226,7 +226,7 @@ function ChatCBTab() {
               <button
                 key={q}
                 onClick={() => handleSubmit(q)}
-                className="text-sm px-4 py-2 rounded-full border border-border bg-white text-text-muted hover:border-accent hover:text-accent transition-colors"
+                className="text-sm px-4 py-2 rounded-full border border-border bg-surface text-text-muted hover:border-accent hover:text-accent transition-colors"
               >
                 {q}
               </button>
@@ -242,7 +242,7 @@ function ChatCBTab() {
                 "max-w-[85%] rounded-2xl px-5 py-4",
                 msg.role === "user"
                   ? "bg-accent text-white"
-                  : "bg-white border border-border shadow-sm"
+                  : "bg-surface border border-border shadow-sm"
               )}>
                 <p className={cn(
                   "text-sm leading-relaxed whitespace-pre-wrap",
@@ -276,7 +276,7 @@ function ChatCBTab() {
 
           {loading && (
             <div className="flex justify-start">
-              <div className="bg-white border border-border rounded-2xl px-5 py-4 shadow-sm">
+              <div className="bg-surface border border-border rounded-2xl px-5 py-4 shadow-sm">
                 <div className="flex items-center gap-2 text-sm text-text-muted">
                   <span className="animate-pulse">Researching</span>
                   <span className="animate-bounce">...</span>
@@ -298,7 +298,7 @@ function ChatCBTab() {
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
               placeholder="Ask a follow-up..."
-              className="w-full h-14 rounded-2xl border border-border-strong bg-white pl-5 pr-14 text-base text-text shadow-md focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              className="w-full h-14 rounded-2xl border border-border-strong bg-surface pl-5 pr-14 text-base text-text shadow-md focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
             />
             <button
               onClick={() => handleSubmit()}
@@ -402,7 +402,7 @@ function DrugMixTab() {
             onChange={(e) => setMeds(e.target.value)}
             placeholder="Enter one medication per line, e.g.:\nWarfarin\nMetformin\nLisinopril"
             rows={5}
-            className="w-full rounded-xl border border-border-strong bg-white px-4 py-3 text-base text-text focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+            className="w-full rounded-xl border border-border-strong bg-surface px-4 py-3 text-base text-text focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
           />
           <Button onClick={checkMix} disabled={!meds.trim()} className="mt-4 rounded-xl w-full">
             Check interactions
@@ -501,7 +501,7 @@ function ResearchTab() {
               onChange={(e) => setPubmedQuery(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handlePubmedSearch()}
               placeholder="Search PubMed for cannabis research..."
-              className="flex-1 h-12 rounded-xl border border-border-strong bg-white px-4 text-base text-text focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              className="flex-1 h-12 rounded-xl border border-border-strong bg-surface px-4 text-base text-text focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
             />
             <Button
               onClick={handlePubmedSearch}
@@ -569,7 +569,7 @@ function ResearchTab() {
         <select
           value={cannabinoidFilter}
           onChange={(e) => setCannabinoidFilter(e.target.value)}
-          className="rounded-xl border border-border-strong bg-white px-4 h-10 text-sm text-text"
+          className="rounded-xl border border-border-strong bg-surface px-4 h-10 text-sm text-text"
         >
           <option value="">All cannabinoids</option>
           {cannabinoids.map((c) => <option key={c} value={c}>{c}</option>)}
@@ -577,7 +577,7 @@ function ResearchTab() {
         <select
           value={conditionFilter}
           onChange={(e) => setConditionFilter(e.target.value)}
-          className="rounded-xl border border-border-strong bg-white px-4 h-10 text-sm text-text"
+          className="rounded-xl border border-border-strong bg-surface px-4 h-10 text-sm text-text"
         >
           <option value="">All conditions</option>
           {conditions.map((c) => <option key={c} value={c}>{c}</option>)}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,172 @@
+import { ImageResponse } from "next/og";
+
+/**
+ * Default OG image for the Leafjourney marketing site.
+ * Used by `/`, `/about`, `/security`, etc. unless a page declares its
+ * own `opengraph-image.tsx`. The Leafmart storefront has its own
+ * per-product OG generator at `app/leafmart/products/[slug]/opengraph-image.tsx`.
+ *
+ * Edge runtime — pure ImageResponse with no DB or filesystem reads.
+ * `next/og` does not have access to CSS custom properties, so the design
+ * tokens are inlined as hex literals. Keep these in sync with `globals.css`
+ * (light-mode `.theme-leafmart` block).
+ */
+
+export const runtime = "edge";
+export const alt = "Leafjourney — AI-native cannabis care platform";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const COLORS = {
+  bg: "#FFFCF7",      // --bg
+  bgDeep: "#F6F0E4",  // --bg-deep
+  ink: "#152119",     // --ink
+  leaf: "#1F4D37",    // --leaf
+  textSoft: "#4A5651",// --text-soft
+  highlight: "#B8782F", // --highlight
+};
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          backgroundImage: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgDeep} 100%)`,
+          padding: "80px 96px",
+          fontFamily: "sans-serif",
+          position: "relative",
+        }}
+      >
+        {/* Ambient washes — `next/og` supports a small subset of SVG so
+            we approximate the homepage's radial gradient with two layered divs. */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            width: 700,
+            height: 400,
+            backgroundImage: `radial-gradient(ellipse at top right, ${COLORS.highlight}22 0%, transparent 70%)`,
+            display: "flex",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            width: 700,
+            height: 400,
+            backgroundImage: `radial-gradient(ellipse at bottom left, ${COLORS.leaf}22 0%, transparent 70%)`,
+            display: "flex",
+          }}
+        />
+
+        {/* Top — eyebrow + brand mark */}
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 28,
+              background: COLORS.leaf,
+              color: "#FFF8E8",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 32,
+              fontWeight: 700,
+            }}
+          >
+            L
+          </div>
+          <div
+            style={{
+              fontSize: 28,
+              fontWeight: 600,
+              color: COLORS.ink,
+              letterSpacing: -0.5,
+            }}
+          >
+            Leafjourney
+          </div>
+        </div>
+
+        {/* Middle — headline */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            flex: 1,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 84,
+              lineHeight: 1.02,
+              fontWeight: 500,
+              letterSpacing: -2,
+              color: COLORS.ink,
+              maxWidth: 920,
+            }}
+          >
+            Cannabis wellness,
+          </div>
+          <div
+            style={{
+              fontSize: 84,
+              lineHeight: 1.02,
+              fontWeight: 500,
+              letterSpacing: -2,
+              fontStyle: "italic",
+              color: COLORS.leaf,
+              maxWidth: 920,
+            }}
+          >
+            doctor-guided.
+          </div>
+        </div>
+
+        {/* Bottom — tagline + trust strip */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            borderTop: `1px solid ${COLORS.bgDeep}`,
+            paddingTop: 28,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              color: COLORS.textSoft,
+              fontWeight: 500,
+              maxWidth: 700,
+            }}
+          >
+            AI-native care platform · patient portal · clinician workspace · practice ops
+          </div>
+          <div
+            style={{
+              fontSize: 16,
+              color: COLORS.leaf,
+              fontWeight: 600,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+            }}
+          >
+            Physician built
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Wordmark } from "@/components/ui/logo";
@@ -5,12 +6,35 @@ import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { AmbientMusicPlayer } from "@/components/ui/ambient-music";
 import { LiveConsole } from "@/components/marketing/live-console";
 import { Reveal } from "@/components/marketing/reveal";
+import { JsonLd } from "@/components/marketing/JsonLd";
+import { organizationJsonLd, webSiteJsonLd, SITE_URL } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "Leafjourney — AI-native cannabis care platform",
+  description:
+    "An AI-native care platform for modern cannabis medicine. Patient portal, clinician workspace, and practice operations in one unified system.",
+  alternates: { canonical: SITE_URL },
+  // Public marketing surface — override the layout's default noindex.
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Leafjourney — AI-native cannabis care platform",
+    description:
+      "Patient portal, clinician workspace, and practice operations in one unified system. Built for the modern cannabis clinic.",
+    url: SITE_URL,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
 
 // Public marketing / acquisition home page.
 // Editorial, warm, botanical — with a live agent console to sell the core value prop.
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-bg relative overflow-hidden">
+      {/* Site-wide structured data — Organization + WebSite. Google
+          de-dups, so embedding once on the homepage is enough. */}
+      <JsonLd data={[organizationJsonLd(), webSiteJsonLd()]} />
+
       {/* Global ambient wash */}
       <div
         aria-hidden="true"

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,17 +1,25 @@
 import type { MetadataRoute } from "next";
-import { SITE_URL } from "@/lib/leafmart/seo";
+import { SITE_URL } from "@/lib/seo";
 
 /**
  * Site-wide robots policy. Only the public Leafmart storefront and a few
  * marketing routes are crawlable; the patient/clinician/operator portals
- * stay private. The sitemap entry points crawlers at the Leafmart sitemap.
+ * stay private. Two sitemaps are listed — one for marketing, one for the
+ * Leafmart storefront — so crawlers can index each independently.
  */
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: "*",
-        allow: ["/leafmart", "/about", "/pricing", "/security"],
+        allow: [
+          "/",
+          "/leafmart",
+          "/about",
+          "/pricing",
+          "/security",
+          "/education",
+        ],
         disallow: [
           "/api/",
           "/(auth)/",
@@ -23,6 +31,9 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: `${SITE_URL}/leafmart/sitemap.xml`,
+    sitemap: [
+      `${SITE_URL}/sitemap.xml`,
+      `${SITE_URL}/leafmart/sitemap.xml`,
+    ],
   };
 }

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -10,11 +10,23 @@ import {
 } from "@/components/ui/card";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { Badge } from "@/components/ui/badge";
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/seo";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Security & Data Ownership — Leafjourney",
   description:
     "Your data belongs to you. Learn about our security practices and data ownership framework.",
+  alternates: { canonical: `${SITE_URL}/security` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Security & Data Ownership — Leafjourney",
+    description:
+      "HIPAA-compliant infrastructure with patient data ownership built in. Audit logs, encryption, and a portability framework that puts you in control.",
+    url: `${SITE_URL}/security`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
 };
 
 const SECURITY_PILLARS = [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * Root marketing sitemap. The Leafmart storefront has its own at
+ * `app/leafmart/sitemap.ts` (covers product + category routes); this one
+ * covers only the parent-brand marketing pages.
+ *
+ * Excluded:
+ * - `/pricing` — redirects to `/`, would create a duplicate
+ * - `/developer` — disallowed in robots.txt (private-by-default for V1)
+ * - portal/clinician/operator routes — private, never indexed
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/security`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/education`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+  ];
+}

--- a/src/components/marketing/JsonLd.tsx
+++ b/src/components/marketing/JsonLd.tsx
@@ -1,0 +1,24 @@
+import { ldJson } from "@/lib/seo";
+
+/**
+ * Renders one or more JSON-LD blocks server-side.
+ * Pass a single object or an array; each becomes its own <script> tag —
+ * Google prefers separate blocks over a single combined object.
+ *
+ * Mirrors `@/components/leafmart/JsonLd` but pulls from the marketing
+ * `@/lib/seo` so the marketing tree has zero dep on the storefront.
+ */
+export function JsonLd({ data }: { data: unknown | unknown[] }) {
+  const blocks = Array.isArray(data) ? data : [data];
+  return (
+    <>
+      {blocks.map((block, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: ldJson(block) }}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,55 @@
+/**
+ * Site-wide SEO helpers and structured-data builders for the Leafjourney
+ * marketing site (homepage, /about, /pricing, /security, /education,
+ * /developer).
+ *
+ * Leafmart-specific structured data (Product, BreadcrumbList, FAQ,
+ * CollectionPage) lives in `@/lib/leafmart/seo` — keep these scoped so
+ * the parent brand and the storefront sub-brand stay distinct in
+ * crawler eyes.
+ */
+
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+  "https://leafjourney.com";
+
+export const ORG_NAME = "Leafjourney";
+export const ORG_DESCRIPTION =
+  "An AI-native care platform for modern cannabis medicine. Patient portal, clinician workspace, and practice operations in one unified system.";
+
+export function absoluteUrl(path: string): string {
+  if (path.startsWith("http")) return path;
+  return `${SITE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+/**
+ * Render JSON-LD as a string suitable for dangerouslySetInnerHTML.
+ * Escapes the closing `</script>` sequence so user copy can't break out.
+ */
+export function ldJson(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+/* ── Structured-data builders ─────────────────────────────────── */
+
+export function organizationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: ORG_NAME,
+    url: SITE_URL,
+    description: ORG_DESCRIPTION,
+    logo: absoluteUrl("/icon.svg"),
+    sameAs: [],
+  };
+}
+
+export function webSiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: ORG_NAME,
+    url: SITE_URL,
+    description: ORG_DESCRIPTION,
+  };
+}


### PR DESCRIPTION
## Summary

Sprint 5 SEO/perf/polish work for the Leafjourney marketing site. All five active public pages (\`/\`, \`/about\`, \`/security\`, \`/education\`, \`/developer\`) now have full metadata. Root structured data, OG image, and sitemap added. Education page picks up dark-mode support.

## Tickets

| | Status | Notes |
|---|---|---|
| T-1 JSON-LD | ✅ | New \`lib/seo.ts\` (Org + WebSite for Leafjourney parent brand), new \`components/marketing/JsonLd.tsx\`. Embedded once on \`/\` (Google de-dups). |
| T-2 Meta tags | ✅ | All five active public pages. Each opts back in to indexing via \`robots: { index: true, follow: true }\` since the root layout defaults to \`noindex\` for V1. \`/developer\` keeps noindex per robots.txt disallow. |
| T-3 OG image | ✅ | Root \`opengraph-image.tsx\` (edge runtime, design-token gradient, Wordmark + tagline). |
| T-4 Sitemap | ✅ | Root \`sitemap.ts\` covers /, /about, /security, /education. \`robots.ts\` updated to point at both \`/sitemap.xml\` and \`/leafmart/sitemap.xml\`. |
| T-5 404 | ⏭ Skipped | Existing \`not-found.tsx\` already uses the design system properly; briefing snippet would have been a regression. |
| T-6 Mobile | ✅ Audit only | No issues found. \`max-w-[1280px]\` is capped with responsive padding; the two \`overflow-x-auto\` instances are intentional UX (code block, tab strip). |
| T-7 Dark mode | ✅ | Fixed 9 hardcoded \`bg-white\` instances on \`/education\` (form inputs, chat bubbles, search bars, selects) to use \`bg-surface\`. Same bug class as PR #97. |
| T-8 Perf | ✅ Audit only | No \`<img>\` or \`next/image\` instances on public pages — nothing to lazy-load. Run \`npx lighthouse <preview-url> --only-categories=performance,seo,accessibility\` after deploy. |

## Test plan
- [ ] CI green
- [ ] After merge, hit \`/sitemap.xml\` and \`/robots.txt\` on the deploy — both should serve correctly
- [ ] Hit \`/opengraph-image\` to verify the root OG image renders (Wordmark + tagline gradient)
- [ ] Visit \`/education\` in dark mode — form inputs, chat bubbles, search bar, selects should all be dark surface (not white)
- [ ] Run Lighthouse on a preview deploy: \`npx lighthouse <url> --only-categories=performance,seo,accessibility\`
- [ ] Use Google Rich Results Test on the homepage to confirm Organization + WebSite JSON-LD parse cleanly

## Out of scope (filed for later)
- Restoring \`as const\` on \`OG_COLORS\` (was widened to \`Record<string, string>\` in Sprint 2 to unblock build).
- Light-mode \`best-sellers\` icon chip at 2.85:1 — needs \`--cloud-stamp\` darkened from \`#4A4A4A\` → \`#2D2D2D\`.
- Hero overlays (\`bg-white/65, /85, /60\`) on the homepage pill, partner cards, MC portrait — Sprint 1 audit noted; not re-verified in dark mode.

## Risk notes
- The robots override (turning indexing back on for public marketing pages) means we ARE making the marketing site discoverable. Confirm this matches the V1 launch plan before merging — there's a comment in \`layout.tsx\` ('private by default in V1') that this PR partially reverses (intentionally, per briefing).
- Branched off main BEFORE the recently-merged PR #98 (dark mode button contrast cleanup) and the in-flight \`feat/leafjourney-shared-layout\` Agent 1 work. CI should rebase cleanly, but if conflicts surface in \`src/app/page.tsx\` or \`src/app/layout.tsx\` they'll be from the SiteHeader/SiteFooter refactor and should be straightforward to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)