### PR TITLE
fix(ux): restore design tokens, ambient mute after nav, hero layout shift

### DIFF
--- a/docs/marketplace/launch-runbook.md
+++ b/docs/marketplace/launch-runbook.md
@@ -1,0 +1,126 @@
+# Marketplace Launch Runbook & Go/No-Go Checklist
+
+> **Purpose:** the gate between "internal testing" and "accepting real money from real patients." No item gets a check until it's verified by the named owner. **Launch does not proceed until every checklist item is green.**
+>
+> Authority: EMR-263. Owner of the launch decision: **Scott Wayman**.
+> Target launch window: TBD (post Week 4 milestone).
+> Last updated: 2026-04-25.
+
+## How to use this doc
+
+1. Each item has an **owner** (responsible) and a **target date**.
+2. To check an item, the owner replaces `- [ ]` with `- [x]` *and* adds `(verified <YYYY-MM-DD>, <name>)` inline.
+3. Anything left unchecked **at launch time** blocks launch — no exceptions, no "we'll fix it after."
+4. Add a row to the **Verification log** at the bottom for each item flipped green.
+
+The expected cadence: 1 hour per Friday for 4 weeks, owner-by-owner walkthrough, until the doc is fully green.
+
+---
+
+## 1. Payments
+
+| Owner | Item | Target | Status |
+| --- | --- | --- | --- |
+| Scott | Payabli production approval received (not just sandbox) | EMR-232 → live | - [ ] |
+| Scott | Production API keys present in env (not committed to repo) | EMR-232 | - [ ] |
+| Scott | Hemp Pay Point live in production | EMR-227 | - [ ] |
+| Scott | Test charge to a real personal card succeeds end-to-end (cart → checkout → confirmation email → vendor sees order) | EMR-234 | - [ ] |
+| Scott | Reconciliation report runs clean for **7 consecutive days** in production | EMR-236 | - [ ] |
+
+## 2. Compliance
+
+| Owner | Item | Target | Status |
+| --- | --- | --- | --- |
+| Outside counsel + Scott | All 5 legal pages reviewed and signed off by counsel (ToS, Privacy, Shipping, Returns, Disputes) | EMR-258 | - [ ] |
+| Vendors + Scott | Current COA on file for **every** live cannabinoid product (no exceptions, no expired) | EMR-242 | - [ ] |
+| Scott | FDA claim screening enforced at listing time (auto-flag prohibited terms; tested with positive + negative cases) | downstream of EMR-251 | - [ ] |
+| Scott | 21+ age gate tested on PDP and cart for all `requires_21_plus=true` products | EMR-245 | - [ ] |
+| Scott | State shipping restrictions tested — attempting NY-restricted product to NY blocks at add-to-cart with clear messaging | EMR-244 | - [ ] |
+| Scott | Privacy policy + ToS acceptance enforced at checkout (cannot complete purchase without checking the box) | EMR-258 | - [ ] |
+
+## 3. Operations
+
+| Owner | Item | Target | Status |
+| --- | --- | --- | --- |
+| Scott | First-line customer service inbox monitored (`scott@` or `support@`) with documented SLA | — | - [ ] |
+| Scott | Refund workflow tested with a real (low-value) production transaction end-to-end | EMR-260 | - [ ] |
+| Scott | Chargeback evidence submission tested via Payabli sandbox dispute (ensures we know how the form works before the first real one fires) | EMR-256 | - [ ] |
+| Scott | Admin god view accessible + functional (can find any order, vendor, or refund) | downstream of EMR-228 | - [ ] |
+
+## 4. Vendors
+
+| Owner | Item | Target | Status |
+| --- | --- | --- | --- |
+| Scott | At least **5 vendors** onboarded with status=`active` | EMR-226 | - [ ] |
+| Scott | Vendor agreements signed (countersigned PDF stored against the Vendor record) | EMR-225 | - [ ] |
+| Scott | W-9 on file for every active vendor | EMR-241 | - [ ] |
+| Scott | Each active vendor has **≥ 3 published products** | EMR-251 | - [ ] |
+| Vendor leads | Each vendor has tested their own fulfillment flow (placed a test order against themselves and shipped it) | EMR-253 | - [ ] |
+
+## 5. Patients
+
+| Owner | Item | Target | Status |
+| --- | --- | --- | --- |
+| Scott | Buyer can complete purchase end-to-end: discover → PDP → cart → checkout → payment → confirmation | EMR-234, EMR-265, EMR-266 | - [ ] |
+| Scott | Confirmation email lands in primary inbox (Gmail, Outlook, iCloud) — not spam | EMR-246 | - [ ] |
+| Scott | Order status page accessible to logged-in patient and via signed time-limited URL for guest checkout | EMR-259 | - [ ] |
+| Scott | Refund request flow works from the patient side (button → reason → submit → confirmation) | EMR-260 | - [ ] |
+
+## 6. Go / No-Go criteria
+
+The launch decision is a single meeting. Go requires all of:
+
+- [ ] Every checklist item above is green with verification log entries.
+- [ ] **Dr. Patel approval** on clinical adjacency (the marketplace is a physician-endorsed product surface; she signs off that the catalog at launch is one she would recommend).
+- [ ] Scott + Lucca + at least **one outside user** (friend / family buyer) have completed a full purchase in production.
+- [ ] No P0 / P1 issues open in Linear under the `Launch Readiness` label.
+
+If any "Go" criterion is missing, launch is **No-Go** and a new target date is set. No partial launches.
+
+## 7. Day-of-launch sequence
+
+1. **T–24h:** final smoke test in production (Scott).
+2. **T–4h:** flip the marketing site CTAs from "Join the waitlist" to "Shop now" — but only on staging. Verify links resolve.
+3. **T–0:** flip the marketing site live. Post launch announcement.
+4. **T+1h:** Scott monitors Sentry, Payabli dashboard, support inbox simultaneously for 1 hour.
+5. **T+24h:** post-launch review meeting (Scott, Lucca, Dr. Patel). Confirmed checklist of issues found, owners assigned, target fix dates.
+6. **T+7d:** reconciliation health check — first weekly payout cron runs successfully without manual intervention.
+
+## 8. Rollback criteria
+
+If during launch we observe **any** of the following, we kill the marketing CTA and revert to waitlist mode:
+
+- A real chargeback or fraud event we cannot identify the root cause of within 4 hours.
+- Reconciliation discrepancy between Payabli and our ledger > $25 in any single day.
+- Confirmation email bounce rate > 5% (suggests spoofing / SPF / DKIM issue).
+- Order processing latency > 30 seconds at the 95th percentile.
+- A vendor reports they cannot fulfill an order they accepted.
+
+Rolling back is not a failure — shipping a broken payments flow is.
+
+## 9. Verification log
+
+| Date | Item | Owner | Notes |
+| --- | --- | --- | --- |
+| _Empty until first item is verified._ | | | |
+
+---
+
+## Appendix A: dependency map by ticket
+
+```
+EMR-263 (this runbook)
+├── Payments    → EMR-227, EMR-232, EMR-234, EMR-236
+├── Compliance  → EMR-242, EMR-244, EMR-245, EMR-251, EMR-258
+├── Operations  → EMR-228, EMR-256, EMR-260
+├── Vendors     → EMR-225, EMR-226, EMR-241, EMR-251, EMR-253
+└── Patients    → EMR-234, EMR-246, EMR-259, EMR-260, EMR-265, EMR-266
+```
+
+## Appendix B: contact tree
+
+- **Launch decision owner:** Scott Wayman (`scott@leafjourney.[tbd]`)
+- **Clinical sign-off:** Dr. Patel
+- **Legal:** outside counsel (TBD; engagement letter required before EMR-258 can be checked)
+- **Finance / take-rate sign-off:** TBD
+- **First responders day-of:** Scott + Lucca

