### PR TITLE
fix(ui): use sprout icon for browser tab favicon

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,27 +1,9 @@
-<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+<svg width="32" height="32" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <title>Leafjourney</title>
-  <defs>
-    <linearGradient id="lj-leaf" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#4A8362"/>
-      <stop offset="100%" stop-color="#1F4D37"/>
-    </linearGradient>
-  </defs>
-
-  <!-- warm cream rounded background, matching --bg (#F8F4EB) -->
-  <rect width="32" height="32" rx="7" fill="#F8F4EB"/>
-
-  <!-- central stem -->
-  <path d="M 16 28 L 16 5"
-        stroke="#1F4D37" stroke-width="1.3" stroke-linecap="round" fill="none"/>
-
-  <!-- lower pair -->
-  <path d="M 16 22 C 13 22, 9 20, 7 18 C 11 20, 14 21, 16 22 Z" fill="url(#lj-leaf)"/>
-  <path d="M 16 22 C 19 22, 23 20, 25 18 C 21 20, 18 21, 16 22 Z" fill="url(#lj-leaf)"/>
-
-  <!-- middle pair -->
-  <path d="M 16 15 C 13 15, 10 14, 8 12 C 11 14, 14 14, 16 15 Z" fill="url(#lj-leaf)"/>
-  <path d="M 16 15 C 19 15, 22 14, 24 12 C 21 14, 18 14, 16 15 Z" fill="url(#lj-leaf)"/>
-
-  <!-- top leaf -->
-  <path d="M 16 8 C 13 6, 14 4, 16 3 C 18 4, 19 6, 16 8 Z" fill="url(#lj-leaf)"/>
+  <rect width="24" height="24" rx="5" fill="#F8F4EB"/>
+  <g fill="none" stroke="#1F4D37" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14 9.536V7a4 4 0 0 1 4-4h1.5a.5.5 0 0 1 .5.5V5a4 4 0 0 1-4 4 4 4 0 0 0-4 4c0 2 1 3 1 5a5 5 0 0 1-1 3"/>
+    <path d="M4 9a5 5 0 0 1 8 4 5 5 0 0 1-8-4"/>
+    <path d="M5 21h14"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- Replaces the five-leaf Leafjourney mark in `src/app/icon.svg` with the lucide `Sprout` glyph already used throughout the app (landing tabs, plant-health UI, hero art).
- Keeps the same cream `#F8F4EB` rounded background and `#1F4D37` brand-green stroke so the tab icon stays on-brand.
- Renders crisply at 16/32px — the previous composition collapsed visually at favicon sizes.

Single-file change. Next.js's app-router `icon.svg` convention serves it as the favicon automatically — no metadata or layout edits needed.

## Test plan
- [ ] `next dev`, hard-refresh a tab, confirm the sprout shows in the browser tab.
- [ ] Visual check at 16px (tab) and 32px (bookmark bar / pinned tab).
- [ ] Confirm dark-mode tab background still has enough contrast against the cream tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)