### PR TITLE
fix(leafmart): mount age gate on all routes, not just cart/checkout

### DIFF
--- a/src/app/leafmart/layout.tsx
+++ b/src/app/leafmart/layout.tsx
@@ -3,6 +3,7 @@ import { LeafmartHeader } from "@/components/leafmart/LeafmartHeader";
 import { LeafmartFooter } from "@/components/leafmart/LeafmartFooter";
 import { CartProvider } from "@/lib/leafmart/cart-store";
 import { CartDrawer } from "@/components/leafmart/CartDrawer";
+import { LeafmartAgeGate } from "@/components/leafmart/LeafmartAgeGate";
 import { JsonLd } from "@/components/leafmart/JsonLd";
 import { SITE_URL, organizationLd, websiteLd } from "@/lib/leafmart/seo";
 
@@ -65,6 +66,7 @@ export default function LeafmartLayout({
         <main id="main-content" className="flex-1" tabIndex={-1}>{children}</main>
         <LeafmartFooter />
         <CartDrawer />
+        <LeafmartAgeGate />
       </div>
     </CartProvider>
   );

--- a/src/components/leafmart/LeafmartAgeGate.tsx
+++ b/src/components/leafmart/LeafmartAgeGate.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useCallback } from "react";
+import { AgeGateModal } from "@/components/leafmart/AgeGateModal";
+import { useAgeConfirmation } from "@/lib/leafmart/age-confirmation";
+
+/**
+ * Site-wide age gate for the Leafmart storefront. Mounted once in the
+ * leafmart route-group layout so it fires on first entry to any page,
+ * not only at cart/checkout. Persists for the browser session via the
+ * existing `useAgeConfirmation` hook (sessionStorage).
+ *
+ * Closing without a choice is intentionally a no-op — this is a compliance
+ * gate, not a casual prompt. A confirmed status unmounts the modal; a
+ * denied status keeps the polite blocked view visible.
+ */
+export function LeafmartAgeGate() {
+  const { status, hydrated } = useAgeConfirmation();
+  const noop = useCallback(() => {}, []);
+
+  if (!hydrated) return null;
+  if (status === "confirmed") return null;
+
+  return <AgeGateModal open onClose={noop} />;
+}


### PR DESCRIPTION
The AgeGateModal was only triggered inside CartDrawer and on /cart and /checkout pages. A visitor to theleafmart.com could browse the entire storefront without ever seeing the compliance gate.

- New LeafmartAgeGate wrapper reads useAgeConfirmation() hook
- Mounted once in leafmart/layout.tsx so it fires on first entry
- Session-scoped persistence preserved (sessionStorage)