### PR TITLE
Track 7: Leafmart marketplace & growth — distributor, Q&A, reviews+photos, details, checkout, vendor portal

### DIFF
--- a/src/app/(operator)/ops/marketplace-benchmark/page.tsx
+++ b/src/app/(operator)/ops/marketplace-benchmark/page.tsx
@@ -1,0 +1,171 @@
+// EMR-303 — internal report: how Theleafmart's storefront compares to
+// Amazon. Scopes the next round of marketplace work and lets PMs share
+// a single screen with leadership.
+
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  BENCHMARK_FEATURES,
+  categoryScores,
+  gapAreas,
+  overallParity,
+  type BenchmarkFeature,
+} from "@/lib/marketplace/benchmark";
+
+export const metadata = { title: "Marketplace Benchmark" };
+
+const STATUS_TONE: Record<BenchmarkFeature["theleafmartStatus"], string> = {
+  shipped: "bg-leaf-soft text-leaf-ink",
+  partial: "bg-amber-100 text-amber-800",
+  missing: "bg-rose-100 text-rose-800",
+};
+
+const CATEGORY_LABEL: Record<BenchmarkFeature["category"], string> = {
+  discovery: "Discovery",
+  pdp: "Product detail page",
+  checkout: "Checkout",
+  post_purchase: "Post-purchase",
+  trust: "Trust",
+  vendor: "Vendor portal",
+  personalization: "Personalization",
+};
+
+export default async function MarketplaceBenchmarkPage() {
+  await requireUser();
+
+  const parity = overallParity();
+  const scores = categoryScores().sort((a, b) => a.parityScore - b.parityScore);
+  const gaps = gapAreas();
+
+  return (
+    <PageShell>
+      <PageHeader
+        eyebrow="EMR-303"
+        title="Marketplace benchmark"
+        description="How the Theleafmart storefront stacks up against Amazon, by category. Driven by the BENCHMARK_FEATURES matrix in src/lib/marketplace/benchmark.ts."
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Overall parity</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="font-display text-4xl tabular-nums">
+              {(parity * 100).toFixed(0)}%
+            </div>
+            <p className="text-sm text-text-muted mt-1">
+              Shipped + half-credit for partial, across {BENCHMARK_FEATURES.length}{" "}
+              tracked features.
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Open gaps</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="font-display text-4xl tabular-nums">{gaps.length}</div>
+            <p className="text-sm text-text-muted mt-1">
+              {gaps.filter((g) => g.priority === "P0").length} P0 ·{" "}
+              {gaps.filter((g) => g.priority === "P1").length} P1 ·{" "}
+              {gaps.filter((g) => g.priority === "P2").length} P2
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Weakest category</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="font-display text-2xl">
+              {scores[0] ? CATEGORY_LABEL[scores[0].category] : "—"}
+            </div>
+            <p className="text-sm text-text-muted mt-1">
+              {scores[0]
+                ? `${(scores[0].parityScore * 100).toFixed(0)}% parity — start here`
+                : "No data"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Parity by category</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {scores.map((s) => (
+              <div key={s.category} className="flex items-center gap-3">
+                <span className="text-sm w-44 shrink-0">
+                  {CATEGORY_LABEL[s.category]}
+                </span>
+                <div className="flex-1 h-2 rounded-full bg-border/50 overflow-hidden">
+                  <div
+                    className="h-full bg-leaf"
+                    style={{ width: `${s.parityScore * 100}%` }}
+                  />
+                </div>
+                <span className="text-xs text-text-muted w-32 text-right tabular-nums">
+                  {s.shipped} shipped · {s.partial} partial · {s.missing} missing
+                </span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Feature matrix</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase text-text-muted border-b border-border">
+                  <th className="py-2 pr-4">Feature</th>
+                  <th className="py-2 pr-4">Category</th>
+                  <th className="py-2 pr-4">Amazon reference</th>
+                  <th className="py-2 pr-4">Status</th>
+                  <th className="py-2 pr-4">Priority</th>
+                  <th className="py-2 pr-4">Ticket</th>
+                </tr>
+              </thead>
+              <tbody>
+                {BENCHMARK_FEATURES.map((f) => (
+                  <tr key={f.id} className="border-b border-border/50 align-top">
+                    <td className="py-3 pr-4">
+                      <div className="font-medium text-text">{f.name}</div>
+                      {f.notes && (
+                        <div className="text-xs text-text-muted mt-1">{f.notes}</div>
+                      )}
+                    </td>
+                    <td className="py-3 pr-4 text-text-muted">
+                      {CATEGORY_LABEL[f.category]}
+                    </td>
+                    <td className="py-3 pr-4 text-text-muted">{f.amazonReference}</td>
+                    <td className="py-3 pr-4">
+                      <span
+                        className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_TONE[f.theleafmartStatus]}`}
+                      >
+                        {f.theleafmartStatus}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <Badge>{f.priority}</Badge>
+                    </td>
+                    <td className="py-3 pr-4 font-mono text-xs">{f.ticket ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/src/app/api/leafmart/cart/share/route.ts
+++ b/src/app/api/leafmart/cart/share/route.ts
@@ -1,0 +1,54 @@
+// EMR-310 — POST /api/leafmart/cart/share
+//
+// Encodes the supplied cart into a signed share token and returns the
+// URL the customer can copy/text/email. The HMAC secret never leaves
+// the server; clients only see the URL.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { buildShareUrl, type SharePayload } from "@/lib/marketplace/share";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  items: z
+    .array(
+      z.object({
+        slug: z.string().min(1),
+        quantity: z.number().int().min(1).max(99),
+      }),
+    )
+    .min(1)
+    .max(25),
+  from: z.string().min(1).max(80).optional(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = Body.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  const payload: SharePayload = {
+    iat: new Date().toISOString(),
+    items: parsed.data.items,
+    from: parsed.data.from,
+  };
+
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.APP_URL ??
+    new URL(req.url).origin;
+
+  try {
+    const url = buildShareUrl({ baseUrl, payload });
+    return NextResponse.json({ url });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "could_not_encode" },
+      { status: 422 },
+    );
+  }
+}

--- a/src/app/api/leafmart/products/[slug]/questions/route.ts
+++ b/src/app/api/leafmart/products/[slug]/questions/route.ts
@@ -1,0 +1,48 @@
+// EMR-305 — POST /api/leafmart/products/[slug]/questions
+//
+// Accept a customer question for a PDP. Runs the cheap pre-moderation
+// gate before the heavier AI moderation pass (review-moderation.ts).
+// On success, returns a placeholder shape that the client uses to
+// reconcile its optimistic insert.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { preModerateQuestion } from "@/lib/marketplace/qa";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  authorName: z.string().min(1).max(80),
+  body: z.string().min(1).max(2000),
+});
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await ctx.params;
+  const json = await req.json().catch(() => null);
+  const parsed = Body.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
+  }
+
+  const result = preModerateQuestion({
+    productSlug: slug,
+    authorName: parsed.data.authorName,
+    body: parsed.data.body,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: "rejected", reasons: result.reasons },
+      { status: 422 },
+    );
+  }
+
+  // Persistence is wired by the storefront DB story (EMR-305 backend).
+  // Today we acknowledge the optimistic id; the row will land once the
+  // ProductQuestion table ships.
+  return NextResponse.json({ id: result.id, status: "pending_moderation" });
+}

--- a/src/app/api/leafmart/products/[slug]/reviews/route.ts
+++ b/src/app/api/leafmart/products/[slug]/reviews/route.ts
@@ -1,0 +1,75 @@
+// EMR-306 — POST /api/leafmart/products/[slug]/reviews
+//
+// Accepts multipart form data with the review body and 0..N photos.
+// Runs the moderation pipeline (review-moderation.ts) and returns the
+// final verdict so the client can show the right confirmation copy.
+
+import { NextResponse } from "next/server";
+import {
+  moderateReviewFully,
+  type ReviewSubmission,
+  type ReviewPhoto,
+} from "@/lib/marketplace/review-moderation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_PHOTOS = 6;
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await ctx.params;
+  const form = await req.formData().catch(() => null);
+  if (!form) {
+    return NextResponse.json({ error: "invalid_form" }, { status: 400 });
+  }
+
+  const authorName = String(form.get("authorName") ?? "").trim();
+  const ratingRaw = Number(form.get("rating"));
+  const title = String(form.get("title") ?? "").trim();
+  const body = String(form.get("body") ?? "").trim();
+
+  // Photos arrive as photo_0..photo_N; captions as caption_0..caption_N.
+  const photos: ReviewPhoto[] = [];
+  for (let i = 0; i < MAX_PHOTOS; i++) {
+    const file = form.get(`photo_${i}`);
+    if (!(file instanceof File)) break;
+    const caption = String(form.get(`caption_${i}`) ?? "").trim() || undefined;
+    photos.push({
+      id: `photo-${slug}-${i}-${Date.now()}`,
+      // The real storage handoff (envelope-encrypt + upload) is owned by
+      // the photo storage worker; we only carry the metadata into the
+      // moderator. The handoff lands when the storage backend is wired in.
+      storageKey: `pending/${slug}/${i}-${file.name}`,
+      mimeType: file.type,
+      sizeBytes: file.size,
+      caption,
+    });
+  }
+
+  const submission: ReviewSubmission = {
+    productSlug: slug,
+    authorName,
+    rating: ratingRaw,
+    title: title || undefined,
+    body,
+    photos,
+  };
+
+  const result = await moderateReviewFully(submission);
+
+  if (result.verdict === "rejected") {
+    return NextResponse.json(
+      { verdict: result.verdict, reasons: result.reasons },
+      { status: 422 },
+    );
+  }
+
+  return NextResponse.json({
+    verdict: result.verdict,
+    reasons: result.reasons,
+    photoFlags: result.photoFlags,
+  });
+}

--- a/src/app/vendor-portal/analytics/page.tsx
+++ b/src/app/vendor-portal/analytics/page.tsx
@@ -1,0 +1,179 @@
+// EMR-315 — Vendor analytics dashboard.
+//
+// Surfaces revenue, orders, top-performing products, and traffic metrics.
+// All math is computed in `lib/marketplace/vendor-analytics.ts` so the
+// page stays a thin renderer; swapping demo aggregations for DB-backed
+// ones is a one-line change in the loader.
+
+import {
+  demoSnapshot,
+  defaultRange,
+  formatCents,
+  formatPercent,
+  type VendorAnalyticsSnapshot,
+} from "@/lib/marketplace/vendor-analytics";
+
+export const metadata = { title: "Vendor analytics" };
+
+export default async function VendorAnalyticsPage() {
+  const range = defaultRange();
+  const snapshot = demoSnapshot("demo-vendor", range);
+
+  return (
+    <main className="px-6 lg:px-12 py-10 max-w-[1200px] mx-auto">
+      <header className="mb-8 flex items-end justify-between flex-wrap gap-3">
+        <div>
+          <p className="eyebrow text-[var(--leaf)] mb-2">Vendor portal</p>
+          <h1 className="font-display text-3xl tracking-tight text-[var(--ink)]">
+            Analytics
+          </h1>
+          <p className="text-[var(--text-soft)] mt-2 max-w-2xl">
+            Revenue, orders, and traffic for your products on Leafmart.
+          </p>
+        </div>
+        <p className="text-[12.5px] text-[var(--muted)]">
+          {range.start} — {range.end}
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <Tile
+          label="Gross revenue"
+          value={formatCents(snapshot.revenue.grossCents)}
+          sub={`Net ${formatCents(snapshot.revenue.netCents)} after take rate`}
+        />
+        <Tile
+          label="Orders"
+          value={snapshot.orders.count.toLocaleString()}
+          sub={`${formatCents(snapshot.orders.averageOrderValueCents)} AOV`}
+        />
+        <Tile
+          label="Refund rate"
+          value={formatPercent(snapshot.orders.refundRate)}
+          sub={`${snapshot.orders.refundCount} refunds`}
+        />
+      </section>
+
+      <section className="rounded-xl border border-[var(--border)] p-6 mb-8">
+        <p className="eyebrow text-[var(--muted)] mb-3">Daily revenue (last 30 days)</p>
+        <Sparkline values={snapshot.revenue.daily} />
+      </section>
+
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <Tile
+          label="PDP views"
+          value={snapshot.traffic.pdpViews.toLocaleString()}
+        />
+        <Tile
+          label="Cart adds"
+          value={snapshot.traffic.cartAdds.toLocaleString()}
+        />
+        <Tile
+          label="Conversion"
+          value={formatPercent(snapshot.traffic.conversionRate, 2)}
+          sub="Orders / PDP views"
+        />
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg text-[var(--ink)] mb-4">
+          Top products
+        </h2>
+        <TopProductsTable rows={snapshot.topProducts} />
+      </section>
+    </main>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5">
+      <p className="text-[11.5px] uppercase text-[var(--muted)] tracking-wide mb-1">
+        {label}
+      </p>
+      <p className="font-display text-3xl text-[var(--ink)] tabular-nums">
+        {value}
+      </p>
+      {sub && <p className="text-[12.5px] text-[var(--muted)] mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  const width = 600;
+  const height = 80;
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const step = width / Math.max(1, values.length - 1);
+  const points = values
+    .map((v, i) => {
+      const x = i * step;
+      const y = height - ((v - min) / Math.max(1, max - min)) * height;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-20"
+      preserveAspectRatio="none"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="text-[var(--leaf)]"
+      />
+    </svg>
+  );
+}
+
+function TopProductsTable({
+  rows,
+}: {
+  rows: VendorAnalyticsSnapshot["topProducts"];
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] overflow-hidden">
+      <table className="w-full text-[14px]">
+        <thead>
+          <tr className="bg-[var(--surface-muted)] text-left text-[11.5px] uppercase text-[var(--muted)]">
+            <th className="py-3 px-4 font-medium">Product</th>
+            <th className="py-3 px-4 font-medium text-right">Units sold</th>
+            <th className="py-3 px-4 font-medium text-right">Gross</th>
+            <th className="py-3 px-4 font-medium text-right">Reviews</th>
+            <th className="py-3 px-4 font-medium text-right">Rating</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--border)]">
+          {rows.map((r) => (
+            <tr key={r.productSlug}>
+              <td className="py-3 px-4 font-medium text-[var(--ink)]">
+                {r.productName}
+              </td>
+              <td className="py-3 px-4 text-right tabular-nums">{r.unitsSold}</td>
+              <td className="py-3 px-4 text-right tabular-nums">
+                {formatCents(r.grossCents)}
+              </td>
+              <td className="py-3 px-4 text-right tabular-nums">
+                {r.reviewCount.toLocaleString()}
+              </td>
+              <td className="py-3 px-4 text-right tabular-nums">
+                {r.averageRating.toFixed(1)} / 5
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/vendor-portal/tax-documents/page.tsx
+++ b/src/app/vendor-portal/tax-documents/page.tsx
@@ -1,0 +1,152 @@
+// EMR-315 — Vendor self-service tax documents page.
+//
+// Lists the documents the vendor can download (W-9 echo, 1099-K, annual
+// summary, monthly settlements). Render-time the page hydrates the
+// vendor's tax profile from the demo helper; the real impl swaps in a
+// DB-backed lookup once VendorPayout aggregations land.
+
+import Link from "next/link";
+import {
+  listTaxDocuments,
+  demoVendorTaxProfile,
+  type VendorTaxDocument,
+} from "@/lib/marketplace/vendor-tax";
+
+export const metadata = { title: "Tax documents" };
+
+const KIND_LABEL: Record<VendorTaxDocument["kind"], string> = {
+  "1099_k": "1099-K",
+  w9_on_file: "W-9 on file",
+  annual_summary: "Annual summary",
+  monthly_settlement: "Monthly settlement",
+};
+
+const STATUS_TONE: Record<VendorTaxDocument["status"], string> = {
+  available: "bg-emerald-100 text-emerald-800",
+  pending: "bg-amber-100 text-amber-800",
+  ineligible: "bg-stone-100 text-stone-700",
+  missing_prerequisite: "bg-rose-100 text-rose-800",
+};
+
+const STATUS_LABEL: Record<VendorTaxDocument["status"], string> = {
+  available: "Available",
+  pending: "Pending",
+  ineligible: "Ineligible",
+  missing_prerequisite: "Action required",
+};
+
+export default async function VendorTaxDocumentsPage() {
+  // The vendor id comes from the vendor portal session; demo for now.
+  const profile = demoVendorTaxProfile("demo-vendor");
+  const docs = listTaxDocuments(profile);
+
+  const grouped = {
+    annual: docs.filter(
+      (d) => d.kind === "1099_k" || d.kind === "w9_on_file" || d.kind === "annual_summary",
+    ),
+    monthly: docs.filter((d) => d.kind === "monthly_settlement"),
+  };
+
+  return (
+    <main className="px-6 lg:px-12 py-10 max-w-[1200px] mx-auto">
+      <header className="mb-8">
+        <p className="eyebrow text-[var(--leaf)] mb-2">Vendor portal</p>
+        <h1 className="font-display text-3xl tracking-tight text-[var(--ink)]">
+          Tax documents
+        </h1>
+        <p className="text-[var(--text-soft)] mt-2 max-w-2xl">
+          Download your annual tax forms, monthly settlement reports, and the
+          W-9 we have on file. Documents become available once the relevant
+          period closes.
+        </p>
+      </header>
+
+      <section className="mb-10">
+        <h2 className="font-display text-lg text-[var(--ink)] mb-4">
+          Annual & onboarding
+        </h2>
+        <DocTable docs={grouped.annual} />
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg text-[var(--ink)] mb-4">
+          Monthly settlement statements
+        </h2>
+        <DocTable docs={grouped.monthly} />
+      </section>
+
+      <p className="text-[12px] text-[var(--muted)] mt-10">
+        Need a correction? Email{" "}
+        <Link href="mailto:vendors@leafjourney.com" className="text-[var(--leaf)] hover:underline">
+          vendors@leafjourney.com
+        </Link>{" "}
+        within 30 days of issuance.
+      </p>
+    </main>
+  );
+}
+
+function DocTable({ docs }: { docs: VendorTaxDocument[] }) {
+  if (docs.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-[var(--border)] p-6 text-[13px] text-[var(--muted)]">
+        Nothing here yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] overflow-hidden">
+      <table className="w-full text-[14px]">
+        <thead>
+          <tr className="bg-[var(--surface-muted)] text-left text-[11.5px] uppercase text-[var(--muted)]">
+            <th className="py-3 px-4 font-medium">Document</th>
+            <th className="py-3 px-4 font-medium">Period</th>
+            <th className="py-3 px-4 font-medium">Status</th>
+            <th className="py-3 px-4 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--border)]">
+          {docs.map((d) => (
+            <tr key={d.id}>
+              <td className="py-3 px-4 font-medium text-[var(--ink)]">
+                {KIND_LABEL[d.kind]}
+                {d.hint && (
+                  <p className="text-[12px] text-[var(--muted)] mt-1 font-normal">
+                    {d.hint}
+                  </p>
+                )}
+              </td>
+              <td className="py-3 px-4 text-[var(--text)]">
+                {d.periodLabel ?? d.taxYear}
+              </td>
+              <td className="py-3 px-4">
+                <span
+                  className={`inline-flex px-2 py-0.5 rounded-full text-[11.5px] font-medium ${STATUS_TONE[d.status]}`}
+                >
+                  {STATUS_LABEL[d.status]}
+                </span>
+              </td>
+              <td className="py-3 px-4 text-right">
+                {d.status === "available" && d.storageKey ? (
+                  <a
+                    href={`/api/vendor-portal/tax-documents/${encodeURIComponent(d.id)}`}
+                    className="text-[13px] text-[var(--leaf)] font-medium hover:underline"
+                  >
+                    Download
+                  </a>
+                ) : d.status === "pending" && d.availableAt ? (
+                  <span className="text-[12px] text-[var(--muted)]">
+                    Available {d.availableAt.slice(0, 10)}
+                  </span>
+                ) : (
+                  <span className="text-[12px] text-[var(--muted)]">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/leafmart/CheckoutCompareSimilar.tsx
+++ b/src/components/leafmart/CheckoutCompareSimilar.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+// EMR-310 — Compare similar items module for the checkout flow.
+//
+// Drops next to the cart summary on the checkout page. Surfaces 2-3
+// alternates per cart item that match on format/category, with a
+// side-by-side spec comparison so the customer can swap a product
+// without leaving checkout.
+//
+// Designed to be dropped in by the checkout page; takes the cart and
+// the comparable products as props so the parent stays in control of
+// data fetching.
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { LeafmartProduct } from "./LeafmartProductCard";
+
+interface CartLine {
+  product: LeafmartProduct;
+  quantity: number;
+}
+
+interface ComparableSet {
+  /** The cart item being compared against. */
+  cartLine: CartLine;
+  /** Up to 3 similar products. */
+  alternates: LeafmartProduct[];
+}
+
+interface Props {
+  comparableSets: ComparableSet[];
+  /** Called when the customer picks an alternate to swap into the cart. */
+  onSwap: (cartSlug: string, alternateSlug: string) => void;
+}
+
+export function CheckoutCompareSimilar({ comparableSets, onSwap }: Props) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const active = comparableSets[activeIndex];
+
+  if (comparableSets.length === 0) return null;
+
+  return (
+    <section className="rounded-3xl border border-[var(--border)] bg-[var(--surface-muted)] p-6 mt-6">
+      <p className="eyebrow text-[var(--leaf)] mb-2">Before you check out</p>
+      <h3 className="font-display text-[20px] font-medium text-[var(--ink)] mb-4">
+        Compare similar items
+      </h3>
+
+      {comparableSets.length > 1 && (
+        <div className="flex items-center gap-1 mb-4 overflow-x-auto">
+          {comparableSets.map((set, i) => (
+            <button
+              key={set.cartLine.product.slug}
+              onClick={() => setActiveIndex(i)}
+              className={`shrink-0 rounded-full px-3 py-1.5 text-[12.5px] font-medium transition-colors ${
+                i === activeIndex
+                  ? "bg-[var(--ink)] text-[var(--bg)]"
+                  : "bg-[var(--surface)] border border-[var(--border)] text-[var(--text-soft)]"
+              }`}
+            >
+              {set.cartLine.product.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {active && <CompareTable set={active} onSwap={onSwap} />}
+    </section>
+  );
+}
+
+function CompareTable({
+  set,
+  onSwap,
+}: {
+  set: ComparableSet;
+  onSwap: (cartSlug: string, alternateSlug: string) => void;
+}) {
+  const columns = useMemo(
+    () => [set.cartLine.product, ...set.alternates],
+    [set],
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-[13px]">
+        <thead>
+          <tr className="text-left">
+            <th className="py-2 pr-4 text-[11.5px] uppercase text-[var(--muted)] font-medium">
+              Spec
+            </th>
+            {columns.map((p, i) => (
+              <th
+                key={p.slug}
+                className="py-2 pr-4 align-top min-w-[160px]"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-[var(--ink)] text-[13px]">
+                    {p.name}
+                  </span>
+                  {i === 0 && (
+                    <span className="rounded-full bg-[var(--leaf)] text-[var(--bg)] text-[10px] px-2 py-0.5 font-semibold">
+                      In cart
+                    </span>
+                  )}
+                </div>
+                <div className="text-[11.5px] text-[var(--muted)]">{p.partner}</div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--border)]">
+          <Row label="Format" cells={columns.map((p) => p.formatLabel)} />
+          <Row label="Dose" cells={columns.map((p) => p.dose)} />
+          <Row
+            label="Price"
+            cells={columns.map((p) => `$${p.price.toFixed(2)}`)}
+          />
+          <Row
+            label="Improvement"
+            cells={columns.map((p) =>
+              p.pct > 0 ? `${p.pct}% (n=${p.n})` : "n/a",
+            )}
+          />
+          <Row
+            label="Lab verified"
+            cells={columns.map((p) =>
+              (p.labVerified ?? true) ? "Yes" : "No",
+            )}
+          />
+          <tr>
+            <td className="py-3 pr-4 text-[var(--muted)] text-[12px]">Action</td>
+            {columns.map((p, i) => (
+              <td key={p.slug} className="py-3 pr-4">
+                {i === 0 ? (
+                  <span className="text-[var(--muted)] text-[12px]">—</span>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => onSwap(set.cartLine.product.slug, p.slug)}
+                      className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-3 py-1.5 text-[12px] font-medium hover:bg-[var(--leaf)]"
+                    >
+                      Swap into cart
+                    </button>
+                    <Link
+                      href={`/leafmart/products/${p.slug}`}
+                      className="text-[12px] text-[var(--leaf)] hover:underline"
+                    >
+                      View
+                    </Link>
+                  </div>
+                )}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Row({ label, cells }: { label: string; cells: string[] }) {
+  return (
+    <tr>
+      <td className="py-2.5 pr-4 text-[var(--muted)] text-[12px] whitespace-nowrap">
+        {label}
+      </td>
+      {cells.map((c, i) => (
+        <td key={i} className="py-2.5 pr-4 text-[var(--text)] tabular-nums">
+          {c}
+        </td>
+      ))}
+    </tr>
+  );
+}

--- a/src/components/leafmart/CheckoutShareModule.tsx
+++ b/src/components/leafmart/CheckoutShareModule.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+// EMR-310 — Share module for the checkout flow.
+//
+// Lets a customer share their cart with a friend or family member —
+// useful for gift-cart / co-purchase flows. The share link encodes the
+// cart contents into a signed token (see `lib/marketplace/share.ts`)
+// so the recipient lands on /leafmart/cart with the items pre-loaded.
+//
+// We don't post anywhere; the encoding happens via a server endpoint
+// that holds the HMAC secret. The component just orchestrates UX:
+// click → fetch token → copy to clipboard → confirm.
+
+import { useState, useCallback } from "react";
+
+interface Props {
+  cartItems: Array<{ slug: string; quantity: number }>;
+  /** Sender display name, used in the share preview text. */
+  fromName?: string;
+}
+
+export function CheckoutShareModule({ cartItems, fromName }: Props) {
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUrl = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/leafmart/cart/share", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: cartItems, from: fromName }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.url) {
+        setError(data?.error ?? "Could not create share link.");
+        return;
+      }
+      setShareUrl(data.url);
+    } finally {
+      setLoading(false);
+    }
+  }, [cartItems, fromName]);
+
+  const copy = useCallback(async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setError("Couldn't access clipboard. Copy manually below.");
+    }
+  }, [shareUrl]);
+
+  if (cartItems.length === 0) return null;
+
+  return (
+    <section className="rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-6 mt-4">
+      <p className="eyebrow text-[var(--leaf)] mb-2">Send this cart</p>
+      <h3 className="font-display text-[18px] font-medium text-[var(--ink)] mb-2">
+        Share with someone
+      </h3>
+      <p className="text-[13px] text-[var(--text-soft)] leading-relaxed mb-4">
+        Buying for a partner or parent? Send the cart and let them check out, or
+        keep the link as a wishlist.
+      </p>
+
+      {!shareUrl ? (
+        <button
+          onClick={fetchUrl}
+          disabled={loading}
+          className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-5 py-2 text-[13px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-50"
+        >
+          {loading ? "Generating link…" : "Generate share link"}
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={shareUrl}
+              className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-[12.5px] font-mono"
+              onClick={(e) => (e.currentTarget as HTMLInputElement).select()}
+            />
+            <button
+              onClick={copy}
+              className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-4 py-2 text-[12.5px] font-medium hover:bg-[var(--leaf)] transition-colors whitespace-nowrap"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <div className="flex gap-2">
+            <a
+              href={`mailto:?subject=${encodeURIComponent("My Leafmart cart")}&body=${encodeURIComponent(shareUrl)}`}
+              className="text-[12.5px] text-[var(--leaf)] hover:underline"
+            >
+              Email link
+            </a>
+            <span className="text-[var(--muted)]">·</span>
+            <a
+              href={`sms:?&body=${encodeURIComponent(shareUrl)}`}
+              className="text-[12.5px] text-[var(--leaf)] hover:underline"
+            >
+              Text link
+            </a>
+          </div>
+          <p className="text-[11.5px] text-[var(--muted)]">
+            Anyone with the link can load this cart. The link is signed and
+            tamper-resistant.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-[12px] text-rose-700 mt-3">{error}</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/leafmart/ProductDetailsList.tsx
+++ b/src/components/leafmart/ProductDetailsList.tsx
@@ -1,0 +1,70 @@
+// EMR-307 — AI-curated Product Details list rendered on the PDP.
+//
+// Server component (no client interactivity needed). Two columns of
+// scannable bullets — highlights on the left, full specs on the right.
+
+import type {
+  CuratedProductDetails,
+  ProductDetailItem,
+} from "@/lib/marketplace/product-details";
+
+const EMPHASIS_TONE: Record<NonNullable<ProductDetailItem["emphasis"]>, string> = {
+  trust: "text-[var(--leaf)]",
+  warning: "text-amber-700",
+  neutral: "text-[var(--text)]",
+};
+
+export function ProductDetailsList({ details }: { details: CuratedProductDetails }) {
+  if (details.highlights.length === 0 && details.specs.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="px-4 sm:px-6 lg:px-14 py-10 sm:py-12 max-w-[1440px] mx-auto border-t border-[var(--border)]">
+      <p className="eyebrow text-[var(--leaf)] mb-2">About this product</p>
+      <h2 className="font-display text-[26px] sm:text-[32px] font-normal tracking-tight text-[var(--ink)] mb-6 sm:mb-8">
+        Product details
+      </h2>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 sm:gap-12">
+        {details.highlights.length > 0 && (
+          <div>
+            <p className="eyebrow text-[var(--muted)] mb-3">Highlights</p>
+            <ul className="space-y-2.5">
+              {details.highlights.map((item, i) => (
+                <DetailRow key={i} item={item} />
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {details.specs.length > 0 && (
+          <div>
+            <p className="eyebrow text-[var(--muted)] mb-3">Specifications</p>
+            <ul className="space-y-2.5">
+              {details.specs.map((item, i) => (
+                <DetailRow key={i} item={item} />
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function DetailRow({ item }: { item: ProductDetailItem }) {
+  const tone = item.emphasis ? EMPHASIS_TONE[item.emphasis] : "text-[var(--text)]";
+  return (
+    <li className="flex items-start gap-3 text-[14px] leading-relaxed">
+      <span
+        aria-hidden="true"
+        className="mt-2 w-1.5 h-1.5 rounded-full bg-[var(--leaf)] shrink-0"
+      />
+      <div className="flex-1 flex items-baseline gap-2 flex-wrap">
+        <span className="text-[var(--muted)] text-[13px]">{item.label}</span>
+        <span className={`font-medium ${tone}`}>{item.value}</span>
+      </div>
+    </li>
+  );
+}

--- a/src/components/leafmart/ProductQATab.tsx
+++ b/src/components/leafmart/ProductQATab.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+// EMR-305 — Expandable Q&A tab on the PDP.
+//
+// Lives below the buy box, opens lazily so the initial PDP paint isn't
+// dragged down by the Q&A list when most visitors never expand it. The
+// "Ask a question" form posts through the same moderation gate as the
+// server (preModerateQuestion) and then surfaces an optimistic pending
+// thread until the real id is returned.
+
+import { useMemo, useState } from "react";
+import type { ProductQuestion, QAResponderRole } from "@/lib/marketplace/qa";
+
+interface Props {
+  productSlug: string;
+  initialQuestions: ProductQuestion[];
+}
+
+const ROLE_LABEL: Record<QAResponderRole, string> = {
+  clinician: "Clinician",
+  vendor: "Vendor",
+  customer: "Customer",
+  moderator: "Moderator",
+};
+
+const ROLE_TONE: Record<QAResponderRole, string> = {
+  clinician: "bg-[var(--leaf)] text-[var(--bg)]",
+  vendor: "bg-[var(--ink)] text-[var(--bg)]",
+  customer: "bg-[var(--surface-muted)] text-[var(--text)]",
+  moderator: "bg-[var(--peach)] text-[var(--ink)]",
+};
+
+export function ProductQATab({ productSlug, initialQuestions }: Props) {
+  const [open, setOpen] = useState(false);
+  const [questions, setQuestions] = useState(initialQuestions);
+  const [draft, setDraft] = useState("");
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const totalAnswered = useMemo(
+    () => questions.filter((q) => q.answers.length > 0).length,
+    [questions],
+  );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (draft.trim().length < 10) {
+      setError("Question must be at least 10 characters.");
+      return;
+    }
+    if (!name.trim()) {
+      setError("Add your first name so the vendor can reply.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      // Optimistic insert; the API will replace with the persisted row.
+      const optimistic: ProductQuestion = {
+        id: `pending-${Date.now()}`,
+        productSlug,
+        authorName: name.trim(),
+        body: draft.trim(),
+        createdAt: new Date().toISOString(),
+        helpfulCount: 0,
+        answers: [],
+      };
+      setQuestions((q) => [optimistic, ...q]);
+      setDraft("");
+
+      const res = await fetch(`/api/leafmart/products/${productSlug}/questions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ authorName: name.trim(), body: optimistic.body }),
+      });
+      if (!res.ok) {
+        // Roll back the optimistic row.
+        setQuestions((q) => q.filter((x) => x.id !== optimistic.id));
+        const data = await res.json().catch(() => ({}));
+        setError(data?.error ?? "Could not submit question.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="px-4 sm:px-6 lg:px-14 max-w-[1440px] mx-auto border-t border-[var(--border)]">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between py-6 sm:py-7 text-left"
+      >
+        <div>
+          <p className="eyebrow text-[var(--leaf)] mb-1">Customer questions</p>
+          <h2 className="font-display text-[22px] sm:text-[26px] font-normal tracking-tight text-[var(--ink)]">
+            Q&amp;A
+            <span className="text-[var(--muted)] font-normal text-[15px] ml-2">
+              ({questions.length} asked · {totalAnswered} answered)
+            </span>
+          </h2>
+        </div>
+        <span
+          aria-hidden="true"
+          className={`text-[var(--muted)] text-2xl transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        >
+          ⌄
+        </span>
+      </button>
+
+      {open && (
+        <div className="pb-10 sm:pb-12">
+          <form
+            onSubmit={handleSubmit}
+            className="rounded-2xl bg-[var(--surface-muted)] p-5 sm:p-6 mb-6"
+          >
+            <p className="eyebrow text-[var(--leaf)] mb-3">Ask a question</p>
+            <input
+              type="text"
+              placeholder="First name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full mb-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-[14px]"
+            />
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="What do you want to know about this product?"
+              rows={3}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-[14px] resize-y"
+            />
+            {error && (
+              <p className="text-[12px] text-rose-700 mt-2">{error}</p>
+            )}
+            <div className="flex items-center justify-between mt-3">
+              <p className="text-[11.5px] text-[var(--muted)]">
+                Submissions are screened before they appear publicly.
+              </p>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-5 py-2 text-[13px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-50"
+              >
+                {submitting ? "Submitting…" : "Submit question"}
+              </button>
+            </div>
+          </form>
+
+          {questions.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-[var(--border)] p-8 text-center text-[13px] text-[var(--muted)]">
+              No questions yet. Be the first to ask.
+            </div>
+          ) : (
+            <ul className="space-y-5">
+              {questions.map((q) => (
+                <QAItem key={q.id} question={q} />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function QAItem({ question }: { question: ProductQuestion }) {
+  return (
+    <li className="rounded-2xl bg-[var(--surface)] border border-[var(--border)] p-5">
+      <div className="flex items-start justify-between gap-3 mb-2 flex-wrap">
+        <p className="font-medium text-[var(--ink)] text-[14.5px]">
+          Q. {question.body}
+        </p>
+        <span className="text-[11.5px] text-[var(--muted)] whitespace-nowrap">
+          asked by {question.authorName}
+        </span>
+      </div>
+      {question.answers.length === 0 ? (
+        <p className="text-[12.5px] text-[var(--muted)] italic">Awaiting answer</p>
+      ) : (
+        <ul className="space-y-3 mt-3">
+          {question.answers.map((a) => (
+            <li
+              key={a.id}
+              className="border-l-2 border-[var(--leaf)] pl-4 text-[13.5px] text-[var(--text-soft)]"
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span className="font-medium text-[var(--text)] text-[13px]">
+                  {a.authorName}
+                </span>
+                <span
+                  className={`inline-flex px-2 py-0.5 rounded-full text-[10.5px] font-semibold uppercase tracking-wide ${ROLE_TONE[a.authorRole]}`}
+                >
+                  {ROLE_LABEL[a.authorRole]}
+                </span>
+              </div>
+              <p className="leading-relaxed">{a.body}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/src/components/leafmart/ReviewSubmissionForm.tsx
+++ b/src/components/leafmart/ReviewSubmissionForm.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+// EMR-306 — Review submission form with photo uploads.
+//
+// Uploads run as multipart/form-data. The server route hands each photo
+// off to the moderation pipeline (review-moderation.ts). This form does
+// the cheap client-side gating (size, mime, count) so users get feedback
+// before bytes leave their machine.
+
+import { useState, useCallback } from "react";
+import { StarRating } from "./StarRating";
+
+interface Props {
+  productSlug: string;
+  onClose: () => void;
+}
+
+const MAX_PHOTOS = 6;
+const MAX_PHOTO_BYTES = 8 * 1024 * 1024;
+const ALLOWED_MIME = ["image/jpeg", "image/png", "image/webp"];
+
+interface PendingPhoto {
+  id: string;
+  file: File;
+  previewUrl: string;
+  caption: string;
+}
+
+export function ReviewSubmissionForm({ productSlug, onClose }: Props) {
+  const [rating, setRating] = useState(5);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [author, setAuthor] = useState("");
+  const [photos, setPhotos] = useState<PendingPhoto[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files) return;
+      const next: PendingPhoto[] = [...photos];
+      for (const file of Array.from(files)) {
+        if (next.length >= MAX_PHOTOS) {
+          setError(`Up to ${MAX_PHOTOS} photos per review.`);
+          break;
+        }
+        if (!ALLOWED_MIME.includes(file.type)) {
+          setError(`Photos must be JPEG, PNG, or WebP. Got ${file.type}.`);
+          continue;
+        }
+        if (file.size > MAX_PHOTO_BYTES) {
+          setError(`${file.name} is over 8MB.`);
+          continue;
+        }
+        next.push({
+          id: `pending-${Date.now()}-${file.name}`,
+          file,
+          previewUrl: URL.createObjectURL(file),
+          caption: "",
+        });
+      }
+      setPhotos(next);
+    },
+    [photos],
+  );
+
+  const removePhoto = useCallback((id: string) => {
+    setPhotos((prev) => {
+      const target = prev.find((p) => p.id === id);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  }, []);
+
+  const updateCaption = useCallback((id: string, caption: string) => {
+    setPhotos((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, caption } : p)),
+    );
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (body.trim().length < 20) {
+      setError("Reviews must be at least 20 characters.");
+      return;
+    }
+    if (!author.trim()) {
+      setError("Add your name.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const fd = new FormData();
+      fd.set("authorName", author.trim());
+      fd.set("rating", String(rating));
+      fd.set("title", title.trim());
+      fd.set("body", body.trim());
+      photos.forEach((p, i) => {
+        fd.append(`photo_${i}`, p.file, p.file.name);
+        fd.append(`caption_${i}`, p.caption.trim());
+      });
+
+      const res = await fetch(`/api/leafmart/products/${productSlug}/reviews`, {
+        method: "POST",
+        body: fd,
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data?.error ?? "Could not submit review.");
+        return;
+      }
+      setSubmitted(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="rounded-2xl bg-[var(--surface-muted)] border border-[var(--border)] p-6">
+        <p className="eyebrow text-[var(--leaf)] mb-2">Thanks for your review</p>
+        <p className="text-[14px] text-[var(--text)] mb-4">
+          We screen every review for medical claims and image quality. You&apos;ll
+          see it on this page once moderation clears.
+        </p>
+        <button
+          onClick={onClose}
+          className="text-[13px] font-medium text-[var(--leaf)] hover:underline"
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-2xl bg-[var(--surface-muted)] border border-[var(--border)] p-5 sm:p-6"
+    >
+      <p className="eyebrow text-[var(--leaf)] mb-3">Write a review</p>
+
+      <label className="block text-[12.5px] text-[var(--muted)] mb-2">
+        Your rating
+      </label>
+      <div className="flex items-center gap-1.5 mb-4">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => setRating(n)}
+            className="p-0.5"
+            aria-label={`${n} stars`}
+          >
+            <StarRating rating={n <= rating ? 5 : 0} size={22} />
+          </button>
+        ))}
+        <span className="text-[12.5px] text-[var(--muted)] ml-2 tabular-nums">
+          {rating}/5
+        </span>
+      </div>
+
+      <input
+        type="text"
+        placeholder="Your name"
+        value={author}
+        onChange={(e) => setAuthor(e.target.value)}
+        className="w-full mb-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-[14px]"
+      />
+      <input
+        type="text"
+        placeholder="Headline (optional)"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="w-full mb-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-[14px]"
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="What did you experience? What worked, what didn't?"
+        rows={4}
+        className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-[14px] resize-y mb-4"
+      />
+
+      <label className="block text-[12.5px] text-[var(--muted)] mb-2">
+        Add photos ({photos.length}/{MAX_PHOTOS})
+      </label>
+      <input
+        type="file"
+        multiple
+        accept={ALLOWED_MIME.join(",")}
+        onChange={(e) => handleFiles(e.target.files)}
+        className="block text-[13px] mb-3"
+      />
+      {photos.length > 0 && (
+        <ul className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
+          {photos.map((p) => (
+            <li
+              key={p.id}
+              className="rounded-lg overflow-hidden bg-[var(--surface)] border border-[var(--border)]"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={p.previewUrl}
+                alt="Review photo preview"
+                className="w-full h-28 object-cover"
+              />
+              <div className="p-2 space-y-2">
+                <input
+                  type="text"
+                  placeholder="Caption (optional)"
+                  value={p.caption}
+                  onChange={(e) => updateCaption(p.id, e.target.value)}
+                  className="w-full rounded border border-[var(--border)] px-2 py-1 text-[12px]"
+                />
+                <button
+                  type="button"
+                  onClick={() => removePhoto(p.id)}
+                  className="text-[11.5px] text-rose-700 hover:underline"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <p className="text-[12px] text-rose-700 mb-3">{error}</p>
+      )}
+
+      <div className="flex items-center justify-between mt-2 flex-wrap gap-3">
+        <p className="text-[11.5px] text-[var(--muted)] max-w-md">
+          We screen for medical claims and inappropriate imagery. Reviews appear
+          once approved.
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-[var(--border)] px-4 py-2 text-[13px]"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-full bg-[var(--ink)] text-[var(--bg)] px-5 py-2 text-[13px] font-medium hover:bg-[var(--leaf)] transition-colors disabled:opacity-50"
+          >
+            {submitting ? "Submitting…" : "Submit review"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/marketplace/benchmark.test.ts
+++ b/src/lib/marketplace/benchmark.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  BENCHMARK_FEATURES,
+  categoryScores,
+  gapAreas,
+  overallParity,
+} from "./benchmark";
+
+describe("benchmark matrix", () => {
+  it("every feature has a unique id", () => {
+    const ids = BENCHMARK_FEATURES.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("ticketed gaps reference real EMR ticket ids", () => {
+    for (const f of BENCHMARK_FEATURES) {
+      if (f.ticket) {
+        expect(f.ticket).toMatch(/^EMR-\d+$/);
+      }
+    }
+  });
+});
+
+describe("categoryScores", () => {
+  it("partial gets half credit, shipped gets full credit", () => {
+    const scores = categoryScores();
+    for (const s of scores) {
+      expect(s.parityScore).toBeGreaterThanOrEqual(0);
+      expect(s.parityScore).toBeLessThanOrEqual(1);
+      const expected =
+        s.total === 0 ? 0 : (s.shipped + 0.5 * s.partial) / s.total;
+      expect(s.parityScore).toBeCloseTo(expected);
+    }
+  });
+
+  it("totals sum back to the feature count", () => {
+    const totalFromBuckets = categoryScores().reduce((acc, s) => acc + s.total, 0);
+    expect(totalFromBuckets).toBe(BENCHMARK_FEATURES.length);
+  });
+});
+
+describe("gapAreas", () => {
+  it("excludes shipped features", () => {
+    expect(gapAreas().every((f) => f.theleafmartStatus !== "shipped")).toBe(true);
+  });
+
+  it("orders P0 before P1 before P2", () => {
+    const gaps = gapAreas();
+    const order = { P0: 0, P1: 1, P2: 2 } as const;
+    for (let i = 1; i < gaps.length; i++) {
+      expect(order[gaps[i].priority]).toBeGreaterThanOrEqual(
+        order[gaps[i - 1].priority],
+      );
+    }
+  });
+});
+
+describe("overallParity", () => {
+  it("returns a value between 0 and 1", () => {
+    const parity = overallParity();
+    expect(parity).toBeGreaterThanOrEqual(0);
+    expect(parity).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/lib/marketplace/benchmark.ts
+++ b/src/lib/marketplace/benchmark.ts
@@ -1,0 +1,243 @@
+// EMR-303 — Rival Amazon / Theleafmart benchmark.
+//
+// Codifies the consumer storefront feature parity matrix vs Amazon as a
+// queryable structure. Two consumers:
+//   - Internal `/ops/marketplace-benchmark` report (PM/leadership review)
+//   - Roadmap planning — agents can ask `gapAreas()` to pick what to build
+//
+// Status values reflect the Theleafmart storefront, not the clinical EMR.
+
+export type BenchmarkStatus = "shipped" | "partial" | "missing";
+
+export type BenchmarkPriority = "P0" | "P1" | "P2";
+
+export interface BenchmarkFeature {
+  id: string;
+  category:
+    | "discovery"
+    | "pdp"
+    | "checkout"
+    | "post_purchase"
+    | "trust"
+    | "vendor"
+    | "personalization";
+  name: string;
+  amazonReference: string;
+  theleafmartStatus: BenchmarkStatus;
+  priority: BenchmarkPriority;
+  notes?: string;
+  /** Optional Linear ticket that drives the gap. */
+  ticket?: string;
+}
+
+export const BENCHMARK_FEATURES: BenchmarkFeature[] = [
+  // Discovery
+  {
+    id: "search-typeahead",
+    category: "discovery",
+    name: "Typeahead search with category suggestions",
+    amazonReference: "Department-aware typeahead",
+    theleafmartStatus: "partial",
+    priority: "P1",
+    notes: "Search exists; needs category-segmented suggestions and recent-searches.",
+  },
+  {
+    id: "facet-filters",
+    category: "discovery",
+    name: "Faceted filters (cannabinoid, format, terpene, price)",
+    amazonReference: "Left-rail facet filters",
+    theleafmartStatus: "shipped",
+    priority: "P0",
+  },
+  {
+    id: "compare-grid",
+    category: "discovery",
+    name: "Compare similar items side-by-side",
+    amazonReference: "Compare with similar items",
+    theleafmartStatus: "missing",
+    priority: "P1",
+    ticket: "EMR-310",
+  },
+
+  // PDP
+  {
+    id: "pdp-qa",
+    category: "pdp",
+    name: "Customer Q&A on PDP",
+    amazonReference: "Customer questions & answers section",
+    theleafmartStatus: "missing",
+    priority: "P1",
+    ticket: "EMR-305",
+  },
+  {
+    id: "pdp-reviews-photos",
+    category: "pdp",
+    name: "Reviews with customer photos",
+    amazonReference: "Customer images carousel + photo upload",
+    theleafmartStatus: "partial",
+    priority: "P0",
+    notes: "Reviews ship; photo upload + AI moderation pending.",
+    ticket: "EMR-306",
+  },
+  {
+    id: "pdp-details-list",
+    category: "pdp",
+    name: "Bulleted Product Details (specifications)",
+    amazonReference: "About this item bullets",
+    theleafmartStatus: "missing",
+    priority: "P1",
+    ticket: "EMR-307",
+  },
+  {
+    id: "pdp-recommendations",
+    category: "pdp",
+    name: "Pairs-well-with / frequently bought together",
+    amazonReference: "Frequently bought together",
+    theleafmartStatus: "shipped",
+    priority: "P1",
+    notes: "PairsWellWith component is live on PDP.",
+  },
+
+  // Checkout
+  {
+    id: "checkout-share",
+    category: "checkout",
+    name: "Share cart / wishlist via link",
+    amazonReference: "Share with friends",
+    theleafmartStatus: "missing",
+    priority: "P2",
+    ticket: "EMR-310",
+  },
+  {
+    id: "checkout-1click",
+    category: "checkout",
+    name: "Saved payment + one-step checkout",
+    amazonReference: "1-Click",
+    theleafmartStatus: "partial",
+    priority: "P1",
+    notes: "Saved cards via Payabli; not yet a single-click flow.",
+  },
+
+  // Post-purchase
+  {
+    id: "order-tracking",
+    category: "post_purchase",
+    name: "Live order tracking with carrier integration",
+    amazonReference: "Track package",
+    theleafmartStatus: "partial",
+    priority: "P0",
+  },
+
+  // Trust
+  {
+    id: "verified-badge",
+    category: "trust",
+    name: "Verified-purchase badge on reviews",
+    amazonReference: "Verified Purchase",
+    theleafmartStatus: "shipped",
+    priority: "P0",
+  },
+  {
+    id: "coa-on-file",
+    category: "trust",
+    name: "Lab COA on every product",
+    amazonReference: "n/a — Leafmart differentiator",
+    theleafmartStatus: "shipped",
+    priority: "P0",
+    notes: "Differentiator: Amazon does not offer COA-on-file for cannabinoid products.",
+  },
+
+  // Vendor
+  {
+    id: "vendor-tax-docs",
+    category: "vendor",
+    name: "Vendor self-service tax documents",
+    amazonReference: "Seller Central tax forms",
+    theleafmartStatus: "missing",
+    priority: "P0",
+    ticket: "EMR-315",
+  },
+  {
+    id: "vendor-analytics",
+    category: "vendor",
+    name: "Vendor analytics dashboard",
+    amazonReference: "Seller Central reports",
+    theleafmartStatus: "missing",
+    priority: "P0",
+    ticket: "EMR-315",
+  },
+
+  // Personalization
+  {
+    id: "personalized-shelf",
+    category: "personalization",
+    name: "Personalized recommendations shelf",
+    amazonReference: "Recommended for you",
+    theleafmartStatus: "partial",
+    priority: "P1",
+    notes: "Clinician-pick shelf exists; user-history-aware shelf pending.",
+  },
+];
+
+export interface CategoryScore {
+  category: BenchmarkFeature["category"];
+  shipped: number;
+  partial: number;
+  missing: number;
+  total: number;
+  /** Score = shipped + 0.5 * partial, normalized 0–1. */
+  parityScore: number;
+}
+
+/**
+ * Compute parity by category. `partial` counts as half-credit so a
+ * category with 2 shipped + 2 partial scores higher than 2 shipped + 2
+ * missing — the gap visualization in the report uses this nuance.
+ */
+export function categoryScores(): CategoryScore[] {
+  const buckets = new Map<BenchmarkFeature["category"], CategoryScore>();
+  for (const f of BENCHMARK_FEATURES) {
+    const b = buckets.get(f.category) ?? {
+      category: f.category,
+      shipped: 0,
+      partial: 0,
+      missing: 0,
+      total: 0,
+      parityScore: 0,
+    };
+    if (f.theleafmartStatus === "shipped") b.shipped += 1;
+    else if (f.theleafmartStatus === "partial") b.partial += 1;
+    else b.missing += 1;
+    b.total += 1;
+    buckets.set(f.category, b);
+  }
+  return [...buckets.values()].map((b) => ({
+    ...b,
+    parityScore: b.total === 0 ? 0 : (b.shipped + 0.5 * b.partial) / b.total,
+  }));
+}
+
+/**
+ * Open gaps sorted by priority then category, useful for roadmap views.
+ */
+export function gapAreas(): BenchmarkFeature[] {
+  const order: Record<BenchmarkPriority, number> = { P0: 0, P1: 1, P2: 2 };
+  return BENCHMARK_FEATURES.filter((f) => f.theleafmartStatus !== "shipped").sort(
+    (a, b) => order[a.priority] - order[b.priority] || a.category.localeCompare(b.category),
+  );
+}
+
+export function overallParity(): number {
+  const totals = BENCHMARK_FEATURES.reduce(
+    (acc, f) => {
+      if (f.theleafmartStatus === "shipped") acc.shipped += 1;
+      else if (f.theleafmartStatus === "partial") acc.partial += 1;
+      acc.total += 1;
+      return acc;
+    },
+    { shipped: 0, partial: 0, total: 0 },
+  );
+  return totals.total === 0
+    ? 0
+    : (totals.shipped + 0.5 * totals.partial) / totals.total;
+}

--- a/src/lib/marketplace/distributor.test.ts
+++ b/src/lib/marketplace/distributor.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  eligibleDistributors,
+  verifyProvenance,
+  type SourceProvenance,
+  type Distributor,
+} from "./distributor";
+
+describe("eligibleDistributors", () => {
+  it("filters out distributors without a license in the destination state", async () => {
+    const result = await eligibleDistributors({
+      state: "FL",
+      format: "tincture",
+      thcRegulated: false,
+    });
+    // None of the demo distributors hold an FL license.
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes CBD-only distributors when product is THC-regulated", async () => {
+    const result = await eligibleDistributors({
+      state: "CA",
+      format: "tincture",
+      thcRegulated: true,
+    });
+    expect(result.every((d) => d.thcRegulatedShipping)).toBe(true);
+    expect(result.find((d) => d.id === "dist-allwell")).toBeUndefined();
+  });
+
+  it("sorts tier1 distributors ahead of tier2", async () => {
+    const result = await eligibleDistributors({
+      state: "CA",
+      format: "tincture",
+      thcRegulated: false,
+    });
+    if (result.length >= 2) {
+      const tierOrder = { tier1: 0, tier2: 1, tier3: 2 } as const;
+      for (let i = 1; i < result.length; i++) {
+        expect(tierOrder[result[i].tier]).toBeGreaterThanOrEqual(
+          tierOrder[result[i - 1].tier],
+        );
+      }
+    }
+  });
+});
+
+describe("verifyProvenance", () => {
+  const baseDistributor: Distributor = {
+    id: "dist-x",
+    name: "X",
+    legalName: "X LLC",
+    tier: "tier1",
+    licenses: { CA: "L1" },
+    permittedFormats: ["tincture"],
+    thcRegulatedShipping: true,
+    contactName: "C",
+    contactEmail: "c@x",
+    active: true,
+  };
+
+  const baseProvenance: SourceProvenance = {
+    productId: "prod-1",
+    sourceKind: "licensed_distributor",
+    vendorId: "v-1",
+    distributorId: "dist-x",
+    lotNumber: "LOT-123",
+    receivedAt: "2026-04-01T00:00:00Z",
+    coaStorageKey: "coa/lot-123.pdf",
+  };
+
+  it("passes when all checks succeed", () => {
+    const result = verifyProvenance(baseProvenance, baseDistributor);
+    expect(result.ok).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it("fails when COA is missing", () => {
+    const result = verifyProvenance(
+      { ...baseProvenance, coaStorageKey: null },
+      baseDistributor,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain("no COA on file");
+  });
+
+  it("fails when sourceKind says licensed_distributor but distributorId is null", () => {
+    const result = verifyProvenance(
+      { ...baseProvenance, distributorId: null },
+      null,
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      result.reasons.some((r) => r.includes("distributorId is null")),
+    ).toBe(true);
+  });
+
+  it("fails when distributor is inactive", () => {
+    const result = verifyProvenance(baseProvenance, {
+      ...baseDistributor,
+      active: false,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.includes("inactive"))).toBe(true);
+  });
+});

--- a/src/lib/marketplace/distributor.ts
+++ b/src/lib/marketplace/distributor.ts
@@ -1,0 +1,161 @@
+// EMR-302 — Distributor model + source framework.
+//
+// Tracks where a product came from (vendor → distributor → provenance
+// chain). Anchors the marketplace's compliance story: every stocked SKU
+// must trace back to a licensed distributor and a verifiable source for
+// state-by-state compliance audits.
+//
+// The distributor data layer is intentionally separate from `vendors`.
+// A vendor *sells* on Leafmart; a distributor *moves* product between
+// the vendor and the operator/dispensary. One vendor can have many
+// distributors (regional warehouses, tiered partners), and one
+// distributor can serve many vendors.
+
+import type { ProductFormat } from "./types";
+
+export type DistributorTier = "tier1" | "tier2" | "tier3";
+
+export type SourceKind =
+  | "vendor_direct"
+  | "licensed_distributor"
+  | "co_manufacturer"
+  | "internal_transfer";
+
+export interface Distributor {
+  id: string;
+  name: string;
+  legalName: string;
+  tier: DistributorTier;
+  /** State licenses keyed by USPS state code → license number. */
+  licenses: Record<string, string>;
+  /** Formats this distributor is permitted to move. */
+  permittedFormats: ProductFormat[];
+  /** True if the distributor is approved to ship into THC-regulated states. */
+  thcRegulatedShipping: boolean;
+  contactName: string;
+  contactEmail: string;
+  active: boolean;
+}
+
+export interface SourceProvenance {
+  productId: string;
+  sourceKind: SourceKind;
+  vendorId: string;
+  distributorId: string | null;
+  /** Lot/batch identifier from the manufacturer. Required for COA join. */
+  lotNumber: string;
+  /** ISO date string. */
+  receivedAt: string;
+  /** Storage key for the COA PDF. Joined to the COA tracker by lotNumber. */
+  coaStorageKey: string | null;
+  /** Chain-of-custody notes captured at intake. */
+  custodyNotes?: string;
+}
+
+export interface ProvenanceVerification {
+  ok: boolean;
+  reasons: string[];
+}
+
+const DEMO_DISTRIBUTORS: Distributor[] = [
+  {
+    id: "dist-pacific",
+    name: "Pacific Greenline",
+    legalName: "Pacific Greenline Distribution LLC",
+    tier: "tier1",
+    licenses: { CA: "C11-0000123-LIC", OR: "050-1018392B5C" },
+    permittedFormats: ["tincture", "topical", "capsule", "edible", "vape", "flower"],
+    thcRegulatedShipping: true,
+    contactName: "M. Alvarez",
+    contactEmail: "ops@pacificgreenline.example",
+    active: true,
+  },
+  {
+    id: "dist-mountain",
+    name: "Mountain Source Co.",
+    legalName: "Mountain Source Cooperative",
+    tier: "tier2",
+    licenses: { CO: "405-00821", NV: "C-23-0001" },
+    permittedFormats: ["tincture", "topical", "edible", "beverage", "serum"],
+    thcRegulatedShipping: true,
+    contactName: "K. Yamada",
+    contactEmail: "logistics@mountainsource.example",
+    active: true,
+  },
+  {
+    id: "dist-allwell",
+    name: "Allwell Hemp Logistics",
+    legalName: "Allwell Hemp Logistics, Inc.",
+    tier: "tier1",
+    licenses: { US: "DEA-NO-CTRL" },
+    permittedFormats: ["tincture", "topical", "capsule", "serum", "patch"],
+    // CBD-only — does not ship Schedule I product across state lines.
+    thcRegulatedShipping: false,
+    contactName: "R. Chen",
+    contactEmail: "shipping@allwell.example",
+    active: true,
+  },
+];
+
+export async function listDistributors(): Promise<Distributor[]> {
+  return DEMO_DISTRIBUTORS.filter((d) => d.active);
+}
+
+export async function getDistributor(id: string): Promise<Distributor | null> {
+  return DEMO_DISTRIBUTORS.find((d) => d.id === id) ?? null;
+}
+
+/**
+ * Pick eligible distributors for a product going to a given state.
+ * Eligibility rules:
+ *   1. Distributor must be active
+ *   2. Distributor must hold a license in the destination state
+ *   3. Distributor must be approved for the product's format
+ *   4. If the product is THC-regulated, distributor must be cleared for it
+ *
+ * Sorted tier1 → tier3 so the operator picks the strongest partner first.
+ */
+export async function eligibleDistributors(opts: {
+  state: string;
+  format: ProductFormat;
+  thcRegulated: boolean;
+}): Promise<Distributor[]> {
+  const tierOrder: Record<DistributorTier, number> = { tier1: 0, tier2: 1, tier3: 2 };
+  return DEMO_DISTRIBUTORS.filter((d) => {
+    if (!d.active) return false;
+    if (!d.licenses[opts.state]) return false;
+    if (!d.permittedFormats.includes(opts.format)) return false;
+    if (opts.thcRegulated && !d.thcRegulatedShipping) return false;
+    return true;
+  }).sort((a, b) => tierOrder[a.tier] - tierOrder[b.tier]);
+}
+
+/**
+ * Verify a provenance record against a distributor. Failed checks are
+ * surfaced as human-readable reasons so the operator UI can render them
+ * inline without parsing error codes.
+ */
+export function verifyProvenance(
+  provenance: SourceProvenance,
+  distributor: Distributor | null,
+): ProvenanceVerification {
+  const reasons: string[] = [];
+
+  if (!provenance.lotNumber.trim()) {
+    reasons.push("missing lot number");
+  }
+  if (!provenance.coaStorageKey) {
+    reasons.push("no COA on file");
+  }
+  if (provenance.sourceKind === "licensed_distributor" && !provenance.distributorId) {
+    reasons.push("source kind is licensed_distributor but distributorId is null");
+  }
+  if (provenance.distributorId && !distributor) {
+    reasons.push("distributor record not found");
+  }
+  if (distributor && !distributor.active) {
+    reasons.push(`distributor ${distributor.name} is inactive`);
+  }
+
+  return { ok: reasons.length === 0, reasons };
+}

--- a/src/lib/marketplace/product-details.ts
+++ b/src/lib/marketplace/product-details.ts
@@ -1,0 +1,167 @@
+// EMR-307 — AI-curated Product Details list.
+//
+// Generates the bullet-list of product specifics that renders on PDPs
+// (cannabinoid profile, terpenes, intended use, dosing window, etc.).
+// The "AI-curated" angle is that the bullets are derived from the
+// structured product record using deterministic rules + LLM-summarized
+// hints — so the bullets stay scannable and consistent across the
+// catalog instead of free-text from each vendor.
+//
+// We keep deterministic generation here so the PDP renders without
+// model latency; an offline curator job can refresh the cached bullets
+// when the structured fields drift.
+
+import "server-only";
+
+import type { LeafmartProduct } from "@/components/leafmart/LeafmartProductCard";
+import type { MarketplaceProduct } from "./types";
+
+export interface ProductDetailItem {
+  label: string;
+  value: string;
+  /** Optional hint for the UI on how to render the row. */
+  emphasis?: "trust" | "warning" | "neutral";
+}
+
+export interface CuratedProductDetails {
+  /** Top-line bullets — these appear first and are most scannable. */
+  highlights: ProductDetailItem[];
+  /** Specs — full structured detail. */
+  specs: ProductDetailItem[];
+}
+
+function pct(n: number | undefined, suffix = "mg/mL"): string | null {
+  if (n === undefined || n === null) return null;
+  return `${n} ${suffix}`;
+}
+
+/**
+ * Derive details from the canonical MarketplaceProduct shape.
+ * This is the input the PDP server fetcher already has on hand.
+ */
+export function curatedDetailsForMarketplaceProduct(
+  product: MarketplaceProduct,
+): CuratedProductDetails {
+  const highlights: ProductDetailItem[] = [];
+  const specs: ProductDetailItem[] = [];
+
+  // Highlights — pick the 3-5 most decision-relevant fields.
+  if (product.beginnerFriendly) {
+    highlights.push({
+      label: "Beginner friendly",
+      value: "Low-dose, gentle starting point",
+      emphasis: "trust",
+    });
+  }
+  if (product.labVerified) {
+    highlights.push({
+      label: "Lab verified",
+      value: "COA on file for every batch",
+      emphasis: "trust",
+    });
+  }
+  if (product.clinicianPick) {
+    highlights.push({
+      label: "Clinician selected",
+      value: "Reviewed by Leafjourney medical lead",
+      emphasis: "trust",
+    });
+  }
+  if (product.onsetTime) {
+    highlights.push({ label: "Onset", value: product.onsetTime });
+  }
+  if (product.duration) {
+    highlights.push({ label: "Duration", value: product.duration });
+  }
+
+  // Specs — full cannabinoid + terpene + use-case picture.
+  const thc = pct(product.thcContent);
+  const cbd = pct(product.cbdContent);
+  const cbn = pct(product.cbnContent);
+  if (thc) specs.push({ label: "THC", value: thc });
+  if (cbd) specs.push({ label: "CBD", value: cbd });
+  if (cbn) specs.push({ label: "CBN", value: cbn });
+  if (product.strainType && product.strainType !== "n/a") {
+    specs.push({
+      label: "Strain type",
+      value: product.strainType.charAt(0).toUpperCase() + product.strainType.slice(1),
+    });
+  }
+  if (product.terpeneProfile && Object.keys(product.terpeneProfile).length > 0) {
+    const top = Object.entries(product.terpeneProfile)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 3)
+      .map(([name, val]) => `${capitalize(name)} ${(val * 100).toFixed(0)}%`)
+      .join(" · ");
+    specs.push({ label: "Top terpenes", value: top });
+  }
+  if (product.useCases.length > 0) {
+    specs.push({
+      label: "Best for",
+      value: product.useCases.map(capitalize).join(", "),
+    });
+  }
+  if (product.dosageGuidance) {
+    specs.push({ label: "Dosage guidance", value: product.dosageGuidance });
+  }
+  if (product.requires21Plus) {
+    specs.push({
+      label: "Age restricted",
+      value: "Buyer must confirm 21+ at checkout",
+      emphasis: "warning",
+    });
+  }
+
+  return { highlights, specs };
+}
+
+/**
+ * The PDP page works in `LeafmartProduct` shape (UI-mapped). When the
+ * full structured product isn't in scope, this derives whatever bullets
+ * we can from the leaner shape. Falls back to format-derived defaults
+ * so the section is never empty.
+ */
+export function curatedDetailsForLeafmartProduct(
+  product: LeafmartProduct,
+): CuratedProductDetails {
+  const highlights: ProductDetailItem[] = [];
+  const specs: ProductDetailItem[] = [];
+
+  if (product.labVerified ?? true) {
+    highlights.push({
+      label: "Lab verified",
+      value: "COA on file for every batch",
+      emphasis: "trust",
+    });
+  }
+  if (product.clinicianPick ?? true) {
+    highlights.push({
+      label: "Clinician selected",
+      value: "Reviewed by Leafjourney medical lead",
+      emphasis: "trust",
+    });
+  }
+  highlights.push({ label: "Format", value: product.formatLabel });
+  highlights.push({ label: "Dose", value: product.dose });
+
+  specs.push({ label: "Brand", value: product.partner });
+  if (product.pct > 0) {
+    specs.push({
+      label: "Patient improvement",
+      value: `${product.pct}% reported improvement (n=${product.n})`,
+    });
+  }
+  specs.push({
+    label: "Verified buyer reviews",
+    value:
+      product.reviewCount && product.reviewCount > 0
+        ? `${product.reviewCount.toLocaleString()} reviews · ${(product.averageRating ?? 0).toFixed(1)}/5`
+        : "Be the first to review",
+  });
+
+  return { highlights, specs };
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}

--- a/src/lib/marketplace/qa.ts
+++ b/src/lib/marketplace/qa.ts
@@ -1,0 +1,135 @@
+// EMR-305 — Product Q&A.
+//
+// Data layer for the expandable Q&A tab on PDPs. Customer-submitted
+// questions and vendor / clinician responses, plus helpfulness votes
+// to surface useful threads first.
+//
+// Falls back to demo data when the database is empty so the Q&A tab
+// always renders something useful (the PDP must never look broken).
+
+import "server-only";
+
+export type QAResponderRole = "vendor" | "clinician" | "customer" | "moderator";
+
+export interface ProductQuestion {
+  id: string;
+  productSlug: string;
+  authorName: string;
+  body: string;
+  createdAt: string;
+  helpfulCount: number;
+  answers: ProductAnswer[];
+}
+
+export interface ProductAnswer {
+  id: string;
+  authorName: string;
+  authorRole: QAResponderRole;
+  body: string;
+  createdAt: string;
+  helpfulCount: number;
+}
+
+const DEMO_QA: ProductQuestion[] = [
+  {
+    id: "q-1",
+    productSlug: "solace-nightfall-tincture",
+    authorName: "Megan R.",
+    body: "Will this make me groggy in the morning?",
+    createdAt: "2026-03-12T18:24:00Z",
+    helpfulCount: 14,
+    answers: [
+      {
+        id: "a-1",
+        authorName: "Dr. N.H. Patel, DO",
+        authorRole: "clinician",
+        body: "The CBN-to-CBD ratio here is tuned to support sleep onset without next-morning sedation. Most patients in our cohort report no grogginess at the 0.5–1.0 mL dose. Start low and titrate.",
+        createdAt: "2026-03-13T01:11:00Z",
+        helpfulCount: 22,
+      },
+    ],
+  },
+  {
+    id: "q-2",
+    productSlug: "solace-nightfall-tincture",
+    authorName: "Tom B.",
+    body: "Can I take this if I'm already on melatonin?",
+    createdAt: "2026-03-15T22:02:00Z",
+    helpfulCount: 6,
+    answers: [
+      {
+        id: "a-2",
+        authorName: "Solace Botanicals",
+        authorRole: "vendor",
+        body: "Many customers stack with melatonin without issue, but please review with your prescriber if you take other sleep medications. Our Drug Mix tool can flag interactions.",
+        createdAt: "2026-03-16T14:30:00Z",
+        helpfulCount: 5,
+      },
+    ],
+  },
+];
+
+export async function listProductQuestions(
+  productSlug: string,
+): Promise<ProductQuestion[]> {
+  const list = DEMO_QA.filter((q) => q.productSlug === productSlug);
+  return rankQuestions(list);
+}
+
+/**
+ * Rank by total helpful votes (question + best answer) so the most
+ * useful threads land at the top of the tab. Newer questions with no
+ * votes still surface above 0-vote stale threads via createdAt tiebreak.
+ */
+export function rankQuestions(questions: ProductQuestion[]): ProductQuestion[] {
+  return [...questions].sort((a, b) => {
+    const score = (q: ProductQuestion) =>
+      q.helpfulCount +
+      q.answers.reduce((s, a) => Math.max(s, a.helpfulCount), 0);
+    const diff = score(b) - score(a);
+    if (diff !== 0) return diff;
+    return +new Date(b.createdAt) - +new Date(a.createdAt);
+  });
+}
+
+export interface SubmitQuestionInput {
+  productSlug: string;
+  authorName: string;
+  body: string;
+}
+
+export interface SubmittedQuestion {
+  ok: boolean;
+  /** Slug-stable id so the optimistic UI can reconcile after server confirm. */
+  id: string;
+  /** Reasons to reject / hold for moderation. */
+  reasons: string[];
+}
+
+const MIN_QUESTION_LEN = 10;
+const MAX_QUESTION_LEN = 600;
+
+/**
+ * Lightweight pre-moderation. Real moderation runs on the server side
+ * via the same pipeline as reviews (review-moderation.ts) — this is the
+ * cheap front gate that rejects obviously empty / malformed submissions
+ * before round-tripping to the AI moderator.
+ */
+export function preModerateQuestion(input: SubmitQuestionInput): SubmittedQuestion {
+  const reasons: string[] = [];
+  const trimmed = input.body.trim();
+  if (trimmed.length < MIN_QUESTION_LEN) {
+    reasons.push(`question must be at least ${MIN_QUESTION_LEN} characters`);
+  }
+  if (trimmed.length > MAX_QUESTION_LEN) {
+    reasons.push(`question must be ${MAX_QUESTION_LEN} characters or fewer`);
+  }
+  if (!input.authorName.trim()) {
+    reasons.push("author name required");
+  }
+
+  // Deterministic optimistic id derived from slug + timestamp so client
+  // and server agree on the placeholder until the DB row is created.
+  const id = `q-${input.productSlug}-${Date.now()}`;
+  return { ok: reasons.length === 0, id, reasons };
+}

--- a/src/lib/marketplace/review-moderation.test.ts
+++ b/src/lib/marketplace/review-moderation.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  preModerateReview,
+  moderateReview,
+  moderateReviewFully,
+  type ReviewSubmission,
+} from "./review-moderation";
+
+const baseReview: ReviewSubmission = {
+  productSlug: "solace-nightfall-tincture",
+  authorName: "Megan R.",
+  rating: 5,
+  title: "Real, restful sleep",
+  body: "I have been using this nightly for three weeks and it has noticeably improved my sleep onset without leaving me groggy in the morning.",
+  photos: [],
+};
+
+describe("preModerateReview", () => {
+  it("passes a clean review", () => {
+    expect(preModerateReview(baseReview).ok).toBe(true);
+  });
+
+  it("rejects too-short body", () => {
+    const r = preModerateReview({ ...baseReview, body: "great" });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith("body_too_short_"))).toBe(true);
+  });
+
+  it("rejects out-of-range rating", () => {
+    const r = preModerateReview({ ...baseReview, rating: 7 });
+    expect(r.ok).toBe(false);
+    expect(r.reasons).toContain("rating_out_of_range");
+  });
+
+  it("rejects banned terms", () => {
+    const r = preModerateReview({
+      ...baseReview,
+      body: baseReview.body + " visit casino now",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith("hard_block_"))).toBe(true);
+  });
+
+  it("rejects photos with disallowed mime", () => {
+    const r = preModerateReview({
+      ...baseReview,
+      photos: [
+        {
+          id: "p-1",
+          storageKey: "k",
+          mimeType: "image/gif",
+          sizeBytes: 100,
+        },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith("bad_mime_"))).toBe(true);
+  });
+
+  it("rejects oversized photos", () => {
+    const r = preModerateReview({
+      ...baseReview,
+      photos: [
+        {
+          id: "p-2",
+          storageKey: "k",
+          mimeType: "image/jpeg",
+          sizeBytes: 20 * 1024 * 1024,
+        },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((x) => x.startsWith("photo_too_large_"))).toBe(true);
+  });
+});
+
+describe("moderateReview", () => {
+  it("auto-approves substantive, claim-free reviews", async () => {
+    const result = await moderateReview(baseReview);
+    expect(result.verdict).toBe("auto_approved");
+  });
+
+  it("flags medical claim hints for manual review", async () => {
+    const result = await moderateReview({
+      ...baseReview,
+      body: "This product cured my chronic pain completely after one dose.",
+    });
+    expect(result.verdict).toBe("needs_review");
+    expect(result.reasons).toContain("medical_claim_hint");
+  });
+
+  it("flags photos when caption hints at NSFW content", async () => {
+    const result = await moderateReview({
+      ...baseReview,
+      photos: [
+        {
+          id: "p-3",
+          storageKey: "k",
+          mimeType: "image/jpeg",
+          sizeBytes: 1024,
+          caption: "definitely nsfw caption here",
+        },
+      ],
+    });
+    expect(result.verdict).toBe("needs_review");
+    expect(result.photoFlags).toHaveLength(1);
+    expect(result.photoFlags[0].photoId).toBe("p-3");
+  });
+});
+
+describe("moderateReviewFully", () => {
+  it("returns rejected when pre-moderation fails", async () => {
+    const result = await moderateReviewFully({ ...baseReview, rating: 9 });
+    expect(result.verdict).toBe("rejected");
+  });
+});

--- a/src/lib/marketplace/review-moderation.ts
+++ b/src/lib/marketplace/review-moderation.ts
@@ -1,0 +1,173 @@
+// EMR-306 — Reviews with photos + AI moderation.
+//
+// Two-stage pipeline:
+//   1. `preModerateReview` — cheap deterministic checks (length, banned
+//      terms, photo MIME/size). Runs synchronously before the row is
+//      persisted, blocks obvious garbage with no LLM cost.
+//   2. `moderateReview` (async) — AI moderation of the review body and
+//      attached photos via the configured model client. Tags the row
+//      with a status that the public PDP query filters on.
+//
+// Anything that's `auto_approved` shows on the PDP immediately. Anything
+// `needs_review` waits for a moderator. `rejected` never shows.
+
+export type ModerationVerdict = "auto_approved" | "needs_review" | "rejected";
+
+export interface ReviewPhoto {
+  id: string;
+  storageKey: string;
+  mimeType: string;
+  sizeBytes: number;
+  /** Optional caption written by the reviewer. */
+  caption?: string;
+}
+
+export interface ReviewSubmission {
+  productSlug: string;
+  authorName: string;
+  rating: number;
+  title?: string;
+  body: string;
+  photos: ReviewPhoto[];
+}
+
+export interface PreModerationResult {
+  ok: boolean;
+  reasons: string[];
+}
+
+export interface ModerationResult {
+  verdict: ModerationVerdict;
+  /** Human-readable reasons surfaced to the moderator queue. */
+  reasons: string[];
+  /** Per-photo flags so the moderator UI can render which image tripped what. */
+  photoFlags: Array<{ photoId: string; reasons: string[] }>;
+}
+
+const MIN_BODY = 20;
+const MAX_BODY = 4000;
+const MAX_TITLE = 120;
+const MAX_PHOTOS = 6;
+const MAX_PHOTO_BYTES = 8 * 1024 * 1024; // 8 MB
+const ALLOWED_PHOTO_MIME = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+// A small, deliberately conservative banlist used by the deterministic
+// pre-moderation pass. The full medical-claim screening lives in
+// fda-claim-screening.ts and runs in the AI pass.
+const HARD_BLOCKED_TERMS = [
+  "buy followers",
+  "click here for",
+  "casino",
+  "bitcoin giveaway",
+];
+
+// Phrases that suggest the reviewer is making a medical claim. We don't
+// auto-reject — the AI pass adjudicates — but we tag for moderator review.
+const MEDICAL_CLAIM_HINTS = [
+  /\bcure[sd]?\b/i,
+  /\btreat[s]? cancer\b/i,
+  /\breplaces? (my )?(prescription|medication|chemo)\b/i,
+  /\bdiagnos(es|is|ed)\b/i,
+];
+
+export function preModerateReview(
+  submission: ReviewSubmission,
+): PreModerationResult {
+  const reasons: string[] = [];
+
+  if (!submission.authorName.trim()) reasons.push("author_name_required");
+  if (Number.isNaN(submission.rating) || submission.rating < 1 || submission.rating > 5) {
+    reasons.push("rating_out_of_range");
+  }
+  const body = submission.body.trim();
+  if (body.length < MIN_BODY) reasons.push(`body_too_short_${MIN_BODY}`);
+  if (body.length > MAX_BODY) reasons.push(`body_too_long_${MAX_BODY}`);
+
+  if (submission.title && submission.title.length > MAX_TITLE) {
+    reasons.push(`title_too_long_${MAX_TITLE}`);
+  }
+
+  if (submission.photos.length > MAX_PHOTOS) {
+    reasons.push(`too_many_photos_${MAX_PHOTOS}`);
+  }
+  for (const p of submission.photos) {
+    if (!ALLOWED_PHOTO_MIME.has(p.mimeType)) {
+      reasons.push(`bad_mime_${p.id}_${p.mimeType}`);
+    }
+    if (p.sizeBytes > MAX_PHOTO_BYTES) {
+      reasons.push(`photo_too_large_${p.id}`);
+    }
+  }
+
+  const lower = body.toLowerCase();
+  for (const term of HARD_BLOCKED_TERMS) {
+    if (lower.includes(term)) {
+      reasons.push(`hard_block_${term.replace(/\s+/g, "_")}`);
+    }
+  }
+
+  return { ok: reasons.length === 0, reasons };
+}
+
+/**
+ * Stage 2 — AI-assisted moderation of body + photos.
+ *
+ * The real implementation calls the configured model client to score the
+ * body for spam / medical claims / abuse, and scans each photo for
+ * NSFW / non-product content. Today we run a deterministic stand-in so
+ * the storefront UX is testable end-to-end before the model wiring lands.
+ */
+export async function moderateReview(
+  submission: ReviewSubmission,
+): Promise<ModerationResult> {
+  const reasons: string[] = [];
+  const photoFlags: ModerationResult["photoFlags"] = [];
+
+  const body = submission.body.trim();
+  for (const pattern of MEDICAL_CLAIM_HINTS) {
+    if (pattern.test(body)) {
+      reasons.push("medical_claim_hint");
+      break;
+    }
+  }
+
+  // Photos: stand-in heuristic — flag photos with a caption that mentions
+  // explicit / non-product content. Real impl runs vision moderation.
+  for (const photo of submission.photos) {
+    const flags: string[] = [];
+    if (photo.caption && /\b(nude|nsfw)\b/i.test(photo.caption)) {
+      flags.push("caption_nsfw_hint");
+    }
+    if (flags.length > 0) photoFlags.push({ photoId: photo.id, reasons: flags });
+  }
+
+  if (reasons.includes("medical_claim_hint") || photoFlags.length > 0) {
+    return { verdict: "needs_review", reasons, photoFlags };
+  }
+
+  // Star-rating + body sanity — single-word "great" reviews go to manual
+  // queue rather than auto-approve, so the PDP isn't padded with spam.
+  if (body.split(/\s+/).length < 5) {
+    return {
+      verdict: "needs_review",
+      reasons: ["low_substance"],
+      photoFlags: [],
+    };
+  }
+
+  return { verdict: "auto_approved", reasons: [], photoFlags: [] };
+}
+
+/**
+ * Convenience: run both stages and collapse to a single verdict.
+ * Pre-moderation failure short-circuits to `rejected`.
+ */
+export async function moderateReviewFully(
+  submission: ReviewSubmission,
+): Promise<ModerationResult> {
+  const pre = preModerateReview(submission);
+  if (!pre.ok) {
+    return { verdict: "rejected", reasons: pre.reasons, photoFlags: [] };
+  }
+  return moderateReview(submission);
+}

--- a/src/lib/marketplace/share.test.ts
+++ b/src/lib/marketplace/share.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeShareToken,
+  decodeShareToken,
+  buildShareUrl,
+  type SharePayload,
+} from "./share";
+
+const samplePayload: SharePayload = {
+  iat: "2026-04-28T00:00:00Z",
+  items: [
+    { slug: "solace-nightfall-tincture", quantity: 1 },
+    { slug: "calm-day-capsules", quantity: 2 },
+  ],
+  from: "Megan",
+};
+
+describe("share tokens", () => {
+  it("round-trips encode → decode", () => {
+    const token = encodeShareToken(samplePayload);
+    const decoded = decodeShareToken(token);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.items).toEqual(samplePayload.items);
+    expect(decoded?.from).toBe("Megan");
+  });
+
+  it("rejects tampered tokens", () => {
+    const token = encodeShareToken(samplePayload);
+    // Flip the signature.
+    const [body, sig] = token.split(".");
+    const flipped = sig.startsWith("a") ? "b" + sig.slice(1) : "a" + sig.slice(1);
+    expect(decodeShareToken(`${body}.${flipped}`)).toBeNull();
+  });
+
+  it("rejects malformed tokens", () => {
+    expect(decodeShareToken("garbage")).toBeNull();
+    expect(decodeShareToken(".sig")).toBeNull();
+    expect(decodeShareToken("body.")).toBeNull();
+  });
+
+  it("rejects payloads with non-numeric quantities", () => {
+    const token = encodeShareToken(samplePayload);
+    const [body] = token.split(".");
+    // Re-decode body, mutate, encode different body — signature won't match,
+    // proving the HMAC catches body tampering.
+    const decoded = decodeShareToken(`${body}.deadbeef`);
+    expect(decoded).toBeNull();
+  });
+
+  it("throws when given >25 items", () => {
+    const big: SharePayload = {
+      iat: "2026-04-28T00:00:00Z",
+      items: Array.from({ length: 26 }, (_, i) => ({
+        slug: `prod-${i}`,
+        quantity: 1,
+      })),
+    };
+    expect(() => encodeShareToken(big)).toThrow();
+  });
+});
+
+describe("buildShareUrl", () => {
+  it("attaches the token as a `share` query param", () => {
+    const url = buildShareUrl({
+      baseUrl: "https://leafmart.example",
+      payload: samplePayload,
+    });
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/leafmart/cart");
+    expect(parsed.searchParams.get("share")).not.toBeNull();
+  });
+});

--- a/src/lib/marketplace/share.ts
+++ b/src/lib/marketplace/share.ts
@@ -1,0 +1,106 @@
+// EMR-310 — Share-cart token helpers.
+//
+// Powers the "Share" module on checkout. The share link encodes the
+// cart contents (slug + quantity) into an opaque, URL-safe token so a
+// recipient hitting the link gets a pre-loaded cart on Leafmart.
+//
+// Tokens are HMAC-signed so a tampered cart can't impersonate a real
+// share. The HMAC secret comes from `LEAFMART_SHARE_SECRET`; in dev we
+// fall back to a stable string so links work without env wiring.
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+const DEV_SECRET = "leafmart-share-dev-secret";
+
+export interface ShareableCartItem {
+  slug: string;
+  quantity: number;
+}
+
+export interface SharePayload {
+  /** ISO date the share was created. */
+  iat: string;
+  items: ShareableCartItem[];
+  /** Optional first-name / display name of the sender. */
+  from?: string;
+}
+
+function getSecret(): string {
+  return process.env.LEAFMART_SHARE_SECRET ?? DEV_SECRET;
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(str: string): Buffer {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    str.length + ((4 - (str.length % 4)) % 4),
+    "=",
+  );
+  return Buffer.from(padded, "base64");
+}
+
+function sign(body: string): string {
+  return createHmac("sha256", getSecret()).update(body).digest("hex");
+}
+
+/**
+ * Encode a payload into a URL-safe `body.signature` token.
+ * Tokens are bounded to ~1KB; we cap at 25 items so a malicious sender
+ * can't blow up downstream parsers via a giant cart.
+ */
+export function encodeShareToken(payload: SharePayload): string {
+  if (payload.items.length > 25) {
+    throw new Error("share_token_too_large");
+  }
+  const body = base64UrlEncode(Buffer.from(JSON.stringify(payload), "utf8"));
+  const sig = sign(body);
+  return `${body}.${sig}`;
+}
+
+/**
+ * Decode + verify a token. Returns null on any signature mismatch or
+ * malformed input — callers should treat null as "show the empty
+ * cart, ignore the share link" rather than surfacing an error to the
+ * recipient (the goal is a friendly recovery, not a 500).
+ */
+export function decodeShareToken(token: string): SharePayload | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  const expected = sign(body);
+  if (
+    sig.length !== expected.length ||
+    !timingSafeEqual(Buffer.from(sig, "hex"), Buffer.from(expected, "hex"))
+  ) {
+    return null;
+  }
+
+  try {
+    const json = base64UrlDecode(body).toString("utf8");
+    const parsed = JSON.parse(json) as SharePayload;
+    if (!parsed || !Array.isArray(parsed.items)) return null;
+    if (parsed.items.some((i) => typeof i.slug !== "string" || typeof i.quantity !== "number")) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(opts: {
+  baseUrl: string;
+  payload: SharePayload;
+}): string {
+  const token = encodeShareToken(opts.payload);
+  const url = new URL("/leafmart/cart", opts.baseUrl);
+  url.searchParams.set("share", token);
+  return url.toString();
+}

--- a/src/lib/marketplace/vendor-analytics.ts
+++ b/src/lib/marketplace/vendor-analytics.ts
@@ -1,0 +1,139 @@
+// EMR-315 — Vendor analytics aggregations.
+//
+// Drives the vendor portal analytics dashboard. Every metric is derived
+// here so the page stays a thin renderer; the heavy lifting (DB
+// aggregations + caching) belongs in this module.
+
+import "server-only";
+
+export interface VendorAnalyticsRange {
+  /** Inclusive start, ISO date. */
+  start: string;
+  /** Inclusive end, ISO date. */
+  end: string;
+}
+
+export interface RevenueMetric {
+  grossCents: number;
+  takeRateCents: number;
+  netCents: number;
+  /** Spark series: 30 daily values for the trailing window. */
+  daily: number[];
+}
+
+export interface OrderMetric {
+  count: number;
+  averageOrderValueCents: number;
+  refundCount: number;
+  refundRate: number;
+}
+
+export interface ProductPerformanceRow {
+  productSlug: string;
+  productName: string;
+  unitsSold: number;
+  grossCents: number;
+  averageRating: number;
+  reviewCount: number;
+}
+
+export interface TrafficMetric {
+  pdpViews: number;
+  conversionRate: number;
+  cartAdds: number;
+}
+
+export interface VendorAnalyticsSnapshot {
+  vendorId: string;
+  range: VendorAnalyticsRange;
+  revenue: RevenueMetric;
+  orders: OrderMetric;
+  topProducts: ProductPerformanceRow[];
+  traffic: TrafficMetric;
+}
+
+const DEMO_DAILY = [
+  280, 312, 340, 295, 360, 410, 388, 401, 425, 460, 472, 489, 510, 478, 502,
+  531, 555, 540, 558, 590, 612, 635, 660, 642, 690, 712, 738, 720, 758, 802,
+];
+
+/**
+ * Demo snapshot used by the vendor portal page until the real
+ * aggregation pipeline lands. The shape is what the dashboard consumes;
+ * swapping in DB-backed data is a one-function change.
+ */
+export function demoSnapshot(
+  vendorId: string,
+  range: VendorAnalyticsRange,
+): VendorAnalyticsSnapshot {
+  const grossCents = DEMO_DAILY.reduce((s, d) => s + d * 100, 0);
+  const takeRateCents = Math.round(grossCents * 0.12);
+  return {
+    vendorId,
+    range,
+    revenue: {
+      grossCents,
+      takeRateCents,
+      netCents: grossCents - takeRateCents,
+      daily: DEMO_DAILY,
+    },
+    orders: {
+      count: 312,
+      averageOrderValueCents: Math.round(grossCents / 312),
+      refundCount: 11,
+      refundRate: 11 / 312,
+    },
+    topProducts: [
+      {
+        productSlug: "solace-nightfall-tincture",
+        productName: "Nightfall Sleep Tincture",
+        unitsSold: 184,
+        grossCents: 184 * 64 * 100,
+        averageRating: 4.8,
+        reviewCount: 132,
+      },
+      {
+        productSlug: "calm-day-capsules",
+        productName: "Calm Day Capsules",
+        unitsSold: 98,
+        grossCents: 98 * 48 * 100,
+        averageRating: 4.6,
+        reviewCount: 84,
+      },
+      {
+        productSlug: "recovery-balm",
+        productName: "Recovery Balm",
+        unitsSold: 76,
+        grossCents: 76 * 38 * 100,
+        averageRating: 4.7,
+        reviewCount: 61,
+      },
+    ],
+    traffic: {
+      pdpViews: 14_812,
+      conversionRate: 312 / 14_812,
+      cartAdds: 921,
+    },
+  };
+}
+
+export function defaultRange(now: Date = new Date()): VendorAnalyticsRange {
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 29);
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export function formatPercent(value: number, digits = 1): string {
+  return `${(value * 100).toFixed(digits)}%`;
+}

--- a/src/lib/marketplace/vendor-tax.ts
+++ b/src/lib/marketplace/vendor-tax.ts
@@ -1,0 +1,178 @@
+// EMR-315 — Vendor tax document data layer.
+//
+// The vendor portal needs to surface per-year tax documents (1099-K,
+// W-9 echo, monthly settlement reports). This module centralizes the
+// status logic so both the vendor-facing page and the operator-facing
+// status counter agree on what "ready" means.
+//
+// Document availability is a function of:
+//   - tax year (1099-Ks issue after Jan 31 of the following year)
+//   - vendor onboarding status (W-9 must be on file for 1099 issuance)
+//   - federal threshold ($600 from 2024 onward — see IRS notice)
+
+import "server-only";
+
+export type TaxDocKind =
+  | "1099_k"
+  | "w9_on_file"
+  | "annual_summary"
+  | "monthly_settlement";
+
+export type TaxDocStatus =
+  | "available"
+  | "pending"
+  | "ineligible"
+  | "missing_prerequisite";
+
+export interface VendorTaxDocument {
+  id: string;
+  kind: TaxDocKind;
+  taxYear: number;
+  /** Coarse period label for monthly statements: "2026-03". */
+  periodLabel?: string;
+  status: TaxDocStatus;
+  /** ISO date when the document becomes available; null if already available. */
+  availableAt: string | null;
+  /** Storage key for download once `available`; null otherwise. */
+  storageKey: string | null;
+  /** Human-readable hint shown in the UI when status != "available". */
+  hint?: string;
+}
+
+export interface VendorTaxProfile {
+  vendorId: string;
+  hasW9OnFile: boolean;
+  /** YTD gross marketplace volume in cents. */
+  ytdVolumeCents: number;
+  /** Onboarding completion year. */
+  onboardedYear: number;
+}
+
+const FEDERAL_1099K_THRESHOLD_CENTS = 600 * 100;
+
+/**
+ * Cutover date for 1099-K availability. The IRS requires issuance by
+ * Jan 31 of the year after the tax year; we publish on Feb 1 to give
+ * ops a one-day buffer for last-minute corrections.
+ */
+function nineteenkAvailableAt(taxYear: number): Date {
+  return new Date(Date.UTC(taxYear + 1, 1, 1));
+}
+
+export function listTaxDocuments(
+  profile: VendorTaxProfile,
+  now: Date = new Date(),
+): VendorTaxDocument[] {
+  const docs: VendorTaxDocument[] = [];
+
+  // W-9 echo: vendor's own copy of what they uploaded during onboarding.
+  docs.push({
+    id: `w9-${profile.vendorId}`,
+    kind: "w9_on_file",
+    taxYear: profile.onboardedYear,
+    status: profile.hasW9OnFile ? "available" : "missing_prerequisite",
+    availableAt: profile.hasW9OnFile ? null : null,
+    storageKey: profile.hasW9OnFile ? `vendor-tax/${profile.vendorId}/w9.pdf` : null,
+    hint: profile.hasW9OnFile
+      ? undefined
+      : "Upload your W-9 in Settings to enable 1099 issuance.",
+  });
+
+  // 1099-K for the current and prior tax year.
+  const currentYear = now.getUTCFullYear();
+  for (const year of [currentYear, currentYear - 1]) {
+    if (year < profile.onboardedYear) continue;
+
+    if (!profile.hasW9OnFile) {
+      docs.push({
+        id: `1099k-${profile.vendorId}-${year}`,
+        kind: "1099_k",
+        taxYear: year,
+        status: "missing_prerequisite",
+        availableAt: null,
+        storageKey: null,
+        hint: "1099-K issuance is blocked until W-9 is on file.",
+      });
+      continue;
+    }
+
+    if (profile.ytdVolumeCents < FEDERAL_1099K_THRESHOLD_CENTS && year === currentYear) {
+      docs.push({
+        id: `1099k-${profile.vendorId}-${year}`,
+        kind: "1099_k",
+        taxYear: year,
+        status: "ineligible",
+        availableAt: null,
+        storageKey: null,
+        hint: "Volume below the $600 federal threshold for this tax year.",
+      });
+      continue;
+    }
+
+    const availableAt = nineteenkAvailableAt(year);
+    if (now >= availableAt) {
+      docs.push({
+        id: `1099k-${profile.vendorId}-${year}`,
+        kind: "1099_k",
+        taxYear: year,
+        status: "available",
+        availableAt: null,
+        storageKey: `vendor-tax/${profile.vendorId}/1099k-${year}.pdf`,
+      });
+    } else {
+      docs.push({
+        id: `1099k-${profile.vendorId}-${year}`,
+        kind: "1099_k",
+        taxYear: year,
+        status: "pending",
+        availableAt: availableAt.toISOString(),
+        storageKey: null,
+        hint: `1099-K issues on ${availableAt.toISOString().slice(0, 10)}.`,
+      });
+    }
+  }
+
+  // Annual summary for the prior year (always available once the year ends).
+  const priorYear = currentYear - 1;
+  if (priorYear >= profile.onboardedYear) {
+    docs.push({
+      id: `annual-${profile.vendorId}-${priorYear}`,
+      kind: "annual_summary",
+      taxYear: priorYear,
+      status: "available",
+      availableAt: null,
+      storageKey: `vendor-tax/${profile.vendorId}/annual-${priorYear}.pdf`,
+    });
+  }
+
+  // Monthly settlement statements for the trailing 3 months.
+  for (let i = 1; i <= 3; i++) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
+    const period = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+    docs.push({
+      id: `monthly-${profile.vendorId}-${period}`,
+      kind: "monthly_settlement",
+      taxYear: d.getUTCFullYear(),
+      periodLabel: period,
+      status: "available",
+      availableAt: null,
+      storageKey: `vendor-tax/${profile.vendorId}/monthly-${period}.pdf`,
+    });
+  }
+
+  return docs;
+}
+
+/**
+ * Demo profile so the vendor portal page renders without DB plumbing.
+ * The real implementation hydrates this from the Vendor + VendorPayout
+ * tables.
+ */
+export function demoVendorTaxProfile(vendorId: string): VendorTaxProfile {
+  return {
+    vendorId,
+    hasW9OnFile: true,
+    ytdVolumeCents: 28_400 * 100,
+    onboardedYear: 2024,
+  };
+}


### PR DESCRIPTION
## Summary

Scaffolds **seven Track 7 tickets** (EMR-302, 303, 305, 306, 307, 310, 315) in their natural homes. All-additive: new files only, no edits to existing pages or shared components. A follow-up PR will wire the new components into the PDP and checkout pages.

| Ticket | What landed |
|---|---|
| **EMR-302** | `lib/marketplace/distributor.ts` — Distributor + SourceProvenance types, eligibility filter (state license × format × THC clearance), provenance verifier |
| **EMR-303** | `lib/marketplace/benchmark.ts` — 15-feature Theleafmart-vs-Amazon parity matrix, scoring, gap roadmap; internal report at `/(operator)/ops/marketplace-benchmark` |
| **EMR-305** | `lib/marketplace/qa.ts` + `components/leafmart/ProductQATab.tsx` + POST `/api/leafmart/products/[slug]/questions` — lazy-expanding Q&A tab with optimistic insert |
| **EMR-306** | `lib/marketplace/review-moderation.ts` — two-stage pipeline (deterministic pre-moderation → AI moderation stand-in); `ReviewSubmissionForm.tsx` with photo upload (JPEG/PNG/WebP, 8MB, 6 max); POST `/api/leafmart/products/[slug]/reviews` |
| **EMR-307** | `lib/marketplace/product-details.ts` — deterministic curator over MarketplaceProduct + LeafmartProduct; `ProductDetailsList.tsx` two-column highlights/specs |
| **EMR-310** | `lib/marketplace/share.ts` — HMAC-signed share token; `CheckoutCompareSimilar.tsx` (side-by-side swap), `CheckoutShareModule.tsx` (copy/email/text); POST `/api/leafmart/cart/share` |
| **EMR-315** | `lib/marketplace/vendor-tax.ts` (1099-K threshold, W-9 prerequisite, monthly statements) + `vendor-analytics.ts`; pages at `/vendor-portal/tax-documents` and `/vendor-portal/analytics` |

## Verification

- **Tests:** 30 new tests added across `distributor.test.ts`, `benchmark.test.ts`, `review-moderation.test.ts`, `share.test.ts`. Full marketplace suite: **105/105 passing**.
- **Type check:** `tsc --noEmit` clean.

## What's NOT in this PR

To keep scope additive and avoid colliding with concurrent agents working on the PDP and checkout pages, **none of the existing pages are modified**. The next PR will wire:

- `ProductQATab` + `ProductDetailsList` into `app/leafmart/products/[slug]/page.tsx`
- `ReviewSubmissionForm` + photo carousel into `ProductReviews.tsx` (will need a `LeafmartReviewPhoto` type)
- `CheckoutCompareSimilar` + `CheckoutShareModule` into `app/leafmart/checkout/page.tsx`

Each component takes data as props, so wiring is mechanical.

## Notes for review

- Q&A and reviews have a server-side moderation gate but persistence is stubbed pending the `ProductQuestion`/`ProductReview` table changes — the API responses are shaped so the optimistic UI works today.
- `LEAFMART_SHARE_SECRET` env var is consumed by `share.ts`; falls back to a stable dev secret so links work locally without env wiring.
- `marketplace-benchmark` page lives under `(operator)/ops` because it's an internal PM/leadership tool, not a customer-facing surface.

## Test plan

- [ ] `npm test -- src/lib/marketplace` — all 105 pass
- [ ] `npm run typecheck` — clean
- [ ] Visit `/ops/marketplace-benchmark` (operator role) — feature matrix renders
- [ ] Visit `/vendor-portal/tax-documents` and `/vendor-portal/analytics` — pages render with demo data
- [ ] After follow-up wiring PR: PDP shows Q&A tab + Product Details list; reviews accept photos; checkout shows Compare + Share modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)