### PR TITLE
feat(dns): add theleafmart.com to middleware routing

### DIFF
--- a/src/lib/leafmart/seo.ts
+++ b/src/lib/leafmart/seo.ts
@@ -8,7 +8,7 @@ import type { LeafmartProduct } from "@/components/leafmart/LeafmartProductCard"
 
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
-  "https://leafmart.com";
+  "https://www.theleafmart.com";
 
 export const ORG_NAME = "Leafmart";
 export const ORG_LEGAL_NAME = "Leafjourney Health";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,7 @@
 // 4. For leafjourney.com (or localhost), passes through normally
 //
 // Domain config:
-//   leafmart.com / www.leafmart.com / leafmart.localhost → Leafmart
+//   leafmart.com / www.leafmart.com / theleafmart.com / www.theleafmart.com → Leafmart
 //   Everything else → Leafjourney (EMR)
 
 import { NextResponse, type NextRequest } from "next/server";
@@ -17,6 +17,8 @@ import { NextResponse, type NextRequest } from "next/server";
 const LEAFMART_HOSTS = [
   "leafmart.com",
   "www.leafmart.com",
+  "theleafmart.com",
+  "www.theleafmart.com",
   "leafmart.localhost",
 ];
 


### PR DESCRIPTION
Adds theleafmart.com and www.theleafmart.com to the middleware LEAFMART_HOSTS array so the new domain routes correctly to the Leafmart storefront. Also updates the canonical URL fallback in seo.ts from leafmart.com to www.theleafmart.com.

**DNS is already configured** — Squarespace records point at Render, and both domains are verified in the Render dashboard. This PR adds the app-level routing so the middleware recognizes the new hostnames.