### PR TITLE
feat(leafmart): add Education + Advocacy nav tabs (EMR-292)

### DIFF
--- a/src/app/advocacy/page.tsx
+++ b/src/app/advocacy/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { Eyebrow } from "@/components/ui/ornament";
+import { SITE_URL } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "Advocacy — Leafjourney",
+  description:
+    "Leafjourney's home for cannabis advocacy — policy reform, patient access, and the organizations doing the work in our communities.",
+  alternates: { canonical: `${SITE_URL}/advocacy` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Advocacy — Leafjourney",
+    description:
+      "Cannabis advocacy, legislative reform, and the Leafjourney charitable fund.",
+    url: `${SITE_URL}/advocacy`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function AdvocacyPage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <SiteHeader />
+
+      <main className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-16 pb-24 text-center">
+        <Eyebrow className="justify-center mb-4">Coming soon</Eyebrow>
+        <h1 className="font-display text-4xl md:text-5xl lg:text-6xl tracking-tight text-text">
+          Advocacy
+        </h1>
+        <p className="text-lg text-text-muted mt-5 max-w-2xl mx-auto leading-relaxed">
+          Leafjourney is building a public home for our advocacy work — cannabis
+          policy reform, the Leafjourney charitable fund, and a curated registry
+          of patient-facing advocacy organizations and medical charities you can
+          support directly.
+        </p>
+        <p className="text-base text-text-muted mt-4 max-w-2xl mx-auto">
+          We&apos;ll publish more here as the program comes online.
+        </p>
+
+        <Link
+          href="/about"
+          className="inline-flex items-center mt-10 text-sm text-text-muted hover:text-text transition-colors"
+        >
+          ← About Leafjourney
+        </Link>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -19,6 +19,7 @@ export default function robots(): MetadataRoute.Robots {
           "/pricing",
           "/security",
           "/education",
+          "/advocacy",
         ],
         disallow: [
           "/api/",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -38,5 +38,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.7,
     },
+    {
+      url: `${SITE_URL}/advocacy`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 }

--- a/src/components/leafmart/LeafmartHeader.tsx
+++ b/src/components/leafmart/LeafmartHeader.tsx
@@ -18,6 +18,8 @@ const NAV_LINKS = [
 const SECONDARY_LINKS = [
   { label: "The Method", href: "/leafmart/about" },
   { label: "Vendors", href: "/leafmart/vendors" },
+  { label: "Education", href: "/education" },
+  { label: "Advocacy", href: "/advocacy" },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Appends **Education** (`/education`, existing page) and **Advocacy** (`/advocacy`, new stub) to `LeafmartHeader` secondary nav, alongside *The Method* and *Vendors*. Single source of truth — desktop nav and mobile slide-down menu both consume `SECONDARY_LINKS`.
- New `/advocacy` page is a server component reusing the marketing `SiteHeader`/`SiteFooter` shell with a "Coming soon" hero — placeholder copy nods to the planned scope (cannabis policy reform, charitable fund, advocacy-org registry).
- Registers `/advocacy` in `robots.ts` (allowlist) and `sitemap.ts` (priority 0.6, monthly cadence) for parity with `/education`.

Closes [EMR-292](https://linear.app/emr-project/issue/EMR-292).

## Files touched
- `src/components/leafmart/LeafmartHeader.tsx` — 2 lines added to `SECONDARY_LINKS`
- `src/app/advocacy/page.tsx` — **new** (52 lines)
- `src/app/robots.ts` — `/advocacy` added to allowlist
- `src/app/sitemap.ts` — `/advocacy` added to marketing sitemap

## Order chosen
`The Method · Vendors · Education · Advocacy` — appended after the existing two so muscle memory for current users stays intact. Happy to reorder if you prefer (e.g. interleaved or alphabetical).

## Scope note
The ticket says "use all the previous prompts to fill in those tab links." I didn't have those prompts in this session — `/education` is already a real page, so it just gets linked. `/advocacy` is a stub today: structurally complete, SEO-registered, but the copy is a placeholder. Suggest a follow-up ticket to land the actual advocacy content (legislative portal, charitable fund, org registry) once the program is shaped.

## Test plan
- [ ] `/leafmart` (desktop) — secondary nav shows: *The Method · Vendors · Education · Advocacy*
- [ ] `/leafmart` (mobile, hamburger open) — same four links appear in the secondary section above FAQ
- [ ] Click **Education** → lands on `/education` (existing ChatCB / Cannabis Wheel / etc. page)
- [ ] Click **Advocacy** → lands on `/advocacy`, shows "Coming soon" hero with SiteHeader + SiteFooter
- [ ] `/robots.txt` lists `/advocacy` under Allow
- [ ] `/sitemap.xml` includes `/advocacy`
- [ ] Lighthouse / dark mode pass on `/advocacy` (uses existing tokens — should be free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)