### PR TITLE
feat(portal): Phase 7 Track 1 UX consolidation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -572,6 +572,18 @@
 }
 
 /* ==========================================================================
+   Utility — invisible scrollbar (used by horizontal sub-tab nav, etc.)
+   The bar still scrolls; we just hide its chrome to keep the row clean.
+   ========================================================================== */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* ==========================================================================
    ADA — Reduced motion: disable ALL transitions and animations globally
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/education/ResearchTab.tsx
+++ b/src/components/education/ResearchTab.tsx
@@ -23,6 +23,12 @@ import {
 } from "@/lib/domain/chatcb";
 import { searchPubMedArticles, type PubMedSearchResult } from "@/app/education/actions";
 
+// Kander book links — single source of truth so the URLs can be swapped to
+// our hosted PDF / mirrored web copy without hunting through the JSX.
+const KANDER_PDF_URL =
+  "https://archive.org/download/cannabis-and-cannabinoids-in-cancer-treatment/CannabisAndCancer-JustinKander.pdf";
+const KANDER_WEB_URL = "https://www.cannabisandcancer.com/";
+
 export function ResearchTab() {
   const [cannabinoidFilter, setCannabinoidFilter] = useState("");
   const [conditionFilter, setConditionFilter] = useState("");
@@ -237,8 +243,12 @@ export function ResearchTab() {
               By Justin Kander. A comprehensive compilation of human cases and research demonstrating the interaction between cannabinoids and cancer.
             </p>
             <div className="flex flex-wrap gap-3 justify-center md:justify-start">
-              <button
-                type="button"
+              <a
+                href={KANDER_PDF_URL}
+                download
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Download Cannabis and Cancer PDF"
                 className={cn(
                   "inline-flex items-center justify-center gap-2 h-12 px-6 rounded-xl",
                   "bg-white text-indigo-700 font-semibold text-sm shadow-lg shadow-indigo-900/30",
@@ -249,9 +259,12 @@ export function ResearchTab() {
               >
                 <Download className="w-4 h-4" strokeWidth={2.5} />
                 Download PDF
-              </button>
-              <button
-                type="button"
+              </a>
+              <a
+                href={KANDER_WEB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Read Cannabis and Cancer web version (opens in new tab)"
                 className={cn(
                   "inline-flex items-center justify-center gap-2 h-12 px-6 rounded-xl",
                   "bg-white/10 text-white font-semibold text-sm border border-white/40 backdrop-blur-md",
@@ -262,7 +275,7 @@ export function ResearchTab() {
               >
                 <ExternalLink className="w-4 h-4" strokeWidth={2.5} />
                 Read Web Version
-              </button>
+              </a>
             </div>
           </div>
         </CardContent>

--- a/src/components/shell/PatientSectionNav.tsx
+++ b/src/components/shell/PatientSectionNav.tsx
@@ -26,12 +26,12 @@ const SECTIONS: Record<string, { title: string; tabs: TabDef[] }> = {
   health: {
     title: "My Health",
     tabs: [
-      { label: "My Results", href: "/portal/records" },
+      { label: "My Records", href: "/portal/records" },
       { label: "Medications", href: "/portal/medications" },
       { label: "Dosing plan", href: "/portal/dosing" },
       { label: "Labs", href: "/portal/labs" },
       { label: "Assessments", href: "/portal/assessments" },
-      { label: "Outcomes", href: "/portal/outcomes" },
+      { label: "Log check-in", href: "/portal/outcomes" },
       { label: "Care plan", href: "/portal/care-plan" },
       { label: "Care guide", href: "/portal/education" },
       { label: "Learn", href: "/portal/learn" },
@@ -65,36 +65,50 @@ export function PatientSectionNav({ section }: { section: keyof typeof SECTIONS 
   if (!config) return null;
 
   return (
-    <nav
-      className="flex flex-wrap items-center gap-1 border-b border-border mb-8"
-      aria-label={`${config.title} sections`}
-    >
-      {config.tabs.map((tab) => {
-        const isActive = pathname === tab.href || pathname.startsWith(tab.href + "/");
-        return (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            className={cn(
-              "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors rounded-t-md whitespace-nowrap",
-              isActive
-                ? "text-accent"
-                : "text-text-muted hover:text-text hover:bg-surface-muted"
-            )}
-          >
-            <span
+    // Mobile portrait fix (EMR-117): horizontal scroll instead of wrap so the
+    // 9-tab Health row stays a single scannable row instead of stacking three
+    // deep on iPhone portrait. Right-edge fade hint signals more content.
+    <div className="relative -mx-4 sm:mx-0 mb-8">
+      <nav
+        className={cn(
+          "flex items-center gap-1 border-b border-border",
+          "overflow-x-auto scroll-smooth no-scrollbar",
+          "px-4 sm:px-0",
+        )}
+        aria-label={`${config.title} sections`}
+      >
+        {config.tabs.map((tab) => {
+          const isActive = pathname === tab.href || pathname.startsWith(tab.href + "/");
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
-                "h-1.5 w-1.5 rounded-full shrink-0",
-                isActive ? "bg-accent" : "bg-border-strong/50"
+                "relative flex items-center gap-2 px-4 py-2.5 text-sm transition-colors rounded-t-md whitespace-nowrap shrink-0",
+                isActive
+                  ? "text-accent font-semibold"
+                  : "text-text-muted font-medium hover:text-text hover:bg-surface-muted"
               )}
-            />
-            {tab.label}
-            {isActive && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full" />
-            )}
-          </Link>
-        );
-      })}
-    </nav>
+            >
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full shrink-0 transition-colors",
+                  isActive ? "bg-accent" : "bg-border-strong/50"
+                )}
+              />
+              {tab.label}
+              {isActive && (
+                <span className="absolute bottom-0 left-2 right-2 h-[2px] bg-accent rounded-full" />
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute right-0 top-0 bottom-px w-8 bg-gradient-to-l from-bg to-transparent sm:hidden"
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Frontend-only UX pass for Phase 7 Track 1. Three small, scoped edits that move the needle on five tickets.

## What's in it

### EMR-117 — iOS portrait mode nav fix
The patient sub-tab nav (`PatientSectionNav`) used `flex flex-wrap` — on iPhone portrait, the 9-tab Health row stacked three-deep and pushed content below the fold. Switched to a single-row horizontal scroll with a fade hint on the right edge.

- `overflow-x-auto scroll-smooth no-scrollbar` keeps it one row.
- New `.no-scrollbar` utility in `globals.css` (cross-browser hide, scroll behavior preserved).
- Right-edge gradient mask only on `sm:` and below so it stays subtle on desktop.

### EMR-118 — clearer active tab
- Active tab: `font-semibold` (was matching inactive `font-medium`).
- Underline thickened from `h-0.5` (0.5px on most DPIs) → `h-[2px]`.
- Added `aria-current="page"` for screen readers.

### EMR-194 / EMR-196 — patient-nav rename pass
- "My Results" → **"My Records"**
- "Outcomes" → **"Log check-in"** (label matches the user action)

### EMR-202 — Justin Kander book links wired
The "Cannabis and Cancer" featured-resource card on `ResearchTab` had two `<button>` stubs with no destinations. Now real `<a>` tags backed by two named constants at the top of the file:

```tsx
const KANDER_PDF_URL = "https://archive.org/download/.../CannabisAndCancer-JustinKander.pdf";
const KANDER_WEB_URL = "https://www.cannabisandcancer.com/";
```

Single source of truth — swap when we host the PDF ourselves. `target="_blank"` + `rel="noopener noreferrer"` on the web link, `download` hint on the PDF anchor, `aria-label` on both.

## Out of scope (deliberately not in this PR)

| Ticket | Why |
|---|---|
| EMR-205 (P1 portal skeleton) | Already shipped — `fix(EMR-205)` series on main |
| EMR-204 | Already shipped — `fix(EMR-204) clean up POTENCY 710` |
| EMR-119 (9-tab consolidation) | Needs a product call before collapsing Health-section tabs; not a one-line nav change |
| EMR-200 (Reddit threads on Chat & Learn) | Non-trivial new feature, not "consolidation" |
| EMR-203 (Sign AssemblyAI BAA) | Compliance / vendor, not UX |

## Test plan
- [ ] iPhone SE portrait (375px): Health sub-nav scrolls horizontally, no wrap, no horizontal page scroll.
- [ ] Desktop (≥640px): right-edge fade is hidden; tabs sit on a single row.
- [ ] Active tab shows clearly bolder weight + thicker underline; `aria-current="page"` reads correctly in VoiceOver.
- [ ] `/portal/records` shows "My Records" in tab; `/portal/outcomes` shows "Log check-in".
- [ ] On `/education` Research tab: "Download PDF" downloads, "Read Web Version" opens cannabisandcancer.com in new tab.
- [ ] Reduced-motion users still get an instant scroll (the `no-scrollbar` change doesn't introduce animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)