### PR TITLE
fix(leafmart): rename Dr. Patel specialty Internal medicine → Family medicine (EMR-293)

### DIFF
--- a/src/app/leafmart/consult/page.tsx
+++ b/src/app/leafmart/consult/page.tsx
@@ -95,7 +95,7 @@ export default function ConsultPage() {
 
           <div className="hidden lg:flex justify-end">
             <div className="w-full max-w-[360px] bg-white/40 rounded-[32px] p-3">
-              <Portrait tone="sage" caption="Dr. Patel · Internal medicine" />
+              <Portrait tone="sage" caption="Dr. Patel · Family medicine" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Single-line caption fix on the Leafmart consult page hero portrait: **Internal medicine → Family medicine**

Closes [EMR-293](https://linear.app/emr-project/issue/EMR-293).

## Files touched
- `src/app/leafmart/consult/page.tsx` (line 98)

## Test plan
- [ ] `/leafmart/consult` desktop hero portrait caption now reads **Dr. Patel · Family medicine**
- [ ] No other Internal/Internal medicine references remain (verified via `git grep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)