### PR TITLE
feat(leafmart): liquid-glass 21+ age confirmation gate

### DIFF
--- a/src/app/leafmart/cart/page.tsx
+++ b/src/app/leafmart/cart/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ProductSilhouette } from "@/components/leafmart/ProductSilhouette";
 import { useCart, formatUSD } from "@/lib/leafmart/cart-store";
+import { useAgeConfirmation } from "@/lib/leafmart/age-confirmation";
+import { AgeGateModal } from "@/components/leafmart/AgeGateModal";
 import { DEMO_PRODUCTS } from "@/components/leafmart/demo-data";
 
 const TAX_RATE = 0.0875;
@@ -12,6 +15,10 @@ const REMOVE_ANIM_MS = 260;
 
 export default function CartPage() {
   const { items, updateQuantity, removeItem, subtotal } = useCart();
+  const router = useRouter();
+  const { isConfirmed, isDenied } = useAgeConfirmation();
+  const [ageGateOpen, setAgeGateOpen] = useState(false);
+  const cartRequiresAge = items.some((i) => i.product.requiresAgeVerification);
 
   const tax = useMemo(() => subtotal * TAX_RATE, [subtotal]);
   const total = subtotal + tax;
@@ -268,12 +275,29 @@ export default function CartPage() {
               {formatUSD(total)}
             </span>
           </div>
-          <Link
-            href="/leafmart/checkout"
-            className="mt-6 block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
-          >
-            Continue to checkout
-          </Link>
+          {cartRequiresAge && (!isConfirmed || isDenied) ? (
+            <button
+              type="button"
+              onClick={() => setAgeGateOpen(true)}
+              aria-haspopup="dialog"
+              className="mt-6 block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            >
+              Continue to checkout
+            </button>
+          ) : (
+            <Link
+              href="/leafmart/checkout"
+              className="mt-6 block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-4 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+            >
+              Continue to checkout
+            </Link>
+          )}
+
+          <AgeGateModal
+            open={ageGateOpen}
+            onClose={() => setAgeGateOpen(false)}
+            onConfirmed={() => router.push("/leafmart/checkout")}
+          />
 
           {/* Trust signal stack */}
           <ul className="mt-5 space-y-3 text-[12px] text-[var(--text-soft)] leading-relaxed">

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useCart, formatUSD } from "@/lib/leafmart/cart-store";
+import { useAgeConfirmation } from "@/lib/leafmart/age-confirmation";
+import { AgeGateModal } from "@/components/leafmart/AgeGateModal";
 import { ProductSilhouette } from "@/components/leafmart/ProductSilhouette";
 
 const TAX_RATE = 0.0875;
@@ -195,6 +197,21 @@ function labelClass() {
 
 export default function CheckoutPage() {
   const { items, subtotal, clearCart } = useCart();
+  const ageConfirmation = useAgeConfirmation();
+  const cartRequiresAge = items.some((i) => i.product.requiresAgeVerification);
+  const ageGateBlocking =
+    cartRequiresAge &&
+    ageConfirmation.hydrated &&
+    !ageConfirmation.isConfirmed;
+  const [ageGateOpen, setAgeGateOpen] = useState(false);
+
+  // Defensive guard: if a user lands on /leafmart/checkout directly (deep
+  // link, refresh) with regulated items in cart but no confirmation yet,
+  // open the gate before letting them fill in payment info.
+  useEffect(() => {
+    if (ageGateBlocking) setAgeGateOpen(true);
+  }, [ageGateBlocking]);
+
   const [step, setStep] = useState<StepIndex>(0);
   // Direction drives the slide-in animation when stepping forward vs back.
   const [direction, setDirection] = useState<Direction>("forward");
@@ -545,7 +562,16 @@ export default function CheckoutPage() {
 
   // ── Steps 0–2 ──────────────────────────────────────────────────
   return (
-    <section className="max-w-[1100px] mx-auto px-6 lg:px-10 py-12 lg:py-16">
+    <section
+      className="max-w-[1100px] mx-auto px-6 lg:px-10 py-12 lg:py-16"
+      aria-busy={ageGateBlocking}
+    >
+      <AgeGateModal
+        open={ageGateOpen}
+        onClose={() => setAgeGateOpen(false)}
+        onConfirmed={() => setAgeGateOpen(false)}
+      />
+
       <div className="text-center mb-3">
         <p className="eyebrow text-[var(--text-soft)]">Secure checkout</p>
       </div>

--- a/src/components/leafmart/AgeGateModal.tsx
+++ b/src/components/leafmart/AgeGateModal.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  confirmAgeOver21,
+  denyAgeOver21,
+  useAgeConfirmation,
+} from "@/lib/leafmart/age-confirmation";
+
+export type AgeGateModalProps = {
+  open: boolean;
+  /** Called when the user dismisses without making a choice (Escape, backdrop). */
+  onClose: () => void;
+  /** Called after the user confirms 21+. The parent typically continues the
+   *  purchase flow (navigate to /checkout, etc.). */
+  onConfirmed?: () => void;
+  /** Optional: where the polite "browse other products" CTA navigates to in
+   *  the blocked state. Defaults to `/leafmart`. */
+  browseHref?: string;
+};
+
+/**
+ * Reusable, accessible 21+ age confirmation. Liquid-glass panel with a
+ * frosted backdrop, an inner highlight, and the brand's quiet luxury tone.
+ *
+ * Two states:
+ *  - `prompt` — the user picks "I am 21 or older" or "I am not 21".
+ *  - `blocked` — shown after a "not 21" answer; offers a polite exit.
+ */
+export function AgeGateModal({
+  open,
+  onClose,
+  onConfirmed,
+  browseHref = "/leafmart",
+}: AgeGateModalProps) {
+  const titleId = useId();
+  const descId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const primaryRef = useRef<HTMLButtonElement>(null);
+  const { status } = useAgeConfirmation();
+  const [stage, setStage] = useState<"prompt" | "blocked">("prompt");
+
+  // When the modal re-opens, sync stage with the persisted denial state so
+  // a previously-denied user lands directly in the polite blocked view.
+  useEffect(() => {
+    if (open) {
+      setStage(status === "denied" ? "blocked" : "prompt");
+    }
+  }, [open, status]);
+
+  // Escape, focus management, and body-scroll lock — same primitives the
+  // existing CartDrawer uses, just tuned for a centered dialog.
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const body = document.body;
+    const prevOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", onKey);
+
+    // Move focus into the dialog after the enter transition.
+    const focusTimer = window.setTimeout(() => {
+      primaryRef.current?.focus();
+    }, 80);
+
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      window.clearTimeout(focusTimer);
+      body.style.overflow = prevOverflow;
+      previouslyFocused?.focus?.();
+    };
+  }, [open, onClose, stage]);
+
+  const handleConfirm = useCallback(() => {
+    confirmAgeOver21();
+    onConfirmed?.();
+    onClose();
+  }, [onConfirmed, onClose]);
+
+  const handleDeny = useCallback(() => {
+    denyAgeOver21();
+    setStage("blocked");
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      className="fixed inset-0 z-[60] flex items-center justify-center px-4 py-8 sm:py-12"
+    >
+      {/* Frosted backdrop — keeps the storefront softly visible behind. */}
+      <button
+        type="button"
+        aria-label="Dismiss age confirmation"
+        onClick={onClose}
+        tabIndex={-1}
+        className="absolute inset-0 bg-[var(--ink)]/35 backdrop-blur-md cursor-default animate-in fade-in duration-300"
+      />
+
+      {/* Liquid-glass panel */}
+      <div
+        ref={dialogRef}
+        className={[
+          "relative w-full max-w-md mx-auto",
+          "rounded-3xl overflow-hidden",
+          "bg-[var(--surface)]/80 supports-[backdrop-filter]:bg-[var(--surface)]/65",
+          "backdrop-blur-2xl backdrop-saturate-150",
+          "border border-white/40",
+          "shadow-[0_20px_60px_-20px_rgba(21,33,25,0.45),0_0_0_1px_rgba(31,77,55,0.06)]",
+          "animate-in fade-in zoom-in-95 slide-in-from-bottom-2 duration-400",
+        ].join(" ")}
+      >
+        {/* Inner highlight + soft brand wash */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-3xl"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 38%), radial-gradient(120% 80% at 50% -10%, rgba(31,77,55,0.10) 0%, rgba(31,77,55,0) 60%)",
+          }}
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -top-px left-6 right-6 h-px"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 50%, rgba(255,255,255,0) 100%)",
+          }}
+        />
+
+        <div className="relative p-7 sm:p-9">
+          {stage === "prompt" ? (
+            <PromptView
+              titleId={titleId}
+              descId={descId}
+              primaryRef={primaryRef}
+              onConfirm={handleConfirm}
+              onDeny={handleDeny}
+            />
+          ) : (
+            <BlockedView
+              titleId={titleId}
+              descId={descId}
+              primaryRef={primaryRef}
+              browseHref={browseHref}
+              onClose={onClose}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PromptView({
+  titleId,
+  descId,
+  primaryRef,
+  onConfirm,
+  onDeny,
+}: {
+  titleId: string;
+  descId: string;
+  primaryRef: React.RefObject<HTMLButtonElement>;
+  onConfirm: () => void;
+  onDeny: () => void;
+}) {
+  return (
+    <>
+      <div className="flex justify-center mb-5">
+        <AgePill />
+      </div>
+      <h2
+        id={titleId}
+        className="font-display text-[26px] sm:text-[28px] leading-tight tracking-tight text-[var(--ink)] text-center"
+      >
+        Age confirmation required
+      </h2>
+      <p
+        id={descId}
+        className="mt-3 text-[14.5px] leading-relaxed text-[var(--muted)] text-center max-w-[28ch] mx-auto"
+      >
+        To purchase select products on The LifeMart, you must be 21 years of
+        age or older. By continuing, you confirm that you meet this requirement
+        and agree to use these products responsibly.
+      </p>
+
+      <div className="mt-7 flex flex-col gap-2.5">
+        <button
+          ref={primaryRef}
+          type="button"
+          onClick={onConfirm}
+          className="w-full rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+        >
+          I am 21 or older
+        </button>
+        <button
+          type="button"
+          onClick={onDeny}
+          className="w-full rounded-full border border-[var(--border)] bg-[var(--bg)]/60 text-[var(--ink)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--surface-muted)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+        >
+          I am not 21
+        </button>
+      </div>
+
+      <p className="mt-5 text-center text-[11.5px] leading-relaxed text-[var(--muted)]/85">
+        Please follow all applicable laws in your state or jurisdiction.
+      </p>
+    </>
+  );
+}
+
+function BlockedView({
+  titleId,
+  descId,
+  primaryRef,
+  browseHref,
+  onClose,
+}: {
+  titleId: string;
+  descId: string;
+  primaryRef: React.RefObject<HTMLButtonElement>;
+  browseHref: string;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <div className="flex justify-center mb-5">
+        <AgePill muted />
+      </div>
+      <h2
+        id={titleId}
+        className="font-display text-[26px] sm:text-[28px] leading-tight tracking-tight text-[var(--ink)] text-center"
+      >
+        Thanks for your honesty
+      </h2>
+      <p
+        id={descId}
+        className="mt-3 text-[14.5px] leading-relaxed text-[var(--muted)] text-center max-w-[30ch] mx-auto"
+      >
+        These products are only available to customers who are 21 or older.
+        We&rsquo;d love to help you explore everything else The LifeMart has to
+        offer.
+      </p>
+
+      <div className="mt-7 flex flex-col gap-2.5">
+        <Link
+          ref={primaryRef as unknown as React.RefObject<HTMLAnchorElement>}
+          href={browseHref}
+          onClick={onClose}
+          className="w-full block text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+        >
+          Browse other products
+        </Link>
+        <button
+          type="button"
+          onClick={onClose}
+          className="w-full rounded-full border border-[var(--border)] bg-[var(--bg)]/60 text-[var(--ink)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--surface-muted)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+        >
+          Close
+        </button>
+      </div>
+    </>
+  );
+}
+
+/** Small refined "21+" mark — a frosted shield-like badge in the brand palette. */
+function AgePill({ muted = false }: { muted?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={[
+        "relative inline-flex items-center justify-center",
+        "h-12 px-5 rounded-full",
+        "bg-[var(--surface-muted)]/70 supports-[backdrop-filter]:bg-white/55",
+        "backdrop-blur-md",
+        "border border-white/60",
+        "shadow-[inset_0_1px_0_rgba(255,255,255,0.7),0_8px_22px_-12px_rgba(31,77,55,0.45)]",
+      ].join(" ")}
+    >
+      <span
+        className="absolute inset-0 rounded-full pointer-events-none"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 50%)",
+        }}
+      />
+      <span
+        className={[
+          "relative font-display text-[16px] tracking-[0.04em]",
+          muted ? "text-[var(--muted)]" : "text-[var(--leaf)]",
+        ].join(" ")}
+      >
+        <span className="font-medium">21</span>
+        <span className="ml-0.5 align-top text-[12px]">+</span>
+      </span>
+    </span>
+  );
+}

