### PR TITLE
Track 5: Patient Finance & Access (EMR-111 → EMR-123)

### DIFF
--- a/src/app/(operator)/ops/access-log/page.tsx
+++ b/src/app/(operator)/ops/access-log/page.tsx
@@ -1,0 +1,232 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  reconstructSessions,
+  aggregateByRole,
+  buildHipaaExport,
+  type AccessRole,
+} from "@/lib/billing/access-log";
+
+export const metadata = { title: "Master Access Log" };
+
+const ROLE_TONE: Record<AccessRole, "highlight" | "accent" | "info" | "success" | "warning" | "neutral"> = {
+  patient: "info",
+  provider: "highlight",
+  office_manager: "accent",
+  researcher: "success",
+  system: "neutral",
+};
+
+function formatSeconds(s: number): string {
+  if (s < 60) return `${Math.round(s)}s`;
+  if (s < 3600) return `${(s / 60).toFixed(1)}m`;
+  return `${(s / 3600).toFixed(1)}h`;
+}
+
+export default async function AccessLogPage({
+  searchParams,
+}: {
+  searchParams: { patient?: string; days?: string };
+}) {
+  const user = await requireUser();
+  const organizationId = user.organizationId!;
+  const sinceDays = Math.max(1, Math.min(90, parseInt(searchParams.days ?? "14", 10) || 14));
+  const sinceCutoff = new Date(Date.now() - sinceDays * 86_400_000);
+
+  // Pull recent AuditLog rows that look like chart access — this is
+  // the "read" side of `recordChartAccess()`.
+  const rows = await prisma.auditLog.findMany({
+    where: {
+      organizationId,
+      createdAt: { gte: sinceCutoff },
+      action: {
+        in: [
+          "chart.viewed",
+          "section.viewed",
+          "field.edited",
+          "document.downloaded",
+          "message.sent",
+          "rx.signed",
+          "claim.submitted",
+          "session.heartbeat",
+        ],
+      },
+      ...(searchParams.patient
+        ? { subjectType: "patient", subjectId: searchParams.patient }
+        : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    take: 1000,
+  });
+
+  const normalized = rows.map((r) => ({
+    action: r.action,
+    actorUserId: r.actorUserId,
+    metadata: (r.metadata as Record<string, unknown>) ?? {},
+    createdAt: r.createdAt,
+  }));
+
+  const sessions = reconstructSessions(normalized);
+  const byRole = aggregateByRole(sessions);
+  const hipaaExport = searchParams.patient
+    ? buildHipaaExport(searchParams.patient, normalized)
+    : [];
+
+  const totalEvents = rows.length;
+  const totalSessions = sessions.length;
+  const uniqueActors = new Set(rows.map((r) => r.actorUserId).filter(Boolean)).size;
+  const uniquePatients = new Set(rows.map((r) => r.subjectId).filter(Boolean)).size;
+
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <PageHeader
+        eyebrow="Compliance"
+        title="Master access log"
+        description={`Immutable record of every chart access — last ${sinceDays} days. Filter by patient to scope a HIPAA audit; export from the panel below.`}
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Events" value={totalEvents.toLocaleString()} size="md" />
+        <StatCard label="Sessions" value={totalSessions.toLocaleString()} tone="accent" size="md" />
+        <StatCard label="Distinct actors" value={String(uniqueActors)} size="md" />
+        <StatCard label="Distinct patients" value={String(uniquePatients)} size="md" />
+      </div>
+
+      <form action="/ops/access-log" method="get" className="mb-6 flex gap-2 items-end">
+        <label className="flex flex-col gap-1 flex-1">
+          <span className="text-xs text-text-muted">Patient id</span>
+          <input
+            name="patient"
+            defaultValue={searchParams.patient ?? ""}
+            placeholder="Optional — leave blank for org-wide view"
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-text-muted">Days</span>
+          <input
+            type="number"
+            name="days"
+            defaultValue={String(sinceDays)}
+            min={1}
+            max={90}
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm w-24"
+          />
+        </label>
+        <button
+          type="submit"
+          className="rounded-md bg-text px-4 py-2 text-sm text-surface hover:opacity-90"
+        >
+          Apply
+        </button>
+      </form>
+
+      <Card tone="raised" className="mb-6">
+        <CardHeader>
+          <CardTitle>Click analytics by role</CardTitle>
+          <CardDescription>
+            Mean session length and click counts per role across the selected window.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {byRole.length === 0 ? (
+            <EmptyState
+              title="No sessions in this window"
+              description="Adjust the days filter or wait for activity."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left">
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Role</th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Sessions</th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Avg clicks</th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Avg session</th>
+                    <th className="py-2 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Top destinations</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {byRole.map((r) => (
+                    <tr key={r.role}>
+                      <td className="py-3 pr-4">
+                        <Badge tone={ROLE_TONE[r.role]}>{r.role}</Badge>
+                      </td>
+                      <td className="py-3 pr-4 tabular-nums text-text">{r.sessionCount}</td>
+                      <td className="py-3 pr-4 tabular-nums text-text">
+                        {r.avgClicksPerSession.toFixed(1)}
+                      </td>
+                      <td className="py-3 pr-4 tabular-nums text-text">
+                        {formatSeconds(r.avgSessionSeconds)}
+                      </td>
+                      <td className="py-3 text-text-muted text-xs">
+                        {r.topDestinations.map((d) => `${d.section} (${d.count})`).join(" · ") || "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {searchParams.patient && (
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle>HIPAA export preview · {searchParams.patient}</CardTitle>
+            <CardDescription>
+              Deterministic, immutable export rows. Pipe through the compliance team's PDF generator.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {hipaaExport.length === 0 ? (
+              <p className="text-sm text-text-subtle">
+                No events recorded for this patient in the window.
+              </p>
+            ) : (
+              <div className="max-h-96 overflow-y-auto">
+                <table className="w-full text-xs">
+                  <thead className="sticky top-0 bg-surface">
+                    <tr className="border-b border-border text-left">
+                      <th className="py-2 pr-3 text-text-subtle">When</th>
+                      <th className="py-2 pr-3 text-text-subtle">Actor</th>
+                      <th className="py-2 pr-3 text-text-subtle">Role</th>
+                      <th className="py-2 pr-3 text-text-subtle">Action</th>
+                      <th className="py-2 pr-3 text-text-subtle">Section</th>
+                      <th className="py-2 text-text-subtle">Field</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/50">
+                    {hipaaExport.slice(0, 200).map((row, i) => (
+                      <tr key={i}>
+                        <td className="py-2 pr-3 tabular-nums text-text-muted">{row.timestampIso}</td>
+                        <td className="py-2 pr-3 text-text">{row.actorUserId ?? "system"}</td>
+                        <td className="py-2 pr-3">
+                          <Badge tone={ROLE_TONE[row.actorRole]}>{row.actorRole}</Badge>
+                        </td>
+                        <td className="py-2 pr-3 text-text">{row.action}</td>
+                        <td className="py-2 pr-3 text-text-muted">{row.section}</td>
+                        <td className="py-2 text-text-muted">{row.field ?? "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {hipaaExport.length > 200 && (
+                  <p className="text-xs text-text-subtle mt-2">
+                    Showing first 200 of {hipaaExport.length}. PDF export includes all rows.
+                  </p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/allergy-alerts/page.tsx
+++ b/src/app/(operator)/ops/allergy-alerts/page.tsx
@@ -1,0 +1,167 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  summarizeAlerts,
+  requiresStopInterstitial,
+  type AllergyRecord,
+  type ContraindicationRecord,
+  type ChartAlert,
+} from "@/lib/billing/allergy-alerts";
+
+export const metadata = { title: "Allergies + Contraindications" };
+
+const TONE_BADGE: Record<ChartAlert["tone"], "danger" | "warning" | "highlight" | "info"> = {
+  danger: "danger",
+  warning: "warning",
+  caution: "highlight",
+  info: "info",
+};
+
+// Sample fixtures — wires to prisma.patient + prisma.medicationAllergy
+// in the next iteration once the contraindication source-of-truth model
+// lands. Page validates the banner sort + interstitial logic today.
+const FIXTURES: Array<{
+  patient: string;
+  mrn: string;
+  allergies: AllergyRecord[];
+  contraindications: ContraindicationRecord[];
+}> = [
+  {
+    patient: "Maya Castillo",
+    mrn: "MRN-A0042",
+    allergies: [
+      {
+        id: "a1",
+        substance: "Penicillin",
+        reaction: "Anaphylaxis at age 12",
+        severity: "fatal",
+        recordedAt: new Date("2024-02-08"),
+        selfReported: false,
+      },
+      {
+        id: "a2",
+        substance: "Sulfa",
+        reaction: "Hives + facial swelling",
+        severity: "severe",
+        recordedAt: new Date("2025-09-14"),
+        selfReported: true,
+      },
+    ],
+    contraindications: [
+      {
+        id: "c1",
+        trigger: "CBD + Atorvastatin",
+        description:
+          "CBD inhibits CYP3A4 — atorvastatin levels can rise to myopathy-risk range.",
+        severity: "major",
+        source: "drug-cannabis",
+        recordedAt: new Date("2025-11-02"),
+      },
+    ],
+  },
+  {
+    patient: "Jonas Reiter",
+    mrn: "MRN-B0119",
+    allergies: [],
+    contraindications: [
+      {
+        id: "c2",
+        trigger: "THC + Pregabalin",
+        description:
+          "Additive CNS depression — increased risk of falls and cognitive impairment.",
+        severity: "moderate",
+        source: "drug-cannabis",
+        recordedAt: new Date("2026-01-12"),
+      },
+      {
+        id: "c3",
+        trigger: "Grapefruit juice",
+        description: "CYP3A4 inhibition; clinically meaningful with current statin regimen.",
+        severity: "monitor",
+        source: "drug-condition",
+        recordedAt: new Date("2025-08-20"),
+      },
+    ],
+  },
+];
+
+export default function AllergyAlertsPage() {
+  const summaries = FIXTURES.map((p) => ({
+    ...p,
+    alerts: summarizeAlerts(p.allergies, p.contraindications),
+  }));
+
+  const totalAlerts = summaries.reduce((acc, p) => acc + p.alerts.length, 0);
+  const totalStop = summaries.filter((p) => requiresStopInterstitial(p.alerts)).length;
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Patient safety"
+        title="Allergies + contraindications"
+        description="Top-of-chart alert payloads. Same logic powers the chart banner, the prescribe-modal block, and the prior-auth packet builder — single source of truth."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Patients in view" value={String(FIXTURES.length)} size="md" />
+        <StatCard label="Active alerts" value={String(totalAlerts)} tone="warning" size="md" />
+        <StatCard
+          label="STOP interstitials"
+          value={String(totalStop)}
+          tone="danger"
+          hint="Non-dismissible"
+          size="md"
+        />
+        <StatCard
+          label="Avg per chart"
+          value={summaries.length === 0 ? "—" : (totalAlerts / summaries.length).toFixed(1)}
+          size="md"
+        />
+      </div>
+
+      <div className="space-y-4">
+        {summaries.map((p) => (
+          <Card key={p.mrn} tone="raised">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle>{p.patient}</CardTitle>
+                  <CardDescription>MRN {p.mrn}</CardDescription>
+                </div>
+                {requiresStopInterstitial(p.alerts) && (
+                  <Badge tone="danger">STOP interstitial active</Badge>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              {p.alerts.length === 0 ? (
+                <p className="text-sm text-text-subtle">No active alerts on file.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {p.alerts.map((alert) => (
+                    <li
+                      key={alert.id}
+                      className="border border-border rounded-md px-4 py-3 flex items-start justify-between gap-3"
+                    >
+                      <div>
+                        <div className="text-sm font-medium text-text">{alert.headline}</div>
+                        <div className="text-xs text-text-muted mt-1">{alert.detail}</div>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <Badge tone={TONE_BADGE[alert.tone]}>{alert.kind}</Badge>
+                        <span className="text-[11px] text-text-subtle">prio {alert.priority}</span>
+                        {!alert.dismissible && <Badge tone="danger">locked</Badge>}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/education/page.tsx
+++ b/src/app/(operator)/ops/education/page.tsx
@@ -1,0 +1,155 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  EDUCATION_ENTRIES,
+  searchEducation,
+  entriesByCategory,
+  type CompoundCategory,
+  type EducationEntry,
+} from "@/lib/billing/education-db";
+
+export const metadata = { title: "Cannabis Education Database" };
+
+const CATEGORY_LABEL: Record<CompoundCategory, string> = {
+  cannabinoid: "Cannabinoids",
+  terpene: "Terpenes",
+  flavonoid: "Flavonoids",
+  receptor: "Receptors",
+  dosing: "Dosing",
+  system: "Systems",
+};
+
+const CATEGORY_TONE: Record<CompoundCategory, "highlight" | "accent" | "success" | "info" | "warning" | "neutral"> = {
+  cannabinoid: "highlight",
+  terpene: "accent",
+  flavonoid: "success",
+  receptor: "info",
+  dosing: "warning",
+  system: "neutral",
+};
+
+const CATEGORY_ORDER: CompoundCategory[] = [
+  "cannabinoid",
+  "terpene",
+  "flavonoid",
+  "receptor",
+  "system",
+  "dosing",
+];
+
+export default async function EducationDbPage({
+  searchParams,
+}: {
+  searchParams: { q?: string; category?: CompoundCategory };
+}) {
+  const query = (searchParams.q ?? "").trim();
+  const category = searchParams.category;
+  let results: EducationEntry[];
+  if (query) {
+    results = searchEducation(query, 50);
+  } else if (category) {
+    results = entriesByCategory(category);
+  } else {
+    results = EDUCATION_ENTRIES;
+  }
+
+  const counts = CATEGORY_ORDER.map((c) => ({
+    category: c,
+    count: entriesByCategory(c).length,
+  }));
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Education curation"
+        title="Cannabis Education Database"
+        description="Curated reference data behind the patient Education tab and the appeals-letter generator. Search compounds, scan categories, drop one-line summaries into payer correspondence."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mb-8">
+        <StatCard label="Entries" value={String(EDUCATION_ENTRIES.length)} size="sm" />
+        {counts.map((c) => (
+          <StatCard
+            key={c.category}
+            label={CATEGORY_LABEL[c.category]}
+            value={String(c.count)}
+            size="sm"
+          />
+        ))}
+      </div>
+
+      <form action="/ops/education" method="get" className="mb-6 flex gap-2">
+        <input
+          type="search"
+          name="q"
+          defaultValue={query}
+          placeholder="Search by name, alias, or text…"
+          className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm"
+        />
+        <select
+          name="category"
+          defaultValue={category ?? ""}
+          className="rounded-md border border-border bg-surface px-3 py-2 text-sm"
+        >
+          <option value="">All categories</option>
+          {CATEGORY_ORDER.map((c) => (
+            <option key={c} value={c}>
+              {CATEGORY_LABEL[c]}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="rounded-md bg-text px-4 py-2 text-sm text-surface hover:opacity-90"
+        >
+          Search
+        </button>
+      </form>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {results.map((entry) => (
+          <Card key={entry.id} tone="raised">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle>{entry.name}</CardTitle>
+                  <CardDescription>{entry.aliases.join(" · ") || entry.id}</CardDescription>
+                </div>
+                <Badge tone={CATEGORY_TONE[entry.category]}>
+                  {CATEGORY_LABEL[entry.category]}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-text mb-3">{entry.oneLineSummary}</p>
+              <ul className="text-sm text-text-muted space-y-1 list-disc pl-5">
+                {entry.body.map((line, i) => (
+                  <li key={i}>{line}</li>
+                ))}
+              </ul>
+              {entry.aromaticNotes && entry.aromaticNotes.length > 0 && (
+                <p className="text-xs text-text-subtle mt-3">
+                  <span className="font-medium">Aromatic notes:</span>{" "}
+                  {entry.aromaticNotes.join(", ")}
+                </p>
+              )}
+              {entry.reportedEffects && entry.reportedEffects.length > 0 && (
+                <p className="text-xs text-text-subtle mt-1">
+                  <span className="font-medium">Reported effects:</span>{" "}
+                  {entry.reportedEffects.join(", ")}
+                </p>
+              )}
+              {entry.citations.length > 0 && (
+                <p className="text-xs text-text-subtle mt-2">
+                  Citations: {entry.citations.join(", ")}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/eob/page.tsx
+++ b/src/app/(operator)/ops/eob/page.tsx
@@ -1,0 +1,202 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  parseEra835,
+  topPatientRespReasons,
+  buildSummaryPrompt,
+  type ParsedEob,
+  type Era835ClaimSegment,
+  type Era835Header,
+} from "@/lib/billing/eob";
+
+export const metadata = { title: "EOB Inbox" };
+
+function formatMoney(cents: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+}
+
+// Sample 835 fixtures — once the clearinghouse webhook lands these come
+// from prisma.adjudicationResult / prisma.clearinghouseSubmission. The
+// parser is the same; only the source changes.
+const SAMPLE_HEADER: Era835Header = {
+  payerName: "Aetna",
+  paidDate: "2026-04-21",
+  checkOrEftNumber: "EFT-998877",
+};
+
+const SAMPLE_CLAIMS: Array<{ patient: string; mrn: string; segment: Era835ClaimSegment; matchedClaimId: string }> = [
+  {
+    patient: "Maya Castillo",
+    mrn: "MRN-A0042",
+    matchedClaimId: "clm_01H8XVQ",
+    segment: {
+      payerClaimNumber: "AET-2026-04-22001",
+      patientControlNumber: "PCN-A0042-04",
+      cptLines: [
+        {
+          cptCode: "99214",
+          description: "Office visit, established, moderate complexity",
+          billedCents: 21500,
+          allowedCents: 13800,
+          paidCents: 11040,
+          adjustments: [
+            { groupCode: "CO", carc: "45", amountCents: 7700 },
+            { groupCode: "PR", carc: "1", amountCents: 1500, rarc: "N782" },
+            { groupCode: "PR", carc: "2", amountCents: 1260 },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    patient: "Jonas Reiter",
+    mrn: "MRN-B0119",
+    matchedClaimId: "clm_01H8XW3",
+    segment: {
+      payerClaimNumber: "AET-2026-04-22014",
+      patientControlNumber: "PCN-B0119-04",
+      cptLines: [
+        {
+          cptCode: "99213",
+          description: "Office visit, established, low complexity",
+          billedCents: 16500,
+          allowedCents: 9800,
+          paidCents: 0,
+          adjustments: [
+            { groupCode: "CO", carc: "45", amountCents: 6700 },
+            { groupCode: "PR", carc: "204", amountCents: 9800 },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+export default function EobInboxPage() {
+  const parsed: Array<{ patient: string; mrn: string; eob: ParsedEob }> = SAMPLE_CLAIMS.map(
+    (s) => ({
+      patient: s.patient,
+      mrn: s.mrn,
+      eob: parseEra835(SAMPLE_HEADER, s.segment, s.matchedClaimId),
+    }),
+  );
+
+  const totalPaid = parsed.reduce((sum, p) => sum + p.eob.totals.paidCents, 0);
+  const totalPR = parsed.reduce((sum, p) => sum + p.eob.totals.patientRespCents, 0);
+  const totalCO = parsed.reduce((sum, p) => sum + p.eob.totals.contractualAdjustmentCents, 0);
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Remittance"
+        title="EOB inbox"
+        description="Parsed payer remittance — surfaced to the patient portal billing tab AND the doctor's chart drawer with the same source of truth."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="EOBs parsed" value={String(parsed.length)} size="md" />
+        <StatCard label="Insurance paid" value={formatMoney(totalPaid)} tone="success" size="md" />
+        <StatCard
+          label="Patient responsibility"
+          value={formatMoney(totalPR)}
+          tone="warning"
+          size="md"
+        />
+        <StatCard label="Contractual adj." value={formatMoney(totalCO)} tone="neutral" size="md" />
+      </div>
+
+      <div className="space-y-4">
+        {parsed.map((p) => {
+          const topReasons = topPatientRespReasons(p.eob, 3);
+          const promptPreview = buildSummaryPrompt({
+            payerName: p.eob.payerName,
+            serviceDate: p.eob.paidDate,
+            totals: p.eob.totals,
+            topReasons,
+          });
+          return (
+            <Card key={p.mrn} tone="raised">
+              <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <CardTitle>
+                      {p.patient} <span className="text-text-subtle text-sm">· {p.mrn}</span>
+                    </CardTitle>
+                    <CardDescription>
+                      {p.eob.payerName} · paid {p.eob.paidDate} · #{p.eob.payerClaimNumber}
+                    </CardDescription>
+                  </div>
+                  <div className="flex gap-2">
+                    {p.eob.fromFreeText && <Badge tone="warning">free-text</Badge>}
+                    {p.eob.unmatchedLines.length > 0 && (
+                      <Badge tone="danger">{p.eob.unmatchedLines.length} unmatched</Badge>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+                  <Stat label="Billed" value={formatMoney(p.eob.totals.billedCents)} />
+                  <Stat label="Allowed" value={formatMoney(p.eob.totals.allowedCents)} />
+                  <Stat label="Paid" value={formatMoney(p.eob.totals.paidCents)} tone="success" />
+                  <Stat
+                    label="Patient resp."
+                    value={formatMoney(p.eob.totals.patientRespCents)}
+                    tone="warning"
+                  />
+                  <Stat
+                    label="Contractual"
+                    value={formatMoney(p.eob.totals.contractualAdjustmentCents)}
+                  />
+                </div>
+                {topReasons.length > 0 && (
+                  <div className="mb-4">
+                    <div className="text-[10px] uppercase tracking-wider text-text-subtle mb-2">
+                      Top patient-resp reasons
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {topReasons.map((r) => (
+                        <Badge key={r.carc} tone="warning">
+                          CARC {r.carc} · {r.bucket} · {formatMoney(r.amountCents)}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <details className="text-xs text-text-muted">
+                  <summary className="cursor-pointer text-text">
+                    AI summary prompt (deterministic facts only)
+                  </summary>
+                  <pre className="mt-2 p-3 bg-surface-muted rounded-md overflow-x-auto whitespace-pre-wrap">
+                    {promptPreview}
+                  </pre>
+                </details>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </PageShell>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "success" | "warning" }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-text-subtle">{label}</div>
+      <div
+        className={
+          tone === "success"
+            ? "text-success font-medium tabular-nums"
+            : tone === "warning"
+              ? "text-[color:var(--warning)] font-medium tabular-nums"
+              : "text-text font-medium tabular-nums"
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(operator)/ops/international-billing/page.tsx
+++ b/src/app/(operator)/ops/international-billing/page.tsx
@@ -1,0 +1,132 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  listCountryRules,
+  formatCountryMoney,
+  publicCoverageUnlikely,
+  SUPPORTED_COUNTRIES,
+} from "@/lib/billing/international";
+
+export const metadata = { title: "International Billing" };
+
+export default function InternationalBillingPage() {
+  const rules = listCountryRules();
+  const totalCarriers = rules.reduce((sum, r) => sum + r.carriers.length, 0);
+  const reimbursableCount = rules.filter((r) => r.cannabisPolicy.reimbursableUnderPublic).length;
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Global rollout"
+        title="International billing framework"
+        description="Country-aware billing rules registry. Each country has its own coding system, currency, filing windows, and cannabis-reimbursement posture. Launch coverage: US, UK, Canada, Germany, Australia."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Countries live" value={String(SUPPORTED_COUNTRIES.length)} size="md" />
+        <StatCard label="Carriers wired" value={String(totalCarriers)} size="md" />
+        <StatCard
+          label="Public reimbursement"
+          value={`${reimbursableCount}/${rules.length}`}
+          tone="accent"
+          size="md"
+        />
+        <StatCard
+          label="Coding systems"
+          value={String(new Set(rules.map((r) => r.codingSystem)).size)}
+          size="md"
+        />
+      </div>
+
+      <div className="space-y-4">
+        {rules.map((rule) => (
+          <Card key={rule.countryCode} tone="raised">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle>
+                    {rule.countryName}{" "}
+                    <span className="text-text-subtle text-sm font-normal">· {rule.countryCode}</span>
+                  </CardTitle>
+                  <CardDescription>
+                    {rule.codingSystem} · {rule.currency} · {rule.locale}
+                  </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                  {publicCoverageUnlikely(rule.countryCode) ? (
+                    <Badge tone="warning">Self-pay route likely</Badge>
+                  ) : (
+                    <Badge tone="success">Public reimbursement available</Badge>
+                  )}
+                  <Badge tone="info">VAT {rule.vatRate}%</Badge>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-text-subtle">
+                    Timely filing
+                  </div>
+                  <div className="text-text font-medium">{rule.timelyFilingDays} days</div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-text-subtle">
+                    Appeal window
+                  </div>
+                  <div className="text-text font-medium">{rule.appealDeadlineDays} days</div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-text-subtle">
+                    Sample charge
+                  </div>
+                  <div className="text-text font-medium tabular-nums">
+                    {formatCountryMoney(rule.countryCode, 12500)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-text-subtle">
+                    Medical taxable
+                  </div>
+                  <div className="text-text font-medium">
+                    {rule.medicalServicesTaxable ? "Yes" : "No"}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mb-4">
+                <div className="text-[10px] uppercase tracking-wider text-text-subtle mb-2">
+                  Carriers
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {rule.carriers.map((c) => (
+                    <Badge
+                      key={c.id}
+                      tone={
+                        c.kind === "national"
+                          ? "highlight"
+                          : c.kind === "regional"
+                            ? "info"
+                            : "neutral"
+                      }
+                    >
+                      {c.displayName}
+                      {!c.electronicSubmission && " · paper"}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+
+              <div className="text-xs text-text-muted bg-surface-muted rounded-md p-3 leading-relaxed">
+                <span className="font-medium text-text">Cannabis policy: </span>
+                {rule.cannabisPolicy.citation}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/payment-methods/page.tsx
+++ b/src/app/(operator)/ops/payment-methods/page.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Avatar } from "@/components/ui/avatar";
+import { formatDate } from "@/lib/utils/format";
+
+export const metadata = { title: "Stored Payment Methods" };
+
+export default async function PaymentMethodsPage() {
+  const user = await requireUser();
+  const organizationId = user.organizationId!;
+
+  const methods = await prisma.storedPaymentMethod.findMany({
+    where: {
+      active: true,
+      patient: { organizationId },
+    },
+    include: {
+      patient: { select: { id: true, firstName: true, lastName: true } },
+    },
+    orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
+    take: 100,
+  });
+
+  const cardCount = methods.filter((m) => m.type === "card").length;
+  const achCount = methods.filter((m) => m.type === "ach").length;
+  const defaultCount = methods.filter((m) => m.isDefault).length;
+  const uniquePatients = new Set(methods.map((m) => m.patientId)).size;
+
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <PageHeader
+        eyebrow="Patient finance"
+        title="Stored payment methods"
+        description="Tokenized card + ACH on file across the practice. Tokens are processor-side (Payabli) — only last 4 + brand are stored locally."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Active methods" value={String(methods.length)} size="md" />
+        <StatCard label="Patients on file" value={String(uniquePatients)} size="md" />
+        <StatCard label="Cards" value={String(cardCount)} tone="accent" size="md" />
+        <StatCard label="ACH" value={String(achCount)} tone="info" size="md" />
+      </div>
+
+      {methods.length === 0 ? (
+        <EmptyState
+          title="No stored methods yet"
+          description="Patients can save a card or bank account from the portal billing tab. Tokens are stored at Payabli — never PAN."
+        />
+      ) : (
+        <Card tone="raised">
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left">
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Patient</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Type</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Brand</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Last 4</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Expires</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Saved</th>
+                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Default</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {methods.map((m) => (
+                    <tr key={m.id} className="hover:bg-surface-muted/40 transition-colors">
+                      <td className="py-3 px-5">
+                        <Link
+                          href={`/clinic/patients/${m.patient.id}`}
+                          className="flex items-center gap-2 group"
+                        >
+                          <Avatar
+                            firstName={m.patient.firstName}
+                            lastName={m.patient.lastName}
+                            size="sm"
+                          />
+                          <span className="font-medium text-text group-hover:text-accent transition-colors">
+                            {m.patient.firstName} {m.patient.lastName}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="py-3 px-5">
+                        <Badge tone={m.type === "card" ? "accent" : "info"}>
+                          {m.type.toUpperCase()}
+                        </Badge>
+                      </td>
+                      <td className="py-3 px-5 text-text">{m.brand ?? "—"}</td>
+                      <td className="py-3 px-5 tabular-nums text-text">•••• {m.last4}</td>
+                      <td className="py-3 px-5 tabular-nums text-text-muted">
+                        {m.expiryMonth && m.expiryYear
+                          ? `${String(m.expiryMonth).padStart(2, "0")}/${String(m.expiryYear).slice(-2)}`
+                          : "—"}
+                      </td>
+                      <td className="py-3 px-5 text-text-muted">{formatDate(m.createdAt)}</td>
+                      <td className="py-3 px-5">{m.isDefault ? <Badge tone="success">Default</Badge> : null}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <p className="text-xs text-text-subtle mt-6">
+        {defaultCount} patient(s) have a default method set. Charges flow through{" "}
+        <code className="bg-surface-muted px-1 py-0.5 rounded">chargeStoredMethod()</code> in{" "}
+        <code className="bg-surface-muted px-1 py-0.5 rounded">src/lib/billing/payment-methods.ts</code>{" "}
+        and book to the FinancialEvent ledger before the receipt is generated.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/research-exports/page.tsx
+++ b/src/app/(operator)/ops/research-exports/page.tsx
@@ -1,0 +1,213 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  CohortPseudonymizer,
+  buildCohortManifest,
+  categorizePayer,
+  deIdentifyPatient,
+  deIdentifyClaim,
+  suppressSmallCells,
+  type RawPatientFacts,
+  type RawClaimFacts,
+} from "@/lib/billing/research-export";
+
+export const metadata = { title: "Researcher Exports" };
+
+// Stable salt for the demo cohort. In production each cohort manifest
+// generates its own random salt and stores it next to the export.
+const DEMO_SALT = "cohort_2026Q2_demo__salt_at_least_16_chars";
+
+const RAW_PATIENTS: RawPatientFacts[] = [
+  { patientId: "p1", dateOfBirth: new Date("1957-08-12"), sex: "female", race: "Black or African American", ethnicity: "Non-Hispanic", smokingStatus: "former", substanceHistory: null, zipCode: "80302", socioeconomicTier: "middle" },
+  { patientId: "p2", dateOfBirth: new Date("1971-02-22"), sex: "male", race: "White", ethnicity: "Non-Hispanic", smokingStatus: "never", substanceHistory: "occasional alcohol", zipCode: "80303", socioeconomicTier: "middle" },
+  { patientId: "p3", dateOfBirth: new Date("1986-11-30"), sex: "female", race: "Asian", ethnicity: "Non-Hispanic", smokingStatus: "never", substanceHistory: null, zipCode: "80305", socioeconomicTier: "upper" },
+  { patientId: "p4", dateOfBirth: new Date("1992-04-04"), sex: "male", race: "White", ethnicity: "Hispanic", smokingStatus: "current", substanceHistory: "cannabis daily", zipCode: "80301", socioeconomicTier: "lower" },
+  { patientId: "p5", dateOfBirth: new Date("1934-09-09"), sex: "female", race: "White", ethnicity: "Non-Hispanic", smokingStatus: "former", substanceHistory: null, zipCode: "03601", socioeconomicTier: "lower" }, // restricted ZIP3
+];
+
+const RAW_CLAIMS: RawClaimFacts[] = [
+  { claimId: "c1", patientId: "p1", encounterId: "e1", serviceDate: new Date("2026-03-14"), payerName: "Medicare", cptCodes: ["99214", "99454"], icd10Codes: ["I10", "G89.4"], billedCents: 38000, paidCents: 26500, patientRespCents: 6000, status: "paid", denialCategory: null },
+  { claimId: "c2", patientId: "p2", encounterId: "e2", serviceDate: new Date("2026-03-22"), payerName: "Aetna", cptCodes: ["99213"], icd10Codes: ["F41.1"], billedCents: 18500, paidCents: 11800, patientRespCents: 2900, status: "paid", denialCategory: null },
+  { claimId: "c3", patientId: "p3", encounterId: "e3", serviceDate: new Date("2026-04-04"), payerName: "Self pay", cptCodes: ["99204"], icd10Codes: ["F12.10"], billedCents: 30000, paidCents: 30000, patientRespCents: 0, status: "paid", denialCategory: null },
+  { claimId: "c4", patientId: "p4", encounterId: "e4", serviceDate: new Date("2026-04-12"), payerName: "Medicaid", cptCodes: ["99214"], icd10Codes: ["F12.10", "M54.5"], billedCents: 22000, paidCents: 0, patientRespCents: 0, status: "denied", denialCategory: "non_covered_service" },
+  { claimId: "c5", patientId: "p5", encounterId: "e5", serviceDate: new Date("2026-04-22"), payerName: "Medicare", cptCodes: ["99457", "99458"], icd10Codes: ["I10"], billedCents: 14500, paidCents: 11200, patientRespCents: 0, status: "paid", denialCategory: null },
+];
+
+export default function ResearchExportsPage({
+  searchParams,
+}: {
+  searchParams: { minCell?: string };
+}) {
+  const minCellSize = Math.max(1, parseInt(searchParams.minCell ?? "1", 10) || 1);
+  const pseudo = new CohortPseudonymizer(DEMO_SALT);
+
+  const deIdentifiedPatients = RAW_PATIENTS.map((p) => deIdentifyPatient(p, pseudo));
+  const deIdentifiedClaims = RAW_CLAIMS.map((c) => deIdentifyClaim(c, pseudo));
+
+  const { kept, suppressedBuckets } = suppressSmallCells(deIdentifiedPatients, minCellSize);
+  const keptIds = new Set(kept.map((p) => p.pseudonym));
+  const filteredClaims = deIdentifiedClaims.filter((c) => keptIds.has(c.patientPseudonym));
+
+  const manifest = buildCohortManifest({
+    cohortId: "demo_2026q2",
+    scope: "billing-and-outcomes",
+    patientCount: kept.length,
+    claimCount: filteredClaims.length,
+    minCellSize,
+  });
+
+  const payerMix = filteredClaims.reduce<Record<string, number>>((acc, c) => {
+    acc[c.payerCategory] = (acc[c.payerCategory] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <PageHeader
+        eyebrow="Research portal"
+        title="Researcher exports"
+        description="HIPAA Safe Harbor de-identification of billing + claim data for the researcher portal. Cohort-scoped pseudonyms, generalized geography, small-cell suppression."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Patients (post-suppression)" value={String(kept.length)} size="md" />
+        <StatCard label="Claims" value={String(filteredClaims.length)} tone="accent" size="md" />
+        <StatCard
+          label="Suppressed buckets"
+          value={String(suppressedBuckets.length)}
+          tone={suppressedBuckets.length > 0 ? "warning" : "success"}
+          hint={suppressedBuckets.join(", ") || "none"}
+          size="md"
+        />
+        <StatCard label="Cohort id" value={manifest.cohortId} size="md" />
+      </div>
+
+      <Card tone="raised" className="mb-6">
+        <CardHeader>
+          <CardTitle>Cohort manifest</CardTitle>
+          <CardDescription>
+            Stored alongside the export. Researchers see this — it's their proof of de-identification rigor.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="text-xs bg-surface-muted rounded-md p-3 overflow-x-auto">
+            {JSON.stringify(manifest, null, 2)}
+          </pre>
+        </CardContent>
+      </Card>
+
+      <Card tone="raised" className="mb-6">
+        <CardHeader>
+          <CardTitle>Patient cohort (de-identified)</CardTitle>
+          <CardDescription>
+            Direct identifiers dropped. Age capped at 89; ZIP generalized to first 3 digits with
+            Safe Harbor restricted prefixes mapped to "000".
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {kept.length === 0 ? (
+            <EmptyState
+              title="All buckets suppressed"
+              description="Lower the minimum cell size to view the cohort."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border text-left">
+                    <th className="py-2 pr-3 text-text-subtle">Pseudonym</th>
+                    <th className="py-2 pr-3 text-text-subtle">Age</th>
+                    <th className="py-2 pr-3 text-text-subtle">Sex</th>
+                    <th className="py-2 pr-3 text-text-subtle">Race</th>
+                    <th className="py-2 pr-3 text-text-subtle">Ethnicity</th>
+                    <th className="py-2 pr-3 text-text-subtle">Smoking</th>
+                    <th className="py-2 pr-3 text-text-subtle">ZIP3</th>
+                    <th className="py-2 text-text-subtle">SES</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {kept.map((p) => (
+                    <tr key={p.pseudonym}>
+                      <td className="py-2 pr-3 font-mono text-[11px]">{p.pseudonym}</td>
+                      <td className="py-2 pr-3 tabular-nums">{p.ageYears}</td>
+                      <td className="py-2 pr-3">{p.sex}</td>
+                      <td className="py-2 pr-3">{p.race}</td>
+                      <td className="py-2 pr-3">{p.ethnicity}</td>
+                      <td className="py-2 pr-3">{p.smokingStatus}</td>
+                      <td className="py-2 pr-3 tabular-nums">
+                        {p.zipPrefix === "000" ? <Badge tone="warning">000</Badge> : p.zipPrefix}
+                      </td>
+                      <td className="py-2">{p.socioeconomicTier}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card tone="raised">
+        <CardHeader>
+          <CardTitle>Claim cohort</CardTitle>
+          <CardDescription>
+            Service date generalized to month. Payer name → category. Sample of {filteredClaims.length} claims.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2 mb-4">
+            {Object.entries(payerMix).map(([cat, count]) => (
+              <Badge
+                key={cat}
+                tone={categorizePayer(cat).startsWith("medic") ? "info" : "accent"}
+              >
+                {cat}: {count}
+              </Badge>
+            ))}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border text-left">
+                  <th className="py-2 pr-3 text-text-subtle">Claim</th>
+                  <th className="py-2 pr-3 text-text-subtle">Patient</th>
+                  <th className="py-2 pr-3 text-text-subtle">Month</th>
+                  <th className="py-2 pr-3 text-text-subtle">Payer</th>
+                  <th className="py-2 pr-3 text-text-subtle">CPTs</th>
+                  <th className="py-2 pr-3 text-text-subtle">ICD-10</th>
+                  <th className="py-2 pr-3 text-text-subtle text-right">Billed</th>
+                  <th className="py-2 pr-3 text-text-subtle text-right">Paid</th>
+                  <th className="py-2 text-text-subtle">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {filteredClaims.map((c) => (
+                  <tr key={c.claimPseudonym}>
+                    <td className="py-2 pr-3 font-mono text-[11px]">{c.claimPseudonym.slice(0, 12)}…</td>
+                    <td className="py-2 pr-3 font-mono text-[11px]">{c.patientPseudonym.slice(0, 12)}…</td>
+                    <td className="py-2 pr-3 tabular-nums">{c.serviceMonth}</td>
+                    <td className="py-2 pr-3">{c.payerCategory}</td>
+                    <td className="py-2 pr-3">{c.cptCodes.join(", ")}</td>
+                    <td className="py-2 pr-3">{c.icd10Codes.join(", ")}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">${(c.billedCents / 100).toFixed(2)}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">${(c.paidCents / 100).toFixed(2)}</td>
+                    <td className="py-2">
+                      <Badge
+                        tone={c.status === "paid" ? "success" : c.status === "denied" ? "danger" : "neutral"}
+                      >
+                        {c.status}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/rpm/page.tsx
+++ b/src/app/(operator)/ops/rpm/page.tsx
@@ -1,0 +1,225 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  evaluateRpmMonth,
+  summarizeTrends,
+  TRANSMISSION_DAYS_REQUIRED,
+  type RpmReading,
+  type ProviderReviewEvent,
+  type RpmBillingPeriod,
+} from "@/lib/billing/rpm";
+
+export const metadata = { title: "Medicare RPM" };
+
+const MONTH_START = new Date("2026-04-01T00:00:00Z");
+const MONTH_END = new Date("2026-04-30T23:59:59Z");
+
+// Sample fixture cohort — once device webhooks (Omron / Dexcom) are live
+// these come from the integrations layer. The eligibility math is the
+// same; only the data source changes.
+const COHORT: Array<{
+  patient: string;
+  mrn: string;
+  setupAlreadyBilled: boolean;
+  readings: RpmReading[];
+  reviews: ProviderReviewEvent[];
+}> = [
+  {
+    patient: "Eleanor Park",
+    mrn: "MRN-C0301",
+    setupAlreadyBilled: true,
+    readings: buildBpReadings("MRN-C0301", 22),
+    reviews: [
+      {
+        patientId: "MRN-C0301",
+        providerId: "prv_01",
+        startedAt: new Date("2026-04-15T15:00:00Z"),
+        endedAt: new Date("2026-04-15T15:25:00Z"),
+        interactiveCommunication: true,
+        signedAt: new Date("2026-04-15T15:30:00Z"),
+        notes: "BP trending down on uptitrated lisinopril; reinforce DASH.",
+      },
+      {
+        patientId: "MRN-C0301",
+        providerId: "prv_01",
+        startedAt: new Date("2026-04-22T09:00:00Z"),
+        endedAt: new Date("2026-04-22T09:30:00Z"),
+        interactiveCommunication: true,
+        signedAt: new Date("2026-04-22T09:35:00Z"),
+        notes: "Review of weekly readings; medication adherence confirmed.",
+      },
+    ],
+  },
+  {
+    patient: "Marcus Doyle",
+    mrn: "MRN-C0314",
+    setupAlreadyBilled: false,
+    readings: buildBpReadings("MRN-C0314", 12),
+    reviews: [
+      {
+        patientId: "MRN-C0314",
+        providerId: "prv_02",
+        startedAt: new Date("2026-04-10T11:00:00Z"),
+        endedAt: new Date("2026-04-10T11:18:00Z"),
+        interactiveCommunication: true,
+        signedAt: new Date("2026-04-10T11:20:00Z"),
+        notes: "New device setup + education.",
+      },
+    ],
+  },
+];
+
+export default function RpmPage() {
+  const evaluations = COHORT.map((p) => {
+    const period: RpmBillingPeriod = {
+      monthStart: MONTH_START,
+      monthEnd: MONTH_END,
+      patientId: p.mrn,
+      setupAlreadyBilled: p.setupAlreadyBilled,
+    };
+    const lines = evaluateRpmMonth({ period, readings: p.readings, reviews: p.reviews });
+    const trends = summarizeTrends(p.readings);
+    const distinctDays = new Set(
+      p.readings.map((r) => r.measuredAt.toISOString().slice(0, 10)),
+    ).size;
+    const minutes = p.reviews
+      .filter((r) => r.interactiveCommunication)
+      .reduce(
+        (sum, r) => sum + Math.round((r.endedAt.getTime() - r.startedAt.getTime()) / 60_000),
+        0,
+      );
+    return { ...p, lines, trends, distinctDays, minutes };
+  });
+
+  const totalLines = evaluations.reduce((sum, e) => sum + e.lines.length, 0);
+  const total99454 = evaluations.filter((e) => e.lines.some((l) => l.cpt === "99454")).length;
+  const total99457 = evaluations.filter((e) => e.lines.some((l) => l.cpt === "99457")).length;
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Remote monitoring"
+        title="Medicare RPM"
+        description="Monthly RPM billing preview — CPT 99453 / 99454 / 99457 / 99458 evaluated against device transmissions and provider time. Pure logic; safe to run before claim drop."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Patients in month" value={String(COHORT.length)} size="md" />
+        <StatCard label="Total claim lines" value={String(totalLines)} tone="accent" size="md" />
+        <StatCard label="Eligible 99454" value={String(total99454)} tone="success" size="md" />
+        <StatCard label="Eligible 99457" value={String(total99457)} tone="success" size="md" />
+      </div>
+
+      <div className="space-y-4">
+        {evaluations.map((e) => (
+          <Card key={e.mrn} tone="raised">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle>
+                    {e.patient}{" "}
+                    <span className="text-text-subtle text-sm font-normal">· {e.mrn}</span>
+                  </CardTitle>
+                  <CardDescription>
+                    {e.distinctDays} transmission days · {e.minutes} interactive minutes ·
+                    {e.setupAlreadyBilled ? " setup already billed" : " setup pending"}
+                  </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                  {e.distinctDays >= TRANSMISSION_DAYS_REQUIRED ? (
+                    <Badge tone="success">Transmissions met</Badge>
+                  ) : (
+                    <Badge tone="warning">
+                      {TRANSMISSION_DAYS_REQUIRED - e.distinctDays} more days needed
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="mb-4">
+                <div className="text-[10px] uppercase tracking-wider text-text-subtle mb-2">
+                  Vital trends
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                  {e.trends.map((t) => (
+                    <div key={t.metric} className="border border-border rounded-md px-3 py-2">
+                      <div className="text-xs text-text-subtle capitalize">{t.metric}</div>
+                      <div className="text-text font-medium tabular-nums">
+                        {t.latest} {t.unit}{" "}
+                        {t.delta !== null && (
+                          <span
+                            className={
+                              t.direction === "up"
+                                ? "text-[color:var(--warning)] text-xs"
+                                : t.direction === "down"
+                                  ? "text-success text-xs"
+                                  : "text-text-subtle text-xs"
+                            }
+                          >
+                            {t.delta > 0 ? "↑" : t.delta < 0 ? "↓" : "→"} {Math.abs(t.delta)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {e.lines.length === 0 ? (
+                <p className="text-sm text-text-subtle">No CPT lines eligible this month.</p>
+              ) : (
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-text-subtle mb-2">
+                    Eligible CPT lines
+                  </div>
+                  <ul className="space-y-2">
+                    {e.lines.map((line, i) => (
+                      <li
+                        key={i}
+                        className="border border-border rounded-md px-4 py-3 flex items-start justify-between gap-3"
+                      >
+                        <div>
+                          <div className="text-sm font-medium text-text">
+                            CPT {line.cpt}{" "}
+                            <span className="text-text-subtle">× {line.units}</span>
+                          </div>
+                          <div className="text-xs text-text-muted mt-1">{line.rationale}</div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}
+
+// Helper: synthesize daily BP readings for the preview cohort.
+function buildBpReadings(mrn: string, days: number): RpmReading[] {
+  const out: RpmReading[] = [];
+  for (let i = 0; i < days; i++) {
+    const date = new Date(MONTH_START.getTime() + i * 86_400_000);
+    out.push({
+      patientId: mrn,
+      deviceId: `omron-${mrn}`,
+      category: "blood_pressure",
+      measuredAt: date,
+      receivedAt: date,
+      values: {
+        systolic: 128 + ((i * 3) % 14) - 7,
+        diastolic: 82 + ((i * 5) % 10) - 5,
+        pulse: 70 + ((i * 7) % 12) - 6,
+      },
+      units: { systolic: "mmHg", diastolic: "mmHg", pulse: "bpm" },
+      source: "omron",
+    });
+  }
+  return out;
+}

--- a/src/app/(operator)/ops/translation/page.tsx
+++ b/src/app/(operator)/ops/translation/page.tsx
@@ -1,0 +1,147 @@
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import {
+  SUPPORTED_LANGUAGES,
+  StubTranslationProvider,
+  translateStatement,
+  phrase,
+  type SupportedLanguage,
+} from "@/lib/billing/translation";
+
+export const metadata = { title: "Statement Translation" };
+
+const SAMPLE_STATEMENT = {
+  totals: {
+    totalCharges: "$425.00",
+    insurancePaid: "$278.40",
+    adjustments: "$77.00",
+    priorBalance: "$0.00",
+    amountDue: "$69.60",
+  },
+  dueDate: "2026-05-21",
+  providerNotes:
+    "Your visit on April 12 included an extended discussion of cannabis dosing and a refill of your CBD tincture. Please call if any questions arise.",
+  eobSummary:
+    "Aetna paid your provider $278.40 of the $425.00 billed. After contractual adjustments, your responsibility is $69.60 — most of that is your annual deductible.",
+};
+
+export default async function TranslationPage({
+  searchParams,
+}: {
+  searchParams: { lang?: SupportedLanguage };
+}) {
+  const target: SupportedLanguage = (searchParams.lang as SupportedLanguage) ?? "es";
+  const provider = new StubTranslationProvider();
+  const translated = await translateStatement(SAMPLE_STATEMENT, target, provider);
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Patient access"
+        title="In-app translation"
+        description="Statement / EOB translation across the platform's supported languages. Static phrases are table-driven (zero LLM cost); free-text routes through the configured provider."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Languages" value={String(SUPPORTED_LANGUAGES.length)} size="md" />
+        <StatCard label="RTL supported" value="Arabic" size="md" />
+        <StatCard label="Provider" value={provider.name} hint="Configurable" size="md" />
+        <StatCard label="Glossary domains" value="3" hint="statement / EOB / general" size="md" />
+      </div>
+
+      <Card tone="raised" className="mb-6">
+        <CardHeader>
+          <CardTitle>Supported languages</CardTitle>
+          <CardDescription>
+            English is the source. Static statement phrases are pre-translated to all 8 launch
+            languages; free-text is provider-routed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {SUPPORTED_LANGUAGES.map((lang) => (
+              <a
+                key={lang.code}
+                href={`/ops/translation?lang=${lang.code}`}
+                className={
+                  lang.code === target
+                    ? "px-3 py-1.5 rounded-md bg-text text-surface text-sm"
+                    : "px-3 py-1.5 rounded-md border border-border text-sm hover:bg-surface-muted"
+                }
+              >
+                <span className="font-medium">{lang.nativeName}</span>{" "}
+                <span className="text-xs opacity-75">{lang.englishName}</span>
+                {lang.rtl && (
+                  <Badge tone="info" className="ml-2">
+                    RTL
+                  </Badge>
+                )}
+              </a>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card tone="raised">
+        <CardHeader>
+          <CardTitle>
+            Statement preview ·{" "}
+            {SUPPORTED_LANGUAGES.find((l) => l.code === target)?.nativeName}
+          </CardTitle>
+          <CardDescription>
+            Same payload, translated. Money values stay locale-formatted; labels use the static
+            phrase table.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            className={`border border-border rounded-lg p-6 bg-surface ${translated.rtl ? "text-right" : ""}`}
+            dir={translated.rtl ? "rtl" : "ltr"}
+          >
+            <h2 className="text-2xl font-display mb-2">{translated.labels["statement.title"]}</h2>
+            <p className="text-sm text-text-muted mb-6">
+              {translated.labels["statement.dueDate"]}: {translated.dueDate}
+            </p>
+
+            <dl className="grid grid-cols-2 gap-y-2 text-sm mb-6">
+              <dt className="text-text-muted">{translated.labels["statement.totalCharges"]}</dt>
+              <dd className="tabular-nums">{translated.totals.totalCharges}</dd>
+              <dt className="text-text-muted">{translated.labels["statement.insurancePaid"]}</dt>
+              <dd className="tabular-nums">{translated.totals.insurancePaid}</dd>
+              <dt className="text-text-muted">{translated.labels["statement.adjustments"]}</dt>
+              <dd className="tabular-nums">{translated.totals.adjustments}</dd>
+              <dt className="text-text-muted">{translated.labels["statement.priorBalance"]}</dt>
+              <dd className="tabular-nums">{translated.totals.priorBalance}</dd>
+              <dt className="font-medium">{translated.labels["statement.amountDue"]}</dt>
+              <dd className="tabular-nums font-medium">{translated.totals.amountDue}</dd>
+            </dl>
+
+            <div className="bg-surface-muted rounded-md p-4 mb-4">
+              <div className="text-xs uppercase tracking-wider text-text-subtle mb-1">
+                {phrase("eob.summary", target)}
+              </div>
+              <p className="text-sm">{translated.eobSummary}</p>
+            </div>
+
+            <div className="text-sm text-text-muted mb-6">{translated.providerNotes}</div>
+
+            <div className="flex gap-3">
+              <button className="px-4 py-2 rounded-md bg-text text-surface text-sm">
+                {translated.labels["statement.payNow"]}
+              </button>
+              <button className="px-4 py-2 rounded-md border border-border text-sm">
+                {translated.labels["statement.paymentPlan"]}
+              </button>
+            </div>
+
+            <p className="text-xs text-text-subtle mt-6">
+              {translated.labels["statement.thankYou"]}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/wallet-cards/page.tsx
+++ b/src/app/(operator)/ops/wallet-cards/page.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatCard } from "@/components/ui/stat-card";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  buildWalletCard,
+  formatMedicationLine,
+  walletCardCacheKey,
+  WALLET_CARD_DIMENSIONS_MM,
+  type WalletCardData,
+} from "@/lib/billing/wallet-card";
+
+export const metadata = { title: "Medication Wallet Cards" };
+
+// Sample preview deck — wired to real `prisma.patient` in the next iteration
+// when we have a confirmed cannabis-rx + supplements join. Surface today
+// validates the layout + cache hashing across the patient population.
+const PREVIEW_CARDS: WalletCardData[] = [
+  buildWalletCard({
+    patient: {
+      fullName: "Maya Castillo",
+      dateOfBirth: "1986-03-12",
+      mrn: "MRN-A0042",
+      allergiesSummary: "PCN, sulfa",
+    },
+    practiceName: "Leafjourney Care · Boulder",
+    practiceContact: "(720) 555-0144",
+    medications: [
+      { name: "CBD oil 25mg/mL", frequency: "1 mL sublingual at bedtime", category: "cannabis", indication: "insomnia" },
+      { name: "Atorvastatin 20mg", frequency: "Once daily", category: "rx" },
+      { name: "Sertraline 50mg", frequency: "Once daily", category: "rx" },
+      { name: "Magnesium glycinate 400mg", frequency: "Once daily", category: "supplement" },
+      { name: "Vitamin D3 2000 IU", frequency: "Once daily", category: "supplement" },
+    ],
+    emergencyContact: { name: "Diego Castillo", relationship: "Spouse", phone: "(720) 555-0190" },
+  }),
+  buildWalletCard({
+    patient: {
+      fullName: "Jonas Reiter",
+      dateOfBirth: "1971-11-04",
+      mrn: "MRN-B0119",
+      allergiesSummary: "NKDA",
+    },
+    practiceName: "Leafjourney Care · Berlin",
+    practiceContact: "+49 30 1234 5678",
+    medications: [
+      { name: "THC:CBD 1:1 5mg", frequency: "Twice daily oral", category: "cannabis", indication: "neuropathic pain" },
+      { name: "Pregabalin 75mg", frequency: "Twice daily", category: "rx" },
+      { name: "Metformin 500mg", frequency: "With meals, 2× daily", category: "rx" },
+      { name: "Lisinopril 10mg", frequency: "Once daily", category: "rx" },
+      { name: "Aspirin 81mg", frequency: "Once daily", category: "rx" },
+      { name: "B12 1000mcg", frequency: "Weekly", category: "supplement" },
+      { name: "Omega-3 1000mg", frequency: "Once daily", category: "supplement" },
+      { name: "Curcumin 500mg", frequency: "Once daily", category: "supplement" },
+      { name: "Probiotic 50B CFU", frequency: "Once daily", category: "supplement" },
+    ],
+    emergencyContact: { name: "Eva Reiter", relationship: "Daughter", phone: "+49 30 1234 5680" },
+  }),
+];
+
+export default function WalletCardsPage() {
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Patient experience"
+        title="Medication wallet cards"
+        description="Credit-card-sized printable summary patients can carry. Auto-updates when meds change. Renderer is layout-agnostic — same data drives the print sheet, the portal preview, and Apple Wallet."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <StatCard label="Generated this month" value="—" hint="Wire to FinancialEvent" size="md" />
+        <StatCard label="Patients enrolled" value={String(PREVIEW_CARDS.length)} size="md" />
+        <StatCard
+          label="Card size"
+          value={`${WALLET_CARD_DIMENSIONS_MM.widthMm}×${WALLET_CARD_DIMENSIONS_MM.heightMm}mm`}
+          hint="ISO 7810 ID-1"
+          size="md"
+        />
+        <StatCard label="Default language" value="English" hint="Translate via EMR-122" size="md" />
+      </div>
+
+      {PREVIEW_CARDS.length === 0 ? (
+        <EmptyState
+          title="No wallet cards yet"
+          description="Cards generate automatically when a patient has at least one active medication."
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {PREVIEW_CARDS.map((card) => (
+            <WalletCardPreview key={card.patient.mrn} card={card} />
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+function WalletCardPreview({ card }: { card: WalletCardData }) {
+  const cacheKey = walletCardCacheKey(card);
+  return (
+    <Card tone="raised">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle>{card.patient.fullName}</CardTitle>
+            <CardDescription>
+              MRN {card.patient.mrn} · DOB {card.patient.dateOfBirth}
+            </CardDescription>
+          </div>
+          <Badge tone="info">cache {cacheKey}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="bg-surface-muted border border-border rounded-lg p-4 mb-3">
+          <div className="text-[10px] uppercase tracking-wider text-text-subtle mb-2">
+            {card.practiceName}
+          </div>
+          <div className="text-xs text-text-muted mb-2">
+            Allergies: {card.patient.allergiesSummary || "NKDA"}
+          </div>
+          <ul className="text-xs text-text space-y-0.5 tabular-nums">
+            {card.medications.map((m, i) => (
+              <li key={i}>{formatMedicationLine(m)}</li>
+            ))}
+          </ul>
+          {card.truncated && (
+            <div className="text-[10px] text-text-subtle mt-2">
+              +{card.truncatedCount} more on portal
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between text-xs text-text-subtle">
+          <span>
+            {card.medications.length} meds · {card.emergencyContact?.name ?? "no emergency contact"}
+          </span>
+          <Link
+            href={`/portal/wallet-card/${card.patient.mrn}`}
+            className="text-accent hover:underline"
+          >
+            Print →
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/billing/access-log.ts
+++ b/src/lib/billing/access-log.ts
@@ -1,0 +1,223 @@
+/**
+ * Master Access Log + Click Analytics (EMR-121)
+ * ---------------------------------------------
+ * Builds on the existing `AuditLog` Prisma model. AuditLog already
+ * captures actor + action + subject; this module adds:
+ *
+ *   1. A higher-level `recordChartAccess()` API that the chart shell
+ *      calls on every section view, edit, and time-on-task tick. The
+ *      method writes to AuditLog with a stable metadata schema so
+ *      downstream analytics and HIPAA exports can rely on the shape.
+ *
+ *   2. Aggregation helpers that turn raw rows into the click-analytics
+ *      story per role (patient / provider / office_manager).
+ *
+ *   3. A HIPAA-export builder that produces a deterministic audit
+ *      report — one row per chart access — formatted for the
+ *      compliance team's PDF generator.
+ *
+ * Immutability: this module never updates or deletes existing rows.
+ * AuditLog has no update path in the schema.
+ */
+
+export type AccessRole = "patient" | "provider" | "office_manager" | "researcher" | "system";
+
+export type AccessAction =
+  | "chart.viewed"
+  | "section.viewed"
+  | "field.edited"
+  | "document.downloaded"
+  | "message.sent"
+  | "rx.signed"
+  | "claim.submitted"
+  | "session.heartbeat";
+
+export interface ChartAccessEvent {
+  organizationId: string;
+  actorUserId: string | null;
+  actorRole: AccessRole;
+  patientId: string;
+  action: AccessAction;
+  section: string;
+  field?: string;
+  metadata?: Record<string, unknown>;
+  sessionId: string;
+  occurredAt?: Date;
+}
+
+export interface AccessLogStore {
+  append(row: {
+    organizationId: string;
+    actorUserId: string | null;
+    action: string;
+    subjectType: string;
+    subjectId: string;
+    metadata: Record<string, unknown>;
+    createdAt: Date;
+  }): Promise<void>;
+  listForPatient(
+    patientId: string,
+    sinceDays: number,
+  ): Promise<
+    Array<{
+      action: string;
+      actorUserId: string | null;
+      metadata: Record<string, unknown>;
+      createdAt: Date;
+    }>
+  >;
+}
+
+/** Append a chart-access event to AuditLog with a stable metadata schema. */
+export async function recordChartAccess(
+  event: ChartAccessEvent,
+  store: AccessLogStore,
+): Promise<void> {
+  await store.append({
+    organizationId: event.organizationId,
+    actorUserId: event.actorUserId,
+    action: event.action,
+    subjectType: "patient",
+    subjectId: event.patientId,
+    metadata: {
+      role: event.actorRole,
+      section: event.section,
+      field: event.field ?? null,
+      sessionId: event.sessionId,
+      ...event.metadata,
+    },
+    createdAt: event.occurredAt ?? new Date(),
+  });
+}
+
+export interface SessionStats {
+  sessionId: string;
+  actorUserId: string | null;
+  role: AccessRole;
+  start: Date;
+  end: Date;
+  durationSeconds: number;
+  /** Click-equivalent events (excludes heartbeats). */
+  clicks: number;
+  destinations: string[];
+}
+
+export interface RoleClickAnalytics {
+  role: AccessRole;
+  sessionCount: number;
+  avgClicksPerSession: number;
+  avgSessionSeconds: number;
+  topDestinations: Array<{ section: string; count: number }>;
+}
+
+/** Reconstruct sessions from raw rows. A session is "all rows sharing
+ * a sessionId, in time order." Single-event sessions get a 30s floor. */
+export function reconstructSessions(
+  rows: Array<{
+    action: string;
+    actorUserId: string | null;
+    metadata: Record<string, unknown>;
+    createdAt: Date;
+  }>,
+): SessionStats[] {
+  const bySession = new Map<string, typeof rows>();
+  for (const r of rows) {
+    const sessionId = (r.metadata?.sessionId as string) ?? "unknown";
+    const arr = bySession.get(sessionId) ?? [];
+    arr.push(r);
+    bySession.set(sessionId, arr);
+  }
+
+  const out: SessionStats[] = [];
+  for (const [sessionId, list] of bySession) {
+    list.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    const start = list[0].createdAt;
+    const end = list[list.length - 1].createdAt;
+    const duration = Math.max(30, Math.floor((end.getTime() - start.getTime()) / 1000));
+    const clicks = list.filter((r) => r.action !== "session.heartbeat").length;
+    const destinations = list
+      .map((r) => (r.metadata?.section as string) ?? null)
+      .filter((s): s is string => !!s);
+    out.push({
+      sessionId,
+      actorUserId: list[0].actorUserId,
+      role: ((list[0].metadata?.role as AccessRole) ?? "system"),
+      start,
+      end,
+      durationSeconds: duration,
+      clicks,
+      destinations,
+    });
+  }
+  return out;
+}
+
+export function aggregateByRole(sessions: SessionStats[]): RoleClickAnalytics[] {
+  const byRole = new Map<AccessRole, SessionStats[]>();
+  for (const s of sessions) {
+    const arr = byRole.get(s.role) ?? [];
+    arr.push(s);
+    byRole.set(s.role, arr);
+  }
+
+  const out: RoleClickAnalytics[] = [];
+  for (const [role, list] of byRole) {
+    const totalClicks = list.reduce((acc, s) => acc + s.clicks, 0);
+    const totalSeconds = list.reduce((acc, s) => acc + s.durationSeconds, 0);
+    const destCounts = new Map<string, number>();
+    for (const s of list) {
+      for (const d of s.destinations) {
+        destCounts.set(d, (destCounts.get(d) ?? 0) + 1);
+      }
+    }
+    const topDestinations = Array.from(destCounts.entries())
+      .map(([section, count]) => ({ section, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    out.push({
+      role,
+      sessionCount: list.length,
+      avgClicksPerSession: list.length === 0 ? 0 : totalClicks / list.length,
+      avgSessionSeconds: list.length === 0 ? 0 : totalSeconds / list.length,
+      topDestinations,
+    });
+  }
+  return out;
+}
+
+export interface HipaaExportRow {
+  timestampIso: string;
+  actorUserId: string | null;
+  actorRole: AccessRole;
+  patientId: string;
+  action: string;
+  section: string;
+  field: string | null;
+  sessionId: string;
+}
+
+/** Deterministic, immutable export rows for the HIPAA audit PDF. */
+export function buildHipaaExport(
+  patientId: string,
+  rows: Array<{
+    action: string;
+    actorUserId: string | null;
+    metadata: Record<string, unknown>;
+    createdAt: Date;
+  }>,
+): HipaaExportRow[] {
+  return rows
+    .slice()
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    .map((r) => ({
+      timestampIso: r.createdAt.toISOString(),
+      actorUserId: r.actorUserId,
+      actorRole: ((r.metadata?.role as AccessRole) ?? "system"),
+      patientId,
+      action: r.action,
+      section: (r.metadata?.section as string) ?? "",
+      field: ((r.metadata?.field as string) ?? null),
+      sessionId: ((r.metadata?.sessionId as string) ?? ""),
+    }));
+}

--- a/src/lib/billing/allergy-alerts.ts
+++ b/src/lib/billing/allergy-alerts.ts
@@ -1,0 +1,150 @@
+/**
+ * Allergies + Contraindications Surfacing (EMR-113)
+ * -------------------------------------------------
+ * The contraindication check already runs at prescribe-time. Per Dr.
+ * Patel: the data must also be visible from the moment a chart loads,
+ * not buried behind the prescribe modal.
+ *
+ * This module produces the chart-banner payload + sort/dedupe rules
+ * the chart shell renders. Pure logic — the React banner reads what
+ * comes out of `summarizeAlerts()` and renders it without computing
+ * priority itself.
+ *
+ * Lives in `lib/billing` because the same alert payload is consumed by
+ * the claim-scrub engine (a contraindication is a denial-pattern
+ * predictor) and the prior-auth packet builder (auth submissions
+ * require an allergy roster). Keeping one source of truth avoids the
+ * "the chart shows X but the claim says Y" drift Dr. Patel called
+ * out in TICKETS.md.
+ */
+
+export type AllergySeverity = "fatal" | "severe" | "moderate" | "mild" | "unknown";
+export type ContraindicationSeverity = "absolute" | "major" | "moderate" | "monitor";
+
+export interface AllergyRecord {
+  id: string;
+  substance: string;
+  reaction: string;
+  severity: AllergySeverity;
+  recordedAt: Date;
+  selfReported: boolean;
+}
+
+export interface ContraindicationRecord {
+  id: string;
+  trigger: string;
+  description: string;
+  severity: ContraindicationSeverity;
+  source: "drug-drug" | "drug-condition" | "drug-cannabis";
+  recordedAt: Date;
+}
+
+export interface ChartAlert {
+  id: string;
+  kind: "allergy" | "contraindication";
+  headline: string;
+  detail: string;
+  tone: "danger" | "warning" | "caution" | "info";
+  priority: number;
+  dismissible: boolean;
+}
+
+const ALLERGY_PRIORITY: Record<AllergySeverity, number> = {
+  fatal: 100,
+  severe: 80,
+  moderate: 50,
+  mild: 30,
+  unknown: 20,
+};
+
+const CONTRA_PRIORITY: Record<ContraindicationSeverity, number> = {
+  absolute: 95,
+  major: 75,
+  moderate: 45,
+  monitor: 25,
+};
+
+const ALLERGY_TONE: Record<AllergySeverity, ChartAlert["tone"]> = {
+  fatal: "danger",
+  severe: "danger",
+  moderate: "warning",
+  mild: "caution",
+  unknown: "info",
+};
+
+const CONTRA_TONE: Record<ContraindicationSeverity, ChartAlert["tone"]> = {
+  absolute: "danger",
+  major: "warning",
+  moderate: "caution",
+  monitor: "info",
+};
+
+/**
+ * Convert raw allergy + contraindication records into the banner-ready
+ * alert list. Sorted by priority desc; deduplicated by substance so a
+ * patient with three "PCN" entries doesn't get three banners.
+ */
+export function summarizeAlerts(
+  allergies: AllergyRecord[],
+  contraindications: ContraindicationRecord[],
+): ChartAlert[] {
+  const seenSubstances = new Set<string>();
+  const out: ChartAlert[] = [];
+
+  for (const a of allergies) {
+    const key = a.substance.trim().toLowerCase();
+    if (seenSubstances.has(key)) continue;
+    seenSubstances.add(key);
+    const sevLabel =
+      a.severity === "unknown"
+        ? "Allergy"
+        : `${a.severity[0].toUpperCase()}${a.severity.slice(1)} allergy`;
+    out.push({
+      id: `allergy:${a.id}`,
+      kind: "allergy",
+      headline: `${sevLabel}: ${a.substance}`,
+      detail: a.selfReported
+        ? `Patient-reported reaction: ${a.reaction}`
+        : `Confirmed reaction: ${a.reaction}`,
+      tone: ALLERGY_TONE[a.severity],
+      priority: ALLERGY_PRIORITY[a.severity],
+      dismissible: a.severity !== "fatal" && a.severity !== "severe",
+    });
+  }
+
+  for (const c of contraindications) {
+    const sevLabel =
+      c.severity === "absolute"
+        ? "Absolute contraindication"
+        : `${c.severity[0].toUpperCase()}${c.severity.slice(1)} interaction`;
+    out.push({
+      id: `contra:${c.id}`,
+      kind: "contraindication",
+      headline: `${sevLabel}: ${c.trigger}`,
+      detail: c.description,
+      tone: CONTRA_TONE[c.severity],
+      priority: CONTRA_PRIORITY[c.severity],
+      dismissible: c.severity !== "absolute",
+    });
+  }
+
+  out.sort((a, b) => b.priority - a.priority);
+  return out;
+}
+
+/** Returns true if the chart's top banner should be the "STOP — review
+ * before prescribing" interstitial rather than a standard alert strip. */
+export function requiresStopInterstitial(alerts: ChartAlert[]): boolean {
+  return alerts.some((a) => !a.dismissible);
+}
+
+/** Cross-check a planned prescription against the active alert list. */
+export function alertsForPrescription(
+  drugName: string,
+  alerts: ChartAlert[],
+): ChartAlert[] {
+  const needle = drugName.toLowerCase();
+  return alerts.filter(
+    (a) => a.headline.toLowerCase().includes(needle) || a.detail.toLowerCase().includes(needle),
+  );
+}

--- a/src/lib/billing/education-db.ts
+++ b/src/lib/billing/education-db.ts
@@ -1,0 +1,298 @@
+/**
+ * Cannabis Education Database (EMR-111)
+ * -------------------------------------
+ * Curated, code-resident reference data for terpenes, cannabinoids,
+ * receptors, dosing fundamentals, flavonoids, and the endocannabinoid
+ * system. Searchable through `searchEducation()`.
+ *
+ * Why it lives in `lib/billing`: claim narratives, denial appeals, and
+ * patient statements all need plain-language descriptions of cannabis
+ * compounds when the payer asks "what is CBG and why are you billing
+ * for it." `enrichClaimLine()` pulls a one-sentence summary keyed on
+ * the active ingredient so the appeal letter generator (EMR appeals
+ * agent) can drop a citation without a network call.
+ *
+ * Builds on the existing Research Corpus — reference these compound
+ * ids when linking out to the 50+ MCL-classified studies.
+ *
+ * Data shape is intentionally pure JSON-ish so it can later be moved
+ * into Prisma (CannabisEducationEntry) without a code rewrite.
+ */
+
+export type CompoundCategory =
+  | "cannabinoid"
+  | "terpene"
+  | "flavonoid"
+  | "receptor"
+  | "dosing"
+  | "system";
+
+export interface EducationEntry {
+  id: string;
+  category: CompoundCategory;
+  name: string;
+  aliases: string[];
+  oneLineSummary: string;
+  body: string[];
+  aromaticNotes?: string[];
+  reportedEffects?: string[];
+  citations: string[];
+}
+
+export const EDUCATION_ENTRIES: EducationEntry[] = [
+  {
+    id: "thc",
+    category: "cannabinoid",
+    name: "Tetrahydrocannabinol",
+    aliases: ["THC", "delta-9-THC", "Δ9-THC"],
+    oneLineSummary:
+      "The primary psychoactive cannabinoid in cannabis; binds CB1 receptors and produces the characteristic 'high.'",
+    body: [
+      "Partial agonist at CB1; weaker activity at CB2.",
+      "Dose-dependent biphasic effects: low doses anxiolytic, high doses anxiogenic.",
+      "Metabolized hepatically to 11-OH-THC, which is more potent than the parent.",
+    ],
+    reportedEffects: ["analgesia", "appetite stimulation", "anti-emetic", "muscle relaxation"],
+    citations: ["10.1186/s42238-025-00295-7"],
+  },
+  {
+    id: "cbd",
+    category: "cannabinoid",
+    name: "Cannabidiol",
+    aliases: ["CBD"],
+    oneLineSummary:
+      "Non-intoxicating cannabinoid with broad receptor activity; the most studied compound in the MCL corpus.",
+    body: [
+      "Negative allosteric modulator at CB1; blunts THC psychoactivity in mixed extracts.",
+      "5-HT1A and TRPV1 activity contribute to anxiolytic and anti-inflammatory effects.",
+      "Inhibits CYP3A4 and CYP2C19 — clinically meaningful drug interactions.",
+    ],
+    reportedEffects: ["anxiolytic", "anti-inflammatory", "anticonvulsant"],
+    citations: ["10.1186/s42238-025-00295-7"],
+  },
+  {
+    id: "cbn",
+    category: "cannabinoid",
+    name: "Cannabinol",
+    aliases: ["CBN"],
+    oneLineSummary:
+      "Mildly psychoactive degradation product of THC; commonly associated with sedation in patient reports.",
+    body: [
+      "Forms via THC oxidation in aged or heat-exposed cannabis.",
+      "Weak CB1 agonist; sedative effects often co-occur with myrcene-rich chemovars.",
+    ],
+    reportedEffects: ["sedation", "analgesia"],
+    citations: [],
+  },
+  {
+    id: "cbg",
+    category: "cannabinoid",
+    name: "Cannabigerol",
+    aliases: ["CBG", "mother cannabinoid"],
+    oneLineSummary:
+      "Non-intoxicating cannabinoid; biosynthetic precursor to THC, CBD, and CBC.",
+    body: [
+      "Agonist at α2-adrenergic receptors; partial agonist at 5-HT1A.",
+      "Emerging evidence for IBD and glaucoma indications in the MCL corpus.",
+    ],
+    reportedEffects: ["anti-inflammatory", "neuroprotective"],
+    citations: [],
+  },
+  {
+    id: "cbc",
+    category: "cannabinoid",
+    name: "Cannabichromene",
+    aliases: ["CBC"],
+    oneLineSummary:
+      "Non-intoxicating cannabinoid acting primarily on TRPA1 and TRPV channels.",
+    body: ["Studied for analgesic and anti-inflammatory potential.", "Often present in young flower."],
+    citations: [],
+  },
+  {
+    id: "myrcene",
+    category: "terpene",
+    name: "Myrcene",
+    aliases: ["β-myrcene"],
+    oneLineSummary:
+      "Earthy, musky terpene most associated with sedating, 'couch-lock' chemovars.",
+    body: ["Also found in mango, hops, and lemongrass.", "May enhance cannabinoid permeability across the BBB (preliminary)."],
+    aromaticNotes: ["earthy", "musky", "ripe fruit"],
+    reportedEffects: ["sedation", "muscle relaxation"],
+    citations: [],
+  },
+  {
+    id: "limonene",
+    category: "terpene",
+    name: "Limonene",
+    aliases: ["d-limonene"],
+    oneLineSummary:
+      "Bright, citrus-forward terpene most associated with elevated mood.",
+    body: ["Used as a flavoring agent and in industrial solvents.", "Studied for anxiolytic and antidepressant effects."],
+    aromaticNotes: ["citrus", "lemon zest"],
+    reportedEffects: ["mood elevation", "anxiolytic"],
+    citations: [],
+  },
+  {
+    id: "pinene",
+    category: "terpene",
+    name: "Pinene",
+    aliases: ["α-pinene", "β-pinene"],
+    oneLineSummary:
+      "Pine-forward terpene that may counteract THC-induced short-term memory impairment.",
+    body: ["Bronchodilator activity in animal models.", "Inhibits acetylcholinesterase — proposed mechanism for cognitive effects."],
+    aromaticNotes: ["pine", "rosemary"],
+    citations: [],
+  },
+  {
+    id: "linalool",
+    category: "terpene",
+    name: "Linalool",
+    aliases: ["linalol"],
+    oneLineSummary:
+      "Floral, lavender-like terpene with anxiolytic and sedative profile.",
+    body: ["Primary aromatic compound in lavender essential oil."],
+    aromaticNotes: ["lavender", "floral"],
+    reportedEffects: ["anxiolytic", "sedation"],
+    citations: [],
+  },
+  {
+    id: "caryophyllene",
+    category: "terpene",
+    name: "β-Caryophyllene",
+    aliases: ["BCP", "caryophyllene"],
+    oneLineSummary:
+      "Peppery terpene that uniquely binds CB2 receptors — the only known dietary cannabinoid.",
+    body: ["Generally Recognized as Safe (GRAS) by the FDA as a flavoring.", "Studied for anti-inflammatory and analgesic effects via CB2."],
+    aromaticNotes: ["pepper", "spice", "clove"],
+    reportedEffects: ["anti-inflammatory", "analgesic"],
+    citations: [],
+  },
+  {
+    id: "cb1",
+    category: "receptor",
+    name: "CB1 Receptor",
+    aliases: ["CB1"],
+    oneLineSummary:
+      "G-protein-coupled receptor concentrated in the central nervous system; mediates cannabis's psychoactive effects.",
+    body: [
+      "Densely expressed in basal ganglia, hippocampus, and cerebellum.",
+      "Agonism produces analgesia, sedation, appetite stimulation, and intoxication.",
+    ],
+    citations: [],
+  },
+  {
+    id: "cb2",
+    category: "receptor",
+    name: "CB2 Receptor",
+    aliases: ["CB2"],
+    oneLineSummary:
+      "G-protein-coupled receptor concentrated in immune tissue; mediates anti-inflammatory effects without intoxication.",
+    body: [
+      "Highest expression in spleen, tonsils, and immune cells.",
+      "Therapeutic target for inflammation, autoimmunity, and neuropathic pain.",
+    ],
+    citations: [],
+  },
+  {
+    id: "ecs",
+    category: "system",
+    name: "Endocannabinoid System",
+    aliases: ["ECS"],
+    oneLineSummary:
+      "Endogenous signaling network of cannabinoid receptors and lipid messengers that regulates homeostasis.",
+    body: [
+      "Primary endogenous ligands: anandamide (AEA) and 2-arachidonoylglycerol (2-AG).",
+      "Modulated by FAAH and MAGL enzymes.",
+      "Implicated in mood, pain, appetite, sleep, and immune function.",
+    ],
+    citations: [],
+  },
+  {
+    id: "dosing-titration",
+    category: "dosing",
+    name: "Start Low, Go Slow",
+    aliases: ["titration", "starting dose"],
+    oneLineSummary:
+      "Standard cannabis-naïve titration: begin at the lowest effective dose and increase only after a stability window.",
+    body: [
+      "Typical THC start: 1–2.5 mg oral; reassess after 3–5 days.",
+      "Inhaled onset 2–10 min; oral onset 30–120 min — duration drives titration cadence.",
+      "Document patient response in the per-product outcome log on every step-up.",
+    ],
+    citations: [],
+  },
+  {
+    id: "quercetin",
+    category: "flavonoid",
+    name: "Quercetin",
+    aliases: [],
+    oneLineSummary: "Flavonoid present in cannabis with antioxidant activity.",
+    body: ["Also found in onions, capers, and apples."],
+    citations: [],
+  },
+  {
+    id: "cannflavins",
+    category: "flavonoid",
+    name: "Cannflavins A & B",
+    aliases: ["cannflavin"],
+    oneLineSummary:
+      "Cannabis-specific flavonoids studied for anti-inflammatory effects roughly 30× aspirin in vitro.",
+    body: ["Distinct from THC/CBD — non-cannabinoid bioactives."],
+    citations: [],
+  },
+];
+
+/**
+ * Substring search across name, aliases, and body. Case-insensitive.
+ */
+export function searchEducation(query: string, limit = 25): EducationEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return EDUCATION_ENTRIES.slice(0, limit);
+
+  const scored: Array<{ entry: EducationEntry; score: number }> = [];
+  for (const entry of EDUCATION_ENTRIES) {
+    let score = 0;
+    if (entry.name.toLowerCase() === q) score += 100;
+    else if (entry.name.toLowerCase().includes(q)) score += 40;
+    if (entry.aliases.some((a) => a.toLowerCase() === q)) score += 60;
+    else if (entry.aliases.some((a) => a.toLowerCase().includes(q))) score += 20;
+    if (entry.oneLineSummary.toLowerCase().includes(q)) score += 5;
+    if (entry.body.some((line) => line.toLowerCase().includes(q))) score += 2;
+    if (score > 0) scored.push({ entry, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map((s) => s.entry);
+}
+
+export function getEducationEntry(idOrAlias: string): EducationEntry | null {
+  const needle = idOrAlias.toLowerCase();
+  return (
+    EDUCATION_ENTRIES.find(
+      (e) =>
+        e.id === needle ||
+        e.name.toLowerCase() === needle ||
+        e.aliases.some((a) => a.toLowerCase() === needle),
+    ) ?? null
+  );
+}
+
+/**
+ * Given a free-form claim line description ("CBG tincture 10mg"),
+ * return the most relevant compound entry, or null. Used by the
+ * appeals agent to attach plain-language education to denial appeals.
+ */
+export function enrichClaimLine(description: string): EducationEntry | null {
+  const lower = description.toLowerCase();
+  for (const entry of EDUCATION_ENTRIES) {
+    if (lower.includes(entry.name.toLowerCase())) return entry;
+    for (const alias of entry.aliases) {
+      const re = new RegExp(`\\b${alias.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+      if (re.test(lower)) return entry;
+    }
+  }
+  return null;
+}
+
+export function entriesByCategory(category: CompoundCategory): EducationEntry[] {
+  return EDUCATION_ENTRIES.filter((e) => e.category === category);
+}

--- a/src/lib/billing/eob.ts
+++ b/src/lib/billing/eob.ts
@@ -1,0 +1,262 @@
+/**
+ * EOB Parsing + Surfacing (EMR-115)
+ * ---------------------------------
+ * When a payer EOB lands (835 ERA or PDF), we need to:
+ *   1. Parse it into a normalized shape that both the patient portal
+ *      and the doctor's chart view can consume.
+ *   2. Generate an AI-ready summary input (plain-language template +
+ *      structured facts) that the LLM can fill without inventing
+ *      numbers.
+ *   3. Surface it to the patient portal billing tab AND the chart's
+ *      claims drawer with the same source of truth.
+ *
+ * The parser handles two inputs:
+ *   - 835 ERA segments — re-uses `remittance.ts` taxonomy for CARC /
+ *     RARC semantics (PR vs CO vs OA vs PI).
+ *   - Free-text EOB body — for paper / fax EOBs scanned by the
+ *     patient. Lower-confidence; the agent flags fields it couldn't
+ *     extract instead of guessing.
+ *
+ * The plain-language template is structured so the LLM can only
+ * substitute the facts we computed deterministically — no
+ * hallucinated dollar amounts.
+ */
+
+import {
+  GROUP_CODE_SEMANTICS,
+  type GroupCode,
+  type PatientRespBucket,
+} from "@/lib/billing/remittance";
+
+export interface EobLine {
+  cptCode: string;
+  description: string;
+  billedCents: number;
+  allowedCents: number;
+  paidCents: number;
+  adjustmentsCents: number;
+  patientRespByBucket: Partial<Record<PatientRespBucket, number>>;
+  reasonCodes: Array<{
+    groupCode: GroupCode;
+    carc: string;
+    rarc?: string;
+    amountCents: number;
+  }>;
+}
+
+export interface ParsedEob {
+  payerName: string;
+  payerClaimNumber: string;
+  claimId: string | null;
+  checkOrEftNumber: string | null;
+  paidDate: string;
+  totals: {
+    billedCents: number;
+    allowedCents: number;
+    paidCents: number;
+    patientRespCents: number;
+    contractualAdjustmentCents: number;
+  };
+  lines: EobLine[];
+  unmatchedLines: Array<{ rawText: string; reason: string }>;
+  fromFreeText: boolean;
+}
+
+export interface Era835ClaimSegment {
+  payerClaimNumber: string;
+  patientControlNumber: string;
+  cptLines: Array<{
+    cptCode: string;
+    description?: string;
+    billedCents: number;
+    allowedCents: number;
+    paidCents: number;
+    adjustments: Array<{
+      groupCode: GroupCode;
+      carc: string;
+      rarc?: string;
+      amountCents: number;
+    }>;
+  }>;
+}
+
+export interface Era835Header {
+  payerName: string;
+  paidDate: string;
+  checkOrEftNumber: string | null;
+}
+
+/** Convert a parsed 835 ERA into our normalized EOB shape. */
+export function parseEra835(
+  header: Era835Header,
+  claim: Era835ClaimSegment,
+  matchedClaimId: string | null,
+): ParsedEob {
+  const lines: EobLine[] = claim.cptLines.map((line) => {
+    const patientRespByBucket: Partial<Record<PatientRespBucket, number>> = {};
+    for (const adj of line.adjustments) {
+      if (adj.groupCode !== "PR") continue;
+      const bucket = bucketForCarc(adj.carc);
+      patientRespByBucket[bucket] = (patientRespByBucket[bucket] ?? 0) + adj.amountCents;
+    }
+    return {
+      cptCode: line.cptCode,
+      description: line.description ?? line.cptCode,
+      billedCents: line.billedCents,
+      allowedCents: line.allowedCents,
+      paidCents: line.paidCents,
+      adjustmentsCents: line.adjustments.reduce((sum, a) => sum + a.amountCents, 0),
+      patientRespByBucket,
+      reasonCodes: line.adjustments,
+    };
+  });
+
+  const totals = lines.reduce(
+    (acc, line) => {
+      acc.billedCents += line.billedCents;
+      acc.allowedCents += line.allowedCents;
+      acc.paidCents += line.paidCents;
+      for (const groupCode of Object.keys(GROUP_CODE_SEMANTICS) as GroupCode[]) {
+        const lineSum = line.reasonCodes
+          .filter((r) => r.groupCode === groupCode)
+          .reduce((sum, r) => sum + r.amountCents, 0);
+        if (groupCode === "PR") acc.patientRespCents += lineSum;
+        if (groupCode === "CO") acc.contractualAdjustmentCents += lineSum;
+      }
+      return acc;
+    },
+    {
+      billedCents: 0,
+      allowedCents: 0,
+      paidCents: 0,
+      patientRespCents: 0,
+      contractualAdjustmentCents: 0,
+    },
+  );
+
+  return {
+    payerName: header.payerName,
+    payerClaimNumber: claim.payerClaimNumber,
+    claimId: matchedClaimId,
+    checkOrEftNumber: header.checkOrEftNumber,
+    paidDate: header.paidDate,
+    totals,
+    lines,
+    unmatchedLines: [],
+    fromFreeText: false,
+  };
+}
+
+/** Heuristic free-text parser for a paper EOB. Conservative — flags
+ * "couldn't parse" rather than booking wrong numbers. */
+export function parseFreeTextEob(rawText: string): ParsedEob {
+  const payerName =
+    /^\s*(?:from|payer)[:\s]+(.+)$/im.exec(rawText)?.[1]?.trim() ?? "Unknown payer";
+  const payerClaimNumber =
+    /(?:claim\s*(?:number|#))[:\s]+([A-Z0-9-]+)/i.exec(rawText)?.[1] ?? "";
+  const paidDate = /(?:paid\s*(?:date|on))[:\s]+([0-9/.-]+)/i.exec(rawText)?.[1] ?? "";
+  const checkOrEftNumber =
+    /(?:check|eft)\s*#[:\s]*([A-Z0-9-]+)/i.exec(rawText)?.[1] ?? null;
+
+  const billed = matchMoney(rawText, /total\s+billed[:\s]+\$?([\d,.]+)/i);
+  const allowed = matchMoney(rawText, /total\s+allowed[:\s]+\$?([\d,.]+)/i);
+  const paid = matchMoney(rawText, /total\s+paid[:\s]+\$?([\d,.]+)/i);
+  const pr = matchMoney(rawText, /patient\s+responsibility[:\s]+\$?([\d,.]+)/i);
+  const co = matchMoney(rawText, /(?:contractual|adjustment)[:\s]+\$?([\d,.]+)/i);
+
+  return {
+    payerName,
+    payerClaimNumber,
+    claimId: null,
+    checkOrEftNumber,
+    paidDate,
+    totals: {
+      billedCents: billed,
+      allowedCents: allowed,
+      paidCents: paid,
+      patientRespCents: pr,
+      contractualAdjustmentCents: co,
+    },
+    lines: [],
+    unmatchedLines: [
+      {
+        rawText: rawText.slice(0, 400),
+        reason: "Free-text EOB — line items require human review.",
+      },
+    ],
+    fromFreeText: true,
+  };
+}
+
+function matchMoney(text: string, re: RegExp): number {
+  const m = re.exec(text);
+  if (!m) return 0;
+  const n = parseFloat(m[1].replace(/,/g, ""));
+  if (!isFinite(n)) return 0;
+  return Math.round(n * 100);
+}
+
+const CARC_BUCKET: Record<string, PatientRespBucket> = {
+  "1": "deductible",
+  "2": "coinsurance",
+  "3": "copay",
+  "96": "non_covered",
+  "204": "non_covered",
+  "23": "prior_payer_paid",
+};
+
+function bucketForCarc(carc: string): PatientRespBucket {
+  return CARC_BUCKET[carc] ?? "other";
+}
+
+export interface PlainLanguageSummaryInput {
+  payerName: string;
+  serviceDate: string;
+  totals: ParsedEob["totals"];
+  topReasons: Array<{ carc: string; amountCents: number; bucket: PatientRespBucket | "other" }>;
+}
+
+/**
+ * Build a structured prompt the AI summarizer fills in. The numbers
+ * are passed in as facts the model MUST reproduce verbatim — the
+ * prompt explicitly forbids adjusting them.
+ */
+export function buildSummaryPrompt(input: PlainLanguageSummaryInput): string {
+  const fmt = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+  return [
+    `You are explaining a medical bill summary to a patient.`,
+    `Use ONLY the numbers below. Do not change them or invent new ones.`,
+    `Tone: friendly, plain language, 4–6 sentences.`,
+    ``,
+    `Payer: ${input.payerName}`,
+    `Date of service: ${input.serviceDate}`,
+    `Total billed: ${fmt(input.totals.billedCents)}`,
+    `Insurance allowed amount: ${fmt(input.totals.allowedCents)}`,
+    `Insurance paid: ${fmt(input.totals.paidCents)}`,
+    `Contractual adjustment (insurance discount): ${fmt(input.totals.contractualAdjustmentCents)}`,
+    `Your responsibility: ${fmt(input.totals.patientRespCents)}`,
+    ``,
+    `Reasons for your responsibility:`,
+    ...input.topReasons.map((r) => `  - CARC ${r.carc} (${r.bucket}): ${fmt(r.amountCents)}`),
+  ].join("\n");
+}
+
+export function topPatientRespReasons(
+  eob: ParsedEob,
+  n = 3,
+): PlainLanguageSummaryInput["topReasons"] {
+  const byCarc = new Map<string, { amountCents: number; bucket: PatientRespBucket | "other" }>();
+  for (const line of eob.lines) {
+    for (const r of line.reasonCodes) {
+      if (r.groupCode !== "PR") continue;
+      const bucket = bucketForCarc(r.carc);
+      const cur = byCarc.get(r.carc) ?? { amountCents: 0, bucket };
+      cur.amountCents += r.amountCents;
+      byCarc.set(r.carc, cur);
+    }
+  }
+  return Array.from(byCarc.entries())
+    .map(([carc, v]) => ({ carc, amountCents: v.amountCents, bucket: v.bucket }))
+    .sort((a, b) => b.amountCents - a.amountCents)
+    .slice(0, n);
+}

--- a/src/lib/billing/international.ts
+++ b/src/lib/billing/international.ts
@@ -1,0 +1,215 @@
+/**
+ * International Multi-Country Billing Framework (EMR-116)
+ * -------------------------------------------------------
+ * The US-only billing primitives in this directory (CPT, CARC, NPI,
+ * 837P) don't generalize. Every country has its own coding system,
+ * filing rules, currency, and reimbursement nuances. This module is
+ * the registry the rest of the billing pipeline routes through to ask
+ * country-aware questions:
+ *
+ *   - "Which procedure code system applies for this country?"
+ *   - "What's the reimbursement currency + locale formatting?"
+ *   - "Who are the major insurance carriers I can submit to?"
+ *   - "Is cannabis explicitly excluded by national policy?"
+ *   - "What's the timely filing window?"
+ *
+ * Like `payer-rules.ts`, this is intentionally code-resident for v1
+ * with launch coverage of US, UK, Canada, Germany, Australia per Dr.
+ * Patel's spec.
+ */
+
+export type Iso3166Alpha2 = "US" | "GB" | "CA" | "DE" | "AU";
+
+export type CodingSystem =
+  | "CPT_HCPCS_ICD10CM"
+  | "OPCS4_ICD10"
+  | "CCI_ICD10CA"
+  | "OPS_ICD10GM"
+  | "MBS_ICD10AM";
+
+export type CurrencyCode = "USD" | "GBP" | "CAD" | "EUR" | "AUD";
+
+export interface CountryCarrier {
+  id: string;
+  displayName: string;
+  kind: "national" | "private" | "regional";
+  electronicSubmission: boolean;
+}
+
+export interface CannabisPolicy {
+  legalNationally: boolean;
+  reimbursableUnderPublic: boolean;
+  citation: string;
+}
+
+export interface CountryBillingRule {
+  countryCode: Iso3166Alpha2;
+  countryName: string;
+  codingSystem: CodingSystem;
+  currency: CurrencyCode;
+  /** BCP-47 locale used for currency + date formatting. */
+  locale: string;
+  timelyFilingDays: number;
+  appealDeadlineDays: number;
+  vatRate: number;
+  medicalServicesTaxable: boolean;
+  carriers: CountryCarrier[];
+  cannabisPolicy: CannabisPolicy;
+}
+
+const REGISTRY: Record<Iso3166Alpha2, CountryBillingRule> = {
+  US: {
+    countryCode: "US",
+    countryName: "United States",
+    codingSystem: "CPT_HCPCS_ICD10CM",
+    currency: "USD",
+    locale: "en-US",
+    timelyFilingDays: 365,
+    appealDeadlineDays: 180,
+    vatRate: 0,
+    medicalServicesTaxable: false,
+    carriers: [
+      { id: "medicare", displayName: "Medicare", kind: "national", electronicSubmission: true },
+      { id: "medicaid", displayName: "Medicaid", kind: "regional", electronicSubmission: true },
+      { id: "uhc", displayName: "UnitedHealthcare", kind: "private", electronicSubmission: true },
+      { id: "anthem", displayName: "Anthem BCBS", kind: "private", electronicSubmission: true },
+      { id: "aetna", displayName: "Aetna", kind: "private", electronicSubmission: true },
+      { id: "cigna", displayName: "Cigna", kind: "private", electronicSubmission: true },
+    ],
+    cannabisPolicy: {
+      legalNationally: false,
+      reimbursableUnderPublic: false,
+      citation:
+        "Cannabis remains a Schedule I substance under the U.S. Controlled Substances Act; commercial coverage is at payer discretion.",
+    },
+  },
+  GB: {
+    countryCode: "GB",
+    countryName: "United Kingdom",
+    codingSystem: "OPCS4_ICD10",
+    currency: "GBP",
+    locale: "en-GB",
+    timelyFilingDays: 180,
+    appealDeadlineDays: 60,
+    vatRate: 20,
+    medicalServicesTaxable: false,
+    carriers: [
+      { id: "nhs", displayName: "NHS", kind: "national", electronicSubmission: true },
+      { id: "bupa", displayName: "Bupa", kind: "private", electronicSubmission: true },
+      { id: "axa-health", displayName: "AXA Health", kind: "private", electronicSubmission: true },
+      { id: "vitality", displayName: "Vitality", kind: "private", electronicSubmission: true },
+    ],
+    cannabisPolicy: {
+      legalNationally: true,
+      reimbursableUnderPublic: false,
+      citation:
+        "Medical cannabis is legal in the UK under specialist prescription (since 2018); NHS reimbursement is rare and requires private route in most cases.",
+    },
+  },
+  CA: {
+    countryCode: "CA",
+    countryName: "Canada",
+    codingSystem: "CCI_ICD10CA",
+    currency: "CAD",
+    locale: "en-CA",
+    timelyFilingDays: 365,
+    appealDeadlineDays: 90,
+    vatRate: 5,
+    medicalServicesTaxable: false,
+    carriers: [
+      { id: "ohip", displayName: "OHIP (Ontario)", kind: "regional", electronicSubmission: true },
+      { id: "msp-bc", displayName: "MSP (British Columbia)", kind: "regional", electronicSubmission: true },
+      { id: "ramq", displayName: "RAMQ (Québec)", kind: "regional", electronicSubmission: true },
+      { id: "manulife", displayName: "Manulife", kind: "private", electronicSubmission: true },
+      { id: "sunlife", displayName: "Sun Life", kind: "private", electronicSubmission: true },
+    ],
+    cannabisPolicy: {
+      legalNationally: true,
+      reimbursableUnderPublic: false,
+      citation:
+        "Medical cannabis is federally legal under the Cannabis Act (2018); Veterans Affairs Canada and many private extended-health plans reimburse with documentation.",
+    },
+  },
+  DE: {
+    countryCode: "DE",
+    countryName: "Germany",
+    codingSystem: "OPS_ICD10GM",
+    currency: "EUR",
+    locale: "de-DE",
+    timelyFilingDays: 90,
+    appealDeadlineDays: 30,
+    vatRate: 19,
+    medicalServicesTaxable: false,
+    carriers: [
+      { id: "tk", displayName: "Techniker Krankenkasse", kind: "national", electronicSubmission: true },
+      { id: "aok", displayName: "AOK", kind: "national", electronicSubmission: true },
+      { id: "barmer", displayName: "BARMER", kind: "national", electronicSubmission: true },
+      { id: "dak", displayName: "DAK-Gesundheit", kind: "national", electronicSubmission: true },
+    ],
+    cannabisPolicy: {
+      legalNationally: true,
+      reimbursableUnderPublic: true,
+      citation:
+        "Cannabis als Medizin Gesetz (March 2017) authorizes statutory health insurance reimbursement on prior approval (§ 31 Abs. 6 SGB V).",
+    },
+  },
+  AU: {
+    countryCode: "AU",
+    countryName: "Australia",
+    codingSystem: "MBS_ICD10AM",
+    currency: "AUD",
+    locale: "en-AU",
+    timelyFilingDays: 730,
+    appealDeadlineDays: 28,
+    vatRate: 10,
+    medicalServicesTaxable: false,
+    carriers: [
+      { id: "medicare-au", displayName: "Medicare (Australia)", kind: "national", electronicSubmission: true },
+      { id: "bupa-au", displayName: "Bupa Australia", kind: "private", electronicSubmission: true },
+      { id: "medibank", displayName: "Medibank", kind: "private", electronicSubmission: true },
+      { id: "hcf", displayName: "HCF", kind: "private", electronicSubmission: true },
+    ],
+    cannabisPolicy: {
+      legalNationally: true,
+      reimbursableUnderPublic: false,
+      citation:
+        "Medical cannabis is accessible through TGA Special Access Scheme and Authorised Prescriber pathway; PBS subsidy is limited to specific products and indications.",
+    },
+  },
+};
+
+export const SUPPORTED_COUNTRIES: Iso3166Alpha2[] = ["US", "GB", "CA", "DE", "AU"];
+
+export function getCountryRule(code: Iso3166Alpha2): CountryBillingRule {
+  return REGISTRY[code];
+}
+
+export function listCountryRules(): CountryBillingRule[] {
+  return SUPPORTED_COUNTRIES.map((c) => REGISTRY[c]);
+}
+
+export function formatCountryMoney(
+  countryCode: Iso3166Alpha2,
+  minorUnits: number,
+): string {
+  const rule = REGISTRY[countryCode];
+  return new Intl.NumberFormat(rule.locale, {
+    style: "currency",
+    currency: rule.currency,
+  }).format(minorUnits / 100);
+}
+
+export function withinTimelyFiling(
+  countryCode: Iso3166Alpha2,
+  serviceDate: Date,
+  asOf: Date = new Date(),
+): boolean {
+  const rule = REGISTRY[countryCode];
+  const ageDays = Math.floor((asOf.getTime() - serviceDate.getTime()) / 86_400_000);
+  return ageDays <= rule.timelyFilingDays;
+}
+
+export function publicCoverageUnlikely(countryCode: Iso3166Alpha2): boolean {
+  const policy = REGISTRY[countryCode].cannabisPolicy;
+  return !policy.reimbursableUnderPublic;
+}

--- a/src/lib/billing/payment-methods.ts
+++ b/src/lib/billing/payment-methods.ts
@@ -1,0 +1,250 @@
+/**
+ * Stored Payment Methods + Receipts (EMR-114)
+ * -------------------------------------------
+ * Tokenized card / ACH storage backed by the existing
+ * `StoredPaymentMethod` Prisma model and the `PaymentGateway`
+ * interface in `lib/payments`. This module is the billing-side
+ * orchestrator that:
+ *
+ *   - Verifies a tokenized method via the configured gateway and
+ *     persists it (no PAN, last4 + brand only).
+ *   - Charges a stored token and books a `FinancialEvent` so the
+ *     internal ledger stays the source of truth (PRD § 3.3).
+ *   - Generates a deterministic receipt payload (date, invoice
+ *     number, line items, balance after) suitable for the patient
+ *     portal billing tab and for emailed PDFs.
+ *   - Computes the patient's running balance from FinancialEvent
+ *     rows so the billing tab can render "You owe $X" / "Credit on
+ *     file: $Y" without a recompute on every page hit.
+ *
+ * Payabli integration is wired through the gateway interface — same
+ * surface as the stub gateway used in dev/CI. Status from TICKETS.md:
+ * "partially done — StoredPaymentMethod exists; Payabli scaffolded."
+ * This module fills the remaining glue.
+ */
+
+import type {
+  PaymentGateway,
+  PaymentMethod,
+  TokenizedPaymentMethod,
+} from "@/lib/payments/types";
+
+export interface StoredMethodSummary {
+  id: string;
+  type: "card" | "ach";
+  last4: string;
+  brand: string | null;
+  expiryMonth: number | null;
+  expiryYear: number | null;
+  isDefault: boolean;
+  consentedAt: string;
+}
+
+export interface ReceiptLineItem {
+  description: string;
+  amountCents: number;
+}
+
+export interface Receipt {
+  receiptNumber: string;
+  patientId: string;
+  paymentIntentId: string;
+  issuedAt: string;
+  amountCents: number;
+  method: PaymentMethod;
+  last4?: string;
+  brand?: string;
+  lineItems: ReceiptLineItem[];
+  /** Patient balance AFTER this payment posted. */
+  balanceAfterCents: number;
+  practice: {
+    name: string;
+    address?: string;
+    phone?: string;
+    taxId?: string;
+  };
+}
+
+export interface BalanceSnapshot {
+  /** Positive = patient owes practice. Negative = credit on file. */
+  netCents: number;
+  owedCents: number;
+  creditCents: number;
+  asOf: string;
+}
+
+export interface StoreMethodInput {
+  patientId: string;
+  token: string;
+  setDefault: boolean;
+}
+
+export interface ChargeStoredInput {
+  patientId: string;
+  methodId: string;
+  amountCents: number;
+  description: string;
+  reference?: string;
+}
+
+export interface PaymentMethodStore {
+  insert(record: {
+    patientId: string;
+    type: "card" | "ach";
+    last4: string;
+    brand: string | null;
+    expiryMonth: number | null;
+    expiryYear: number | null;
+    tokenReference: string;
+    isDefault: boolean;
+  }): Promise<StoredMethodSummary>;
+  setDefault(patientId: string, methodId: string): Promise<void>;
+  list(patientId: string): Promise<StoredMethodSummary[]>;
+  getActiveById(methodId: string): Promise<{
+    id: string;
+    patientId: string;
+    tokenReference: string;
+    last4: string;
+    brand: string | null;
+    type: "card" | "ach";
+  } | null>;
+  deactivate(methodId: string): Promise<void>;
+}
+
+export interface LedgerStore {
+  appendEvent(event: {
+    organizationId: string;
+    patientId: string;
+    type: "patient_payment" | "credit_applied" | "refund_issued" | "chargeback";
+    amountCents: number;
+    description: string;
+    paymentId?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void>;
+  computeBalance(patientId: string): Promise<BalanceSnapshot>;
+}
+
+/**
+ * Validate a token with the gateway and persist it as a
+ * StoredPaymentMethod. Never accepts raw card / account numbers — that
+ * stays at the gateway hosted-fields layer.
+ */
+export async function storePaymentMethod(
+  input: StoreMethodInput,
+  deps: { gateway: PaymentGateway; store: PaymentMethodStore },
+): Promise<StoredMethodSummary> {
+  const verified: TokenizedPaymentMethod = await deps.gateway.verifyToken(input.token);
+
+  const inserted = await deps.store.insert({
+    patientId: input.patientId,
+    type: verified.type,
+    last4: verified.last4,
+    brand: verified.brand ?? null,
+    expiryMonth: verified.expiryMonth ?? null,
+    expiryYear: verified.expiryYear ?? null,
+    tokenReference: verified.token,
+    isDefault: input.setDefault,
+  });
+
+  if (input.setDefault) {
+    await deps.store.setDefault(input.patientId, inserted.id);
+  }
+  return inserted;
+}
+
+/**
+ * Charge a stored method and produce a receipt + ledger entry.
+ *
+ * Booking order is intentional:
+ *   1. Gateway charge (external — may fail).
+ *   2. Ledger append (internal — must succeed once the charge clears).
+ *   3. Receipt is computed from the ledger snapshot, NOT from the
+ *      gateway response, so the receipt's "balance after" line is
+ *      always reconciled against our source of truth.
+ */
+export async function chargeStoredMethod(
+  input: ChargeStoredInput,
+  deps: {
+    gateway: PaymentGateway;
+    store: PaymentMethodStore;
+    ledger: LedgerStore;
+    organizationId: string;
+    practice: Receipt["practice"];
+    receiptNumber?: () => string;
+    now?: () => Date;
+  },
+): Promise<Receipt> {
+  const method = await deps.store.getActiveById(input.methodId);
+  if (!method || method.patientId !== input.patientId) {
+    throw new Error("payment_method_not_found");
+  }
+
+  const intent = await deps.gateway.chargeStoredMethod({
+    token: method.tokenReference,
+    amountCents: input.amountCents,
+    clientReferenceId: input.reference ?? `patient:${input.patientId}`,
+    description: input.description,
+    patientId: input.patientId,
+  });
+
+  if (intent.status !== "captured" && intent.status !== "authorized") {
+    throw new Error(
+      `payment_failed:${intent.status}:${intent.errorMessage ?? "unknown"}`,
+    );
+  }
+
+  await deps.ledger.appendEvent({
+    organizationId: deps.organizationId,
+    patientId: input.patientId,
+    type: "patient_payment",
+    amountCents: input.amountCents,
+    description: input.description,
+    paymentId: intent.id,
+    metadata: {
+      gateway: deps.gateway.name,
+      methodId: method.id,
+      last4: method.last4,
+      brand: method.brand,
+      reference: input.reference,
+    },
+  });
+
+  const balance = await deps.ledger.computeBalance(input.patientId);
+  const issuedAt = (deps.now?.() ?? new Date()).toISOString();
+  const receiptNumber = (deps.receiptNumber ?? defaultReceiptNumber)();
+
+  return {
+    receiptNumber,
+    patientId: input.patientId,
+    paymentIntentId: intent.id,
+    issuedAt,
+    amountCents: input.amountCents,
+    method: method.type,
+    last4: method.last4,
+    brand: method.brand ?? undefined,
+    lineItems: [{ description: input.description, amountCents: input.amountCents }],
+    balanceAfterCents: balance.netCents,
+    practice: deps.practice,
+  };
+}
+
+function defaultReceiptNumber(): string {
+  const epoch = Date.now().toString(36).toUpperCase();
+  const rand = Math.floor(Math.random() * 0xffff)
+    .toString(16)
+    .toUpperCase()
+    .padStart(4, "0");
+  return `RCPT-${epoch}-${rand}`;
+}
+
+/**
+ * Patient-portal display string for the billing tab header.
+ * - Positive net → "$X.XX due"
+ * - Negative net → "$X.XX credit on file"
+ * - Zero → "Paid in full"
+ */
+export function formatBalanceForPortal(snap: BalanceSnapshot): string {
+  if (snap.netCents === 0) return "Paid in full";
+  const dollars = (Math.abs(snap.netCents) / 100).toFixed(2);
+  return snap.netCents > 0 ? `$${dollars} due` : `$${dollars} credit on file`;
+}

--- a/src/lib/billing/research-export.ts
+++ b/src/lib/billing/research-export.ts
@@ -1,0 +1,235 @@
+/**
+ * Researcher Portal — De-identified Billing Export (EMR-123)
+ * ----------------------------------------------------------
+ * The researcher role gets de-identified access to clinical + billing
+ * data per the EMR-123 spec. This module covers the billing slice:
+ * de-identifying claim + payment records so the population analytics
+ * dashboard can show cohort-level reimbursement patterns without
+ * exposing PHI.
+ *
+ * De-identification rules follow HIPAA Safe Harbor:
+ *   - Drop direct identifiers (name, address, phone, email, MRN,
+ *     account/medical record numbers, full DOB).
+ *   - Keep age in years (cap at 89; rollup to "90+").
+ *   - Keep race / sex / smoking history (per spec — researcher needs
+ *     these for cohort definitions).
+ *   - Replace patient/encounter/claim ids with stable per-cohort
+ *     pseudonyms via HMAC-SHA256.
+ *   - Generalize geographic data to the first 3 ZIP digits, dropping
+ *     ZIPs in regions with fewer than 20,000 residents.
+ *
+ * The pseudonym salt MUST be cohort-scoped: two researchers running
+ * the same query on the same source data get DIFFERENT id mappings.
+ * That prevents cross-researcher collusion to re-identify a subject.
+ */
+
+import { createHmac } from "node:crypto";
+
+export type ResearchScope = "billing-only" | "billing-and-outcomes" | "full-clinical";
+
+export interface RawPatientFacts {
+  patientId: string;
+  /** Date of birth — used to derive age, then dropped. */
+  dateOfBirth: Date;
+  sex: "male" | "female" | "other" | "unknown";
+  race: string | null;
+  ethnicity: string | null;
+  smokingStatus: string | null;
+  substanceHistory: string | null;
+  zipCode: string;
+  socioeconomicTier: string | null;
+}
+
+export interface RawClaimFacts {
+  claimId: string;
+  patientId: string;
+  encounterId: string;
+  serviceDate: Date;
+  payerName: string | null;
+  cptCodes: string[];
+  icd10Codes: string[];
+  billedCents: number;
+  paidCents: number;
+  patientRespCents: number;
+  status: string;
+  denialCategory: string | null;
+}
+
+export interface DeIdentifiedPatient {
+  pseudonym: string;
+  ageYears: number | "90+";
+  sex: RawPatientFacts["sex"];
+  race: string | null;
+  ethnicity: string | null;
+  smokingStatus: string | null;
+  substanceHistory: string | null;
+  zipPrefix: string | null;
+  socioeconomicTier: string | null;
+}
+
+export interface DeIdentifiedClaim {
+  claimPseudonym: string;
+  patientPseudonym: string;
+  encounterPseudonym: string;
+  serviceMonth: string;
+  payerCategory: PayerCategory;
+  cptCodes: string[];
+  icd10Codes: string[];
+  billedCents: number;
+  paidCents: number;
+  patientRespCents: number;
+  status: string;
+  denialCategory: string | null;
+}
+
+export type PayerCategory =
+  | "medicare"
+  | "medicaid"
+  | "commercial"
+  | "self_pay"
+  | "workers_comp"
+  | "other";
+
+// HIPAA Safe Harbor restricted ZIP3 prefixes (population < 20,000).
+const SAFE_HARBOR_RESTRICTED_ZIP3 = new Set([
+  "036", "059", "063", "102", "203", "556", "692", "790",
+  "821", "823", "830", "831", "878", "879", "884", "890", "893",
+]);
+
+function generalizeZip(zip: string): string | null {
+  if (!zip) return null;
+  const prefix = zip.slice(0, 3);
+  if (!/^\d{3}$/.test(prefix)) return null;
+  return SAFE_HARBOR_RESTRICTED_ZIP3.has(prefix) ? "000" : prefix;
+}
+
+function ageFromDob(dob: Date, asOf: Date): number | "90+" {
+  const years = Math.floor((asOf.getTime() - dob.getTime()) / (365.25 * 86_400_000));
+  if (years >= 90) return "90+";
+  return Math.max(0, years);
+}
+
+/**
+ * Cohort-scoped pseudonymizer. Constructed with a secret salt that
+ * must be unique per (cohort, exporter) pair. The salt is generated
+ * by the caller and stored alongside the cohort manifest — never
+ * logged.
+ */
+export class CohortPseudonymizer {
+  constructor(private readonly salt: string) {
+    if (!salt || salt.length < 16) {
+      throw new Error("cohort_salt_too_short");
+    }
+  }
+  pseudonymize(prefix: string, value: string): string {
+    const hmac = createHmac("sha256", this.salt);
+    hmac.update(`${prefix}:${value}`);
+    return `${prefix}_${hmac.digest("hex").slice(0, 16)}`;
+  }
+}
+
+/** Bucket a free-form payer name into a HIPAA-safe category. */
+export function categorizePayer(payerName: string | null): PayerCategory {
+  if (!payerName) return "self_pay";
+  const lower = payerName.toLowerCase();
+  if (lower.includes("medicare")) return "medicare";
+  if (lower.includes("medicaid")) return "medicaid";
+  if (lower.includes("workers") || lower.includes("workers'") || lower.includes("comp"))
+    return "workers_comp";
+  if (lower.includes("self") || lower.includes("cash") || lower.includes("private pay"))
+    return "self_pay";
+  return "commercial";
+}
+
+export function deIdentifyPatient(
+  raw: RawPatientFacts,
+  pseudonymizer: CohortPseudonymizer,
+  asOf: Date = new Date(),
+): DeIdentifiedPatient {
+  return {
+    pseudonym: pseudonymizer.pseudonymize("pt", raw.patientId),
+    ageYears: ageFromDob(raw.dateOfBirth, asOf),
+    sex: raw.sex,
+    race: raw.race,
+    ethnicity: raw.ethnicity,
+    smokingStatus: raw.smokingStatus,
+    substanceHistory: raw.substanceHistory,
+    zipPrefix: generalizeZip(raw.zipCode),
+    socioeconomicTier: raw.socioeconomicTier,
+  };
+}
+
+export function deIdentifyClaim(
+  raw: RawClaimFacts,
+  pseudonymizer: CohortPseudonymizer,
+): DeIdentifiedClaim {
+  return {
+    claimPseudonym: pseudonymizer.pseudonymize("cl", raw.claimId),
+    patientPseudonym: pseudonymizer.pseudonymize("pt", raw.patientId),
+    encounterPseudonym: pseudonymizer.pseudonymize("en", raw.encounterId),
+    serviceMonth: raw.serviceDate.toISOString().slice(0, 7),
+    payerCategory: categorizePayer(raw.payerName),
+    cptCodes: raw.cptCodes,
+    icd10Codes: raw.icd10Codes,
+    billedCents: raw.billedCents,
+    paidCents: raw.paidCents,
+    patientRespCents: raw.patientRespCents,
+    status: raw.status,
+    denialCategory: raw.denialCategory,
+  };
+}
+
+export interface CohortManifest {
+  cohortId: string;
+  scope: ResearchScope;
+  generatedAt: string;
+  patientCount: number;
+  claimCount: number;
+  /** Suppression triggered when a sub-cohort < this threshold. */
+  minCellSize: number;
+}
+
+/**
+ * Suppress sub-cohorts that fall under the minimum cell size — a
+ * standard re-identification safeguard.
+ */
+export function suppressSmallCells<T extends { sex: string; ageYears: number | "90+" }>(
+  patients: T[],
+  minCellSize: number,
+): { kept: T[]; suppressedBuckets: string[] } {
+  const buckets = new Map<string, T[]>();
+  for (const p of patients) {
+    const ageBand =
+      p.ageYears === "90+"
+        ? "90+"
+        : `${Math.floor(p.ageYears / 10) * 10}-${Math.floor(p.ageYears / 10) * 10 + 9}`;
+    const key = `${p.sex}/${ageBand}`;
+    const arr = buckets.get(key) ?? [];
+    arr.push(p);
+    buckets.set(key, arr);
+  }
+  const kept: T[] = [];
+  const suppressedBuckets: string[] = [];
+  for (const [key, list] of buckets) {
+    if (list.length >= minCellSize) kept.push(...list);
+    else suppressedBuckets.push(key);
+  }
+  return { kept, suppressedBuckets };
+}
+
+export function buildCohortManifest(input: {
+  cohortId: string;
+  scope: ResearchScope;
+  patientCount: number;
+  claimCount: number;
+  minCellSize: number;
+}): CohortManifest {
+  return {
+    cohortId: input.cohortId,
+    scope: input.scope,
+    generatedAt: new Date().toISOString(),
+    patientCount: input.patientCount,
+    claimCount: input.claimCount,
+    minCellSize: input.minCellSize,
+  };
+}

--- a/src/lib/billing/rpm.ts
+++ b/src/lib/billing/rpm.ts
@@ -1,0 +1,199 @@
+/**
+ * Medicare RPM (Remote Patient Monitoring) — EMR-120
+ * --------------------------------------------------
+ * RPM device data lands in the patient chart, accumulates against the
+ * monthly billing cycle, and emits a CPT-coded claim line when the
+ * billing thresholds are met. Per CMS guidance:
+ *
+ *   - 99453 — initial setup + patient education (one-time, per device)
+ *   - 99454 — supply of device + daily transmissions ≥ 16 days
+ *             in a 30-day calendar window
+ *   - 99457 — first 20 minutes of clinical management per calendar
+ *             month (provider-time-based, requires interactive
+ *             communication with the patient)
+ *   - 99458 — each additional 20 minutes (add-on to 99457)
+ *
+ * This module is the deterministic eligibility engine. The RPM
+ * billing agent (future) wraps it to actually drop claim lines.
+ */
+
+export type RpmDeviceCategory = "blood_pressure" | "glucose" | "weight" | "spo2" | "ecg";
+
+export interface RpmReading {
+  patientId: string;
+  deviceId: string;
+  category: RpmDeviceCategory;
+  measuredAt: Date;
+  receivedAt: Date;
+  values: Record<string, number>;
+  units: Record<string, string>;
+  source: string;
+}
+
+export interface ProviderReviewEvent {
+  patientId: string;
+  providerId: string;
+  startedAt: Date;
+  endedAt: Date;
+  /** Required by CMS for 99457: real-time interactive contact. */
+  interactiveCommunication: boolean;
+  signedAt: Date;
+  notes: string;
+}
+
+export type RpmCpt = "99453" | "99454" | "99457" | "99458";
+
+export interface RpmBillingLine {
+  cpt: RpmCpt;
+  units: number;
+  rationale: string;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+export interface RpmBillingPeriod {
+  monthStart: Date;
+  monthEnd: Date;
+  patientId: string;
+  /** Whether 99453 has ever been billed for this device on this
+   * patient. CMS allows it once per device. */
+  setupAlreadyBilled: boolean;
+}
+
+export interface RpmEvaluationInput {
+  period: RpmBillingPeriod;
+  readings: RpmReading[];
+  reviews: ProviderReviewEvent[];
+}
+
+export const TRANSMISSION_DAYS_REQUIRED = 16;
+export const NINETY_NINE_457_THRESHOLD_MIN = 20;
+export const NINETY_NINE_458_BLOCK_MIN = 20;
+
+/** Pure evaluator: given a month of readings + reviews, return the
+ * claim lines that are eligible to bill. Does not write to the DB. */
+export function evaluateRpmMonth(input: RpmEvaluationInput): RpmBillingLine[] {
+  const { period, readings, reviews } = input;
+  const out: RpmBillingLine[] = [];
+
+  if (!period.setupAlreadyBilled && readings.length > 0) {
+    out.push({
+      cpt: "99453",
+      units: 1,
+      rationale: "Initial setup + patient education for RPM device.",
+      periodStart: period.monthStart,
+      periodEnd: period.monthEnd,
+    });
+  }
+
+  const distinctDays = new Set<string>();
+  for (const r of readings) {
+    if (r.measuredAt < period.monthStart || r.measuredAt > period.monthEnd) continue;
+    distinctDays.add(r.measuredAt.toISOString().slice(0, 10));
+  }
+  if (distinctDays.size >= TRANSMISSION_DAYS_REQUIRED) {
+    out.push({
+      cpt: "99454",
+      units: 1,
+      rationale: `Device supplied + ${distinctDays.size} distinct transmission days (CMS requires ${TRANSMISSION_DAYS_REQUIRED}).`,
+      periodStart: period.monthStart,
+      periodEnd: period.monthEnd,
+    });
+  }
+
+  const inPeriodReviews = reviews.filter(
+    (r) =>
+      r.startedAt >= period.monthStart &&
+      r.startedAt <= period.monthEnd &&
+      r.interactiveCommunication,
+  );
+  const totalMinutes = inPeriodReviews.reduce(
+    (sum, r) => sum + minutesBetween(r.startedAt, r.endedAt),
+    0,
+  );
+
+  if (totalMinutes >= NINETY_NINE_457_THRESHOLD_MIN) {
+    out.push({
+      cpt: "99457",
+      units: 1,
+      rationale: `${totalMinutes} minutes of interactive clinical management (≥${NINETY_NINE_457_THRESHOLD_MIN} min required).`,
+      periodStart: period.monthStart,
+      periodEnd: period.monthEnd,
+    });
+
+    const additional = Math.floor(
+      (totalMinutes - NINETY_NINE_457_THRESHOLD_MIN) / NINETY_NINE_458_BLOCK_MIN,
+    );
+    if (additional > 0) {
+      out.push({
+        cpt: "99458",
+        units: additional,
+        rationale: `${additional} additional 20-minute block(s) beyond the first 20 minutes (total ${totalMinutes} min).`,
+        periodStart: period.monthStart,
+        periodEnd: period.monthEnd,
+      });
+    }
+  }
+
+  return out;
+}
+
+export interface VitalTrend {
+  metric: string;
+  latest: number;
+  unit: string;
+  prior: number | null;
+  delta: number | null;
+  direction: "up" | "down" | "flat" | "new";
+  measuredAt: Date;
+}
+
+/** Trend summary for the chart vitals section. */
+export function summarizeTrends(readings: RpmReading[]): VitalTrend[] {
+  const byMetric = new Map<string, RpmReading[]>();
+  for (const r of readings) {
+    for (const k of Object.keys(r.values)) {
+      const arr = byMetric.get(k) ?? [];
+      arr.push(r);
+      byMetric.set(k, arr);
+    }
+  }
+
+  const trends: VitalTrend[] = [];
+  for (const [metric, list] of byMetric) {
+    list.sort((a, b) => a.measuredAt.getTime() - b.measuredAt.getTime());
+    const latest = list[list.length - 1];
+    const prior = list.length > 1 ? list[list.length - 2] : null;
+    const latestVal = latest.values[metric];
+    const priorVal = prior?.values[metric] ?? null;
+    const delta = priorVal === null ? null : latestVal - priorVal;
+    const direction: VitalTrend["direction"] =
+      priorVal === null ? "new" : delta === 0 ? "flat" : delta! > 0 ? "up" : "down";
+    trends.push({
+      metric,
+      latest: latestVal,
+      unit: latest.units[metric] ?? "",
+      prior: priorVal,
+      delta,
+      direction,
+      measuredAt: latest.measuredAt,
+    });
+  }
+  return trends;
+}
+
+function minutesBetween(start: Date, end: Date): number {
+  return Math.max(0, Math.round((end.getTime() - start.getTime()) / 60_000));
+}
+
+/** Format a CMS-required attestation line stored verbatim against the
+ * 99457/99458 claim line so a downstream auditor can see exactly which
+ * interactive review supported the bill. */
+export function attestationLine(review: ProviderReviewEvent): string {
+  const minutes = minutesBetween(review.startedAt, review.endedAt);
+  return [
+    `RPM clinical management — ${minutes} min`,
+    `Interactive: ${review.interactiveCommunication ? "yes" : "no"}`,
+    `Provider sign-off: ${review.signedAt.toISOString()}`,
+  ].join(" · ");
+}

--- a/src/lib/billing/translation.ts
+++ b/src/lib/billing/translation.ts
@@ -1,0 +1,219 @@
+/**
+ * Statement + Document Translation (EMR-122)
+ * ------------------------------------------
+ * The platform-wide translation effort spans messaging, video
+ * captions, and documents. The pieces that touch billing —
+ * statements, EOB summaries, payment-plan terms — live here so the
+ * statement renderer can produce a translated PDF without depending
+ * on the message-thread translator or the captions pipeline.
+ *
+ * Two layers:
+ *   1. Static template phrases (statement headers, line-item labels,
+ *      payment instructions). Pre-translated, table-driven, no LLM
+ *      runtime cost.
+ *   2. Dynamic free-text (provider notes embedded in a statement,
+ *      AI-generated EOB summary). Routed through the configurable
+ *      translation provider.
+ *
+ * The translation provider is abstracted behind an interface — same
+ * pattern as `PaymentGateway`. Day-1 implementations: a stub that
+ * passes English through unchanged (CI/dev), and a real provider
+ * that hits Google Translate / DeepL.
+ */
+
+export type SupportedLanguage = "en" | "es" | "vi" | "gu" | "hi" | "zh" | "ar" | "fr";
+
+export const SUPPORTED_LANGUAGES: Array<{
+  code: SupportedLanguage;
+  englishName: string;
+  nativeName: string;
+  rtl: boolean;
+}> = [
+  { code: "en", englishName: "English", nativeName: "English", rtl: false },
+  { code: "es", englishName: "Spanish", nativeName: "Español", rtl: false },
+  { code: "vi", englishName: "Vietnamese", nativeName: "Tiếng Việt", rtl: false },
+  { code: "gu", englishName: "Gujarati", nativeName: "ગુજરાતી", rtl: false },
+  { code: "hi", englishName: "Hindi", nativeName: "हिन्दी", rtl: false },
+  { code: "zh", englishName: "Mandarin", nativeName: "中文", rtl: false },
+  { code: "ar", englishName: "Arabic", nativeName: "العربية", rtl: true },
+  { code: "fr", englishName: "French", nativeName: "Français", rtl: false },
+];
+
+export function isRtl(lang: SupportedLanguage): boolean {
+  return SUPPORTED_LANGUAGES.find((l) => l.code === lang)?.rtl ?? false;
+}
+
+export type StatementPhraseKey =
+  | "statement.title"
+  | "statement.dueDate"
+  | "statement.amountDue"
+  | "statement.priorBalance"
+  | "statement.insurancePaid"
+  | "statement.adjustments"
+  | "statement.totalCharges"
+  | "statement.payNow"
+  | "statement.paymentPlan"
+  | "statement.contactBilling"
+  | "statement.thankYou"
+  | "eob.title"
+  | "eob.summary"
+  | "eob.youOwe"
+  | "eob.insurancePaid";
+
+const STATIC_PHRASES: Record<StatementPhraseKey, Record<SupportedLanguage, string>> = {
+  "statement.title": {
+    en: "Statement", es: "Estado de cuenta", vi: "Bản sao kê", gu: "નિવેદન",
+    hi: "विवरण", zh: "账单", ar: "كشف الحساب", fr: "Relevé",
+  },
+  "statement.dueDate": {
+    en: "Due date", es: "Fecha de vencimiento", vi: "Hạn thanh toán", gu: "નિયત તારીખ",
+    hi: "नियत तारीख", zh: "到期日", ar: "تاريخ الاستحقاق", fr: "Date d’échéance",
+  },
+  "statement.amountDue": {
+    en: "Amount due", es: "Monto adeudado", vi: "Số tiền phải trả", gu: "બાકી રકમ",
+    hi: "देय राशि", zh: "应付金额", ar: "المبلغ المستحق", fr: "Montant dû",
+  },
+  "statement.priorBalance": {
+    en: "Prior balance", es: "Saldo anterior", vi: "Số dư trước", gu: "પૂર્વ બેલેન્સ",
+    hi: "पिछला शेष", zh: "先前余额", ar: "الرصيد السابق", fr: "Solde antérieur",
+  },
+  "statement.insurancePaid": {
+    en: "Insurance paid", es: "Pago del seguro", vi: "Bảo hiểm đã trả", gu: "વીમો ચૂકવ્યો",
+    hi: "बीमा द्वारा भुगतान", zh: "保险已付", ar: "دفع التأمين", fr: "Payé par l’assurance",
+  },
+  "statement.adjustments": {
+    en: "Adjustments", es: "Ajustes", vi: "Điều chỉnh", gu: "સમાયોજનો",
+    hi: "समायोजन", zh: "调整", ar: "التعديلات", fr: "Ajustements",
+  },
+  "statement.totalCharges": {
+    en: "Total charges", es: "Cargos totales", vi: "Tổng phí", gu: "કુલ શુલ્ક",
+    hi: "कुल शुल्क", zh: "总费用", ar: "إجمالي الرسوم", fr: "Frais totaux",
+  },
+  "statement.payNow": {
+    en: "Pay now", es: "Pagar ahora", vi: "Thanh toán ngay", gu: "હમણાં ચૂકવો",
+    hi: "अभी भुगतान करें", zh: "立即支付", ar: "ادفع الآن", fr: "Payer maintenant",
+  },
+  "statement.paymentPlan": {
+    en: "Set up a payment plan", es: "Establecer un plan de pago", vi: "Thiết lập kế hoạch thanh toán",
+    gu: "ચુકવણી યોજના સેટ કરો", hi: "भुगतान योजना सेट करें", zh: "设置付款计划",
+    ar: "إعداد خطة الدفع", fr: "Mettre en place un plan de paiement",
+  },
+  "statement.contactBilling": {
+    en: "Questions? Contact billing.", es: "¿Preguntas? Comuníquese con facturación.",
+    vi: "Có câu hỏi? Liên hệ bộ phận thanh toán.", gu: "પ્રશ્નો? બિલિંગનો સંપર્ક કરો.",
+    hi: "प्रश्न? बिलिंग से संपर्क करें।", zh: "有疑问？请联系账单部门。",
+    ar: "هل لديك أسئلة؟ اتصل بقسم الفواتير.", fr: "Des questions ? Contactez la facturation.",
+  },
+  "statement.thankYou": {
+    en: "Thank you for choosing our practice.", es: "Gracias por elegir nuestra práctica.",
+    vi: "Cảm ơn bạn đã chọn phòng khám của chúng tôi.", gu: "અમારી પ્રેક્ટિસ પસંદ કરવા બદલ આભાર.",
+    hi: "हमारे क्लिनिक को चुनने के लिए धन्यवाद।", zh: "感谢您选择我们的诊所。",
+    ar: "شكرًا لاختياركم عيادتنا.", fr: "Merci d’avoir choisi notre cabinet.",
+  },
+  "eob.title": {
+    en: "Explanation of Benefits", es: "Explicación de beneficios", vi: "Giải thích quyền lợi",
+    gu: "લાભોની સમજૂતી", hi: "लाभों की व्याख्या", zh: "福利说明",
+    ar: "بيان المزايا", fr: "Explication des prestations",
+  },
+  "eob.summary": {
+    en: "Plain-language summary", es: "Resumen en lenguaje sencillo",
+    vi: "Tóm tắt ngôn ngữ đơn giản", gu: "સરળ ભાષામાં સારાંશ",
+    hi: "सरल भाषा में सारांश", zh: "通俗语言摘要",
+    ar: "ملخص بلغة بسيطة", fr: "Résumé en langage simple",
+  },
+  "eob.youOwe": {
+    en: "Your responsibility", es: "Su responsabilidad", vi: "Trách nhiệm của bạn",
+    gu: "તમારી જવાબદારી", hi: "आपकी ज़िम्मेदारी", zh: "您应付的金额",
+    ar: "ما تتحمله", fr: "Votre responsabilité",
+  },
+  "eob.insurancePaid": {
+    en: "Insurance paid", es: "Pago del seguro", vi: "Bảo hiểm đã trả", gu: "વીમો ચૂકવ્યો",
+    hi: "बीमा द्वारा भुगतान", zh: "保险已付", ar: "دفع التأمين", fr: "Payé par l’assurance",
+  },
+};
+
+export function phrase(key: StatementPhraseKey, lang: SupportedLanguage): string {
+  return STATIC_PHRASES[key][lang] ?? STATIC_PHRASES[key].en;
+}
+
+export interface TranslationProvider {
+  readonly name: string;
+  translate(input: {
+    text: string;
+    targetLang: SupportedLanguage;
+    sourceLang?: SupportedLanguage;
+    domain?: "billing-statement" | "eob-summary" | "general";
+  }): Promise<string>;
+}
+
+/** Pass-through for tests + dev. */
+export class StubTranslationProvider implements TranslationProvider {
+  readonly name = "stub";
+  async translate(input: {
+    text: string;
+    targetLang: SupportedLanguage;
+    sourceLang?: SupportedLanguage;
+  }): Promise<string> {
+    if (!input.sourceLang || input.sourceLang === input.targetLang) return input.text;
+    return `[${input.targetLang}] ${input.text}`;
+  }
+}
+
+export interface TranslatableStatement {
+  totals: {
+    totalCharges: string;
+    insurancePaid: string;
+    adjustments: string;
+    priorBalance: string;
+    amountDue: string;
+  };
+  dueDate: string;
+  providerNotes: string;
+  eobSummary: string;
+}
+
+/**
+ * Translate a full statement payload. Static phrases use the table;
+ * dynamic prose routes through the provider. Returns a new object —
+ * input is not mutated.
+ */
+export async function translateStatement(
+  src: TranslatableStatement,
+  targetLang: SupportedLanguage,
+  provider: TranslationProvider,
+): Promise<{
+  labels: Record<StatementPhraseKey, string>;
+  totals: TranslatableStatement["totals"];
+  dueDate: string;
+  providerNotes: string;
+  eobSummary: string;
+  rtl: boolean;
+}> {
+  const labels = Object.fromEntries(
+    (Object.keys(STATIC_PHRASES) as StatementPhraseKey[]).map((k) => [k, phrase(k, targetLang)]),
+  ) as Record<StatementPhraseKey, string>;
+
+  const [providerNotes, eobSummary] = await Promise.all([
+    provider.translate({
+      text: src.providerNotes,
+      targetLang,
+      sourceLang: "en",
+      domain: "billing-statement",
+    }),
+    provider.translate({
+      text: src.eobSummary,
+      targetLang,
+      sourceLang: "en",
+      domain: "eob-summary",
+    }),
+  ]);
+
+  return {
+    labels,
+    totals: src.totals,
+    dueDate: src.dueDate,
+    providerNotes,
+    eobSummary,
+    rtl: isRtl(targetLang),
+  };
+}

--- a/src/lib/billing/wallet-card.ts
+++ b/src/lib/billing/wallet-card.ts
@@ -1,0 +1,121 @@
+/**
+ * Medication Wallet Card (EMR-112)
+ * --------------------------------
+ * Generates a credit-card-sized printable medication summary patients
+ * can carry. Includes cannabis Rx, conventional meds, and supplements.
+ *
+ * Lives in `lib/billing` because the same data feeds the patient
+ * statement footer ("Active medications on file as of <date>") and
+ * the prior-auth agent's submission packet — both billing-adjacent
+ * surfaces.
+ *
+ * Render boundary: this module produces a layout-agnostic
+ * `WalletCardData` structure. The PDF renderer (server route or
+ * client print sheet) consumes that shape — no DOM coupling here so
+ * the same data can drive a print sheet, an Apple Wallet pass, or a
+ * patient-portal preview.
+ */
+
+export interface WalletCardMedication {
+  name: string;
+  frequency: string;
+  category: "cannabis" | "rx" | "supplement";
+  indication?: string;
+}
+
+export interface WalletCardPatient {
+  fullName: string;
+  dateOfBirth: string;
+  mrn: string;
+  /** Single allergy line: "PCN, sulfa" — empty string = "NKDA". */
+  allergiesSummary: string;
+}
+
+export interface WalletCardEmergencyContact {
+  name: string;
+  relationship: string;
+  phone: string;
+}
+
+export interface WalletCardData {
+  patient: WalletCardPatient;
+  medications: WalletCardMedication[];
+  emergencyContact: WalletCardEmergencyContact | null;
+  practiceName: string;
+  practiceContact: string;
+  generatedAt: string;
+  /** Truncation flag — set when the medication list exceeds the card's
+   * physical capacity and entries had to be dropped. */
+  truncated: boolean;
+  truncatedCount: number;
+}
+
+/** Card capacity — most that fits on a CR80 (3.375"×2.125") at 8pt. */
+export const WALLET_CARD_MAX_MEDS = 8;
+
+/** ISO 7810 ID-1 (CR80) physical dimensions in mm. */
+export const WALLET_CARD_DIMENSIONS_MM = { widthMm: 85.6, heightMm: 53.98 };
+
+interface BuildInput {
+  patient: WalletCardPatient;
+  medications: WalletCardMedication[];
+  emergencyContact?: WalletCardEmergencyContact | null;
+  practiceName: string;
+  practiceContact: string;
+  generatedAt?: Date;
+}
+
+/**
+ * Build the wallet-card payload. Sorts cannabis Rx first (the patient
+ * is more likely to be asked about it in an ER context), then
+ * conventional Rx, then supplements.
+ */
+export function buildWalletCard(input: BuildInput): WalletCardData {
+  const sorted = [...input.medications].sort((a, b) => {
+    const order = { cannabis: 0, rx: 1, supplement: 2 } as const;
+    if (order[a.category] !== order[b.category]) {
+      return order[a.category] - order[b.category];
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  const visible = sorted.slice(0, WALLET_CARD_MAX_MEDS);
+  const dropped = sorted.length - visible.length;
+
+  return {
+    patient: input.patient,
+    medications: visible,
+    emergencyContact: input.emergencyContact ?? null,
+    practiceName: input.practiceName,
+    practiceContact: input.practiceContact,
+    generatedAt: (input.generatedAt ?? new Date()).toISOString(),
+    truncated: dropped > 0,
+    truncatedCount: Math.max(0, dropped),
+  };
+}
+
+/** Format a single medication line — keeps to ~52 chars to avoid wrap on CR80 at 8pt. */
+export function formatMedicationLine(med: WalletCardMedication): string {
+  const base = `${med.name} — ${med.frequency}`;
+  return base.length > 52 ? base.slice(0, 49) + "…" : base;
+}
+
+/**
+ * Stable hash of medications + patient identity. The portal "Print
+ * wallet card" button compares this against the cached PDF; a changed
+ * hash invalidates and re-renders. Simple FNV-1a — deterministic and
+ * dependency-free.
+ */
+export function walletCardCacheKey(data: WalletCardData): string {
+  const payload = JSON.stringify({
+    p: data.patient.mrn,
+    a: data.patient.allergiesSummary,
+    m: data.medications.map((m) => `${m.category}:${m.name}:${m.frequency}`),
+  });
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < payload.length; i++) {
+    hash ^= payload.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return ("00000000" + (hash >>> 0).toString(16)).slice(-8);
+}


### PR DESCRIPTION
## Summary

Track 5 (Patient Finance & Access) — 10 tickets from `TICKETS.md` scaffolded across `src/lib/billing` and `src/app/(operator)/ops`.

> **Branch-name note:** the original task asked me to use `scwayman/track-7-financial-ops`, but that branch was already in active use by another agent committing genuinely-Track-7 RCM work (ERA ingestion, payer contracts, lockbox, NSF, statements, etc.). Files I wrote there were getting wiped between calls as the other agent's checkout/commit cycles ran. To preserve this work cleanly without polluting their branch, I created a fresh `scwayman/track-5-patient-finance` branch from `main`. Re-target if you want a different base.

## Tickets covered

| Ticket | Lib module | Operator page |
| --- | --- | --- |
| EMR-111 — Cannabis Education DB | `lib/billing/education-db.ts` | `/ops/education` |
| EMR-112 — Medication Wallet Card | `lib/billing/wallet-card.ts` | `/ops/wallet-cards` |
| EMR-113 — Allergies + Contraindications surfacing | `lib/billing/allergy-alerts.ts` | `/ops/allergy-alerts` |
| EMR-114 — Tokenized CC + ACH storage | `lib/billing/payment-methods.ts` | `/ops/payment-methods` |
| EMR-115 — EOB into portal + chart | `lib/billing/eob.ts` | `/ops/eob` |
| EMR-116 — International billing framework | `lib/billing/international.ts` | `/ops/international-billing` |
| EMR-120 — Medicare RPM | `lib/billing/rpm.ts` | `/ops/rpm` |
| EMR-121 — Master Access Log + Click Analytics | `lib/billing/access-log.ts` | `/ops/access-log` |
| EMR-122 — In-app Translation + Captions | `lib/billing/translation.ts` | `/ops/translation` |
| EMR-123 — Researcher Portal | `lib/billing/research-export.ts` | `/ops/research-exports` |

## Why several non-finance tickets land in `lib/billing`

The user-specified target directories were `src/lib/billing` and `src/app/(operator)/ops`. A few tickets (Education DB, Wallet Card, Translation, Researcher) don't naturally live in billing, so they were implemented with the billing-adjacent slant the directories imply — e.g.:

- **Education DB** is modeled as the source the appeals-letter generator uses to pull plain-language compound descriptions for payer correspondence.
- **Wallet Card** sits in billing because the same data feeds the patient statement footer and the prior-auth packet builder.
- **Translation** focuses on the statement / EOB slice of the platform-wide translation effort.
- **Researcher Portal** module covers the de-identified billing + claim export surface (cohort manifests, HMAC pseudonyms, HIPAA Safe Harbor cell suppression).

If you'd prefer them in different locations, they're self-contained and easy to move.

## Approach

- Pure logic in `lib/billing` — deterministic helpers, dependency-free where possible (FNV-1a in wallet-card, HMAC-SHA256 in research-export).
- Storage adapters (`PaymentMethodStore`, `LedgerStore`, `AccessLogStore`, `TranslationProvider`) are interfaces so the orchestrators are unit-testable without Prisma.
- All ops pages reuse existing UI primitives (`PageShell`, `PageHeader`, `Card`, `Badge`, `StatCard`, `EmptyState`) — visually consistent with `/ops/billing`, `/ops/aging`, `/ops/denials`.
- Where Prisma models exist (`StoredPaymentMethod`, `AuditLog`), pages query them directly. Where the data source isn't yet wired (RPM device readings, EOB ingestion, contraindication source-of-truth, researcher cohort source data), pages use clearly-labelled in-file fixtures — comments mark the integration seams.

## Test plan

- [ ] `npx tsc --noEmit` clean across new files (verified locally — no errors in any of the 20 new files)
- [ ] `npm run dev` and visit each new `/ops/*` route to confirm rendering against current data
- [ ] Wire `recordChartAccess()` from `lib/billing/access-log.ts` into the chart shell and verify analytics aggregation against real `AuditLog` rows
- [ ] Replace `/ops/payment-methods` Prisma query with org-scoped find once the patient-org relation is confirmed
- [ ] Hook the EOB parser into the clearinghouse webhook (currently uses sample 835 segments)
- [ ] Decide on the wallet-card render target (PDF route vs. Apple Wallet pass) — `WalletCardData` is layout-agnostic
- [ ] Confirm payer name → category buckets cover all live payers in `categorizePayer` (research-export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)