### PR TITLE
feat: colorize Cannabis Wheel surfaces across the app

### DIFF
--- a/src/app/(patient)/portal/chatcb/page.tsx
+++ b/src/app/(patient)/portal/chatcb/page.tsx
@@ -37,7 +37,19 @@ export default async function ChatCBPage() {
               <Button variant="secondary">Browse research</Button>
             </Link>
             <Link href="/portal/combo-wheel">
-              <Button>Try the Cannabis Wheel</Button>
+              <Button className="gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-full ring-1 ring-white/40 shadow-[0_0_0_1px_rgba(255,255,255,0.15)]"
+                  style={{
+                    background:
+                      "conic-gradient(from 0deg, #2D8B5E, #4FA77B, #E8A838, #B86896, #6B4F8B, #1F8AB6, #2D8B5E)",
+                  }}
+                >
+                  <span className="block h-1 w-1 rounded-full bg-white" />
+                </span>
+                Try the Cannabis Wheel
+              </Button>
             </Link>
           </div>
         </CardContent>

--- a/src/app/leafmart/marketplace/page.tsx
+++ b/src/app/leafmart/marketplace/page.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { prisma } from "@/lib/db/prisma";
 import { listAffiliatePartners } from "@/lib/affiliate/partners";
+import { cn } from "@/lib/utils/cn";
 
 export const metadata: Metadata = {
   title: "Marketplace",
@@ -70,6 +71,11 @@ interface Surface {
   cta: string;
   count?: string;
   highlight?: string;
+  // When set, the card renders a colored conic-gradient orb in the
+  // header instead of the default LeafSprig — used for the wheel
+  // surfaces so they read as proprietary pharmacology tools rather
+  // than catalog tiles.
+  wheelAccent?: "cannabis" | "supplement";
 }
 
 export default async function MarketplaceHubPage() {
@@ -135,6 +141,7 @@ export default async function MarketplaceHubPage() {
         "Our signature pharmacology tool. Mix cannabinoids and terpenes; see the combined therapeutic profile.",
       cta: "Open the wheel →",
       highlight: "Proprietary",
+      wheelAccent: "cannabis",
     },
     {
       href: "/portal/supplement-wheel",
@@ -144,6 +151,7 @@ export default async function MarketplaceHubPage() {
         "Stack evidence-based supplements that complement your cannabis regimen. Surfaces interactions automatically.",
       cta: "Build your stack →",
       highlight: "New",
+      wheelAccent: "supplement",
     },
     {
       href: "/store",
@@ -178,38 +186,66 @@ export default async function MarketplaceHubPage() {
 
       <section className="max-w-[1320px] mx-auto px-6 lg:px-12">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          {surfaces.map((s) => (
-            <Link
-              key={s.href}
-              href={s.href}
-              className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-2xl"
-            >
-              <Card
-                tone="raised"
-                className="h-full transition-transform group-hover:-translate-y-0.5 group-hover:shadow-md"
+          {surfaces.map((s) => {
+            const wheelGradient =
+              s.wheelAccent === "cannabis"
+                ? "conic-gradient(from 0deg, #2D8B5E, #4FA77B, #E8A838, #B86896, #6B4F8B, #1F8AB6, #2D8B5E)"
+                : s.wheelAccent === "supplement"
+                  ? "conic-gradient(from 0deg, #1F8AB6, #5BB8D8, #8BC34A, #FFB347, #E8A838, #B86896, #1F8AB6)"
+                  : null;
+            return (
+              <Link
+                key={s.href}
+                href={s.href}
+                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-2xl"
               >
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <Eyebrow>{s.eyebrow}</Eyebrow>
-                    {s.highlight && <Badge tone="accent">{s.highlight}</Badge>}
-                  </div>
-                  <CardTitle className="text-xl mt-2 flex items-center gap-2">
-                    <LeafSprig size={14} className="text-accent" />
-                    {s.title}
-                  </CardTitle>
-                  {s.count && (
-                    <CardDescription className="text-xs mt-1">{s.count}</CardDescription>
+                <Card
+                  tone="raised"
+                  className={cn(
+                    "h-full transition-transform group-hover:-translate-y-0.5 group-hover:shadow-md",
+                    wheelGradient && "relative overflow-hidden"
                   )}
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-text-muted leading-relaxed mb-4">
-                    {s.description}
-                  </p>
-                  <p className="text-sm font-medium text-accent">{s.cta}</p>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
+                >
+                  {wheelGradient && (
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute -top-16 -right-16 h-44 w-44 rounded-full opacity-30 blur-3xl"
+                      style={{ background: wheelGradient }}
+                    />
+                  )}
+                  <CardHeader className="pb-3 relative">
+                    <div className="flex items-center justify-between gap-2">
+                      <Eyebrow>{s.eyebrow}</Eyebrow>
+                      {s.highlight && <Badge tone="accent">{s.highlight}</Badge>}
+                    </div>
+                    <CardTitle className="text-xl mt-2 flex items-center gap-2">
+                      {wheelGradient ? (
+                        <span
+                          aria-hidden="true"
+                          className="relative inline-flex h-5 w-5 items-center justify-center rounded-full ring-1 ring-black/5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.18)]"
+                          style={{ background: wheelGradient }}
+                        >
+                          <span className="block h-1.5 w-1.5 rounded-full bg-white/95" />
+                        </span>
+                      ) : (
+                        <LeafSprig size={14} className="text-accent" />
+                      )}
+                      {s.title}
+                    </CardTitle>
+                    {s.count && (
+                      <CardDescription className="text-xs mt-1">{s.count}</CardDescription>
+                    )}
+                  </CardHeader>
+                  <CardContent className="relative">
+                    <p className="text-sm text-text-muted leading-relaxed mb-4">
+                      {s.description}
+                    </p>
+                    <p className="text-sm font-medium text-accent">{s.cta}</p>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -429,21 +429,52 @@ export default function HomePage() {
             </p>
           </div>
           <div className="relative overflow-hidden rounded-3xl border border-accent/20 bg-gradient-to-br from-accent/[0.04] via-surface-raised to-highlight/[0.04] p-6 md:p-10">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-24 -left-24 h-72 w-72 rounded-full opacity-50 blur-3xl"
+              style={{
+                background:
+                  "conic-gradient(from 200deg, #2D8B5E33, #E8A83833, #B8689633, #6B4F8B33, #2D8B5E33)",
+              }}
+            />
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8 relative">
               {WELLNESS_WHEEL_PILLARS.map((pillar) => {
                 const Icon = pillar.icon;
                 return (
                   <div
                     key={pillar.title}
-                    className="text-center p-5 rounded-2xl bg-surface/60 border border-border/50"
+                    className="group relative overflow-hidden text-center p-5 rounded-2xl bg-surface/70 border transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_40px_-22px_var(--pillar-color)]"
+                    style={{
+                      ["--pillar-color" as string]: pillar.color,
+                      borderColor: `${pillar.color}33`,
+                    }}
                   >
-                    <div className="w-12 h-12 rounded-2xl bg-accent/10 flex items-center justify-center mx-auto mb-3 ring-1 ring-accent/15">
-                      <Icon className="w-6 h-6 text-accent" />
+                    <div
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                      style={{
+                        background: `radial-gradient(circle at 50% 0%, ${pillar.color}1f, transparent 70%)`,
+                      }}
+                    />
+                    <div
+                      className="relative w-14 h-14 rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-[0_10px_24px_-10px_var(--pillar-color)]"
+                      style={{
+                        background: `linear-gradient(135deg, ${pillar.color}, ${pillar.colorEnd})`,
+                      }}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="absolute inset-0 rounded-2xl ring-1 ring-white/30"
+                      />
+                      <Icon
+                        className="relative w-7 h-7 text-white"
+                        strokeWidth={2.25}
+                      />
                     </div>
-                    <h3 className="font-display text-lg text-text tracking-tight mb-1">
+                    <h3 className="relative font-display text-lg text-text tracking-tight mb-1">
                       {pillar.title}
                     </h3>
-                    <p className="text-sm text-text-muted">{pillar.body}</p>
+                    <p className="relative text-sm text-text-muted">{pillar.body}</p>
                   </div>
                 );
               })}
@@ -788,6 +819,11 @@ type WellnessWheelPillar = {
   icon: LucideIcon;
   title: string;
   body: string;
+  // Pillar swatches mirror the wheel's compound palette so the framing
+  // tiles read as a key for the wheel below — cannabinoid green, terpene
+  // gold, condition violet.
+  color: string;
+  colorEnd: string;
 };
 
 const WELLNESS_WHEEL_PILLARS: WellnessWheelPillar[] = [
@@ -796,17 +832,23 @@ const WELLNESS_WHEEL_PILLARS: WellnessWheelPillar[] = [
     title: "6 Cannabinoids",
     body:
       "THC, CBD, CBN, CBG, CBC, THCV — each with evidence-backed therapeutic profiles.",
+    color: "#2D8B5E",
+    colorEnd: "#4FA77B",
   },
   {
     icon: Flower2,
     title: "8 Terpenes",
     body:
       "Myrcene, limonene, linalool, pinene, caryophyllene, and more — the aromatic compounds that shape the effect.",
+    color: "#E8A838",
+    colorEnd: "#F2C46B",
   },
   {
     icon: Target,
     title: "10 Condition Guides",
     body:
       "Pain, insomnia, anxiety, PTSD, nausea, and more — matched to the best cannabinoid + terpene combinations.",
+    color: "#7C5BAA",
+    colorEnd: "#B07ECC",
   },
 ];

--- a/src/components/education/EducationTabs.tsx
+++ b/src/components/education/EducationTabs.tsx
@@ -6,6 +6,34 @@ import { Users, Atom, Sparkles, BookOpen } from "lucide-react";
 
 export type TabKey = "community" | "wheel" | "chatcb" | "research";
 
+// Colorful conic disc that stands in for the wheel tab's icon. Lives in
+// place of a single-tone Lucide glyph so the proprietary pharmacology
+// tool reads as the visual hero of the tab strip.
+function WheelDisc({ active }: { active: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative inline-flex h-4 w-4 items-center justify-center rounded-full",
+        active
+          ? "ring-1 ring-white/70 shadow-[0_0_0_1px_rgba(255,255,255,0.3)]"
+          : "ring-1 ring-black/5 shadow-[0_2px_6px_-2px_rgba(45,139,94,0.5)]"
+      )}
+      style={{
+        background:
+          "conic-gradient(from 0deg, #2D8B5E, #4FA77B, #E8A838, #B86896, #6B4F8B, #1F8AB6, #2D8B5E)",
+      }}
+    >
+      <span
+        className={cn(
+          "block h-1 w-1 rounded-full",
+          active ? "bg-white" : "bg-surface"
+        )}
+      />
+    </span>
+  );
+}
+
 export const EDUCATION_TABS: { key: TabKey; label: string; Icon: React.ElementType }[] = [
   { key: "community", label: "Community", Icon: Users },
   { key: "wheel", label: "Cannabis Combo Wheel", Icon: Atom },
@@ -95,7 +123,11 @@ export function EducationTabs({
                     : "bg-white/50 text-text-muted border-border hover:text-text hover:border-accent/40 hover:bg-white"
                 )}
               >
-                <Icon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+                {tab.key === "wheel" ? (
+                  <WheelDisc active={active} />
+                ) : (
+                  <Icon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+                )}
                 {tab.label}
               </button>
             );

--- a/src/components/layout/MobilePortraitNav.tsx
+++ b/src/components/layout/MobilePortraitNav.tsx
@@ -18,6 +18,10 @@ export interface MobileNavTab {
   label: string;
   href: string;
   icon: string;
+  // Optional 6-stop conic gradient. When present the tile renders the
+  // icon as a colorful "wheel" disc instead of a flat glyph — used for
+  // wheel/pharmacology surfaces so they read as proprietary tools.
+  wheelGradient?: boolean;
 }
 
 export interface MobileNavGroup {
@@ -43,7 +47,7 @@ export const DEFAULT_GROUPS: MobileNavGroup[] = [
     tabs: [
       { label: "ChatCB", href: "/education", icon: "❦" },
       { label: "Research", href: "/education#research", icon: "⚘" },
-      { label: "Wheel", href: "/education#wheel", icon: "⚫" },
+      { label: "Wheel", href: "/education#wheel", icon: "", wheelGradient: true },
       { label: "Drug Mix", href: "/education#drugmix", icon: "⚗" },
     ],
   },
@@ -148,12 +152,25 @@ export function MobilePortraitNav({
                     href={t.href}
                     className="flex flex-col items-center justify-center gap-1 rounded-xl bg-surface border border-border/60 px-2 py-3 hover:bg-surface-muted hover:border-accent/40 transition-all"
                   >
-                    <span
-                      className="text-base text-accent leading-none"
-                      aria-hidden
-                    >
-                      {t.icon}
-                    </span>
+                    {t.wheelGradient ? (
+                      <span
+                        className="relative inline-flex h-5 w-5 items-center justify-center rounded-full shadow-[0_2px_6px_-1px_rgba(45,139,94,0.55)]"
+                        style={{
+                          background:
+                            "conic-gradient(from 0deg, #2D8B5E, #4FA77B, #E8A838, #B86896, #6B4F8B, #1F8AB6, #2D8B5E)",
+                        }}
+                        aria-hidden
+                      >
+                        <span className="block h-1.5 w-1.5 rounded-full bg-white/90 ring-1 ring-black/5" />
+                      </span>
+                    ) : (
+                      <span
+                        className="text-base text-accent leading-none"
+                        aria-hidden
+                      >
+                        {t.icon}
+                      </span>
+                    )}
                     <span className="text-[10.5px] font-medium text-text leading-tight text-center">
                       {t.label}
                     </span>


### PR DESCRIPTION
## Summary
- Dr. Patel flagged that secondary surfaces referencing the Cannabis Wheel render flat / monochrome, undermining the wheel's identity as the proprietary pharmacology tool. This pass keeps the SVG wheel itself untouched (already colorful) and elevates every framing surface with the wheel's own conic palette.
- Cannabinoid green → terpene gold → condition violet → indigo, applied consistently as colored orbs, gradient pillars, and ambient glows.

## Changes
- **`src/app/page.tsx`** — `WELLNESS_WHEEL_PILLARS` row gets per-pillar gradient orbs (cannabinoids green, terpenes gold, conditions violet), hover lift, and a soft conic glow behind the row so the framing reads as a key for the wheel below.
- **`src/components/layout/MobilePortraitNav.tsx`** — replaces the literal `⚫` black-circle glyph for the "Wheel" tab with a 7-stop conic-gradient disc and a small white center hub mirroring the SVG wheel.
- **`src/components/education/EducationTabs.tsx`** — Cannabis Combo Wheel tab swaps the generic `Atom` Lucide icon for a mini conic disc.
- **`src/app/leafmart/marketplace/page.tsx`** — Cannabis Combo Wheel and Supplement Wheel cards render a colored conic orb in place of `LeafSprig` plus a corner conic glow, separating proprietary tools from catalog tiles.
- **`src/app/(patient)/portal/chatcb/page.tsx`** — "Try the Cannabis Wheel" CTA gets a leading conic disc.

## Test plan
- [ ] Public landing (`/`): scroll to Wellness Wheel section — verify three pillars now have distinct colored gradient orbs (green/gold/violet), hover lifts, and conic glow behind the row
- [ ] Mobile portrait (resize <768px): open landing, swipe to "Learn" group — verify Wheel tab shows a colorful conic disc instead of `⚫`
- [ ] `/education`: click through the Cannabis Combo Wheel tab — verify tab icon is a mini conic disc, both active and inactive states
- [ ] `/leafmart/marketplace`: verify Cannabis Combo Wheel and Supplement Wheel cards have colored orbs + corner conic glow, while other cards retain their `LeafSprig`
- [ ] `/portal/chatcb`: verify "Try the Cannabis Wheel" button has the conic disc icon
- [ ] No regressions on other navigation icons or marketplace tiles
- [ ] Type check passes (no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)