--- a/src/components/leafmart/CartDrawer.tsx
+++ b/src/components/leafmart/CartDrawer.tsx
@@ -1,15 +1,25 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useCart, formatUSD } from "@/lib/leafmart/cart-store";
+import { useAgeConfirmation } from "@/lib/leafmart/age-confirmation";
 import { ProductSilhouette } from "./ProductSilhouette";
+import { AgeGateModal } from "./AgeGateModal";
 
 const FREE_SHIPPING_THRESHOLD = 75;
 const REMOVE_ANIM_MS = 240;
 
 export function CartDrawer() {
   const { items, isOpen, closeCart, removeItem, updateQuantity, subtotal, itemCount } = useCart();
+  const router = useRouter();
+  const { isConfirmed, isDenied } = useAgeConfirmation();
+  const [ageGateOpen, setAgeGateOpen] = useState(false);
+
+  // True when the cart has at least one regulated item (THC > 0). The gate
+  // only fires for these — non-regulated wellness products checkout freely.
+  const cartRequiresAge = items.some((i) => i.product.requiresAgeVerification);
   const dialogRef = useRef<HTMLElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
@@ -276,13 +286,31 @@ export function CartDrawer() {
             <p className="text-[11.5px] text-[var(--muted)] mb-3.5 leading-relaxed">
               Shipping &amp; tax calculated at checkout. Typically ships in 1–2 business days.
             </p>
-            <Link
-              href="/leafmart/checkout"
-              onClick={closeCart}
-              className="block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
-            >
-              Checkout · {formatUSD(subtotal)}
-            </Link>
+            {cartRequiresAge && !isConfirmed ? (
+              <button
+                type="button"
+                onClick={() => setAgeGateOpen(true)}
+                className="block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+                aria-haspopup="dialog"
+              >
+                Checkout · {formatUSD(subtotal)}
+              </button>
+            ) : (
+              <Link
+                href="/leafmart/checkout"
+                onClick={closeCart}
+                aria-disabled={cartRequiresAge && isDenied}
+                onClickCapture={(e) => {
+                  if (cartRequiresAge && isDenied) {
+                    e.preventDefault();
+                    setAgeGateOpen(true);
+                  }
+                }}
+                className="block w-full text-center rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[13.5px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors"
+              >
+                Checkout · {formatUSD(subtotal)}
+              </Link>
+            )}
             <Link
               href="/leafmart/cart"
               onClick={closeCart}
@@ -293,6 +321,15 @@ export function CartDrawer() {
           </footer>
         )}
       </aside>
+
+      <AgeGateModal
+        open={ageGateOpen}
+        onClose={() => setAgeGateOpen(false)}
+        onConfirmed={() => {
+          closeCart();
+          router.push("/leafmart/checkout");
+        }}
+      />
     </>
   );
 }