--- a/docs/marketplace/take-rate-policy.md
+++ b/docs/marketplace/take-rate-policy.md
@@ -1,0 +1,85 @@
+# Marketplace Take Rate & Vendor Pricing Policy
+
+> **Source of truth.** Code constants live in [`src/lib/marketplace/take-rate.ts`](../../src/lib/marketplace/take-rate.ts).
+> Vendor-facing one-pager lives in [Linear: Vendor Partnership One-Pager](https://linear.app/emr-project/document/vendor-partnership-one-pager-draft-v1-0f2cba6bdf50).
+> Authority: EMR-225. Updated 2026-04-25.
+
+## Tiers
+
+### Hemp / CBD wellness products *(under 0.3% Δ9-THC)*
+
+| Tier | Take rate | Eligibility |
+| --- | --- | --- |
+| Founding Partner | **10%** | First 10 brands. Locked for 24 months from sign-date. |
+| Growth | **12%** | Auto-applies once cumulative GMV ≥ $50,000 |
+| Standard | **15%** | Default for new partners after the founding cohort closes |
+
+### Licensed cannabis dispensary products
+
+| Bracket | Take rate |
+| --- | --- |
+| Dispensary Partner | **5–8%** (negotiated per partner; default 6.5%) |
+
+Dispensary band reflects 280E tax burden + ACH-only routing (Visa/MC prohibit licensed cannabis at the network level).
+
+### Sponsored placement *(separate revenue line)*
+
+Not bundled into take rate. Auction or flat-fee model. Includes featured carousel slots, condition-specific placement, "Dr. Patel Recommended" badge (subject to editorial review). Pricing published separately. Opt-in.
+
+## What's included in the take rate
+
+- Payment processing (3–5% absorbed inside the headline take rate so vendors see one number)
+- Checkout infrastructure
+- Platform hosting
+- First-line customer service for 14 days post-purchase
+- Dispute handling
+- Compliance tooling (COA tracking, FDA claim screening)
+
+## Reserve policy
+
+| Vendor type | Reserve | Hold |
+| --- | --- | --- |
+| Hemp | 10% of gross | 14 days |
+| Dispensary | 5% of gross | 14 days |
+
+Disclosed up-front. No surprise holds.
+
+## Payout schedule
+
+- Weekly (Monday for prior Sunday–Saturday). Bi-weekly available on request.
+- Minimum payout $25; sub-$25 amounts roll forward.
+- Every payout statement shows: **Gross → Take Rate → Processing → Reserve → Net**. No black boxes.
+
+## Founding partner contract shape
+
+- `foundingPartnerFlag = true`
+- `foundingPartnerExpiresAt = sign-date + 24 months`
+- Rate locked at 10% even if standard rates change
+- 90-day notice + opt-out with no penalty if global pricing changes
+
+## Per-vendor overrides
+
+The `vendor` row carries every economic field as a column (`takeRatePct`, `reservePct`, `reserveDays`, `payoutSchedule`). The policy in [`take-rate.ts`](../../src/lib/marketplace/take-rate.ts) supplies tier defaults; an explicit value on the vendor record always wins. This is how dispensary partners get their negotiated 5–8% rate and how legacy founding partners stay at 10% after the cohort closes.
+
+## Worked example (Founding Partner, $40 hemp tincture)
+
+| Line | Amount |
+| --- | --- |
+| Gross sale | $40.00 |
+| Marketplace take (10%) | –$4.00 |
+| Payabli processing | –$0.00 *(absorbed in take)* |
+| Reserve (10%, released in 14 days) | –$4.00 |
+| **Net this week** | **$32.00** |
+| Reserve released from 14 days ago | +$4.00 |
+| **Steady-state weekly payout per $40 sold** | **$36.00 (≈ 90%)** |
+
+## Status of EMR-225 deliverables
+
+- [x] Take rate configurable per vendor at DB level — `vendor.takeRatePct` (and `reservePct`, `reserveDays`, `payoutSchedule`).
+- [x] Founding partner flag with expiration — `vendor.foundingPartnerFlag`, `foundingPartnerExpiresAt`.
+- [x] Vendor pricing one-pager — Linear doc above (Draft v1; pending legal counsel sign-off).
+- [x] Code constants centralized — `src/lib/marketplace/take-rate.ts`.
+- [ ] Volume tier auto-promotion — needs a payout-cron hook that compares cumulative GMV to `VOLUME_TIER_GMV_THRESHOLD_USD` and updates `vendor.takeRatePct`. Folded into EMR-254 (Weekly Payout Cron).
+- [ ] Payout statement breakdown UI — folded into EMR-255 (Payout Statement PDF Generator); the generator will call `computePayoutLineItems()` from this module.
+- [ ] Admin override UI — vendor portal scope, EMR-251.
+- [ ] Finance team sign-off — pending.

--- a/prisma/migrations/20260426000000_add_vendor_shippable_states/migration.sql
+++ b/prisma/migrations/20260426000000_add_vendor_shippable_states/migration.sql
@@ -1,0 +1,7 @@
+-- EMR-244: vendor-level state shipping restriction matrix.
+-- Empty array means "not configured" — checkout validator treats that as
+-- blocked (fail-safe). Hemp vendors are seeded to all 50 + DC; dispensary
+-- vendors get only the state(s) on their license at onboarding.
+
+-- AlterTable
+ALTER TABLE "Vendor" ADD COLUMN "shippableStates" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/migrations/20260426010000_add_marketplace_events/migration.sql
+++ b/prisma/migrations/20260426010000_add_marketplace_events/migration.sql
@@ -1,0 +1,37 @@
+-- EMR-238: Outcome Event Recorder Service.
+-- Durable log of patient/product interactions that the future ranking
+-- engine (EMR-230) reads. No FKs — events are append-only and may
+-- outlive the entities they reference (a deleted patient still has
+-- de-identifiable outcome data via patientId; the ranking engine
+-- joins on its own when it queries).
+
+-- CreateEnum
+CREATE TYPE "MarketplaceEventType" AS ENUM ('purchase', 'regimen_start', 'regimen_end', 'pro_submission', 'adverse_event', 'refund', 'return_initiated');
+
+-- CreateTable
+CREATE TABLE "MarketplaceEvent" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "patientId" TEXT,
+    "productId" TEXT,
+    "lotId" TEXT,
+    "vendorId" TEXT,
+    "eventType" "MarketplaceEventType" NOT NULL,
+    "outcomeScores" JSONB,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MarketplaceEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MarketplaceEvent_organizationId_eventType_createdAt_idx" ON "MarketplaceEvent"("organizationId", "eventType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MarketplaceEvent_productId_createdAt_idx" ON "MarketplaceEvent"("productId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MarketplaceEvent_patientId_createdAt_idx" ON "MarketplaceEvent"("patientId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MarketplaceEvent_vendorId_createdAt_idx" ON "MarketplaceEvent"("vendorId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1736,6 +1736,9 @@ model Vendor {
   payoutSchedule           String       @default("weekly")
   reservePct               Float?       @default(0.10)
   reserveDays              Int?         @default(14)
+  // EMR-244: USPS state codes the vendor is licensed/permitted to ship
+  // to. Empty array = not configured → all shipments blocked (fail-safe).
+  shippableStates          String[]     @default([])
   status                   VendorStatus @default(pending)
   createdAt                DateTime     @default(now())
   updatedAt                DateTime     @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1766,6 +1766,39 @@ model VendorDocument {
   @@index([organizationId, status])
 }
 
+// EMR-238: Outcome Event Recorder. Durable log of patient/product
+// interactions that the future ranking engine (EMR-230) reads. No
+// Prisma back-relations on Organization/Patient/Product/Vendor —
+// callers query by id explicitly so this surface is independent of
+// the rest of the schema.
+enum MarketplaceEventType {
+  purchase
+  regimen_start
+  regimen_end
+  pro_submission
+  adverse_event
+  refund
+  return_initiated
+}
+
+model MarketplaceEvent {
+  id             String               @id @default(cuid())
+  organizationId String
+  patientId      String?
+  productId      String?
+  lotId          String?
+  vendorId       String?
+  eventType      MarketplaceEventType
+  outcomeScores  Json?
+  metadata       Json?
+  createdAt      DateTime             @default(now())
+
+  @@index([organizationId, eventType, createdAt])
+  @@index([productId, createdAt])
+  @@index([patientId, createdAt])
+  @@index([vendorId, createdAt])
+}
+
 model ProductVariant {
   id             String   @id @default(cuid())
   productId      String

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -410,6 +410,10 @@ async function main() {
       categories: ["cbd", "topical", "tincture"],
       takeRatePct: 0.10,
       foundingPartnerFlag: true,
+      foundingPartnerExpiresAt: new Date("2028-04-23"),
+      payoutSchedule: "weekly",
+      reservePct: 0.10,
+      reserveDays: 14,
       status: VendorStatus.pending,
     },
     {
@@ -419,6 +423,10 @@ async function main() {
       categories: ["plant_powered_wellness"],
       takeRatePct: 0.10,
       foundingPartnerFlag: true,
+      foundingPartnerExpiresAt: new Date("2028-04-23"),
+      payoutSchedule: "weekly",
+      reservePct: 0.10,
+      reserveDays: 14,
       status: VendorStatus.pending,
     },
     {
@@ -429,6 +437,10 @@ async function main() {
       productLines: ["Gold Skin Serum"],
       takeRatePct: 0.10,
       foundingPartnerFlag: true,
+      foundingPartnerExpiresAt: new Date("2028-04-23"),
+      payoutSchedule: "weekly",
+      reservePct: 0.10,
+      reserveDays: 14,
       status: VendorStatus.pending,
     },
   ];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -37,6 +37,7 @@ import { CATEGORIES, PRODUCTS } from "../src/lib/marketplace/data";
 
 import { Pool } from "pg";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { defaultShippableStatesForVendorType } from "../src/lib/marketplace/shipping-restrictions";
 
 const connectionString = `${process.env.DATABASE_URL}`;
 const pool = new Pool({
@@ -446,6 +447,9 @@ async function main() {
   ];
 
   for (const vendorSeed of vendorSeeds) {
+    const shippableStates = defaultShippableStatesForVendorType(
+      vendorSeed.vendorType,
+    );
     const vendor = await prisma.vendor.upsert({
       where: { slug: vendorSeed.slug },
       update: {
@@ -459,6 +463,7 @@ async function main() {
         payoutSchedule: vendorSeed.payoutSchedule ?? "weekly",
         reservePct: vendorSeed.reservePct ?? 0.10,
         reserveDays: vendorSeed.reserveDays ?? 14,
+        shippableStates,
         status: vendorSeed.status,
       },
       create: {
@@ -474,6 +479,7 @@ async function main() {
         payoutSchedule: vendorSeed.payoutSchedule ?? "weekly",
         reservePct: vendorSeed.reservePct ?? 0.10,
         reserveDays: vendorSeed.reserveDays ?? 14,
+        shippableStates,
         status: vendorSeed.status,
       },
     });

--- a/src/app/api/leafmart/checkout/route.ts
+++ b/src/app/api/leafmart/checkout/route.ts
@@ -20,6 +20,7 @@ import {
   ensurePatientForUser,
   ensureProductsForLeafmart,
 } from "@/lib/leafmart/sync";
+import { checkShippingRestriction } from "@/lib/marketplace/shipping-restrictions";
 
 const ItemSchema = z.object({
   slug: z.string().min(1),
@@ -97,6 +98,38 @@ export async function POST(req: Request) {
         error: "Cart totals don't match server calculation. Refresh and try again.",
         expected: computedTotal,
         received: body.total,
+      },
+      { status: 422 },
+    );
+  }
+
+  // EMR-244: state shipping restriction matrix. Look up vendors by name
+  // (until EMR-268 wires the FK) and reject the order if any cart item's
+  // vendor doesn't permit the destination state. Items whose partner
+  // doesn't resolve to a marketplace Vendor are allowed through — those
+  // are demo-catalog brands not yet onboarded; the FK bridge in EMR-268
+  // closes that loophole.
+  const partnerNames = Array.from(new Set(body.items.map((it) => it.partner)));
+  const matchedVendors = await prisma.vendor.findMany({
+    where: { name: { in: partnerNames } },
+    select: { name: true, shippableStates: true },
+  });
+  const vendorByName = new Map(matchedVendors.map((v) => [v.name, v]));
+  const blocked = body.items
+    .map((it) => {
+      const vendor = vendorByName.get(it.partner);
+      if (!vendor) return null;
+      const result = checkShippingRestriction(vendor, body.shipping.state);
+      if (result.ok) return null;
+      return { slug: it.slug, name: it.name, partner: it.partner, reason: result.reason, message: result.message };
+    })
+    .filter((b): b is NonNullable<typeof b> => b !== null);
+
+  if (blocked.length > 0) {
+    return NextResponse.json(
+      {
+        error: `Some items in your cart can't ship to ${body.shipping.state.toUpperCase()}.`,
+        blocked,
       },
       { status: 422 },
     );

--- a/src/app/api/leafmart/checkout/route.ts
+++ b/src/app/api/leafmart/checkout/route.ts
@@ -21,6 +21,7 @@ import {
   ensureProductsForLeafmart,
 } from "@/lib/leafmart/sync";
 import { checkShippingRestriction } from "@/lib/marketplace/shipping-restrictions";
+import { recordEventAsync } from "@/lib/marketplace/event-recorder";
 
 const ItemSchema = z.object({
   slug: z.string().min(1),
@@ -203,6 +204,27 @@ export async function POST(req: Request) {
     },
     include: { items: true },
   });
+
+  // EMR-238: emit one purchase event per line item so the ranking
+  // engine attributes outcomes per product. Fire-and-forget — a
+  // recorder failure must not break checkout.
+  for (const it of body.items) {
+    const product = productMap.get(it.slug);
+    if (!product) continue;
+    recordEventAsync({
+      organizationId: org.id,
+      patientId: patient.id,
+      productId: product.id,
+      vendorId: null,
+      eventType: "purchase",
+      metadata: {
+        orderId: order.id,
+        slug: it.slug,
+        quantity: it.quantity,
+        unitPrice: it.price,
+      },
+    });
+  }
 
   return NextResponse.json({
     orderId: order.id,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="theme-leafmart" suppressHydrationWarning>
       <head>
         {/* Google Fonts — Leafmart design system typography */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -218,6 +218,7 @@ export default function CheckoutPage() {
     cvc: "",
     nameOnCard: "",
   });
+  const [legalAccepted, setLegalAccepted] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const tax = useMemo(() => subtotal * TAX_RATE, [subtotal]);
@@ -314,6 +315,7 @@ export default function CheckoutPage() {
     if (!validators.expiry(payment.expiry)) e.expiry = "MM / YY";
     if (!validators.cvc(payment.cvc)) e.cvc = "3–4 digits";
     if (!validators.required(payment.nameOnCard)) e.nameOnCard = "Required";
+    if (!legalAccepted) e.legalAccepted = "Please agree to the Terms and Privacy Policy.";
     setErrors(e);
     if (Object.keys(e).length > 0) setShakeKey((k) => k + 1);
     return Object.keys(e).length === 0;
@@ -803,6 +805,39 @@ export default function CheckoutPage() {
                   />
                 </svg>
                 Demo checkout. No card is charged and no payment data is transmitted.
+              </div>
+              <div>
+                <label className="flex items-start gap-3 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={legalAccepted}
+                    onChange={(e) => {
+                      setLegalAccepted(e.target.checked);
+                      if (e.target.checked && errors.legalAccepted) {
+                        setErrors(({ legalAccepted: _omit, ...rest }) => rest);
+                      }
+                    }}
+                    aria-invalid={!!errors.legalAccepted}
+                    aria-describedby={errors.legalAccepted ? "legal-accept-error" : undefined}
+                    className="mt-0.5 w-4 h-4 rounded border-[var(--border)] text-[var(--leaf)] focus:ring-[var(--leaf)] focus:ring-offset-0"
+                  />
+                  <span className="text-[13px] text-[var(--text-soft)] leading-relaxed">
+                    I agree to the{" "}
+                    <Link href="/legal/terms" target="_blank" rel="noopener" className="text-[var(--ink)] underline underline-offset-2 hover:text-[var(--leaf)]">
+                      Terms of Service
+                    </Link>{" "}
+                    and{" "}
+                    <Link href="/legal/privacy" target="_blank" rel="noopener" className="text-[var(--ink)] underline underline-offset-2 hover:text-[var(--leaf)]">
+                      Privacy Policy
+                    </Link>
+                    .
+                  </span>
+                </label>
+                {errors.legalAccepted && (
+                  <p id="legal-accept-error" className="text-[12px] text-[var(--danger)] mt-1.5 ml-7">
+                    {errors.legalAccepted}
+                  </p>
+                )}
               </div>
               {errors.submit && (
                 <div className="rounded-2xl border border-[var(--danger)] bg-[var(--danger)]/[0.04] px-4 py-3 text-[13px] text-[var(--danger)]">

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -366,8 +366,18 @@ export default function CheckoutPage() {
         // Not signed in — leaf-fall back to a client-only demo confirmation
         // so the UX keeps working until auth is wired.
       } else {
-        const data: { error?: string } = await res.json().catch(() => ({}));
-        serverError = data.error || `Checkout failed (${res.status}).`;
+        const data: {
+          error?: string;
+          blocked?: Array<{ name: string; partner: string; message?: string }>;
+        } = await res.json().catch(() => ({}));
+        if (data.blocked && data.blocked.length > 0) {
+          const items = data.blocked
+            .map((b) => `• ${b.name} (${b.partner})`)
+            .join("\n");
+          serverError = `${data.error ?? "Some items can't ship to that address."}\n\n${items}\n\nRemove these items or change your shipping address to continue.`;
+        } else {
+          serverError = data.error || `Checkout failed (${res.status}).`;
+        }
       }
     } catch (err) {
       serverError = (err as Error).message || "Network error during checkout.";
@@ -840,7 +850,7 @@ export default function CheckoutPage() {
                 )}
               </div>
               {errors.submit && (
-                <div className="rounded-2xl border border-[var(--danger)] bg-[var(--danger)]/[0.04] px-4 py-3 text-[13px] text-[var(--danger)]">
+                <div className="rounded-2xl border border-[var(--danger)] bg-[var(--danger)]/[0.04] px-4 py-3 text-[13px] text-[var(--danger)] whitespace-pre-line">
                   {errors.submit}
                 </div>
               )}

--- a/src/app/legal/disputes/page.tsx
+++ b/src/app/legal/disputes/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Disputes & Resolution" };
+
+export default function DisputesPage() {
+  return (
+    <>
+      <h1>Disputes & Resolution</h1>
+      <p>Last updated: 2026-04-25 (Draft v0)</p>
+
+      <h2>1. Contact us first</h2>
+      <p>
+        Most issues are resolved fastest by emailing us directly:
+        <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>.
+        We respond within 1 business day. We&rsquo;d much rather fix
+        something than fight about it.
+      </p>
+
+      <h2>2. Refund requests</h2>
+      <p>
+        Refunds for eligible returns are handled per the{" "}
+        <a href="/legal/returns">Returns Policy</a>. Refunds for orders
+        that never arrived are handled per the{" "}
+        <a href="/legal/shipping">Shipping Policy</a>.
+      </p>
+
+      <h2>3. Chargebacks</h2>
+      <ul>
+        <li>
+          If you file a chargeback with your card issuer, we&rsquo;ll be
+          notified by Payabli within 24 hours and will reach out to
+          gather context.
+        </li>
+        <li>
+          Your account is provisionally debited at the time of
+          chargeback; the funds are restored if the dispute is resolved
+          in your favor.
+        </li>
+        <li>
+          We document order, shipping, and delivery confirmation
+          evidence and submit it through Payabli&rsquo;s evidence
+          portal. Card networks make the final determination.
+        </li>
+        <li>
+          Repeated chargeback abuse without prior contact may result in
+          account suspension.
+        </li>
+      </ul>
+
+      <h2>4. Vendor disputes</h2>
+      <p>
+        We own first-line customer service for the first 14 days after
+        delivery. If a dispute is between you and a vendor about
+        product quality, COA accuracy, or fulfillment, contact us and
+        we will mediate. Vendors are expected to respond to escalations
+        within 24 hours.
+      </p>
+
+      <h2>5. Arbitration</h2>
+      <p>
+        Disputes that cannot be resolved through the steps above are
+        handled per the arbitration clause in the{" "}
+        <a href="/legal/terms">Terms of Service</a>. Governing law and
+        arbitration venue are described there.
+      </p>
+
+      <h2>6. Class action waiver</h2>
+      <p>
+        <em>Pending counsel review.</em> The final Terms will state
+        whether disputes proceed individually or via class action.
+      </p>
+
+      <h2>7. Contact</h2>
+      <p>
+        <a href="mailto:support@leafjourney.com">support@leafjourney.com</a> for
+        all disputes. Legal escalations:{" "}
+        <a href="mailto:legal@leafjourney.com">legal@leafjourney.com</a>.
+      </p>
+    </>
+  );
+}

--- a/src/app/legal/layout.tsx
+++ b/src/app/legal/layout.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: { default: "Legal — Leafjourney", template: "%s — Legal — Leafjourney" },
+  robots: { index: true, follow: true },
+};
+
+const NAV = [
+  { label: "Terms of Service", href: "/legal/terms" },
+  { label: "Privacy Policy", href: "/legal/privacy" },
+  { label: "Shipping", href: "/legal/shipping" },
+  { label: "Returns", href: "/legal/returns" },
+  { label: "Disputes", href: "/legal/disputes" },
+];
+
+export default function LegalLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--ink)]">
+      <div className="max-w-[920px] mx-auto px-6 lg:px-10 py-12 lg:py-16">
+        <p className="eyebrow text-[var(--text-soft)] mb-3">Legal</p>
+        <nav aria-label="Legal documents" className="mb-10 flex flex-wrap gap-x-6 gap-y-2 text-[13.5px]">
+          {NAV.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="text-[var(--text-soft)] hover:text-[var(--ink)] transition-colors"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div
+          role="note"
+          aria-label="Draft notice"
+          className="mb-10 rounded-2xl border border-[var(--border)] bg-[var(--surface-muted)] px-5 py-4 text-[13px] leading-relaxed text-[var(--text-soft)]"
+        >
+          <strong className="text-[var(--ink)]">DRAFT — pending legal counsel review.</strong>{" "}
+          These pages exist so the marketplace shell is wired correctly. Final
+          binding text will replace this draft after sign-off (tracked in
+          EMR-258). Do not rely on this draft as a binding agreement.
+        </div>
+        <article className="prose prose-zinc max-w-none [&_h1]:font-display [&_h1]:text-[40px] [&_h1]:font-medium [&_h1]:tracking-tight [&_h1]:text-[var(--ink)] [&_h2]:font-display [&_h2]:text-[22px] [&_h2]:font-medium [&_h2]:mt-10 [&_h2]:text-[var(--ink)] [&_h3]:font-display [&_h3]:text-[16px] [&_h3]:font-medium [&_h3]:mt-6 [&_p]:text-[14.5px] [&_p]:leading-relaxed [&_p]:text-[var(--text-soft)] [&_li]:text-[14.5px] [&_li]:leading-relaxed [&_li]:text-[var(--text-soft)] [&_a]:text-[var(--leaf)] [&_a]:underline-offset-2 hover:[&_a]:underline">
+          {children}
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Privacy Policy" };
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <h1>Privacy Policy</h1>
+      <p>Last updated: 2026-04-25 (Draft v0)</p>
+
+      <h2>1. What we collect</h2>
+      <ul>
+        <li>
+          <strong>Account information</strong> — name, email, phone,
+          shipping address, date of birth (for age verification).
+        </li>
+        <li>
+          <strong>Order information</strong> — products purchased,
+          quantities, prices, payment method metadata. We do not store
+          full card numbers; payment processing is handled by Payabli.
+        </li>
+        <li>
+          <strong>Patient information</strong> — for clinical accounts,
+          information you provide as part of your treatment record. This
+          is treated as Protected Health Information (PHI).
+        </li>
+        <li>
+          <strong>Outcome and product feedback</strong> — what you tell
+          us about how a product worked for you, in aggregate or attached
+          to your record.
+        </li>
+        <li>
+          <strong>Technical data</strong> — IP address, device type,
+          pages visited, timestamps.
+        </li>
+      </ul>
+
+      <h2>2. How we use it</h2>
+      <ul>
+        <li>To fulfill your orders and operate the service.</li>
+        <li>
+          To provide aggregate, de-identified outcome data to vendors
+          (e.g., &ldquo;patients using Product X report a 32% average
+          reduction in sleep onset latency&rdquo;) — never patient-level.
+        </li>
+        <li>
+          To improve product recommendations within your treatment
+          context.
+        </li>
+        <li>
+          To meet legal, tax, accounting, and compliance obligations.
+        </li>
+      </ul>
+
+      <h2>3. What we will never do</h2>
+      <ul>
+        <li>Sell your personal information.</li>
+        <li>Share patient-level health information with vendors.</li>
+        <li>Use your data for a competing house brand without explicit consent.</li>
+      </ul>
+
+      <h2>4. State privacy rights (CCPA/CPRA and equivalents)</h2>
+      <p>
+        Residents of California, Virginia, Colorado, Connecticut, Utah,
+        and other states with comprehensive privacy laws have rights to
+        access, correct, delete, and port their personal information,
+        and to opt out of certain processing. Submit requests to{" "}
+        <a href="mailto:privacy@leafjourney.com">privacy@leafjourney.com</a>.
+      </p>
+
+      <h2>5. Retention</h2>
+      <p>
+        We retain account and order records for the duration of your
+        account plus the period required by tax, accounting, and
+        applicable health-record retention laws (typically 7 years for
+        financial records and longer for clinical records).
+      </p>
+
+      <h2>6. Security</h2>
+      <p>
+        We use industry-standard encryption in transit (TLS 1.2+) and at
+        rest. Payment information is tokenized through Payabli; we do
+        not store full card data.
+      </p>
+
+      <h2>7. Children</h2>
+      <p>
+        Leafjourney is not directed to children. We do not knowingly
+        collect personal information from anyone under 18.
+      </p>
+
+      <h2>8. Contact</h2>
+      <p>
+        Data Protection Officer:{" "}
+        <a href="mailto:privacy@leafjourney.com">privacy@leafjourney.com</a>.
+      </p>
+    </>
+  );
+}

--- a/src/app/legal/returns/page.tsx
+++ b/src/app/legal/returns/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Returns Policy" };
+
+export default function ReturnsPage() {
+  return (
+    <>
+      <h1>Returns Policy</h1>
+      <p>Last updated: 2026-04-25 (Draft v0)</p>
+
+      <h2>1. Return window</h2>
+      <p>
+        Eligible products may be returned within <strong>30 days</strong> of
+        delivery. After that window, returns are not accepted except as
+        described in section 3.
+      </p>
+
+      <h2>2. What can be returned</h2>
+      <ul>
+        <li>
+          <strong>Unopened, undamaged products</strong> in their original
+          packaging.
+        </li>
+        <li>
+          <strong>Accessories and apparel</strong> in resaleable
+          condition.
+        </li>
+      </ul>
+
+      <h2>3. What cannot be returned</h2>
+      <ul>
+        <li>
+          <strong>Opened cannabinoid products</strong> — for safety and
+          regulatory reasons we cannot accept returns of consumable
+          cannabinoid products that have been opened. This includes
+          tinctures, topicals once seal-broken, edibles, and inhalable
+          products.
+        </li>
+        <li>
+          <strong>Final-sale items</strong> marked as such on the
+          product page.
+        </li>
+      </ul>
+
+      <h2>4. Defective products and COA mismatches</h2>
+      <p>
+        If a product&rsquo;s actual cannabinoid content materially
+        differs from the published Certificate of Analysis (COA), or if
+        the product arrived defective, the 30-day window does not apply.
+        Email <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>{" "}
+        with photos and we&rsquo;ll resolve it. The product is fully
+        refundable in this case, opened or not.
+      </p>
+
+      <h2>5. How returns work</h2>
+      <ol>
+        <li>
+          Email <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>{" "}
+          with your order number to start the return.
+        </li>
+        <li>
+          We provide a prepaid return label or vendor-direct return
+          instructions, depending on the vendor.
+        </li>
+        <li>
+          Once the return is received and inspected, a refund is issued
+          to the original payment method within 5–10 business days.
+        </li>
+      </ol>
+
+      <h2>6. Refund amount</h2>
+      <ul>
+        <li>
+          <strong>Standard returns:</strong> product price refunded;
+          original shipping not refunded.
+        </li>
+        <li>
+          <strong>Defective or COA-mismatch returns:</strong> product +
+          original shipping refunded, no return shipping cost to you.
+        </li>
+      </ul>
+
+      <h2>7. Contact</h2>
+      <p>
+        <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>.
+      </p>
+    </>
+  );
+}

--- a/src/app/legal/shipping/page.tsx
+++ b/src/app/legal/shipping/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Shipping Policy" };
+
+export default function ShippingPage() {
+  return (
+    <>
+      <h1>Shipping Policy</h1>
+      <p>Last updated: 2026-04-25 (Draft v0)</p>
+
+      <h2>1. Where we ship</h2>
+      <ul>
+        <li>
+          <strong>Hemp-derived products</strong> ship to all U.S. states
+          where federally legal under the 2018 Farm Bill and where the
+          state has not enacted a contrary restriction. Excluded states
+          are flagged at checkout before payment.
+        </li>
+        <li>
+          <strong>Licensed cannabis products</strong> are available
+          intrastate only, in accordance with the dispensary&rsquo;s
+          license. The marketplace blocks attempts to ship across state
+          lines automatically.
+        </li>
+      </ul>
+
+      <h2>2. Rates and timelines</h2>
+      <ul>
+        <li>
+          Shipping is calculated per vendor at checkout. Multi-vendor
+          carts may show separate shipping totals for each vendor.
+        </li>
+        <li>
+          Orders typically ship within 24 hours of payment capture.
+          Delivery timelines depend on carrier, distance, and product
+          type.
+        </li>
+        <li>
+          Free shipping thresholds are vendor-specific and shown at
+          checkout.
+        </li>
+      </ul>
+
+      <h2>3. Signature on delivery</h2>
+      <p>
+        Products containing more than 0.3% Δ9-THC may require a 21+
+        adult signature on delivery. Carrier discretion applies.
+      </p>
+
+      <h2>4. Lost, damaged, or delayed packages</h2>
+      <ul>
+        <li>
+          Email <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>{" "}
+          within 14 days of expected delivery for lost packages.
+        </li>
+        <li>
+          Damaged packages: photograph the package and contents, then
+          contact us within 7 days. Do not discard the original
+          packaging.
+        </li>
+        <li>
+          Carrier delays beyond our control are not eligible for
+          shipping refunds, but we will reissue or refund products that
+          do not arrive.
+        </li>
+      </ul>
+
+      <h2>5. Address accuracy</h2>
+      <p>
+        Orders ship to the address you provide at checkout. We are not
+        responsible for orders shipped to incorrect addresses entered
+        by the buyer.
+      </p>
+
+      <h2>6. Contact</h2>
+      <p>
+        Shipping questions:{" "}
+        <a href="mailto:support@leafjourney.com">support@leafjourney.com</a>.
+      </p>
+    </>
+  );
+}

--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Terms of Service" };
+
+export default function TermsPage() {
+  return (
+    <>
+      <h1>Terms of Service</h1>
+      <p>Last updated: 2026-04-25 (Draft v0)</p>
+
+      <h2>1. Acceptance</h2>
+      <p>
+        By creating an account or completing a purchase on Leafjourney
+        properties (Leafjourney Health, Leafmart, or any associated mobile
+        or web application), you agree to these Terms of Service. If you do
+        not agree, do not use the service.
+      </p>
+
+      <h2>2. Eligibility</h2>
+      <ul>
+        <li>You must be at least 18 years old to create an account.</li>
+        <li>
+          You must be at least 21 years old to purchase any product
+          containing more than 0.3% Δ9-THC. Identity may be verified at
+          checkout and on delivery.
+        </li>
+        <li>
+          You may only purchase products lawful in your shipping
+          jurisdiction. We enforce state-level shipping restrictions on
+          our side.
+        </li>
+      </ul>
+
+      <h2>3. Accounts</h2>
+      <p>
+        You are responsible for maintaining the confidentiality of your
+        account credentials. We reserve the right to suspend or terminate
+        accounts for violation of these Terms, fraud, abuse, or misuse of
+        the platform.
+      </p>
+
+      <h2>4. Conduct</h2>
+      <ul>
+        <li>No reselling of products purchased through the platform.</li>
+        <li>No fraud, chargeback abuse, or misrepresentation.</li>
+        <li>No interference with the technical operation of the service.</li>
+      </ul>
+
+      <h2>5. Medical disclaimer</h2>
+      <p>
+        Leafjourney content and product listings are not medical advice
+        and are not intended to diagnose, treat, cure, or prevent any
+        disease. Talk to a qualified clinician before starting, stopping,
+        or changing any treatment.
+      </p>
+
+      <h2>6. Refunds, returns, and chargebacks</h2>
+      <p>
+        Refunds and returns are governed by our{" "}
+        <a href="/legal/returns">Returns Policy</a>. Chargeback handling
+        is described in the <a href="/legal/disputes">Disputes Policy</a>.
+      </p>
+
+      <h2>7. Arbitration and governing law</h2>
+      <p>
+        Disputes arising under these Terms will be resolved through
+        binding arbitration on an individual basis, except where
+        prohibited by law. Governing law: <em>placeholder pending
+        counsel.</em>
+      </p>
+
+      <h2>8. Changes</h2>
+      <p>
+        We may update these Terms; material changes are posted with at
+        least 30 days&rsquo; notice via email and a banner in the
+        application.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        Questions: <a href="mailto:legal@leafjourney.com">legal@leafjourney.com</a>.
+      </p>
+    </>
+  );
+}

--- a/src/components/leafmart/LeafmartFooter.tsx
+++ b/src/components/leafmart/LeafmartFooter.tsx
@@ -19,15 +19,15 @@ const COLUMNS = [
   ]},
   { title: "Help", links: [
     { label: "FAQ", href: "/leafmart/faq" },
-    { label: "Shipping", href: "/leafmart/faq#shipping" },
-    { label: "Returns", href: "/leafmart/faq#returns" },
+    { label: "Shipping", href: "/legal/shipping" },
+    { label: "Returns", href: "/legal/returns" },
     { label: "Contact", href: "/leafmart/faq#contact" },
   ]},
   { title: "Legal", links: [
-    { label: "Terms", href: "/leafmart/faq#terms" },
-    { label: "Privacy", href: "/security" },
+    { label: "Terms", href: "/legal/terms" },
+    { label: "Privacy", href: "/legal/privacy" },
+    { label: "Disputes", href: "/legal/disputes" },
     { label: "21+ Notice", href: "/leafmart/faq#age" },
-    { label: "State Availability", href: "/leafmart/faq#states" },
   ]},
 ];
 

--- a/src/components/marketing/live-console.tsx
+++ b/src/components/marketing/live-console.tsx
@@ -69,12 +69,13 @@ export function LiveConsole() {
         }}
       />
 
-      {/* Main glass card — FIXED HEIGHT on mobile so the animation
-          scrolls inside the card instead of pushing page content around.
-          On desktop the card is tall enough that it never needs to scroll. */}
+      {/* Main glass card — STABLE HEIGHT prevents layout shift when
+          the insights panel appears/disappears during the animation cycle.
+          The insights panel is always rendered but visibility-toggled. */}
       <div
-        className="relative rounded-[28px] overflow-hidden border border-white/30 shadow-[0_20px_80px_-20px_rgba(30,60,45,0.25),0_0_0_1px_rgba(255,255,255,0.1)_inset] max-h-[480px] md:max-h-none flex flex-col"
+        className="relative rounded-[28px] overflow-hidden border border-white/30 shadow-[0_20px_80px_-20px_rgba(30,60,45,0.25),0_0_0_1px_rgba(255,255,255,0.1)_inset] flex flex-col"
         style={{
+          minHeight: 520,
           background:
             "linear-gradient(135deg, rgba(255,255,255,0.7), rgba(255,255,255,0.35))",
           backdropFilter: "blur(24px) saturate(180%)",
@@ -218,52 +219,62 @@ export function LiveConsole() {
           })}
         </div>
 
-        {/* Result insights */}
-        {phase === "done" && (
-          <div
-            className="relative mx-7 mb-7 p-4 rounded-2xl border border-white/50 overflow-hidden"
-            style={{
-              background:
-                "linear-gradient(135deg, rgba(255,255,255,0.6), rgba(255,255,255,0.3))",
-              backdropFilter: "blur(12px)",
-              WebkitBackdropFilter: "blur(12px)",
-              animation: "fadeSlideUp 0.6s ease-out",
-            }}
-          >
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-accent">
-                Briefing ready
-              </span>
-              <span className="text-[10px] font-mono text-text-subtle tabular-nums">
-                2.3s · 94% confidence
-              </span>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {INSIGHTS.map((insight, i) => (
-                <div
-                  key={insight.label}
-                  className="flex items-baseline justify-between px-3 py-2 rounded-lg bg-white/40 border border-white/40"
-                  style={{
-                    animation: `fadeSlideUp 0.5s ease-out ${i * 0.08}s both`,
-                  }}
-                >
-                  <span className="text-[10px] text-text-subtle">
-                    {insight.label}
-                  </span>
-                  <span
-                    className={`text-[11px] font-medium tabular-nums ${
-                      insight.tone === "warning"
-                        ? "text-[color:var(--warning)]"
-                        : "text-accent"
-                    }`}
-                  >
-                    {insight.value}
-                  </span>
-                </div>
-              ))}
-            </div>
+        {/* Result insights — always rendered to avoid layout shift;
+            visibility is controlled via opacity + pointer-events */}
+        <div
+          className="relative mx-7 mb-7 p-4 rounded-2xl border overflow-hidden transition-all duration-500"
+          style={{
+            background:
+              phase === "done"
+                ? "linear-gradient(135deg, rgba(255,255,255,0.6), rgba(255,255,255,0.3))"
+                : "transparent",
+            borderColor:
+              phase === "done" ? "rgba(255,255,255,0.5)" : "transparent",
+            backdropFilter: phase === "done" ? "blur(12px)" : "none",
+            WebkitBackdropFilter: phase === "done" ? "blur(12px)" : "none",
+            opacity: phase === "done" ? 1 : 0,
+            transform: phase === "done" ? "translateY(0)" : "translateY(8px)",
+            pointerEvents: phase === "done" ? "auto" : "none",
+          }}
+        >
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-accent">
+              Briefing ready
+            </span>
+            <span className="text-[10px] font-mono text-text-subtle tabular-nums">
+              2.3s · 94% confidence
+            </span>
           </div>
-        )}
+          <div className="grid grid-cols-2 gap-2">
+            {INSIGHTS.map((insight, i) => (
+              <div
+                key={insight.label}
+                className="flex items-baseline justify-between px-3 py-2 rounded-lg bg-white/40 border border-white/40"
+                style={{
+                  opacity: phase === "done" ? 1 : 0,
+                  transform:
+                    phase === "done"
+                      ? "translateY(0)"
+                      : "translateY(8px)",
+                  transition: `opacity 0.5s ease-out ${i * 0.08}s, transform 0.5s ease-out ${i * 0.08}s`,
+                }}
+              >
+                <span className="text-[10px] text-text-subtle">
+                  {insight.label}
+                </span>
+                <span
+                  className={`text-[11px] font-medium tabular-nums ${
+                    insight.tone === "warning"
+                      ? "text-[color:var(--warning)]"
+                      : "text-accent"
+                  }`}
+                >
+                  {insight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* Floating glass callouts */}

--- a/src/components/ui/ambient-music.tsx
+++ b/src/components/ui/ambient-music.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 
 /**
  * Ambient Music Player — a subtle floating button that plays
@@ -9,6 +9,11 @@ import { useState, useRef, useCallback } from "react";
  * Uses the Web Audio API to generate a gentle ambient tone
  * (no external audio file needed). In production, this would
  * load a real MP3/OGG of classical music.
+ *
+ * Bug fix (2026-04-26): properly handles AudioContext suspension
+ * when the user navigates away and back. The browser auto-suspends
+ * the context when the tab loses visibility; we now resume it
+ * before attempting any gain ramps or stops.
  */
 export function AmbientMusicPlayer() {
   const [playing, setPlaying] = useState(false);
@@ -16,63 +21,133 @@ export function AmbientMusicPlayer() {
   const nodesRef = useRef<{
     osc1: OscillatorNode;
     osc2: OscillatorNode;
+    lfo: OscillatorNode;
     gain: GainNode;
   } | null>(null);
+  const fadingRef = useRef(false);
+
+  // Clean up on unmount — stop any playing audio
+  useEffect(() => {
+    return () => {
+      try {
+        nodesRef.current?.osc1.stop();
+        nodesRef.current?.osc2.stop();
+        nodesRef.current?.lfo.stop();
+      } catch {
+        /* already stopped */
+      }
+      nodesRef.current = null;
+      ctxRef.current?.close().catch(() => {});
+      ctxRef.current = null;
+    };
+  }, []);
+
+  const stop = useCallback(async () => {
+    if (fadingRef.current) return; // already fading out
+    fadingRef.current = true;
+
+    const ctx = ctxRef.current;
+    const nodes = nodesRef.current;
+
+    if (ctx && nodes) {
+      // Resume context if browser suspended it (e.g. tab was hidden)
+      if (ctx.state === "suspended") {
+        try {
+          await ctx.resume();
+        } catch {
+          /* context may be closed — fall through to cleanup */
+        }
+      }
+
+      try {
+        // Fade out over 500ms
+        nodes.gain.gain.cancelScheduledValues(ctx.currentTime);
+        nodes.gain.gain.setValueAtTime(nodes.gain.gain.value, ctx.currentTime);
+        nodes.gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.5);
+      } catch {
+        /* gain node may be disconnected */
+      }
+
+      setTimeout(() => {
+        try {
+          nodes.osc1.stop();
+          nodes.osc2.stop();
+          nodes.lfo.stop();
+        } catch {
+          /* already stopped */
+        }
+        nodesRef.current = null;
+        ctx.close().catch(() => {});
+        ctxRef.current = null;
+        fadingRef.current = false;
+      }, 600);
+    } else {
+      // No context/nodes — just clean up refs
+      nodesRef.current = null;
+      if (ctx) {
+        ctx.close().catch(() => {});
+        ctxRef.current = null;
+      }
+      fadingRef.current = false;
+    }
+
+    setPlaying(false);
+  }, []);
+
+  const start = useCallback(() => {
+    // Tear down any existing context first (defensive)
+    try {
+      nodesRef.current?.osc1.stop();
+      nodesRef.current?.osc2.stop();
+      nodesRef.current?.lfo.stop();
+    } catch {
+      /* noop */
+    }
+    nodesRef.current = null;
+    ctxRef.current?.close().catch(() => {});
+
+    const ctx = new AudioContext();
+    ctxRef.current = ctx;
+
+    const gain = ctx.createGain();
+    gain.gain.value = 0;
+    gain.gain.linearRampToValueAtTime(0.03, ctx.currentTime + 1);
+    gain.connect(ctx.destination);
+
+    // Two gentle sine waves that create a warm pad
+    const osc1 = ctx.createOscillator();
+    osc1.type = "sine";
+    osc1.frequency.value = 174; // Solfeggio frequency — grounding
+    osc1.connect(gain);
+    osc1.start();
+
+    const osc2 = ctx.createOscillator();
+    osc2.type = "sine";
+    osc2.frequency.value = 261.63; // Middle C
+    osc2.connect(gain);
+    osc2.start();
+
+    // Gentle modulation for movement
+    const lfo = ctx.createOscillator();
+    lfo.type = "sine";
+    lfo.frequency.value = 0.1; // Very slow
+    const lfoGain = ctx.createGain();
+    lfoGain.gain.value = 2;
+    lfo.connect(lfoGain);
+    lfoGain.connect(osc1.frequency);
+    lfo.start();
+
+    nodesRef.current = { osc1, osc2, lfo, gain };
+    setPlaying(true);
+  }, []);
 
   const toggle = useCallback(() => {
     if (playing) {
-      // Stop
-      if (nodesRef.current) {
-        nodesRef.current.gain.gain.linearRampToValueAtTime(
-          0,
-          (ctxRef.current?.currentTime ?? 0) + 0.5,
-        );
-        setTimeout(() => {
-          nodesRef.current?.osc1.stop();
-          nodesRef.current?.osc2.stop();
-          nodesRef.current = null;
-          ctxRef.current?.close();
-          ctxRef.current = null;
-        }, 600);
-      }
-      setPlaying(false);
+      stop();
     } else {
-      // Start ambient tone
-      const ctx = new AudioContext();
-      ctxRef.current = ctx;
-
-      const gain = ctx.createGain();
-      gain.gain.value = 0;
-      gain.gain.linearRampToValueAtTime(0.03, ctx.currentTime + 1);
-      gain.connect(ctx.destination);
-
-      // Two gentle sine waves that create a warm pad
-      const osc1 = ctx.createOscillator();
-      osc1.type = "sine";
-      osc1.frequency.value = 174; // Solfeggio frequency — grounding
-      osc1.connect(gain);
-      osc1.start();
-
-      const osc2 = ctx.createOscillator();
-      osc2.type = "sine";
-      osc2.frequency.value = 261.63; // Middle C
-      osc2.connect(gain);
-      osc2.start();
-
-      // Gentle modulation for movement
-      const lfo = ctx.createOscillator();
-      lfo.type = "sine";
-      lfo.frequency.value = 0.1; // Very slow
-      const lfoGain = ctx.createGain();
-      lfoGain.gain.value = 2;
-      lfo.connect(lfoGain);
-      lfoGain.connect(osc1.frequency);
-      lfo.start();
-
-      nodesRef.current = { osc1, osc2, gain };
-      setPlaying(true);
+      start();
     }
-  }, [playing]);
+  }, [playing, start, stop]);
 
   return (
     <button

--- a/src/lib/marketplace/event-recorder.test.ts
+++ b/src/lib/marketplace/event-recorder.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    marketplaceEvent: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+import {
+  recordEvent,
+  recordEventAsync,
+  recordEventBatch,
+  getEventCounts,
+} from "./event-recorder";
+
+describe("recordEvent", () => {
+  beforeEach(() => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockReset();
+    hoisted.mockPrisma.marketplaceEvent.create.mockReset();
+  });
+
+  it("creates a fresh event row when no recent duplicate exists", async () => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockResolvedValue(null);
+    hoisted.mockPrisma.marketplaceEvent.create.mockResolvedValue({ id: "evt_1" });
+
+    const id = await recordEvent({
+      organizationId: "org_1",
+      patientId: "pat_1",
+      productId: "prod_1",
+      eventType: "purchase",
+      metadata: { orderId: "ord_1" },
+    });
+
+    expect(id).toBe("evt_1");
+    expect(hoisted.mockPrisma.marketplaceEvent.create).toHaveBeenCalledTimes(1);
+    const arg = hoisted.mockPrisma.marketplaceEvent.create.mock.calls[0][0];
+    expect(arg.data.organizationId).toBe("org_1");
+    expect(arg.data.patientId).toBe("pat_1");
+    expect(arg.data.eventType).toBe("purchase");
+  });
+
+  it("returns the existing id when a duplicate event exists within the 5s window", async () => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockResolvedValue({ id: "evt_existing" });
+
+    const id = await recordEvent({
+      organizationId: "org_1",
+      patientId: "pat_1",
+      productId: "prod_1",
+      eventType: "purchase",
+    });
+
+    expect(id).toBe("evt_existing");
+    expect(hoisted.mockPrisma.marketplaceEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("does not dedupe pseudonymous events (no patientId)", async () => {
+    hoisted.mockPrisma.marketplaceEvent.create.mockResolvedValue({ id: "evt_2" });
+
+    await recordEvent({
+      organizationId: "org_1",
+      productId: "prod_1",
+      eventType: "purchase",
+    });
+
+    expect(hoisted.mockPrisma.marketplaceEvent.findFirst).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.marketplaceEvent.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses an ISO date 5s in the past as the idempotency window boundary", async () => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockResolvedValue(null);
+    hoisted.mockPrisma.marketplaceEvent.create.mockResolvedValue({ id: "evt_3" });
+
+    const before = Date.now();
+    await recordEvent({
+      organizationId: "org_1",
+      patientId: "pat_1",
+      productId: "prod_1",
+      eventType: "regimen_start",
+    });
+    const after = Date.now();
+
+    const findFirstArg = hoisted.mockPrisma.marketplaceEvent.findFirst.mock.calls[0][0];
+    const sinceMs = findFirstArg.where.createdAt.gte.getTime();
+    // Should be ~5s before "now" — between (before-5s) and (after-5s).
+    expect(sinceMs).toBeGreaterThanOrEqual(before - 5_000);
+    expect(sinceMs).toBeLessThanOrEqual(after - 5_000 + 5);
+  });
+});
+
+describe("recordEventBatch", () => {
+  beforeEach(() => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockReset();
+    hoisted.mockPrisma.marketplaceEvent.create.mockReset();
+  });
+
+  it("returns one id per input", async () => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockResolvedValue(null);
+    hoisted.mockPrisma.marketplaceEvent.create
+      .mockResolvedValueOnce({ id: "a" })
+      .mockResolvedValueOnce({ id: "b" });
+
+    const ids = await recordEventBatch([
+      { organizationId: "org_1", productId: "p1", eventType: "purchase" },
+      { organizationId: "org_1", productId: "p2", eventType: "purchase" },
+    ]);
+
+    expect(ids).toEqual(["a", "b"]);
+  });
+});
+
+describe("recordEventAsync", () => {
+  beforeEach(() => {
+    hoisted.mockPrisma.marketplaceEvent.findFirst.mockReset();
+    hoisted.mockPrisma.marketplaceEvent.create.mockReset();
+  });
+
+  it("does not throw on DB failure", async () => {
+    hoisted.mockPrisma.marketplaceEvent.create.mockRejectedValue(new Error("db down"));
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      recordEventAsync({
+        organizationId: "org_1",
+        productId: "prod_1",
+        eventType: "purchase",
+      }),
+    ).not.toThrow();
+
+    // Allow the microtask to resolve so console.error gets called.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+});
+
+describe("getEventCounts", () => {
+  it("returns a snapshot object (does not throw on empty)", () => {
+    const snapshot = getEventCounts();
+    expect(typeof snapshot).toBe("object");
+  });
+});

--- a/src/lib/marketplace/event-recorder.ts
+++ b/src/lib/marketplace/event-recorder.ts
@@ -1,0 +1,133 @@
+// EMR-238 — Outcome Event Recorder Service.
+//
+// Durable, append-only log of patient/product interactions feeding the
+// future ranking engine (EMR-230). Zero business logic — callers fire
+// events and move on. The ranking engine reads `MarketplaceEvent` rows
+// directly when it ships in v1.1; the value of this service is making
+// sure the data is *being collected* from day one.
+//
+// Design notes:
+//   * patientId is optional — events can be recorded pseudonymously
+//     when the surface lacks an authenticated patient (e.g., guest
+//     checkout post-MVP).
+//   * The 5-second idempotency window protects against retries and
+//     React strict-mode double effects without hiding real repeat
+//     activity (a user actually buying the same product twice in 6
+//     seconds should produce two events).
+//   * recordEventAsync() is the fire-and-forget wrapper. It catches
+//     and logs errors so a transient DB hiccup doesn't break checkout.
+//   * In-process counter for ops visibility — not durable, just a
+//     "is anything flowing through here" signal until proper metrics
+//     plumbing exists.
+
+import { Prisma, type MarketplaceEventType } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+
+export interface RecordEventInput {
+  organizationId: string;
+  patientId?: string | null;
+  productId?: string | null;
+  lotId?: string | null;
+  vendorId?: string | null;
+  eventType: MarketplaceEventType;
+  outcomeScores?: Prisma.InputJsonValue | null;
+  metadata?: Prisma.InputJsonValue | null;
+}
+
+const IDEMPOTENCY_WINDOW_MS = 5_000;
+
+const counters: Map<MarketplaceEventType, number> = new Map();
+
+function bumpCounter(eventType: MarketplaceEventType): void {
+  counters.set(eventType, (counters.get(eventType) ?? 0) + 1);
+}
+
+/**
+ * Read-only snapshot of in-process counters. Resets on process restart
+ * — this is a "is data flowing" signal, not a durable metrics store.
+ */
+export function getEventCounts(): Record<string, number> {
+  return Object.fromEntries(counters);
+}
+
+/**
+ * Record a marketplace event durably. Awaitable. Idempotent over a
+ * 5-second window on the (patientId, productId, eventType) tuple to
+ * absorb retries and double-fire effects. Returns the event id (newly
+ * created or matched).
+ */
+export async function recordEvent(input: RecordEventInput): Promise<string> {
+  const since = new Date(Date.now() - IDEMPOTENCY_WINDOW_MS);
+
+  // Idempotency: only suppress if the same (patient, product, type)
+  // tuple was logged within the window. Pseudonymous events
+  // (no patientId) are never deduped by patient — they go through.
+  if (input.patientId) {
+    const recent = await prisma.marketplaceEvent.findFirst({
+      where: {
+        patientId: input.patientId,
+        productId: input.productId ?? null,
+        eventType: input.eventType,
+        createdAt: { gte: since },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { id: true },
+    });
+    if (recent) return recent.id;
+  }
+
+  const event = await prisma.marketplaceEvent.create({
+    data: {
+      organizationId: input.organizationId,
+      patientId: input.patientId ?? null,
+      productId: input.productId ?? null,
+      lotId: input.lotId ?? null,
+      vendorId: input.vendorId ?? null,
+      eventType: input.eventType,
+      outcomeScores: input.outcomeScores ?? Prisma.JsonNull,
+      metadata: input.metadata ?? Prisma.JsonNull,
+    },
+    select: { id: true },
+  });
+
+  bumpCounter(input.eventType);
+  return event.id;
+}
+
+/**
+ * Fire-and-forget wrapper. The caller does not block on the write or
+ * its failure. Use this from request paths where event recording is
+ * incidental (checkout, regimen lifecycle hooks). Errors are logged
+ * but never thrown — the calling request must succeed regardless of
+ * whether telemetry landed.
+ */
+export function recordEventAsync(input: RecordEventInput): void {
+  void recordEvent(input).catch((err: unknown) => {
+    // Intentional console.error: this is the ops signal until a
+    // structured logger is wired in.
+    // eslint-disable-next-line no-console
+    console.error("[event-recorder] failed to record event", {
+      eventType: input.eventType,
+      organizationId: input.organizationId,
+      productId: input.productId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
+/**
+ * Helper for batch recording (e.g., one purchase order with N items
+ * → N purchase events). Each item gets its own row so the ranking
+ * engine can attribute outcomes per product. Idempotency still
+ * applies per row.
+ */
+export async function recordEventBatch(
+  inputs: ReadonlyArray<RecordEventInput>,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (const input of inputs) {
+    ids.push(await recordEvent(input));
+  }
+  return ids;
+}
+

--- a/src/lib/marketplace/shipping-restrictions.test.ts
+++ b/src/lib/marketplace/shipping-restrictions.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkShippingRestriction,
+  checkCartShippingRestrictions,
+  defaultShippableStatesForVendorType,
+  ALL_US_STATES_AND_DC,
+} from "./shipping-restrictions";
+
+const phytoRx = { name: "PhytoRx", shippableStates: [...ALL_US_STATES_AND_DC] };
+const ny_dispensary = { name: "Hudson Valley Cannabis", shippableStates: ["NY"] };
+const unconfigured = { name: "New Vendor Co.", shippableStates: [] as string[] };
+
+describe("checkShippingRestriction", () => {
+  it("permits a state in the vendor's allowlist", () => {
+    expect(checkShippingRestriction(phytoRx, "CA").ok).toBe(true);
+    expect(checkShippingRestriction(ny_dispensary, "NY").ok).toBe(true);
+  });
+
+  it("blocks a state not in the vendor's allowlist with reason and message", () => {
+    const result = checkShippingRestriction(ny_dispensary, "CA");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("state_not_permitted");
+    expect(result.message).toContain("CA");
+    expect(result.message).toContain("Hudson Valley Cannabis");
+  });
+
+  it("treats unconfigured vendor as fail-safe blocked, not permitted", () => {
+    const result = checkShippingRestriction(unconfigured, "CA");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("vendor_not_configured");
+  });
+
+  it("rejects bogus state codes", () => {
+    expect(checkShippingRestriction(phytoRx, "ZZ").reason).toBe("invalid_state");
+    expect(checkShippingRestriction(phytoRx, "").reason).toBe("invalid_state");
+  });
+
+  it("is case-insensitive on the state code", () => {
+    expect(checkShippingRestriction(ny_dispensary, "ny").ok).toBe(true);
+    expect(checkShippingRestriction(ny_dispensary, "Ny").ok).toBe(true);
+  });
+
+  it("permits DC for an all-states hemp vendor", () => {
+    expect(checkShippingRestriction(phytoRx, "DC").ok).toBe(true);
+  });
+});
+
+describe("checkCartShippingRestrictions", () => {
+  it("returns ok=true when every item permits the state", () => {
+    const result = checkCartShippingRestrictions(
+      [
+        { productSlug: "a", productName: "A", vendor: phytoRx },
+        { productSlug: "b", productName: "B", vendor: phytoRx },
+      ],
+      "CA",
+    );
+    expect(result.ok).toBe(true);
+    expect(result.blocked).toHaveLength(0);
+  });
+
+  it("collects every blocked item rather than short-circuiting", () => {
+    const result = checkCartShippingRestrictions(
+      [
+        { productSlug: "a", productName: "A", vendor: phytoRx },
+        { productSlug: "b", productName: "B", vendor: ny_dispensary },
+        { productSlug: "c", productName: "C", vendor: unconfigured },
+      ],
+      "CA",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.blocked).toHaveLength(2);
+    expect(result.blocked.map((b) => b.item.productSlug)).toEqual(["b", "c"]);
+  });
+});
+
+describe("defaultShippableStatesForVendorType", () => {
+  it("returns all 50 + DC for hemp brands", () => {
+    expect(defaultShippableStatesForVendorType("hemp_brand")).toHaveLength(51);
+    expect(defaultShippableStatesForVendorType("hemp_brand")).toContain("CA");
+    expect(defaultShippableStatesForVendorType("hemp_brand")).toContain("DC");
+  });
+
+  it("returns empty array for licensed dispensaries (must be set explicitly)", () => {
+    expect(defaultShippableStatesForVendorType("licensed_dispensary")).toEqual([]);
+  });
+});

--- a/src/lib/marketplace/shipping-restrictions.ts
+++ b/src/lib/marketplace/shipping-restrictions.ts
@@ -1,0 +1,123 @@
+// EMR-244 — State Shipping Restriction Matrix.
+//
+// Each vendor declares the USPS state codes it's licensed to ship to.
+// Carts and checkout validate that every cart item's vendor permits
+// shipping to the buyer's state. Empty `shippableStates` is treated as
+// "not configured" → blocked. This is the fail-safe direction: a
+// misconfigured vendor cannot accidentally ship into a restricted
+// state.
+
+import type { Vendor } from "@prisma/client";
+
+export const ALL_US_STATES_AND_DC: readonly string[] = [
+  "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA",
+  "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA",
+  "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
+  "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX",
+  "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+];
+
+export const ALL_US_STATES_AND_DC_SET: ReadonlySet<string> = new Set(
+  ALL_US_STATES_AND_DC,
+);
+
+export type ShippingRestrictionReason =
+  | "ok"
+  | "vendor_not_configured"
+  | "state_not_permitted"
+  | "invalid_state";
+
+export interface ShippingRestrictionResult {
+  ok: boolean;
+  reason: ShippingRestrictionReason;
+  message?: string;
+}
+
+type VendorShippingInputs = Pick<Vendor, "name" | "shippableStates">;
+
+/**
+ * Returns whether a given vendor permits shipping to a given USPS state
+ * code. Case-insensitive on the state code. Returns a structured reason
+ * so the caller can surface the right message at the right surface
+ * (cart toast, checkout banner, vendor portal warning).
+ */
+export function checkShippingRestriction(
+  vendor: VendorShippingInputs,
+  stateCode: string,
+): ShippingRestrictionResult {
+  const normalized = stateCode?.toUpperCase().trim();
+
+  if (!normalized || !ALL_US_STATES_AND_DC_SET.has(normalized)) {
+    return {
+      ok: false,
+      reason: "invalid_state",
+      message: "Enter a valid US state.",
+    };
+  }
+
+  if (!vendor.shippableStates || vendor.shippableStates.length === 0) {
+    return {
+      ok: false,
+      reason: "vendor_not_configured",
+      message: `${vendor.name} hasn't set up shipping yet — please reach out before purchasing.`,
+    };
+  }
+
+  const permitted = vendor.shippableStates.some(
+    (s) => s.toUpperCase() === normalized,
+  );
+
+  if (!permitted) {
+    return {
+      ok: false,
+      reason: "state_not_permitted",
+      message: `${vendor.name} doesn't currently ship to ${normalized}.`,
+    };
+  }
+
+  return { ok: true, reason: "ok" };
+}
+
+export interface CartItemForRestriction<V extends VendorShippingInputs> {
+  productSlug: string;
+  productName: string;
+  vendor: V;
+}
+
+export interface CartShippingRestrictionResult<V extends VendorShippingInputs> {
+  ok: boolean;
+  blocked: Array<{
+    item: CartItemForRestriction<V>;
+    result: ShippingRestrictionResult;
+  }>;
+}
+
+/**
+ * Convenience helper for checkout: runs `checkShippingRestriction`
+ * against every item in a cart and returns the full list of blocked
+ * items in one pass. Callers display a per-item message and a CTA to
+ * remove the blocked items.
+ */
+export function checkCartShippingRestrictions<V extends VendorShippingInputs>(
+  items: ReadonlyArray<CartItemForRestriction<V>>,
+  stateCode: string,
+): CartShippingRestrictionResult<V> {
+  const blocked: CartShippingRestrictionResult<V>["blocked"] = [];
+  for (const item of items) {
+    const result = checkShippingRestriction(item.vendor, stateCode);
+    if (!result.ok) blocked.push({ item, result });
+  }
+  return { ok: blocked.length === 0, blocked };
+}
+
+/**
+ * Helper for onboarding / admin: returns the default shippableStates
+ * array for a new vendor based on type. Hemp = all 50 + DC; dispensary
+ * = empty (must be set to the licensed state(s) explicitly during
+ * onboarding).
+ */
+export function defaultShippableStatesForVendorType(
+  vendorType: "hemp_brand" | "licensed_dispensary",
+): string[] {
+  return vendorType === "hemp_brand" ? [...ALL_US_STATES_AND_DC] : [];
+}

--- a/src/lib/marketplace/take-rate.test.ts
+++ b/src/lib/marketplace/take-rate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveTakeRate,
+  computePayoutLineItems,
+  VOLUME_TIER_GMV_THRESHOLD_USD,
+} from "./take-rate";
+
+const baseVendor = {
+  vendorType: "hemp_brand" as const,
+  takeRatePct: 0.10,
+  foundingPartnerFlag: true,
+  foundingPartnerExpiresAt: new Date("2028-04-23"),
+  reservePct: 0.10,
+  reserveDays: 14,
+};
+
+describe("resolveTakeRate", () => {
+  it("returns founding_partner tier while flag active and not expired", () => {
+    const result = resolveTakeRate(baseVendor, 0, new Date("2026-04-25"));
+    expect(result.tier).toBe("founding_partner");
+    expect(result.takeRatePct).toBe(0.10);
+  });
+
+  it("falls through to standard when founding flag has expired", () => {
+    const result = resolveTakeRate(
+      { ...baseVendor, takeRatePct: 0.15 },
+      0,
+      new Date("2030-01-01"),
+    );
+    expect(result.tier).toBe("standard");
+    expect(result.takeRatePct).toBe(0.15);
+  });
+
+  it("upgrades to growth tier once cumulative GMV crosses threshold", () => {
+    const result = resolveTakeRate(
+      { ...baseVendor, foundingPartnerFlag: false, takeRatePct: 0.12 },
+      VOLUME_TIER_GMV_THRESHOLD_USD,
+      new Date("2030-01-01"),
+    );
+    expect(result.tier).toBe("growth");
+    expect(result.takeRatePct).toBe(0.12);
+  });
+
+  it("uses dispensary policy regardless of founding flag", () => {
+    const result = resolveTakeRate(
+      {
+        ...baseVendor,
+        vendorType: "licensed_dispensary",
+        takeRatePct: 0.065,
+        reservePct: 0.05,
+      },
+      0,
+    );
+    expect(result.tier).toBe("dispensary");
+    expect(result.reservePct).toBe(0.05);
+  });
+});
+
+describe("computePayoutLineItems", () => {
+  it("matches the worked example from the policy doc ($40 sale, 10% take, 10% reserve)", () => {
+    const breakdown = resolveTakeRate(baseVendor, 0, new Date("2026-04-25"));
+    const lines = computePayoutLineItems(40, breakdown);
+    expect(lines.grossUsd).toBe(40);
+    expect(lines.takeRateUsd).toBe(4);
+    expect(lines.reserveHeldUsd).toBe(4);
+    expect(lines.netUsd).toBe(32);
+  });
+});

--- a/src/lib/marketplace/take-rate.ts
+++ b/src/lib/marketplace/take-rate.ts
@@ -1,0 +1,128 @@
+// Marketplace Take Rate Policy (EMR-225)
+//
+// Encodes the vendor pricing model defined in
+// docs/marketplace/take-rate-policy.md so downstream callers
+// (onboarding wizard, payout cron, vendor dashboard, payout statement
+// PDF) read one source of truth rather than inlining magic numbers.
+
+import type { Vendor } from "@prisma/client";
+
+export type TakeRateTier =
+  | "founding_partner"
+  | "growth"
+  | "standard"
+  | "dispensary";
+
+export interface TakeRateBreakdown {
+  tier: TakeRateTier;
+  takeRatePct: number;
+  reservePct: number;
+  reserveDays: number;
+}
+
+export const TAKE_RATE_POLICY = {
+  hemp: {
+    founding_partner: { takeRatePct: 0.10, reservePct: 0.10, reserveDays: 14 },
+    growth:           { takeRatePct: 0.12, reservePct: 0.10, reserveDays: 14 },
+    standard:         { takeRatePct: 0.15, reservePct: 0.10, reserveDays: 14 },
+  },
+  dispensary: {
+    // Per-partner negotiated band 5–8%; default to the midpoint until
+    // an explicit override is stored on the vendor record.
+    dispensary: { takeRatePct: 0.065, reservePct: 0.05, reserveDays: 14 },
+  },
+} as const;
+
+export const VOLUME_TIER_GMV_THRESHOLD_USD = 50_000;
+
+export const FOUNDING_PARTNER_LOCK_MONTHS = 24;
+
+export const FOUNDING_PARTNER_COHORT_CAP = 10;
+
+type TakeRateInputs = Pick<
+  Vendor,
+  | "vendorType"
+  | "takeRatePct"
+  | "foundingPartnerFlag"
+  | "foundingPartnerExpiresAt"
+  | "reservePct"
+  | "reserveDays"
+>;
+
+/**
+ * Resolve the effective take-rate breakdown for a vendor at a given
+ * cumulative-GMV checkpoint. Per-vendor overrides on the Vendor row
+ * always win — this function exists to compute the policy default
+ * when no override is set, and to assign the correct tier label for
+ * vendor-facing payout statements.
+ */
+export function resolveTakeRate(
+  vendor: TakeRateInputs,
+  cumulativeGmvUsd: number,
+  now: Date = new Date(),
+): TakeRateBreakdown {
+  const isDispensary = vendor.vendorType === "licensed_dispensary";
+
+  if (isDispensary) {
+    const policy = TAKE_RATE_POLICY.dispensary.dispensary;
+    return {
+      tier: "dispensary",
+      takeRatePct: vendor.takeRatePct ?? policy.takeRatePct,
+      reservePct: vendor.reservePct ?? policy.reservePct,
+      reserveDays: vendor.reserveDays ?? policy.reserveDays,
+    };
+  }
+
+  const foundingActive =
+    vendor.foundingPartnerFlag &&
+    (!vendor.foundingPartnerExpiresAt ||
+      vendor.foundingPartnerExpiresAt > now);
+
+  if (foundingActive) {
+    const policy = TAKE_RATE_POLICY.hemp.founding_partner;
+    return {
+      tier: "founding_partner",
+      takeRatePct: vendor.takeRatePct ?? policy.takeRatePct,
+      reservePct: vendor.reservePct ?? policy.reservePct,
+      reserveDays: vendor.reserveDays ?? policy.reserveDays,
+    };
+  }
+
+  const tier: TakeRateTier =
+    cumulativeGmvUsd >= VOLUME_TIER_GMV_THRESHOLD_USD ? "growth" : "standard";
+  const policy = TAKE_RATE_POLICY.hemp[tier];
+
+  return {
+    tier,
+    takeRatePct: vendor.takeRatePct ?? policy.takeRatePct,
+    reservePct: vendor.reservePct ?? policy.reservePct,
+    reserveDays: vendor.reserveDays ?? policy.reserveDays,
+  };
+}
+
+export interface PayoutLineItems {
+  grossUsd: number;
+  takeRateUsd: number;
+  reserveHeldUsd: number;
+  netUsd: number;
+}
+
+/**
+ * Per-payout breakdown shown to vendors. Processing fees are absorbed
+ * into the take rate by policy (see take-rate-policy.md) — vendors see
+ * one clean number, not a separate processing line. Reserve is held
+ * for `reserveDays` then released in a future payout.
+ */
+export function computePayoutLineItems(
+  grossUsd: number,
+  breakdown: TakeRateBreakdown,
+): PayoutLineItems {
+  const takeRateUsd = round2(grossUsd * breakdown.takeRatePct);
+  const reserveHeldUsd = round2(grossUsd * breakdown.reservePct);
+  const netUsd = round2(grossUsd - takeRateUsd - reserveHeldUsd);
+  return { grossUsd: round2(grossUsd), takeRateUsd, reserveHeldUsd, netUsd };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}


### PR DESCRIPTION
## Changes

### 1. Design tokens — white page fix
`layout.tsx`: Added `theme-leafmart` class to `<html>` so the Verdant Apothecary CSS custom properties cascade to the entire document. Without this class, all `var(--bg)`, `var(--text)`, etc. resolve to nothing → plain white page.

### 2. Ambient music mute bug
`ambient-music.tsx`: The browser auto-suspends the `AudioContext` when the tab/page loses visibility. On return, gain ramps silently fail against a suspended context. Now we:
- Resume the AudioContext before any stop operations
- Track a `fadingRef` to prevent double-stop race conditions
- Store and clean up the LFO oscillator (was leaking)
- Clean up all audio nodes on component unmount

### 3. Hero layout shift
`live-console.tsx`: The "Briefing ready" insights panel was conditionally rendered (`{phase === "done" && ...}`), which mounted/unmounted DOM nodes and shifted the hero card height by ~150px. Now the panel is always in the DOM with a stable `minHeight: 520` on the card, and visibility is controlled via `opacity`/`pointer-events`/`transform` transitions.

## Verification
- Tested ambient music: start → navigate to About → return → mute ✓
- Tested hero card: full animation cycle with no layout shift ✓
- Design tokens: warm parchment background renders correctly ✓