### PR TITLE
Fix Clerk UI overlapping and dark mode bugs

### DIFF
--- a/src/app/(auth)/sign-in/[[...sign-in]]/clerk-signin-box.tsx
+++ b/src/app/(auth)/sign-in/[[...sign-in]]/clerk-signin-box.tsx
@@ -12,23 +12,19 @@ export default function ClerkSignInBox() {
       signUpUrl="/sign-up"
       appearance={{
         variables: {
-          colorPrimary: "hsl(var(--accent))",
-          colorBackground: "transparent",
-          colorInputBackground: "transparent",
+          colorPrimary: "#2E5A44",
+          colorText: "#152119",
+          colorTextSecondary: "#5E6C64",
+          colorBackground: "white",
+          colorInputBackground: "white",
+          colorInputText: "#152119",
         },
         elements: {
           rootBox: "w-full",
-          cardBox: "shadow-none border-0 bg-transparent p-0 m-0",
-          card: "bg-transparent shadow-none border-0 p-0 m-0",
+          cardBox: "shadow-none border-none",
+          card: "shadow-none border-none",
           headerTitle: "hidden",
           headerSubtitle: "hidden",
-          formButtonPrimary:
-            "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
-          socialButtonsBlockButton:
-            "border border-border hover:bg-surface-muted rounded-md",
-          formFieldInput:
-            "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
-          footerActionLink: "text-accent hover:text-accent/80",
         },
         layout: {
           socialButtonsPlacement: "top",

--- a/src/app/(auth)/sign-up/[[...sign-up]]/clerk-signup-box.tsx
+++ b/src/app/(auth)/sign-up/[[...sign-up]]/clerk-signup-box.tsx
@@ -12,23 +12,19 @@ export default function ClerkSignUpBox() {
       signInUrl="/sign-in"
       appearance={{
         variables: {
-          colorPrimary: "hsl(var(--accent))",
-          colorBackground: "transparent",
-          colorInputBackground: "transparent",
+          colorPrimary: "#2E5A44",
+          colorText: "#152119",
+          colorTextSecondary: "#5E6C64",
+          colorBackground: "white",
+          colorInputBackground: "white",
+          colorInputText: "#152119",
         },
         elements: {
           rootBox: "w-full",
-          cardBox: "shadow-none border-0 bg-transparent p-0 m-0",
-          card: "bg-transparent shadow-none border-0 p-0 m-0",
+          cardBox: "shadow-none border-none",
+          card: "shadow-none border-none",
           headerTitle: "hidden",
           headerSubtitle: "hidden",
-          formButtonPrimary:
-            "bg-accent hover:bg-accent/90 text-white font-medium rounded-md shadow-sm",
-          socialButtonsBlockButton:
-            "border border-border hover:bg-surface-muted rounded-md",
-          formFieldInput:
-            "rounded-md border border-border-strong bg-surface focus:border-accent focus:ring-2 focus:ring-accent/20",
-          footerActionLink: "text-accent hover:text-accent/80",
         },
         layout: {
           socialButtonsPlacement: "top",


### PR DESCRIPTION
## Summary
- Replace transparent/CSS-variable-driven Clerk appearance with explicit color values on the sign-in and sign-up boxes
- Remove redundant element class overrides that were causing overlapping cards
- Fixes dark-mode unreadability and the double-card UI bug

## Test plan
- [ ] Visit `/sign-in` in light and dark mode and confirm a single, readable card
- [ ] Visit `/sign-up` in light and dark mode and confirm a single, readable card
- [ ] Verify form inputs, primary button, and social buttons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)