--- a/src/components/leafmart/LeafmartProductCard.tsx
+++ b/src/components/leafmart/LeafmartProductCard.tsx
@@ -52,6 +52,12 @@ export interface LeafmartProduct {
   clinicianNote?: string | null;
   variants?: LeafmartVariant[];
   reviews?: LeafmartReview[];
+
+  // True when the product is regulated and requires the customer to confirm
+  // they are 21 or older before purchase. Derived server-side from THC content
+  // (any non-zero THC flips this on); other regulated categories can extend
+  // this rule in `mapProductToLeafmart`.
+  requiresAgeVerification?: boolean;
 }
 
 export function LeafmartProductCard({ product }: { product: LeafmartProduct }) {

--- a/src/lib/leafmart/age-confirmation.ts
+++ b/src/lib/leafmart/age-confirmation.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Lightweight client-side age-of-purchase confirmation for regulated products.
+ *
+ * Storage: sessionStorage. The confirmation lasts the browser session and is
+ * cleared when the tab/window closes — long enough to avoid re-prompting
+ * during a single shopping flow, short enough that returning visitors are
+ * asked again. We deliberately don't persist this to localStorage or cookies
+ * so we never carry a "yes" answer past the device the user is on.
+ *
+ * This is not identity verification. It's a UX safeguard layered on top of
+ * the server-side checkout API, which performs the binding check.
+ */
+
+export const AGE_CONFIRMED_KEY = "leafmart:age-confirmed-21:v1";
+export const AGE_DENIED_KEY = "leafmart:age-denied:v1";
+export const AGE_EVENT = "leafmart:age-confirmation-changed";
+
+export type AgeStatus = "unknown" | "confirmed" | "denied";
+
+function readStatus(): AgeStatus {
+  if (typeof window === "undefined") return "unknown";
+  try {
+    if (sessionStorage.getItem(AGE_CONFIRMED_KEY) === "1") return "confirmed";
+    if (sessionStorage.getItem(AGE_DENIED_KEY) === "1") return "denied";
+  } catch {
+    // sessionStorage disabled — treat every visit as unknown.
+  }
+  return "unknown";
+}
+
+function broadcast() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(AGE_EVENT));
+}
+
+export function confirmAgeOver21() {
+  try {
+    sessionStorage.setItem(AGE_CONFIRMED_KEY, "1");
+    sessionStorage.removeItem(AGE_DENIED_KEY);
+  } catch {
+    // ignore
+  }
+  broadcast();
+}
+
+export function denyAgeOver21() {
+  try {
+    sessionStorage.setItem(AGE_DENIED_KEY, "1");
+    sessionStorage.removeItem(AGE_CONFIRMED_KEY);
+  } catch {
+    // ignore
+  }
+  broadcast();
+}
+
+export function resetAgeConfirmation() {
+  try {
+    sessionStorage.removeItem(AGE_CONFIRMED_KEY);
+    sessionStorage.removeItem(AGE_DENIED_KEY);
+  } catch {
+    // ignore
+  }
+  broadcast();
+}
+
+/**
+ * Reactive view of the current age-confirmation status. Returns `"unknown"`
+ * during SSR and on the very first render, then settles to the stored value
+ * after hydration. Mutations from anywhere in the app (this tab) propagate
+ * via the `AGE_EVENT` custom event.
+ */
+export function useAgeConfirmation() {
+  const [status, setStatus] = useState<AgeStatus>("unknown");
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setStatus(readStatus());
+    setHydrated(true);
+
+    const onChange = () => setStatus(readStatus());
+    window.addEventListener(AGE_EVENT, onChange);
+    // Catch tabs that mutate sessionStorage from another window (rare, but
+    // sessionStorage propagates within the same origin tabs in some browsers).
+    window.addEventListener("storage", onChange);
+    return () => {
+      window.removeEventListener(AGE_EVENT, onChange);
+      window.removeEventListener("storage", onChange);
+    };
+  }, []);
+
+  const confirm = useCallback(() => confirmAgeOver21(), []);
+  const deny = useCallback(() => denyAgeOver21(), []);
+  const reset = useCallback(() => resetAgeConfirmation(), []);
+
+  return {
+    status,
+    hydrated,
+    isConfirmed: status === "confirmed",
+    isDenied: status === "denied",
+    confirm,
+    deny,
+    reset,
+  };
+}

