### PR TITLE
fix(ops): hide keystone business model pricing from UI

### DIFF
--- a/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/agent-fleet.tsx
@@ -135,17 +135,13 @@ export function AgentFleetPanel() {
             Assign a different model to each of the {AGENT_CATALOG.length} agents in the fleet. Agents without
             an override use the practice default ({defaultModel?.name ?? "—"}). Disable any agent you don&apos;t use.
           </p>
-          <p className="text-xs text-text-subtle mt-2">
-            Pricing is keystone: practices pay <strong>max(${LEAFJOURNEY_PRICE_FLOOR_USD}/mo, 2x raw cost)</strong>.
-            Below ~${LEAFJOURNEY_PRICE_FLOOR_USD / 2} in raw cost the floor applies; above that we pass cost through and double it as margin.
-          </p>
         </CardContent>
       </Card>
 
       {/* Fleet totals */}
       <Card tone="raised">
         <CardContent className="py-5">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 items-end">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-6 items-end">
             <div>
               <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">Active agents</p>
               <p className="text-2xl font-display text-text tabular-nums">
@@ -153,20 +149,9 @@ export function AgentFleetPanel() {
               </p>
             </div>
             <div>
-              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">Raw fleet cost</p>
-              <p className="text-2xl font-display text-text tabular-nums">
-                ${fleetTotals.rawMonthly.toFixed(2)}<span className="text-sm text-text-muted font-sans">/mo</span>
-              </p>
-            </div>
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">Leafjourney price</p>
+              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">Estimated cost</p>
               <p className="text-2xl font-display text-accent tabular-nums">
                 ${fleetTotals.leafjourney.toFixed(2)}<span className="text-sm text-text-muted font-sans">/mo</span>
-              </p>
-              <p className="text-[11px] text-text-subtle mt-0.5">
-                {fleetTotals.basis === "floor"
-                  ? `$${LEAFJOURNEY_PRICE_FLOOR_USD} platform minimum`
-                  : "Keystone (2x pass-through)"}
               </p>
             </div>
             <div className="flex justify-end gap-2">
@@ -344,10 +329,7 @@ function AgentRow({
 
       {/* Cost */}
       <div className="col-span-4 md:col-span-2 text-right">
-        <p className="text-sm font-medium text-text tabular-nums">${rawMonthly.toFixed(2)}</p>
-        <p className="text-[10px] text-text-subtle tabular-nums">
-          billed ${leafjourney.toFixed(2)}/mo
-        </p>
+        <p className="text-sm font-medium text-text tabular-nums">${leafjourney.toFixed(2)}/mo</p>
       </div>
     </div>
   );

--- a/src/app/(operator)/ops/settings/ai-config/model-config.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/model-config.tsx
@@ -111,7 +111,7 @@ export function ModelConfigPanel() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div>
               <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
                 Model
@@ -127,23 +127,10 @@ export function ModelConfigPanel() {
             </div>
             <div>
               <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
-                Raw cost
-              </p>
-              <p className="text-sm font-medium text-text">
-                ~${estimatedMonthlyCost}/mo
-              </p>
-            </div>
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
-                Leafjourney price
+                Estimated cost
               </p>
               <p className="text-sm font-medium text-accent">
-                ${leafjourneyPrice.toFixed(2)}/mo
-              </p>
-              <p className="text-[10px] text-text-subtle mt-0.5">
-                {priceBasis === "floor"
-                  ? `$${LEAFJOURNEY_PRICE_FLOOR_USD} platform minimum`
-                  : "Keystone (2x pass-through)"}
+                ~${leafjourneyPrice.toFixed(2)}/mo
               </p>
             </div>
           </div>
@@ -377,31 +364,17 @@ export function ModelConfigPanel() {
       {/* Cost estimate + Save */}
       <Card tone="raised">
         <CardContent className="py-5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <div className="grid grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 gap-8">
             <div>
               <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
-                Raw model cost
+                Estimated cost
               </p>
-              <p className="text-lg font-display text-text tabular-nums">
-                ~${estimatedMonthlyCost}
+              <p className="text-lg font-display text-accent tabular-nums">
+                ~${leafjourneyPrice.toFixed(2)}
                 <span className="text-sm text-text-muted font-sans">/mo</span>
               </p>
               <p className="text-xs text-text-subtle mt-0.5">
                 ~2M tokens/month
-              </p>
-            </div>
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wider text-text-subtle mb-1">
-                Leafjourney price
-              </p>
-              <p className="text-lg font-display text-accent tabular-nums">
-                ${leafjourneyPrice.toFixed(2)}
-                <span className="text-sm text-text-muted font-sans">/mo</span>
-              </p>
-              <p className="text-xs text-text-subtle mt-0.5">
-                {priceBasis === "floor"
-                  ? `$${LEAFJOURNEY_PRICE_FLOOR_USD} floor`
-                  : "2x pass-through"}
               </p>
             </div>
           </div>

--- a/src/app/(operator)/ops/settings/ai-config/page.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/page.tsx
@@ -12,7 +12,7 @@ export default async function AiConfigPage() {
       <PageHeader
         eyebrow="Settings"
         title="AI model configuration"
-        description="Pick a practice-wide default, then tune any agent in the fleet. Pricing is keystone — practices pay max($20/mo, 2x raw model cost)."
+        description="Pick a practice-wide default, then tune any agent in the fleet."
       />
 
       <AiConfigTabs />


### PR DESCRIPTION
Removes internal keystone margin calculations and references from the AI Config dashboard. Now only displays 'Estimated cost' without exposing the markup logic.