### PR TITLE
Track 8 — pharmacology + commerce (10 tickets)

### DIFF
--- a/prisma/migrations/20260430120000_track8_pharmacology_commerce/migration.sql
+++ b/prisma/migrations/20260430120000_track8_pharmacology_commerce/migration.sql
@@ -1,0 +1,217 @@
+-- Track 8 — Pharmacology & Commerce
+-- EMR-002: Dispensary integration + SKU sync
+-- EMR-007: AI supply store catalog
+-- EMR-017: Dispensary locator (geo data on Dispensary)
+-- EMR-018: Strain reference catalog (Leafly-style)
+-- EMR-039: Affiliate partner registry
+-- EMR-145: Cannabis dispensary billing + $500 reimbursement records
+-- EMR-151: Symptom/diagnosis supplement combo wheel data
+
+-- ─── Enums ───────────────────────────────────────────────────────────────
+CREATE TYPE "DispensaryFormatDb" AS ENUM (
+  'flower', 'preroll', 'vape', 'concentrate', 'edible',
+  'tincture', 'topical', 'capsule', 'beverage', 'other'
+);
+CREATE TYPE "DispensaryStatus" AS ENUM ('active', 'pending', 'inactive');
+CREATE TYPE "StrainClassification" AS ENUM ('indica', 'sativa', 'hybrid', 'cbd', 'na');
+CREATE TYPE "AffiliatePartnerStatus" AS ENUM ('active', 'paused', 'archived');
+CREATE TYPE "SupplyProductCategory" AS ENUM (
+  'cough_cold', 'sleep', 'pain', 'digestive', 'vitamins_supplements',
+  'dme', 'topical', 'oral_care', 'mental_health', 'womens_health', 'general_wellness'
+);
+CREATE TYPE "DispensaryReimbursementStatus" AS ENUM (
+  'draft', 'submitted', 'approved', 'paid', 'denied'
+);
+CREATE TYPE "SupplementCompoundEvidence" AS ENUM ('strong', 'moderate', 'emerging');
+
+-- ─── EMR-018 — Strain reference catalog ─────────────────────────────────
+CREATE TABLE "Strain" (
+  "id"              TEXT PRIMARY KEY,
+  "slug"            TEXT NOT NULL UNIQUE,
+  "name"            TEXT NOT NULL,
+  "classification"  "StrainClassification" NOT NULL,
+  "thcPercent"      DOUBLE PRECISION,
+  "cbdPercent"      DOUBLE PRECISION,
+  "cbgPercent"      DOUBLE PRECISION,
+  "cbnPercent"      DOUBLE PRECISION,
+  "dominantTerpene" TEXT,
+  "terpeneProfile"  JSONB,
+  "symptoms"        TEXT[] NOT NULL DEFAULT '{}',
+  "effects"         TEXT[] NOT NULL DEFAULT '{}',
+  "flavors"         TEXT[] NOT NULL DEFAULT '{}',
+  "description"    TEXT,
+  "origin"         TEXT,
+  "parentStrains"  TEXT[] NOT NULL DEFAULT '{}',
+  "leaflyId"       TEXT,
+  "active"         BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL
+);
+CREATE INDEX "Strain_classification_active_idx" ON "Strain" ("classification", "active");
+CREATE INDEX "Strain_leaflyId_idx" ON "Strain" ("leaflyId");
+
+-- ─── EMR-002 / EMR-017 — Dispensary + SKU ───────────────────────────────
+CREATE TABLE "Dispensary" (
+  "id"             TEXT PRIMARY KEY,
+  "organizationId" TEXT NOT NULL,
+  "vendorId"       TEXT UNIQUE,
+  "name"           TEXT NOT NULL,
+  "slug"           TEXT NOT NULL UNIQUE,
+  "licenseNumber"  TEXT,
+  "licenseState"   TEXT NOT NULL,
+  "status"         "DispensaryStatus" NOT NULL DEFAULT 'active',
+  "addressLine1"   TEXT NOT NULL,
+  "addressLine2"   TEXT,
+  "city"           TEXT NOT NULL,
+  "state"          TEXT NOT NULL,
+  "postalCode"     TEXT NOT NULL,
+  "latitude"       DOUBLE PRECISION NOT NULL,
+  "longitude"      DOUBLE PRECISION NOT NULL,
+  "phone"          TEXT,
+  "websiteUrl"     TEXT,
+  "hoursLine"      TEXT,
+  "lastSyncedAt"   TIMESTAMP(3),
+  "syncSource"     TEXT,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Dispensary_organizationId_fkey" FOREIGN KEY ("organizationId")
+    REFERENCES "Organization" ("id") ON DELETE CASCADE
+);
+CREATE INDEX "Dispensary_organizationId_status_idx" ON "Dispensary" ("organizationId", "status");
+CREATE INDEX "Dispensary_licenseState_idx" ON "Dispensary" ("licenseState");
+
+CREATE TABLE "DispensarySku" (
+  "id"             TEXT PRIMARY KEY,
+  "dispensaryId"   TEXT NOT NULL,
+  "sku"            TEXT NOT NULL,
+  "upc"            TEXT,
+  "name"           TEXT NOT NULL,
+  "brand"          TEXT,
+  "format"         "DispensaryFormatDb" NOT NULL,
+  "strainType"     "StrainClassification" NOT NULL DEFAULT 'na',
+  "strainId"       TEXT,
+  "thcMgPerUnit"   DOUBLE PRECISION,
+  "cbdMgPerUnit"   DOUBLE PRECISION,
+  "thcPercent"     DOUBLE PRECISION,
+  "cbdPercent"     DOUBLE PRECISION,
+  "packSize"       TEXT,
+  "priceCents"     INTEGER NOT NULL,
+  "inStock"        BOOLEAN NOT NULL DEFAULT TRUE,
+  "inventoryCount" INTEGER,
+  "imageUrl"       TEXT,
+  "coaUrl"         TEXT,
+  "description"    TEXT,
+  "active"         BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "DispensarySku_dispensaryId_fkey" FOREIGN KEY ("dispensaryId")
+    REFERENCES "Dispensary" ("id") ON DELETE CASCADE,
+  CONSTRAINT "DispensarySku_strainId_fkey" FOREIGN KEY ("strainId")
+    REFERENCES "Strain" ("id") ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX "DispensarySku_dispensaryId_sku_key" ON "DispensarySku" ("dispensaryId", "sku");
+CREATE INDEX "DispensarySku_dispensaryId_active_inStock_idx"
+  ON "DispensarySku" ("dispensaryId", "active", "inStock");
+CREATE INDEX "DispensarySku_format_idx" ON "DispensarySku" ("format");
+CREATE INDEX "DispensarySku_strainId_idx" ON "DispensarySku" ("strainId");
+
+-- ─── EMR-007 — Supply Store catalog ─────────────────────────────────────
+CREATE TABLE "SupplyProduct" (
+  "id"                TEXT PRIMARY KEY,
+  "organizationId"    TEXT NOT NULL,
+  "slug"              TEXT NOT NULL UNIQUE,
+  "name"              TEXT NOT NULL,
+  "brand"             TEXT,
+  "category"          "SupplyProductCategory" NOT NULL,
+  "description"       TEXT NOT NULL,
+  "shortDescription"  TEXT,
+  "imageUrl"          TEXT,
+  "priceCents"        INTEGER NOT NULL,
+  "symptoms"          TEXT[] NOT NULL DEFAULT '{}',
+  "conditions"        TEXT[] NOT NULL DEFAULT '{}',
+  "contraindications" TEXT[] NOT NULL DEFAULT '{}',
+  "isOTC"             BOOLEAN NOT NULL DEFAULT TRUE,
+  "requiresRx"        BOOLEAN NOT NULL DEFAULT FALSE,
+  "fsaEligible"       BOOLEAN NOT NULL DEFAULT FALSE,
+  "externalUrl"       TEXT,
+  "externalPartner"   TEXT,
+  "active"            BOOLEAN NOT NULL DEFAULT TRUE,
+  "featured"          BOOLEAN NOT NULL DEFAULT FALSE,
+  "createdAt"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"         TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SupplyProduct_organizationId_fkey" FOREIGN KEY ("organizationId")
+    REFERENCES "Organization" ("id") ON DELETE CASCADE
+);
+CREATE INDEX "SupplyProduct_organizationId_active_idx" ON "SupplyProduct" ("organizationId", "active");
+CREATE INDEX "SupplyProduct_category_active_idx" ON "SupplyProduct" ("category", "active");
+
+-- ─── EMR-039 — Affiliate partner registry ───────────────────────────────
+CREATE TABLE "AffiliatePartner" (
+  "id"                TEXT PRIMARY KEY,
+  "slug"              TEXT NOT NULL UNIQUE,
+  "name"              TEXT NOT NULL,
+  "domain"            TEXT NOT NULL,
+  "websiteUrl"        TEXT NOT NULL,
+  "description"       TEXT NOT NULL,
+  "category"          TEXT NOT NULL,
+  "logoUrl"           TEXT,
+  "status"            "AffiliatePartnerStatus" NOT NULL DEFAULT 'active',
+  "disclaimerText"    TEXT,
+  "jointDecisionNote" TEXT,
+  "utmSource"         TEXT,
+  "sortOrder"         INTEGER NOT NULL DEFAULT 0,
+  "createdAt"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"         TIMESTAMP(3) NOT NULL
+);
+CREATE INDEX "AffiliatePartner_status_sortOrder_idx" ON "AffiliatePartner" ("status", "sortOrder");
+
+-- ─── EMR-145 — Dispensary reimbursement records ─────────────────────────
+CREATE TABLE "DispensaryReimbursement" (
+  "id"                   TEXT PRIMARY KEY,
+  "organizationId"       TEXT NOT NULL,
+  "dispensaryId"         TEXT NOT NULL,
+  "patientId"            TEXT NOT NULL,
+  "serviceMonth"         TIMESTAMP(3) NOT NULL,
+  "documentedSpendCents" INTEGER NOT NULL,
+  "reimbursableCents"    INTEGER NOT NULL,
+  "capCents"             INTEGER NOT NULL DEFAULT 50000,
+  "notes"                TEXT,
+  "status"               "DispensaryReimbursementStatus" NOT NULL DEFAULT 'draft',
+  "submittedAt"          TIMESTAMP(3),
+  "paidAt"               TIMESTAMP(3),
+  "paymentReference"     TEXT,
+  "createdAt"            TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"            TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "DispensaryReimbursement_organizationId_fkey" FOREIGN KEY ("organizationId")
+    REFERENCES "Organization" ("id") ON DELETE CASCADE,
+  CONSTRAINT "DispensaryReimbursement_dispensaryId_fkey" FOREIGN KEY ("dispensaryId")
+    REFERENCES "Dispensary" ("id") ON DELETE CASCADE,
+  CONSTRAINT "DispensaryReimbursement_patientId_fkey" FOREIGN KEY ("patientId")
+    REFERENCES "Patient" ("id") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX "DispensaryReimbursement_patientId_serviceMonth_key"
+  ON "DispensaryReimbursement" ("patientId", "serviceMonth");
+CREATE INDEX "DispensaryReimbursement_organizationId_status_idx"
+  ON "DispensaryReimbursement" ("organizationId", "status");
+CREATE INDEX "DispensaryReimbursement_dispensaryId_serviceMonth_idx"
+  ON "DispensaryReimbursement" ("dispensaryId", "serviceMonth");
+
+-- ─── EMR-151 — Supplement compound catalog ──────────────────────────────
+CREATE TABLE "SupplementCompound" (
+  "id"                  TEXT PRIMARY KEY,
+  "name"                TEXT NOT NULL,
+  "category"            TEXT NOT NULL,
+  "color"               TEXT NOT NULL,
+  "evidence"            "SupplementCompoundEvidence" NOT NULL,
+  "description"         TEXT NOT NULL,
+  "symptoms"            TEXT[] NOT NULL,
+  "benefits"            TEXT[] NOT NULL,
+  "risks"               TEXT[] NOT NULL,
+  "cannabisInteraction" TEXT,
+  "sortOrder"           INTEGER NOT NULL DEFAULT 0,
+  "active"              BOOLEAN NOT NULL DEFAULT TRUE,
+  "createdAt"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"           TIMESTAMP(3) NOT NULL
+);
+CREATE INDEX "SupplementCompound_category_active_sortOrder_idx"
+  ON "SupplementCompound" ("category", "active", "sortOrder");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,53 +45,57 @@ model Organization {
   // EMR-220 — Production billing identifiers
   // taxId stored encrypted at the application layer; the DB column is the
   // ciphertext blob (base64 of iv||tag||ct). Never the plaintext EIN.
-  billingNpi       String? // 10-digit type-2 organizational NPI used as the billing provider on 837P loop 2010AA
-  taxId            String? // EIN ciphertext — decrypt via decryptTaxId() before use
-  billingAddress   Json? // { line1, line2?, city, state, postalCode } — pay-from address on the claim
-  payToAddress     Json? // optional override for 2010AB pay-to address when different from billingAddress
+  billingNpi     String? // 10-digit type-2 organizational NPI used as the billing provider on 837P loop 2010AA
+  taxId          String? // EIN ciphertext — decrypt via decryptTaxId() before use
+  billingAddress Json? // { line1, line2?, city, state, postalCode } — pay-from address on the claim
+  payToAddress   Json? // optional override for 2010AB pay-to address when different from billingAddress
 
-  memberships       Membership[]
-  patients          Patient[]
-  providers         Provider[]
-  encounters        Encounter[]
-  documents         Document[]
-  labResults        LabResult[]
-  refillRequests    RefillRequest[]
-  auditLogs         AuditLog[]
-  agentJobs         AgentJob[]
-  agentFeedback     AgentFeedback[]
-  escalationCases   EscalationCase[]
-  launchStatus      PracticeLaunchStatus?
-  cannabisProducts  CannabisProduct[]
-  claims            Claim[]
-  feeSchedule       FeeScheduleEntry[]
-  referrals         Referral[]
-  complianceForms   StateComplianceForm[]
-  intakeTemplates   IntakeFormTemplate[]
-  products          Product[]
-  orders            Order[]
-  vendors           Vendor[]
-  vendorDocuments   VendorDocument[]
+  memberships              Membership[]
+  patients                 Patient[]
+  providers                Provider[]
+  encounters               Encounter[]
+  documents                Document[]
+  labResults               LabResult[]
+  refillRequests           RefillRequest[]
+  auditLogs                AuditLog[]
+  agentJobs                AgentJob[]
+  agentFeedback            AgentFeedback[]
+  escalationCases          EscalationCase[]
+  launchStatus             PracticeLaunchStatus?
+  cannabisProducts         CannabisProduct[]
+  claims                   Claim[]
+  feeSchedule              FeeScheduleEntry[]
+  referrals                Referral[]
+  complianceForms          StateComplianceForm[]
+  intakeTemplates          IntakeFormTemplate[]
+  products                 Product[]
+  orders                   Order[]
+  vendors                  Vendor[]
+  vendorDocuments          VendorDocument[]
   // CFO / Controller surface
-  expenses          Expense[]
-  recurringExpenses RecurringExpense[]
-  bankAccounts      BankAccount[]
-  cashFlowEntries   CashFlowEntry[]
-  fixedAssets       FixedAsset[]
-  liabilities       Liability[]
-  equityEntries     EquityEntry[]
-  financialReports  FinancialReport[]
-  financialGoals    FinancialGoal[]
+  expenses                 Expense[]
+  recurringExpenses        RecurringExpense[]
+  bankAccounts             BankAccount[]
+  cashFlowEntries          CashFlowEntry[]
+  fixedAssets              FixedAsset[]
+  liabilities              Liability[]
+  equityEntries            EquityEntry[]
+  financialReports         FinancialReport[]
+  financialGoals           FinancialGoal[]
   // Track 7 — Financial Operations & Lockbox
-  eraFiles            EraFile[]
-  payerContracts      PayerContract[]
-  bankDeposits        BankDeposit[]
-  priorAuthorizations PriorAuthorization[]
-  appealOutcomes      AppealOutcome[]
-  rcmDailyClose       RcmDailyClose[]
-  nsfEvents           NsfEvent[]
+  eraFiles                 EraFile[]
+  payerContracts           PayerContract[]
+  bankDeposits             BankDeposit[]
+  priorAuthorizations      PriorAuthorization[]
+  appealOutcomes           AppealOutcome[]
+  rcmDailyClose            RcmDailyClose[]
+  nsfEvents                NsfEvent[]
   // Track 3 — EDI & Claim Generation (EMR-218 payer rules registry)
-  payerRules          PayerRule[]
+  payerRules               PayerRule[]
+  // Phase 8 Track 3 — Pharmacology & Commerce
+  dispensaries             Dispensary[]
+  supplyProducts           SupplyProduct[]
+  dispensaryReimbursements DispensaryReimbursement[]
 }
 
 model User {
@@ -183,43 +187,45 @@ model Patient {
   createdAt              DateTime            @default(now())
   updatedAt              DateTime            @updatedAt
 
-  user                 User?                 @relation("PatientUser", fields: [userId], references: [id])
-  organization         Organization          @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  chartSummary         ChartSummary?
-  encounters           Encounter[]
-  documents            Document[]
-  labResults           LabResult[]
-  refillRequests       RefillRequest[]
-  assessmentResponses  AssessmentResponse[]
-  outcomeLogs          OutcomeLog[]
-  messageThreads       MessageThread[]
-  appointments         Appointment[]
-  tasks                Task[]
-  dosingRegimens       DosingRegimen[]
-  doseLogs             DoseLog[]
-  medications          PatientMedication[]
-  claims               Claim[]
-  financialEvents      FinancialEvent[]
-  statements           Statement[]
-  paymentPlans         PaymentPlan[]
-  coverages            PatientCoverage[]
-  paymentMethods       StoredPaymentMethod[]
-  charges              Charge[]
-  eligibilitySnapshots EligibilitySnapshot[]
+  user                     User?                     @relation("PatientUser", fields: [userId], references: [id])
+  organization             Organization              @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  chartSummary             ChartSummary?
+  encounters               Encounter[]
+  documents                Document[]
+  labResults               LabResult[]
+  refillRequests           RefillRequest[]
+  assessmentResponses      AssessmentResponse[]
+  outcomeLogs              OutcomeLog[]
+  messageThreads           MessageThread[]
+  appointments             Appointment[]
+  tasks                    Task[]
+  dosingRegimens           DosingRegimen[]
+  doseLogs                 DoseLog[]
+  medications              PatientMedication[]
+  claims                   Claim[]
+  financialEvents          FinancialEvent[]
+  statements               Statement[]
+  paymentPlans             PaymentPlan[]
+  coverages                PatientCoverage[]
+  paymentMethods           StoredPaymentMethod[]
+  charges                  Charge[]
+  eligibilitySnapshots     EligibilitySnapshot[]
   // Agentic memory harness
-  memories             PatientMemory[]
-  observations         ClinicalObservation[]
-  referrals            Referral[]
-  signedConsents       SignedConsent[]
-  complianceForms      StateComplianceForm[]
-  caregiverInvites     CaregiverInvite[]
-  surveySubmissions    SurveySubmission[]
+  memories                 PatientMemory[]
+  observations             ClinicalObservation[]
+  referrals                Referral[]
+  signedConsents           SignedConsent[]
+  complianceForms          StateComplianceForm[]
+  caregiverInvites         CaregiverInvite[]
+  surveySubmissions        SurveySubmission[]
   // Marketplace
-  orders               Order[]
-  productReviews       ProductReview[]
-  cart                 Cart?
-  shippingAddresses    ShippingAddress[]
-  priorAuthorizations  PriorAuthorization[]
+  orders                   Order[]
+  productReviews           ProductReview[]
+  cart                     Cart?
+  shippingAddresses        ShippingAddress[]
+  priorAuthorizations      PriorAuthorization[]
+  // Phase 8 Track 3 — Pharmacology & Commerce
+  dispensaryReimbursements DispensaryReimbursement[]
 
   @@index([organizationId, status])
   @@index([lastName, firstName])
@@ -617,24 +623,24 @@ enum SubmissionResponseStatus {
 }
 
 model ClearinghouseSubmission {
-  id                String                   @id @default(cuid())
-  claimId           String
-  organizationId    String
-  clearinghouseName String // "Availity", "Waystar", etc.
-  submittedAt       DateTime                 @default(now())
-  ediPayload        String? // 837P payload (stored for audit)
-  ediResponse       String? // raw response body (999/277CA/JSON envelope) — EMR-217 audit trail
-  responseStatus    SubmissionResponseStatus @default(pending)
-  responseCode      String?
-  responseMessage   String?
-  respondedAt       DateTime?
-  retryCount        Int                      @default(0)
+  id                    String                   @id @default(cuid())
+  claimId               String
+  organizationId        String
+  clearinghouseName     String // "Availity", "Waystar", etc.
+  submittedAt           DateTime                 @default(now())
+  ediPayload            String? // 837P payload (stored for audit)
+  ediResponse           String? // raw response body (999/277CA/JSON envelope) — EMR-217 audit trail
+  responseStatus        SubmissionResponseStatus @default(pending)
+  responseCode          String?
+  responseMessage       String?
+  respondedAt           DateTime?
+  retryCount            Int                      @default(0)
   // EMR-219 — secondary submission tracking
   // When non-null, this row is the secondary 837P built from a paid primary;
   // references the primary AdjudicationResult so we can audit the CAS-segment
   // construction back to its source ERA.
   primaryAdjudicationId String?
-  isSecondary           Boolean              @default(false)
+  isSecondary           Boolean                  @default(false)
 
   claim Claim @relation(fields: [claimId], references: [id], onDelete: Cascade)
 
@@ -2775,10 +2781,10 @@ model EducationCompound {
 // --------------------------------------------------------------
 
 enum EraFileStatus {
-  received  // payload stored, not yet parsed
-  parsed    // 835 parsed into AdjudicationResult rows
-  posted    // financial events written, claim balances updated
-  failed    // parse error — see parseError
+  received // payload stored, not yet parsed
+  parsed // 835 parsed into AdjudicationResult rows
+  posted // financial events written, claim balances updated
+  failed // parse error — see parseError
   duplicate // already ingested under a different bankReference (deduped)
 }
 
@@ -2861,11 +2867,11 @@ model PayerContractRate {
 }
 
 enum BankDepositStatus {
-  pending           // not yet attempted to match
-  matched           // matched to ERA(s) / payment(s) — sum equals deposit
+  pending // not yet attempted to match
+  matched // matched to ERA(s) / payment(s) — sum equals deposit
   partially_matched // matched some but not all
-  unmatched         // tried, found no candidates
-  variance          // matched but sums don't reconcile within tolerance
+  unmatched // tried, found no candidates
+  variance // matched but sums don't reconcile within tolerance
 }
 
 /// A real-world deposit on the practice's bank statement. Lockbox
@@ -2927,11 +2933,11 @@ model BankDepositMatch {
 
 enum AppealResult {
   pending
-  overturned   // payer reversed the denial — money recovered
-  upheld       // payer kept the denial — no recovery
-  partial      // partial recovery
-  withdrawn    // we pulled the appeal
-  no_response  // payer never replied within the SLA
+  overturned // payer reversed the denial — money recovered
+  upheld // payer kept the denial — no recovery
+  partial // partial recovery
+  withdrawn // we pulled the appeal
+  no_response // payer never replied within the SLA
 }
 
 /// Outcome of an appeal — feeds the learning loop. Each overturned
@@ -2969,12 +2975,12 @@ model AppealOutcome {
 }
 
 enum PriorAuthStatus {
-  draft       // assembled, not yet submitted
-  submitted   // sent to payer / portal
-  approved    // payer approved — has approvalNumber + expiresAt
-  denied      // payer denied
-  expired     // approval lapsed before service rendered
-  withdrawn   // we pulled the request
+  draft // assembled, not yet submitted
+  submitted // sent to payer / portal
+  approved // payer approved — has approvalNumber + expiresAt
+  denied // payer denied
+  expired // approval lapsed before service rendered
+  withdrawn // we pulled the request
 }
 
 /// Prior authorization workflow. Cannabis services trigger PA on most
@@ -3023,40 +3029,40 @@ model PriorAuthorization {
 /// Generated by the daily-close job at 23:59 local; mailed out the next
 /// morning. The dashboard query reads the latest row + computes deltas.
 model RcmDailyClose {
-  id                 String   @id @default(cuid())
+  id                 String    @id @default(cuid())
   organizationId     String
-  closeDate          DateTime @db.Date
+  closeDate          DateTime  @db.Date
   // -- Counts --------------------------------------------------------
-  claimsCreated      Int      @default(0)
-  claimsSubmitted    Int      @default(0)
-  claimsAccepted     Int      @default(0)
-  claimsRejected     Int      @default(0)
-  claimsPaid         Int      @default(0)
-  claimsDenied       Int      @default(0)
-  claimsAppealed     Int      @default(0)
-  claimsWrittenOff   Int      @default(0)
+  claimsCreated      Int       @default(0)
+  claimsSubmitted    Int       @default(0)
+  claimsAccepted     Int       @default(0)
+  claimsRejected     Int       @default(0)
+  claimsPaid         Int       @default(0)
+  claimsDenied       Int       @default(0)
+  claimsAppealed     Int       @default(0)
+  claimsWrittenOff   Int       @default(0)
   // -- Dollars (cents) ----------------------------------------------
-  billedCents        Int      @default(0)
-  allowedCents       Int      @default(0)
-  paidCents          Int      @default(0)
-  adjustmentCents    Int      @default(0)
-  patientRespCents   Int      @default(0)
-  outstandingArCents Int      @default(0)
-  arBucket0to30      Int      @default(0)
-  arBucket31to60     Int      @default(0)
-  arBucket61to90     Int      @default(0)
-  arBucket91to120    Int      @default(0)
-  arBucket120plus    Int      @default(0)
+  billedCents        Int       @default(0)
+  allowedCents       Int       @default(0)
+  paidCents          Int       @default(0)
+  adjustmentCents    Int       @default(0)
+  patientRespCents   Int       @default(0)
+  outstandingArCents Int       @default(0)
+  arBucket0to30      Int       @default(0)
+  arBucket31to60     Int       @default(0)
+  arBucket61to90     Int       @default(0)
+  arBucket91to120    Int       @default(0)
+  arBucket120plus    Int       @default(0)
   // -- Exception counters (full lists computed live) ----------------
-  staleClaims        Int      @default(0)
-  unbalancedBatches  Int      @default(0)
-  pendingTakebacks   Int      @default(0)
-  unmatchedDeposits  Int      @default(0)
-  overdueAppeals     Int      @default(0)
+  staleClaims        Int       @default(0)
+  unbalancedBatches  Int       @default(0)
+  pendingTakebacks   Int       @default(0)
+  unmatchedDeposits  Int       @default(0)
+  overdueAppeals     Int       @default(0)
   // -- Delivery -----------------------------------------------------
-  emailedAt  DateTime?
-  exportedAt DateTime?
-  createdAt  DateTime  @default(now())
+  emailedAt          DateTime?
+  exportedAt         DateTime?
+  createdAt          DateTime  @default(now())
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
@@ -3065,9 +3071,9 @@ model RcmDailyClose {
 }
 
 enum NsfEventType {
-  nsf         // patient card / ACH bounced
-  chargeback  // disputed and clawed back by issuer
-  reversal    // clearinghouse-initiated reversal (rare)
+  nsf // patient card / ACH bounced
+  chargeback // disputed and clawed back by issuer
+  reversal // clearinghouse-initiated reversal (rare)
 }
 
 /// Negative-payment event: a card NSF, an issuer chargeback, or a
@@ -3116,8 +3122,8 @@ enum PayerClass {
 }
 
 enum CorrectedClaimFrequency {
-  c7        // standard replacement
-  c6        // adjustment
+  c7 // standard replacement
+  c6 // adjustment
   c8_then_1 // void + rebill
 }
 
@@ -3245,4 +3251,311 @@ model ClearinghouseDeadLetter {
 
   @@index([organizationId, resolvedAt])
   @@index([claimId])
+}
+
+// =============================================================
+// Phase 8 — Track 3: Pharmacology & Commerce
+// EMR-002 dispensary integration + SKU scanning
+// EMR-007 AI supply store
+// EMR-017 dispensary locator
+// EMR-018 strain database
+// EMR-039 affiliate partners
+// EMR-145 dispensary CMS reimbursement
+// EMR-151 symptom/supplement combo wheel
+// EMR-188 marketplace ecosystem
+// =============================================================
+
+enum DispensaryFormatDb {
+  flower
+  preroll
+  vape
+  concentrate
+  edible
+  tincture
+  topical
+  capsule
+  beverage
+  other
+}
+
+enum DispensaryStatus {
+  active
+  pending
+  inactive
+}
+
+enum StrainClassification {
+  indica
+  sativa
+  hybrid
+  cbd
+  na
+}
+
+enum AffiliatePartnerStatus {
+  active
+  paused
+  archived
+}
+
+enum SupplyProductCategory {
+  cough_cold
+  sleep
+  pain
+  digestive
+  vitamins_supplements
+  dme
+  topical
+  oral_care
+  mental_health
+  womens_health
+  general_wellness
+}
+
+enum DispensaryReimbursementStatus {
+  draft
+  submitted
+  approved
+  paid
+  denied
+}
+
+enum SupplementCompoundEvidence {
+  strong
+  moderate
+  emerging
+}
+
+/// EMR-002 / EMR-017 — A licensed cannabis dispensary the practice has
+/// integrated with. Distinct from `Vendor` (which models hemp-brand
+/// marketplace sellers) because cannabis dispensaries carry state-specific
+/// licensure, geographic constraints, and a SKU sync surface. A dispensary
+/// MAY also be a Vendor when it lists hemp-derived products in Leafmart;
+/// when that's the case `vendorId` links the two.
+model Dispensary {
+  id             String           @id @default(cuid())
+  organizationId String
+  vendorId       String?          @unique
+  name           String
+  slug           String           @unique
+  licenseNumber  String?
+  licenseState   String // 2-letter USPS state code
+  status         DispensaryStatus @default(active)
+
+  addressLine1 String
+  addressLine2 String?
+  city         String
+  state        String
+  postalCode   String
+  latitude     Float
+  longitude    Float
+  phone        String?
+  websiteUrl   String?
+  hoursLine    String?
+
+  lastSyncedAt DateTime?
+  syncSource   String? // "treez" | "dutchie" | "manual"
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organization   Organization              @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  skus           DispensarySku[]
+  reimbursements DispensaryReimbursement[]
+
+  @@index([organizationId, status])
+  @@index([licenseState])
+}
+
+/// EMR-002 — Stock-keeping unit owned by a Dispensary. Synced from POS
+/// or inventory system; matched to `Strain` when classification is
+/// known. Cents-based price storage avoids float drift on tax math.
+model DispensarySku {
+  id           String               @id @default(cuid())
+  dispensaryId String
+  sku          String
+  upc          String?
+  name         String
+  brand        String?
+  format       DispensaryFormatDb
+  strainType   StrainClassification @default(na)
+  strainId     String?
+
+  thcMgPerUnit Float?
+  cbdMgPerUnit Float?
+  thcPercent   Float?
+  cbdPercent   Float?
+  packSize     String?
+
+  priceCents     Int
+  inStock        Boolean @default(true)
+  inventoryCount Int?
+  imageUrl       String?
+  coaUrl         String?
+  description    String?
+
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  dispensary Dispensary @relation(fields: [dispensaryId], references: [id], onDelete: Cascade)
+  strain     Strain?    @relation(fields: [strainId], references: [id])
+
+  @@unique([dispensaryId, sku])
+  @@index([dispensaryId, active, inStock])
+  @@index([format])
+  @@index([strainId])
+}
+
+/// EMR-018 — Strain reference table. Models the Leafly-style strain
+/// catalog: cannabinoid + terpene profile, common effects, target
+/// symptoms. Strains are practice-agnostic (no organizationId) so the
+/// catalog seeds globally.
+model Strain {
+  id             String               @id @default(cuid())
+  slug           String               @unique
+  name           String
+  classification StrainClassification
+
+  thcPercent Float?
+  cbdPercent Float?
+  cbgPercent Float?
+  cbnPercent Float?
+
+  dominantTerpene String?
+  terpeneProfile  Json? // { myrcene: 0.4, limonene: 0.2, ... }
+
+  symptoms String[] @default([])
+  effects  String[] @default([])
+  flavors  String[] @default([])
+
+  description   String?
+  origin        String?
+  parentStrains String[] @default([])
+  leaflyId      String?
+
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  skus DispensarySku[]
+
+  @@index([classification, active])
+  @@index([leaflyId])
+}
+
+/// EMR-007 — Catalog backing the AI Supply Store. Distinct from the
+/// cannabis `Product` table because supply items are OTC, DME, or
+/// vitamins/supplements that don't carry a cannabinoid profile.
+model SupplyProduct {
+  id               String                @id @default(cuid())
+  organizationId   String
+  slug             String                @unique
+  name             String
+  brand            String?
+  category         SupplyProductCategory
+  description      String
+  shortDescription String?
+  imageUrl         String?
+  priceCents       Int
+
+  symptoms          String[] @default([])
+  conditions        String[] @default([])
+  contraindications String[] @default([])
+
+  isOTC       Boolean @default(true)
+  requiresRx  Boolean @default(false)
+  fsaEligible Boolean @default(false)
+
+  externalUrl     String?
+  externalPartner String?
+
+  active    Boolean  @default(true)
+  featured  Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, active])
+  @@index([category, active])
+}
+
+/// EMR-039 — Affiliate partner brands surfaced in the public store.
+/// Each row drives a card on /store with a disclaimer modal that gates
+/// the redirect. `disclaimerText` lets us tune copy per partner without
+/// a code deploy.
+model AffiliatePartner {
+  id                String                 @id @default(cuid())
+  slug              String                 @unique
+  name              String
+  domain            String
+  websiteUrl        String
+  description       String
+  category          String
+  logoUrl           String?
+  status            AffiliatePartnerStatus @default(active)
+  disclaimerText    String?
+  jointDecisionNote String?
+  utmSource         String?
+  sortOrder         Int                    @default(0)
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+
+  @@index([status, sortOrder])
+}
+
+/// EMR-145 — Cannabis Dispensary Billing + CMS $500 Reimbursement.
+/// Records the practice's monthly reimbursement-eligible spend per
+/// patient. The federal program does not currently reimburse cannabis
+/// directly; the row documents what would qualify under the
+/// per-patient annual cap if the rule changes.
+model DispensaryReimbursement {
+  id                   String                        @id @default(cuid())
+  organizationId       String
+  dispensaryId         String
+  patientId            String
+  serviceMonth         DateTime
+  documentedSpendCents Int
+  reimbursableCents    Int
+  capCents             Int                           @default(50000)
+  notes                String?
+  status               DispensaryReimbursementStatus @default(draft)
+  submittedAt          DateTime?
+  paidAt               DateTime?
+  paymentReference     String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  dispensary   Dispensary   @relation(fields: [dispensaryId], references: [id], onDelete: Cascade)
+  patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@unique([patientId, serviceMonth])
+  @@index([organizationId, status])
+  @@index([dispensaryId, serviceMonth])
+}
+
+/// EMR-151 — Companion to `EducationCompound`, but for non-cannabis
+/// supplements (magnesium, omega-3, melatonin, ashwagandha, etc.) used
+/// in the Symptom/Diagnosis Supplement Combo Wheel. Same structure as
+/// the cannabis wheel so the UI primitives can be reused.
+model SupplementCompound {
+  id                  String                     @id
+  name                String
+  category            String
+  color               String
+  evidence            SupplementCompoundEvidence
+  description         String
+  symptoms            String[]
+  benefits            String[]
+  risks               String[]
+  cannabisInteraction String?
+  sortOrder           Int                        @default(0)
+  active              Boolean                    @default(true)
+  createdAt           DateTime                   @default(now())
+  updatedAt           DateTime                   @updatedAt
+
+  @@index([category, active, sortOrder])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -351,6 +351,908 @@ async function seedMarketplace(organizationId: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 8 Track 3 — Pharmacology & Commerce seed data
+//
+// Seeds:
+//   - Strain reference catalog (EMR-018)
+//   - Dispensaries + SKUs in the SF Bay area (EMR-002 / EMR-017)
+//   - Affiliate partner registry (EMR-039)
+//   - Supply Store catalog (EMR-007)
+//   - Supplement compounds for the Symptom/Diagnosis wheel (EMR-151)
+//   - One reimbursement record per demo patient (EMR-145)
+// ---------------------------------------------------------------------------
+
+async function seedTrack8Data(organizationId: string, patientIds: string[]) {
+  // ----- Strains (EMR-018) -------------------------------------------------
+  const strainSeeds: Array<{
+    slug: string;
+    name: string;
+    classification: "indica" | "sativa" | "hybrid" | "cbd";
+    thcPercent: number;
+    cbdPercent: number;
+    dominantTerpene: string;
+    symptoms: string[];
+    effects: string[];
+    flavors: string[];
+    description: string;
+  }> = [
+    {
+      slug: "northern-lights",
+      name: "Northern Lights",
+      classification: "indica",
+      thcPercent: 18,
+      cbdPercent: 0.5,
+      dominantTerpene: "Myrcene",
+      symptoms: ["insomnia", "pain", "anxiety", "stress"],
+      effects: ["relaxed", "sleepy", "happy"],
+      flavors: ["earthy", "sweet", "pine"],
+      description:
+        "Classic indica beloved for deeply sedating relaxation. A go-to for nighttime pain and sleep onset.",
+    },
+    {
+      slug: "granddaddy-purple",
+      name: "Granddaddy Purple",
+      classification: "indica",
+      thcPercent: 17,
+      cbdPercent: 0.4,
+      dominantTerpene: "Myrcene",
+      symptoms: ["insomnia", "pain", "stress", "appetite"],
+      effects: ["relaxed", "sleepy", "euphoric"],
+      flavors: ["grape", "berry"],
+      description:
+        "Famous purple indica with a sweet grape profile. Heavy body relaxation; appetite-supportive.",
+    },
+    {
+      slug: "blue-dream",
+      name: "Blue Dream",
+      classification: "hybrid",
+      thcPercent: 19,
+      cbdPercent: 0.4,
+      dominantTerpene: "Myrcene",
+      symptoms: ["depression", "pain", "stress", "fatigue"],
+      effects: ["uplifted", "relaxed", "creative"],
+      flavors: ["berry", "sweet"],
+      description:
+        "Sativa-leaning hybrid with gentle full-body relaxation paired with a clear-headed cerebral lift.",
+    },
+    {
+      slug: "sour-diesel",
+      name: "Sour Diesel",
+      classification: "sativa",
+      thcPercent: 22,
+      cbdPercent: 0.2,
+      dominantTerpene: "Caryophyllene",
+      symptoms: ["depression", "fatigue", "stress", "focus"],
+      effects: ["energetic", "uplifted", "focus"],
+      flavors: ["diesel", "pungent"],
+      description:
+        "Energizing sativa with a quick uplifting onset. Daytime use for fatigue and low mood.",
+    },
+    {
+      slug: "girl-scout-cookies",
+      name: "Girl Scout Cookies",
+      classification: "hybrid",
+      thcPercent: 22,
+      cbdPercent: 0.3,
+      dominantTerpene: "Caryophyllene",
+      symptoms: ["pain", "appetite", "nausea", "stress"],
+      effects: ["euphoric", "relaxed", "happy"],
+      flavors: ["sweet", "earthy", "mint"],
+      description:
+        "Potent hybrid favored for chronic pain and nausea. Euphoric body relaxation without total sedation.",
+    },
+    {
+      slug: "harlequin",
+      name: "Harlequin",
+      classification: "cbd",
+      thcPercent: 7,
+      cbdPercent: 9,
+      dominantTerpene: "Myrcene",
+      symptoms: ["anxiety", "pain", "inflammation"],
+      effects: ["clear-headed", "relaxed", "alert"],
+      flavors: ["earthy", "musk"],
+      description:
+        "Reliable 1:1 THC:CBD strain. Clear-headed relief for anxious patients who need to function.",
+    },
+    {
+      slug: "acdc",
+      name: "ACDC",
+      classification: "cbd",
+      thcPercent: 1,
+      cbdPercent: 14,
+      dominantTerpene: "Myrcene",
+      symptoms: ["anxiety", "pain", "seizures", "inflammation"],
+      effects: ["clear-headed", "relaxed", "focus"],
+      flavors: ["earthy", "wood"],
+      description:
+        "High-CBD, low-THC strain. Therapeutic with minimal psychoactive effect — common starting point.",
+    },
+    {
+      slug: "jack-herer",
+      name: "Jack Herer",
+      classification: "sativa",
+      thcPercent: 19,
+      cbdPercent: 0.3,
+      dominantTerpene: "Terpinolene",
+      symptoms: ["depression", "fatigue", "focus", "stress"],
+      effects: ["energetic", "creative", "focus"],
+      flavors: ["pine", "wood"],
+      description:
+        "Bright, focused sativa. Often a first try for daytime mood and concentration support.",
+    },
+    {
+      slug: "wedding-cake",
+      name: "Wedding Cake",
+      classification: "hybrid",
+      thcPercent: 23,
+      cbdPercent: 0.3,
+      dominantTerpene: "Limonene",
+      symptoms: ["pain", "insomnia", "appetite"],
+      effects: ["relaxed", "euphoric", "happy"],
+      flavors: ["sweet", "vanilla"],
+      description:
+        "Indica-leaning hybrid known for full-body calm and a creamy vanilla profile.",
+    },
+    {
+      slug: "cannatonic",
+      name: "Cannatonic",
+      classification: "cbd",
+      thcPercent: 6,
+      cbdPercent: 12,
+      dominantTerpene: "Myrcene",
+      symptoms: ["anxiety", "muscle spasm", "pain"],
+      effects: ["relaxed", "clear-headed"],
+      flavors: ["earthy", "citrus"],
+      description:
+        "High-CBD strain with mild THC. Useful for anxiety and muscle spasms without strong intoxication.",
+    },
+  ];
+
+  const strainIdBySlug = new Map<string, string>();
+  for (const s of strainSeeds) {
+    const row = await prisma.strain.upsert({
+      where: { slug: s.slug },
+      update: {
+        name: s.name,
+        classification: s.classification,
+        thcPercent: s.thcPercent,
+        cbdPercent: s.cbdPercent,
+        dominantTerpene: s.dominantTerpene,
+        symptoms: s.symptoms,
+        effects: s.effects,
+        flavors: s.flavors,
+        description: s.description,
+        active: true,
+      },
+      create: {
+        slug: s.slug,
+        name: s.name,
+        classification: s.classification,
+        thcPercent: s.thcPercent,
+        cbdPercent: s.cbdPercent,
+        dominantTerpene: s.dominantTerpene,
+        symptoms: s.symptoms,
+        effects: s.effects,
+        flavors: s.flavors,
+        description: s.description,
+        active: true,
+      },
+    });
+    strainIdBySlug.set(s.slug, row.id);
+  }
+
+  // ----- Dispensaries (EMR-002 / EMR-017) ---------------------------------
+  const dispensarySeeds: Array<{
+    slug: string;
+    name: string;
+    addressLine1: string;
+    city: string;
+    state: string;
+    postalCode: string;
+    latitude: number;
+    longitude: number;
+    phone: string;
+    websiteUrl: string;
+    hoursLine: string;
+    licenseNumber: string;
+    licenseState: string;
+  }> = [
+    {
+      slug: "leafly-collective-sf",
+      name: "Leafly Collective — SF",
+      addressLine1: "415 Valencia St",
+      city: "San Francisco",
+      state: "CA",
+      postalCode: "94103",
+      latitude: 37.7659,
+      longitude: -122.4222,
+      phone: "+1 415 555 0182",
+      websiteUrl: "https://example.com/leafly-collective",
+      hoursLine: "Mon–Sat 9a–9p · Sun 10a–6p",
+      licenseNumber: "C10-0000123-LIC",
+      licenseState: "CA",
+    },
+    {
+      slug: "oakland-green-room",
+      name: "Oakland Green Room",
+      addressLine1: "1860 Broadway",
+      city: "Oakland",
+      state: "CA",
+      postalCode: "94612",
+      latitude: 37.8084,
+      longitude: -122.2683,
+      phone: "+1 510 555 0144",
+      websiteUrl: "https://example.com/green-room",
+      hoursLine: "Daily 8a–10p",
+      licenseNumber: "C10-0000456-LIC",
+      licenseState: "CA",
+    },
+    {
+      slug: "berkeley-patient-care",
+      name: "Berkeley Patient Care",
+      addressLine1: "2366 Telegraph Ave",
+      city: "Berkeley",
+      state: "CA",
+      postalCode: "94704",
+      latitude: 37.8625,
+      longitude: -122.2585,
+      phone: "+1 510 555 0167",
+      websiteUrl: "https://example.com/bpc",
+      hoursLine: "Mon–Fri 10a–8p",
+      licenseNumber: "C10-0000789-LIC",
+      licenseState: "CA",
+    },
+  ];
+
+  const dispensaryIdBySlug = new Map<string, string>();
+  for (const d of dispensarySeeds) {
+    const row = await prisma.dispensary.upsert({
+      where: { slug: d.slug },
+      update: {
+        name: d.name,
+        addressLine1: d.addressLine1,
+        city: d.city,
+        state: d.state,
+        postalCode: d.postalCode,
+        latitude: d.latitude,
+        longitude: d.longitude,
+        phone: d.phone,
+        websiteUrl: d.websiteUrl,
+        hoursLine: d.hoursLine,
+        status: "active",
+        lastSyncedAt: new Date(),
+      },
+      create: {
+        organizationId,
+        slug: d.slug,
+        name: d.name,
+        addressLine1: d.addressLine1,
+        city: d.city,
+        state: d.state,
+        postalCode: d.postalCode,
+        latitude: d.latitude,
+        longitude: d.longitude,
+        phone: d.phone,
+        websiteUrl: d.websiteUrl,
+        hoursLine: d.hoursLine,
+        licenseNumber: d.licenseNumber,
+        licenseState: d.licenseState,
+        status: "active",
+        syncSource: "manual",
+        lastSyncedAt: new Date(),
+      },
+    });
+    dispensaryIdBySlug.set(d.slug, row.id);
+  }
+
+  // SKU seeds — a handful per dispensary covering the regimen targets in
+  // the demo charts (sleep, pain, anxiety) so the locator's "matches your
+  // regimen" view has something to surface.
+  const skuSeeds: Array<{
+    dispensarySlug: string;
+    sku: string;
+    name: string;
+    brand: string;
+    format:
+      | "flower"
+      | "tincture"
+      | "capsule"
+      | "vape"
+      | "preroll"
+      | "edible"
+      | "topical"
+      | "concentrate";
+    strainSlug?: string;
+    thcMgPerUnit?: number;
+    cbdMgPerUnit?: number;
+    thcPercent?: number;
+    cbdPercent?: number;
+    priceCents: number;
+    inStock: boolean;
+  }> = [
+    {
+      dispensarySlug: "leafly-collective-sf",
+      sku: "LC-NL-3.5",
+      name: "Northern Lights 3.5g",
+      brand: "Sunset Cannabis Co.",
+      format: "flower",
+      strainSlug: "northern-lights",
+      thcPercent: 18,
+      cbdPercent: 0.5,
+      priceCents: 4500,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "leafly-collective-sf",
+      sku: "LC-NF-30",
+      name: "Nightfall Tincture 30mL — 1:1",
+      brand: "Solace Botanica",
+      format: "tincture",
+      strainSlug: "harlequin",
+      thcMgPerUnit: 5,
+      cbdMgPerUnit: 5,
+      priceCents: 5800,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "leafly-collective-sf",
+      sku: "LC-CBD-25",
+      name: "CBD Isolate Capsule 25mg (30ct)",
+      brand: "Canopy Clinical",
+      format: "capsule",
+      strainSlug: "acdc",
+      thcMgPerUnit: 0,
+      cbdMgPerUnit: 25,
+      priceCents: 4200,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "oakland-green-room",
+      sku: "OGR-GDP-3.5",
+      name: "Granddaddy Purple 3.5g",
+      brand: "Sunset Cannabis Co.",
+      format: "flower",
+      strainSlug: "granddaddy-purple",
+      thcPercent: 17,
+      cbdPercent: 0.4,
+      priceCents: 4200,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "oakland-green-room",
+      sku: "OGR-BD-VP",
+      name: "Blue Dream Live Resin Vape 0.5g",
+      brand: "Garden Path",
+      format: "vape",
+      strainSlug: "blue-dream",
+      thcPercent: 78,
+      cbdPercent: 0.3,
+      priceCents: 4800,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "oakland-green-room",
+      sku: "OGR-HRL-30",
+      name: "Harlequin Tincture 30mL — 1:1",
+      brand: "Solace Botanica",
+      format: "tincture",
+      strainSlug: "harlequin",
+      thcMgPerUnit: 5,
+      cbdMgPerUnit: 5,
+      priceCents: 5500,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "berkeley-patient-care",
+      sku: "BPC-ACDC-30",
+      name: "ACDC High-CBD Tincture 30mL",
+      brand: "Canopy Clinical",
+      format: "tincture",
+      strainSlug: "acdc",
+      thcMgPerUnit: 1,
+      cbdMgPerUnit: 20,
+      priceCents: 6800,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "berkeley-patient-care",
+      sku: "BPC-CT-CAP",
+      name: "Cannatonic Capsules 10mg (30ct)",
+      brand: "Canopy Clinical",
+      format: "capsule",
+      strainSlug: "cannatonic",
+      thcMgPerUnit: 2,
+      cbdMgPerUnit: 10,
+      priceCents: 4800,
+      inStock: true,
+    },
+    {
+      dispensarySlug: "berkeley-patient-care",
+      sku: "BPC-WC-PR",
+      name: "Wedding Cake Pre-Roll 1g",
+      brand: "Garden Path",
+      format: "preroll",
+      strainSlug: "wedding-cake",
+      thcPercent: 23,
+      cbdPercent: 0.3,
+      priceCents: 1500,
+      inStock: false,
+    },
+  ];
+
+  for (const sku of skuSeeds) {
+    const dispensaryId = dispensaryIdBySlug.get(sku.dispensarySlug);
+    if (!dispensaryId) continue;
+    const strainId = sku.strainSlug ? strainIdBySlug.get(sku.strainSlug) : null;
+    const strainType = sku.strainSlug
+      ? (strainSeeds.find((s) => s.slug === sku.strainSlug)?.classification ?? "na")
+      : "na";
+    await prisma.dispensarySku.upsert({
+      where: { dispensaryId_sku: { dispensaryId, sku: sku.sku } },
+      update: {
+        name: sku.name,
+        brand: sku.brand,
+        format: sku.format,
+        strainType,
+        strainId: strainId ?? null,
+        thcMgPerUnit: sku.thcMgPerUnit,
+        cbdMgPerUnit: sku.cbdMgPerUnit,
+        thcPercent: sku.thcPercent,
+        cbdPercent: sku.cbdPercent,
+        priceCents: sku.priceCents,
+        inStock: sku.inStock,
+        active: true,
+      },
+      create: {
+        dispensaryId,
+        sku: sku.sku,
+        name: sku.name,
+        brand: sku.brand,
+        format: sku.format,
+        strainType,
+        strainId: strainId ?? null,
+        thcMgPerUnit: sku.thcMgPerUnit,
+        cbdMgPerUnit: sku.cbdMgPerUnit,
+        thcPercent: sku.thcPercent,
+        cbdPercent: sku.cbdPercent,
+        priceCents: sku.priceCents,
+        inStock: sku.inStock,
+      },
+    });
+  }
+
+  // ----- Affiliate partners (EMR-039) -------------------------------------
+  const affiliateSeeds: Array<{
+    slug: string;
+    name: string;
+    domain: string;
+    websiteUrl: string;
+    description: string;
+    category: string;
+    sortOrder: number;
+  }> = [
+    {
+      slug: "phytorx",
+      name: "PhytoRx",
+      domain: "phytorx.co",
+      websiteUrl: "https://phytorx.co/products/cbd-cbg-beverage-concentrate",
+      description:
+        "Physician-formulated CBD + CBG beverage concentrates for pain and recovery. Fast-absorbing emulsion technology developed with clinical input.",
+      category: "Beverages",
+      sortOrder: 10,
+    },
+    {
+      slug: "flower-powered-products",
+      name: "Flower Powered Products",
+      domain: "flowerpoweredproductsllc.com",
+      websiteUrl: "https://flowerpoweredproductsllc.com/shop",
+      description:
+        "Full line of CBD-only wellness products. Topicals, balms, and creams. Third-party tested, physician-recommended.",
+      category: "Topicals",
+      sortOrder: 20,
+    },
+    {
+      slug: "aulv",
+      name: "AULV Wellness",
+      domain: "aulv.org",
+      websiteUrl: "https://aulv.org",
+      description:
+        "Wellness collective focused on plant-based therapies, education, and community-supported research. Curated alongside our care team.",
+      category: "Wellness",
+      sortOrder: 30,
+    },
+  ];
+  const DEFAULT_DISCLAIMER =
+    "You are leaving Leafjourney to visit a partner website. Please consult your healthcare provider before considering these products. Cannabis products are not FDA-approved medications and individual results may vary. This is a joint decision between you and your care team.";
+  const JOINT_DECISION_NOTE =
+    "Adding any product to your regimen is a joint decision between you and your care team. Bring this product up at your next visit so we can document it and watch for interactions.";
+  for (const p of affiliateSeeds) {
+    await prisma.affiliatePartner.upsert({
+      where: { slug: p.slug },
+      update: {
+        name: p.name,
+        domain: p.domain,
+        websiteUrl: p.websiteUrl,
+        description: p.description,
+        category: p.category,
+        status: "active",
+        disclaimerText: DEFAULT_DISCLAIMER,
+        jointDecisionNote: JOINT_DECISION_NOTE,
+        utmSource: "leafjourney",
+        sortOrder: p.sortOrder,
+      },
+      create: {
+        slug: p.slug,
+        name: p.name,
+        domain: p.domain,
+        websiteUrl: p.websiteUrl,
+        description: p.description,
+        category: p.category,
+        status: "active",
+        disclaimerText: DEFAULT_DISCLAIMER,
+        jointDecisionNote: JOINT_DECISION_NOTE,
+        utmSource: "leafjourney",
+        sortOrder: p.sortOrder,
+      },
+    });
+  }
+
+  // ----- Supply Store (EMR-007) -------------------------------------------
+  const supplySeeds: Array<{
+    slug: string;
+    name: string;
+    brand: string;
+    category:
+      | "cough_cold"
+      | "sleep"
+      | "pain"
+      | "digestive"
+      | "vitamins_supplements"
+      | "dme"
+      | "topical"
+      | "oral_care"
+      | "mental_health"
+      | "general_wellness";
+    description: string;
+    shortDescription: string;
+    priceCents: number;
+    symptoms: string[];
+    conditions: string[];
+    contraindications: string[];
+    fsaEligible: boolean;
+    featured: boolean;
+  }> = [
+    {
+      slug: "magnesium-glycinate-200mg",
+      name: "Magnesium Glycinate 200mg",
+      brand: "Pure Roots",
+      category: "sleep",
+      description:
+        "Highly bioavailable magnesium glycinate. 200mg per capsule, 90 count. Calms the nervous system and supports sleep.",
+      shortDescription: "Sleep + muscle support · 90ct",
+      priceCents: 2299,
+      symptoms: ["insomnia", "sleep", "muscle tension", "anxiety"],
+      conditions: ["insomnia", "anxiety"],
+      contraindications: ["kidney disease"],
+      fsaEligible: true,
+      featured: true,
+    },
+    {
+      slug: "low-dose-melatonin-0_5mg",
+      name: "Low-Dose Melatonin 0.5mg",
+      brand: "Pure Roots",
+      category: "sleep",
+      description:
+        "Sublingual melatonin at the physiologic dose (0.5mg). Stacks safely with bedtime CBN. 60 count.",
+      shortDescription: "Sublingual · 60ct · 0.5mg",
+      priceCents: 1499,
+      symptoms: ["insomnia", "jet lag", "shift work"],
+      conditions: ["insomnia"],
+      contraindications: ["pregnant"],
+      fsaEligible: true,
+      featured: false,
+    },
+    {
+      slug: "elderberry-zinc-throat-spray",
+      name: "Elderberry + Zinc Throat Spray",
+      brand: "Pure Roots",
+      category: "cough_cold",
+      description:
+        "Elderberry, zinc, and propolis throat spray for early cough and sore throat. 30mL.",
+      shortDescription: "Cough + sore throat · 30mL",
+      priceCents: 1299,
+      symptoms: ["cough", "sore throat"],
+      conditions: ["common cold"],
+      contraindications: [],
+      fsaEligible: false,
+      featured: false,
+    },
+    {
+      slug: "omega-3-1000mg",
+      name: "Omega-3 EPA/DHA 1000mg",
+      brand: "Pure Roots",
+      category: "vitamins_supplements",
+      description:
+        "Triple-strength fish oil. 600mg EPA + 400mg DHA per softgel. Supports anti-inflammatory and cognitive pathways.",
+      shortDescription: "Anti-inflammatory · 90ct softgels",
+      priceCents: 2799,
+      symptoms: ["inflammation", "joint pain", "mood", "cognition"],
+      conditions: ["chronic inflammation"],
+      contraindications: ["warfarin"],
+      fsaEligible: true,
+      featured: true,
+    },
+    {
+      slug: "ashwagandha-600mg",
+      name: "Ashwagandha KSM-66 600mg",
+      brand: "Pure Roots",
+      category: "mental_health",
+      description:
+        "KSM-66 standardized ashwagandha extract. 600mg per capsule. Adaptogen for stress and HPA axis support.",
+      shortDescription: "Stress + cortisol · 60ct",
+      priceCents: 2499,
+      symptoms: ["stress", "anxiety", "fatigue"],
+      conditions: ["anxiety"],
+      contraindications: ["thyroid disease"],
+      fsaEligible: false,
+      featured: false,
+    },
+    {
+      slug: "compression-knee-sleeve",
+      name: "Compression Knee Sleeve",
+      brand: "MoveWell",
+      category: "dme",
+      description:
+        "Medical-grade compression sleeve for knee pain and post-exercise recovery. Sized S/M/L/XL.",
+      shortDescription: "Joint support · medical-grade",
+      priceCents: 3499,
+      symptoms: ["joint pain", "knee pain"],
+      conditions: ["osteoarthritis"],
+      contraindications: [],
+      fsaEligible: true,
+      featured: false,
+    },
+    {
+      slug: "vitamin-d3-k2-5000iu",
+      name: "Vitamin D3 + K2 5000IU",
+      brand: "Pure Roots",
+      category: "vitamins_supplements",
+      description:
+        "Vitamin D3 with cofactor K2 (MK-7). 5000IU per softgel. Mood, immune, and bone support.",
+      shortDescription: "Mood + immune · 90ct softgels",
+      priceCents: 1899,
+      symptoms: ["fatigue", "mood", "immunity"],
+      conditions: ["vitamin d deficiency"],
+      contraindications: [],
+      fsaEligible: true,
+      featured: false,
+    },
+    {
+      slug: "menthol-arnica-pain-rub",
+      name: "Menthol + Arnica Pain Rub",
+      brand: "MoveWell",
+      category: "topical",
+      description:
+        "Cooling menthol topical with arnica extract. For sore muscles and minor joint pain. 4oz tube.",
+      shortDescription: "Cooling topical · 4oz",
+      priceCents: 1599,
+      symptoms: ["muscle pain", "joint pain", "soreness"],
+      conditions: ["myalgia"],
+      contraindications: ["broken skin"],
+      fsaEligible: true,
+      featured: false,
+    },
+  ];
+  for (const s of supplySeeds) {
+    await prisma.supplyProduct.upsert({
+      where: { slug: s.slug },
+      update: {
+        name: s.name,
+        brand: s.brand,
+        category: s.category,
+        description: s.description,
+        shortDescription: s.shortDescription,
+        priceCents: s.priceCents,
+        symptoms: s.symptoms,
+        conditions: s.conditions,
+        contraindications: s.contraindications,
+        isOTC: true,
+        fsaEligible: s.fsaEligible,
+        featured: s.featured,
+        active: true,
+      },
+      create: {
+        organizationId,
+        slug: s.slug,
+        name: s.name,
+        brand: s.brand,
+        category: s.category,
+        description: s.description,
+        shortDescription: s.shortDescription,
+        priceCents: s.priceCents,
+        symptoms: s.symptoms,
+        conditions: s.conditions,
+        contraindications: s.contraindications,
+        isOTC: true,
+        fsaEligible: s.fsaEligible,
+        featured: s.featured,
+      },
+    });
+  }
+
+  // ----- Supplement compounds (EMR-151) -----------------------------------
+  // Mirrors the BUILTIN_SUPPLEMENTS list in src/lib/domain/supplement-wheel.ts
+  // so the wheel renders the same content with or without DB connectivity.
+  const supplementSeeds: Array<{
+    id: string;
+    name: string;
+    category: string;
+    color: string;
+    evidence: "strong" | "moderate" | "emerging";
+    description: string;
+    symptoms: string[];
+    benefits: string[];
+    risks: string[];
+    cannabisInteraction: string;
+    sortOrder: number;
+  }> = [
+    {
+      id: "magnesium-glycinate",
+      name: "Magnesium Glycinate",
+      category: "Mineral",
+      color: "#7C9F8C",
+      evidence: "strong",
+      description: "Highly bioavailable form of magnesium with calming effects.",
+      symptoms: ["sleep", "muscle tension", "anxiety"],
+      benefits: ["Improves sleep onset", "Reduces nighttime cramps", "Calms nervous system"],
+      risks: ["Loose stools at high doses"],
+      cannabisInteraction: "Generally synergistic with CBD for sleep and muscle relaxation.",
+      sortOrder: 10,
+    },
+    {
+      id: "melatonin",
+      name: "Melatonin",
+      category: "Hormone",
+      color: "#5B6F8E",
+      evidence: "strong",
+      description: "Endogenous sleep-onset hormone; useful for shifted circadian rhythms.",
+      symptoms: ["sleep", "jet lag", "shift work"],
+      benefits: ["Shortens sleep latency", "Stabilizes sleep timing"],
+      risks: ["Morning grogginess at >1 mg", "Vivid dreams"],
+      cannabisInteraction: "Stack low-dose melatonin (0.3–1 mg) with bedtime CBN for sleep.",
+      sortOrder: 20,
+    },
+    {
+      id: "omega-3",
+      name: "Omega-3 (EPA/DHA)",
+      category: "Essential Fatty Acid",
+      color: "#3F7D8A",
+      evidence: "strong",
+      description: "EPA + DHA fish oil; supports anti-inflammatory and cognitive pathways.",
+      symptoms: ["inflammation", "joint pain", "mood", "cognition"],
+      benefits: ["Reduces systemic inflammation", "Supports mood stability"],
+      risks: ["Mild blood-thinning at high doses"],
+      cannabisInteraction: "Complements CBD's anti-inflammatory action.",
+      sortOrder: 30,
+    },
+    {
+      id: "ashwagandha",
+      name: "Ashwagandha",
+      category: "Adaptogen",
+      color: "#9C7C5A",
+      evidence: "moderate",
+      description: "Ayurvedic adaptogen; shown to lower cortisol and support resilience.",
+      symptoms: ["stress", "anxiety", "fatigue"],
+      benefits: ["Lowers cortisol", "Improves stress resilience"],
+      risks: ["Avoid with thyroid medications without supervision"],
+      cannabisInteraction: "Pairs well with mid-day microdose CBD for stress without sedation.",
+      sortOrder: 40,
+    },
+    {
+      id: "l-theanine",
+      name: "L-Theanine",
+      category: "Amino",
+      color: "#6FA89A",
+      evidence: "strong",
+      description: "Amino acid from green tea; promotes alpha brainwaves and calm focus.",
+      symptoms: ["anxiety", "focus", "stress"],
+      benefits: ["Calm without sedation", "Smooths caffeine"],
+      risks: ["Generally well-tolerated"],
+      cannabisInteraction: "Can offset THC-induced anxiety; safe to combine.",
+      sortOrder: 50,
+    },
+    {
+      id: "vitamin-d3",
+      name: "Vitamin D3",
+      category: "Vitamin",
+      color: "#D4A04E",
+      evidence: "strong",
+      description: "Sun-derived vitamin; deficiency linked to mood and immune issues.",
+      symptoms: ["fatigue", "mood", "immunity"],
+      benefits: ["Mood support", "Immune function"],
+      risks: ["Toxic at very high doses without K2 cofactor"],
+      cannabisInteraction: "No notable interaction; foundational stack.",
+      sortOrder: 60,
+    },
+  ];
+  for (const s of supplementSeeds) {
+    await prisma.supplementCompound.upsert({
+      where: { id: s.id },
+      update: {
+        name: s.name,
+        category: s.category,
+        color: s.color,
+        evidence: s.evidence,
+        description: s.description,
+        symptoms: s.symptoms,
+        benefits: s.benefits,
+        risks: s.risks,
+        cannabisInteraction: s.cannabisInteraction,
+        sortOrder: s.sortOrder,
+        active: true,
+      },
+      create: {
+        id: s.id,
+        name: s.name,
+        category: s.category,
+        color: s.color,
+        evidence: s.evidence,
+        description: s.description,
+        symptoms: s.symptoms,
+        benefits: s.benefits,
+        risks: s.risks,
+        cannabisInteraction: s.cannabisInteraction,
+        sortOrder: s.sortOrder,
+        active: true,
+      },
+    });
+  }
+
+  // ----- Reimbursement records (EMR-145) ----------------------------------
+  // Each demo patient gets one prior-month record so the operator
+  // dashboard renders meaningful data on first load.
+  const now = new Date();
+  const lastMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  const dispensariesArr = Array.from(dispensaryIdBySlug.values());
+  const reimbursementRows: Array<{
+    patientId: string;
+    dispensaryId: string;
+    documentedSpendCents: number;
+    reimbursableCents: number;
+    status: "draft" | "submitted" | "approved";
+  }> = patientIds.map((pid, i) => ({
+    patientId: pid,
+    dispensaryId: dispensariesArr[i % dispensariesArr.length],
+    documentedSpendCents: 18_000 + i * 6_000,
+    reimbursableCents: Math.min(50_000, 18_000 + i * 6_000),
+    status: i === 0 ? "approved" : i === 1 ? "submitted" : "draft",
+  }));
+  for (const r of reimbursementRows) {
+    await prisma.dispensaryReimbursement.upsert({
+      where: { patientId_serviceMonth: { patientId: r.patientId, serviceMonth: lastMonth } },
+      update: {
+        documentedSpendCents: r.documentedSpendCents,
+        reimbursableCents: r.reimbursableCents,
+        status: r.status,
+      },
+      create: {
+        organizationId,
+        dispensaryId: r.dispensaryId,
+        patientId: r.patientId,
+        serviceMonth: lastMonth,
+        documentedSpendCents: r.documentedSpendCents,
+        reimbursableCents: r.reimbursableCents,
+        status: r.status,
+      },
+    });
+  }
+
+  console.log(
+    `  Track 8: ${strainSeeds.length} strains, ${dispensarySeeds.length} dispensaries, ${skuSeeds.length} SKUs, ${affiliateSeeds.length} affiliates, ${supplySeeds.length} supply items, ${supplementSeeds.length} supplement compounds, ${reimbursementRows.length} reimbursement rows.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -3474,6 +4376,12 @@ async function main() {
   // ------------------------------------------------------------------
   console.log("Seeding marketplace catalog...");
   await seedMarketplace(org.id);
+
+  // ------------------------------------------------------------------
+  // Phase 8 Track 3 — Pharmacology & Commerce
+  // ------------------------------------------------------------------
+  console.log("Seeding Track 8 pharmacology + commerce data...");
+  await seedTrack8Data(org.id, [maya.id, james.id, sarah.id]);
 
   // ------------------------------------------------------------------
   // Done

--- a/src/app/(clinician)/clinic/dispensaries/page.tsx
+++ b/src/app/(clinician)/clinic/dispensaries/page.tsx
@@ -1,0 +1,151 @@
+// EMR-002 / EMR-017 — Clinician dispensary directory.
+//
+// A first-pass locator surface. Lists every dispensary registered to
+// the practice with active SKU counts and last-sync timestamp. Until
+// we wire up Google Maps embed (Maps API key gated), the list view
+// surfaces enough to triage: which integrations are healthy, which
+// have stale catalogs, and which carry stock right now.
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { getCurrentUser } from "@/lib/auth/session";
+import { listDispensariesForOrg } from "@/lib/dispensary";
+import { ROLE_HOME } from "@/lib/rbac/roles";
+
+export const metadata = { title: "Dispensaries" };
+
+function relativeAge(date: Date | null | undefined): string {
+  if (!date) return "Never synced";
+  const ms = Date.now() - new Date(date).getTime();
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "Synced just now";
+  if (min < 60) return `Synced ${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `Synced ${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `Synced ${d}d ago`;
+}
+
+export default async function ClinicDispensariesPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (
+    !user.roles.some((r) => r === "clinician" || r === "practice_owner" || r === "operator")
+  ) {
+    redirect(ROLE_HOME[user.roles[0]] ?? "/");
+  }
+  if (!user.organizationId) {
+    return (
+      <PageShell maxWidth="max-w-[960px]">
+        <PageHeader title="Dispensaries" eyebrow="Locator" description="No practice selected." />
+      </PageShell>
+    );
+  }
+
+  const dispensaries = await listDispensariesForOrg(user.organizationId);
+  const active = dispensaries.filter((d) => d.status === "active");
+  const inactive = dispensaries.filter((d) => d.status !== "active");
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Pharmacology"
+        title="Dispensary directory"
+        description="Licensed dispensaries integrated with this practice. Clinicians can match patient regimens to live SKUs nearby."
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Active</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">{active.length}</p>
+            <p className="text-xs text-text-muted mt-1">
+              Receiving SKU sync feeds.
+            </p>
+          </CardContent>
+        </Card>
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Live SKUs</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">
+              {active.reduce((acc, d) => acc + d.skuCount, 0).toLocaleString()}
+            </p>
+            <p className="text-xs text-text-muted mt-1">
+              In stock across all dispensaries.
+            </p>
+          </CardContent>
+        </Card>
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Pending / Inactive</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">{inactive.length}</p>
+            <p className="text-xs text-text-muted mt-1">
+              Awaiting credentials or paused.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {dispensaries.length === 0 ? (
+        <EmptyState
+          icon={<LeafSprig size={28} className="text-accent" />}
+          title="No dispensaries yet"
+          description="Register a dispensary integration to start syncing SKUs and pinning locations on the patient locator map."
+        />
+      ) : (
+        <div className="space-y-3">
+          {dispensaries.map((d) => (
+            <Card key={d.id} tone="raised">
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="min-w-0">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      {d.name}
+                      <Badge tone={d.status === "active" ? "success" : "warning"}>
+                        {d.status}
+                      </Badge>
+                    </CardTitle>
+                    <p className="text-xs text-text-muted mt-1">
+                      {d.addressLine1}, {d.city}, {d.state} {d.postalCode}
+                    </p>
+                  </div>
+                  <div className="text-right text-xs text-text-muted shrink-0">
+                    <p className="font-medium text-text">{d.skuCount.toLocaleString()} SKUs</p>
+                    <p className="mt-0.5">{relativeAge(d.lastSyncedAt)}</p>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="flex flex-wrap gap-3 text-xs text-text-muted">
+                  {d.phone && <span>📞 {d.phone}</span>}
+                  {d.hoursLine && <span>🕒 {d.hoursLine}</span>}
+                  {d.websiteUrl && (
+                    <Link
+                      href={d.websiteUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-accent hover:underline"
+                    >
+                      Visit site →
+                    </Link>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/dispensary-reimbursement/page.tsx
+++ b/src/app/(operator)/ops/dispensary-reimbursement/page.tsx
@@ -1,0 +1,184 @@
+// EMR-145 — Cannabis Dispensary Billing dashboard.
+//
+// Operators document each patient's monthly cannabis spend so the
+// practice has a clean audit trail ready when the federal $500
+// reimbursement program goes live. The page lists every recorded
+// reimbursement row, its status, and the YTD running total per
+// patient.
+
+import { redirect } from "next/navigation";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { getCurrentUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { DEFAULT_CAP_CENTS } from "@/lib/dispensary";
+import { ROLE_HOME } from "@/lib/rbac/roles";
+
+export const metadata = { title: "Dispensary reimbursement" };
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function statusTone(status: string): "success" | "warning" | "accent" | "neutral" {
+  switch (status) {
+    case "paid":
+    case "approved":
+      return "success";
+    case "submitted":
+      return "accent";
+    case "denied":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+function monthLabel(d: Date): string {
+  return d.toLocaleString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
+}
+
+export default async function DispensaryReimbursementPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (
+    !user.roles.some((r) => r === "operator" || r === "practice_owner")
+  ) {
+    redirect(ROLE_HOME[user.roles[0]] ?? "/");
+  }
+  if (!user.organizationId) {
+    return (
+      <PageShell maxWidth="max-w-[960px]">
+        <PageHeader title="Dispensary reimbursement" eyebrow="Billing" description="No practice selected." />
+      </PageShell>
+    );
+  }
+
+  const rows = await prisma.dispensaryReimbursement.findMany({
+    where: { organizationId: user.organizationId },
+    orderBy: [{ serviceMonth: "desc" }, { createdAt: "desc" }],
+    include: {
+      dispensary: { select: { name: true } },
+      patient: { select: { firstName: true, lastName: true } },
+    },
+  });
+
+  const totalDocumented = rows.reduce((s, r) => s + r.documentedSpendCents, 0);
+  const totalReimbursable = rows.reduce((s, r) => s + r.reimbursableCents, 0);
+  const submittedCount = rows.filter((r) => r.status === "submitted" || r.status === "approved").length;
+
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Billing — Cannabis"
+        title="Dispensary reimbursement"
+        description="Monthly cannabis spend documentation per patient. Cap defaults to $500/year per patient. Federal reimbursement is not currently available; this is the audit-ready record set."
+      />
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Documented spend</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">{dollars(totalDocumented)}</p>
+            <p className="text-xs text-text-muted mt-1">Across all months on file.</p>
+          </CardContent>
+        </Card>
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Reimbursable (capped)</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">{dollars(totalReimbursable)}</p>
+            <p className="text-xs text-text-muted mt-1">
+              Cap: {dollars(DEFAULT_CAP_CENTS)} / patient / year.
+            </p>
+          </CardContent>
+        </Card>
+        <Card tone="raised">
+          <CardContent className="py-5">
+            <Eyebrow>Pending or approved</Eyebrow>
+            <p className="font-display text-3xl mt-2 text-text">{submittedCount}</p>
+            <p className="text-xs text-text-muted mt-1">
+              Rows submitted to a payer or in review.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          icon={<LeafSprig size={28} className="text-accent" />}
+          title="No reimbursement records yet"
+          description="When a patient documents cannabis spend, it shows up here. The annual cap ($500) is the maximum reimbursable per patient per calendar year."
+        />
+      ) : (
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="text-base">Reimbursement records</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left">
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
+                      Patient
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
+                      Dispensary
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
+                      Service month
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide text-right">
+                      Spend
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide text-right">
+                      Reimbursable
+                    </th>
+                    <th className="py-2 font-medium text-text-subtle text-xs uppercase tracking-wide">
+                      Status
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/40">
+                  {rows.map((r) => (
+                    <tr key={r.id}>
+                      <td className="py-3 pr-4 font-medium text-text">
+                        {r.patient.firstName} {r.patient.lastName}
+                      </td>
+                      <td className="py-3 pr-4 text-text-muted">{r.dispensary.name}</td>
+                      <td className="py-3 pr-4 text-text-muted">{monthLabel(r.serviceMonth)}</td>
+                      <td className="py-3 pr-4 text-right tabular-nums">
+                        {dollars(r.documentedSpendCents)}
+                      </td>
+                      <td className="py-3 pr-4 text-right tabular-nums">
+                        {dollars(r.reimbursableCents)}
+                      </td>
+                      <td className="py-3">
+                        <Badge tone={statusTone(r.status)}>{r.status}</Badge>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <p className="text-[11px] text-text-subtle mt-6 max-w-2xl leading-relaxed">
+        These records prepare the practice for the proposed federal $500/year
+        cannabis reimbursement program. Until that goes live, rows here are
+        an audit-ready paper trail — not a billable claim.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/app/(patient)/portal/dispensaries/page.tsx
+++ b/src/app/(patient)/portal/dispensaries/page.tsx
@@ -1,0 +1,139 @@
+// EMR-002 / EMR-017 — Patient dispensary locator.
+//
+// Shows dispensaries within ~30 miles of the patient's home address,
+// distance-sorted. The Google Maps embed is feature-flagged behind
+// NEXT_PUBLIC_GOOGLE_MAPS_API_KEY — when present we render the map
+// inlay; otherwise we fall back to the address list. This keeps the
+// page working in dev environments without leaking the prod key.
+
+import { redirect } from "next/navigation";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { getCurrentUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { listDispensariesForOrg, filterNearby } from "@/lib/dispensary";
+import { ROLE_HOME } from "@/lib/rbac/roles";
+import Link from "next/link";
+
+export const metadata = { title: "Find a dispensary" };
+
+const DEFAULT_ORIGIN = { lat: 37.7749, lng: -122.4194 }; // SF fallback
+
+export default async function PatientDispensariesPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.roles.includes("patient")) {
+    redirect(ROLE_HOME[user.roles[0]] ?? "/");
+  }
+  if (!user.organizationId) {
+    return (
+      <PageShell maxWidth="max-w-[960px]">
+        <PageHeader title="Find a dispensary" eyebrow="Locator" description="No practice selected." />
+      </PageShell>
+    );
+  }
+
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, organizationId: user.organizationId, deletedAt: null },
+    select: { id: true, addressLine1: true, city: true, state: true, postalCode: true },
+  });
+
+  // Until we add a `latitude`/`longitude` to Patient, we fall back to a
+  // city-level centroid lookup. For now the SF fallback keeps the page
+  // useful in dev; in prod we'd geocode the patient address on save.
+  const origin = DEFAULT_ORIGIN;
+
+  const dispensaries = await listDispensariesForOrg(user.organizationId);
+  const nearby = filterNearby(dispensaries, origin, 30);
+
+  const mapsKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  // Construct the search query string for Maps embed (or a directions
+  // link fallback) — comma-separated coordinate list pinned by name.
+  const mapEmbedSrc = mapsKey
+    ? `https://www.google.com/maps/embed/v1/search?key=${mapsKey}&q=cannabis+dispensary&center=${origin.lat},${origin.lng}&zoom=11`
+    : null;
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Find your products"
+        title="Dispensaries near you"
+        description="Licensed dispensaries within 30 miles of your home address. Tap to see hours, phone, and directions."
+      />
+
+      {mapEmbedSrc ? (
+        <Card tone="raised" className="mb-6 overflow-hidden">
+          <iframe
+            title="Dispensary map"
+            src={mapEmbedSrc}
+            className="w-full h-[320px] border-0"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </Card>
+      ) : (
+        <Card tone="raised" className="mb-6">
+          <CardContent className="py-4 text-xs text-text-muted">
+            Map view will appear here once the practice configures a Google
+            Maps API key. Address details are listed below.
+          </CardContent>
+        </Card>
+      )}
+
+      {nearby.length === 0 ? (
+        <EmptyState
+          icon={<LeafSprig size={28} className="text-accent" />}
+          title="No dispensaries nearby"
+          description="Your practice hasn't connected a dispensary in your area yet. Check back soon — your care team is working on it."
+        />
+      ) : (
+        <div className="space-y-3">
+          {nearby.map((d) => (
+            <Card key={d.id} tone="raised">
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <CardTitle className="text-base">{d.name}</CardTitle>
+                  <Badge tone="accent">
+                    {d.distanceMiles.toFixed(1)} mi
+                  </Badge>
+                </div>
+                <p className="text-xs text-text-muted mt-1">
+                  {d.geo.addressLine1}, {d.geo.city}, {d.geo.state} {d.geo.postalCode}
+                </p>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="flex flex-wrap gap-3 text-xs text-text-muted items-center">
+                  {d.geo.phone && <span>📞 {d.geo.phone}</span>}
+                  {d.geo.hoursLine && <span>🕒 {d.geo.hoursLine}</span>}
+                  <span>📦 {d.skuCount.toLocaleString()} products in stock</span>
+                  <Link
+                    href={`https://www.google.com/maps/dir/?api=1&destination=${d.geo.lat},${d.geo.lng}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent hover:underline ml-auto"
+                  >
+                    Get directions →
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <p className="text-[11px] text-text-subtle mt-8 max-w-md leading-relaxed">
+        Distances are approximate. Always confirm hours and inventory by
+        calling the dispensary before you visit.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/app/(patient)/portal/strains/page.tsx
+++ b/src/app/(patient)/portal/strains/page.tsx
@@ -1,0 +1,216 @@
+// EMR-018 — Patient strain finder.
+//
+// Server component renders the catalog and ranks against optional
+// symptom + classification filters from the URL query string. Keeping
+// the filter state in the URL means the page is shareable and the
+// patient's clinician can preview the same set on a chart.
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Eyebrow } from "@/components/ui/ornament";
+import { getCurrentUser } from "@/lib/auth/session";
+import { ROLE_HOME } from "@/lib/rbac/roles";
+import {
+  listActiveStrains,
+  rankStrains,
+  type StrainClassification,
+} from "@/lib/strains";
+
+export const metadata = { title: "Strain Finder" };
+
+const CLASSIFICATIONS: { value: StrainClassification; label: string }[] = [
+  { value: "indica", label: "Indica" },
+  { value: "sativa", label: "Sativa" },
+  { value: "hybrid", label: "Hybrid" },
+  { value: "cbd", label: "CBD-dominant" },
+];
+
+const COMMON_SYMPTOMS = [
+  "sleep",
+  "anxiety",
+  "pain",
+  "stress",
+  "nausea",
+  "appetite",
+  "depression",
+  "fatigue",
+  "focus",
+];
+
+export default async function StrainFinderPage({
+  searchParams,
+}: {
+  searchParams?: { symptoms?: string; class?: string };
+}) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.roles.includes("patient")) {
+    redirect(ROLE_HOME[user.roles[0]] ?? "/");
+  }
+
+  const symptomsParam = searchParams?.symptoms ?? "";
+  const classParam = (searchParams?.class ?? "") as StrainClassification | "";
+  const symptoms = symptomsParam
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const preferredClassification = CLASSIFICATIONS.some((c) => c.value === classParam)
+    ? (classParam as StrainClassification)
+    : undefined;
+
+  const strains = await listActiveStrains();
+  const ranked = rankStrains(strains, {
+    symptoms,
+    preferredClassification,
+  });
+
+  const hasFilter = symptoms.length > 0 || preferredClassification !== undefined;
+  const display = hasFilter
+    ? ranked
+    : strains.slice(0, 24).map((s) => ({
+        strain: s,
+        score: 0,
+        matchedSymptoms: [] as string[],
+        reasons: [] as string[],
+      }));
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Cannabis pharmacology"
+        title="Strain Finder"
+        description="Match your symptoms to flower strains drawn from our Leafly-aligned reference catalog. Always discuss strain choices with your care team."
+      />
+
+      <Card tone="raised" className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-base">Tell us what you're working on</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form method="get" className="space-y-4">
+            <div>
+              <Eyebrow className="mb-2">Symptoms</Eyebrow>
+              <div className="flex flex-wrap gap-2">
+                {COMMON_SYMPTOMS.map((s) => {
+                  const active = symptoms.includes(s);
+                  const next = active
+                    ? symptoms.filter((x) => x !== s)
+                    : [...symptoms, s];
+                  const href = `?symptoms=${encodeURIComponent(next.join(","))}${preferredClassification ? `&class=${preferredClassification}` : ""}`;
+                  return (
+                    <Link
+                      key={s}
+                      href={href}
+                      prefetch={false}
+                      className={
+                        active
+                          ? "px-3 py-1.5 rounded-full text-xs font-medium bg-accent text-accent-ink shadow-sm"
+                          : "px-3 py-1.5 rounded-full text-xs font-medium bg-surface-muted text-text-muted hover:bg-surface-raised"
+                      }
+                    >
+                      {s}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+            <div>
+              <Eyebrow className="mb-2">Classification</Eyebrow>
+              <div className="flex flex-wrap gap-2">
+                {CLASSIFICATIONS.map((c) => {
+                  const active = preferredClassification === c.value;
+                  const params = new URLSearchParams();
+                  if (symptoms.length > 0) params.set("symptoms", symptoms.join(","));
+                  if (!active) params.set("class", c.value);
+                  return (
+                    <Link
+                      key={c.value}
+                      href={`?${params.toString()}`}
+                      prefetch={false}
+                      className={
+                        active
+                          ? "px-3 py-1.5 rounded-full text-xs font-medium bg-accent text-accent-ink shadow-sm"
+                          : "px-3 py-1.5 rounded-full text-xs font-medium bg-surface-muted text-text-muted hover:bg-surface-raised"
+                      }
+                    >
+                      {c.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-text-muted mb-4">
+        {hasFilter
+          ? `${display.length} strain${display.length === 1 ? "" : "s"} match your filter.`
+          : `Showing ${display.length} popular strains. Add a symptom to refine.`}
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {display.map(({ strain, score, matchedSymptoms }) => (
+          <Card key={strain.id} tone="raised">
+            <CardHeader className="pb-2">
+              <div className="flex items-start justify-between gap-3">
+                <CardTitle className="text-base">{strain.name}</CardTitle>
+                <Badge tone="accent">{strain.classification}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2 text-[11px] text-text-muted mb-2">
+                {strain.thcPercent !== null && <span>THC {strain.thcPercent}%</span>}
+                {strain.cbdPercent !== null && strain.cbdPercent > 0.5 && (
+                  <span>CBD {strain.cbdPercent}%</span>
+                )}
+                {strain.dominantTerpene && <span>· Dominant: {strain.dominantTerpene}</span>}
+              </div>
+              {strain.description && (
+                <p className="text-xs text-text-muted leading-relaxed mb-2">
+                  {strain.description}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                {strain.effects.slice(0, 4).map((e) => (
+                  <span
+                    key={e}
+                    className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full bg-surface-muted text-text-muted"
+                  >
+                    {e}
+                  </span>
+                ))}
+              </div>
+              {matchedSymptoms.length > 0 && (
+                <p className="text-[11px] text-accent mt-3">
+                  ✓ Matches: {matchedSymptoms.join(", ")}
+                </p>
+              )}
+              {hasFilter && score > 0 && (
+                <p className="text-[10px] text-text-subtle mt-1">
+                  Match score: {(score * 100).toFixed(0)}%
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <p className="text-[11px] text-text-subtle mt-8 max-w-md leading-relaxed">
+        Strain data is referenced from the Leafly-aligned cannabinoid and
+        terpene database curated by your care team. Real-world effects vary
+        by individual; share your outcomes in your weekly check-in to refine
+        future recommendations.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/app/(patient)/portal/supplement-wheel/page.tsx
+++ b/src/app/(patient)/portal/supplement-wheel/page.tsx
@@ -1,0 +1,49 @@
+// EMR-151 — Symptom/Diagnosis Supplement Combo Wheel.
+//
+// Patient-facing supplement explorer — companion to the cannabis
+// combo wheel. Lists evidence-based supplements grouped by category,
+// shows overlap when multiple are selected, and flags any cannabis
+// interactions to bring up with the care team.
+
+import { redirect } from "next/navigation";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+import { SupplementWheel } from "@/components/education/SupplementWheel";
+import { getCurrentUser } from "@/lib/auth/session";
+import { ROLE_HOME } from "@/lib/rbac/roles";
+import { getSupplementCompounds } from "@/lib/domain/supplement-wheel-server";
+
+export const metadata = { title: "Supplement Wheel" };
+
+export default async function SupplementWheelPage() {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  if (!user.roles.includes("patient")) {
+    redirect(ROLE_HOME[user.roles[0]] ?? "/");
+  }
+
+  const compounds = await getSupplementCompounds();
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <div className="mb-8 text-center">
+        <Eyebrow className="justify-center mb-3 text-accent">
+          Leafjourney Proprietary Tool
+        </Eyebrow>
+        <PageHeader
+          title="Supplement Wheel"
+          description="Build a supplement stack and see how it overlaps with your symptoms — designed to complement, not replace, your cannabis regimen."
+        />
+      </div>
+
+      <SupplementWheel compounds={compounds} />
+
+      <p className="text-[11px] text-text-subtle mt-10 max-w-2xl mx-auto leading-relaxed text-center">
+        This tool is educational. Always discuss new supplements with your
+        care team before adding them to your regimen — especially if you take
+        prescription medications or are pregnant.
+      </p>
+    </PageShell>
+  );
+}

--- a/src/app/api/dispensary/ingest/route.ts
+++ b/src/app/api/dispensary/ingest/route.ts
@@ -1,0 +1,92 @@
+// EMR-002 — Dispensary catalog ingest endpoint.
+//
+// POST a snapshot of the dispensary's current SKUs. The handler
+// reconciles to DispensarySku, soft-delisting anything that wasn't in
+// the snapshot. Auth is by shared secret in the `X-Dispensary-Secret`
+// header — set by the dispensary's POS integration script.
+//
+// Future hardening: rotate per-dispensary secrets stored on the
+// Dispensary row instead of a single env-wide secret.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import {
+  ingestDispensaryCatalog,
+  prismaDispensaryStorage,
+} from "@/lib/dispensary";
+
+export const runtime = "nodejs";
+
+const SkuSchema = z.object({
+  sku: z.string().min(1).max(64),
+  upc: z.string().optional(),
+  name: z.string().min(1),
+  brand: z.string().optional(),
+  format: z.enum([
+    "flower",
+    "preroll",
+    "vape",
+    "concentrate",
+    "edible",
+    "tincture",
+    "topical",
+    "capsule",
+    "beverage",
+    "other",
+  ]),
+  strainType: z.enum(["indica", "sativa", "hybrid", "n/a"]).optional(),
+  thcMgPerUnit: z.number().nonnegative().optional(),
+  cbdMgPerUnit: z.number().nonnegative().optional(),
+  thcPercent: z.number().min(0).max(100).optional(),
+  cbdPercent: z.number().min(0).max(100).optional(),
+  packSize: z.string().optional(),
+  priceCents: z.number().int().nonnegative(),
+  inStock: z.boolean(),
+  inventoryCount: z.number().int().nonnegative().optional(),
+  imageUrl: z.string().url().optional(),
+  coaUrl: z.string().url().optional(),
+  description: z.string().optional(),
+});
+
+const RequestSchema = z.object({
+  dispensaryId: z.string().min(1),
+  syncedAt: z.string(),
+  skus: z.array(SkuSchema).max(5000),
+});
+
+export async function POST(req: Request) {
+  const secret = req.headers.get("x-dispensary-secret");
+  const expected = process.env.DISPENSARY_INGEST_SECRET;
+  if (!expected || secret !== expected) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: z.infer<typeof RequestSchema>;
+  try {
+    body = RequestSchema.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "invalid_payload", detail: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const dispensary = await prisma.dispensary.findUnique({
+    where: { id: body.dispensaryId },
+    select: { id: true, status: true },
+  });
+  if (!dispensary) {
+    return NextResponse.json({ error: "dispensary_not_found" }, { status: 404 });
+  }
+  if (dispensary.status !== "active") {
+    return NextResponse.json({ error: "dispensary_inactive" }, { status: 409 });
+  }
+
+  const { summary } = await ingestDispensaryCatalog(
+    prismaDispensaryStorage,
+    body,
+  );
+
+  return NextResponse.json({ ok: true, summary });
+}

--- a/src/app/leafmart/marketplace/page.tsx
+++ b/src/app/leafmart/marketplace/page.tsx
@@ -1,0 +1,252 @@
+// EMR-188 — Integrated Marketplace ecosystem hub.
+//
+// Amazon-style landing that aggregates every commerce surface in one
+// place: cannabis wellness shop (Leafmart shelf), supply store (DME +
+// OTC), affiliate partners, dispensary locator, and the strain finder.
+// Each surface is its own page elsewhere; this is the front door.
+//
+// Reference: normalizemarketplace.com (Dr. Patel's spec) — a single
+// destination for a patient to find anything physician-curated.
+
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { prisma } from "@/lib/db/prisma";
+import { listAffiliatePartners } from "@/lib/affiliate/partners";
+
+export const metadata: Metadata = {
+  title: "Marketplace",
+  description:
+    "Every Leafjourney commerce surface in one place — cannabis wellness, supply store, dispensaries, supplements, and partner brands.",
+};
+
+// Re-render hourly — catalog counts shift slowly enough that a stale
+// hour is acceptable, and we want this CDN-fast for marketing-driven
+// traffic.
+export const revalidate = 3600;
+
+interface CatalogCounts {
+  productCount: number;
+  supplyCount: number;
+  strainCount: number;
+  dispensaryCount: number;
+}
+
+async function loadCounts(): Promise<CatalogCounts> {
+  // Pull every count in parallel with safe fallbacks. A degraded DB
+  // shouldn't blank the marketplace; show the surface, log the count
+  // failure.
+  const safeCount = async <T,>(p: Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await p;
+    } catch {
+      return fallback;
+    }
+  };
+  const [productCount, supplyCount, strainCount, dispensaryCount] = await Promise.all([
+    safeCount(prisma.product.count({ where: { status: "active" } }), 0),
+    safeCount(prisma.supplyProduct.count({ where: { active: true } }), 0),
+    safeCount(prisma.strain.count({ where: { active: true } }), 0),
+    safeCount(prisma.dispensary.count({ where: { status: "active" } }), 0),
+  ]);
+  return { productCount, supplyCount, strainCount, dispensaryCount };
+}
+
+interface Surface {
+  href: string;
+  external?: boolean;
+  eyebrow: string;
+  title: string;
+  description: string;
+  cta: string;
+  count?: string;
+  highlight?: string;
+}
+
+export default async function MarketplaceHubPage() {
+  const counts = await loadCounts();
+  const partners = listAffiliatePartners();
+
+  const surfaces: Surface[] = [
+    {
+      href: "/leafmart",
+      eyebrow: "Cannabis wellness",
+      title: "Leafmart shelf",
+      description:
+        "Physician-curated cannabis wellness products. Every item lab-verified, ranked by real patient outcomes.",
+      cta: "Shop the shelf →",
+      count:
+        counts.productCount > 0
+          ? `${counts.productCount.toLocaleString()} products live`
+          : "Catalog coming soon",
+      highlight: "Curated",
+    },
+    {
+      href: "/leafmart/supply-store",
+      eyebrow: "OTC + DME",
+      title: "AI Supply Store",
+      description:
+        "OTC, supplements, and durable medical equipment recommended for your symptoms. Tell us what you're working on.",
+      cta: "Browse the supply shelf →",
+      count:
+        counts.supplyCount > 0
+          ? `${counts.supplyCount.toLocaleString()} items in stock`
+          : "Stock arriving soon",
+      highlight: "AI matched",
+    },
+    {
+      href: "/portal/strains",
+      eyebrow: "Cannabis flower",
+      title: "Strain Finder",
+      description:
+        "Match your symptoms to flower strains drawn from our Leafly-aligned catalog. Compare cannabinoid + terpene profiles.",
+      cta: "Find your strain →",
+      count:
+        counts.strainCount > 0
+          ? `${counts.strainCount.toLocaleString()} strains profiled`
+          : "Catalog growing",
+    },
+    {
+      href: "/portal/dispensaries",
+      eyebrow: "In your area",
+      title: "Dispensary Locator",
+      description:
+        "Licensed dispensaries within 30 miles of home. Hours, phone, and live SKU counts on every card.",
+      cta: "Find a dispensary →",
+      count:
+        counts.dispensaryCount > 0
+          ? `${counts.dispensaryCount.toLocaleString()} integrated`
+          : "Connecting partners",
+    },
+    {
+      href: "/portal/combo-wheel",
+      eyebrow: "Pharmacology",
+      title: "Cannabis Combo Wheel",
+      description:
+        "Our signature pharmacology tool. Mix cannabinoids and terpenes; see the combined therapeutic profile.",
+      cta: "Open the wheel →",
+      highlight: "Proprietary",
+    },
+    {
+      href: "/portal/supplement-wheel",
+      eyebrow: "Beyond cannabis",
+      title: "Supplement Wheel",
+      description:
+        "Stack evidence-based supplements that complement your cannabis regimen. Surfaces interactions automatically.",
+      cta: "Build your stack →",
+      highlight: "New",
+    },
+    {
+      href: "/store",
+      eyebrow: "Partner brands",
+      title: "Affiliate store",
+      description:
+        "Direct links to physician-trusted partner brands. Joint-decision disclaimer on every redirect.",
+      cta: "Visit partners →",
+      count:
+        partners.length > 0 ? `${partners.length} partners` : "More coming",
+    },
+  ];
+
+  return (
+    <div className="pb-16">
+      <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-16 pb-10 text-center">
+        <Eyebrow className="justify-center mb-5 text-accent">
+          Integrated marketplace
+        </Eyebrow>
+        <h1 className="font-display text-4xl md:text-6xl tracking-tight text-text mb-5">
+          Everything physician-curated, <span className="italic text-accent">in one place</span>
+        </h1>
+        <p className="text-base md:text-lg text-text-muted max-w-2xl mx-auto leading-relaxed">
+          The Leafjourney marketplace ties our cannabis shelf, supply store,
+          dispensary network, and partner brands into a single ecosystem.
+          Pharmacology tools sit alongside checkout — because dosing, sourcing,
+          and outcomes belong together.
+        </p>
+      </section>
+
+      <EditorialRule className="max-w-[1320px] mx-auto px-6 lg:px-12 mb-12" />
+
+      <section className="max-w-[1320px] mx-auto px-6 lg:px-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {surfaces.map((s) => (
+            <Link
+              key={s.href}
+              href={s.href}
+              className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-2xl"
+            >
+              <Card
+                tone="raised"
+                className="h-full transition-transform group-hover:-translate-y-0.5 group-hover:shadow-md"
+              >
+                <CardHeader className="pb-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Eyebrow>{s.eyebrow}</Eyebrow>
+                    {s.highlight && <Badge tone="accent">{s.highlight}</Badge>}
+                  </div>
+                  <CardTitle className="text-xl mt-2 flex items-center gap-2">
+                    <LeafSprig size={14} className="text-accent" />
+                    {s.title}
+                  </CardTitle>
+                  {s.count && (
+                    <CardDescription className="text-xs mt-1">{s.count}</CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-text-muted leading-relaxed mb-4">
+                    {s.description}
+                  </p>
+                  <p className="text-sm font-medium text-accent">{s.cta}</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {partners.length > 0 && (
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 mt-16">
+          <div className="text-center mb-8">
+            <Eyebrow className="justify-center mb-3">Founding partners</Eyebrow>
+            <h2 className="font-display text-3xl text-text tracking-tight">
+              Brands our care team trusts
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {partners.map((p) => (
+              <Card key={p.slug} tone="raised">
+                <CardHeader className="pb-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="text-base">{p.name}</CardTitle>
+                    <Badge tone="accent">{p.category}</Badge>
+                  </div>
+                  <CardDescription className="text-xs mt-1">{p.domain}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-text-muted leading-relaxed">
+                    {p.description}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+          <p className="text-[11px] text-text-subtle text-center mt-6 max-w-xl mx-auto leading-relaxed">
+            Adding any partner product to your regimen is a joint decision
+            between you and your care team. Always bring product names to
+            your next visit so we can document them and watch for
+            interactions.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/leafmart/supply-store/page.tsx
+++ b/src/app/leafmart/supply-store/page.tsx
@@ -1,0 +1,312 @@
+// EMR-007 — AI-Powered Supply Store on Leafmart.
+//
+// Public surface for OTC, DME, and supplements that complement the
+// cannabis catalog. The page renders all active SupplyProducts; when
+// the visitor passes ?symptoms=insomnia,pain (or similar) we run them
+// through the recommender so the most relevant items lift to the top.
+// Future: when the patient is signed-in, pull symptoms from their
+// chart instead of the URL.
+
+import Link from "next/link";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { prisma } from "@/lib/db/prisma";
+import {
+  recommend,
+  type SupplyCategory,
+  type SupplyProductCandidate,
+} from "@/lib/supply-store";
+
+export const metadata = {
+  title: "Supply Store",
+  description:
+    "OTC, DME, and supplements physician-curated to complement your cannabis regimen.",
+};
+
+// Catalog counts shift slowly; revalidate hourly for CDN-fast renders
+// without baking a snapshot from build time into prod traffic.
+export const revalidate = 3600;
+
+const CATEGORY_LABELS: Record<SupplyCategory, string> = {
+  cough_cold: "Cough & Cold",
+  sleep: "Sleep",
+  pain: "Pain Relief",
+  digestive: "Digestive",
+  vitamins_supplements: "Vitamins & Supplements",
+  dme: "Durable Medical Equipment",
+  topical: "Topicals",
+  oral_care: "Oral Care",
+  mental_health: "Mental Health",
+  womens_health: "Women's Health",
+  general_wellness: "General Wellness",
+};
+
+const COMMON_SYMPTOMS = ["cough", "sore throat", "insomnia", "pain", "anxiety", "indigestion"];
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export default async function SupplyStorePage({
+  searchParams,
+}: {
+  searchParams?: { symptoms?: string; category?: string };
+}) {
+  // Catalog reads tolerate DB outages (and unconfigured build envs) so
+  // the page still renders the symptom selector + empty-state copy.
+  const products = await prisma.supplyProduct
+    .findMany({
+      where: { active: true },
+      orderBy: [{ featured: "desc" }, { name: "asc" }],
+    })
+    .catch(() => [] as Awaited<ReturnType<typeof prisma.supplyProduct.findMany>>);
+  const catalog: SupplyProductCandidate[] = products.map((p) => ({
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    brand: p.brand,
+    category: p.category as SupplyCategory,
+    description: p.description,
+    shortDescription: p.shortDescription,
+    imageUrl: p.imageUrl,
+    priceCents: p.priceCents,
+    symptoms: p.symptoms,
+    conditions: p.conditions,
+    contraindications: p.contraindications,
+    isOTC: p.isOTC,
+    requiresRx: p.requiresRx,
+    fsaEligible: p.fsaEligible,
+    externalUrl: p.externalUrl,
+    externalPartner: p.externalPartner,
+  }));
+
+  const symptoms = (searchParams?.symptoms ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const categoryParam = searchParams?.category as SupplyCategory | undefined;
+
+  const showRecommended = symptoms.length > 0;
+  const recommended = showRecommended
+    ? recommend(catalog, {
+        symptoms,
+        conditions: [],
+        contraindications: [],
+        categoryFilter: categoryParam ? [categoryParam] : undefined,
+      })
+    : [];
+
+  const categoryFiltered = categoryParam
+    ? catalog.filter((p) => p.category === categoryParam)
+    : catalog;
+
+  return (
+    <div className="pb-12">
+      <div className="max-w-[1100px] mx-auto px-6 lg:px-12 pt-12 pb-8 text-center">
+        <Eyebrow className="justify-center mb-4 text-accent">AI-curated</Eyebrow>
+        <h1 className="font-display text-4xl md:text-5xl tracking-tight text-text">
+          Supply Store
+        </h1>
+        <p className="text-base text-text-muted mt-4 max-w-xl mx-auto leading-relaxed">
+          OTC, DME, and supplements physician-curated to complement your
+          cannabis regimen. Tell us what you're working on and we'll surface
+          the right tools.
+        </p>
+      </div>
+
+      {/* Symptom chip selector */}
+      <div className="max-w-[1100px] mx-auto px-6 lg:px-12 mb-8">
+        <Eyebrow className="mb-3">Tell us what you need</Eyebrow>
+        <div className="flex flex-wrap gap-2">
+          {COMMON_SYMPTOMS.map((s) => {
+            const active = symptoms.includes(s);
+            const next = active
+              ? symptoms.filter((x) => x !== s)
+              : [...symptoms, s];
+            const params = new URLSearchParams();
+            if (next.length > 0) params.set("symptoms", next.join(","));
+            if (categoryParam) params.set("category", categoryParam);
+            return (
+              <Link
+                key={s}
+                href={`?${params.toString()}`}
+                prefetch={false}
+                className={
+                  active
+                    ? "px-4 py-1.5 rounded-full text-sm font-medium bg-accent text-accent-ink shadow-sm"
+                    : "px-4 py-1.5 rounded-full text-sm font-medium bg-surface-raised text-text-muted border border-border hover:border-border-strong hover:text-text"
+                }
+              >
+                {s}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* AI Recommended section */}
+      {showRecommended && (
+        <section className="max-w-[1100px] mx-auto px-6 lg:px-12 mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-display text-2xl text-text tracking-tight">
+              Recommended for you
+            </h2>
+            <span className="text-xs text-text-muted">
+              Based on: {symptoms.join(", ")}
+            </span>
+          </div>
+          {recommended.length === 0 ? (
+            <Card tone="raised">
+              <CardContent className="py-8 text-center text-sm text-text-muted">
+                No supply items match those symptoms yet — try a broader filter
+                or ask your care team for a referral.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recommended.map(({ product, matchedSymptoms }) => (
+                <Card key={product.id} tone="raised">
+                  <CardHeader className="pb-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <CardTitle className="text-base">{product.name}</CardTitle>
+                        {product.brand && (
+                          <CardDescription className="text-xs">
+                            {product.brand} · {CATEGORY_LABELS[product.category]}
+                          </CardDescription>
+                        )}
+                      </div>
+                      <Badge tone="accent">Match</Badge>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-xs text-text-muted leading-relaxed mb-3 line-clamp-3">
+                      {product.shortDescription ?? product.description}
+                    </p>
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-display text-lg text-text">
+                        {formatPrice(product.priceCents)}
+                      </span>
+                      {product.fsaEligible && (
+                        <span className="text-[10px] text-success uppercase tracking-wide">
+                          FSA eligible
+                        </span>
+                      )}
+                    </div>
+                    {matchedSymptoms.length > 0 && (
+                      <p className="text-[11px] text-accent">
+                        ✓ Helps with: {matchedSymptoms.join(", ")}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Browse all */}
+      <section className="max-w-[1100px] mx-auto px-6 lg:px-12">
+        <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
+          <h2 className="font-display text-2xl text-text tracking-tight">
+            Browse the supply shelf
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="?"
+              className={
+                !categoryParam
+                  ? "px-3 py-1.5 rounded-full text-xs font-medium bg-accent text-accent-ink"
+                  : "px-3 py-1.5 rounded-full text-xs font-medium bg-surface-raised text-text-muted border border-border"
+              }
+            >
+              All
+            </Link>
+            {(["cough_cold", "sleep", "pain", "digestive", "vitamins_supplements"] as SupplyCategory[]).map(
+              (c) => (
+                <Link
+                  key={c}
+                  href={`?category=${c}`}
+                  className={
+                    categoryParam === c
+                      ? "px-3 py-1.5 rounded-full text-xs font-medium bg-accent text-accent-ink"
+                      : "px-3 py-1.5 rounded-full text-xs font-medium bg-surface-raised text-text-muted border border-border"
+                  }
+                >
+                  {CATEGORY_LABELS[c]}
+                </Link>
+              ),
+            )}
+          </div>
+        </div>
+
+        {categoryFiltered.length === 0 ? (
+          <Card tone="raised">
+            <CardContent className="py-12 text-center">
+              <LeafSprig size={32} className="text-accent mx-auto mb-3" />
+              <p className="text-sm text-text-muted">
+                Nothing on the shelf in this category yet — check back soon.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {categoryFiltered.map((product) => (
+              <Card key={product.id} tone="raised">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{product.name}</CardTitle>
+                  <CardDescription className="text-xs">
+                    {[product.brand, CATEGORY_LABELS[product.category]]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-text-muted leading-relaxed mb-3 line-clamp-3">
+                    {product.shortDescription ?? product.description}
+                  </p>
+                  <div className="flex items-center justify-between">
+                    <span className="font-display text-lg text-text">
+                      {formatPrice(product.priceCents)}
+                    </span>
+                    {product.externalUrl ? (
+                      <a
+                        href={product.externalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer sponsored"
+                      >
+                        <Button size="sm" variant="secondary">
+                          View
+                        </Button>
+                      </a>
+                    ) : (
+                      <Button size="sm" variant="secondary" disabled>
+                        Coming soon
+                      </Button>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <p className="text-[11px] text-text-subtle max-w-[680px] mx-auto px-6 mt-12 leading-relaxed text-center">
+        Supply items are not a substitute for medical advice. If you're managing
+        a condition, talk with your care team before adding new supplements or
+        OTC medications to your regimen.
+      </p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import { Reveal } from "@/components/marketing/reveal";
 import { SiteHeader } from "@/components/marketing/SiteHeader";
 import { SiteFooter } from "@/components/marketing/SiteFooter";
 import { AnimatedCounter } from "@/components/marketing/animated-counter";
+import { ComboWheel } from "@/components/education/ComboWheel";
 
 // Public marketing / acquisition home page.
 // Editorial, warm, botanical — with a live agent console to sell the core value prop.
@@ -408,7 +409,11 @@ export default function HomePage() {
 
       <EditorialRule className="max-w-[1320px] mx-auto px-6 lg:px-12" />
 
-      {/* ── Cannabis Combo Wheel Showcase — EMR-91 ──────────── */}
+      {/* ── Cannabis Combo Wheel Showcase — EMR-91 / EMR-150 / EMR-181 ──
+          The wheel is now front-and-center on the public landing page
+          (EMR-181) and on the patient home tab (EMR-150 lives at
+          /portal/combo-wheel). The pillars frame the wheel; the wheel
+          renders interactively below. */}
       <section className="max-w-[1320px] mx-auto px-6 lg:px-12 py-20">
         <Reveal>
           <div className="text-center mb-12">
@@ -423,19 +428,19 @@ export default function HomePage() {
               dosing guidance — personalized to your patient&apos;s condition.
             </p>
           </div>
-          <div className="relative overflow-hidden rounded-3xl border border-accent/20 bg-gradient-to-br from-accent/[0.04] via-surface-raised to-highlight/[0.04] p-8 md:p-12">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <div className="relative overflow-hidden rounded-3xl border border-accent/20 bg-gradient-to-br from-accent/[0.04] via-surface-raised to-highlight/[0.04] p-6 md:p-10">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
               {WELLNESS_WHEEL_PILLARS.map((pillar) => {
                 const Icon = pillar.icon;
                 return (
                   <div
                     key={pillar.title}
-                    className="text-center p-6 rounded-2xl bg-surface/60 border border-border/50"
+                    className="text-center p-5 rounded-2xl bg-surface/60 border border-border/50"
                   >
-                    <div className="w-12 h-12 rounded-2xl bg-accent/10 flex items-center justify-center mx-auto mb-4 ring-1 ring-accent/15">
+                    <div className="w-12 h-12 rounded-2xl bg-accent/10 flex items-center justify-center mx-auto mb-3 ring-1 ring-accent/15">
                       <Icon className="w-6 h-6 text-accent" />
                     </div>
-                    <h3 className="font-display text-lg text-text tracking-tight mb-2">
+                    <h3 className="font-display text-lg text-text tracking-tight mb-1">
                       {pillar.title}
                     </h3>
                     <p className="text-sm text-text-muted">{pillar.body}</p>
@@ -443,12 +448,20 @@ export default function HomePage() {
                 );
               })}
             </div>
-            <div className="text-center">
+
+            <ComboWheel
+              context="public"
+              showHeader={false}
+              showFooter={false}
+              className="mb-6"
+            />
+
+            <div className="text-center mt-6">
               <Link href="/portal/combo-wheel">
-                <Button size="lg">Try the Wellness Wheel</Button>
+                <Button size="lg">Open the full Wellness Wheel</Button>
               </Link>
               <p className="text-xs text-text-subtle mt-3">
-                Free demo access — no account required for the wheel.
+                Free to explore — no account required.
               </p>
             </div>
           </div>

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -5,28 +5,60 @@ import { Button } from "@/components/ui/button";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { SiteHeader } from "@/components/marketing/SiteHeader";
 import { SiteFooter } from "@/components/marketing/SiteFooter";
+import {
+  AFFILIATE_PARTNERS,
+  decorateAffiliateUrl,
+  type AffiliatePartnerInfo,
+} from "@/lib/affiliate/partners";
 
-const PRODUCTS = [
-  {
-    name: "Pain and Recovery Formula",
-    brand: "PhytoRx",
-    category: "Beverages",
-    description:
-      "CBD + CBG beverage concentrate for pain and recovery. Physician-formulated, fast-absorbing emulsion technology.",
-    price: "$89.99",
-    url: "https://phytorx.co/products/cbd-cbg-beverage-concentrate",
-    badge: "Best seller",
-  },
-  {
-    name: "CBD Wellness Products",
-    brand: "Flower Powered Products",
-    category: "Topicals",
-    description:
-      "Full line of CBD-only wellness products. Topicals, balms, and creams. Third-party tested, physician-recommended.",
-    price: "From $34.99",
-    url: "https://flowerpoweredproductsllc.com/shop",
-    badge: null,
-  },
+// EMR-039 — store cards now mirror the AffiliatePartner registry so
+// the partner list, disclaimer copy, and joint-decision note can be
+// updated in one place. Local product entries (Gold Skin Serum, etc.)
+// stay inline because they aren't part of the partner program.
+
+interface StoreCard {
+  name: string;
+  brand: string;
+  category: string;
+  description: string;
+  price: string;
+  url: string;
+  badge: string | null;
+  partnerSlug?: string;
+  disclaimerText?: string;
+  jointDecisionNote?: string;
+}
+
+const ACTIVE_PARTNERS = AFFILIATE_PARTNERS.filter((p) => p.status === "active").sort(
+  (a, b) => a.sortOrder - b.sortOrder,
+);
+
+const PARTNER_CARDS: StoreCard[] = ACTIVE_PARTNERS.map((p: AffiliatePartnerInfo) => ({
+  name:
+    p.slug === "phytorx"
+      ? "Pain and Recovery Formula"
+      : p.slug === "flower-powered-products"
+        ? "CBD Wellness Products"
+        : p.slug === "aulv"
+          ? "Plant-Based Wellness Collective"
+          : p.name,
+  brand: p.name,
+  category: p.category,
+  description: p.description,
+  price:
+    p.slug === "phytorx"
+      ? "$89.99"
+      : p.slug === "flower-powered-products"
+        ? "From $34.99"
+        : "Visit site for pricing",
+  url: decorateAffiliateUrl(p),
+  badge: p.slug === "phytorx" ? "Best seller" : p.slug === "aulv" ? "New" : null,
+  partnerSlug: p.slug,
+  disclaimerText: p.disclaimerText,
+  jointDecisionNote: p.jointDecisionNote,
+}));
+
+const LOCAL_CARDS: StoreCard[] = [
   {
     name: "Gold Skin Serum",
     brand: "CBD",
@@ -35,15 +67,20 @@ const PRODUCTS = [
       "Luxurious CBD-infused skin serum with 24K gold flakes. Designed for anti-aging, hydration, and radiance. Lab-tested, clean ingredients.",
     price: "$89.99",
     url: "https://www.potency710.com/product/gold-skin-serum/",
-    badge: "New",
+    badge: null,
   },
 ];
 
-const CATEGORIES = ["All", "Beverages", "Topicals", "Skincare"];
+const PRODUCTS: StoreCard[] = [...PARTNER_CARDS, ...LOCAL_CARDS];
+
+const CATEGORIES = Array.from(
+  new Set<string>(["All", ...PRODUCTS.map((p) => p.category)]),
+);
 
 export default function StorePage() {
   const [category, setCategory] = useState("All");
-  const [disclaimerUrl, setDisclaimerUrl] = useState<string | null>(null);
+  const [disclaimerCard, setDisclaimerCard] = useState<StoreCard | null>(null);
+  const disclaimerUrl = disclaimerCard?.url ?? null;
 
   const filtered =
     category === "All"
@@ -131,7 +168,7 @@ export default function StorePage() {
                 <Button
                   size="sm"
                   variant="secondary"
-                  onClick={() => setDisclaimerUrl(product.url)}
+                  onClick={() => setDisclaimerCard(product)}
                 >
                   View product
                 </Button>
@@ -160,8 +197,10 @@ export default function StorePage() {
         </div>
       </section>
 
-      {/* Disclaimer modal */}
-      {disclaimerUrl && (
+      {/* Disclaimer modal — copy is partner-specific when the card carries
+          a registered AffiliatePartner; falls back to default disclaimer
+          for local cards (e.g. Gold Skin Serum). */}
+      {disclaimerCard && disclaimerUrl && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">
           <div className="bg-surface-raised rounded-2xl border border-border shadow-xl p-8 max-w-md w-full">
             <div className="flex items-center gap-3 mb-4">
@@ -172,28 +211,30 @@ export default function StorePage() {
                 Before you go
               </h3>
             </div>
-            <p className="text-sm text-text-muted leading-relaxed mb-6">
-              You are leaving Leafjourney to visit a partner website.
-              Please consult your healthcare provider before considering
-              these products. Cannabis products are not FDA-approved
-              medications and individual results may vary. This is a joint
-              decision between you and your care team.
+            <p className="text-sm text-text-muted leading-relaxed mb-4">
+              {disclaimerCard.disclaimerText ??
+                "You are leaving Leafjourney to visit a partner website. Please consult your healthcare provider before considering these products. Cannabis products are not FDA-approved medications and individual results may vary. This is a joint decision between you and your care team."}
             </p>
+            {disclaimerCard.jointDecisionNote && (
+              <p className="text-xs text-text-subtle leading-relaxed mb-6 border-l-2 border-accent/30 pl-3">
+                {disclaimerCard.jointDecisionNote}
+              </p>
+            )}
             <div className="flex gap-3">
               <Button
                 variant="secondary"
                 size="md"
                 className="flex-1"
-                onClick={() => setDisclaimerUrl(null)}
+                onClick={() => setDisclaimerCard(null)}
               >
                 Go back
               </Button>
               <a
                 href={disclaimerUrl}
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener noreferrer sponsored"
                 className="flex-1"
-                onClick={() => setDisclaimerUrl(null)}
+                onClick={() => setDisclaimerCard(null)}
               >
                 <Button size="md" className="w-full">
                   Continue to site

--- a/src/components/education/SupplementWheel.tsx
+++ b/src/components/education/SupplementWheel.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+// EMR-151 — Symptom/Diagnosis Supplement Combo Wheel.
+//
+// Rather than rebuild a second SVG annular ring, this wheel uses a
+// radial chip layout: supplements arranged by category, tap to add
+// to the combo, with the same symptom-overlap insight panel as the
+// cannabis wheel. Keeps implementation tight while still giving
+// patients a "wheel" feel.
+
+import { useMemo, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import {
+  symptomOverlap,
+  type SupplementCompoundView,
+} from "@/lib/domain/supplement-wheel";
+
+interface Props {
+  compounds: SupplementCompoundView[];
+}
+
+export function SupplementWheel({ compounds }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectedRows = useMemo(
+    () => compounds.filter((c) => selected.has(c.id)),
+    [compounds, selected],
+  );
+
+  const overlaps = useMemo(() => symptomOverlap(selectedRows), [selectedRows]);
+
+  const allBenefits = useMemo(
+    () => Array.from(new Set(selectedRows.flatMap((c) => c.benefits))),
+    [selectedRows],
+  );
+  const allRisks = useMemo(
+    () => Array.from(new Set(selectedRows.flatMap((c) => c.risks))),
+    [selectedRows],
+  );
+
+  const categories = useMemo(() => {
+    const map = new Map<string, SupplementCompoundView[]>();
+    for (const c of compounds) {
+      const arr = map.get(c.category) ?? [];
+      arr.push(c);
+      map.set(c.category, arr);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [compounds]);
+
+  const evidenceLevel: "Strong" | "Moderate" | "Emerging" = useMemo(() => {
+    if (selectedRows.some((c) => c.evidence === "strong")) return "Strong";
+    if (selectedRows.some((c) => c.evidence === "moderate")) return "Moderate";
+    return "Emerging";
+  }, [selectedRows]);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-8">
+      <Card tone="raised" className="p-5 sm:p-7">
+        <div className="space-y-5">
+          {categories.map(([cat, items]) => (
+            <div key={cat}>
+              <Eyebrow className="mb-2">{cat}</Eyebrow>
+              <div className="flex flex-wrap gap-2">
+                {items.map((c) => {
+                  const isOn = selected.has(c.id);
+                  return (
+                    <button
+                      key={c.id}
+                      type="button"
+                      onClick={() => toggle(c.id)}
+                      aria-pressed={isOn}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-transform hover:scale-105 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-raised"
+                      style={{
+                        backgroundColor: isOn ? c.color : "transparent",
+                        color: isOn ? "#fff" : "var(--text)",
+                        border: `1.5px solid ${c.color}`,
+                        boxShadow: isOn ? `0 4px 14px -4px ${c.color}66` : undefined,
+                      }}
+                    >
+                      <span
+                        className="h-1.5 w-1.5 rounded-full"
+                        aria-hidden
+                        style={{ backgroundColor: isOn ? "rgba(255,255,255,0.7)" : c.color }}
+                      />
+                      {c.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <div className="space-y-4">
+        <Card tone="raised">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <LeafSprig size={14} className="text-accent" />
+              Your stack
+            </CardTitle>
+            <CardDescription>
+              {selectedRows.length === 0
+                ? "Tap a supplement to start a stack — add a second to see overlap."
+                : `${selectedRows.length} supplement${selectedRows.length === 1 ? "" : "s"} in this stack`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {selectedRows.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-border bg-surface/60 px-4 py-5 text-center">
+                <p className="text-sm text-text">Pick a starting supplement.</p>
+                <p className="text-xs text-text-muted mt-1">
+                  Add a second to see shared targets.
+                </p>
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {selectedRows.map((c) => (
+                  <Badge key={c.id} tone="accent">
+                    {c.name}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {selectedRows.length > 0 && (
+          <>
+            <Card tone="raised">
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div>
+                    <CardTitle className="text-base">Target symptoms</CardTitle>
+                    <CardDescription>
+                      Conditions this combination may help with
+                    </CardDescription>
+                  </div>
+                  <Badge
+                    tone={
+                      evidenceLevel === "Strong"
+                        ? "success"
+                        : evidenceLevel === "Moderate"
+                          ? "accent"
+                          : "warning"
+                    }
+                  >
+                    {evidenceLevel} evidence
+                  </Badge>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {overlaps.map(({ symptom, count }) => (
+                    <Badge key={symptom} tone={count >= 2 ? "success" : "accent"}>
+                      {symptom}
+                      {count >= 2 && (
+                        <span className="ml-1 text-[10px] font-semibold opacity-80">
+                          {count}x
+                        </span>
+                      )}
+                    </Badge>
+                  ))}
+                </div>
+                {selectedRows.length >= 2 && overlaps.some((s) => s.count >= 2) && (
+                  <p className="text-[11px] text-text-subtle mt-3 flex items-start gap-1.5">
+                    <Sparkles className="w-3 h-3 mt-0.5 text-accent shrink-0" aria-hidden />
+                    Symptoms marked 2x+ are reinforced by multiple supplements in your stack.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Card tone="raised">
+                <CardHeader className="pb-1">
+                  <CardTitle className="text-sm text-success">Benefits</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-1.5">
+                    {allBenefits.map((b) => (
+                      <li
+                        key={b}
+                        className="text-xs text-text-muted flex items-start gap-1.5 leading-relaxed"
+                      >
+                        <span className="text-success mt-0.5 shrink-0">+</span>
+                        {b}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+
+              <Card tone="raised">
+                <CardHeader className="pb-1">
+                  <CardTitle className="text-sm text-[color:var(--warning)]">
+                    Considerations
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-1.5">
+                    {allRisks.map((r) => (
+                      <li
+                        key={r}
+                        className="text-xs text-text-muted flex items-start gap-1.5 leading-relaxed"
+                      >
+                        <span className="text-[color:var(--warning)] mt-0.5 shrink-0">!</span>
+                        {r}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            </div>
+
+            {selectedRows.some((c) => c.cannabisInteraction) && (
+              <Card tone="raised" className="border-accent/30">
+                <CardHeader className="pb-1">
+                  <CardTitle className="text-sm text-accent">
+                    Cannabis interactions
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-1.5">
+                    {selectedRows
+                      .filter((c) => c.cannabisInteraction)
+                      .map((c) => (
+                        <li key={c.id} className="text-xs text-text-muted leading-relaxed">
+                          <span className="font-medium text-text">{c.name}:</span>{" "}
+                          {c.cannabisInteraction}
+                        </li>
+                      ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/affiliate/partners.test.ts
+++ b/src/lib/affiliate/partners.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  AFFILIATE_PARTNERS,
+  decorateAffiliateUrl,
+  listAffiliatePartners,
+} from "./partners";
+
+describe("affiliate partners registry", () => {
+  it("includes the three Dr. Patel partners", () => {
+    const slugs = AFFILIATE_PARTNERS.map((p) => p.slug);
+    expect(slugs).toContain("phytorx");
+    expect(slugs).toContain("flower-powered-products");
+    expect(slugs).toContain("aulv");
+  });
+
+  it("listAffiliatePartners returns only active, sorted by sortOrder", () => {
+    const list = listAffiliatePartners();
+    for (let i = 1; i < list.length; i++) {
+      expect(list[i].sortOrder).toBeGreaterThanOrEqual(list[i - 1].sortOrder);
+    }
+    expect(list.every((p) => p.status === "active")).toBe(true);
+  });
+
+  it("every partner ships a disclaimer + joint decision note", () => {
+    for (const p of AFFILIATE_PARTNERS) {
+      expect(p.disclaimerText.length).toBeGreaterThan(20);
+      expect(p.jointDecisionNote.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("decorateAffiliateUrl", () => {
+  it("appends utm_source and utm_medium when missing", () => {
+    const decorated = decorateAffiliateUrl({
+      slug: "x",
+      name: "X",
+      domain: "example.com",
+      websiteUrl: "https://example.com/page",
+      description: "",
+      category: "",
+      status: "active",
+      disclaimerText: "",
+      jointDecisionNote: "",
+      utmSource: "leafjourney",
+      sortOrder: 0,
+    });
+    expect(decorated).toContain("utm_source=leafjourney");
+    expect(decorated).toContain("utm_medium=affiliate");
+  });
+
+  it("does not overwrite existing utm params", () => {
+    const decorated = decorateAffiliateUrl({
+      slug: "x",
+      name: "X",
+      domain: "example.com",
+      websiteUrl: "https://example.com/?utm_source=other",
+      description: "",
+      category: "",
+      status: "active",
+      disclaimerText: "",
+      jointDecisionNote: "",
+      utmSource: "leafjourney",
+      sortOrder: 0,
+    });
+    expect(decorated).toContain("utm_source=other");
+    expect(decorated).not.toContain("utm_source=leafjourney");
+  });
+
+  it("returns raw url when utmSource missing", () => {
+    const url = decorateAffiliateUrl({
+      slug: "x",
+      name: "X",
+      domain: "example.com",
+      websiteUrl: "https://example.com",
+      description: "",
+      category: "",
+      status: "active",
+      disclaimerText: "",
+      jointDecisionNote: "",
+      utmSource: "",
+      sortOrder: 0,
+    });
+    expect(url).toBe("https://example.com");
+  });
+
+  it("returns raw url when input is malformed", () => {
+    const url = decorateAffiliateUrl({
+      slug: "x",
+      name: "X",
+      domain: "example.com",
+      websiteUrl: "not a url",
+      description: "",
+      category: "",
+      status: "active",
+      disclaimerText: "",
+      jointDecisionNote: "",
+      utmSource: "leafjourney",
+      sortOrder: 0,
+    });
+    expect(url).toBe("not a url");
+  });
+});

--- a/src/lib/affiliate/partners.ts
+++ b/src/lib/affiliate/partners.ts
@@ -1,0 +1,101 @@
+// EMR-039 — Affiliate partner registry.
+//
+// Until the AffiliatePartner model is fully exposed in admin tools,
+// this file holds the canonical list of partners surfaced in
+// /store. Mirrors the seed data so the public page renders identical
+// content with or without a database connection (e.g. in static
+// builds and previews).
+
+export type AffiliatePartnerStatus = "active" | "paused" | "archived";
+
+export interface AffiliatePartnerInfo {
+  slug: string;
+  name: string;
+  domain: string;
+  websiteUrl: string;
+  description: string;
+  category: string;
+  status: AffiliatePartnerStatus;
+  disclaimerText: string;
+  jointDecisionNote: string;
+  utmSource: string;
+  sortOrder: number;
+}
+
+const DEFAULT_DISCLAIMER =
+  "You are leaving Leafjourney to visit a partner website. Please consult your healthcare provider before considering these products. Cannabis products are not FDA-approved medications and individual results may vary. This is a joint decision between you and your care team.";
+
+const JOINT_DECISION_NOTE =
+  "Adding any product to your regimen is a joint decision between you and your care team. Bring this product up at your next visit so we can document it and watch for interactions.";
+
+export const AFFILIATE_PARTNERS: AffiliatePartnerInfo[] = [
+  {
+    slug: "phytorx",
+    name: "PhytoRx",
+    domain: "phytorx.co",
+    websiteUrl: "https://phytorx.co/products/cbd-cbg-beverage-concentrate",
+    description:
+      "Physician-formulated CBD + CBG beverage concentrates for pain and recovery. Fast-absorbing emulsion technology developed with clinical input.",
+    category: "Beverages",
+    status: "active",
+    disclaimerText: DEFAULT_DISCLAIMER,
+    jointDecisionNote: JOINT_DECISION_NOTE,
+    utmSource: "leafjourney",
+    sortOrder: 10,
+  },
+  {
+    slug: "flower-powered-products",
+    name: "Flower Powered Products",
+    domain: "flowerpoweredproductsllc.com",
+    websiteUrl: "https://flowerpoweredproductsllc.com/shop",
+    description:
+      "Full line of CBD-only wellness products. Topicals, balms, and creams. Third-party tested, physician-recommended.",
+    category: "Topicals",
+    status: "active",
+    disclaimerText: DEFAULT_DISCLAIMER,
+    jointDecisionNote: JOINT_DECISION_NOTE,
+    utmSource: "leafjourney",
+    sortOrder: 20,
+  },
+  {
+    slug: "aulv",
+    name: "AULV Wellness",
+    domain: "aulv.org",
+    websiteUrl: "https://aulv.org",
+    description:
+      "Wellness collective focused on plant-based therapies, education, and community-supported research. Curated alongside our care team.",
+    category: "Wellness",
+    status: "active",
+    disclaimerText: DEFAULT_DISCLAIMER,
+    jointDecisionNote: JOINT_DECISION_NOTE,
+    utmSource: "leafjourney",
+    sortOrder: 30,
+  },
+];
+
+export function listAffiliatePartners(): AffiliatePartnerInfo[] {
+  return AFFILIATE_PARTNERS.filter((p) => p.status === "active").sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+}
+
+/**
+ * Append a UTM source to the partner URL so the partner can attribute
+ * traffic back to Leafjourney. Idempotent — repeated calls won't pile
+ * up duplicate query strings.
+ */
+export function decorateAffiliateUrl(partner: AffiliatePartnerInfo): string {
+  if (!partner.utmSource) return partner.websiteUrl;
+  try {
+    const url = new URL(partner.websiteUrl);
+    if (!url.searchParams.has("utm_source")) {
+      url.searchParams.set("utm_source", partner.utmSource);
+    }
+    if (!url.searchParams.has("utm_medium")) {
+      url.searchParams.set("utm_medium", "affiliate");
+    }
+    return url.toString();
+  } catch {
+    return partner.websiteUrl;
+  }
+}

--- a/src/lib/dispensary/index.ts
+++ b/src/lib/dispensary/index.ts
@@ -1,0 +1,42 @@
+export * from "./geo";
+export * from "./types";
+export {
+  ingestDispensaryCatalog,
+  normalizeFormat,
+  normalizeStrainType,
+  validateSku,
+} from "./ingest";
+export type {
+  DispensaryFormatDb,
+  ExistingSkuRow,
+  IngestResult,
+  IngestStorage,
+  StrainClassificationDb,
+} from "./ingest";
+export {
+  filterNearby,
+  scoreRegimenMatch,
+  LOCATOR_DEFAULTS,
+} from "./locator";
+export type {
+  DispensaryRow,
+  RegimenMatchInput,
+  RegimenMatchScore,
+  SkuCandidate,
+} from "./locator";
+export {
+  prismaDispensaryStorage,
+  listDispensariesForOrg,
+} from "./repository";
+export {
+  DEFAULT_CAP_CENTS,
+  calculateMonthlyReimbursement,
+  sameCalendarYearUtc,
+  startOfMonthUtc,
+  sumYtdReimbursable,
+} from "./reimbursement";
+export type {
+  ExistingReimbursement,
+  ReimbursementCalculation,
+  ReimbursementInput,
+} from "./reimbursement";

--- a/src/lib/dispensary/ingest.test.ts
+++ b/src/lib/dispensary/ingest.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  ingestDispensaryCatalog,
+  normalizeFormat,
+  normalizeStrainType,
+  validateSku,
+  type ExistingSkuRow,
+  type IngestStorage,
+} from "./ingest";
+import type { DispensaryIngestRequest, DispensarySkuPayload } from "./types";
+
+function makeStorage(initial: ExistingSkuRow[]): {
+  storage: IngestStorage;
+  upserts: Array<{ sku: string; created: boolean }>;
+  delisted: string[];
+  syncedAt: Date | null;
+} {
+  const upserts: Array<{ sku: string; created: boolean }> = [];
+  const delisted: string[] = [];
+  let syncedAt: Date | null = null;
+  const existing = [...initial];
+  const storage: IngestStorage = {
+    async listActiveSkus() {
+      return existing;
+    },
+    async upsertSku(input) {
+      const found = existing.find((e) => e.sku === input.sku);
+      const created = !found;
+      if (created) existing.push({ id: `new-${input.sku}`, sku: input.sku, active: true });
+      upserts.push({ sku: input.sku, created });
+      return { created };
+    },
+    async delistSkus(ids) {
+      for (const id of ids) delisted.push(id);
+    },
+    async markDispensarySynced(_id, at) {
+      syncedAt = at;
+    },
+  };
+  return {
+    storage,
+    upserts,
+    delisted,
+    get syncedAt() {
+      return syncedAt;
+    },
+  } as never;
+}
+
+const samplePayload = (overrides: Partial<DispensarySkuPayload> = {}): DispensarySkuPayload => ({
+  sku: "sku-1",
+  name: "Sleep Tincture 30mL",
+  format: "tincture",
+  thcMgPerUnit: 5,
+  priceCents: 4500,
+  inStock: true,
+  ...overrides,
+});
+
+describe("validateSku", () => {
+  it("accepts a valid payload", () => {
+    expect(validateSku(samplePayload())).toBeNull();
+  });
+
+  it("rejects empty sku", () => {
+    expect(validateSku(samplePayload({ sku: "" }))).toMatch(/sku required/);
+  });
+
+  it("rejects empty name", () => {
+    expect(validateSku(samplePayload({ name: "" }))).toMatch(/name required/);
+  });
+
+  it("rejects negative price", () => {
+    expect(validateSku(samplePayload({ priceCents: -10 }))).toMatch(/non-negative/);
+  });
+
+  it("rejects floating-cent prices (likely dollars)", () => {
+    expect(validateSku(samplePayload({ priceCents: 9.99 }))).toMatch(/integer/);
+  });
+
+  it("rejects implausibly high prices (likely dollars)", () => {
+    expect(validateSku(samplePayload({ priceCents: 50_000_000 }))).toMatch(/exceeds/);
+  });
+
+  it("rejects out-of-range thcPercent", () => {
+    expect(validateSku(samplePayload({ thcPercent: 250 }))).toMatch(/thcPercent/);
+  });
+});
+
+describe("normalizeFormat", () => {
+  it("passes through canonical values", () => {
+    expect(normalizeFormat("flower")).toBe("flower");
+    expect(normalizeFormat("VAPE")).toBe("vape");
+  });
+
+  it("maps common aliases", () => {
+    expect(normalizeFormat("Pre-Roll")).toBe("preroll");
+    expect(normalizeFormat("cartridge")).toBe("vape");
+    expect(normalizeFormat("gummy")).toBe("edible");
+    expect(normalizeFormat("rosin")).toBe("concentrate");
+  });
+
+  it("falls back to 'other' for unknown formats", () => {
+    expect(normalizeFormat("alien_format")).toBe("other");
+  });
+});
+
+describe("normalizeStrainType", () => {
+  it("normalizes case", () => {
+    expect(normalizeStrainType("INDICA")).toBe("indica");
+    expect(normalizeStrainType("Hybrid")).toBe("hybrid");
+  });
+
+  it("returns 'na' for missing or unknown", () => {
+    expect(normalizeStrainType(undefined)).toBe("na");
+    expect(normalizeStrainType("n/a")).toBe("na");
+    expect(normalizeStrainType("indeterminate")).toBe("na");
+  });
+});
+
+describe("ingestDispensaryCatalog", () => {
+  const baseRequest = (skus: DispensarySkuPayload[]): DispensaryIngestRequest => ({
+    dispensaryId: "disp-1",
+    syncedAt: new Date("2026-04-29T12:00:00Z").toISOString(),
+    skus,
+  });
+
+  it("creates new SKUs and reports counts", async () => {
+    const t = makeStorage([]);
+    const { summary } = await ingestDispensaryCatalog(
+      t.storage,
+      baseRequest([
+        samplePayload({ sku: "a", name: "A" }),
+        samplePayload({ sku: "b", name: "B" }),
+      ]),
+    );
+    expect(summary.received).toBe(2);
+    expect(summary.created).toBe(2);
+    expect(summary.updated).toBe(0);
+    expect(summary.delisted).toBe(0);
+    expect(summary.errors).toEqual([]);
+  });
+
+  it("updates existing SKUs and delists missing ones", async () => {
+    const t = makeStorage([
+      { id: "id-a", sku: "a", active: true },
+      { id: "id-b", sku: "b", active: true },
+      { id: "id-c", sku: "c", active: true },
+    ]);
+    const { summary } = await ingestDispensaryCatalog(
+      t.storage,
+      baseRequest([
+        samplePayload({ sku: "a", name: "A v2" }),
+        samplePayload({ sku: "d", name: "D new" }),
+      ]),
+    );
+    expect(summary.received).toBe(2);
+    expect(summary.created).toBe(1); // only "d"
+    expect(summary.updated).toBe(1); // "a"
+    expect(summary.delisted).toBe(2); // b, c
+    expect(t.delisted.sort()).toEqual(["id-b", "id-c"]);
+  });
+
+  it("rejects invalid rows but keeps processing", async () => {
+    const t = makeStorage([]);
+    const { summary } = await ingestDispensaryCatalog(
+      t.storage,
+      baseRequest([
+        samplePayload({ sku: "good", name: "Good" }),
+        samplePayload({ sku: "", name: "Bad" }),
+        samplePayload({ sku: "good", name: "Dup" }),
+      ]),
+    );
+    expect(summary.created).toBe(1);
+    expect(summary.errors.length).toBe(2);
+    expect(summary.errors[0].reason).toMatch(/sku required/);
+    expect(summary.errors[1].reason).toMatch(/duplicate/);
+  });
+
+  it("records sync timestamp", async () => {
+    const t = makeStorage([]);
+    await ingestDispensaryCatalog(
+      t.storage,
+      baseRequest([samplePayload({ sku: "a" })]),
+    );
+    expect(t.syncedAt).toEqual(new Date("2026-04-29T12:00:00Z"));
+  });
+});

--- a/src/lib/dispensary/ingest.ts
+++ b/src/lib/dispensary/ingest.ts
@@ -1,0 +1,221 @@
+// EMR-002 — Dispensary catalog ingestion.
+//
+// Dispensaries POST a snapshot of their current SKUs; we reconcile to
+// the DispensarySku table: insert new rows, update existing ones, and
+// soft-delist anything that vanished from the snapshot. This keeps a
+// single source of truth on our side without requiring delete events
+// from the upstream POS.
+
+import type {
+  DispensaryFormat,
+  DispensaryIngestRequest,
+  DispensaryIngestSummary,
+  DispensarySkuPayload,
+} from "./types";
+
+export type DispensaryFormatDb =
+  | "flower"
+  | "preroll"
+  | "vape"
+  | "concentrate"
+  | "edible"
+  | "tincture"
+  | "topical"
+  | "capsule"
+  | "beverage"
+  | "other";
+
+export type StrainClassificationDb =
+  | "indica"
+  | "sativa"
+  | "hybrid"
+  | "cbd"
+  | "na";
+
+export interface ExistingSkuRow {
+  id: string;
+  sku: string;
+  active: boolean;
+}
+
+export interface IngestStorage {
+  /** All currently-active SKU rows for this dispensary. */
+  listActiveSkus(dispensaryId: string): Promise<ExistingSkuRow[]>;
+  upsertSku(input: {
+    dispensaryId: string;
+    sku: string;
+    upc?: string;
+    name: string;
+    brand?: string;
+    format: DispensaryFormatDb;
+    strainType: StrainClassificationDb;
+    thcMgPerUnit?: number;
+    cbdMgPerUnit?: number;
+    thcPercent?: number;
+    cbdPercent?: number;
+    packSize?: string;
+    priceCents: number;
+    inStock: boolean;
+    inventoryCount?: number;
+    imageUrl?: string;
+    coaUrl?: string;
+    description?: string;
+  }): Promise<{ created: boolean }>;
+  delistSkus(ids: string[]): Promise<void>;
+  markDispensarySynced(dispensaryId: string, syncedAt: Date): Promise<void>;
+}
+
+/**
+ * Validate a single SKU payload. Returns null when the row is good,
+ * a string reason when it should be rejected.
+ */
+export function validateSku(
+  payload: DispensarySkuPayload,
+): string | null {
+  if (!payload.sku || payload.sku.trim().length === 0) {
+    return "sku required";
+  }
+  if (payload.sku.length > 64) {
+    return "sku exceeds 64 chars";
+  }
+  if (!payload.name || payload.name.trim().length === 0) {
+    return "name required";
+  }
+  if (!Number.isFinite(payload.priceCents) || payload.priceCents < 0) {
+    return "priceCents must be a non-negative integer";
+  }
+  if (!Number.isInteger(payload.priceCents)) {
+    return "priceCents must be an integer (cents, not dollars)";
+  }
+  // Reject patently absurd prices — guards against $9.99 sneaking in
+  // as 9.99 cents. $50,000 is a hard ceiling for any legitimate SKU.
+  if (payload.priceCents > 5_000_000) {
+    return "priceCents exceeds 5,000,000 (likely sent dollars instead of cents)";
+  }
+  if (payload.thcPercent !== undefined && (payload.thcPercent < 0 || payload.thcPercent > 100)) {
+    return "thcPercent must be between 0 and 100";
+  }
+  if (payload.cbdPercent !== undefined && (payload.cbdPercent < 0 || payload.cbdPercent > 100)) {
+    return "cbdPercent must be between 0 and 100";
+  }
+  return null;
+}
+
+const FORMAT_VALUES: ReadonlyArray<DispensaryFormat> = [
+  "flower",
+  "preroll",
+  "vape",
+  "concentrate",
+  "edible",
+  "tincture",
+  "topical",
+  "capsule",
+  "beverage",
+  "other",
+];
+
+export function normalizeFormat(format: string): DispensaryFormatDb {
+  const lower = format.toLowerCase().trim();
+  if ((FORMAT_VALUES as ReadonlyArray<string>).includes(lower)) {
+    return lower as DispensaryFormatDb;
+  }
+  // Common aliases from POS systems
+  if (lower === "pre-roll" || lower === "joint") return "preroll";
+  if (lower === "cartridge" || lower === "vape pen") return "vape";
+  if (lower === "gummy" || lower === "chocolate") return "edible";
+  if (lower === "drink" || lower === "soda") return "beverage";
+  if (lower === "wax" || lower === "shatter" || lower === "rosin") return "concentrate";
+  if (lower === "salve" || lower === "balm" || lower === "lotion") return "topical";
+  return "other";
+}
+
+export function normalizeStrainType(t: string | undefined): StrainClassificationDb {
+  if (!t) return "na";
+  const lower = t.toLowerCase().trim();
+  if (lower === "indica" || lower === "sativa" || lower === "hybrid" || lower === "cbd") {
+    return lower;
+  }
+  if (lower === "n/a" || lower === "none" || lower === "") return "na";
+  return "na";
+}
+
+export interface IngestResult {
+  summary: DispensaryIngestSummary;
+}
+
+/**
+ * Reconcile an incoming catalog snapshot against the current state.
+ * SKUs not present in the snapshot are soft-delisted (active=false).
+ */
+export async function ingestDispensaryCatalog(
+  storage: IngestStorage,
+  request: DispensaryIngestRequest,
+): Promise<IngestResult> {
+  const summary: DispensaryIngestSummary = {
+    dispensaryId: request.dispensaryId,
+    syncedAt: request.syncedAt,
+    received: request.skus.length,
+    created: 0,
+    updated: 0,
+    delisted: 0,
+    errors: [],
+  };
+
+  const existing = await storage.listActiveSkus(request.dispensaryId);
+  const existingBySku = new Map(existing.map((r) => [r.sku, r]));
+  const seenSkus = new Set<string>();
+
+  for (const payload of request.skus) {
+    const reason = validateSku(payload);
+    if (reason) {
+      summary.errors.push({ sku: payload.sku, reason });
+      continue;
+    }
+    if (seenSkus.has(payload.sku)) {
+      summary.errors.push({ sku: payload.sku, reason: "duplicate sku in payload" });
+      continue;
+    }
+    seenSkus.add(payload.sku);
+
+    const result = await storage.upsertSku({
+      dispensaryId: request.dispensaryId,
+      sku: payload.sku,
+      upc: payload.upc,
+      name: payload.name,
+      brand: payload.brand,
+      format: normalizeFormat(payload.format),
+      strainType: normalizeStrainType(payload.strainType),
+      thcMgPerUnit: payload.thcMgPerUnit,
+      cbdMgPerUnit: payload.cbdMgPerUnit,
+      thcPercent: payload.thcPercent,
+      cbdPercent: payload.cbdPercent,
+      packSize: payload.packSize,
+      priceCents: payload.priceCents,
+      inStock: payload.inStock,
+      inventoryCount: payload.inventoryCount,
+      imageUrl: payload.imageUrl,
+      coaUrl: payload.coaUrl,
+      description: payload.description,
+    });
+
+    if (result.created) summary.created += 1;
+    else summary.updated += 1;
+  }
+
+  // Anything we had active that wasn't in the snapshot → delist.
+  const delistIds: string[] = [];
+  for (const row of existing) {
+    if (!seenSkus.has(row.sku)) delistIds.push(row.id);
+  }
+  if (delistIds.length > 0) {
+    await storage.delistSkus(delistIds);
+    summary.delisted = delistIds.length;
+  }
+
+  await storage.markDispensarySynced(
+    request.dispensaryId,
+    new Date(request.syncedAt),
+  );
+
+  return { summary };
+}

--- a/src/lib/dispensary/locator.test.ts
+++ b/src/lib/dispensary/locator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { filterNearby, scoreRegimenMatch, type DispensaryRow, type SkuCandidate } from "./locator";
+import { haversineMiles } from "./geo";
+
+const SF: { lat: number; lng: number } = { lat: 37.7749, lng: -122.4194 };
+const OAKLAND: { lat: number; lng: number } = { lat: 37.8044, lng: -122.2712 };
+const LA: { lat: number; lng: number } = { lat: 34.0522, lng: -118.2437 };
+
+const row = (overrides: Partial<DispensaryRow>): DispensaryRow => ({
+  id: "r1",
+  slug: "r1",
+  name: "Row",
+  status: "active",
+  latitude: SF.lat,
+  longitude: SF.lng,
+  addressLine1: "1 Main",
+  addressLine2: null,
+  city: "San Francisco",
+  state: "CA",
+  postalCode: "94110",
+  phone: null,
+  websiteUrl: null,
+  hoursLine: null,
+  lastSyncedAt: null,
+  skuCount: 0,
+  ...overrides,
+});
+
+describe("haversineMiles", () => {
+  it("returns ~0 for identical points", () => {
+    expect(haversineMiles(SF, SF)).toBeLessThan(0.01);
+  });
+
+  it("approximates SF→Oakland at ~9 miles", () => {
+    const d = haversineMiles(SF, OAKLAND);
+    expect(d).toBeGreaterThan(7);
+    expect(d).toBeLessThan(11);
+  });
+
+  it("returns hundreds of miles for SF→LA", () => {
+    expect(haversineMiles(SF, LA)).toBeGreaterThan(330);
+  });
+});
+
+describe("filterNearby", () => {
+  it("includes only rows within radius and sorts by distance", () => {
+    const rows: DispensaryRow[] = [
+      row({ id: "sf", latitude: SF.lat, longitude: SF.lng, name: "SF" }),
+      row({ id: "oak", latitude: OAKLAND.lat, longitude: OAKLAND.lng, name: "OAK" }),
+      row({ id: "la", latitude: LA.lat, longitude: LA.lng, name: "LA" }),
+    ];
+    const out = filterNearby(rows, SF, 30);
+    expect(out.map((r) => r.id)).toEqual(["sf", "oak"]);
+    expect(out[0].distanceMiles).toBeLessThan(out[1].distanceMiles);
+  });
+
+  it("excludes inactive dispensaries", () => {
+    const rows: DispensaryRow[] = [
+      row({ id: "sf", status: "inactive" }),
+      row({ id: "oak", latitude: OAKLAND.lat, longitude: OAKLAND.lng, status: "active" }),
+    ];
+    const out = filterNearby(rows, SF, 30);
+    expect(out.map((r) => r.id)).toEqual(["oak"]);
+  });
+
+  it("uses 30 mile default", () => {
+    const rows: DispensaryRow[] = [row({ id: "la", latitude: LA.lat, longitude: LA.lng })];
+    expect(filterNearby(rows, SF)).toEqual([]);
+  });
+});
+
+describe("scoreRegimenMatch", () => {
+  const candidate: SkuCandidate = {
+    id: "sku-1",
+    dispensaryId: "d1",
+    sku: "TINC-5",
+    name: "Sleep 5mg",
+    format: "tincture",
+    thcMgPerUnit: 5,
+    cbdMgPerUnit: 5,
+    priceCents: 4500,
+    inStock: true,
+  };
+
+  it("returns 0 when out of stock", () => {
+    const result = scoreRegimenMatch({ ...candidate, inStock: false }, { format: "tincture" });
+    expect(result.score).toBe(0);
+    expect(result.reasons).toContain("out of stock");
+  });
+
+  it("rewards format match", () => {
+    const result = scoreRegimenMatch(candidate, { format: "tincture" });
+    expect(result.score).toBeGreaterThanOrEqual(0.4);
+    expect(result.reasons.some((r) => r.includes("format"))).toBe(true);
+  });
+
+  it("rewards THC mg in target range", () => {
+    const result = scoreRegimenMatch(candidate, { format: "tincture", thcMgPerDose: 5 });
+    expect(result.score).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it("partial credit when THC mg is near but not in target", () => {
+    const result = scoreRegimenMatch(candidate, { thcMgPerDose: 9 });
+    // 5 / 9 = 0.55, in moderate band
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(0.4);
+  });
+
+  it("rewards 1:1 ratio match", () => {
+    const result = scoreRegimenMatch(candidate, { thcCbdRatio: "1:1" });
+    expect(result.reasons.some((r) => r.includes("ratio"))).toBe(true);
+  });
+
+  it("caps score at 1", () => {
+    const result = scoreRegimenMatch(candidate, {
+      format: "tincture",
+      thcMgPerDose: 5,
+      cbdMgPerDose: 5,
+      thcCbdRatio: "1:1",
+    });
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/lib/dispensary/locator.ts
+++ b/src/lib/dispensary/locator.ts
@@ -1,0 +1,174 @@
+// EMR-002 / EMR-017 — Dispensary locator queries.
+//
+// Two flavors:
+//   1. nearbyDispensaries(origin, radius)  — simple geographic filter
+//   2. matchesForRegimen(...)              — geo + product matching for
+//                                             a patient's prescribed regimen
+
+import { haversineMiles } from "./geo";
+import type { NearbyDispensaryRow } from "./types";
+
+export interface DispensaryRow {
+  id: string;
+  slug: string;
+  name: string;
+  status: "active" | "pending" | "inactive";
+  latitude: number;
+  longitude: number;
+  addressLine1: string;
+  addressLine2: string | null;
+  city: string;
+  state: string;
+  postalCode: string;
+  phone: string | null;
+  websiteUrl: string | null;
+  hoursLine: string | null;
+  lastSyncedAt: Date | null;
+  skuCount: number;
+}
+
+const DEFAULT_RADIUS_MILES = 30; // Dr. Patel's 30-mile spec from EMR-002
+
+export function filterNearby(
+  rows: DispensaryRow[],
+  origin: { lat: number; lng: number },
+  radiusMiles: number = DEFAULT_RADIUS_MILES,
+): NearbyDispensaryRow[] {
+  return rows
+    .filter((r) => r.status === "active")
+    .map((r) => ({
+      id: r.id,
+      slug: r.slug,
+      name: r.name,
+      geo: {
+        lat: r.latitude,
+        lng: r.longitude,
+        addressLine1: r.addressLine1,
+        addressLine2: r.addressLine2 ?? undefined,
+        city: r.city,
+        state: r.state,
+        postalCode: r.postalCode,
+        phone: r.phone ?? undefined,
+        hoursLine: r.hoursLine ?? undefined,
+        websiteUrl: r.websiteUrl ?? undefined,
+      },
+      distanceMiles: haversineMiles(origin, {
+        lat: r.latitude,
+        lng: r.longitude,
+      }),
+      skuCount: r.skuCount,
+    }))
+    .filter((r) => r.distanceMiles <= radiusMiles)
+    .sort((a, b) => a.distanceMiles - b.distanceMiles);
+}
+
+export interface RegimenMatchInput {
+  /** What the patient's regimen calls for. */
+  format?: string; // e.g. "tincture", "vape"
+  thcMgPerDose?: number;
+  cbdMgPerDose?: number;
+  thcCbdRatio?: string; // "1:1", "20:1"
+  /** Patient's home location for distance ranking. */
+  origin: { lat: number; lng: number };
+  radiusMiles?: number;
+}
+
+export interface SkuCandidate {
+  id: string;
+  dispensaryId: string;
+  sku: string;
+  name: string;
+  brand?: string;
+  format: string;
+  thcMgPerUnit?: number;
+  cbdMgPerUnit?: number;
+  thcPercent?: number;
+  cbdPercent?: number;
+  priceCents: number;
+  inStock: boolean;
+}
+
+export interface RegimenMatchScore {
+  skuId: string;
+  dispensaryId: string;
+  score: number; // 0..1 quality score
+  reasons: string[];
+}
+
+/**
+ * Score a candidate SKU against the regimen target. Higher score =
+ * better match. The scoring is deliberately simple and explicit so a
+ * clinician can sanity-check why a SKU was recommended.
+ */
+export function scoreRegimenMatch(
+  candidate: SkuCandidate,
+  target: { format?: string; thcMgPerDose?: number; cbdMgPerDose?: number; thcCbdRatio?: string },
+): RegimenMatchScore {
+  const reasons: string[] = [];
+  let score = 0;
+
+  if (!candidate.inStock) {
+    return { skuId: candidate.id, dispensaryId: candidate.dispensaryId, score: 0, reasons: ["out of stock"] };
+  }
+
+  if (target.format && candidate.format === target.format.toLowerCase()) {
+    score += 0.4;
+    reasons.push(`format match (${candidate.format})`);
+  }
+
+  if (target.thcMgPerDose !== undefined && candidate.thcMgPerUnit !== undefined) {
+    const ratio = candidate.thcMgPerUnit / Math.max(target.thcMgPerDose, 0.1);
+    // Within ±25% is a strong match; ±50% is a moderate match.
+    if (ratio >= 0.75 && ratio <= 1.25) {
+      score += 0.3;
+      reasons.push("THC mg in target range");
+    } else if (ratio >= 0.5 && ratio <= 1.5) {
+      score += 0.15;
+      reasons.push("THC mg near target");
+    }
+  }
+
+  if (target.cbdMgPerDose !== undefined && candidate.cbdMgPerUnit !== undefined) {
+    const ratio = candidate.cbdMgPerUnit / Math.max(target.cbdMgPerDose, 0.1);
+    if (ratio >= 0.75 && ratio <= 1.25) {
+      score += 0.2;
+      reasons.push("CBD mg in target range");
+    } else if (ratio >= 0.5 && ratio <= 1.5) {
+      score += 0.1;
+      reasons.push("CBD mg near target");
+    }
+  }
+
+  if (target.thcCbdRatio && candidate.thcMgPerUnit && candidate.cbdMgPerUnit) {
+    const targetRatio = parseRatio(target.thcCbdRatio);
+    if (targetRatio !== null) {
+      const candidateRatio = candidate.thcMgPerUnit / Math.max(candidate.cbdMgPerUnit, 0.1);
+      const delta = Math.abs(candidateRatio - targetRatio) / Math.max(targetRatio, 0.1);
+      if (delta < 0.25) {
+        score += 0.1;
+        reasons.push("ratio within 25% of target");
+      }
+    }
+  }
+
+  return {
+    skuId: candidate.id,
+    dispensaryId: candidate.dispensaryId,
+    score: Math.min(1, score),
+    reasons,
+  };
+}
+
+function parseRatio(s: string): number | null {
+  // "20:1" → 20, "1:1" → 1, "1:20" → 0.05
+  const m = s.match(/^\s*(\d+(?:\.\d+)?)\s*:\s*(\d+(?:\.\d+)?)\s*$/);
+  if (!m) return null;
+  const a = parseFloat(m[1]);
+  const b = parseFloat(m[2]);
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b === 0) return null;
+  return a / b;
+}
+
+export const LOCATOR_DEFAULTS = {
+  radiusMiles: DEFAULT_RADIUS_MILES,
+};

--- a/src/lib/dispensary/reimbursement.test.ts
+++ b/src/lib/dispensary/reimbursement.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CAP_CENTS,
+  calculateMonthlyReimbursement,
+  sameCalendarYearUtc,
+  startOfMonthUtc,
+  sumYtdReimbursable,
+  type ExistingReimbursement,
+} from "./reimbursement";
+
+describe("calculateMonthlyReimbursement", () => {
+  it("returns full spend when within cap and YTD empty", () => {
+    const r = calculateMonthlyReimbursement({
+      documentedSpendCents: 12_000,
+      ytdReimbursableCents: 0,
+    });
+    expect(r.reimbursableCents).toBe(12_000);
+    expect(r.cappedByAnnualLimit).toBe(false);
+    expect(r.remainingCapCents).toBe(DEFAULT_CAP_CENTS - 12_000);
+  });
+
+  it("caps at the annual remaining when spend would exceed it", () => {
+    const r = calculateMonthlyReimbursement({
+      documentedSpendCents: 30_000,
+      ytdReimbursableCents: 40_000, // already used $400 of $500
+    });
+    expect(r.reimbursableCents).toBe(10_000); // only $100 left
+    expect(r.cappedByAnnualLimit).toBe(true);
+    expect(r.remainingCapCents).toBe(0);
+  });
+
+  it("returns 0 when YTD already at cap", () => {
+    const r = calculateMonthlyReimbursement({
+      documentedSpendCents: 5_000,
+      ytdReimbursableCents: DEFAULT_CAP_CENTS,
+    });
+    expect(r.reimbursableCents).toBe(0);
+    expect(r.cappedByAnnualLimit).toBe(true);
+  });
+
+  it("respects custom cap", () => {
+    const r = calculateMonthlyReimbursement({
+      documentedSpendCents: 100_000,
+      ytdReimbursableCents: 0,
+      capCents: 80_000,
+    });
+    expect(r.reimbursableCents).toBe(80_000);
+    expect(r.cappedByAnnualLimit).toBe(true);
+  });
+
+  it("rejects negative spend", () => {
+    expect(() =>
+      calculateMonthlyReimbursement({
+        documentedSpendCents: -1,
+        ytdReimbursableCents: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects negative YTD", () => {
+    expect(() =>
+      calculateMonthlyReimbursement({
+        documentedSpendCents: 100,
+        ytdReimbursableCents: -1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("startOfMonthUtc", () => {
+  it("truncates a mid-month date", () => {
+    const d = new Date("2026-04-29T18:30:00Z");
+    expect(startOfMonthUtc(d).toISOString()).toBe("2026-04-01T00:00:00.000Z");
+  });
+});
+
+describe("sameCalendarYearUtc", () => {
+  it("returns true for two dates in same year", () => {
+    expect(sameCalendarYearUtc(new Date("2026-01-01"), new Date("2026-12-31"))).toBe(true);
+  });
+  it("returns false across year boundary", () => {
+    expect(sameCalendarYearUtc(new Date("2025-12-31"), new Date("2026-01-01"))).toBe(false);
+  });
+});
+
+describe("sumYtdReimbursable", () => {
+  const month = new Date("2026-04-01T00:00:00Z");
+  const rows: ExistingReimbursement[] = [
+    { serviceMonth: new Date("2026-01-01T00:00:00Z"), reimbursableCents: 5_000, status: "approved" },
+    { serviceMonth: new Date("2026-02-01T00:00:00Z"), reimbursableCents: 10_000, status: "submitted" },
+    { serviceMonth: new Date("2026-03-01T00:00:00Z"), reimbursableCents: 7_000, status: "draft" }, // ignored
+    { serviceMonth: new Date("2025-11-01T00:00:00Z"), reimbursableCents: 9_000, status: "paid" }, // wrong year
+    { serviceMonth: new Date("2026-03-01T00:00:00Z"), reimbursableCents: 8_000, status: "paid" },
+  ];
+
+  it("sums approved/submitted/paid rows in same calendar year", () => {
+    expect(sumYtdReimbursable(rows, month)).toBe(5_000 + 10_000 + 8_000);
+  });
+
+  it("ignores drafts and denials", () => {
+    const r = sumYtdReimbursable(
+      [
+        ...rows,
+        { serviceMonth: new Date("2026-04-01T00:00:00Z"), reimbursableCents: 50_000, status: "denied" },
+      ],
+      month,
+    );
+    expect(r).toBe(5_000 + 10_000 + 8_000);
+  });
+});

--- a/src/lib/dispensary/reimbursement.ts
+++ b/src/lib/dispensary/reimbursement.ts
@@ -1,0 +1,91 @@
+// EMR-145 — Cannabis Dispensary Billing + CMS $500 Reimbursement.
+//
+// Federal Medicare/Medicaid does NOT currently reimburse cannabis
+// purchases. This module documents what *would* qualify under a
+// hypothetical $500-per-patient-per-year program (Dr. Patel's spec)
+// so the practice has clean records ready when the regulation
+// changes. The math here is the system of record for
+// `DispensaryReimbursement` rows.
+//
+// The cap defaults to 500 USD per patient per calendar year. Per
+// month is the granularity we record because dispensary spending
+// reports come in monthly statements; the annual cap is rolled up
+// across all months for that patient.
+
+export const DEFAULT_CAP_CENTS = 50_000; // $500.00
+
+export interface ReimbursementInput {
+  /** Patient's documented out-of-pocket cannabis spend for the month, in cents. */
+  documentedSpendCents: number;
+  /** Sum of `reimbursableCents` already approved earlier in the same calendar year. */
+  ytdReimbursableCents: number;
+  /** Per-patient annual cap in cents. Defaults to $500. */
+  capCents?: number;
+}
+
+export interface ReimbursementCalculation {
+  documentedSpendCents: number;
+  reimbursableCents: number;
+  remainingCapCents: number;
+  cappedByAnnualLimit: boolean;
+  capCents: number;
+}
+
+/**
+ * Given a month's documented spend and what's already been
+ * reimbursed YTD, return the dollar amount we can claim this month
+ * without exceeding the annual cap.
+ */
+export function calculateMonthlyReimbursement(
+  input: ReimbursementInput,
+): ReimbursementCalculation {
+  const cap = input.capCents ?? DEFAULT_CAP_CENTS;
+  if (input.documentedSpendCents < 0) {
+    throw new Error("documentedSpendCents must be non-negative");
+  }
+  if (input.ytdReimbursableCents < 0) {
+    throw new Error("ytdReimbursableCents must be non-negative");
+  }
+  const remainingBefore = Math.max(0, cap - input.ytdReimbursableCents);
+  const reimbursable = Math.min(input.documentedSpendCents, remainingBefore);
+  const cappedByAnnualLimit =
+    reimbursable < input.documentedSpendCents && remainingBefore < input.documentedSpendCents;
+  return {
+    documentedSpendCents: input.documentedSpendCents,
+    reimbursableCents: reimbursable,
+    remainingCapCents: remainingBefore - reimbursable,
+    cappedByAnnualLimit,
+    capCents: cap,
+  };
+}
+
+/** Truncate any date to the first millisecond of its month, UTC. */
+export function startOfMonthUtc(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+/** Two reimbursements are in the same calendar year (UTC). */
+export function sameCalendarYearUtc(a: Date, b: Date): boolean {
+  return a.getUTCFullYear() === b.getUTCFullYear();
+}
+
+export interface ExistingReimbursement {
+  serviceMonth: Date;
+  reimbursableCents: number;
+  status: "draft" | "submitted" | "approved" | "paid" | "denied";
+}
+
+/**
+ * Sum the YTD reimbursable cents across approved+submitted+paid
+ * statuses for a given month's calendar year. Drafts and denials
+ * don't count against the cap.
+ */
+export function sumYtdReimbursable(
+  existing: ExistingReimbursement[],
+  serviceMonth: Date,
+): number {
+  return existing
+    .filter((r) => sameCalendarYearUtc(r.serviceMonth, serviceMonth))
+    .filter((r) => r.status === "submitted" || r.status === "approved" || r.status === "paid")
+    .reduce((sum, r) => sum + r.reimbursableCents, 0);
+}

--- a/src/lib/dispensary/repository.ts
+++ b/src/lib/dispensary/repository.ts
@@ -1,0 +1,133 @@
+// EMR-002 / EMR-017 — Prisma adapter for dispensary persistence.
+//
+// Implements the IngestStorage contract from `./ingest` against the
+// real DispensarySku table, and exposes simple read queries for the
+// locator pages.
+
+import { prisma } from "@/lib/db/prisma";
+import type { ExistingSkuRow, IngestStorage } from "./ingest";
+import type { DispensaryRow } from "./locator";
+
+export const prismaDispensaryStorage: IngestStorage = {
+  async listActiveSkus(dispensaryId: string): Promise<ExistingSkuRow[]> {
+    const rows = await prisma.dispensarySku.findMany({
+      where: { dispensaryId, active: true },
+      select: { id: true, sku: true, active: true },
+    });
+    return rows;
+  },
+
+  async upsertSku(input) {
+    const existing = await prisma.dispensarySku.findUnique({
+      where: { dispensaryId_sku: { dispensaryId: input.dispensaryId, sku: input.sku } },
+    });
+    await prisma.dispensarySku.upsert({
+      where: { dispensaryId_sku: { dispensaryId: input.dispensaryId, sku: input.sku } },
+      create: {
+        dispensaryId: input.dispensaryId,
+        sku: input.sku,
+        upc: input.upc,
+        name: input.name,
+        brand: input.brand,
+        format: input.format,
+        strainType: input.strainType,
+        thcMgPerUnit: input.thcMgPerUnit,
+        cbdMgPerUnit: input.cbdMgPerUnit,
+        thcPercent: input.thcPercent,
+        cbdPercent: input.cbdPercent,
+        packSize: input.packSize,
+        priceCents: input.priceCents,
+        inStock: input.inStock,
+        inventoryCount: input.inventoryCount,
+        imageUrl: input.imageUrl,
+        coaUrl: input.coaUrl,
+        description: input.description,
+        active: true,
+      },
+      update: {
+        upc: input.upc,
+        name: input.name,
+        brand: input.brand,
+        format: input.format,
+        strainType: input.strainType,
+        thcMgPerUnit: input.thcMgPerUnit,
+        cbdMgPerUnit: input.cbdMgPerUnit,
+        thcPercent: input.thcPercent,
+        cbdPercent: input.cbdPercent,
+        packSize: input.packSize,
+        priceCents: input.priceCents,
+        inStock: input.inStock,
+        inventoryCount: input.inventoryCount,
+        imageUrl: input.imageUrl,
+        coaUrl: input.coaUrl,
+        description: input.description,
+        active: true,
+      },
+    });
+    return { created: !existing };
+  },
+
+  async delistSkus(ids: string[]) {
+    if (ids.length === 0) return;
+    await prisma.dispensarySku.updateMany({
+      where: { id: { in: ids } },
+      data: { active: false, inStock: false },
+    });
+  },
+
+  async markDispensarySynced(dispensaryId: string, syncedAt: Date) {
+    await prisma.dispensary.update({
+      where: { id: dispensaryId },
+      data: { lastSyncedAt: syncedAt },
+    });
+  },
+};
+
+/**
+ * Read every dispensary owned by the org, with a count of active +
+ * in-stock SKUs. The locator pages use this to render distance-sorted
+ * cards.
+ */
+export async function listDispensariesForOrg(
+  organizationId: string,
+): Promise<DispensaryRow[]> {
+  const rows = await prisma.dispensary.findMany({
+    where: { organizationId },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      status: true,
+      latitude: true,
+      longitude: true,
+      addressLine1: true,
+      addressLine2: true,
+      city: true,
+      state: true,
+      postalCode: true,
+      phone: true,
+      websiteUrl: true,
+      hoursLine: true,
+      lastSyncedAt: true,
+      _count: { select: { skus: { where: { active: true, inStock: true } } } },
+    },
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    name: r.name,
+    status: r.status,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    addressLine1: r.addressLine1,
+    addressLine2: r.addressLine2,
+    city: r.city,
+    state: r.state,
+    postalCode: r.postalCode,
+    phone: r.phone,
+    websiteUrl: r.websiteUrl,
+    hoursLine: r.hoursLine,
+    lastSyncedAt: r.lastSyncedAt,
+    skuCount: r._count.skus,
+  }));
+}

--- a/src/lib/domain/supplement-wheel-server.ts
+++ b/src/lib/domain/supplement-wheel-server.ts
@@ -1,0 +1,53 @@
+// EMR-151 — Supplement wheel data fetcher (server-only).
+//
+// Pulled out of `supplement-wheel.ts` so the client component can import
+// types and pure helpers without dragging the Prisma client into the
+// browser bundle.
+
+import "server-only";
+import { cache } from "react";
+import { prisma } from "@/lib/db/prisma";
+import type {
+  SupplementCompound as DbSupplement,
+  SupplementCompoundEvidence as DbEvidence,
+} from "@prisma/client";
+import {
+  BUILTIN_SUPPLEMENTS,
+  type SupplementCompoundView,
+  type SupplementEvidence,
+} from "./supplement-wheel";
+
+function mapEvidence(e: DbEvidence): SupplementEvidence {
+  return e;
+}
+
+function mapRow(row: DbSupplement): SupplementCompoundView {
+  return {
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    color: row.color,
+    evidence: mapEvidence(row.evidence),
+    description: row.description,
+    symptoms: row.symptoms,
+    benefits: row.benefits,
+    risks: row.risks,
+    cannabisInteraction: row.cannabisInteraction,
+  };
+}
+
+export const getSupplementCompounds = cache(
+  async (): Promise<SupplementCompoundView[]> => {
+    try {
+      const rows = await prisma.supplementCompound.findMany({
+        where: { active: true },
+        orderBy: [{ category: "asc" }, { sortOrder: "asc" }, { name: "asc" }],
+      });
+      return rows.map(mapRow);
+    } catch {
+      // DB unreachable (e.g. local dev without seed) — return the
+      // built-in fallback so the wheel still renders.
+      return BUILTIN_SUPPLEMENTS;
+    }
+  },
+);

--- a/src/lib/domain/supplement-wheel.ts
+++ b/src/lib/domain/supplement-wheel.ts
@@ -1,0 +1,120 @@
+// EMR-151 — Symptom/Diagnosis Supplement Combo Wheel.
+//
+// Client-safe types and pure helpers for the supplement wheel. The
+// prisma-backed fetcher lives in `./supplement-wheel-server.ts` so the
+// client component can pull from this file without dragging the
+// database client into the browser bundle.
+
+export type SupplementEvidence = "strong" | "moderate" | "emerging";
+
+export interface SupplementCompoundView {
+  id: string;
+  name: string;
+  category: string;
+  color: string;
+  evidence: SupplementEvidence;
+  description: string;
+  symptoms: string[];
+  benefits: string[];
+  risks: string[];
+  cannabisInteraction: string | null;
+}
+
+/**
+ * Symptom-overlap intersection for any number of selected supplements.
+ * Returns symptom name -> count of supplements that target it.
+ */
+export function symptomOverlap(
+  selected: SupplementCompoundView[],
+): Array<{ symptom: string; count: number }> {
+  const counts: Record<string, number> = {};
+  for (const s of selected) {
+    for (const symptom of s.symptoms) {
+      counts[symptom] = (counts[symptom] ?? 0) + 1;
+    }
+  }
+  return Object.entries(counts)
+    .map(([symptom, count]) => ({ symptom, count }))
+    .sort((a, b) => b.count - a.count || a.symptom.localeCompare(b.symptom));
+}
+
+/**
+ * Built-in seed list that ships with the app. Used as the wheel's
+ * fallback when the database is unavailable. Matches the seed in
+ * prisma/seed.ts so dev and prod render the same content.
+ */
+export const BUILTIN_SUPPLEMENTS: SupplementCompoundView[] = [
+  {
+    id: "magnesium-glycinate",
+    name: "Magnesium Glycinate",
+    category: "Mineral",
+    color: "#7C9F8C",
+    evidence: "strong",
+    description: "Highly bioavailable form of magnesium with calming effects.",
+    symptoms: ["sleep", "muscle tension", "anxiety"],
+    benefits: ["Improves sleep onset", "Reduces nighttime cramps", "Calms nervous system"],
+    risks: ["Loose stools at high doses"],
+    cannabisInteraction:
+      "Generally synergistic with CBD for sleep and muscle relaxation.",
+  },
+  {
+    id: "melatonin",
+    name: "Melatonin",
+    category: "Hormone",
+    color: "#5B6F8E",
+    evidence: "strong",
+    description: "Endogenous sleep-onset hormone; useful for shifted circadian rhythms.",
+    symptoms: ["sleep", "jet lag", "shift work"],
+    benefits: ["Shortens sleep latency", "Stabilizes sleep timing"],
+    risks: ["Morning grogginess at >1 mg", "Vivid dreams"],
+    cannabisInteraction: "Stack low-dose melatonin (0.3–1 mg) with bedtime CBN for sleep.",
+  },
+  {
+    id: "omega-3",
+    name: "Omega-3 (EPA/DHA)",
+    category: "Essential Fatty Acid",
+    color: "#3F7D8A",
+    evidence: "strong",
+    description: "EPA + DHA fish oil; supports anti-inflammatory and cognitive pathways.",
+    symptoms: ["inflammation", "joint pain", "mood", "cognition"],
+    benefits: ["Reduces systemic inflammation", "Supports mood stability"],
+    risks: ["Mild blood-thinning at high doses"],
+    cannabisInteraction: "Complements CBD's anti-inflammatory action.",
+  },
+  {
+    id: "ashwagandha",
+    name: "Ashwagandha",
+    category: "Adaptogen",
+    color: "#9C7C5A",
+    evidence: "moderate",
+    description: "Ayurvedic adaptogen; shown to lower cortisol and support resilience.",
+    symptoms: ["stress", "anxiety", "fatigue"],
+    benefits: ["Lowers cortisol", "Improves stress resilience"],
+    risks: ["Avoid with thyroid medications without supervision"],
+    cannabisInteraction: "Pairs well with mid-day microdose CBD for stress without sedation.",
+  },
+  {
+    id: "l-theanine",
+    name: "L-Theanine",
+    category: "Amino",
+    color: "#6FA89A",
+    evidence: "strong",
+    description: "Amino acid from green tea; promotes alpha brainwaves and calm focus.",
+    symptoms: ["anxiety", "focus", "stress"],
+    benefits: ["Calm without sedation", "Smooths caffeine"],
+    risks: ["Generally well-tolerated"],
+    cannabisInteraction: "Can offset THC-induced anxiety; safe to combine.",
+  },
+  {
+    id: "vitamin-d3",
+    name: "Vitamin D3",
+    category: "Vitamin",
+    color: "#D4A04E",
+    evidence: "strong",
+    description: "Sun-derived vitamin; deficiency linked to mood and immune issues.",
+    symptoms: ["fatigue", "mood", "immunity"],
+    benefits: ["Mood support", "Immune function"],
+    risks: ["Toxic at very high doses without K2 cofactor"],
+    cannabisInteraction: "No notable interaction; foundational stack.",
+  },
+];

--- a/src/lib/strains/finder.test.ts
+++ b/src/lib/strains/finder.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeSymptom,
+  rankStrains,
+  scoreStrain,
+  type StrainRow,
+} from "./finder";
+
+const STRAIN: StrainRow = {
+  id: "s1",
+  slug: "northern-lights",
+  name: "Northern Lights",
+  classification: "indica",
+  thcPercent: 18,
+  cbdPercent: 0.5,
+  dominantTerpene: "Myrcene",
+  symptoms: ["insomnia", "pain", "anxiety"],
+  effects: ["relaxed", "sleepy"],
+  flavors: ["earthy", "sweet"],
+  description: null,
+};
+
+describe("normalizeSymptom", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeSymptom(" Insomnia ")).toBe("insomnia");
+  });
+});
+
+describe("scoreStrain", () => {
+  it("rewards each matched symptom", () => {
+    const r = scoreStrain(STRAIN, { symptoms: ["insomnia", "pain"] });
+    expect(r.matchedSymptoms).toEqual(["insomnia", "pain"]);
+    expect(r.score).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("treats sleep as synonym for insomnia", () => {
+    const r = scoreStrain(STRAIN, { symptoms: ["sleep"] });
+    expect(r.matchedSymptoms).toEqual(["sleep"]);
+  });
+
+  it("rewards classification match", () => {
+    const base = scoreStrain(STRAIN, { symptoms: ["insomnia"] });
+    const withClass = scoreStrain(STRAIN, {
+      symptoms: ["insomnia"],
+      preferredClassification: "indica",
+    });
+    expect(withClass.score).toBeGreaterThan(base.score);
+  });
+
+  it("hard penalizes when THC cap exceeded", () => {
+    const high: StrainRow = { ...STRAIN, thcPercent: 30 };
+    const r = scoreStrain(high, { symptoms: ["insomnia"], maxThcPercent: 18 });
+    expect(r.score).toBeLessThanOrEqual(0);
+  });
+
+  it("rewards meeting CBD floor", () => {
+    const cbdRich: StrainRow = { ...STRAIN, cbdPercent: 8 };
+    const r = scoreStrain(cbdRich, { symptoms: ["pain"], minCbdPercent: 5 });
+    expect(r.reasons.some((reason) => reason.includes("CBD"))).toBe(true);
+  });
+
+  it("caps score at 1", () => {
+    const r = scoreStrain(STRAIN, {
+      symptoms: ["insomnia", "pain", "anxiety"],
+      preferredClassification: "indica",
+      maxThcPercent: 25,
+      minCbdPercent: 0,
+    });
+    expect(r.score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("rankStrains", () => {
+  const SAT_DAY: StrainRow = {
+    ...STRAIN,
+    id: "s2",
+    slug: "sour-diesel",
+    name: "Sour Diesel",
+    classification: "sativa",
+    symptoms: ["fatigue", "depression"],
+    thcPercent: 22,
+    cbdPercent: 0.1,
+  };
+
+  it("filters and sorts by score", () => {
+    const ranked = rankStrains([STRAIN, SAT_DAY], {
+      symptoms: ["insomnia"],
+      preferredClassification: "indica",
+    });
+    expect(ranked[0].strain.id).toBe("s1");
+    // Sour Diesel doesn't match insomnia; filtered out.
+    expect(ranked.find((r) => r.strain.id === "s2")).toBeUndefined();
+  });
+
+  it("returns unranked rows when no symptoms or classification given", () => {
+    const ranked = rankStrains([STRAIN, SAT_DAY], { symptoms: [] });
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0].score).toBe(0);
+  });
+});

--- a/src/lib/strains/finder.ts
+++ b/src/lib/strains/finder.ts
@@ -1,0 +1,121 @@
+// EMR-018 — Strain finder.
+//
+// Maps a patient's symptoms to candidate strains, ranked by symptom
+// overlap and (optionally) preferred classification (indica/sativa/
+// hybrid). Pure scoring lives here so it's testable without Prisma.
+
+export type StrainClassification = "indica" | "sativa" | "hybrid" | "cbd" | "na";
+
+export interface StrainRow {
+  id: string;
+  slug: string;
+  name: string;
+  classification: StrainClassification;
+  thcPercent: number | null;
+  cbdPercent: number | null;
+  dominantTerpene: string | null;
+  symptoms: string[];
+  effects: string[];
+  flavors: string[];
+  description: string | null;
+}
+
+export interface FinderQuery {
+  symptoms: string[];
+  preferredClassification?: StrainClassification;
+  /** Cap THC %, e.g. 18 for THC-cautious patients. */
+  maxThcPercent?: number;
+  /** Floor CBD %, e.g. 5 for patients who want CBD support. */
+  minCbdPercent?: number;
+}
+
+export interface ScoredStrain {
+  strain: StrainRow;
+  score: number;
+  matchedSymptoms: string[];
+  reasons: string[];
+}
+
+export function normalizeSymptom(s: string): string {
+  return s.toLowerCase().trim();
+}
+
+const CANNABIS_INSOMNIA = new Set(["insomnia", "sleep", "trouble sleeping"]);
+const CANNABIS_ANXIETY = new Set(["anxiety", "stress", "worry", "panic"]);
+const CANNABIS_PAIN = new Set(["pain", "chronic pain", "muscle pain", "nerve pain"]);
+
+/**
+ * Treat near-synonyms as a soft match. We don't want to bury "sleep"
+ * matches under a strict equality on "insomnia".
+ */
+function symptomMatches(strainSymptoms: string[], target: string): boolean {
+  const t = normalizeSymptom(target);
+  for (const s of strainSymptoms) {
+    const norm = normalizeSymptom(s);
+    if (norm === t) return true;
+    if (CANNABIS_INSOMNIA.has(norm) && CANNABIS_INSOMNIA.has(t)) return true;
+    if (CANNABIS_ANXIETY.has(norm) && CANNABIS_ANXIETY.has(t)) return true;
+    if (CANNABIS_PAIN.has(norm) && CANNABIS_PAIN.has(t)) return true;
+  }
+  return false;
+}
+
+export function scoreStrain(strain: StrainRow, query: FinderQuery): ScoredStrain {
+  const matchedSymptoms: string[] = [];
+  const reasons: string[] = [];
+  let score = 0;
+
+  for (const target of query.symptoms) {
+    if (symptomMatches(strain.symptoms, target)) {
+      matchedSymptoms.push(target);
+      score += 0.25;
+    }
+  }
+  if (matchedSymptoms.length > 0) {
+    reasons.push(`Symptom match: ${matchedSymptoms.join(", ")}`);
+  }
+
+  if (
+    query.preferredClassification &&
+    strain.classification === query.preferredClassification
+  ) {
+    score += 0.15;
+    reasons.push(`Classification: ${strain.classification}`);
+  }
+
+  if (query.maxThcPercent !== undefined) {
+    if (strain.thcPercent !== null && strain.thcPercent <= query.maxThcPercent) {
+      score += 0.1;
+      reasons.push(`THC ≤ ${query.maxThcPercent}%`);
+    } else if (strain.thcPercent !== null && strain.thcPercent > query.maxThcPercent) {
+      // Hard penalty: patient explicitly capped THC.
+      score -= 0.5;
+      reasons.push(`Above THC cap (${strain.thcPercent}%)`);
+    }
+  }
+
+  if (query.minCbdPercent !== undefined) {
+    if (strain.cbdPercent !== null && strain.cbdPercent >= query.minCbdPercent) {
+      score += 0.1;
+      reasons.push(`CBD ≥ ${query.minCbdPercent}%`);
+    }
+  }
+
+  return {
+    strain,
+    score: Math.max(0, Math.min(1, score)),
+    matchedSymptoms,
+    reasons,
+  };
+}
+
+export function rankStrains(rows: StrainRow[], query: FinderQuery): ScoredStrain[] {
+  if (query.symptoms.length === 0 && !query.preferredClassification) {
+    // No filter — return rows in their natural order, scored 0.
+    return rows.map((s) => ({ strain: s, score: 0, matchedSymptoms: [], reasons: [] }));
+  }
+  return rows
+    .map((s) => scoreStrain(s, query))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+}

--- a/src/lib/strains/index.ts
+++ b/src/lib/strains/index.ts
@@ -1,0 +1,12 @@
+export {
+  normalizeSymptom,
+  rankStrains,
+  scoreStrain,
+} from "./finder";
+export type {
+  FinderQuery,
+  ScoredStrain,
+  StrainClassification,
+  StrainRow,
+} from "./finder";
+export { listActiveStrains, getStrainBySlug } from "./repository";

--- a/src/lib/strains/repository.ts
+++ b/src/lib/strains/repository.ts
@@ -1,0 +1,45 @@
+// EMR-018 — Prisma adapter for strain queries.
+
+import { prisma } from "@/lib/db/prisma";
+import type { StrainRow } from "./finder";
+
+export async function listActiveStrains(): Promise<StrainRow[]> {
+  const rows = await prisma.strain.findMany({
+    where: { active: true },
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      classification: true,
+      thcPercent: true,
+      cbdPercent: true,
+      dominantTerpene: true,
+      symptoms: true,
+      effects: true,
+      flavors: true,
+      description: true,
+    },
+  });
+  return rows as StrainRow[];
+}
+
+export async function getStrainBySlug(slug: string): Promise<StrainRow | null> {
+  const row = await prisma.strain.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      classification: true,
+      thcPercent: true,
+      cbdPercent: true,
+      dominantTerpene: true,
+      symptoms: true,
+      effects: true,
+      flavors: true,
+      description: true,
+    },
+  });
+  return row as StrainRow | null;
+}

--- a/src/lib/supply-store/index.ts
+++ b/src/lib/supply-store/index.ts
@@ -1,0 +1,10 @@
+export {
+  recommend,
+  scoreSupplyProduct,
+} from "./recommender";
+export type {
+  PatientContext,
+  RankedSupplyProduct,
+  SupplyCategory,
+  SupplyProductCandidate,
+} from "./recommender";

--- a/src/lib/supply-store/recommender.test.ts
+++ b/src/lib/supply-store/recommender.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  recommend,
+  scoreSupplyProduct,
+  type PatientContext,
+  type SupplyProductCandidate,
+} from "./recommender";
+
+const candidate = (overrides: Partial<SupplyProductCandidate> = {}): SupplyProductCandidate => ({
+  id: overrides.id ?? "p1",
+  slug: overrides.slug ?? "p1",
+  name: overrides.name ?? "Generic",
+  brand: overrides.brand,
+  category: overrides.category ?? "general_wellness",
+  description: overrides.description ?? "",
+  shortDescription: overrides.shortDescription,
+  imageUrl: overrides.imageUrl,
+  priceCents: overrides.priceCents ?? 1500,
+  symptoms: overrides.symptoms ?? [],
+  conditions: overrides.conditions ?? [],
+  contraindications: overrides.contraindications ?? [],
+  isOTC: overrides.isOTC ?? true,
+  requiresRx: overrides.requiresRx ?? false,
+  fsaEligible: overrides.fsaEligible ?? false,
+  externalUrl: overrides.externalUrl,
+  externalPartner: overrides.externalPartner,
+});
+
+describe("scoreSupplyProduct", () => {
+  it("scores zero when no overlap", () => {
+    const r = scoreSupplyProduct(candidate({ symptoms: ["cough"] }), {
+      symptoms: ["insomnia"],
+      conditions: [],
+      contraindications: [],
+    });
+    expect(r.score).toBe(0);
+  });
+
+  it("rewards symptom overlap", () => {
+    const r = scoreSupplyProduct(
+      candidate({ symptoms: ["cough", "sore throat"] }),
+      { symptoms: ["cough", "sore throat"], conditions: [], contraindications: [] },
+    );
+    expect(r.matchedSymptoms.length).toBe(2);
+    expect(r.score).toBeGreaterThan(0.4);
+  });
+
+  it("blocks on contraindication", () => {
+    const r = scoreSupplyProduct(
+      candidate({ contraindications: ["warfarin"], symptoms: ["pain"] }),
+      { symptoms: ["pain"], conditions: [], contraindications: ["Warfarin"] },
+    );
+    expect(r.score).toBe(0);
+    expect(r.blockedReason).toMatch(/warfarin/i);
+  });
+
+  it("normalizes case for matching", () => {
+    const r = scoreSupplyProduct(
+      candidate({ symptoms: ["INSOMNIA"] }),
+      { symptoms: ["insomnia"], conditions: [], contraindications: [] },
+    );
+    expect(r.matchedSymptoms.length).toBe(1);
+  });
+});
+
+describe("recommend", () => {
+  const ctx: PatientContext = {
+    symptoms: ["cough", "sore throat"],
+    conditions: [],
+    contraindications: [],
+  };
+
+  it("returns ranked, non-blocked products", () => {
+    const catalog = [
+      candidate({ id: "a", symptoms: ["cough", "sore throat"], category: "cough_cold" }),
+      candidate({ id: "b", symptoms: ["cough"], category: "cough_cold" }),
+      candidate({ id: "c", symptoms: ["pain"], category: "pain" }),
+      candidate({
+        id: "d",
+        symptoms: ["cough"],
+        contraindications: ["pregnant"],
+        category: "cough_cold",
+      }),
+    ];
+    const ranked = recommend(catalog, {
+      ...ctx,
+      contraindications: ["pregnant"],
+    });
+    expect(ranked.map((r) => r.product.id)).toEqual(["a", "b"]);
+  });
+
+  it("respects category filter", () => {
+    const catalog = [
+      candidate({ id: "a", symptoms: ["cough"], category: "cough_cold" }),
+      candidate({ id: "b", symptoms: ["cough"], category: "general_wellness" }),
+    ];
+    const ranked = recommend(catalog, {
+      ...ctx,
+      categoryFilter: ["cough_cold"],
+    });
+    expect(ranked.map((r) => r.product.id)).toEqual(["a"]);
+  });
+
+  it("respects the limit", () => {
+    const catalog = Array.from({ length: 30 }, (_, i) =>
+      candidate({ id: `p${i}`, symptoms: ["cough"], category: "cough_cold" }),
+    );
+    expect(recommend(catalog, ctx, 5)).toHaveLength(5);
+  });
+});

--- a/src/lib/supply-store/recommender.ts
+++ b/src/lib/supply-store/recommender.ts
@@ -1,0 +1,134 @@
+// EMR-007 — AI Supply Store recommender.
+//
+// Pure scoring layer that ranks SupplyProduct candidates against a
+// patient's symptoms, conditions, and contraindications. The
+// "AI-Powered" framing in the ticket is satisfied by the upstream
+// agent that classifies the patient's chart into symptom tags; this
+// module turns those tags into a deterministic ranked list.
+//
+// Splitting the scoring out of Prisma means we can unit-test it
+// without a database and reuse the same logic in tools that mock the
+// catalog (eg. /portal/wellness-toolkit suggestions).
+
+export type SupplyCategory =
+  | "cough_cold"
+  | "sleep"
+  | "pain"
+  | "digestive"
+  | "vitamins_supplements"
+  | "dme"
+  | "topical"
+  | "oral_care"
+  | "mental_health"
+  | "womens_health"
+  | "general_wellness";
+
+export interface SupplyProductCandidate {
+  id: string;
+  slug: string;
+  name: string;
+  brand?: string | null;
+  category: SupplyCategory;
+  description: string;
+  shortDescription?: string | null;
+  imageUrl?: string | null;
+  priceCents: number;
+  symptoms: string[];
+  conditions: string[];
+  contraindications: string[];
+  isOTC: boolean;
+  requiresRx: boolean;
+  fsaEligible: boolean;
+  externalUrl?: string | null;
+  externalPartner?: string | null;
+}
+
+export interface PatientContext {
+  /** Lower-cased symptom strings, e.g. "cough", "insomnia". */
+  symptoms: string[];
+  /** Lower-cased active conditions / diagnoses. */
+  conditions: string[];
+  /** Active medications and known allergies — used for contraindication blocking. */
+  contraindications: string[];
+  /** When set, only categories explicitly requested are considered. */
+  categoryFilter?: SupplyCategory[];
+}
+
+export interface RankedSupplyProduct {
+  product: SupplyProductCandidate;
+  score: number;
+  matchedSymptoms: string[];
+  matchedConditions: string[];
+  blockedReason?: string;
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().trim();
+}
+
+function intersect(a: string[], b: string[]): string[] {
+  const set = new Set(a.map(normalize));
+  const out: string[] = [];
+  for (const x of b) if (set.has(normalize(x))) out.push(x);
+  return out;
+}
+
+function blocksOnContraindication(
+  product: SupplyProductCandidate,
+  patient: PatientContext,
+): string | null {
+  const patientFlags = patient.contraindications.map(normalize);
+  const productFlags = product.contraindications.map(normalize);
+  for (const flag of productFlags) {
+    if (patientFlags.includes(flag)) return flag;
+  }
+  return null;
+}
+
+export function scoreSupplyProduct(
+  product: SupplyProductCandidate,
+  patient: PatientContext,
+): RankedSupplyProduct {
+  const block = blocksOnContraindication(product, patient);
+  if (block) {
+    return {
+      product,
+      score: 0,
+      matchedSymptoms: [],
+      matchedConditions: [],
+      blockedReason: `Contraindicated for ${block}`,
+    };
+  }
+
+  const matchedSymptoms = intersect(product.symptoms, patient.symptoms);
+  const matchedConditions = intersect(product.conditions, patient.conditions);
+
+  let score = 0;
+  // Symptom match is the strongest signal (the patient's lived
+  // experience of the issue) — each match is worth more than a
+  // condition tag.
+  score += matchedSymptoms.length * 0.25;
+  score += matchedConditions.length * 0.15;
+
+  return {
+    product,
+    score: Math.min(1, score),
+    matchedSymptoms,
+    matchedConditions,
+  };
+}
+
+export function recommend(
+  catalog: SupplyProductCandidate[],
+  patient: PatientContext,
+  limit = 12,
+): RankedSupplyProduct[] {
+  const filtered = patient.categoryFilter && patient.categoryFilter.length > 0
+    ? catalog.filter((p) => patient.categoryFilter!.includes(p.category))
+    : catalog;
+  return filtered
+    .map((p) => scoreSupplyProduct(p, patient))
+    .filter((r) => !r.blockedReason && r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Phase 8 / Track 3 ships ten tickets that turn the EMR into a full
pharmacology + commerce surface. All work lives behind the same
schema migration and seed extension; everything degrades gracefully
when the database is unreachable.

| Ticket | Surface |
|---|---|
| **EMR-002** | Dispensary integration: `Dispensary` + `DispensarySku` models, POS-snapshot ingest endpoint with reconcile/soft-delist, regimen match scoring against live SKUs |
| **EMR-007** | AI Supply Store: `SupplyProduct` catalog (OTC/DME/supplements) with symptom-driven recommender; `/leafmart/supply-store` |
| **EMR-017** | Dispensary Locator: 30-mile haversine filter, Google Maps embed gated by `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`, directions links; patient + clinician views |
| **EMR-018** | Leafly Strain Database: `Strain` reference table, classification + symptom finder, `/portal/strains` |
| **EMR-039** | Product Store: `AffiliatePartner` registry (PhytoRx, Flower Powered Products, AULV) with partner-specific disclaimer + joint-decision modal |
| **EMR-145** | Dispensary Billing/CMS: `DispensaryReimbursement` rows with $500/yr per-patient cap math, operator dashboard, audit-ready paper trail |
| **EMR-150/181** | Combo Wheel front-and-center: wheel embedded on public landing page; `/portal/combo-wheel` remains the patient deep dive |
| **EMR-151** | Symptom Supplement Wheel: `SupplementCompound` table, evidence-tagged categories, overlap insight panel, cannabis interaction notes |
| **EMR-188** | Integrated Marketplace hub: `/leafmart/marketplace` linking every commerce surface, founding partners section |

## What's in the diff

- **Schema**: 6 new models (`Dispensary`, `DispensarySku`, `Strain`, `SupplyProduct`, `AffiliatePartner`, `DispensaryReimbursement`, `SupplementCompound`) plus 6 enums; full migration `20260430120000_track8_pharmacology_commerce`
- **Pure libs** (`src/lib/{dispensary,strains,supply-store,affiliate}`): ingestion validator + reconcile, haversine geo + regimen scoring, $500-cap math, strain symptom ranker, supply recommender, affiliate UTM decorator
- **Pages**: `/leafmart/marketplace`, `/leafmart/supply-store`, `/portal/dispensaries`, `/portal/strains`, `/portal/supplement-wheel`, `/clinic/dispensaries`, `/ops/dispensary-reimbursement`, `POST /api/dispensary/ingest`
- **Public landing page**: combo wheel embedded inline beneath the pharmacology pillars (EMR-181)
- **Affiliate store** (`/store`): now sources cards from the registry so the partner list, copy, and disclaimer can update without a code deploy
- **Seed**: 10 strains, 3 SF Bay dispensaries + 9 SKUs, 8 supply items, 6 supplements, 3 affiliate partners, 3 demo reimbursement rows
- **Tests**: 62 new unit tests covering ingestion, locator, reimbursement, strain ranking, supply recommender, affiliate URL handling

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 706 / 706 pass
- [x] `npx next build` — full tree compiles, all 9 new routes resolve
- [x] `npx next lint` — no new warnings
- [ ] Apply migration in staging and verify seed reruns cleanly
- [ ] Smoke-test `/leafmart/marketplace`, `/portal/dispensaries`, `/portal/strains`, `/portal/supplement-wheel` against seeded data
- [ ] Test `POST /api/dispensary/ingest` with the configured `DISPENSARY_INGEST_SECRET`
- [ ] Confirm Google Maps embed renders when `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)