--- a/src/lib/leafmart/products.ts
+++ b/src/lib/leafmart/products.ts
@@ -227,6 +227,7 @@ export function mapProductToLeafmart(p: ProductWithJoins): LeafmartProduct {
       verified: r.verified,
       createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : String(r.createdAt),
     })),
+    requiresAgeVerification: (p.thcContent ?? 0) > 0,
   };
 }
 


### PR DESCRIPTION
## Summary
- Reusable, accessible 21+ age-gate that fires only at checkout chokepoints when the cart contains a regulated item (THC > 0).
- Liquid-glass panel in the Verdant palette — frosted backdrop, inner highlight, soft brand-tinted ring, gentle shadow. No alarm-triangle energy.
- `sessionStorage`-backed confirmation under `leafmart:age-confirmed-21:v1` so the user isn't re-prompted within a single shopping flow; clears on tab close. The binding identity check stays on the existing `/api/leafmart/checkout`.

## What's in it
- **New** `src/components/leafmart/AgeGateModal.tsx` — `role="dialog"`, focus trap, Escape close, body-scroll lock, `prompt`/`blocked` stages.
- **New** `src/lib/leafmart/age-confirmation.ts` — `useAgeConfirmation()` hook + `confirmAgeOver21` / `denyAgeOver21` / `resetAgeConfirmation` actions, broadcast via a custom `AGE_EVENT` so every consumer in the tree stays in sync.
- **Mod** `LeafmartProductCard.tsx` + `products.ts` — surfaces `requiresAgeVerification: boolean` on `LeafmartProduct`, derived from `p.thcContent > 0` in `mapProductToLeafmart()`.
- **Mod** `CartDrawer.tsx` — Checkout CTA intercepts when cart contains regulated items and the user is unconfirmed/denied.
- **Mod** `app/leafmart/cart/page.tsx` — same intercept on "Continue to checkout".
- **Mod** `app/leafmart/checkout/page.tsx` — defensive `useEffect` guard for direct deep-links / refreshes.

## Where the gate appears
1. Cart drawer Checkout button (most common entry).
2. `/leafmart/cart` "Continue to checkout" CTA (full-page parity).
3. `/leafmart/checkout` entry (auto-opens if user lands here without confirmation).

Non-regulated wellness products checkout without interruption.

## Design notes
- `bg-[var(--surface)]/65` + `backdrop-blur-2xl backdrop-saturate-150`, `rounded-3xl`.
- Inner highlight: dual-pseudo `linear-gradient` + `radial-gradient` brand wash.
- 21+ pill: frosted-white capsule, `var(--leaf)` numerals, inset white highlight + soft `--leaf` glow.
- Buttons: existing storefront pill style (`bg-[var(--ink)] hover:bg-[var(--leaf)]` for primary).

## Test plan
- [ ] Cart with at least one THC > 0 product → drawer Checkout button opens the gate; confirming routes to `/leafmart/checkout`.
- [ ] Cart with no regulated items → drawer Checkout link navigates directly with no gate.
- [ ] Decline ("I am not 21") → polite blocked view; subsequent checkout attempts re-open the modal in blocked state.
- [ ] Hard-refresh on `/leafmart/checkout` with a regulated cart and no prior confirmation → gate auto-opens before the form.
- [ ] Escape key, backdrop click, and Tab focus trap behave correctly.
- [ ] sessionStorage entry clears when the tab closes; persists across pages within the session.
- [ ] Mobile (≤ 640px): panel pads correctly, buttons stack, focus order remains logical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)