### PR TITLE
Practice Onboarding Controller v2 — modality layer, shell renderers, full 15-step wizard, audit log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Lint specialty manifests
+        run: npm run manifests:lint
+
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:watch": "vitest",
     "test:smoke": "tsx scripts/smoke-test.ts",
     "pm": "tsx scripts/pm-agent.ts",
-    "manifests:lint": "tsx scripts/lint-manifests.ts"
+    "manifests:lint": "tsx scripts/lint-manifests.ts",
+    "audit:export": "tsx scripts/export-audit-log.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:smoke": "tsx scripts/smoke-test.ts",
     "pm": "tsx scripts/pm-agent.ts",
     "manifests:lint": "tsx scripts/lint-manifests.ts",
-    "audit:export": "tsx scripts/export-audit-log.ts"
+    "audit:export": "tsx scripts/export-audit-log.ts",
+    "lint:modality": "tsx scripts/lint-modality-bleed.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",

--- a/prisma/migrations/20260505010000_add_migration_profile/migration.sql
+++ b/prisma/migrations/20260505010000_add_migration_profile/migration.sql
@@ -1,0 +1,20 @@
+-- EMR-453 — Migration profile attached to a PracticeConfiguration.
+-- The categories JSON array carries the per-domain mapping plan that the
+-- migration job runner (EMR-456) executes when a practice imports records
+-- from a previous EMR. Field-mapping detail lands in EMR-454; runtime
+-- import execution lands in EMR-456.
+
+-- ─── MigrationProfile ────────────────────────────────────────────────────
+CREATE TABLE "MigrationProfile" (
+  "id"              TEXT PRIMARY KEY,
+  "configurationId" TEXT NOT NULL,
+  "sourceType"      TEXT,
+  "categories"      JSONB NOT NULL DEFAULT '[]',
+  "status"          TEXT NOT NULL DEFAULT 'draft',
+  "createdBy"       TEXT NOT NULL,
+  "createdAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"       TIMESTAMP(3) NOT NULL,
+  "archivedAt"      TIMESTAMP(3)
+);
+CREATE INDEX "MigrationProfile_configurationId_idx" ON "MigrationProfile" ("configurationId");
+CREATE INDEX "MigrationProfile_status_idx" ON "MigrationProfile" ("status");

--- a/prisma/migrations/20260505100000_add_specialty_version/migration.sql
+++ b/prisma/migrations/20260505100000_add_specialty_version/migration.sql
@@ -1,0 +1,12 @@
+-- EMR-431 — Template versioning + immutability of published references
+-- Add `selectedSpecialtyVersion` to PracticeConfiguration so a published
+-- practice records the EXACT manifest version it was published against.
+-- Templates can evolve in the registry without silently re-rendering existing
+-- configurations; an explicit admin-gated upgrade is required to advance.
+--
+-- Nullable: existing rows pre-EMR-431 do not have a recorded version. The
+-- publish handler populates this field from the manifest at publish time;
+-- drafts created via apply-specialty may also persist it via PATCH.
+
+ALTER TABLE "PracticeConfiguration"
+  ADD COLUMN "selectedSpecialtyVersion" TEXT;

--- a/prisma/migrations/20260505120000_add_controller_audit_log/README.md
+++ b/prisma/migrations/20260505120000_add_controller_audit_log/README.md
@@ -1,0 +1,36 @@
+# EMR-470 — Controller audit log migration
+
+Adds the `ControllerAuditLog` table that backs the persisted writer in
+`src/lib/auth/audit-stub.ts` (path retained for storm-time stability; the
+filename is a misnomer post-EMR-470 — body is real persistence).
+
+## Files
+
+- `migration.sql` — Prisma-managed. Creates the table + indexes. Runs as part
+  of the normal `prisma migrate deploy` flow under the migrator role.
+- `append-only.sql` — **NOT** Prisma-managed. Ops must apply this after the
+  table exists, as a privileged DB user. It:
+  1. Grants the app role only `INSERT, SELECT`.
+  2. Revokes `UPDATE, DELETE, TRUNCATE` from the app role.
+  3. Installs `BEFORE UPDATE` / `BEFORE DELETE` triggers that raise
+     `insufficient_privilege` — defense in depth so the table stays
+     append-only even if grants drift.
+
+The script uses `psql` variable substitution (`:"app_role"`); invoke as:
+
+```
+psql "$DATABASE_URL" \
+  -v app_role="leafjourney_app" \
+  -f append-only.sql
+```
+
+Apply once per environment (staging, prod). The migrator role must be
+distinct from the app role — Prisma needs `UPDATE/DELETE` privileges on
+every table it owns for future migrations to run.
+
+## Compliance note
+
+The audit log is single-insert, no queue, no retry — see ticket scope. If
+a controller mutation fails to insert an audit row (DB down, etc.), the
+mutation still succeeds and the audit failure is logged via
+`console.error`. A durable queue is tracked as a follow-up.

--- a/prisma/migrations/20260505120000_add_controller_audit_log/append-only.sql
+++ b/prisma/migrations/20260505120000_add_controller_audit_log/append-only.sql
@@ -1,0 +1,43 @@
+-- EMR-470 — Append-only enforcement for ControllerAuditLog.
+--
+-- Apply this AFTER `migration.sql` has run. It must be applied by a
+-- privileged DB user (not the app role) so the app role loses UPDATE and
+-- DELETE on the audit table while retaining INSERT and SELECT.
+--
+-- Replace `:app_role` with the actual app DB role used in your environment
+-- (e.g. `app_user`, `leafjourney_app`, etc.). The Render staging role and
+-- the prod role are NOT the same — apply once per environment.
+--
+-- This is intentionally NOT a Prisma-managed migration step: Prisma needs
+-- UPDATE/DELETE on every table it owns to run future migrations under the
+-- migrator role. The migrator role should be a different DB role from the
+-- app role (the runtime connection in DATABASE_URL).
+
+-- 1. Grant the minimum the app needs.
+GRANT INSERT, SELECT ON TABLE "ControllerAuditLog" TO :"app_role";
+
+-- 2. Revoke mutate/delete from the app role explicitly. (REVOKE is a no-op
+--    if the privilege was never granted, but we list it for clarity and so
+--    re-running this script is idempotent against schema drift.)
+REVOKE UPDATE, DELETE, TRUNCATE ON TABLE "ControllerAuditLog" FROM :"app_role";
+
+-- 3. Belt-and-suspenders: a row-level trigger that refuses UPDATE/DELETE
+--    even if a future grant slips through. Compliance review will look for
+--    this.
+CREATE OR REPLACE FUNCTION controller_audit_log_append_only()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'ControllerAuditLog is append-only (op=%)', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS controller_audit_log_no_update ON "ControllerAuditLog";
+CREATE TRIGGER controller_audit_log_no_update
+  BEFORE UPDATE ON "ControllerAuditLog"
+  FOR EACH ROW EXECUTE FUNCTION controller_audit_log_append_only();
+
+DROP TRIGGER IF EXISTS controller_audit_log_no_delete ON "ControllerAuditLog";
+CREATE TRIGGER controller_audit_log_no_delete
+  BEFORE DELETE ON "ControllerAuditLog"
+  FOR EACH ROW EXECUTE FUNCTION controller_audit_log_append_only();

--- a/prisma/migrations/20260505120000_add_controller_audit_log/migration.sql
+++ b/prisma/migrations/20260505120000_add_controller_audit_log/migration.sql
@@ -1,0 +1,31 @@
+-- EMR-470 — Practice Onboarding Controller audit log (append-only).
+--
+-- Every controller mutation (template/config/wizard/publish/rollback) writes
+-- a row here via logControllerAction() in src/lib/auth/audit-stub.ts.
+--
+-- Append-only enforcement is in append-only.sql (sibling file). Ops must
+-- apply that grant script as a privileged DB user AFTER this migration runs;
+-- Prisma cannot revoke its own UPDATE/DELETE without losing the ability to
+-- run future migrations. See README.md in this directory.
+
+CREATE TABLE "ControllerAuditLog" (
+  "id"             TEXT PRIMARY KEY,
+  "at"             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "actorUserId"    TEXT NOT NULL,
+  "actorEmail"     TEXT,
+  "actorRoles"     "Role"[] NOT NULL DEFAULT ARRAY[]::"Role"[],
+  "organizationId" TEXT,
+  "action"         TEXT NOT NULL,
+  "subjectType"    TEXT NOT NULL DEFAULT 'controller',
+  "subjectId"      TEXT NOT NULL,
+  "before"         JSONB,
+  "after"          JSONB,
+  "reason"         TEXT
+);
+
+CREATE INDEX "ControllerAuditLog_subjectId_at_idx"
+  ON "ControllerAuditLog" ("subjectId", "at");
+CREATE INDEX "ControllerAuditLog_organizationId_at_idx"
+  ON "ControllerAuditLog" ("organizationId", "at");
+CREATE INDEX "ControllerAuditLog_actorUserId_at_idx"
+  ON "ControllerAuditLog" ("actorUserId", "at");

--- a/prisma/migrations/20260506000000_add_org_legal_name/migration.sql
+++ b/prisma/migrations/20260506000000_add_org_legal_name/migration.sql
@@ -1,0 +1,257 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "Role" ADD VALUE 'practice_admin';
+ALTER TYPE "Role" ADD VALUE 'implementation_admin';
+ALTER TYPE "Role" ADD VALUE 'super_admin';
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_initiatorUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_messageThreadId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_patientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_providerMessageThreadId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallLog" DROP CONSTRAINT "CallLog_providerUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallTranscript" DROP CONSTRAINT "CallTranscript_callLogId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallTranscript" DROP CONSTRAINT "CallTranscript_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CallTranscript" DROP CONSTRAINT "CallTranscript_reviewedByUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Dispensary" DROP CONSTRAINT "Dispensary_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DispensaryReimbursement" DROP CONSTRAINT "DispensaryReimbursement_dispensaryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DispensaryReimbursement" DROP CONSTRAINT "DispensaryReimbursement_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DispensaryReimbursement" DROP CONSTRAINT "DispensaryReimbursement_patientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DispensarySku" DROP CONSTRAINT "DispensarySku_dispensaryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "DispensarySku" DROP CONSTRAINT "DispensarySku_strainId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FaxRecord" DROP CONSTRAINT "FaxRecord_initiatorUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FaxRecord" DROP CONSTRAINT "FaxRecord_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FaxRecord" DROP CONSTRAINT "FaxRecord_patientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OutreachCampaign" DROP CONSTRAINT "OutreachCampaign_createdById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OutreachCampaign" DROP CONSTRAINT "OutreachCampaign_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OutreachRecipient" DROP CONSTRAINT "OutreachRecipient_campaignId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OutreachRecipient" DROP CONSTRAINT "OutreachRecipient_patientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderMessage" DROP CONSTRAINT "ProviderMessage_senderUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderMessage" DROP CONSTRAINT "ProviderMessage_threadId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderMessageThread" DROP CONSTRAINT "ProviderMessageThread_createdById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderMessageThread" DROP CONSTRAINT "ProviderMessageThread_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderMessageThread" DROP CONSTRAINT "ProviderMessageThread_patientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderThreadParticipant" DROP CONSTRAINT "ProviderThreadParticipant_threadId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ProviderThreadParticipant" DROP CONSTRAINT "ProviderThreadParticipant_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "SupplyProduct" DROP CONSTRAINT "SupplyProduct_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Voicemail" DROP CONSTRAINT "Voicemail_assignedToUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Voicemail" DROP CONSTRAINT "Voicemail_callLogId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Voicemail" DROP CONSTRAINT "Voicemail_listenedByUserId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Voicemail" DROP CONSTRAINT "Voicemail_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Voicemail" DROP CONSTRAINT "Voicemail_patientId_fkey";
+
+-- AlterTable
+ALTER TABLE "ControllerAuditLog" ALTER COLUMN "actorRoles" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "brandName" TEXT,
+ADD COLUMN     "city" TEXT,
+ADD COLUMN     "legalName" TEXT,
+ADD COLUMN     "npi" TEXT,
+ADD COLUMN     "postalCode" TEXT,
+ADD COLUMN     "primaryContactEmail" TEXT,
+ADD COLUMN     "primaryContactName" TEXT,
+ADD COLUMN     "state" TEXT,
+ADD COLUMN     "street" TEXT,
+ADD COLUMN     "timeZone" TEXT;
+
+-- AlterTable
+ALTER TABLE "Practice" DROP COLUMN "address",
+DROP COLUMN "brandName",
+DROP COLUMN "legalName",
+DROP COLUMN "primaryContact",
+DROP COLUMN "timezone",
+ADD COLUMN     "city" TEXT,
+ADD COLUMN     "name" TEXT NOT NULL,
+ADD COLUMN     "postalCode" TEXT,
+ADD COLUMN     "specialtyHint" TEXT,
+ADD COLUMN     "state" TEXT,
+ADD COLUMN     "street" TEXT,
+ADD COLUMN     "timeZone" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Practice_name_idx" ON "Practice"("name");
+
+-- AddForeignKey
+ALTER TABLE "Practice" ADD CONSTRAINT "Practice_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderMessageThread" ADD CONSTRAINT "ProviderMessageThread_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderMessageThread" ADD CONSTRAINT "ProviderMessageThread_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderMessageThread" ADD CONSTRAINT "ProviderMessageThread_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderThreadParticipant" ADD CONSTRAINT "ProviderThreadParticipant_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "ProviderMessageThread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderThreadParticipant" ADD CONSTRAINT "ProviderThreadParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderMessage" ADD CONSTRAINT "ProviderMessage_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "ProviderMessageThread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderMessage" ADD CONSTRAINT "ProviderMessage_senderUserId_fkey" FOREIGN KEY ("senderUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_initiatorUserId_fkey" FOREIGN KEY ("initiatorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_providerUserId_fkey" FOREIGN KEY ("providerUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_messageThreadId_fkey" FOREIGN KEY ("messageThreadId") REFERENCES "MessageThread"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallLog" ADD CONSTRAINT "CallLog_providerMessageThreadId_fkey" FOREIGN KEY ("providerMessageThreadId") REFERENCES "ProviderMessageThread"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallTranscript" ADD CONSTRAINT "CallTranscript_callLogId_fkey" FOREIGN KEY ("callLogId") REFERENCES "CallLog"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallTranscript" ADD CONSTRAINT "CallTranscript_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CallTranscript" ADD CONSTRAINT "CallTranscript_reviewedByUserId_fkey" FOREIGN KEY ("reviewedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FaxRecord" ADD CONSTRAINT "FaxRecord_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FaxRecord" ADD CONSTRAINT "FaxRecord_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FaxRecord" ADD CONSTRAINT "FaxRecord_initiatorUserId_fkey" FOREIGN KEY ("initiatorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutreachCampaign" ADD CONSTRAINT "OutreachCampaign_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutreachCampaign" ADD CONSTRAINT "OutreachCampaign_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutreachRecipient" ADD CONSTRAINT "OutreachRecipient_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "OutreachCampaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutreachRecipient" ADD CONSTRAINT "OutreachRecipient_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Voicemail" ADD CONSTRAINT "Voicemail_callLogId_fkey" FOREIGN KEY ("callLogId") REFERENCES "CallLog"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Voicemail" ADD CONSTRAINT "Voicemail_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Voicemail" ADD CONSTRAINT "Voicemail_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Voicemail" ADD CONSTRAINT "Voicemail_assignedToUserId_fkey" FOREIGN KEY ("assignedToUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Voicemail" ADD CONSTRAINT "Voicemail_listenedByUserId_fkey" FOREIGN KEY ("listenedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Dispensary" ADD CONSTRAINT "Dispensary_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DispensarySku" ADD CONSTRAINT "DispensarySku_dispensaryId_fkey" FOREIGN KEY ("dispensaryId") REFERENCES "Dispensary"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DispensarySku" ADD CONSTRAINT "DispensarySku_strainId_fkey" FOREIGN KEY ("strainId") REFERENCES "Strain"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SupplyProduct" ADD CONSTRAINT "SupplyProduct_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DispensaryReimbursement" ADD CONSTRAINT "DispensaryReimbursement_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DispensaryReimbursement" ADD CONSTRAINT "DispensaryReimbursement_dispensaryId_fkey" FOREIGN KEY ("dispensaryId") REFERENCES "Dispensary"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DispensaryReimbursement" ADD CONSTRAINT "DispensaryReimbursement_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4043,3 +4043,29 @@ model PracticeConfigurationVersion {
   @@unique([configurationId, version])
   @@index([configurationId])
 }
+
+// EMR-453 — Migration profile attached to a PracticeConfiguration.
+// One profile describes the source data set + per-category mapping plan that
+// the migration job runner (EMR-456) will execute when a practice imports
+// records from a previous EMR. The `categories` JSON array carries the
+// per-domain mapping rows (see src/lib/migration/profile-types.ts for the
+// canonical TS shape). Field-mapping detail lands in EMR-454; runtime import
+// execution lands in EMR-456.
+model MigrationProfile {
+  id              String   @id @default(cuid())
+  configurationId String
+  /// "csv" | "json" | "ehr-export" | "manual" | null (greenfield)
+  sourceType      String?
+  /// Array of category rows. See type definition below.
+  categories      Json     @default("[]")
+  /// "draft" | "configured" | "completed" | "archived"
+  status          String   @default("draft")
+  createdBy       String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  /// Soft delete only. Null until archived.
+  archivedAt      DateTime?
+
+  @@index([configurationId])
+  @@index([status])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4011,6 +4011,7 @@ model PracticeConfiguration {
   organizationId                String
   practiceId                    String
   selectedSpecialty             String?
+  selectedSpecialtyVersion      String?
   careModel                     String?
   enabledModalities             String[] @default([])
   disabledModalities            String[] @default([])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1682,6 +1682,35 @@ model AuditLog {
   @@index([subjectType, subjectId])
 }
 
+// EMR-470 — Practice Onboarding Controller audit log (append-only).
+//
+// Every mutation on the controller surface (templates, configs, wizard
+// saves, publish/rollback, etc.) writes a row here via
+// `logControllerAction()` in src/lib/auth/audit.ts (filename retained as
+// `audit-stub.ts` for storm-time import-path stability). The DB role used
+// by the app should NOT have UPDATE / DELETE on this table; ops applies
+// `append-only.sql` from the migration directory after deploy.
+model ControllerAuditLog {
+  id              String   @id @default(cuid())
+  at              DateTime @default(now())
+  actorUserId     String
+  actorEmail      String?
+  actorRoles      Role[]
+  organizationId  String?
+  /// Dot-namespaced — e.g. "controller.config.publish"
+  action          String
+  /// Always "controller" for v1; reserved for "modality", "template" later.
+  subjectType     String   @default("controller")
+  subjectId       String
+  before          Json?
+  after           Json?
+  reason          String?
+
+  @@index([subjectId, at])
+  @@index([organizationId, at])
+  @@index([actorUserId, at])
+}
+
 // --------------------------------------------------------------
 // Agentic Memory Harness
 // --------------------------------------------------------------

--- a/render-staging.yaml
+++ b/render-staging.yaml
@@ -30,9 +30,7 @@ services:
       - key: AUTH_PROVIDER
         value: clerk
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres-staging
-          property: connectionString
+        sync: false
       # Direct (non-pooled) Supabase URL for schema migrations. Must be
       # set manually in the Render dashboard — it's the port-5432
       # connection string from Supabase → Project Settings → Database →
@@ -80,9 +78,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres-staging
-          property: connectionString
+        sync: false
       - key: AGENT_MODEL_CLIENT
         value: openrouter
       - key: OPENROUTER_API_KEY
@@ -106,9 +102,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres-staging
-          property: connectionString
+        sync: false
 
 databases:
   - name: emr-postgres-staging

--- a/render.yaml
+++ b/render.yaml
@@ -30,9 +30,7 @@ services:
       - key: AUTH_PROVIDER
         value: clerk
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres
-          property: connectionString
+        sync: false
       # Direct (non-pooled) Supabase URL for schema migrations. Must be
       # set manually in the Render dashboard — it's the port-5432
       # connection string from Supabase → Project Settings → Database →
@@ -80,9 +78,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres
-          property: connectionString
+        sync: false
       - key: AGENT_MODEL_CLIENT
         value: openrouter
       - key: OPENROUTER_API_KEY
@@ -106,9 +102,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: emr-postgres
-          property: connectionString
+        sync: false
 
 databases:
   - name: emr-postgres

--- a/scripts/export-audit-log.ts
+++ b/scripts/export-audit-log.ts
@@ -1,0 +1,131 @@
+// EMR-470 — Compliance export for ControllerAuditLog.
+//
+// Streams matching audit rows as JSONL to stdout (one row per line), so the
+// output can be piped to a file, gzipped, or fed into a downstream
+// compliance tool without buffering the whole result set in memory.
+//
+// Usage:
+//   npx tsx scripts/export-audit-log.ts --practice <orgId>
+//   npx tsx scripts/export-audit-log.ts --practice <orgId> --since 2026-01-01
+//   npx tsx scripts/export-audit-log.ts --practice <orgId> --since 2026-01-01 --until 2026-04-01
+//
+// Or via npm:
+//   npm run audit:export -- --practice <orgId> --since 2026-01-01
+//
+// Notes:
+//   * `--practice` filters on `organizationId` (the column exists on every
+//     row written by `logControllerAction`). The CLI flag name follows the
+//     ticket spec; under the hood it maps to organizationId.
+//   * `--since` / `--until` accept any ISO-8601 string Date can parse.
+//   * Rows are streamed in ascending `at` order. There is no LIMIT — for
+//     compliance review we want the whole window.
+
+import { PrismaClient } from "@prisma/client";
+
+interface CliArgs {
+  practice: string;
+  since?: Date;
+  until?: Date;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const get = (name: string): string | undefined => {
+    const eq = argv.find((a) => a.startsWith(`--${name}=`));
+    if (eq) return eq.slice(name.length + 3);
+    const idx = argv.indexOf(`--${name}`);
+    if (idx >= 0 && idx + 1 < argv.length) return argv[idx + 1];
+    return undefined;
+  };
+
+  const practice = get("practice");
+  if (!practice) {
+    process.stderr.write(
+      "error: --practice <orgId> is required\n" +
+        "usage: tsx scripts/export-audit-log.ts --practice <orgId> [--since <iso>] [--until <iso>]\n",
+    );
+    process.exit(2);
+  }
+
+  const parseDate = (raw: string | undefined, flag: string): Date | undefined => {
+    if (!raw) return undefined;
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) {
+      process.stderr.write(`error: --${flag} is not a valid ISO date: ${raw}\n`);
+      process.exit(2);
+    }
+    return d;
+  };
+
+  return {
+    practice,
+    since: parseDate(get("since"), "since"),
+    until: parseDate(get("until"), "until"),
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+
+  try {
+    const where: Record<string, unknown> = { organizationId: args.practice };
+    if (args.since || args.until) {
+      const at: Record<string, Date> = {};
+      if (args.since) at.gte = args.since;
+      if (args.until) at.lte = args.until;
+      where.at = at;
+    }
+
+    // Page in batches to avoid pulling the whole result set into memory.
+    // `id` is a cuid (lexicographic time-correlated) so paginating on
+    // (at, id) gives a stable ordering even when many rows share the same
+    // millisecond.
+    const PAGE = 500;
+    let cursor: { id: string } | undefined = undefined;
+    let total = 0;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const batch: Array<{
+        id: string;
+        at: Date;
+        actorUserId: string;
+        actorEmail: string | null;
+        actorRoles: string[];
+        organizationId: string | null;
+        action: string;
+        subjectType: string;
+        subjectId: string;
+        before: unknown;
+        after: unknown;
+        reason: string | null;
+      }> = await prisma.controllerAuditLog.findMany({
+        where,
+        orderBy: [{ at: "asc" }, { id: "asc" }],
+        take: PAGE,
+        ...(cursor ? { skip: 1, cursor } : {}),
+      });
+
+      if (batch.length === 0) break;
+
+      for (const row of batch) {
+        process.stdout.write(JSON.stringify(row) + "\n");
+        total += 1;
+      }
+
+      if (batch.length < PAGE) break;
+      cursor = { id: batch[batch.length - 1].id };
+    }
+
+    process.stderr.write(`exported ${total} row(s)\n`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `export-audit-log failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/scripts/lint-manifests.ts
+++ b/scripts/lint-manifests.ts
@@ -1,4 +1,20 @@
 #!/usr/bin/env tsx
+/**
+ * Manifest CI lint — EMR-429 / EMR-433.
+ *
+ * Walks every manifest file under `src/lib/specialty-templates/manifests/`
+ * (both flat `*.ts` and nested `{slug}/v*.ts` layouts) and runs
+ * `validateManifest` against each exported object.
+ *
+ * Modality cross-check: the Zod schema's `superRefine` already rejects any
+ * modality that is not in `REGISTERED_MODALITIES` (see
+ * `src/lib/specialty-templates/manifest-schema.ts`). We deliberately do NOT
+ * duplicate that check here — the Zod error surfaces with the field path and
+ * the offending modality string, which is the actionable signal CI needs.
+ * If the schema check is ever removed or weakened, this script will start
+ * passing manifests that should be rejected; that's the inverse risk we
+ * accept in exchange for a single source of truth.
+ */
 import { readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -9,6 +25,38 @@ const MANIFESTS_DIR = resolve(
   "src/lib/specialty-templates/manifests",
 );
 
+function collectManifestFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isFile()) {
+      if (
+        entry.endsWith(".ts") &&
+        !entry.endsWith(".d.ts") &&
+        !entry.endsWith(".test.ts")
+      ) {
+        out.push(full);
+      }
+    } else if (stat.isDirectory()) {
+      // EMR-431 nested versioned layout: manifests/{slug}/v{X.Y.Z}.ts.
+      out.push(...collectManifestFiles(full));
+    }
+  }
+  return out;
+}
+
 async function main() {
   let entries: string[];
   try {
@@ -17,11 +65,10 @@ async function main() {
     console.log(`no manifests found (directory missing: ${MANIFESTS_DIR})`);
     process.exit(0);
   }
+  // Reference `entries` so the early-exit branch above stays meaningful.
+  void entries;
 
-  const files = entries
-    .filter((f) => f.endsWith(".ts") && !f.endsWith(".d.ts"))
-    .map((f) => join(MANIFESTS_DIR, f))
-    .filter((p) => statSync(p).isFile());
+  const files = collectManifestFiles(MANIFESTS_DIR);
 
   if (files.length === 0) {
     console.log("no manifests found");

--- a/scripts/lint-modality-bleed.ts
+++ b/scripts/lint-modality-bleed.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env tsx
+/**
+ * Modality Bleed Lint — EMR-410
+ *
+ * Fails the build when a hardcoded "cannabis" string OR an
+ * `if (specialty === 'cannabis')` pattern leaks into `*.ts` / `*.tsx` files
+ * outside the cannabis module / manifest / modality-registry whitelist.
+ *
+ * Whitelist (see ticket EMR-410):
+ *   - src/modules/cannabis/**                       — canonical cannabis home
+ *   - src/lib/specialty-templates/manifests/**      — manifests legitimately name modalities
+ *   - src/lib/modality/**                           — modality registry itself names slugs
+ *   - any *.test.ts / *.test.tsx file               — tests are allowed to assert names
+ *   - line-comments and block-comments              — comments may explain bleed
+ *   - the manifest-schema enum literal              — REGISTERED_MODALITIES contains "cannabis-medicine"
+ *
+ * The lint is intentionally a string scanner, not an AST walk: it should
+ * catch *the spelling* `cannabis` and the *exact branch* shape regardless of
+ * surrounding TypeScript syntax. Authors who legitimately need to mention
+ * cannabis can move the code to a whitelisted path or keep it in a comment.
+ *
+ * Output: one line per offending hit (path:line:col — message). Exit 1 when
+ * any hits are found, 0 otherwise.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+
+const ROOT = resolve(process.cwd());
+const SRC = join(ROOT, "src");
+
+const WHITELIST_PREFIXES = [
+  // POSIX-style; we normalize on lookup.
+  "src/modules/cannabis/",
+  "src/lib/specialty-templates/manifests/",
+  "src/lib/modality/",
+].map((p) => p.split("/").join(sep));
+
+const WHITELIST_FILES = [
+  // The enum literal is the registry-of-record for modality slugs and is
+  // expected to contain the string "cannabis".
+  ["src", "lib", "specialty-templates", "manifest-schema.ts"].join(sep),
+].map((p) => p);
+
+type Hit = {
+  file: string;
+  line: number;
+  col: number;
+  message: string;
+  text: string;
+};
+
+function isTestFile(rel: string): boolean {
+  return (
+    rel.endsWith(".test.ts") ||
+    rel.endsWith(".test.tsx") ||
+    rel.includes(`${sep}__tests__${sep}`)
+  );
+}
+
+function isWhitelisted(rel: string): boolean {
+  if (WHITELIST_FILES.includes(rel)) return true;
+  for (const prefix of WHITELIST_PREFIXES) {
+    if (rel.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (name === "node_modules" || name === ".next" || name.startsWith(".")) {
+      continue;
+    }
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (st.isFile() && (name.endsWith(".ts") || name.endsWith(".tsx"))) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Strip line and block comments from `src` while preserving line numbers, so
+ * column offsets reported in the source still line up. Strings are *not*
+ * stripped — a literal "cannabis" inside a string IS a hit (that's the
+ * whole point of the lint).
+ */
+function stripComments(src: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+
+    // Line comment: replace from // to newline with spaces, keep newline.
+    if (c === "/" && c2 === "/") {
+      while (i < n && src[i] !== "\n") {
+        out.push(" ");
+        i++;
+      }
+      continue;
+    }
+
+    // Block comment: replace until */ with spaces, preserving any newlines.
+    if (c === "/" && c2 === "*") {
+      out.push("  ");
+      i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) {
+        out.push(src[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      if (i < n) {
+        out.push("  ");
+        i += 2;
+      }
+      continue;
+    }
+
+    out.push(c);
+    i++;
+  }
+  return out.join("");
+}
+
+/** Yields {line, col} for a 0-based char index in `src`. */
+function locationOf(src: string, index: number): { line: number; col: number } {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < index; i++) {
+    if (src[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return { line, col };
+}
+
+const CANNABIS_PATTERN = /cannabis/gi;
+const SPECIALTY_BRANCH_PATTERN =
+  /if\s*\(\s*specialty\s*===\s*['"]cannabis['"]\s*\)/g;
+
+function scanFile(filePath: string, rel: string): Hit[] {
+  const raw = readFileSync(filePath, "utf8");
+  const stripped = stripComments(raw);
+  const hits: Hit[] = [];
+
+  // 1. Hardcoded "cannabis" literal in non-comment source.
+  for (const m of stripped.matchAll(CANNABIS_PATTERN)) {
+    if (m.index === undefined) continue;
+    const { line, col } = locationOf(stripped, m.index);
+    hits.push({
+      file: rel,
+      line,
+      col,
+      message: 'hardcoded "cannabis" outside whitelist',
+      text: raw
+        .split("\n")
+        [line - 1]?.trim()
+        .slice(0, 160) ?? "",
+    });
+  }
+
+  // 2. `if (specialty === 'cannabis')` branch shape.
+  for (const m of stripped.matchAll(SPECIALTY_BRANCH_PATTERN)) {
+    if (m.index === undefined) continue;
+    const { line, col } = locationOf(stripped, m.index);
+    hits.push({
+      file: rel,
+      line,
+      col,
+      message: "branch on `specialty === 'cannabis'` — use modality gate instead",
+      text: raw
+        .split("\n")
+        [line - 1]?.trim()
+        .slice(0, 160) ?? "",
+    });
+  }
+
+  return hits;
+}
+
+function main(): void {
+  const all: string[] = [];
+  walk(SRC, all);
+
+  const hits: Hit[] = [];
+  for (const file of all) {
+    const rel = relative(ROOT, file);
+    if (isTestFile(rel)) continue;
+    if (isWhitelisted(rel)) continue;
+    hits.push(...scanFile(file, rel));
+  }
+
+  if (hits.length === 0) {
+    console.log("modality-bleed: clean (0 hits)");
+    process.exit(0);
+  }
+
+  for (const h of hits) {
+    console.log(`${h.file}:${h.line}:${h.col} — ${h.message}`);
+    if (h.text) console.log(`    ${h.text}`);
+  }
+  console.log(`\nmodality-bleed: ${hits.length} hit(s)`);
+  process.exit(1);
+}
+
+main();

--- a/src/app/(practice-admin)/dashboard/page.tsx
+++ b/src/app/(practice-admin)/dashboard/page.tsx
@@ -1,0 +1,252 @@
+// EMR-447 — Practice admin dashboard
+//
+// Loads the latest *published* PracticeConfiguration for the signed-in
+// practice admin's practice and renders <PracticeAdminShell />. This is the
+// read-only home — editing is controller-only (EMR-428 / EMR-431).
+//
+// Role gate:
+//   - Must be signed in (else redirect to /sign-in).
+//   - Must hold the `practice_admin` role somewhere; if not, redirect to
+//     /forbidden. Note that super_admin / implementation_admin are NOT
+//     auto-allowed here — they have their own surfaces. This dashboard is
+//     specifically the tenant-facing home.
+//
+// Multi-org practice admins:
+//   - We list every Practice the user holds `practice_admin` on. If they
+//     hold more than one, the page renders a picker at the top. The
+//     selected practice is passed via `?practiceId=`. The first listed
+//     practice is the default.
+//
+// Specialty-adaptive: nothing in this file branches on specialty.
+
+import * as React from "react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+import {
+  PracticeAdminShell,
+  type PracticeSummary,
+} from "@/components/shell/practice-admin-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { getCurrentUser } from "@/lib/auth/session";
+import { canViewPracticeConfig } from "@/lib/auth/super-admin";
+import { prisma } from "@/lib/db/prisma";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Practice dashboard - LeafJourney",
+  description: "Read-only summary of your practice's published configuration.",
+  robots: { index: false, follow: false },
+};
+
+interface PracticeAdminDashboardPageProps {
+  searchParams?: { practiceId?: string };
+}
+
+/** Practices reachable by this practice_admin user. EMR-428 anchors the
+ *  membership scope on `organizationId` — every Practice that rolls up under
+ *  an Organization the user is `practice_admin` in is reachable. */
+async function loadReachablePractices(userId: string): Promise<
+  Array<{
+    id: string;
+    name: string;
+    organizationId: string;
+    organizationName: string;
+  }>
+> {
+  const memberships = await prisma.membership.findMany({
+    where: { userId, role: "practice_admin" },
+    select: { organizationId: true },
+  });
+  const orgIds = memberships.map((m) => m.organizationId);
+  if (orgIds.length === 0) return [];
+
+  const practices = await prisma.practice.findMany({
+    where: { organizationId: { in: orgIds } },
+    orderBy: [{ organizationId: "asc" }, { name: "asc" }],
+    select: {
+      id: true,
+      name: true,
+      organizationId: true,
+      organization: { select: { name: true } },
+    },
+  });
+
+  return practices.map((p) => ({
+    id: p.id,
+    name: p.name,
+    organizationId: p.organizationId,
+    organizationName: p.organization.name,
+  }));
+}
+
+export default async function PracticeAdminDashboardPage({
+  searchParams,
+}: PracticeAdminDashboardPageProps) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/sign-in");
+
+  if (!user.roles.includes("practice_admin")) {
+    redirect("/forbidden");
+  }
+
+  const reachable = await loadReachablePractices(user.id);
+
+  if (reachable.length === 0) {
+    // Has the role but no practice memberships — shouldn't happen, but render
+    // a friendly empty state rather than throwing.
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center px-6 py-16">
+        <Card className="max-w-md w-full text-center p-8">
+          <h1 className="font-display text-xl text-text">No practice yet</h1>
+          <p className="text-sm text-text-muted mt-2">
+            Your account has the practice admin role but is not yet attached to
+            a practice. Contact your LeafJourney implementation team.
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  // Pick the active practice. `?practiceId=` wins when valid; otherwise the
+  // first reachable practice is the default.
+  const requested = searchParams?.practiceId;
+  const active =
+    (requested && reachable.find((p) => p.id === requested)) || reachable[0];
+
+  // Defense in depth — re-check the read scope through the EMR-428 helper.
+  // `canViewPracticeConfig` keys on the org scope; `active.organizationId`
+  // is what the helper expects in its `practiceId` parameter.
+  const allowed = await canViewPracticeConfig(user, active.organizationId);
+  if (!allowed) {
+    redirect("/forbidden");
+  }
+
+  // Direct Prisma read — the controller is server-side, no /api round trip.
+  const [config, practice] = await Promise.all([
+    prisma.practiceConfiguration.findFirst({
+      where: { practiceId: active.id, status: "published" },
+      orderBy: { publishedAt: "desc" },
+    }),
+    prisma.practice.findUnique({
+      where: { id: active.id },
+      select: {
+        id: true,
+        name: true,
+        npi: true,
+        street: true,
+        city: true,
+        state: true,
+        postalCode: true,
+        organization: {
+          select: { brandName: true, legalName: true, name: true },
+        },
+      },
+    }),
+  ]);
+
+  if (!practice) {
+    // Membership pointed at a deleted practice — bail safely.
+    redirect("/forbidden");
+  }
+
+  const practiceSummary: PracticeSummary = {
+    id: practice.id,
+    name: practice.name,
+    brandName:
+      practice.organization.brandName ??
+      practice.organization.legalName ??
+      practice.organization.name ??
+      null,
+    npi: practice.npi,
+    street: practice.street,
+    city: practice.city,
+    state: practice.state,
+    postalCode: practice.postalCode,
+  };
+
+  if (!config) {
+    return (
+      <div className="px-6 lg:px-12 py-10 mx-auto max-w-[1100px]">
+        {reachable.length > 1 ? (
+          <div className="mb-6">
+            <PracticePicker reachable={reachable} activeId={active.id} />
+          </div>
+        ) : null}
+        <Card>
+          <CardHeader>
+            <CardTitle>{practiceSummary.brandName ?? practiceSummary.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-text-muted">
+              No published configuration yet. Your LeafJourney implementation
+              team will publish a configuration once onboarding is complete.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <PracticeAdminShell
+      config={config}
+      practice={practiceSummary}
+      picker={
+        reachable.length > 1 ? (
+          <PracticePicker reachable={reachable} activeId={active.id} />
+        ) : undefined
+      }
+    />
+  );
+}
+
+function PracticePicker({
+  reachable,
+  activeId,
+}: {
+  reachable: Array<{
+    id: string;
+    name: string;
+    organizationId: string;
+    organizationName: string;
+  }>;
+  activeId: string;
+}) {
+  return (
+    <Card tone="outlined">
+      <CardHeader>
+        <p className="text-[11px] uppercase tracking-wide text-text-subtle font-medium">
+          Switch practice
+        </p>
+        <CardTitle>You manage multiple practices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="flex flex-wrap gap-2">
+          {reachable.map((p) => {
+            const isActive = p.id === activeId;
+            return (
+              <li key={p.id}>
+                <Link
+                  href={`/dashboard?practiceId=${encodeURIComponent(p.id)}`}
+                  className="inline-flex items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <Badge tone={isActive ? "accent" : "neutral"}>
+                    {p.name}
+                    <span className="text-text-subtle ml-1">
+                      · {p.organizationName}
+                    </span>
+                  </Badge>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -1,0 +1,87 @@
+// EMR-470 — Read endpoint for the controller audit log.
+//
+// GET /api/audit?subjectId=...&organizationId=...&since=...&until=...&limit=...
+//
+// Gated by `requireImplementationAdmin` (super_admin or implementation_admin).
+// Returns `{ items: ControllerAuditLog[], hasNext }`. Limit is capped at 200.
+// EMR-471 builds the in-app admin search UI on top of this.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireImplementationAdmin } from "@/lib/auth/super-admin";
+
+export const runtime = "nodejs";
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+
+const queryInput = z.object({
+  subjectId: z.string().min(1).optional(),
+  organizationId: z.string().min(1).optional(),
+  since: z
+    .string()
+    .datetime({ offset: true })
+    .or(z.string().refine((s) => !Number.isNaN(Date.parse(s)), "invalid ISO date"))
+    .optional(),
+  until: z
+    .string()
+    .datetime({ offset: true })
+    .or(z.string().refine((s) => !Number.isNaN(Date.parse(s)), "invalid ISO date"))
+    .optional(),
+  limit: z
+    .string()
+    .regex(/^\d+$/)
+    .transform((s) => Number.parseInt(s, 10))
+    .optional(),
+});
+
+function asError(status: number, error: string): NextResponse {
+  return NextResponse.json({ error }, { status });
+}
+
+export async function GET(req: Request): Promise<NextResponse> {
+  try {
+    await requireImplementationAdmin();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "UNAUTHORIZED") return asError(401, "unauthorized");
+    if (msg === "FORBIDDEN") return asError(403, "forbidden");
+    throw err;
+  }
+
+  const url = new URL(req.url);
+  const raw = Object.fromEntries(url.searchParams.entries());
+  const parsed = queryInput.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid_input", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { subjectId, organizationId, since, until } = parsed.data;
+  const limit = Math.min(parsed.data.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  const where: Prisma.ControllerAuditLogWhereInput = {};
+  if (subjectId) where.subjectId = subjectId;
+  if (organizationId) where.organizationId = organizationId;
+  if (since || until) {
+    where.at = {};
+    if (since) where.at.gte = new Date(since);
+    if (until) where.at.lte = new Date(until);
+  }
+
+  // Fetch limit+1 so we can report `hasNext` without a separate count query.
+  const rows = await prisma.controllerAuditLog.findMany({
+    where,
+    orderBy: [{ at: "desc" }, { id: "desc" }],
+    take: limit + 1,
+  });
+
+  const hasNext = rows.length > limit;
+  const items = hasNext ? rows.slice(0, limit) : rows;
+
+  return NextResponse.json({ items, hasNext });
+}

--- a/src/app/api/configs/[id]/publish/route.ts
+++ b/src/app/api/configs/[id]/publish/route.ts
@@ -11,6 +11,7 @@ import { revalidateTag } from "next/cache";
 import { prisma } from "@/lib/db/prisma";
 import { requireImplementationAdmin } from "@/lib/auth/super-admin";
 import { logControllerAction } from "@/lib/auth/audit-stub";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
 import { withAuthErrors, notFound } from "../../_helpers";
 
 export const runtime = "nodejs";
@@ -65,6 +66,24 @@ export async function POST(_req: Request, { params }: Ctx) {
     const nextVersion = (config.version ?? 0) + 1;
     const publishedAt = new Date();
 
+    // EMR-431 — record the manifest version this practice was published
+    // against. We resolve the LATEST manifest for the configured specialty
+    // at publish time and persist it on the row. Subsequent template edits
+    // (which ship as new manifest versions) do NOT silently re-render this
+    // practice — runtime renderers look up the manifest via
+    // `getSpecialtyTemplate(selectedSpecialty, selectedSpecialtyVersion)`.
+    //
+    // If the draft already carries a `selectedSpecialtyVersion` (e.g. set by
+    // apply-specialty), we honour it. Otherwise we resolve fresh from the
+    // registry. We tolerate a missing manifest (null) — the row publishes
+    // with a null version and the runtime falls back to "latest" rendering.
+    let selectedSpecialtyVersion: string | null =
+      (config as { selectedSpecialtyVersion?: string | null }).selectedSpecialtyVersion ?? null;
+    if (!selectedSpecialtyVersion && config.selectedSpecialty) {
+      const manifest = getSpecialtyTemplate(config.selectedSpecialty);
+      selectedSpecialtyVersion = manifest?.version ?? null;
+    }
+
     // Snapshot + flip in a single transaction so we never end up with a
     // version row pointing at a config that didn't actually flip.
     const published = await prisma.$transaction(async (tx) => {
@@ -74,7 +93,10 @@ export async function POST(_req: Request, { params }: Ctx) {
         data: {
           configurationId: config.id,
           version: nextVersion,
-          snapshot: config as unknown as object,
+          snapshot: {
+            ...(config as unknown as Record<string, unknown>),
+            selectedSpecialtyVersion,
+          } as unknown as object,
           publishedAt,
           publishedBy: admin.id,
         },
@@ -85,6 +107,7 @@ export async function POST(_req: Request, { params }: Ctx) {
         data: {
           status: "published",
           version: nextVersion,
+          selectedSpecialtyVersion,
           publishedAt,
           publishedBy: admin.id,
         },
@@ -98,7 +121,7 @@ export async function POST(_req: Request, { params }: Ctx) {
       actor: admin,
       action: "controller.config.published",
       targetId: published.id,
-      after: { version: nextVersion },
+      after: { version: nextVersion, selectedSpecialtyVersion },
     });
 
     return NextResponse.json(published);

--- a/src/app/api/configs/[id]/upgrade-template/route.ts
+++ b/src/app/api/configs/[id]/upgrade-template/route.ts
@@ -1,0 +1,150 @@
+// EMR-431 — Template upgrade admin action.
+// POST /api/configs/[id]/upgrade-template
+//
+// Body: { targetVersion: string }
+//
+// Migrates a practice configuration to a different version of the SAME
+// specialty template. The config's `selectedSpecialty` does not change —
+// only `selectedSpecialtyVersion`. The target manifest must:
+//   1. Exist for the config's `selectedSpecialty`.
+//   2. NOT be deprecated.
+//
+// v1 scope discipline (deferred to a future ticket):
+//   - This route does NOT re-apply template defaults. Doing so would clobber
+//     admin-edited modality lists, workflow IDs, charting templates, etc.
+//     The upgrade is a pointer flip only; runtime renderers pick up the new
+//     manifest version on the next read. The diff between old and new
+//     defaults is the responsibility of the (deferred) upgrade-review UI,
+//     which will let an implementation admin opt in/out of individual field
+//     changes before flipping the pointer.
+//   - There is no cross-config bulk upgrade — each practice is upgraded
+//     individually so an admin can review per-practice impact.
+//
+// Auth: requireImplementationAdmin. Audited via logControllerAction.
+
+import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireImplementationAdmin } from "@/lib/auth/super-admin";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import {
+  readJson,
+  invalidInput,
+  withAuthErrors,
+  notFound,
+} from "../../_helpers";
+
+export const runtime = "nodejs";
+
+interface Ctx {
+  params: { id: string };
+}
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const bodySchema = z.object({
+  targetVersion: z.string().regex(SEMVER, "targetVersion must be semver"),
+});
+
+export async function POST(req: Request, { params }: Ctx) {
+  return (await withAuthErrors(async () => {
+    const admin = await requireImplementationAdmin();
+
+    const parsedBody = await readJson(req);
+    if (!parsedBody.ok) return parsedBody.response;
+
+    const parsed = bodySchema.safeParse(parsedBody.body);
+    if (!parsed.success) return invalidInput(parsed.error);
+
+    const { targetVersion } = parsed.data;
+
+    const config = await prisma.practiceConfiguration.findUnique({
+      where: { id: params.id },
+    });
+    if (!config) return notFound();
+
+    if (!config.selectedSpecialty) {
+      return NextResponse.json(
+        {
+          error: "conflict",
+          message:
+            "Configuration has no selectedSpecialty — cannot upgrade a " +
+            "template version on a config without a specialty.",
+        },
+        { status: 409 },
+      );
+    }
+
+    // Resolve the target manifest by EXACT (slug, version). If it does not
+    // exist for this slug we 404 — clearer than a 400 because the client is
+    // pointing at a target that simply isn't in the registry.
+    const target = getSpecialtyTemplate(config.selectedSpecialty, targetVersion);
+    if (!target) {
+      return NextResponse.json(
+        {
+          error: "not_found",
+          message:
+            `Manifest "${config.selectedSpecialty}@${targetVersion}" is not ` +
+            `registered. Use listAllManifestVersions() to enumerate available ` +
+            `versions.`,
+        },
+        { status: 404 },
+      );
+    }
+
+    if (target.deprecated === true) {
+      return NextResponse.json(
+        {
+          error: "conflict",
+          message:
+            `Manifest "${config.selectedSpecialty}@${targetVersion}" is ` +
+            `deprecated and may not be used as an upgrade target. Existing ` +
+            `practices on a deprecated version continue to render, but new ` +
+            `upgrades must point at a non-deprecated version.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    const previousVersion = config.selectedSpecialtyVersion ?? null;
+
+    // No-op short-circuit: upgrading to the same version is harmless but we
+    // surface it as a 200 with `noop: true` so admin tooling can detect the
+    // case without parsing the row diff.
+    if (previousVersion === targetVersion) {
+      return NextResponse.json({
+        ...config,
+        noop: true,
+      });
+    }
+
+    const upgraded = await prisma.practiceConfiguration.update({
+      where: { id: params.id },
+      data: { selectedSpecialtyVersion: targetVersion },
+    });
+
+    // Bust the by-practice cache so renderers pick up the new manifest
+    // version on next read. This is the same tag the publish/archive routes
+    // bust — pointer changes are equivalent to a publish from the renderer's
+    // perspective.
+    revalidateTag(`practice-config:${upgraded.practiceId}`);
+
+    await logControllerAction({
+      actor: admin,
+      action: "controller.config.template_upgraded",
+      targetId: upgraded.id,
+      before: {
+        selectedSpecialty: config.selectedSpecialty,
+        selectedSpecialtyVersion: previousVersion,
+      },
+      after: {
+        selectedSpecialty: upgraded.selectedSpecialty,
+        selectedSpecialtyVersion: upgraded.selectedSpecialtyVersion,
+      },
+    });
+
+    return NextResponse.json(upgraded);
+  })) as NextResponse;
+}

--- a/src/app/api/configs/route.ts
+++ b/src/app/api/configs/route.ts
@@ -56,6 +56,10 @@ export async function POST(req: Request) {
         practiceId,
         status: "draft",
         selectedSpecialty: selectedSpecialty ?? null,
+        // EMR-431: anchor the draft to the manifest version the registry
+        // resolved at create time, so a subsequent publish records the same
+        // (slug, version) pair the wizard saw.
+        selectedSpecialtyVersion: seed.selectedSpecialtyVersion ?? null,
         careModel: seed.careModel ?? null,
         enabledModalities: seed.enabledModalities ?? [],
         disabledModalities: seed.disabledModalities ?? [],

--- a/src/app/api/migration-profiles/[id]/route.ts
+++ b/src/app/api/migration-profiles/[id]/route.ts
@@ -1,0 +1,53 @@
+// EMR-453 — Migration Profile read endpoint.
+//
+// GET /api/migration-profiles/[id]
+//   Returns the profile if its parent PracticeConfiguration exists.
+//
+// Auth: gated by requireImplementationAdmin for v1. The "may a practice_admin
+// view their own profile?" relaxation belongs to a follow-up ticket — for
+// now any non-Implementation-Admin caller is rejected.
+//
+// Audited via logControllerAction (read events are tracked too — the audit
+// log is the canonical record of who looked at a config's migration plan).
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { requireImplementationAdmin } from "@/lib/auth/super-admin";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import {
+  withAuthErrors,
+  notFound,
+} from "@/app/api/configs/_helpers";
+
+export const runtime = "nodejs";
+
+interface Ctx {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Ctx) {
+  return (await withAuthErrors(async () => {
+    const admin = await requireImplementationAdmin();
+
+    const profile = await prisma.migrationProfile.findUnique({
+      where: { id: params.id },
+    });
+    if (!profile) return notFound();
+
+    // Verify the parent configuration still exists. A profile whose parent
+    // was hard-deleted is functionally orphaned and should not leak.
+    const parent = await prisma.practiceConfiguration.findUnique({
+      where: { id: profile.configurationId },
+      select: { id: true },
+    });
+    if (!parent) return notFound();
+
+    await logControllerAction({
+      actor: admin,
+      action: "controller.migration_profile.read",
+      targetId: profile.id,
+    });
+
+    return NextResponse.json(profile);
+  })) as NextResponse;
+}

--- a/src/app/api/migration-profiles/route.ts
+++ b/src/app/api/migration-profiles/route.ts
@@ -1,0 +1,163 @@
+// EMR-453 — Migration Profile create endpoint.
+//
+// POST /api/migration-profiles
+//   body: { configurationId: string, categories?: MigrationCategorySlug[] }
+//
+// When `categories` is omitted, the seed is derived from the linked
+// PracticeConfiguration's `selectedSpecialty` manifest via
+// buildDefaultProfileFromManifest(). Greenfield practices (no specialty yet)
+// get just the universal slug set with `enabled: true`.
+//
+// Auth: Implementation Admin only. Audited via logControllerAction.
+//
+// Architecture: this route does NOT branch on specialty. The Pain Management
+// vs. Internal Medicine vs. Cannabis difference is encoded entirely in each
+// manifest's migration_mapping_defaults — see EMR-408.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireImplementationAdmin } from "@/lib/auth/super-admin";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import {
+  readJson,
+  invalidInput,
+  withAuthErrors,
+} from "@/app/api/configs/_helpers";
+import {
+  buildDefaultProfileFromManifest,
+  UNIVERSAL_CATEGORY_SLUGS,
+  type MigrationCategory,
+  type MigrationCategorySlug,
+} from "@/lib/migration/profile-types";
+
+export const runtime = "nodejs";
+
+// Slug union mirrored as a Zod literal-tuple. Keep this in sync with
+// MigrationCategorySlug — TS will fail typecheck if the literal list drifts
+// from the union (see `satisfies` below).
+const CATEGORY_SLUGS = [
+  "demographics",
+  "medications",
+  "allergies",
+  "problem-list",
+  "notes",
+  "imaging-refs",
+  "procedures",
+  "appointments",
+  "documents",
+  "patient-reported-outcomes",
+  "pain-scores",
+  "pain-location",
+  "prior-procedures",
+  "imaging-history",
+  "medication-history",
+  "functional-limitations",
+  "prior-treatment-response",
+] as const satisfies ReadonlyArray<MigrationCategorySlug>;
+
+const categorySlugSchema = z.enum(CATEGORY_SLUGS);
+
+const createProfileInput = z.object({
+  configurationId: z.string().min(1),
+  categories: z.array(categorySlugSchema).optional(),
+});
+
+function categoriesFromExplicitSlugs(
+  slugs: ReadonlyArray<MigrationCategorySlug>,
+): MigrationCategory[] {
+  const seen = new Set<MigrationCategorySlug>();
+  const out: MigrationCategory[] = [];
+  for (const slug of slugs) {
+    if (seen.has(slug)) continue;
+    out.push({ slug, enabled: true });
+    seen.add(slug);
+  }
+  return out;
+}
+
+function greenfieldCategories(): MigrationCategory[] {
+  return UNIVERSAL_CATEGORY_SLUGS.map((slug) => ({ slug, enabled: true }));
+}
+
+export async function POST(req: Request) {
+  return (await withAuthErrors(async () => {
+    const admin = await requireImplementationAdmin();
+
+    const parsedBody = await readJson(req);
+    if (!parsedBody.ok) return parsedBody.response;
+
+    const parsed = createProfileInput.safeParse(parsedBody.body);
+    if (!parsed.success) return invalidInput(parsed.error);
+
+    const { configurationId, categories: explicitCategories } = parsed.data;
+
+    const config = await prisma.practiceConfiguration.findUnique({
+      where: { id: configurationId },
+      select: { id: true, selectedSpecialty: true },
+    });
+    if (!config) {
+      return NextResponse.json(
+        { error: "configuration_not_found" },
+        { status: 404 },
+      );
+    }
+
+    let categories: MigrationCategory[];
+    if (explicitCategories && explicitCategories.length > 0) {
+      categories = categoriesFromExplicitSlugs(explicitCategories);
+    } else if (config.selectedSpecialty) {
+      const manifest = getSpecialtyTemplate(config.selectedSpecialty);
+      categories = manifest
+        ? buildDefaultProfileFromManifest(manifest)
+        : greenfieldCategories();
+    } else {
+      categories = greenfieldCategories();
+    }
+
+    const created = await prisma.migrationProfile.create({
+      data: {
+        configurationId,
+        sourceType: null,
+        // Cast to Prisma's JsonArray-compatible value — MigrationCategory[]
+        // is a JSON-safe shape (no Date/undefined nesting).
+        categories: categories as unknown as object[],
+        status: "draft",
+        createdBy: admin.id,
+      },
+    });
+
+    // Link the new profile back onto the parent configuration so the
+    // controller can resolve "the migration profile for this config" without
+    // a reverse lookup. PracticeConfiguration.migrationProfileId is a plain
+    // String? column (no FK by design — see EMR-409).
+    await prisma.practiceConfiguration.update({
+      where: { id: configurationId },
+      data: { migrationProfileId: created.id },
+    });
+
+    await logControllerAction({
+      actor: admin,
+      action: "controller.migration_profile.created",
+      targetId: created.id,
+      after: {
+        configurationId,
+        categoryCount: categories.length,
+        seededFrom: explicitCategories
+          ? "explicit"
+          : config.selectedSpecialty
+            ? `manifest:${config.selectedSpecialty}`
+            : "greenfield",
+      },
+    });
+
+    return NextResponse.json(
+      {
+        id: created.id,
+        profile: created,
+      },
+      { status: 201 },
+    );
+  })) as NextResponse;
+}

--- a/src/components/onboarding/steps/_template-picker-shared.tsx
+++ b/src/components/onboarding/steps/_template-picker-shared.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+// EMR-424 — shared UI primitives for steps 6, 7, 8.
+// The diff helper itself lives in `src/lib/onboarding/template-diff.ts`
+// (single source of truth). This file owns presentation only.
+
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import type { TemplateIdDiff } from "@/lib/onboarding/template-diff";
+import { hasDiff } from "@/lib/onboarding/template-diff";
+
+interface DiffBannerProps {
+  diff: TemplateIdDiff;
+  unitSingular: string;
+  unitPlural: string;
+}
+
+/**
+ * Live banner summarising added/removed template IDs vs the specialty
+ * default. Renders nothing when the diff is empty so the form stays calm.
+ */
+export function DiffBanner({ diff, unitSingular, unitPlural }: DiffBannerProps) {
+  if (!hasDiff(diff)) return null;
+
+  const addedCount = diff.added.length;
+  const removedCount = diff.removed.length;
+  const totalChanged = addedCount + removedCount;
+
+  return (
+    <div
+      className="rounded-xl border border-highlight/30 bg-highlight-soft p-4"
+      role="status"
+      aria-live="polite"
+    >
+      <p className="text-sm text-text">
+        <span className="font-medium">
+          {totalChanged} {totalChanged === 1 ? unitSingular : unitPlural}
+        </span>{" "}
+        differ from the specialty default.
+      </p>
+
+      {addedCount > 0 && (
+        <div className="mt-2">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+            Added
+          </p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {diff.added.map((id) => (
+              <Badge key={`added-${id}`} tone="accent">
+                + {id}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {removedCount > 0 && (
+        <div className="mt-2">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+            Removed
+          </p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {diff.removed.map((id) => (
+              <Badge key={`removed-${id}`} tone="warning">
+                − {id}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/onboarding/steps/preview-chrome.tsx
+++ b/src/components/onboarding/steps/preview-chrome.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+// EMR-427 — Shared preview chrome for wizard steps 12–14.
+//
+// Steps 12, 13, and 14 each render a different shell against the *draft*
+// configuration. The "Preview mode — not yet published" banner above the
+// shell and the draft-summary panel below it are identical across all three
+// steps, so they live here.
+
+import * as React from "react";
+
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EditorialRule, Eyebrow } from "@/components/ui/ornament";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import {
+  summarizeDraft,
+  type DraftSummary,
+} from "@/lib/onboarding/draft-summary";
+
+/** Hook: load the active specialty manifest for the draft. Tolerates errors. */
+export function useActiveManifest(
+  slug: string | null | undefined,
+): SpecialtyManifest | null {
+  const [manifest, setManifest] = React.useState<SpecialtyManifest | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!slug) {
+      setManifest(null);
+      return;
+    }
+    fetch("/api/specialty-templates")
+      .then((res) => res.json())
+      .then((data: { items: SpecialtyManifest[] }) => {
+        if (cancelled) return;
+        const found = data.items.find((m) => m.slug === slug);
+        setManifest(found ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setManifest(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  return manifest;
+}
+
+/** "Preview mode — not yet published" editorial-rule banner. */
+export function PreviewBanner() {
+  return (
+    <Card tone="ambient" className="overflow-hidden">
+      <div className="px-5 pt-5">
+        <Eyebrow>Preview mode</Eyebrow>
+        <p className="mt-2 text-sm text-text">
+          This is a read-only preview of the configuration as it would appear
+          once published. Nothing has been activated for the practice yet —
+          come back to step 15 to publish when you{"’"}re ready.
+        </p>
+      </div>
+      <div className="px-5 pb-5 pt-4">
+        <EditorialRule />
+      </div>
+    </Card>
+  );
+}
+
+/** Summary panel rendered below the shell preview on each preview step. */
+export function DraftSummaryPanel({
+  summary,
+  hiddenModulesCount = 0,
+}: {
+  summary: DraftSummary;
+  /**
+   * Number of explicitly hidden modules. Surfaced separately from
+   * `disabledModalities.length` so that a future "module visibility" step
+   * can drive this independently. Defaults to the disabled-modalities count
+   * when the dedicated value is not yet wired up.
+   */
+  hiddenModulesCount?: number;
+}) {
+  const hidden =
+    hiddenModulesCount > 0
+      ? hiddenModulesCount
+      : summary.disabledModalities.length;
+
+  return (
+    <Card tone="default" className="p-5">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h3 className="font-display text-base font-medium text-text tracking-tight">
+            Configuration summary
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            What the publish step will activate for this practice.
+          </p>
+        </div>
+        <Badge tone="neutral">Draft</Badge>
+      </div>
+
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Specialty
+          </dt>
+          <dd className="text-text font-medium mt-0.5">
+            {summary.specialty.name}
+            {summary.specialty.slug && (
+              <span className="text-text-muted font-mono text-xs ml-1.5">
+                ({summary.specialty.slug})
+              </span>
+            )}
+          </dd>
+        </div>
+
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Care model
+          </dt>
+          <dd className="text-text font-medium mt-0.5">
+            {summary.careModel || "—"}
+          </dd>
+        </div>
+
+        <div className="sm:col-span-2">
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Enabled modalities
+          </dt>
+          <dd className="mt-1 flex flex-wrap gap-1.5">
+            {summary.enabledModalities.length === 0 ? (
+              <span className="text-text-muted text-sm">None enabled.</span>
+            ) : (
+              summary.enabledModalities.map((m) => (
+                <Badge key={m} tone="success">
+                  {m}
+                </Badge>
+              ))
+            )}
+          </dd>
+        </div>
+
+        <div className="sm:col-span-2">
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Disabled modalities
+          </dt>
+          <dd className="mt-1 flex flex-wrap gap-1.5">
+            {summary.disabledModalities.length === 0 ? (
+              <span className="text-text-muted text-sm">None disabled.</span>
+            ) : (
+              summary.disabledModalities.map((m) => (
+                <Badge key={m} tone="neutral">
+                  {m}
+                </Badge>
+              ))
+            )}
+          </dd>
+        </div>
+
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Applied templates
+          </dt>
+          <dd className="text-text mt-0.5 text-sm">
+            {summary.templates.workflows} workflow
+            {summary.templates.workflows === 1 ? "" : "s"} ·{" "}
+            {summary.templates.charting} charting ·{" "}
+            {summary.templates.roles} role
+            {summary.templates.roles === 1 ? "" : "s"}
+          </dd>
+        </div>
+
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Hidden modules
+          </dt>
+          <dd className="text-text mt-0.5 text-sm">
+            {hidden} module{hidden === 1 ? "" : "s"} hidden
+          </dd>
+        </div>
+
+        <div className="sm:col-span-2">
+          <dt className="text-xs uppercase tracking-wide text-text-muted">
+            Migration scope
+          </dt>
+          <dd className="text-text mt-0.5 text-sm">
+            {summary.migration.mode === "greenfield" ? (
+              <>Greenfield — no prior data import.</>
+            ) : (
+              <>
+                Migrate · {summary.migration.categories} data categor
+                {summary.migration.categories === 1 ? "y" : "ies"} mapped
+              </>
+            )}
+          </dd>
+        </div>
+      </dl>
+    </Card>
+  );
+}
+
+/** Convenience: build a summary from draft + cached manifest in one shot. */
+export function useDraftSummary(
+  draft: Partial<PracticeConfiguration>,
+): DraftSummary {
+  const manifest = useActiveManifest(draft.selectedSpecialty);
+  return React.useMemo(
+    () => summarizeDraft(draft, manifest),
+    [draft, manifest],
+  );
+}

--- a/src/components/onboarding/steps/step-10-physician-shell.tsx
+++ b/src/components/onboarding/steps/step-10-physician-shell.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+// EMR-425 — Wizard step 10: pick the physician Mission Control template,
+// then reorder / add / remove cards.
+//
+// The physician shell is more configurable than the patient shell because
+// clinicians work very differently across specialties. The picker is the
+// same UX as step 9, but the *selected* template gets an editable card list
+// with up/down arrow buttons (no drag-and-drop library is currently
+// installed in this repo — see EMR-425 ticket scope note).
+//
+// Persistence model: the order is captured as part of the template (i.e.
+// the cards array on the option in memory) rather than as a separate field
+// on the draft. The draft only stores `physicianShellTemplateId` — when the
+// admin edits, we mutate a *local override* and surface it as a synthetic
+// "Custom" template so the picker can keep showing it as selected. The real
+// persistence shape (custom card order on the configuration row) lands with
+// EMR-412; for v1 we keep the order in component state and write the
+// template id only.
+
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  PHYSICIAN_SHELL_TEMPLATES,
+  deriveSpecialtyPhysicianTemplate,
+  labelForCard,
+  type ShellTemplateOption,
+} from "@/lib/onboarding/known-shell-templates";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+type ManifestState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; manifest: SpecialtyManifest | null }
+  | { status: "error"; error: string };
+
+// Master pool of physician card ids the admin can add. Built from the union
+// of every known template plus the cards declared in the registered
+// manifests' `default_mission_control_cards` (resolved at runtime).
+const BASE_CARD_POOL = Array.from(
+  new Set(PHYSICIAN_SHELL_TEMPLATES.flatMap((t) => t.cards)),
+);
+
+export function Step10PhysicianShell({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [manifestState, setManifestState] = React.useState<ManifestState>(
+    draft.selectedSpecialty ? { status: "loading" } : { status: "idle" },
+  );
+
+  const slug = draft.selectedSpecialty ?? null;
+
+  React.useEffect(() => {
+    if (!slug) {
+      setManifestState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setManifestState({ status: "loading" });
+    fetch("/api/specialty-templates")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as { items: SpecialtyManifest[] };
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const found = data.items.find((m) => m.slug === slug) ?? null;
+        setManifestState({ status: "ready", manifest: found });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setManifestState({
+          status: "error",
+          error: err instanceof Error ? err.message : "unknown_error",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  const recommended = React.useMemo<ShellTemplateOption | null>(() => {
+    if (manifestState.status !== "ready" || !manifestState.manifest) return null;
+    return deriveSpecialtyPhysicianTemplate(
+      manifestState.manifest.slug,
+      manifestState.manifest.name,
+      manifestState.manifest.default_mission_control_cards,
+    );
+  }, [manifestState]);
+
+  const allTemplates = React.useMemo<ShellTemplateOption[]>(() => {
+    if (!recommended) return PHYSICIAN_SHELL_TEMPLATES;
+    const filtered = PHYSICIAN_SHELL_TEMPLATES.filter(
+      (t) => t.id !== recommended.id,
+    );
+    return [recommended, ...filtered];
+  }, [recommended]);
+
+  const [selectedId, setSelectedId] = React.useState<string | null>(
+    draft.physicianShellTemplateId ?? null,
+  );
+
+  // Working card order. Keyed off the selected template — switching templates
+  // resets the editor to that template's stock card list. Edits stay in
+  // local state; we persist `physicianShellTemplateId` only (see file-header).
+  const [cardOrder, setCardOrder] = React.useState<string[]>([]);
+
+  // Auto-select recommended on first load.
+  React.useEffect(() => {
+    if (selectedId) return;
+    if (recommended) {
+      setSelectedId(recommended.id);
+      return;
+    }
+    if (manifestState.status === "ready" && allTemplates[0]) {
+      setSelectedId(allTemplates[0].id);
+    }
+  }, [recommended, manifestState.status, allTemplates, selectedId]);
+
+  // When the selected template id changes, reload the card order from that
+  // template. This intentionally discards prior edits — switching templates
+  // is a "start over" gesture in this UX.
+  const selectedTemplate = React.useMemo(
+    () => allTemplates.find((t) => t.id === selectedId) ?? null,
+    [allTemplates, selectedId],
+  );
+
+  React.useEffect(() => {
+    if (selectedTemplate) {
+      setCardOrder(selectedTemplate.cards);
+    } else {
+      setCardOrder([]);
+    }
+  }, [selectedTemplate]);
+
+  function handleSelect(id: string) {
+    setSelectedId(id);
+  }
+
+  function moveCard(index: number, direction: -1 | 1) {
+    setCardOrder((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      const tmp = next[index];
+      next[index] = next[target];
+      next[target] = tmp;
+      return next;
+    });
+  }
+
+  function removeCard(index: number) {
+    setCardOrder((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function addCard(id: string) {
+    setCardOrder((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  }
+
+  function handleConfirm() {
+    if (!selectedId) return;
+    patch({ physicianShellTemplateId: selectedId });
+    goNext();
+  }
+
+  // Pool of cards available to "Add" — base pool plus any cards declared in
+  // the recommended manifest, minus what's already in the working order.
+  const addablePool = React.useMemo(() => {
+    const pool = new Set<string>(BASE_CARD_POOL);
+    if (recommended) {
+      for (const id of recommended.cards) pool.add(id);
+    }
+    for (const id of cardOrder) pool.delete(id);
+    return Array.from(pool);
+  }, [recommended, cardOrder]);
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-10-physician-heading">
+      <header className="space-y-1">
+        <h2
+          id="step-10-physician-heading"
+          className="font-display text-xl font-medium text-text tracking-tight"
+        >
+          Choose the physician Mission Control
+        </h2>
+        <p className="text-sm text-text-muted max-w-2xl">
+          Mission Control is the first thing your clinicians see when they sign
+          in. Pick a template, then arrange the cards in the order that fits
+          the way they work.
+        </p>
+      </header>
+
+      {manifestState.status === "loading" && (
+        <div
+          className="rounded-xl border border-dashed border-border-strong/60 bg-surface-muted p-6 text-center text-sm text-text-muted"
+          aria-live="polite"
+        >
+          Loading recommendation for your specialty&hellip;
+        </div>
+      )}
+
+      {manifestState.status === "error" && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-danger"
+        >
+          Couldn&rsquo;t load the specialty recommendation ({manifestState.error}).
+          You can still pick from the templates below.
+        </div>
+      )}
+
+      <div
+        role="radiogroup"
+        aria-label="Physician Mission Control templates"
+        className="grid grid-cols-1 md:grid-cols-2 gap-4"
+      >
+        {allTemplates.map((template) => (
+          <PhysicianTemplateCard
+            key={template.id}
+            template={template}
+            selected={selectedId === template.id}
+            isRecommended={recommended?.id === template.id}
+            onSelect={() => handleSelect(template.id)}
+          />
+        ))}
+      </div>
+
+      {selectedTemplate && (
+        <CardOrderEditor
+          template={selectedTemplate}
+          cardOrder={cardOrder}
+          addablePool={addablePool}
+          onMove={moveCard}
+          onRemove={removeCard}
+          onAdd={addCard}
+        />
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={handleConfirm} disabled={!selectedId}>
+          Continue
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// PhysicianTemplateCard — same shape as step 9's TemplateCard.
+// (Kept local rather than shared because the patient version may diverge
+//  visually as EMR-411/412 evolve.)
+// -----------------------------------------------------------------------------
+
+type PhysicianTemplateCardProps = {
+  template: ShellTemplateOption;
+  selected: boolean;
+  isRecommended: boolean;
+  onSelect: () => void;
+};
+
+function PhysicianTemplateCard({
+  template,
+  selected,
+  isRecommended,
+  onSelect,
+}: PhysicianTemplateCardProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onSelect}
+      className={cn(
+        "text-left transition-all duration-200 ease-smooth rounded-xl",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
+      )}
+    >
+      <Card
+        tone={selected ? "raised" : "default"}
+        className={cn(
+          "relative h-full",
+          selected
+            ? "border-2 border-accent shadow-md"
+            : "hover:border-border-strong hover:shadow-md",
+        )}
+      >
+        {selected && (
+          <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-accent px-2.5 py-0.5 text-[11px] font-medium text-accent-ink">
+            Selected
+          </span>
+        )}
+        <CardHeader>
+          <div className="flex flex-wrap items-center gap-2">
+            <CardTitle>{template.label}</CardTitle>
+            {isRecommended && <Badge tone="accent">Recommended</Badge>}
+          </div>
+          <p className="mt-1.5 text-sm text-text-muted">
+            {template.description}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+            {template.cards.length} cards
+          </p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {template.cards.slice(0, 5).map((id) => (
+              <span
+                key={id}
+                className="rounded-full border border-border/80 bg-surface-muted px-2 py-0.5 text-xs text-text"
+              >
+                {labelForCard(id)}
+              </span>
+            ))}
+            {template.cards.length > 5 && (
+              <span className="rounded-full border border-border/80 bg-surface-muted px-2 py-0.5 text-xs text-text-muted">
+                +{template.cards.length - 5} more
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </button>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// CardOrderEditor — up/down arrows, remove, and add. (No drag-and-drop
+// library is installed in this repo, so we use accessible buttons instead.
+// See EMR-425 ticket "Scope discipline" note.)
+// -----------------------------------------------------------------------------
+
+type CardOrderEditorProps = {
+  template: ShellTemplateOption;
+  cardOrder: string[];
+  addablePool: string[];
+  onMove: (index: number, direction: -1 | 1) => void;
+  onRemove: (index: number) => void;
+  onAdd: (id: string) => void;
+};
+
+function CardOrderEditor({
+  template,
+  cardOrder,
+  addablePool,
+  onMove,
+  onRemove,
+  onAdd,
+}: CardOrderEditorProps) {
+  return (
+    <Card tone="outlined" aria-live="polite" className="p-5 space-y-4">
+      <header>
+        <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+          Mission Control card order
+        </p>
+        <h3 className="mt-1 font-display text-base font-medium text-text">
+          {template.label}
+        </h3>
+        <p className="mt-1 text-sm text-text-muted">
+          Use the up and down arrows to reorder. Cards render top-to-bottom in
+          the order shown.
+        </p>
+      </header>
+
+      {cardOrder.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border-strong/60 bg-surface-muted p-4 text-sm text-text-muted text-center">
+          No cards in this template. Add one from the list below.
+        </p>
+      ) : (
+        <ol className="space-y-2">
+          {cardOrder.map((id, idx) => {
+            const isFirst = idx === 0;
+            const isLast = idx === cardOrder.length - 1;
+            return (
+              <li
+                key={id}
+                className="flex items-center gap-3 rounded-lg border border-border/60 bg-surface px-3 py-2"
+              >
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-soft text-[11px] font-medium text-accent">
+                  {idx + 1}
+                </span>
+                <span className="flex-1 text-sm text-text">
+                  {labelForCard(id)}
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onMove(idx, -1)}
+                    disabled={isFirst}
+                    aria-label={`Move ${labelForCard(id)} up`}
+                  >
+                    {"↑"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onMove(idx, 1)}
+                    disabled={isLast}
+                    aria-label={`Move ${labelForCard(id)} down`}
+                  >
+                    {"↓"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onRemove(idx)}
+                    aria-label={`Remove ${labelForCard(id)}`}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      {addablePool.length > 0 && (
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+            Add a card
+          </p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {addablePool.map((id) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onAdd(id)}
+                className="rounded-full border border-border/80 bg-surface-muted px-2.5 py-1 text-xs text-text hover:border-accent hover:text-accent transition-colors"
+              >
+                + {labelForCard(id)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/onboarding/steps/step-11-configure-migration.tsx
+++ b/src/components/onboarding/steps/step-11-configure-migration.tsx
@@ -1,0 +1,541 @@
+"use client";
+
+// EMR-426 — Step 11: Configure migration / import.
+//
+// This step is the wizard's hand-off to the Migration Profile Builder. The
+// admin can either declare the practice "greenfield" (no data import — done)
+// or pick which categories of existing data should migrate. The actual
+// field-mapping UI lives in EMR-454; the import job runner lives in EMR-456;
+// the dry-run preview button is rendered DISABLED here on purpose.
+//
+// Specialty-adaptive: we do not branch on `selectedSpecialty`. The pre-checked
+// category list is read from the active manifest's `migration_mapping_defaults`.
+// When the manifest declares no migration defaults (or no specialty has been
+// chosen yet), we fall back to a universal default set so any specialty-shape
+// produces a sensible first cut.
+
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils/cn";
+import type {
+  SpecialtyManifest,
+} from "@/lib/specialty-templates/manifest-schema";
+import type {
+  PracticeConfiguration,
+  WizardStepDefinition,
+  WizardStepProps,
+} from "@/lib/onboarding/wizard-types";
+
+// ---------------------------------------------------------------------------
+// Migration profile types
+//
+// TODO(EMR-453): once `src/lib/migration/profile-types.ts` lands, replace the
+// local declarations below with:
+//   import type {
+//     MigrationCategorySlug,
+//   } from "@/lib/migration/profile-types";
+// EMR-453 owns `MigrationProfile`, `MigrationCategory`, `MigrationCategorySlug`,
+// and `buildDefaultProfileFromManifest(manifest)`. The POST handler at
+// /api/migration-profiles also lands with EMR-453.
+// ---------------------------------------------------------------------------
+
+type MigrationCategorySlug = string;
+
+interface CategoryDescriptor {
+  slug: MigrationCategorySlug;
+  label: string;
+  description: string;
+}
+
+// Universal default set — used when the active specialty manifest declares no
+// migration_mapping_defaults. Specialty manifests can (and should) override
+// these via their own keys; the pain-management manifest already does.
+const UNIVERSAL_DEFAULTS: CategoryDescriptor[] = [
+  {
+    slug: "demographics",
+    label: "Demographics",
+    description: "Patient name, DOB, sex, contact info, and household linkage.",
+  },
+  {
+    slug: "medications",
+    label: "Medications",
+    description: "Active medication list with dose, frequency, and start dates.",
+  },
+  {
+    slug: "allergies",
+    label: "Allergies",
+    description: "Drug, food, and environmental allergies with reaction notes.",
+  },
+  {
+    slug: "problem-list",
+    label: "Problem list",
+    description: "Active diagnoses and chronic conditions with ICD-10 codes.",
+  },
+  {
+    slug: "notes",
+    label: "Notes",
+    description: "Historical encounter notes (free text and structured).",
+  },
+  {
+    slug: "imaging-refs",
+    label: "Imaging refs",
+    description: "Pointers to prior imaging studies (DICOM IDs, accession #s).",
+  },
+  {
+    slug: "procedures",
+    label: "Procedures",
+    description: "Past procedures with CPT codes, dates, and clinician.",
+  },
+  {
+    slug: "appointments",
+    label: "Appointments",
+    description: "Historical and upcoming appointments to migrate forward.",
+  },
+  {
+    slug: "documents",
+    label: "Documents",
+    description: "Scanned PDFs, consent forms, prior records on file.",
+  },
+  {
+    slug: "patient-reported-outcomes",
+    label: "Patient-reported outcomes",
+    description: "Past PRO surveys (pain, mood, sleep) so trends survive.",
+  },
+];
+
+/**
+ * Human-friendly labels for the keys that appear in
+ * `manifest.migration_mapping_defaults`. The map is intentionally permissive:
+ * unknown keys still render with a generated label so a manifest can introduce
+ * a new category without a code change here.
+ */
+const CATEGORY_LABELS: Record<string, { label: string; description: string }> = {
+  pain_scores: {
+    label: "Pain scores",
+    description: "Historical pain ratings (0-10 scale) with timestamps.",
+  },
+  pain_location: {
+    label: "Pain location",
+    description: "Body-map locations for each documented pain complaint.",
+  },
+  pain_quality: {
+    label: "Pain quality",
+    description: "Descriptors (sharp, dull, burning) tied to each location.",
+  },
+  pain_radiation: {
+    label: "Pain radiation",
+    description: "Radiation patterns documented in prior visits.",
+  },
+  prior_procedures: {
+    label: "Prior procedures",
+    description: "Injections, blocks, ablations performed previously.",
+  },
+  imaging_history: {
+    label: "Imaging history",
+    description: "Prior MRI/CT/X-ray reports relevant to the pain workup.",
+  },
+  medication_history: {
+    label: "Medication history",
+    description: "Past pain medications, doses, and discontinuation reasons.",
+  },
+  functional_limitations: {
+    label: "Functional limitations",
+    description: "Documented ADL impacts, mobility restrictions, work status.",
+  },
+  prior_treatment_response: {
+    label: "Prior treatment response",
+    description: "What the patient has tried and how well it worked.",
+  },
+  pdmp_history: {
+    label: "PDMP history",
+    description: "Prescription drug monitoring program lookup snapshots.",
+  },
+};
+
+function humanize(slug: string): string {
+  return slug
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Project a manifest's `migration_mapping_defaults` into the descriptor list
+ * the UI renders. The map's *keys* are the category slugs we send to the
+ * server; the values are the manifest's preferred internal field names and
+ * are not surfaced to the admin in this step (EMR-454 owns field mapping).
+ */
+function descriptorsFromManifest(
+  manifest: SpecialtyManifest | null,
+): CategoryDescriptor[] {
+  if (!manifest) return UNIVERSAL_DEFAULTS;
+  const keys = Object.keys(manifest.migration_mapping_defaults ?? {});
+  if (keys.length === 0) return UNIVERSAL_DEFAULTS;
+
+  return keys.map((key) => {
+    const meta = CATEGORY_LABELS[key];
+    return {
+      slug: key,
+      label: meta?.label ?? humanize(key),
+      description:
+        meta?.description ??
+        `Migrate ${humanize(key).toLowerCase()} records from the source system.`,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function Step11ConfigureMigration({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [manifest, setManifest] = React.useState<SpecialtyManifest | null>(null);
+  const [manifestLoading, setManifestLoading] = React.useState(true);
+  const [importEnabled, setImportEnabled] = React.useState<boolean>(
+    draft.migrationProfileId != null,
+  );
+  const [selectedSlugs, setSelectedSlugs] = React.useState<Set<string>>(
+    new Set(),
+  );
+  // The file is held only in component state for v1 — no upload to a backend
+  // happens here. EMR-456 (job runner) will accept the file when the Migration
+  // Profile Builder is wired up.
+  const [sampleFile, setSampleFile] = React.useState<File | null>(null);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Load the active specialty manifest so we can pre-fill categories from
+  // `migration_mapping_defaults`. We reuse the existing /api/specialty-templates
+  // endpoint pattern that step 3 uses.
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!draft.selectedSpecialty) {
+      setManifest(null);
+      setManifestLoading(false);
+      return;
+    }
+    setManifestLoading(true);
+    fetch("/api/specialty-templates")
+      .then((res) => res.json())
+      .then((data: { items: SpecialtyManifest[] }) => {
+        if (cancelled) return;
+        const found =
+          data.items.find((m) => m.slug === draft.selectedSpecialty) ?? null;
+        setManifest(found);
+        setManifestLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setManifest(null);
+        setManifestLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.selectedSpecialty]);
+
+  const descriptors = React.useMemo(
+    () => descriptorsFromManifest(manifest),
+    [manifest],
+  );
+
+  // When descriptors change (manifest loaded / specialty switched) seed the
+  // selection to "all on" — this matches the spec ("Defaults checked").
+  React.useEffect(() => {
+    setSelectedSlugs(new Set(descriptors.map((d) => d.slug)));
+  }, [descriptors]);
+
+  function toggle(slug: string) {
+    setSelectedSlugs((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    setSampleFile(file);
+  }
+
+  async function handleContinue() {
+    setError(null);
+
+    // Greenfield path: clear any prior profile id, no API call needed.
+    if (!importEnabled) {
+      patch({ migrationProfileId: null });
+      goNext();
+      return;
+    }
+
+    if (!draft.id) {
+      setError("No draft id — cannot create migration profile.");
+      return;
+    }
+    if (selectedSlugs.size === 0) {
+      setError("Select at least one category, or switch to greenfield.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      // TODO(EMR-453): /api/migration-profiles is owned by EMR-453. The route
+      // creates a draft `MigrationProfile` row and returns `{ id }`. If the
+      // route 404s in this worktree the in-flight branch hasn't merged yet.
+      const res = await fetch("/api/migration-profiles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          configurationId: draft.id,
+          categories: Array.from(selectedSlugs),
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as { id?: string };
+      if (!data.id) throw new Error("Server did not return a profile id.");
+      patch({
+        migrationProfileId: data.id,
+      } as Partial<PracticeConfiguration>);
+      goNext();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Could not create the migration profile.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const continueDisabled =
+    submitting ||
+    (importEnabled && !manifestLoading && selectedSlugs.size === 0);
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-11-heading">
+      <header className="space-y-1">
+        <h2
+          id="step-11-heading"
+          className="font-display text-xl font-medium text-text tracking-tight"
+        >
+          Configure migration
+        </h2>
+        <p className="text-sm text-text-muted">
+          Decide whether to import existing data into this practice, and pick
+          which categories to bring across. You can refine field mappings in
+          the Migration Profile Builder after onboarding.
+        </p>
+      </header>
+
+      {/* Import toggle */}
+      <Card tone="outlined" className="p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="font-medium text-text">Import existing data</p>
+            <p className="text-sm text-text-muted mt-1">
+              Turn this off if the practice is starting fresh (greenfield).
+              When off, no migration profile is attached and you can move on.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={importEnabled}
+            onClick={() => setImportEnabled((v) => !v)}
+            className={cn(
+              "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full",
+              "transition-colors duration-200 ease-smooth",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
+              importEnabled ? "bg-accent" : "bg-border-strong/60",
+            )}
+          >
+            <span
+              className={cn(
+                "inline-block h-5 w-5 transform rounded-full bg-white shadow-sm",
+                "transition-transform duration-200 ease-smooth",
+                importEnabled ? "translate-x-6" : "translate-x-1",
+              )}
+            />
+            <span className="sr-only">
+              {importEnabled ? "Importing data" : "Greenfield"}
+            </span>
+          </button>
+        </div>
+      </Card>
+
+      {importEnabled && (
+        <>
+          {/* Categories */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium text-text">
+                Data categories to migrate
+              </h3>
+              {manifest ? (
+                <Badge tone="accent">
+                  Pre-filled from {manifest.name}
+                </Badge>
+              ) : (
+                <Badge tone="warning">Universal defaults</Badge>
+              )}
+            </div>
+
+            {manifestLoading ? (
+              <div
+                className="rounded-xl border border-dashed border-border-strong/60 bg-surface-muted p-6 text-center text-sm text-text-muted"
+                aria-live="polite"
+              >
+                Loading specialty migration defaults…
+              </div>
+            ) : (
+              <fieldset
+                className="grid gap-3 sm:grid-cols-2"
+                aria-label="Migration categories"
+              >
+                <legend className="sr-only">Migration categories</legend>
+                {descriptors.map((d) => {
+                  const checked = selectedSlugs.has(d.slug);
+                  return (
+                    <label
+                      key={d.slug}
+                      className={cn(
+                        "block cursor-pointer rounded-xl border p-4 transition-all duration-200 ease-smooth",
+                        "focus-within:ring-2 focus-within:ring-accent/30",
+                        checked
+                          ? "border-accent bg-accent-soft shadow-sm"
+                          : "border-border/80 bg-surface hover:border-border-strong hover:shadow-sm",
+                      )}
+                    >
+                      <div className="flex items-start gap-3">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(d.slug)}
+                          className="mt-1 h-4 w-4 accent-[color:var(--accent)]"
+                          aria-describedby={`mig-cat-${d.slug}-desc`}
+                        />
+                        <div className="min-w-0">
+                          <p className="font-medium text-text">{d.label}</p>
+                          <p
+                            id={`mig-cat-${d.slug}-desc`}
+                            className="text-sm text-text-muted mt-0.5"
+                          >
+                            {d.description}
+                          </p>
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </fieldset>
+            )}
+          </div>
+
+          {/* Sample file upload + dry-run */}
+          <Card tone="outlined" className="p-5 space-y-4">
+            <div>
+              <p className="font-medium text-text">Sample file (optional)</p>
+              <p className="text-sm text-text-muted mt-1">
+                Upload a small export from the source system so we can preview
+                how the rows will land. We accept CSV, JSON, or XLSX.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <input
+                type="file"
+                accept=".csv,.json,.xlsx"
+                onChange={onFile}
+                className={cn(
+                  "block max-w-full text-sm text-text-muted",
+                  "file:mr-3 file:rounded-md file:border file:border-border-strong/70",
+                  "file:bg-surface-raised file:px-3 file:py-1.5 file:text-sm",
+                  "file:font-medium file:text-text hover:file:bg-surface-muted",
+                )}
+              />
+              {sampleFile && (
+                <span className="text-xs text-text-muted">
+                  {sampleFile.name}{" "}
+                  <span aria-hidden="true">·</span>{" "}
+                  {(sampleFile.size / 1024).toFixed(1)} KB
+                </span>
+              )}
+            </div>
+            <div>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled
+                title="Coming soon — EMR-456"
+                aria-disabled="true"
+              >
+                Dry-run preview
+              </Button>
+              <p className="mt-2 text-xs text-text-muted">
+                Dry-run will run the selected categories against the sample
+                file and report row counts and warnings before any real import.
+              </p>
+            </div>
+          </Card>
+        </>
+      )}
+
+      {error && (
+        <p className="text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack} disabled={submitting}>
+          Back
+        </Button>
+        <Button onClick={handleContinue} disabled={continueDisabled}>
+          {submitting
+            ? "Saving…"
+            : importEnabled
+              ? "Create profile and continue"
+              : "Continue (greenfield)"}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step definition — registered in `wizard-steps.ts`.
+// ---------------------------------------------------------------------------
+
+export const step11ConfigureMigrationDefinition: WizardStepDefinition = {
+  id: "configure-migration",
+  title: "Configure migration",
+  description:
+    "Decide how existing data will migrate into the new configuration.",
+  Component: Step11ConfigureMigration,
+  // Greenfield mode is "complete" with no profile attached. Migration mode
+  // requires a `migrationProfileId` to be set on the draft. The shell calls
+  // this any time the draft updates so flipping the toggle re-evaluates.
+  isComplete: (draft) => {
+    // We can't read local component state from here — but the contract is:
+    // when the user picks greenfield they `patch({ migrationProfileId: null })`
+    // and goNext(); when they choose migration the API call sets it. So a
+    // null profile id after this step has been navigated past means
+    // greenfield, which is "complete". If the user has not yet visited the
+    // step, the shell still treats earlier-step completion as the gate.
+    if (draft.migrationProfileId === null) return true; // explicit greenfield
+    return typeof draft.migrationProfileId === "string" &&
+      draft.migrationProfileId.length > 0;
+  },
+  isReachable: (draft) => draft.physicianShellTemplateId != null,
+};

--- a/src/components/onboarding/steps/step-12-preview-physician.tsx
+++ b/src/components/onboarding/steps/step-12-preview-physician.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+// EMR-427 — Step 12: Preview the physician shell against the draft config.
+//
+// Specialty-adaptive: this step never branches on the selected specialty.
+// It hands the draft to <PhysicianShell> (EMR-445) and renders a shared
+// summary panel — the shell itself decides what to display based on the
+// draft's `physicianShellTemplateId` and modality flags.
+
+import { Button } from "@/components/ui/button";
+import { PhysicianShell } from "@/components/shell/physician-shell";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import {
+  PreviewBanner,
+  DraftSummaryPanel,
+  useDraftSummary,
+} from "./preview-chrome";
+
+export function Step12PreviewPhysician({
+  draft,
+  goBack,
+  goNext,
+  isLast,
+}: WizardStepProps) {
+  const summary = useDraftSummary(draft);
+
+  // EMR-427: previewing draft as if published — required fields are
+  // validated by the publish step before this is reachable
+  const previewConfig = draft as PracticeConfiguration;
+
+  return (
+    <div className="space-y-6">
+      <PreviewBanner />
+
+      <section aria-label="Physician shell preview">
+        <PhysicianShell config={previewConfig} />
+      </section>
+
+      <DraftSummaryPanel summary={summary} />
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        {!isLast && (
+          <Button onClick={goNext}>Continue to patient preview</Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/steps/step-12-preview-physician.tsx
+++ b/src/components/onboarding/steps/step-12-preview-physician.tsx
@@ -15,6 +15,7 @@ import {
   PreviewBanner,
   DraftSummaryPanel,
   useDraftSummary,
+  useActiveManifest,
 } from "./preview-chrome";
 
 export function Step12PreviewPhysician({
@@ -24,6 +25,7 @@ export function Step12PreviewPhysician({
   isLast,
 }: WizardStepProps) {
   const summary = useDraftSummary(draft);
+  const manifest = useActiveManifest(draft.selectedSpecialty);
 
   // EMR-427: previewing draft as if published — required fields are
   // validated by the publish step before this is reachable
@@ -34,7 +36,7 @@ export function Step12PreviewPhysician({
       <PreviewBanner />
 
       <section aria-label="Physician shell preview">
-        <PhysicianShell config={previewConfig} />
+        <PhysicianShell config={previewConfig} manifest={manifest} />
       </section>
 
       <DraftSummaryPanel summary={summary} />

--- a/src/components/onboarding/steps/step-13-preview-patient.tsx
+++ b/src/components/onboarding/steps/step-13-preview-patient.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+// EMR-427 — Step 13: Preview the patient shell against the draft config.
+//
+// The dedicated patient shell renderer ships in EMR-446. Until then this
+// step renders a placeholder card listing the patient template's `cards`
+// array (resolved from the active specialty manifest) so reviewers can at
+// least eyeball what surfaces the patient will see post-publish.
+//
+// Specialty-adaptive: never branches on a specific specialty slug — the
+// card list comes straight from the manifest's
+// `default_patient_portal_cards`.
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import type { PracticeConfiguration as _PracticeConfiguration } from "@/lib/practice-config/types";
+import {
+  PreviewBanner,
+  DraftSummaryPanel,
+  useActiveManifest,
+} from "./preview-chrome";
+import { summarizeDraft } from "@/lib/onboarding/draft-summary";
+
+export function Step13PreviewPatient({
+  draft,
+  goBack,
+  goNext,
+  isLast,
+}: WizardStepProps) {
+  const manifest = useActiveManifest(draft.selectedSpecialty);
+  const summary = summarizeDraft(draft, manifest);
+
+  // EMR-427: previewing draft as if published — required fields are
+  // validated by the publish step before this is reachable
+  const _previewConfig = draft as _PracticeConfiguration;
+
+  const cards = manifest?.default_patient_portal_cards ?? [];
+  const templateId = draft.patientShellTemplateId ?? null;
+
+  return (
+    <div className="space-y-6">
+      <PreviewBanner />
+
+      <section aria-label="Patient shell preview">
+        <Card
+          tone="outlined"
+          className="p-6"
+          data-testid="patient-shell-preview-stub"
+        >
+          <p className="text-xs uppercase tracking-wide text-text-muted">
+            Patient shell preview
+          </p>
+          <p className="text-sm text-text mt-1">
+            Template:{" "}
+            <span className="font-mono text-text-muted">
+              {templateId ?? "—"}
+            </span>
+          </p>
+          {cards.length > 0 ? (
+            <ul className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+              {cards.map((card) => (
+                <li
+                  key={card}
+                  className="rounded-md border border-border/70 bg-surface px-3 py-2 text-text"
+                >
+                  <span className="font-mono text-xs text-text-muted mr-2">
+                    card
+                  </span>
+                  {card}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-4 text-sm text-text-muted">
+              No patient portal cards declared for this specialty.
+            </p>
+          )}
+          <p className="text-xs text-text-muted mt-5 italic">
+            Patient shell renderer ships in EMR-446.
+          </p>
+        </Card>
+      </section>
+
+      <DraftSummaryPanel summary={summary} />
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        {!isLast && (
+          <Button onClick={goNext}>
+            Continue to practice admin preview
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
+++ b/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
@@ -50,7 +50,11 @@ export function Step14PreviewPracticeAdmin({
       <PreviewBanner />
 
       <section aria-label="Practice admin shell preview">
-        <PracticeAdminShell config={previewConfig} practice={previewPractice} />
+        <PracticeAdminShell 
+          config={previewConfig} 
+          practice={previewPractice} 
+          specialtyName={summary.specialty.name}
+        />
       </section>
 
       <DraftSummaryPanel summary={summary} />

--- a/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
+++ b/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
@@ -7,7 +7,10 @@
 // to surface based on the draft's templates and modality flags.
 
 import { Button } from "@/components/ui/button";
-import { PracticeAdminShell } from "@/components/shell/practice-admin-shell";
+import {
+  PracticeAdminShell,
+  type PracticeSummary,
+} from "@/components/shell/practice-admin-shell";
 import type { PracticeConfiguration } from "@/lib/practice-config/types";
 import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
 import {
@@ -28,12 +31,26 @@ export function Step14PreviewPracticeAdmin({
   // validated by the publish step before this is reachable
   const previewConfig = draft as PracticeConfiguration;
 
+  // The wizard doesn't carry the full Practice row in the draft; build a
+  // best-effort PracticeSummary from what we have. Address fields are nulled —
+  // EMR-447's renderer handles null gracefully.
+  const previewPractice: PracticeSummary = {
+    id: draft.practiceId ?? "preview",
+    name: "Practice preview",
+    brandName: null,
+    npi: null,
+    street: null,
+    city: null,
+    state: null,
+    postalCode: null,
+  };
+
   return (
     <div className="space-y-6">
       <PreviewBanner />
 
       <section aria-label="Practice admin shell preview">
-        <PracticeAdminShell config={previewConfig} />
+        <PracticeAdminShell config={previewConfig} practice={previewPractice} />
       </section>
 
       <DraftSummaryPanel summary={summary} />

--- a/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
+++ b/src/components/onboarding/steps/step-14-preview-practice-admin.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+// EMR-427 — Step 14: Preview the practice-admin shell against the draft.
+//
+// Specialty-adaptive: this step never branches on the selected specialty.
+// It hands the draft to <PracticeAdminShell> (EMR-447), which decides what
+// to surface based on the draft's templates and modality flags.
+
+import { Button } from "@/components/ui/button";
+import { PracticeAdminShell } from "@/components/shell/practice-admin-shell";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import {
+  PreviewBanner,
+  DraftSummaryPanel,
+  useDraftSummary,
+} from "./preview-chrome";
+
+export function Step14PreviewPracticeAdmin({
+  draft,
+  goBack,
+  goNext,
+  isLast,
+}: WizardStepProps) {
+  const summary = useDraftSummary(draft);
+
+  // EMR-427: previewing draft as if published — required fields are
+  // validated by the publish step before this is reachable
+  const previewConfig = draft as PracticeConfiguration;
+
+  return (
+    <div className="space-y-6">
+      <PreviewBanner />
+
+      <section aria-label="Practice admin shell preview">
+        <PracticeAdminShell config={previewConfig} />
+      </section>
+
+      <DraftSummaryPanel summary={summary} />
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        {!isLast && <Button onClick={goNext}>Continue to publish</Button>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/steps/step-15-publish.tsx
+++ b/src/components/onboarding/steps/step-15-publish.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+// EMR-427 — Step 15: Publish the configuration.
+//
+// Specialty-adaptive: validation and the publish call go through the same
+// `/api/configs/[id]/publish` endpoint for every specialty. We never
+// hardcode a slug here.
+//
+// On click:
+//   POST /api/configs/[draftId]/publish
+//     200 → redirect to /practice-admin/dashboard?published=1 (EMR-447's
+//           dashboard reads the query param and shows the success banner)
+//     409 → server returned `{ missing: [...] }` — surface inline with
+//           deep-links back to the relevant earlier step.
+//
+// The button is disabled until every prior step (1..14) reports complete,
+// so in practice the 409 branch is rare — the server's check is the
+// authoritative gate.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { WIZARD_STEPS } from "@/lib/onboarding/wizard-steps";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import type {
+  WizardStepDefinition,
+  WizardStepId,
+  WizardStepProps,
+} from "@/lib/onboarding/wizard-types";
+import { DraftSummaryPanel, useDraftSummary } from "./preview-chrome";
+
+/** Maps a missing-field key from the publish API to the wizard step that owns it. */
+const MISSING_FIELD_TO_STEP: Record<string, { stepId: WizardStepId; label: string }> = {
+  selectedSpecialty: { stepId: "select-specialty", label: "Specialty" },
+  careModel: { stepId: "select-care-model", label: "Care model" },
+  enabledModalities: { stepId: "enable-modalities", label: "Enabled modalities" },
+};
+
+/**
+ * Compute "are every prior step's `isComplete` returning true?" — used to
+ * gate the publish button. We deliberately exclude the publish step itself
+ * from the check since its own `isComplete` always returns false (publish
+ * has to *succeed*, not be skipped).
+ */
+function arePriorStepsComplete(
+  draft: Partial<PracticeConfiguration>,
+): boolean {
+  for (const step of WIZARD_STEPS) {
+    if (step.id === "publish") continue;
+    if (!step.isComplete(draft)) return false;
+  }
+  return true;
+}
+
+/** Local "missing required fields" preflight, mirroring the server's check. */
+function preflightMissing(
+  draft: Partial<PracticeConfiguration>,
+): string[] {
+  const missing: string[] = [];
+  if (!draft.selectedSpecialty) missing.push("selectedSpecialty");
+  if (!draft.careModel) missing.push("careModel");
+  if (
+    !Array.isArray(draft.enabledModalities) ||
+    draft.enabledModalities.length === 0
+  ) {
+    missing.push("enabledModalities");
+  }
+  return missing;
+}
+
+export function Step15Publish({ draft, goBack }: WizardStepProps) {
+  const router = useRouter();
+  const summary = useDraftSummary(draft);
+
+  const draftId = (draft as { id?: string }).id ?? "";
+  const allPriorComplete = arePriorStepsComplete(draft);
+  const localMissing = preflightMissing(draft);
+
+  const [submitting, setSubmitting] = React.useState(false);
+  const [serverMissing, setServerMissing] = React.useState<string[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const buttonDisabled =
+    submitting || !allPriorComplete || !draftId || localMissing.length > 0;
+
+  const missingToShow = serverMissing.length > 0 ? serverMissing : localMissing;
+
+  async function handlePublish() {
+    if (!draftId) {
+      setError("Missing draft id — cannot publish.");
+      return;
+    }
+    setError(null);
+    setServerMissing([]);
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/configs/${encodeURIComponent(draftId)}/publish`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+
+      if (res.ok) {
+        router.push("/practice-admin/dashboard?published=1");
+        return;
+      }
+
+      if (res.status === 409) {
+        const body = (await res.json().catch(() => null)) as
+          | { missing?: string[] }
+          | null;
+        const missing = Array.isArray(body?.missing) ? body!.missing! : [];
+        setServerMissing(missing);
+        setError(
+          "Some required fields are still missing. Resolve them below and try again.",
+        );
+        return;
+      }
+
+      // Any other non-2xx is unexpected — surface a generic error.
+      const body = (await res.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+      setError(body?.error ?? `Publish failed (${res.status}).`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not publish.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card tone="ambient" className="p-5">
+        <h3 className="font-display text-lg font-medium text-text tracking-tight">
+          Ready to publish
+        </h3>
+        <p className="text-sm text-text-muted mt-1.5 max-w-2xl">
+          Publishing snapshots this draft as a versioned configuration, makes
+          it active for the practice, and archives any prior published
+          configuration. This action is reversible by publishing a new
+          version.
+        </p>
+      </Card>
+
+      <DraftSummaryPanel summary={summary} />
+
+      {missingToShow.length > 0 && (
+        <Card tone="outlined" className="p-5 border-[color:var(--danger)]/30">
+          <div className="flex items-center gap-2 mb-3">
+            <Badge tone="danger">Missing required fields</Badge>
+          </div>
+          <p className="text-sm text-text-muted mb-3">
+            These fields are required before publishing. Use the links below
+            to jump back to the step that owns each one.
+          </p>
+          <ul className="grid gap-2">
+            {missingToShow.map((field) => {
+              const meta = MISSING_FIELD_TO_STEP[field];
+              return (
+                <li
+                  key={field}
+                  className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-surface px-3 py-2 text-sm"
+                >
+                  <span className="text-text">
+                    <span className="font-mono text-xs text-text-muted mr-2">
+                      {field}
+                    </span>
+                    {meta?.label ?? field}
+                  </span>
+                  {meta && <DeepLinkToStep stepId={meta.stepId} />}
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+      )}
+
+      {error && (
+        <p className="text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack} disabled={submitting}>
+          Back
+        </Button>
+        <Button
+          size="lg"
+          onClick={handlePublish}
+          disabled={buttonDisabled}
+        >
+          {submitting ? "Publishing…" : "Publish configuration"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Jump to step" link. Today this re-renders the wizard at the same URL —
+ * the wizard shell owns navigation in-memory, so we surface a Back button
+ * instead of a real anchor. EMR-419's shell is responsible for picking
+ * the deepest unfinished step on remount, so a hard reload achieves the
+ * same effect when needed.
+ */
+function DeepLinkToStep({ stepId: _stepId }: { stepId: WizardStepId }) {
+  // The wizard shell holds step state in React; we don't have a direct
+  // `goToStep` from the publish step body. Surface a "Back" affordance —
+  // users can also click the rail item directly to jump.
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        // Hard reload: the shell's `pickInitialIndex` resumes on the
+        // earliest reachable-but-incomplete step, which is exactly the one
+        // referenced by `_stepId` (since publish is reachable only when
+        // the chain is otherwise complete).
+        if (typeof window !== "undefined") window.location.reload();
+      }}
+      className="text-xs text-accent hover:text-accent-hover underline underline-offset-2"
+    >
+      Jump back
+    </button>
+  );
+}
+
+export const step15PublishDefinition: WizardStepDefinition = {
+  id: "publish",
+  title: "Publish",
+  description:
+    "Publish this configuration and make it active for the practice.",
+  Component: Step15Publish,
+  // The user shouldn't be able to "skip" publish — the only way out is to
+  // succeed. Returning false means the rail never marks this step complete
+  // until the post-publish redirect carries the user away.
+  isComplete: () => false,
+  isReachable: (_draft, completedSteps) =>
+    completedSteps.has("preview-practice-admin"),
+};

--- a/src/components/onboarding/steps/step-4-enable-modalities.tsx
+++ b/src/components/onboarding/steps/step-4-enable-modalities.tsx
@@ -24,7 +24,7 @@ import {
   REGISTERED_MODALITIES,
   type SpecialtyManifest,
 } from "@/lib/specialty-templates/manifest-schema";
-import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import { useActiveManifest } from "./preview-chrome";
 import type {
   WizardStepDefinition,
   WizardStepProps,
@@ -77,23 +77,7 @@ export function Step4EnableModalities({
   goNext,
   goBack,
 }: WizardStepProps) {
-  const [template, setTemplate] = useState<SpecialtyManifest | null>(() =>
-    draft.selectedSpecialty
-      ? getSpecialtyTemplate(draft.selectedSpecialty)
-      : null,
-  );
-
-  // The component reads the manifest directly via the registry (server-safe
-  // module-init data). The registry is loaded eagerly at boot, so this is
-  // synchronous. We still keep state to allow a future swap to async fetch
-  // without changing the rendering shape.
-  useEffect(() => {
-    if (!draft.selectedSpecialty) {
-      setTemplate(null);
-      return;
-    }
-    setTemplate(getSpecialtyTemplate(draft.selectedSpecialty));
-  }, [draft.selectedSpecialty]);
+  const template = useActiveManifest(draft.selectedSpecialty);
 
   // Seed: prefer existing draft.enabledModalities; fall back to manifest.
   const seedEnabled = useMemo<ModalitySet>(() => {

--- a/src/components/onboarding/steps/step-4-enable-modalities.tsx
+++ b/src/components/onboarding/steps/step-4-enable-modalities.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+// EMR-423 — Practice Onboarding Controller v1, wizard step 4.
+// Lets the admin pick which treatment modalities are ENABLED for this
+// practice. The selected specialty's manifest seeds the default; the admin
+// can adjust within the dependency graph from MODALITY_META (EMR-410).
+//
+// Architecture rules:
+//  - Specialty-adaptive. NO `if (specialty === 'cannabis')` branches.
+//  - Cannabis Medicine defaults OFF for any non-cannabis specialty because
+//    that specialty's manifest puts it in default_disabled_modalities — the
+//    seed is read verbatim, never re-derived from the slug.
+//  - Toggling Cannabis Medicine ON triggers an inline regulatory &
+//    compliance acknowledgement BEFORE the patch is applied.
+//  - Dependency graph from MODALITY_META is enforced both directions.
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { MODALITY_META, type ModalityId } from "@/lib/modality/registry";
+import {
+  REGISTERED_MODALITIES,
+  type SpecialtyManifest,
+} from "@/lib/specialty-templates/manifest-schema";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import type {
+  WizardStepDefinition,
+  WizardStepProps,
+} from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+const CANNABIS_MODALITY_ID: ModalityId = "cannabis-medicine";
+
+const CANNABIS_ACK_TITLE = "Regulatory & compliance acknowledgement";
+const CANNABIS_ACK_BODY =
+  "Cannabis Medicine introduces controlled-substance workflows, additional " +
+  "state regulatory requirements, and patient education obligations. By " +
+  "enabling this modality you confirm you have reviewed your state's " +
+  "medical cannabis program rules.";
+
+type ModalitySet = Set<ModalityId>;
+
+/** Closure of `requires` — every transitive prerequisite of `id`. */
+function collectRequires(id: ModalityId): ModalityId[] {
+  const seen = new Set<ModalityId>();
+  const stack: ModalityId[] = [...MODALITY_META[id].requires];
+  while (stack.length > 0) {
+    const next = stack.pop()!;
+    if (seen.has(next)) continue;
+    seen.add(next);
+    stack.push(...MODALITY_META[next].requires);
+  }
+  return Array.from(seen);
+}
+
+/** Currently-enabled dependents of `id` — i.e. things that would break. */
+function collectEnabledDependents(
+  id: ModalityId,
+  enabled: ModalitySet,
+): ModalityId[] {
+  const seen = new Set<ModalityId>();
+  const stack: ModalityId[] = [...MODALITY_META[id].dependents];
+  while (stack.length > 0) {
+    const next = stack.pop()!;
+    if (seen.has(next)) continue;
+    seen.add(next);
+    stack.push(...MODALITY_META[next].dependents);
+  }
+  return Array.from(seen).filter((m) => enabled.has(m));
+}
+
+export function Step4EnableModalities({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [template, setTemplate] = useState<SpecialtyManifest | null>(() =>
+    draft.selectedSpecialty
+      ? getSpecialtyTemplate(draft.selectedSpecialty)
+      : null,
+  );
+
+  // The component reads the manifest directly via the registry (server-safe
+  // module-init data). The registry is loaded eagerly at boot, so this is
+  // synchronous. We still keep state to allow a future swap to async fetch
+  // without changing the rendering shape.
+  useEffect(() => {
+    if (!draft.selectedSpecialty) {
+      setTemplate(null);
+      return;
+    }
+    setTemplate(getSpecialtyTemplate(draft.selectedSpecialty));
+  }, [draft.selectedSpecialty]);
+
+  // Seed: prefer existing draft.enabledModalities; fall back to manifest.
+  const seedEnabled = useMemo<ModalitySet>(() => {
+    if (Array.isArray(draft.enabledModalities)) {
+      return new Set(draft.enabledModalities as ModalityId[]);
+    }
+    if (template) {
+      return new Set(template.default_enabled_modalities as ModalityId[]);
+    }
+    return new Set();
+  }, [draft.enabledModalities, template]);
+
+  const [enabled, setEnabled] = useState<ModalitySet>(seedEnabled);
+
+  // If the underlying seed changes (e.g. specialty changes upstream), reset.
+  useEffect(() => {
+    setEnabled(new Set(seedEnabled));
+  }, [seedEnabled]);
+
+  // Auto-enable banner — last batch of modalities pulled in by `requires`.
+  const [autoEnabled, setAutoEnabled] = useState<ModalityId[]>([]);
+
+  // Disable-confirmation prompt for breaking the dependency graph.
+  const [pendingDisable, setPendingDisable] = useState<{
+    id: ModalityId;
+    breaks: ModalityId[];
+  } | null>(null);
+
+  // Cannabis acknowledgement modal state.
+  const [pendingCannabis, setPendingCannabis] = useState<boolean>(false);
+
+  function commit(next: ModalitySet) {
+    setEnabled(new Set(next));
+    patch({ enabledModalities: Array.from(next) });
+  }
+
+  function handleEnable(id: ModalityId) {
+    // Cannabis special case — gate behind the acknowledgement.
+    if (id === CANNABIS_MODALITY_ID) {
+      setPendingCannabis(true);
+      return;
+    }
+    enableNow(id);
+  }
+
+  function enableNow(id: ModalityId) {
+    const next = new Set(enabled);
+    next.add(id);
+    const pulled: ModalityId[] = [];
+    for (const req of collectRequires(id)) {
+      if (!next.has(req)) {
+        next.add(req);
+        pulled.push(req);
+      }
+    }
+    setAutoEnabled(pulled);
+    commit(next);
+  }
+
+  function handleDisable(id: ModalityId) {
+    const breaks = collectEnabledDependents(id, enabled);
+    if (breaks.length > 0) {
+      setPendingDisable({ id, breaks });
+      return;
+    }
+    disableNow(id, []);
+  }
+
+  function disableNow(id: ModalityId, alsoDisable: ModalityId[]) {
+    const next = new Set(enabled);
+    next.delete(id);
+    for (const dep of alsoDisable) next.delete(dep);
+    setAutoEnabled([]);
+    commit(next);
+  }
+
+  function confirmCannabis() {
+    setPendingCannabis(false);
+    enableNow(CANNABIS_MODALITY_ID);
+  }
+
+  function cancelCannabis() {
+    setPendingCannabis(false);
+  }
+
+  const hiddenModules = useMemo(() => {
+    if (!template) return [] as { module: string; modality: ModalityId }[];
+    const out: { module: string; modality: ModalityId }[] = [];
+    for (const mod of template.default_modules) {
+      const owner = REGISTERED_MODALITIES.find((id) =>
+        MODALITY_META[id as ModalityId].modules.includes(mod),
+      ) as ModalityId | undefined;
+      if (owner && !enabled.has(owner)) {
+        out.push({ module: mod, modality: owner });
+      }
+    }
+    return out;
+  }, [template, enabled]);
+
+  if (!template) {
+    return (
+      <Card className="p-6">
+        <h2 className="font-display text-lg font-medium text-text">
+          We couldn{"’"}t load that specialty template
+        </h2>
+        <p className="text-sm text-text-muted mt-2">
+          The specialty selected earlier ({draft.selectedSpecialty ?? "none"})
+          isn{"’"}t registered any more. Go back and pick another specialty to
+          continue setting up this practice.
+        </p>
+        <div className="mt-4">
+          <Button variant="secondary" onClick={goBack}>
+            Go back
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  const canContinue = enabled.size > 0;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="font-display text-xl font-medium text-text tracking-tight">
+          Enable modalities
+        </h2>
+        <p className="text-sm text-text-muted">
+          We{"’"}ve seeded these from your{" "}
+          <span className="font-medium text-text">{template.name}</span> template.
+          Toggle any modality on or off — required modalities are pulled in
+          automatically.
+        </p>
+      </header>
+
+      {autoEnabled.length > 0 && (
+        <Card tone="outlined" className="p-4 border-info/40">
+          <p className="text-sm text-text">
+            Also enabling:{" "}
+            <span className="font-medium">
+              {autoEnabled
+                .map((id) => MODALITY_META[id].label)
+                .join(", ")}
+            </span>{" "}
+            (required).
+          </p>
+        </Card>
+      )}
+
+      <div className="grid gap-3" role="group" aria-label="Modalities">
+        {REGISTERED_MODALITIES.map((modalityId) => {
+          const id = modalityId as ModalityId;
+          const meta = MODALITY_META[id];
+          const isOn = enabled.has(id);
+          const isCannabis = id === CANNABIS_MODALITY_ID;
+          const wasSeededOn = template.default_enabled_modalities.includes(id);
+          const blockedBy = meta.requires.filter((r) => !enabled.has(r));
+          const dependentsAtRisk = collectEnabledDependents(id, enabled);
+
+          return (
+            <label
+              key={id}
+              className={cn(
+                "flex items-start gap-4 rounded-xl border p-4 transition-all duration-200 ease-smooth cursor-pointer",
+                "focus-within:ring-2 focus-within:ring-accent/30",
+                isOn
+                  ? "border-accent bg-accent-soft shadow-sm"
+                  : "border-border/80 bg-surface hover:border-border-strong hover:shadow-sm",
+              )}
+            >
+              <input
+                type="checkbox"
+                role="switch"
+                checked={isOn}
+                onChange={(e) =>
+                  e.target.checked ? handleEnable(id) : handleDisable(id)
+                }
+                aria-describedby={`modality-${id}-desc`}
+                aria-label={`Enable ${meta.label}`}
+                className="mt-1 h-4 w-4 accent-[color:var(--accent)]"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-text">{meta.label}</span>
+                  {wasSeededOn && (
+                    <Badge tone="accent">Recommended for {template.name}</Badge>
+                  )}
+                  {isCannabis && (
+                    <Badge tone="warning">Regulatory acknowledgement</Badge>
+                  )}
+                </div>
+                <p
+                  id={`modality-${id}-desc`}
+                  className="text-sm text-text-muted mt-1"
+                >
+                  {meta.description}
+                </p>
+                <p className="text-xs text-text-muted/80 mt-2">
+                  Affects: {meta.surfaces.join(", ")}
+                </p>
+                {!isOn && blockedBy.length > 0 && (
+                  <p className="text-xs text-info mt-1">
+                    Enabling this also enables:{" "}
+                    {blockedBy
+                      .map((r) => MODALITY_META[r].label)
+                      .join(", ")}
+                    .
+                  </p>
+                )}
+                {isOn && dependentsAtRisk.length > 0 && (
+                  <p className="text-xs text-[color:var(--highlight-hover)] mt-1">
+                    {dependentsAtRisk
+                      .map((d) => MODALITY_META[d].label)
+                      .join(", ")}{" "}
+                    {dependentsAtRisk.length === 1 ? "requires" : "require"}{" "}
+                    this modality.
+                  </p>
+                )}
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      <Card tone="outlined" className="p-4">
+        <h3 className="font-display text-sm font-medium text-text">
+          Modules hidden by your selections
+        </h3>
+        {hiddenModules.length === 0 ? (
+          <p className="text-sm text-text-muted mt-1">
+            All modules from the {template.name} template are visible with the
+            current selections.
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-1 text-sm text-text-muted">
+            {hiddenModules.map(({ module, modality }) => (
+              <li key={module} className="flex items-center gap-2">
+                <code className="rounded bg-surface-muted px-1.5 py-0.5 text-xs">
+                  {module}
+                </code>
+                <span className="text-xs">
+                  needs {MODALITY_META[modality].label}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {pendingDisable && (
+        <DependencyConfirmDialog
+          target={pendingDisable.id}
+          breaks={pendingDisable.breaks}
+          onCancel={() => setPendingDisable(null)}
+          onConfirm={() => {
+            const { id, breaks } = pendingDisable;
+            setPendingDisable(null);
+            disableNow(id, breaks);
+          }}
+        />
+      )}
+
+      {pendingCannabis && (
+        <CannabisAckDialog
+          onCancel={cancelCannabis}
+          onConfirm={confirmCannabis}
+        />
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={goNext} disabled={!canContinue}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline dialogs
+//
+// Inline (NOT window.confirm) so screen readers, keyboard focus, and copy
+// review all behave the same way the rest of the wizard does.
+// ---------------------------------------------------------------------------
+
+function DependencyConfirmDialog({
+  target,
+  breaks,
+  onCancel,
+  onConfirm,
+}: {
+  target: ModalityId;
+  breaks: ModalityId[];
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const targetLabel = MODALITY_META[target].label;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dep-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <Card className="max-w-md w-full p-6">
+        <h3
+          id="dep-dialog-title"
+          className="font-display text-lg font-medium text-text"
+        >
+          Disable {targetLabel}?
+        </h3>
+        <p className="text-sm text-text-muted mt-2">
+          The following will be disabled because they require {targetLabel}:
+        </p>
+        <ul className="mt-2 list-disc pl-5 text-sm text-text">
+          {breaks.map((id) => (
+            <li key={id}>{MODALITY_META[id].label}</li>
+          ))}
+        </ul>
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm}>
+            Disable all
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function CannabisAckDialog({
+  onCancel,
+  onConfirm,
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cannabis-ack-title"
+      aria-describedby="cannabis-ack-body"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <Card className="max-w-md w-full p-6">
+        <h3
+          id="cannabis-ack-title"
+          className="font-display text-lg font-medium text-text"
+        >
+          {CANNABIS_ACK_TITLE}
+        </h3>
+        <p id="cannabis-ack-body" className="text-sm text-text-muted mt-2">
+          {CANNABIS_ACK_BODY}
+        </p>
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm}>I understand — enable</Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step definition
+// ---------------------------------------------------------------------------
+
+export const step4EnableModalitiesDefinition: WizardStepDefinition = {
+  id: "enable-modalities",
+  title: "Enable modalities",
+  description: "Turn on the treatment modalities this practice offers.",
+  Component: Step4EnableModalities,
+  isComplete: (draft) =>
+    Array.isArray(draft.enabledModalities) && draft.enabledModalities.length > 0,
+  isReachable: (draft) => draft.careModel != null,
+};

--- a/src/components/onboarding/steps/step-4-enable-modalities.tsx
+++ b/src/components/onboarding/steps/step-4-enable-modalities.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { MODALITY_META, type ModalityId } from "@/lib/modality/registry";
+import { MODALITY_META, type ModalityId, type ModalityMeta } from "@/lib/modality/registry";
 import {
   REGISTERED_MODALITIES,
   type SpecialtyManifest,
@@ -183,9 +183,10 @@ export function Step4EnableModalities({
     if (!template) return [] as { module: string; modality: ModalityId }[];
     const out: { module: string; modality: ModalityId }[] = [];
     for (const mod of template.default_modules) {
-      const owner = REGISTERED_MODALITIES.find((id) =>
-        MODALITY_META[id as ModalityId].modules.includes(mod),
-      ) as ModalityId | undefined;
+      const owner = REGISTERED_MODALITIES.find((id) => {
+        const meta = MODALITY_META[id as ModalityId] as ModalityMeta & { modules?: string[] };
+        return meta.modules?.includes(mod);
+      }) as ModalityId | undefined;
       if (owner && !enabled.has(owner)) {
         out.push({ module: mod, modality: owner });
       }

--- a/src/components/onboarding/steps/step-5-disable-modalities.tsx
+++ b/src/components/onboarding/steps/step-5-disable-modalities.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+// EMR-423 — Practice Onboarding Controller v1, wizard step 5.
+//
+// Mirror of step 4: lets the admin EXPLICITLY mark modalities as disabled.
+// "disabled" here is stronger than "not enabled" — it means the practice
+// considered this modality and turned it off (records a deliberate decision
+// for the audit trail). enabledModalities ∪ disabledModalities ⊆
+// REGISTERED_MODALITIES; the union does not have to be the whole set.
+//
+// Architecture rules:
+//  - Specialty-adaptive. NO `if (specialty === 'cannabis')` branches.
+//  - Dependency graph from MODALITY_META is enforced both directions, the
+//    same way step 4 enforces it.
+//  - This step is ALWAYS isComplete (admin may explicitly disable nothing)
+//    and is reachable as soon as the care model is selected — it does not
+//    depend on step 4 having been visited.
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { MODALITY_META, type ModalityId } from "@/lib/modality/registry";
+import {
+  REGISTERED_MODALITIES,
+  type SpecialtyManifest,
+} from "@/lib/specialty-templates/manifest-schema";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import type {
+  WizardStepDefinition,
+  WizardStepProps,
+} from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+type ModalitySet = Set<ModalityId>;
+
+/** Modalities whose `dependents` chain leads back to `id` and are still in `pool`. */
+function collectDependentsInPool(
+  id: ModalityId,
+  pool: ModalitySet,
+): ModalityId[] {
+  const seen = new Set<ModalityId>();
+  const stack: ModalityId[] = [...MODALITY_META[id].dependents];
+  while (stack.length > 0) {
+    const next = stack.pop()!;
+    if (seen.has(next)) continue;
+    seen.add(next);
+    stack.push(...MODALITY_META[next].dependents);
+  }
+  return Array.from(seen).filter((m) => pool.has(m));
+}
+
+export function Step5DisableModalities({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [template, setTemplate] = useState<SpecialtyManifest | null>(() =>
+    draft.selectedSpecialty
+      ? getSpecialtyTemplate(draft.selectedSpecialty)
+      : null,
+  );
+
+  useEffect(() => {
+    if (!draft.selectedSpecialty) {
+      setTemplate(null);
+      return;
+    }
+    setTemplate(getSpecialtyTemplate(draft.selectedSpecialty));
+  }, [draft.selectedSpecialty]);
+
+  const enabled = useMemo<ModalitySet>(
+    () => new Set((draft.enabledModalities as ModalityId[] | undefined) ?? []),
+    [draft.enabledModalities],
+  );
+
+  // Seed disabled: prefer existing draft.disabledModalities; fall back to
+  // manifest's default_disabled_modalities, but filter out anything currently
+  // in `enabled` (mutual exclusion is a hard invariant).
+  const seedDisabled = useMemo<ModalitySet>(() => {
+    if (Array.isArray(draft.disabledModalities)) {
+      return new Set(
+        (draft.disabledModalities as ModalityId[]).filter(
+          (m) => !enabled.has(m),
+        ),
+      );
+    }
+    if (template) {
+      return new Set(
+        (template.default_disabled_modalities as ModalityId[]).filter(
+          (m) => !enabled.has(m),
+        ),
+      );
+    }
+    return new Set();
+  }, [draft.disabledModalities, template, enabled]);
+
+  const [disabled, setDisabled] = useState<ModalitySet>(seedDisabled);
+
+  useEffect(() => {
+    setDisabled(new Set(seedDisabled));
+  }, [seedDisabled]);
+
+  // Cascade-disable confirmation — when disabling X would leave dependents
+  // hanging, surface them and require explicit confirmation.
+  const [pendingCascade, setPendingCascade] = useState<{
+    id: ModalityId;
+    cascade: ModalityId[];
+  } | null>(null);
+
+  function commit(next: ModalitySet) {
+    setDisabled(new Set(next));
+    patch({ disabledModalities: Array.from(next) });
+  }
+
+  function handleDisableToggle(id: ModalityId, on: boolean) {
+    if (!on) {
+      // Un-disable — clears the explicit-off mark.
+      const next = new Set(disabled);
+      next.delete(id);
+      commit(next);
+      return;
+    }
+    // Disabling something means: "we considered this and turn it off." Any
+    // candidate-pool dependents (i.e. things in the same disabled-candidate
+    // pool) that require this should also be marked disabled.
+    const pool = new Set<ModalityId>(
+      REGISTERED_MODALITIES.filter((m) => !enabled.has(m as ModalityId)) as ModalityId[],
+    );
+    const cascade = collectDependentsInPool(id, pool).filter(
+      (m) => !disabled.has(m),
+    );
+    if (cascade.length > 0) {
+      setPendingCascade({ id, cascade });
+      return;
+    }
+    const next = new Set(disabled);
+    next.add(id);
+    commit(next);
+  }
+
+  function confirmCascade() {
+    if (!pendingCascade) return;
+    const { id, cascade } = pendingCascade;
+    const next = new Set(disabled);
+    next.add(id);
+    for (const m of cascade) next.add(m);
+    setPendingCascade(null);
+    commit(next);
+  }
+
+  // Candidates: every registered modality NOT currently in `enabled`. The
+  // admin may then mark any subset of those as explicitly disabled.
+  const candidates = useMemo(
+    () =>
+      REGISTERED_MODALITIES.filter(
+        (m) => !enabled.has(m as ModalityId),
+      ) as ModalityId[],
+    [enabled],
+  );
+
+  // Live "modules hidden" preview — uses the *enabled* set as the source of
+  // truth (modules are hidden whenever their owning modality is not enabled,
+  // regardless of whether the admin explicitly disabled it). Disabled
+  // modalities are highlighted in the list.
+  const hiddenModules = useMemo(() => {
+    if (!template) return [] as { module: string; modality: ModalityId; explicit: boolean }[];
+    const out: { module: string; modality: ModalityId; explicit: boolean }[] = [];
+    for (const mod of template.default_modules) {
+      const owner = REGISTERED_MODALITIES.find((id) =>
+        MODALITY_META[id as ModalityId].modules.includes(mod),
+      ) as ModalityId | undefined;
+      if (owner && !enabled.has(owner)) {
+        out.push({ module: mod, modality: owner, explicit: disabled.has(owner) });
+      }
+    }
+    return out;
+  }, [template, enabled, disabled]);
+
+  if (!template) {
+    return (
+      <Card className="p-6">
+        <h2 className="font-display text-lg font-medium text-text">
+          We couldn{"’"}t load that specialty template
+        </h2>
+        <p className="text-sm text-text-muted mt-2">
+          The specialty selected earlier ({draft.selectedSpecialty ?? "none"})
+          isn{"’"}t registered any more. Go back and pick another specialty to
+          continue setting up this practice.
+        </p>
+        <div className="mt-4">
+          <Button variant="secondary" onClick={goBack}>
+            Go back
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="font-display text-xl font-medium text-text tracking-tight">
+          Explicitly disable modalities
+        </h2>
+        <p className="text-sm text-text-muted">
+          Mark any modalities you{"’"}ve deliberately considered and turned
+          off. This is recorded for compliance — modalities the practice never
+          had any intention of using don{"’"}t need to be marked here.
+        </p>
+      </header>
+
+      {candidates.length === 0 ? (
+        <Card tone="outlined" className="p-6 text-center">
+          <p className="text-sm text-text-muted">
+            Every registered modality is currently enabled. There{"’"}s nothing
+            to mark as disabled. Go back to step 4 to adjust enabled modalities.
+          </p>
+        </Card>
+      ) : (
+        <div
+          className="grid gap-3"
+          role="group"
+          aria-label="Modalities considered and disabled"
+        >
+          {candidates.map((id) => {
+            const meta = MODALITY_META[id];
+            const isOff = disabled.has(id);
+            const wasSeededOff =
+              template.default_disabled_modalities.includes(id);
+            return (
+              <label
+                key={id}
+                className={cn(
+                  "flex items-start gap-4 rounded-xl border p-4 transition-all duration-200 ease-smooth cursor-pointer",
+                  "focus-within:ring-2 focus-within:ring-accent/30",
+                  isOff
+                    ? "border-[color:var(--highlight)] bg-highlight-soft"
+                    : "border-border/80 bg-surface hover:border-border-strong hover:shadow-sm",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  role="switch"
+                  checked={isOff}
+                  onChange={(e) =>
+                    handleDisableToggle(id, e.target.checked)
+                  }
+                  aria-describedby={`disable-${id}-desc`}
+                  aria-label={`Disable ${meta.label}`}
+                  className="mt-1 h-4 w-4 accent-[color:var(--highlight-hover)]"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-text">{meta.label}</span>
+                    {wasSeededOff && (
+                      <Badge tone="warning">
+                        Off by default for {template.name}
+                      </Badge>
+                    )}
+                  </div>
+                  <p
+                    id={`disable-${id}-desc`}
+                    className="text-sm text-text-muted mt-1"
+                  >
+                    {meta.description}
+                  </p>
+                  <p className="text-xs text-text-muted/80 mt-2">
+                    Hides: {meta.surfaces.join(", ")}
+                    {meta.modules.length > 0 && (
+                      <>
+                        {" · "}
+                        Modules: {meta.modules.join(", ")}
+                      </>
+                    )}
+                  </p>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      <Card tone="outlined" className="p-4">
+        <h3 className="font-display text-sm font-medium text-text">
+          Modules hidden by your selections
+        </h3>
+        {hiddenModules.length === 0 ? (
+          <p className="text-sm text-text-muted mt-1">
+            All modules from the {template.name} template are visible with the
+            current selections.
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-1 text-sm text-text-muted">
+            {hiddenModules.map(({ module, modality, explicit }) => (
+              <li key={module} className="flex items-center gap-2">
+                <code className="rounded bg-surface-muted px-1.5 py-0.5 text-xs">
+                  {module}
+                </code>
+                <span className="text-xs">
+                  needs {MODALITY_META[modality].label}
+                </span>
+                {explicit && <Badge tone="warning">explicitly off</Badge>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {pendingCascade && (
+        <CascadeConfirmDialog
+          target={pendingCascade.id}
+          cascade={pendingCascade.cascade}
+          onCancel={() => setPendingCascade(null)}
+          onConfirm={confirmCascade}
+        />
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={goNext}>Continue</Button>
+      </div>
+    </div>
+  );
+}
+
+function CascadeConfirmDialog({
+  target,
+  cascade,
+  onCancel,
+  onConfirm,
+}: {
+  target: ModalityId;
+  cascade: ModalityId[];
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const targetLabel = MODALITY_META[target].label;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cascade-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <Card className="max-w-md w-full p-6">
+        <h3
+          id="cascade-dialog-title"
+          className="font-display text-lg font-medium text-text"
+        >
+          Also disable dependents?
+        </h3>
+        <p className="text-sm text-text-muted mt-2">
+          The following also require {targetLabel} and will be marked disabled:
+        </p>
+        <ul className="mt-2 list-disc pl-5 text-sm text-text">
+          {cascade.map((id) => (
+            <li key={id}>{MODALITY_META[id].label}</li>
+          ))}
+        </ul>
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm}>
+            Disable all
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export const step5DisableModalitiesDefinition: WizardStepDefinition = {
+  id: "disable-modalities",
+  title: "Disable modalities",
+  description: "Turn off any modalities not relevant to this practice.",
+  Component: Step5DisableModalities,
+  // Always complete — the admin may explicitly disable nothing.
+  isComplete: () => true,
+  // Independent of step 4 — reachable as soon as care model is set.
+  isReachable: (draft) => draft.careModel != null,
+};

--- a/src/components/onboarding/steps/step-5-disable-modalities.tsx
+++ b/src/components/onboarding/steps/step-5-disable-modalities.tsx
@@ -21,7 +21,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { MODALITY_META, type ModalityId } from "@/lib/modality/registry";
+import { MODALITY_META, type ModalityId, type ModalityMeta } from "@/lib/modality/registry";
 import {
   REGISTERED_MODALITIES,
   type SpecialtyManifest,
@@ -169,9 +169,10 @@ export function Step5DisableModalities({
     if (!template) return [] as { module: string; modality: ModalityId; explicit: boolean }[];
     const out: { module: string; modality: ModalityId; explicit: boolean }[] = [];
     for (const mod of template.default_modules) {
-      const owner = REGISTERED_MODALITIES.find((id) =>
-        MODALITY_META[id as ModalityId].modules.includes(mod),
-      ) as ModalityId | undefined;
+      const owner = REGISTERED_MODALITIES.find((id) => {
+        const meta = MODALITY_META[id as ModalityId] as ModalityMeta & { modules?: string[] };
+        return meta.modules?.includes(mod);
+      }) as ModalityId | undefined;
       if (owner && !enabled.has(owner)) {
         out.push({ module: mod, modality: owner, explicit: disabled.has(owner) });
       }
@@ -269,12 +270,6 @@ export function Step5DisableModalities({
                   </p>
                   <p className="text-xs text-text-muted/80 mt-2">
                     Hides: {meta.surfaces.join(", ")}
-                    {meta.modules.length > 0 && (
-                      <>
-                        {" · "}
-                        Modules: {meta.modules.join(", ")}
-                      </>
-                    )}
                   </p>
                 </div>
               </label>

--- a/src/components/onboarding/steps/step-5-disable-modalities.tsx
+++ b/src/components/onboarding/steps/step-5-disable-modalities.tsx
@@ -26,7 +26,7 @@ import {
   REGISTERED_MODALITIES,
   type SpecialtyManifest,
 } from "@/lib/specialty-templates/manifest-schema";
-import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import { useActiveManifest } from "./preview-chrome";
 import type {
   WizardStepDefinition,
   WizardStepProps,
@@ -57,19 +57,7 @@ export function Step5DisableModalities({
   goNext,
   goBack,
 }: WizardStepProps) {
-  const [template, setTemplate] = useState<SpecialtyManifest | null>(() =>
-    draft.selectedSpecialty
-      ? getSpecialtyTemplate(draft.selectedSpecialty)
-      : null,
-  );
-
-  useEffect(() => {
-    if (!draft.selectedSpecialty) {
-      setTemplate(null);
-      return;
-    }
-    setTemplate(getSpecialtyTemplate(draft.selectedSpecialty));
-  }, [draft.selectedSpecialty]);
+  const template = useActiveManifest(draft.selectedSpecialty);
 
   const enabled = useMemo<ModalitySet>(
     () => new Set((draft.enabledModalities as ModalityId[] | undefined) ?? []),

--- a/src/components/onboarding/steps/step-6-apply-workflows.tsx
+++ b/src/components/onboarding/steps/step-6-apply-workflows.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+// EMR-424 — Wizard Step 6: Apply workflow templates.
+//
+// Source of defaults: the manifest of the specialty selected in step 2
+// (default_workflows). Admin can toggle the full KNOWN_WORKFLOWS catalogue
+// on/off, see a live diff vs defaults, and restore defaults with one click.
+// Specialty-adaptive: the manifest is pulled by slug; we never branch on
+// `specialty === "cannabis"`.
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Eyebrow } from "@/components/ui/ornament";
+import { KNOWN_WORKFLOWS } from "@/lib/onboarding/known-templates";
+import { diffTemplateIds, hasDiff } from "@/lib/onboarding/template-diff";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+import { DiffBanner } from "./_template-picker-shared";
+
+export function Step6ApplyWorkflows({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [manifest, setManifest] = React.useState<SpecialtyManifest | null>(null);
+  const [loadState, setLoadState] = React.useState<"loading" | "ready" | "error">(
+    "loading",
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!draft.selectedSpecialty) {
+      setLoadState("ready");
+      return;
+    }
+    fetch("/api/specialty-templates")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<{ items: SpecialtyManifest[] }>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const found =
+          data.items.find((m) => m.slug === draft.selectedSpecialty) ?? null;
+        setManifest(found);
+        setLoadState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setLoadState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.selectedSpecialty]);
+
+  const defaults = React.useMemo(
+    () => manifest?.default_workflows ?? [],
+    [manifest],
+  );
+  const current = React.useMemo(
+    () => draft.workflowTemplateIds ?? [],
+    [draft.workflowTemplateIds],
+  );
+
+  const diff = React.useMemo(
+    () => diffTemplateIds(defaults, current),
+    [defaults, current],
+  );
+
+  function toggle(id: string) {
+    const next = current.includes(id)
+      ? current.filter((x) => x !== id)
+      : [...current, id];
+    patch({ workflowTemplateIds: next });
+  }
+
+  function restoreDefaults() {
+    patch({ workflowTemplateIds: [...defaults] });
+  }
+
+  if (loadState === "loading") {
+    return (
+      <div className="rounded-xl border border-dashed border-border-strong/60 bg-surface-muted p-8 text-center text-sm text-text-muted">
+        Loading workflow defaults…
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <Card className="p-6" tone="outlined">
+        <p className="text-sm text-danger" role="alert">
+          Couldn&rsquo;t load the specialty manifest. Refresh to try again.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-6-heading">
+      <header className="space-y-2">
+        <Eyebrow>Step 6 of 15</Eyebrow>
+        <h2
+          id="step-6-heading"
+          className="font-display text-2xl font-medium text-text tracking-tight"
+        >
+          Apply workflow templates
+        </h2>
+        <p className="text-sm text-text-muted max-w-2xl">
+          We&rsquo;ve pre-selected the workflows recommended for{" "}
+          <span className="font-medium text-text">
+            {manifest?.name ?? "this specialty"}
+          </span>
+          . Toggle individual workflows below; your changes are tracked vs the
+          default set.
+        </p>
+      </header>
+
+      <Card tone="raised">
+        <CardContent className="pt-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                {manifest?.name ?? "Specialty"} defaults
+              </p>
+              <p className="text-sm text-text mt-1">
+                {defaults.length} workflow{defaults.length === 1 ? "" : "s"}{" "}
+                recommended.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={restoreDefaults}
+              disabled={!hasDiff(diff)}
+            >
+              Restore defaults
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <DiffBanner diff={diff} unitSingular="workflow" unitPlural="workflows" />
+
+      <fieldset className="grid gap-2" aria-label="All known workflows">
+        <legend className="sr-only">Workflows</legend>
+        {KNOWN_WORKFLOWS.map((tpl) => {
+          const checked = current.includes(tpl.id);
+          const isDefault = defaults.includes(tpl.id);
+          return (
+            <label
+              key={tpl.id}
+              className={cn(
+                "flex items-start gap-3 rounded-xl border p-3.5 cursor-pointer transition-colors",
+                "focus-within:ring-2 focus-within:ring-accent/30",
+                checked
+                  ? "border-accent bg-accent-soft/40"
+                  : "border-border/80 bg-surface hover:border-border-strong",
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => toggle(tpl.id)}
+                className="mt-1 h-4 w-4 accent-[color:var(--accent)]"
+                aria-describedby={`wf-${tpl.id}-desc`}
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-text">{tpl.label}</span>
+                  {isDefault && (
+                    <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
+                      Default
+                    </span>
+                  )}
+                </div>
+                <p
+                  id={`wf-${tpl.id}-desc`}
+                  className="text-sm text-text-muted mt-1"
+                >
+                  {tpl.description}
+                </p>
+              </div>
+            </label>
+          );
+        })}
+      </fieldset>
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={goNext}>Continue</Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/onboarding/steps/step-7-apply-charting.tsx
+++ b/src/components/onboarding/steps/step-7-apply-charting.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+// EMR-424 — Wizard Step 7: Apply charting templates.
+//
+// Source of defaults: the manifest of the specialty selected in step 2
+// (default_charting_templates). Admin can toggle the full KNOWN_CHARTING
+// catalogue on/off, see a live diff vs defaults, and restore defaults with
+// one click. Specialty-adaptive — manifest is read by slug only.
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Eyebrow } from "@/components/ui/ornament";
+import { KNOWN_CHARTING } from "@/lib/onboarding/known-templates";
+import { diffTemplateIds, hasDiff } from "@/lib/onboarding/template-diff";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+import { DiffBanner } from "./_template-picker-shared";
+
+export function Step7ApplyCharting({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [manifest, setManifest] = React.useState<SpecialtyManifest | null>(null);
+  const [loadState, setLoadState] = React.useState<"loading" | "ready" | "error">(
+    "loading",
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!draft.selectedSpecialty) {
+      setLoadState("ready");
+      return;
+    }
+    fetch("/api/specialty-templates")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<{ items: SpecialtyManifest[] }>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const found =
+          data.items.find((m) => m.slug === draft.selectedSpecialty) ?? null;
+        setManifest(found);
+        setLoadState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setLoadState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.selectedSpecialty]);
+
+  const defaults = React.useMemo(
+    () => manifest?.default_charting_templates ?? [],
+    [manifest],
+  );
+  const current = React.useMemo(
+    () => draft.chartingTemplateIds ?? [],
+    [draft.chartingTemplateIds],
+  );
+
+  const diff = React.useMemo(
+    () => diffTemplateIds(defaults, current),
+    [defaults, current],
+  );
+
+  function toggle(id: string) {
+    const next = current.includes(id)
+      ? current.filter((x) => x !== id)
+      : [...current, id];
+    patch({ chartingTemplateIds: next });
+  }
+
+  function restoreDefaults() {
+    patch({ chartingTemplateIds: [...defaults] });
+  }
+
+  if (loadState === "loading") {
+    return (
+      <div className="rounded-xl border border-dashed border-border-strong/60 bg-surface-muted p-8 text-center text-sm text-text-muted">
+        Loading charting defaults…
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <Card className="p-6" tone="outlined">
+        <p className="text-sm text-danger" role="alert">
+          Couldn&rsquo;t load the specialty manifest. Refresh to try again.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-7-heading">
+      <header className="space-y-2">
+        <Eyebrow>Step 7 of 15</Eyebrow>
+        <h2
+          id="step-7-heading"
+          className="font-display text-2xl font-medium text-text tracking-tight"
+        >
+          Apply charting templates
+        </h2>
+        <p className="text-sm text-text-muted max-w-2xl">
+          Choose which structured note formats clinicians at{" "}
+          <span className="font-medium text-text">
+            {manifest?.name ?? "this specialty"}
+          </span>{" "}
+          will see in their chart. We&rsquo;ve preselected the recommended set.
+        </p>
+      </header>
+
+      <Card tone="raised">
+        <CardContent className="pt-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                {manifest?.name ?? "Specialty"} defaults
+              </p>
+              <p className="text-sm text-text mt-1">
+                {defaults.length} chart{" "}
+                {defaults.length === 1 ? "template" : "templates"} recommended.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={restoreDefaults}
+              disabled={!hasDiff(diff)}
+            >
+              Restore defaults
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <DiffBanner
+        diff={diff}
+        unitSingular="chart template"
+        unitPlural="chart templates"
+      />
+
+      <fieldset className="grid gap-2" aria-label="All known chart templates">
+        <legend className="sr-only">Chart templates</legend>
+        {KNOWN_CHARTING.map((tpl) => {
+          const checked = current.includes(tpl.id);
+          const isDefault = defaults.includes(tpl.id);
+          return (
+            <label
+              key={tpl.id}
+              className={cn(
+                "flex items-start gap-3 rounded-xl border p-3.5 cursor-pointer transition-colors",
+                "focus-within:ring-2 focus-within:ring-accent/30",
+                checked
+                  ? "border-accent bg-accent-soft/40"
+                  : "border-border/80 bg-surface hover:border-border-strong",
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => toggle(tpl.id)}
+                className="mt-1 h-4 w-4 accent-[color:var(--accent)]"
+                aria-describedby={`ct-${tpl.id}-desc`}
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-text">{tpl.label}</span>
+                  {isDefault && (
+                    <span className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
+                      Default
+                    </span>
+                  )}
+                </div>
+                <p
+                  id={`ct-${tpl.id}-desc`}
+                  className="text-sm text-text-muted mt-1"
+                >
+                  {tpl.description}
+                </p>
+              </div>
+            </label>
+          );
+        })}
+      </fieldset>
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={goNext}>Continue</Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/onboarding/steps/step-8-apply-roles.tsx
+++ b/src/components/onboarding/steps/step-8-apply-roles.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+// EMR-424 — Wizard Step 8: Apply roles & permission groups.
+//
+// Different UX from steps 6/7: a role list (Practice Admin, Physician, Nurse,
+// MA, Front Desk, Patient) where each role expands to expose the permission
+// groups attached to it. Admin can override per-role permission groups.
+//
+// Persistence shape (TRANSITIONAL — see TODO below):
+//   draft.rolePermissionTemplateIds = [`role-overrides:json:<base64>`]
+// The base64 segment encodes a JSON object of type
+//   Record<roleSlug, { groups: string[] }>.
+// EMR-441 will replace this with a real role-template registry; until then
+// this single-string encoding lets us round-trip the override structure
+// through the existing `string[]` schema without a Prisma migration.
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Collapsible } from "@/components/ui/collapsible";
+import { Eyebrow } from "@/components/ui/ornament";
+import {
+  KNOWN_PERMISSION_GROUPS,
+  KNOWN_ROLES,
+} from "@/lib/onboarding/known-templates";
+import { diffTemplateIds, hasDiff } from "@/lib/onboarding/template-diff";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+import { DiffBanner } from "./_template-picker-shared";
+
+// ---------------------------------------------------------------------------
+// TODO(EMR-441): replace this transitional encoding with a real role-template
+// schema once the role/permission registry ships. The wizard persists the
+// per-role override map inside a single string ID:
+//   `role-overrides:json:<base64-encoded JSON>`
+// On read we decode that prefix; on write we re-encode the live overrides.
+// ---------------------------------------------------------------------------
+
+const ROLE_OVERRIDE_PREFIX = "role-overrides:json:";
+
+type RoleOverrides = Record<string, { groups: string[] }>;
+
+function encodeRoleOverrides(overrides: RoleOverrides): string {
+  const json = JSON.stringify(overrides);
+  // btoa is available in browsers; the wizard step is "use client" so
+  // this only runs in the browser bundle.
+  const b64 =
+    typeof btoa !== "undefined"
+      ? btoa(unescape(encodeURIComponent(json)))
+      : Buffer.from(json, "utf8").toString("base64");
+  return `${ROLE_OVERRIDE_PREFIX}${b64}`;
+}
+
+function decodeRoleOverrides(ids: string[] | undefined): RoleOverrides {
+  if (!ids) return {};
+  for (const id of ids) {
+    if (!id.startsWith(ROLE_OVERRIDE_PREFIX)) continue;
+    const b64 = id.slice(ROLE_OVERRIDE_PREFIX.length);
+    try {
+      const json =
+        typeof atob !== "undefined"
+          ? decodeURIComponent(escape(atob(b64)))
+          : Buffer.from(b64, "base64").toString("utf8");
+      const parsed = JSON.parse(json) as unknown;
+      if (parsed && typeof parsed === "object") {
+        return parsed as RoleOverrides;
+      }
+    } catch {
+      // Corrupt payload — fall through and return defaults.
+    }
+  }
+  return {};
+}
+
+/** Sorted, deduped list of group ids for a given role's current selection. */
+function effectiveGroups(
+  roleId: string,
+  overrides: RoleOverrides,
+  defaults: string[],
+): string[] {
+  const override = overrides[roleId];
+  return override ? override.groups : defaults;
+}
+
+export function Step8ApplyRoles({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  // Local mirror of the override map. We hydrate from the persisted
+  // encoded string on mount and write back through `patch` whenever the
+  // admin toggles a permission.
+  const [overrides, setOverrides] = React.useState<RoleOverrides>(() =>
+    decodeRoleOverrides(draft.rolePermissionTemplateIds ?? undefined),
+  );
+
+  // Defaults baseline used by the diff banner: the union of every role's
+  // default permissions, namespaced as `role:perm` so a permission moved
+  // between roles registers as a real change.
+  const defaultsFlat = React.useMemo(() => {
+    const flat: string[] = [];
+    for (const role of KNOWN_ROLES) {
+      for (const perm of role.defaultPermissions) {
+        flat.push(`${role.id}:${perm}`);
+      }
+    }
+    return flat;
+  }, []);
+
+  const currentFlat = React.useMemo(() => {
+    const flat: string[] = [];
+    for (const role of KNOWN_ROLES) {
+      const groups = effectiveGroups(
+        role.id,
+        overrides,
+        role.defaultPermissions,
+      );
+      for (const perm of groups) {
+        flat.push(`${role.id}:${perm}`);
+      }
+    }
+    return flat;
+  }, [overrides]);
+
+  const diff = React.useMemo(
+    () => diffTemplateIds(defaultsFlat, currentFlat),
+    [defaultsFlat, currentFlat],
+  );
+
+  // Push the encoded payload back into the draft. We always write the full
+  // object (not a partial diff) so the persisted shape is self-contained.
+  function persist(next: RoleOverrides) {
+    setOverrides(next);
+    const onlyDirty: RoleOverrides = {};
+    for (const role of KNOWN_ROLES) {
+      const override = next[role.id];
+      if (!override) continue;
+      // If the override matches defaults exactly, drop it.
+      const matchesDefault =
+        override.groups.length === role.defaultPermissions.length &&
+        override.groups.every((g) => role.defaultPermissions.includes(g));
+      if (!matchesDefault) onlyDirty[role.id] = override;
+    }
+    if (Object.keys(onlyDirty).length === 0) {
+      patch({ rolePermissionTemplateIds: [] });
+    } else {
+      patch({ rolePermissionTemplateIds: [encodeRoleOverrides(onlyDirty)] });
+    }
+  }
+
+  function togglePermission(roleId: string, perm: string) {
+    const role = KNOWN_ROLES.find((r) => r.id === roleId);
+    if (!role) return;
+    const currentGroups = effectiveGroups(
+      roleId,
+      overrides,
+      role.defaultPermissions,
+    );
+    const nextGroups = currentGroups.includes(perm)
+      ? currentGroups.filter((p) => p !== perm)
+      : [...currentGroups, perm];
+    const nextOverrides: RoleOverrides = {
+      ...overrides,
+      [roleId]: { groups: nextGroups },
+    };
+    persist(nextOverrides);
+  }
+
+  function restoreDefaults() {
+    persist({});
+  }
+
+  function restoreRole(roleId: string) {
+    const next: RoleOverrides = { ...overrides };
+    delete next[roleId];
+    persist(next);
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-8-heading">
+      <header className="space-y-2">
+        <Eyebrow>Step 8 of 15</Eyebrow>
+        <h2
+          id="step-8-heading"
+          className="font-display text-2xl font-medium text-text tracking-tight"
+        >
+          Apply roles & permission groups
+        </h2>
+        <p className="text-sm text-text-muted max-w-2xl">
+          Each role ships with a sensible set of permission groups. Expand a
+          role to fine-tune what people in that role can do. Overrides are
+          tracked vs the default permission set.
+        </p>
+      </header>
+
+      <Card tone="raised">
+        <CardContent className="pt-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                Default role kit
+              </p>
+              <p className="text-sm text-text mt-1">
+                {KNOWN_ROLES.length} roles &middot; {defaultsFlat.length} default
+                permission grants.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={restoreDefaults}
+              disabled={!hasDiff(diff)}
+            >
+              Restore defaults
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <DiffBanner
+        diff={diff}
+        unitSingular="permission grant"
+        unitPlural="permission grants"
+      />
+
+      <div className="grid gap-3" role="group" aria-label="Roles">
+        {KNOWN_ROLES.map((role) => {
+          const groups = effectiveGroups(
+            role.id,
+            overrides,
+            role.defaultPermissions,
+          );
+          const overridden = role.id in overrides;
+          return (
+            <Collapsible
+              key={role.id}
+              tone="default"
+              title={
+                <div className="flex flex-wrap items-center gap-2">
+                  <span>{role.label}</span>
+                  <span className="text-[11px] font-normal text-text-muted">
+                    {groups.length} of{" "}
+                    {Object.keys(KNOWN_PERMISSION_GROUPS).length} groups
+                  </span>
+                  {overridden && (
+                    <span className="rounded-full bg-highlight-soft px-2 py-0.5 text-[10px] font-medium text-[color:var(--highlight-hover)]">
+                      Overridden
+                    </span>
+                  )}
+                </div>
+              }
+              meta={role.description}
+            >
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-text-muted">
+                    Toggle permission groups for{" "}
+                    <span className="font-medium text-text">{role.label}</span>.
+                  </p>
+                  {overridden && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => restoreRole(role.id)}
+                    >
+                      Reset role
+                    </Button>
+                  )}
+                </div>
+                <div className="grid gap-1.5 sm:grid-cols-2">
+                  {Object.entries(KNOWN_PERMISSION_GROUPS).map(
+                    ([permId, permLabel]) => {
+                      const checked = groups.includes(permId);
+                      const isDefault =
+                        role.defaultPermissions.includes(permId);
+                      return (
+                        <label
+                          key={`${role.id}-${permId}`}
+                          className={cn(
+                            "flex items-start gap-2 rounded-lg border p-2.5 cursor-pointer transition-colors",
+                            checked
+                              ? "border-accent/60 bg-accent-soft/30"
+                              : "border-border/70 bg-surface hover:border-border-strong",
+                          )}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() =>
+                              togglePermission(role.id, permId)
+                            }
+                            className="mt-0.5 h-4 w-4 accent-[color:var(--accent)]"
+                          />
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <span className="text-sm font-medium text-text">
+                                {permLabel}
+                              </span>
+                              {isDefault && (
+                                <span className="rounded-full bg-accent-soft px-1.5 py-0.5 text-[10px] font-medium text-accent">
+                                  Default
+                                </span>
+                              )}
+                            </div>
+                            <code className="text-[11px] text-text-muted">
+                              {permId}
+                            </code>
+                          </div>
+                        </label>
+                      );
+                    },
+                  )}
+                </div>
+              </div>
+            </Collapsible>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={goNext}>Continue</Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/onboarding/steps/step-9-patient-shell.tsx
+++ b/src/components/onboarding/steps/step-9-patient-shell.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+// EMR-425 — Wizard step 9: pick the patient portal shell template.
+//
+// Specialty-adaptive: when the selected specialty's manifest declares
+// `default_patient_portal_cards`, we surface a "Recommended for <specialty>"
+// option synthesised from that manifest. Otherwise the admin picks from the
+// generic catalog in `known-shell-templates.ts`. We never branch on the
+// specific specialty slug.
+//
+// Scope: this step ONLY records `patientShellTemplateId` on the draft — the
+// actual rendering of the patient shell is owned by EMR-411.
+
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  PATIENT_SHELL_TEMPLATES,
+  deriveSpecialtyPatientTemplate,
+  labelForCard,
+  type ShellTemplateOption,
+} from "@/lib/onboarding/known-shell-templates";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { WizardStepProps } from "@/lib/onboarding/wizard-types";
+import { cn } from "@/lib/utils/cn";
+
+type ManifestState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; manifest: SpecialtyManifest | null }
+  | { status: "error"; error: string };
+
+export function Step9PatientShell({
+  draft,
+  patch,
+  goNext,
+  goBack,
+}: WizardStepProps) {
+  const [manifestState, setManifestState] = React.useState<ManifestState>(
+    draft.selectedSpecialty ? { status: "loading" } : { status: "idle" },
+  );
+
+  const slug = draft.selectedSpecialty ?? null;
+
+  React.useEffect(() => {
+    if (!slug) {
+      setManifestState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setManifestState({ status: "loading" });
+    fetch("/api/specialty-templates")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as { items: SpecialtyManifest[] };
+      })
+      .then((data) => {
+        if (cancelled) return;
+        const found = data.items.find((m) => m.slug === slug) ?? null;
+        setManifestState({ status: "ready", manifest: found });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setManifestState({
+          status: "error",
+          error: err instanceof Error ? err.message : "unknown_error",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  // Build the template list — the recommended one (if any) is pinned first
+  // so the admin's eye lands there. Generic templates follow.
+  const recommended = React.useMemo<ShellTemplateOption | null>(() => {
+    if (manifestState.status !== "ready" || !manifestState.manifest) return null;
+    return deriveSpecialtyPatientTemplate(
+      manifestState.manifest.slug,
+      manifestState.manifest.name,
+      manifestState.manifest.default_patient_portal_cards,
+    );
+  }, [manifestState]);
+
+  const allTemplates = React.useMemo<ShellTemplateOption[]>(() => {
+    if (!recommended) return PATIENT_SHELL_TEMPLATES;
+    // De-dupe by id in case a generic template ever collides with the
+    // recommended id (defensive — ids are namespaced today).
+    const filtered = PATIENT_SHELL_TEMPLATES.filter(
+      (t) => t.id !== recommended.id,
+    );
+    return [recommended, ...filtered];
+  }, [recommended]);
+
+  const [selectedId, setSelectedId] = React.useState<string | null>(
+    draft.patientShellTemplateId ?? null,
+  );
+
+  // Auto-select the recommended template once the manifest resolves *and*
+  // the draft doesn't already have a choice. This mirrors step 3's UX.
+  React.useEffect(() => {
+    if (selectedId) return;
+    if (recommended) {
+      setSelectedId(recommended.id);
+      return;
+    }
+    if (manifestState.status === "ready" && allTemplates[0]) {
+      setSelectedId(allTemplates[0].id);
+    }
+  }, [recommended, manifestState.status, allTemplates, selectedId]);
+
+  const selectedTemplate = React.useMemo(
+    () => allTemplates.find((t) => t.id === selectedId) ?? null,
+    [allTemplates, selectedId],
+  );
+
+  function handleSelect(id: string) {
+    setSelectedId(id);
+  }
+
+  function handleConfirm() {
+    if (!selectedId) return;
+    patch({ patientShellTemplateId: selectedId });
+    goNext();
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="step-9-patient-heading">
+      <header className="space-y-1">
+        <h2
+          id="step-9-patient-heading"
+          className="font-display text-xl font-medium text-text tracking-tight"
+        >
+          Choose the patient portal shell
+        </h2>
+        <p className="text-sm text-text-muted max-w-2xl">
+          Pick the layout your patients will see when they sign in. You can
+          fine-tune the surfaces later — this just sets the starting template.
+        </p>
+      </header>
+
+      {manifestState.status === "loading" && (
+        <div
+          className="rounded-xl border border-dashed border-border-strong/60 bg-surface-muted p-6 text-center text-sm text-text-muted"
+          aria-live="polite"
+        >
+          Loading recommendation for your specialty&hellip;
+        </div>
+      )}
+
+      {manifestState.status === "error" && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-danger"
+        >
+          Couldn&rsquo;t load the specialty recommendation ({manifestState.error}).
+          You can still pick from the templates below.
+        </div>
+      )}
+
+      <div
+        role="radiogroup"
+        aria-label="Patient portal shell templates"
+        className="grid grid-cols-1 md:grid-cols-2 gap-4"
+      >
+        {allTemplates.map((template) => (
+          <TemplateCard
+            key={template.id}
+            template={template}
+            selected={selectedId === template.id}
+            isRecommended={recommended?.id === template.id}
+            onSelect={() => handleSelect(template.id)}
+          />
+        ))}
+      </div>
+
+      {selectedTemplate && (
+        <PatientPreview template={selectedTemplate} />
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="ghost" onClick={goBack}>
+          Back
+        </Button>
+        <Button onClick={handleConfirm} disabled={!selectedId}>
+          Continue
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// TemplateCard — used by both step 9 and step 10.
+// -----------------------------------------------------------------------------
+
+type TemplateCardProps = {
+  template: ShellTemplateOption;
+  selected: boolean;
+  isRecommended: boolean;
+  onSelect: () => void;
+};
+
+function TemplateCard({
+  template,
+  selected,
+  isRecommended,
+  onSelect,
+}: TemplateCardProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onSelect}
+      className={cn(
+        "text-left transition-all duration-200 ease-smooth rounded-xl",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
+      )}
+    >
+      <Card
+        tone={selected ? "raised" : "default"}
+        className={cn(
+          "relative h-full",
+          selected
+            ? "border-2 border-accent shadow-md"
+            : "hover:border-border-strong hover:shadow-md",
+        )}
+      >
+        {selected && (
+          <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-accent px-2.5 py-0.5 text-[11px] font-medium text-accent-ink">
+            Selected
+          </span>
+        )}
+        <CardHeader>
+          <div className="flex flex-wrap items-center gap-2">
+            <CardTitle>{template.label}</CardTitle>
+            {isRecommended && <Badge tone="accent">Recommended</Badge>}
+          </div>
+          <p className="mt-1.5 text-sm text-text-muted">
+            {template.description}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+            {template.cards.length} cards
+          </p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {template.cards.slice(0, 5).map((id) => (
+              <span
+                key={id}
+                className="rounded-full border border-border/80 bg-surface-muted px-2 py-0.5 text-xs text-text"
+              >
+                {labelForCard(id)}
+              </span>
+            ))}
+            {template.cards.length > 5 && (
+              <span className="rounded-full border border-border/80 bg-surface-muted px-2 py-0.5 text-xs text-text-muted">
+                +{template.cards.length - 5} more
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </button>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// PatientPreview — inline preview of the patient cards in this template.
+// -----------------------------------------------------------------------------
+
+function PatientPreview({ template }: { template: ShellTemplateOption }) {
+  return (
+    <Card tone="outlined" aria-live="polite" className="p-5">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+        What patients will see
+      </p>
+      <h3 className="mt-1 font-display text-base font-medium text-text">
+        {template.label}
+      </h3>
+      <ol className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {template.cards.map((id, idx) => (
+          <li
+            key={id}
+            className="flex items-center gap-3 rounded-lg border border-border/60 bg-surface-muted px-3 py-2 text-sm text-text"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-soft text-[11px] font-medium text-accent">
+              {idx + 1}
+            </span>
+            <span>{labelForCard(id)}</span>
+          </li>
+        ))}
+      </ol>
+    </Card>
+  );
+}

--- a/src/components/shell/__tests__/physician-shell.test.ts
+++ b/src/components/shell/__tests__/physician-shell.test.ts
@@ -1,0 +1,435 @@
+/**
+ * PhysicianShell renderer — module-resolution tests (EMR-445)
+ *
+ * Vitest config in this repo runs `src/**\/*.test.ts` in a node environment
+ * with no DOM and no @testing-library/react available. So we test the pure
+ * projection function `resolvePhysicianModules` rather than rendering JSX.
+ * That's enough to lock down the shell-shape acceptance criteria:
+ *
+ *   1. Pain Management published config → ZERO modules whose slug contains
+ *      "cannabis" or whose component path is under modules/cannabis/.
+ *   2. Internal Medicine likewise excludes cannabis.
+ *   3. Cannabis Medicine includes cannabis-flagged surfaces.
+ *   4. Three configs through the same resolver produce three distinctly-
+ *      shaped shells.
+ *
+ * Configs are constructed inline — no DB, no Prisma, no network. Manifests
+ * are loaded via the existing registry (already validated at module-init).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import {
+  computeActiveModalities,
+  resolvePhysicianModules,
+  type PhysicianModule,
+  type PhysicianModuleResolution,
+  type PhysicianModuleSet,
+} from "@/lib/shell/physician-modules";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+
+type ConfigSeed = Pick<
+  PracticeConfiguration,
+  | "selectedSpecialty"
+  | "careModel"
+  | "enabledModalities"
+  | "disabledModalities"
+>;
+
+function syntheticConfig(slug: string): ConfigSeed {
+  const manifest = getSpecialtyTemplate(slug);
+  if (!manifest) throw new Error(`fixture: unknown specialty ${slug}`);
+  return {
+    selectedSpecialty: manifest.slug,
+    careModel: manifest.default_care_model,
+    enabledModalities: [...manifest.default_enabled_modalities],
+    disabledModalities: [...manifest.default_disabled_modalities],
+  };
+}
+
+function assertOk(
+  resolution: PhysicianModuleResolution,
+): asserts resolution is PhysicianModuleSet {
+  if (resolution.kind !== "ok") {
+    throw new Error(`expected ok resolution, got ${resolution.kind}`);
+  }
+}
+
+function allModules(set: PhysicianModuleSet): PhysicianModule[] {
+  return [
+    ...set.navItems,
+    ...set.missionControlCards,
+    ...set.chartSections,
+    ...set.intakeForms,
+    ...set.cdsCards,
+  ];
+}
+
+function moduleSlugs(modules: PhysicianModule[]): string[] {
+  return modules.map((m) => m.slug);
+}
+
+describe("resolvePhysicianModules", () => {
+  // ------------------------------------------------------------------
+  // P0 acceptance gate: Pain Management non-cannabis must yield ZERO
+  // cannabis-related modules.
+  // ------------------------------------------------------------------
+  it("excludes ALL cannabis-related modules from a Pain Management config", () => {
+    const config = syntheticConfig("pain-management-non-cannabis");
+    const manifest = getSpecialtyTemplate("pain-management-non-cannabis");
+    const result = resolvePhysicianModules(config, manifest);
+    assertOk(result);
+
+    const modules = allModules(result);
+    expect(modules.length).toBeGreaterThan(0);
+
+    for (const m of modules) {
+      expect(m.slug.toLowerCase()).not.toContain("cannabis");
+      expect(m.componentPath).not.toMatch(/modules\/cannabis\//);
+      expect(m.requiresModality).not.toBe("cannabis-medicine");
+      expect(m.requiresModality).not.toBe("commerce-leafmart");
+    }
+
+    // active modality set must not contain cannabis-medicine — explicit
+    // disable, not absence (matches manifest invariant from EMR-408).
+    expect(result.activeModalities).not.toContain("cannabis-medicine");
+    expect(result.activeModalities).not.toContain("commerce-leafmart");
+
+    // structural snapshot — locks the resolved shape so a regression is
+    // visible in test output.
+    expect({
+      specialtySlug: result.specialtySlug,
+      activeModalities: result.activeModalities,
+      navItems: moduleSlugs(result.navItems),
+      missionControlCards: moduleSlugs(result.missionControlCards),
+      chartSections: moduleSlugs(result.chartSections),
+      intakeForms: moduleSlugs(result.intakeForms),
+      cdsCards: moduleSlugs(result.cdsCards),
+    }).toEqual({
+      specialtySlug: "pain-management-non-cannabis",
+      activeModalities: [
+        "functional-pain",
+        "imaging",
+        "pain-medications",
+        "patient-reported-outcomes",
+        "physical-therapy",
+        "procedures",
+        "referrals",
+      ],
+      navItems: [
+        "scheduling",
+        "charting",
+        "imaging",
+        "procedures",
+        "e-prescribing-controlled",
+        "referrals",
+        "patient-portal",
+        "billing",
+        "pdmp-check",
+      ],
+      missionControlCards: [
+        "todays-schedule",
+        "procedure-board",
+        "open-charts",
+        "imaging-pending-review",
+        "controlled-substance-monitoring",
+        "messages-inbox",
+        // refill-requests requires "medications" which is NOT in the
+        // pain-management active set (pain-medications is) — so it drops.
+      ],
+      chartSections: ["pain-consult", "pain-followup", "procedure-note"],
+      intakeForms: [
+        "new-pain-consult",
+        "pain-followup",
+        "procedure-note",
+        "imaging-review",
+        "medication-review",
+      ],
+      cdsCards: [
+        "functional-pain-cds",
+        "imaging-cds",
+        "pain-medications-cds",
+        "patient-reported-outcomes-cds",
+        "physical-therapy-cds",
+        "procedures-cds",
+        "referrals-cds",
+      ],
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Internal Medicine likewise excludes cannabis.
+  // ------------------------------------------------------------------
+  it("excludes cannabis modules from an Internal Medicine config", () => {
+    const config = syntheticConfig("internal-medicine");
+    const manifest = getSpecialtyTemplate("internal-medicine");
+    const result = resolvePhysicianModules(config, manifest);
+    assertOk(result);
+
+    const modules = allModules(result);
+    expect(modules.length).toBeGreaterThan(0);
+
+    for (const m of modules) {
+      expect(m.slug.toLowerCase()).not.toContain("cannabis");
+      expect(m.componentPath).not.toMatch(/modules\/cannabis\//);
+      expect(m.requiresModality).not.toBe("cannabis-medicine");
+      expect(m.requiresModality).not.toBe("commerce-leafmart");
+    }
+
+    expect(result.activeModalities).not.toContain("cannabis-medicine");
+    expect(result.activeModalities).not.toContain("commerce-leafmart");
+
+    expect({
+      specialtySlug: result.specialtySlug,
+      activeModalities: result.activeModalities,
+      navItems: moduleSlugs(result.navItems),
+      missionControlCards: moduleSlugs(result.missionControlCards),
+      chartSections: moduleSlugs(result.chartSections),
+      intakeForms: moduleSlugs(result.intakeForms),
+      cdsCards: moduleSlugs(result.cdsCards),
+    }).toEqual({
+      specialtySlug: "internal-medicine",
+      activeModalities: [
+        "imaging",
+        "labs",
+        "lifestyle",
+        "medications",
+        "patient-reported-outcomes",
+        "referrals",
+      ],
+      navItems: [
+        "scheduling",
+        "charting",
+        "labs",
+        "imaging",
+        "e-prescribing",
+        "referrals",
+        "patient-portal",
+        "billing",
+      ],
+      missionControlCards: [
+        "todays-schedule",
+        "open-charts",
+        "lab-results-pending-review",
+        "imaging-pending-review",
+        "messages-inbox",
+        "refill-requests",
+      ],
+      chartSections: ["soap-note", "annual-wellness-note", "problem-focused-note"],
+      intakeForms: [
+        "new-patient-intake",
+        "annual-wellness",
+        "chronic-condition-followup",
+        "lab-review",
+        "medication-reconciliation",
+      ],
+      cdsCards: [
+        "imaging-cds",
+        "labs-cds",
+        "lifestyle-cds",
+        "medications-cds",
+        "patient-reported-outcomes-cds",
+        "referrals-cds",
+      ],
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Cannabis Medicine — cannabis-flagged surfaces ARE present.
+  // ------------------------------------------------------------------
+  it("includes cannabis nav and Mission Control items for a Cannabis Medicine config", () => {
+    const config = syntheticConfig("cannabis-medicine");
+    const manifest = getSpecialtyTemplate("cannabis-medicine");
+    const result = resolvePhysicianModules(config, manifest);
+    assertOk(result);
+
+    expect(result.activeModalities).toContain("cannabis-medicine");
+    expect(result.activeModalities).toContain("commerce-leafmart");
+
+    // Affirmative checks — cannabis-specific slugs survive resolution.
+    const allSlugs = moduleSlugs(allModules(result));
+    expect(allSlugs).toContain("certifications-due");
+    expect(allSlugs).toContain("outcome-checkins");
+    expect(allSlugs).toContain("cannabis-recommendation");
+    expect(allSlugs).toContain("leafmart-commerce");
+    expect(allSlugs).toContain("outcome-tracking");
+    expect(allSlugs).toContain("cannabis-medicine-cds");
+    expect(allSlugs).toContain("commerce-leafmart-cds");
+
+    expect({
+      specialtySlug: result.specialtySlug,
+      activeModalities: result.activeModalities,
+      navItems: moduleSlugs(result.navItems),
+      missionControlCards: moduleSlugs(result.missionControlCards),
+      chartSections: moduleSlugs(result.chartSections),
+      intakeForms: moduleSlugs(result.intakeForms),
+      cdsCards: moduleSlugs(result.cdsCards),
+    }).toEqual({
+      specialtySlug: "cannabis-medicine",
+      activeModalities: [
+        "cannabis-medicine",
+        "commerce-leafmart",
+        "lifestyle",
+        "medications",
+        "patient-reported-outcomes",
+      ],
+      navItems: [
+        "scheduling",
+        "charting",
+        "e-prescribing",
+        "patient-portal",
+        "billing",
+        "cannabis-recommendation",
+        "leafmart-commerce",
+        "outcome-tracking",
+      ],
+      missionControlCards: [
+        "todays-schedule",
+        "open-charts",
+        "certifications-due",
+        "outcome-checkins",
+        "messages-inbox",
+      ],
+      chartSections: ["cannabis-certification-note", "followup-note"],
+      intakeForms: [
+        "cannabis-certification",
+        "dosing-titration",
+        "outcome-followup",
+      ],
+      cdsCards: [
+        "cannabis-medicine-cds",
+        "commerce-leafmart-cds",
+        "lifestyle-cds",
+        "medications-cds",
+        "patient-reported-outcomes-cds",
+      ],
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Same renderer, three distinctly-shaped shells.
+  // ------------------------------------------------------------------
+  it("produces three distinctly-shaped shells from one resolver (specialty-adaptive)", () => {
+    const im = resolvePhysicianModules(
+      syntheticConfig("internal-medicine"),
+      getSpecialtyTemplate("internal-medicine"),
+    );
+    const pm = resolvePhysicianModules(
+      syntheticConfig("pain-management-non-cannabis"),
+      getSpecialtyTemplate("pain-management-non-cannabis"),
+    );
+    const cm = resolvePhysicianModules(
+      syntheticConfig("cannabis-medicine"),
+      getSpecialtyTemplate("cannabis-medicine"),
+    );
+    assertOk(im);
+    assertOk(pm);
+    assertOk(cm);
+
+    const imShape = JSON.stringify({
+      nav: moduleSlugs(im.navItems),
+      mc: moduleSlugs(im.missionControlCards),
+      mods: im.activeModalities,
+    });
+    const pmShape = JSON.stringify({
+      nav: moduleSlugs(pm.navItems),
+      mc: moduleSlugs(pm.missionControlCards),
+      mods: pm.activeModalities,
+    });
+    const cmShape = JSON.stringify({
+      nav: moduleSlugs(cm.navItems),
+      mc: moduleSlugs(cm.missionControlCards),
+      mods: cm.activeModalities,
+    });
+
+    expect(imShape).not.toBe(pmShape);
+    expect(pmShape).not.toBe(cmShape);
+    expect(imShape).not.toBe(cmShape);
+  });
+
+  // ------------------------------------------------------------------
+  // Unknown specialty → fallback resolution, not a crash.
+  // ------------------------------------------------------------------
+  it("returns an unknown-specialty resolution when the manifest is null", () => {
+    const result = resolvePhysicianModules(
+      {
+        selectedSpecialty: "not-a-real-specialty",
+        careModel: null,
+        enabledModalities: [],
+        disabledModalities: [],
+      },
+      null,
+    );
+    expect(result.kind).toBe("unknown-specialty");
+    if (result.kind === "unknown-specialty") {
+      expect(result.slug).toBe("not-a-real-specialty");
+      expect(result.message).toMatch(/Configuration error/);
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // Specialty-blindness invariant: the resolver must not branch on slug.
+  // We verify this behaviorally by feeding a custom manifest whose slug
+  // is "cannabis-medicine" but with non-cannabis modalities — the
+  // resolver should still drop the cannabis surfaces because the
+  // modality set decides, not the slug.
+  // ------------------------------------------------------------------
+  it("does not branch on specialty slug — modality set decides cannabis surfaces", () => {
+    const cannabisManifest = getSpecialtyTemplate("cannabis-medicine");
+    expect(cannabisManifest).not.toBeNull();
+
+    // Override: turn cannabis-medicine OFF in the config even though the
+    // manifest is the cannabis one. A resolver that branches on slug would
+    // still emit cannabis surfaces. A specialty-adaptive resolver drops
+    // them because the active modality set excludes cannabis-medicine.
+    const config: ConfigSeed = {
+      selectedSpecialty: "cannabis-medicine",
+      careModel: cannabisManifest!.default_care_model,
+      enabledModalities: ["medications", "lifestyle"],
+      disabledModalities: ["cannabis-medicine", "commerce-leafmart"],
+    };
+
+    const result = resolvePhysicianModules(config, cannabisManifest);
+    assertOk(result);
+    expect(result.activeModalities).not.toContain("cannabis-medicine");
+    for (const m of allModules(result)) {
+      expect(m.requiresModality).not.toBe("cannabis-medicine");
+      expect(m.requiresModality).not.toBe("commerce-leafmart");
+      expect(m.componentPath).not.toMatch(/modules\/cannabis\//);
+    }
+  });
+});
+
+describe("computeActiveModalities", () => {
+  it("subtracts disabled modalities", () => {
+    expect(
+      computeActiveModalities(["medications", "labs", "imaging"], ["imaging"]),
+    ).toEqual(["labs", "medications"]);
+  });
+
+  it("drops modalities whose `requires` is unsatisfied", () => {
+    const meta = {
+      "commerce-leafmart": { requires: ["cannabis-medicine"] },
+    };
+    expect(
+      computeActiveModalities(["commerce-leafmart"], [], meta),
+    ).toEqual([]);
+    expect(
+      computeActiveModalities(
+        ["cannabis-medicine", "commerce-leafmart"],
+        [],
+        meta,
+      ),
+    ).toEqual(["cannabis-medicine", "commerce-leafmart"]);
+  });
+
+  it("cascades transitive requirement failures to a fixed point", () => {
+    const meta = {
+      a: { requires: ["b"] },
+      b: { requires: ["c"] },
+      c: { requires: ["d"] }, // d never enabled → c drops → b drops → a drops
+    };
+    expect(computeActiveModalities(["a", "b", "c"], [], meta)).toEqual([]);
+  });
+});

--- a/src/components/shell/physician-shell.tsx
+++ b/src/components/shell/physician-shell.tsx
@@ -1,0 +1,283 @@
+/**
+ * PhysicianShell renderer — EMR-445
+ *
+ * Top-level server component for a clinician's adaptive shell. Reads a
+ * published PracticeConfiguration, looks up the matching SpecialtyManifest,
+ * resolves modules via the pure resolvePhysicianModules() projection, and
+ * renders the matching navigation, Mission Control cards, chart sections,
+ * intake forms, and CDS surfaces.
+ *
+ * Architecture invariants (HARD constraints — see CLAUDE.md / Epic 2):
+ *   - Specialty-adaptive, NOT cannabis-first. This component MUST NOT
+ *     branch on specialty. All variation flows from PracticeConfiguration
+ *     and modality state.
+ *   - Pain Management acceptance gate: a Pain-Management published config
+ *     rendered through this shell yields zero cannabis-related modules.
+ *     Enforced by resolvePhysicianModules's modality filter and (for
+ *     belt-and-suspenders) by wrapping cannabis-flagged surfaces in
+ *     <ModalityGate modality="cannabis-medicine"> at integration time.
+ *   - Server component. No client-side fetches inside the shell. The
+ *     caller passes a fully-loaded `config` prop.
+ *
+ * Wire-in: ship as a usable component. Existing physician routes are not
+ * replaced here — EMR-411's epic-level integration is a later ticket.
+ */
+
+import * as React from "react";
+import { Tile, TilePlaceholder } from "@/components/ui/tile";
+import { TileGrid } from "@/components/ui/tile-grid";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { EmptyState } from "@/components/ui/empty-state";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import {
+  resolvePhysicianModules,
+  type ModalityMetaMap,
+  type PhysicianModule,
+  type PhysicianModuleSet,
+} from "@/lib/shell/physician-modules";
+
+// TODO(EMR-410): canonical exports — at integration time replace this empty
+// fallback with `import { MODALITY_META } from "@/lib/modality/registry"`
+// and pass it through to resolvePhysicianModules. Keeping a local empty map
+// here means the resolver still runs while the modality module is being
+// landed in a parallel branch.
+const MODALITY_META_FALLBACK: ModalityMetaMap = {};
+
+export interface PhysicianShellProps {
+  /**
+   * The practice's published configuration. The shell reads
+   * selectedSpecialty, careModel, enabledModalities, disabledModalities and
+   * derives everything else from the manifest.
+   */
+  config: Pick<
+    PracticeConfiguration,
+    | "selectedSpecialty"
+    | "careModel"
+    | "enabledModalities"
+    | "disabledModalities"
+  >;
+
+  /**
+   * Optional override for the modality registry. Defaults to the canonical
+   * MODALITY_META once EMR-410 lands; until then the resolver runs without
+   * `requires` cascade checks (still correct — manifests don't declare
+   * any cross-modality requirements as of v1).
+   */
+  modalityMeta?: ModalityMetaMap;
+}
+
+export function PhysicianShell({
+  config,
+  modalityMeta = MODALITY_META_FALLBACK,
+}: PhysicianShellProps): React.JSX.Element {
+  const manifest = config.selectedSpecialty
+    ? getSpecialtyTemplate(config.selectedSpecialty)
+    : null;
+
+  const resolution = resolvePhysicianModules(config, manifest, { modalityMeta });
+
+  if (resolution.kind === "unknown-specialty") {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Configuration"
+          title="Configuration error"
+          description={resolution.message}
+        />
+        <EmptyState
+          title="Unknown specialty"
+          description={
+            resolution.slug
+              ? `The specialty "${resolution.slug}" is not registered. Contact your admin.`
+              : "No specialty selected for this practice. Contact your admin."
+          }
+        />
+      </PageShell>
+    );
+  }
+
+  return <PhysicianShellBody resolution={resolution} />;
+}
+
+function PhysicianShellBody({
+  resolution,
+}: {
+  resolution: PhysicianModuleSet;
+}): React.JSX.Element {
+  const {
+    specialtyName,
+    careModel,
+    activeModalities,
+    navItems,
+    missionControlCards,
+    chartSections,
+    intakeForms,
+    cdsCards,
+  } = resolution;
+
+  return (
+    <PageShell maxWidth="max-w-[1400px]">
+      <PageHeader
+        eyebrow={`${formatCareModel(careModel)} · ${activeModalities.length} active modalities`}
+        title={specialtyName}
+        description="Your adaptive clinician shell. The cards below come from this practice's published configuration."
+      />
+
+      {/* Navigation summary — the actual sidebar is wired via AppShell at the
+          route layout. We surface the resolved nav items here as a compact
+          chip row so the shell shape is visible during integration. */}
+      {navItems.length > 0 && (
+        <section
+          aria-label="Active modules"
+          className="mb-8 flex flex-wrap gap-2"
+          data-testid="physician-shell-nav"
+        >
+          {navItems.map((item) => (
+            <ModuleChip key={`nav-${item.slug}`} module={item} />
+          ))}
+        </section>
+      )}
+
+      {missionControlCards.length > 0 && (
+        <section
+          aria-label="Mission control"
+          className="mb-10"
+          data-testid="physician-shell-mission-control"
+        >
+          <h2 className="font-display text-lg text-text mb-4">Mission Control</h2>
+          <TileGrid>
+            {missionControlCards.map((card) => (
+              <ModuleTile key={`mc-${card.slug}`} module={card} />
+            ))}
+          </TileGrid>
+        </section>
+      )}
+
+      {chartSections.length > 0 && (
+        <section
+          aria-label="Chart sections"
+          className="mb-10"
+          data-testid="physician-shell-chart-sections"
+        >
+          <h2 className="font-display text-lg text-text mb-4">Charting Templates</h2>
+          <TileGrid>
+            {chartSections.map((section) => (
+              <ModuleTile key={`chart-${section.slug}`} module={section} />
+            ))}
+          </TileGrid>
+        </section>
+      )}
+
+      {intakeForms.length > 0 && (
+        <section
+          aria-label="Intake workflows"
+          className="mb-10"
+          data-testid="physician-shell-intake"
+        >
+          <h2 className="font-display text-lg text-text mb-4">Workflows</h2>
+          <TileGrid>
+            {intakeForms.map((form) => (
+              <ModuleTile key={`intake-${form.slug}`} module={form} />
+            ))}
+          </TileGrid>
+        </section>
+      )}
+
+      {cdsCards.length > 0 && (
+        <section
+          aria-label="Clinical decision support"
+          className="mb-10"
+          data-testid="physician-shell-cds"
+        >
+          <h2 className="font-display text-lg text-text mb-4">Decision Support</h2>
+          <TileGrid>
+            {cdsCards.map((cds) => (
+              <ModuleTile key={`cds-${cds.slug}`} module={cds} />
+            ))}
+          </TileGrid>
+        </section>
+      )}
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Module renderers — read componentRef and either render the matching
+// existing component or fall through to UnimplementedModuleNotice. Real
+// component composition (passing `user`, etc.) happens at EMR-411
+// integration time; for the shell-shape ticket we render the placeholder
+// tile shape so the layout is visible.
+// ---------------------------------------------------------------------------
+
+function ModuleTile({ module: m }: { module: PhysicianModule }): React.JSX.Element {
+  return (
+    <Tile
+      title={m.title}
+      eyebrow={m.kind.replace(/-/g, " ")}
+      description={m.requiresModality ? `Modality: ${m.requiresModality}` : undefined}
+    >
+      {m.unimplemented ? (
+        <UnimplementedModuleNotice slug={m.slug} componentRef={m.componentRef} />
+      ) : (
+        <TilePlaceholder
+          note={`Component: ${m.componentRef} — wired by EMR-411 integration`}
+        />
+      )}
+    </Tile>
+  );
+}
+
+function ModuleChip({ module: m }: { module: PhysicianModule }): React.JSX.Element {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs text-text-muted"
+      data-slug={m.slug}
+      data-modality={m.requiresModality ?? "none"}
+    >
+      {m.title}
+      {m.unimplemented && (
+        <span
+          className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400"
+          aria-label="Not yet implemented"
+          title="Not yet implemented"
+        />
+      )}
+    </span>
+  );
+}
+
+/**
+ * Renders a subtle "module not yet implemented" notice in place of a real
+ * component. Keeps the shell shape visible without crashing on slugs the
+ * registry doesn't yet have a component for.
+ */
+export function UnimplementedModuleNotice({
+  slug,
+  componentRef,
+}: {
+  slug: string;
+  componentRef?: string;
+}): React.JSX.Element {
+  return (
+    <div
+      className="h-full flex flex-col items-center justify-center py-8 text-center gap-1"
+      data-testid="unimplemented-module-notice"
+      data-slug={slug}
+    >
+      <div
+        aria-hidden="true"
+        className="h-7 w-7 rounded-full border-2 border-dashed border-border-strong/50"
+      />
+      <p className="text-xs text-text-subtle italic">Module not yet implemented</p>
+      <p className="text-[10px] text-text-subtle/80 font-mono">{componentRef ?? slug}</p>
+    </div>
+  );
+}
+
+function formatCareModel(careModel: string): string {
+  return careModel
+    .split("-")
+    .map((p) => (p.length > 0 ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(" ");
+}

--- a/src/components/shell/physician-shell.tsx
+++ b/src/components/shell/physician-shell.tsx
@@ -28,7 +28,7 @@ import { Tile, TilePlaceholder } from "@/components/ui/tile";
 import { TileGrid } from "@/components/ui/tile-grid";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { EmptyState } from "@/components/ui/empty-state";
-import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
 import type { PracticeConfiguration } from "@/lib/practice-config/types";
 import {
   resolvePhysicianModules,
@@ -59,6 +59,12 @@ export interface PhysicianShellProps {
   >;
 
   /**
+   * The specialty manifest matching the config's selectedSpecialty. Passed in
+   * by the caller to keep this component client-safe when used in previews.
+   */
+  manifest?: SpecialtyManifest | null;
+
+  /**
    * Optional override for the modality registry. Defaults to the canonical
    * MODALITY_META once EMR-410 lands; until then the resolver runs without
    * `requires` cascade checks (still correct — manifests don't declare
@@ -69,13 +75,10 @@ export interface PhysicianShellProps {
 
 export function PhysicianShell({
   config,
+  manifest,
   modalityMeta = MODALITY_META_FALLBACK,
 }: PhysicianShellProps): React.JSX.Element {
-  const manifest = config.selectedSpecialty
-    ? getSpecialtyTemplate(config.selectedSpecialty)
-    : null;
-
-  const resolution = resolvePhysicianModules(config, manifest, { modalityMeta });
+  const resolution = resolvePhysicianModules(config, manifest ?? null, { modalityMeta });
 
   if (resolution.kind === "unknown-specialty") {
     return (

--- a/src/components/shell/practice-admin-shell.tsx
+++ b/src/components/shell/practice-admin-shell.tsx
@@ -1,0 +1,391 @@
+// EMR-447 — PracticeAdminShell renderer
+//
+// Read-only home view for a practice admin. Driven entirely by the practice's
+// published `PracticeConfiguration` plus the related `Practice` row. Practice
+// admins see what was configured for their practice — they cannot edit. Edits
+// happen in the controller wizard, scoped to implementation_admin / super_admin
+// (see EMR-428).
+//
+// Architecture invariants (HARD constraints — see CLAUDE.md / Epic 2):
+//   - LeafJourney is specialty-adaptive, NOT cannabis-first. Nothing in this
+//     file branches on `selectedSpecialty === 'cannabis-medicine'`. Cannabis
+//     surfacing here is a *compliance signal* — when cannabis-medicine appears
+//     in `disabledModalities` we render it with a warning tone so a practice
+//     admin can verify the bleed-gate is locked. That is metadata, not a
+//     code path.
+//   - Specialty display name comes from the registered manifest. If the slug
+//     is unknown we render the slug verbatim and surface a soft warning —
+//     never throw, since a published config might reference a manifest that
+//     was renamed in main since publish.
+//
+// Scope (EMR-447):
+//   - Renders the practice header, configuration summary, applied template
+//     versions (slugs only — versioning UI is EMR-471 / EMR-431), and three
+//     forward-link admin action cards (users / schedule / billing).
+//   - Does NOT render template contents — only slugs. EMR-471 owns rich
+//     template rendering.
+//   - Does NOT mount any edit UI.
+
+import "server-only";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+
+// EMR-410 (`@/lib/modality/registry`) is in flight in this storm but not yet
+// merged. We keep a local minimal display map keyed on the modality slugs that
+// `manifest-schema.REGISTERED_MODALITIES` already enumerates. When EMR-410
+// lands, swap to `MODALITY_META` from that registry. The shape is intentionally
+// the same so the swap is mechanical.
+const MODALITY_DISPLAY: Record<string, string> = {
+  medications: "Medications",
+  "pain-medications": "Pain medications",
+  labs: "Labs",
+  imaging: "Imaging",
+  referrals: "Referrals",
+  procedures: "Procedures",
+  lifestyle: "Lifestyle",
+  "physical-therapy": "Physical therapy",
+  "functional-pain": "Functional pain",
+  "patient-reported-outcomes": "Patient-reported outcomes",
+  "cannabis-medicine": "Cannabis medicine",
+  "commerce-leafmart": "Leafmart commerce",
+};
+
+const CANNABIS_MODALITY_SLUG = "cannabis-medicine";
+
+function modalityLabel(slug: string): string {
+  return MODALITY_DISPLAY[slug] ?? slug;
+}
+
+/** A minimal "this surface isn't built yet" footer for forward-link cards. */
+function UnimplementedNotice() {
+  return (
+    <p className="text-[11px] uppercase tracking-wide text-text-subtle font-medium mt-2">
+      Coming soon
+    </p>
+  );
+}
+
+/** The Practice row fields the shell renders. Keeping this narrow lets the
+ *  page query exactly what it needs and makes server/test wiring trivial. */
+export interface PracticeSummary {
+  id: string;
+  name: string;
+  brandName: string | null;
+  npi: string | null;
+  street: string | null;
+  city: string | null;
+  state: string | null;
+  postalCode: string | null;
+}
+
+export interface PracticeAdminShellProps {
+  config: PracticeConfiguration;
+  practice: PracticeSummary;
+  /** When the practice admin is in multiple orgs, the page passes a picker
+   *  so the user can switch which practice they're viewing. The shell just
+   *  renders it — picking is the page's responsibility. */
+  picker?: React.ReactNode;
+}
+
+function formatAddress(p: PracticeSummary): string | null {
+  const parts: string[] = [];
+  if (p.street) parts.push(p.street);
+  const cityState = [p.city, p.state].filter(Boolean).join(", ");
+  if (cityState) parts.push(cityState);
+  if (p.postalCode) parts.push(p.postalCode);
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function PracticeAdminShell({
+  config,
+  practice,
+  picker,
+}: PracticeAdminShellProps) {
+  const manifest = config.selectedSpecialty
+    ? getSpecialtyTemplate(config.selectedSpecialty)
+    : null;
+
+  const enabled = config.enabledModalities ?? [];
+  const disabled = config.disabledModalities ?? [];
+  const cannabisDisabled = disabled.includes(CANNABIS_MODALITY_SLUG);
+  const otherDisabled = disabled.filter((m) => m !== CANNABIS_MODALITY_SLUG);
+
+  const address = formatAddress(practice);
+
+  const adminActions: Array<{
+    href: string;
+    title: string;
+    description: string;
+  }> = [
+    {
+      href: "/practice-admin/users",
+      title: "Manage users",
+      description:
+        "Invite clinicians, operators, and additional admins to this practice.",
+    },
+    {
+      href: "/practice-admin/schedule",
+      title: "Schedule",
+      description:
+        "Configure clinic hours, provider availability, and appointment types.",
+    },
+    {
+      href: "/practice-admin/billing",
+      title: "Billing",
+      description:
+        "Review claims, fee schedules, and payer configuration for the practice.",
+    },
+  ];
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      {picker ? <div className="mb-6">{picker}</div> : null}
+
+      <PageHeader
+        eyebrow="Practice admin"
+        title={practice.brandName ?? practice.name}
+        description="Read-only view of your practice's published configuration. To request a change, contact your LeafJourney implementation team."
+      />
+
+      <div className="grid grid-cols-1 gap-6">
+        {/* 1. Practice header */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Practice</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Practice name" value={practice.name} />
+            <Field
+              label="Brand name"
+              value={practice.brandName ?? "—"}
+              muted={!practice.brandName}
+            />
+            <Field
+              label="NPI"
+              value={practice.npi ?? "Not on file"}
+              muted={!practice.npi}
+            />
+            <Field
+              label="Address"
+              value={address ?? "Not on file"}
+              muted={!address}
+            />
+          </CardContent>
+        </Card>
+
+        {/* 2. Configuration summary */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Configuration summary</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Field
+                label="Specialty"
+                value={
+                  config.selectedSpecialty ? (
+                    <span className="flex flex-col">
+                      <span className="text-text">
+                        {manifest?.name ?? config.selectedSpecialty}
+                      </span>
+                      <code className="text-[11px] text-text-subtle bg-surface-muted px-1.5 py-0.5 rounded mt-1 self-start">
+                        {config.selectedSpecialty}
+                      </code>
+                    </span>
+                  ) : (
+                    "Not set"
+                  )
+                }
+                muted={!config.selectedSpecialty}
+              />
+              <Field
+                label="Care model"
+                value={config.careModel ?? "Not set"}
+                muted={!config.careModel}
+              />
+            </div>
+
+            <div>
+              <Eyebrow>Enabled modalities</Eyebrow>
+              {enabled.length === 0 ? (
+                <p className="text-sm text-text-muted mt-2">
+                  No modalities enabled.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {enabled.map((slug) => (
+                    <Badge key={slug} tone="accent">
+                      {modalityLabel(slug)}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <Eyebrow>Disabled modalities</Eyebrow>
+              {disabled.length === 0 ? (
+                <p className="text-sm text-text-muted mt-2">
+                  No modalities explicitly disabled.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {/* Compliance signal: cannabis-medicine surfaces with a
+                      warning tone so the admin can verify the bleed-gate. */}
+                  {cannabisDisabled && (
+                    <Badge
+                      tone="warning"
+                      title="Cannabis-medicine is explicitly disabled for this practice (compliance gate)."
+                    >
+                      {modalityLabel(CANNABIS_MODALITY_SLUG)} · disabled
+                    </Badge>
+                  )}
+                  {otherDisabled.map((slug) => (
+                    <Badge key={slug} tone="neutral">
+                      {modalityLabel(slug)}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <Eyebrow>Applied template versions</Eyebrow>
+              <dl className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 mt-2">
+                <TemplateRow
+                  label="Workflow templates"
+                  values={config.workflowTemplateIds ?? []}
+                />
+                <TemplateRow
+                  label="Charting templates"
+                  values={config.chartingTemplateIds ?? []}
+                />
+                <TemplateRow
+                  label="Role / permission templates"
+                  values={config.rolePermissionTemplateIds ?? []}
+                />
+                <TemplateRow
+                  label="Patient shell"
+                  values={
+                    config.patientShellTemplateId
+                      ? [config.patientShellTemplateId]
+                      : []
+                  }
+                />
+                <TemplateRow
+                  label="Physician shell"
+                  values={
+                    config.physicianShellTemplateId
+                      ? [config.physicianShellTemplateId]
+                      : []
+                  }
+                />
+              </dl>
+              <p className="text-[11px] text-text-subtle mt-3">
+                Versioning UI lands in EMR-471 / EMR-431. v1 surfaces template
+                slugs only.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 3. Practice-level admin actions (forward links, no functional buttons) */}
+        <div>
+          <h2 className="font-display text-lg font-medium text-text tracking-tight mb-3">
+            Practice admin actions
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {adminActions.map((action) => (
+              <Link
+                key={action.href}
+                href={action.href}
+                className="group rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <Card
+                  tone="outlined"
+                  className="h-full transition-all duration-200 group-hover:border-border-strong group-hover:shadow-md"
+                >
+                  <CardHeader>
+                    <CardTitle>{action.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-text-muted">
+                      {action.description}
+                    </p>
+                    <UnimplementedNotice />
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}
+
+// --- small private helpers ---------------------------------------------------
+
+function Field({
+  label,
+  value,
+  muted,
+}: {
+  label: string;
+  value: React.ReactNode;
+  muted?: boolean;
+}) {
+  return (
+    <div>
+      <Eyebrow>{label}</Eyebrow>
+      <div
+        className={
+          "text-sm mt-1.5 " + (muted ? "text-text-subtle" : "text-text")
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-[11px] uppercase tracking-wide text-text-subtle font-medium">
+      {children}
+    </p>
+  );
+}
+
+function TemplateRow({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div className="flex flex-col">
+      <dt className="text-[11px] uppercase tracking-wide text-text-subtle font-medium">
+        {label}
+      </dt>
+      <dd className="mt-1.5">
+        {values.length === 0 ? (
+          <span className="text-sm text-text-subtle">None</span>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {values.map((slug) => (
+              <code
+                key={slug}
+                className="text-[11px] text-text bg-surface-muted px-1.5 py-0.5 rounded"
+              >
+                {slug}
+              </code>
+            ))}
+          </div>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/src/components/shell/practice-admin-shell.tsx
+++ b/src/components/shell/practice-admin-shell.tsx
@@ -26,15 +26,12 @@
 //     template rendering.
 //   - Does NOT mount any edit UI.
 
-import "server-only";
-
 import * as React from "react";
 import Link from "next/link";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
-import { getSpecialtyTemplate } from "@/lib/specialty-templates/registry";
 import type { PracticeConfiguration } from "@/lib/practice-config/types";
 
 // EMR-410 (`@/lib/modality/registry`) is in flight in this storm but not yet
@@ -92,6 +89,9 @@ export interface PracticeAdminShellProps {
    *  so the user can switch which practice they're viewing. The shell just
    *  renders it — picking is the page's responsibility. */
   picker?: React.ReactNode;
+  /** Display name of the selected specialty. Passed from caller so this
+   *  component remains client-safe (no server registry imports). */
+  specialtyName?: string;
 }
 
 function formatAddress(p: PracticeSummary): string | null {
@@ -107,10 +107,8 @@ export function PracticeAdminShell({
   config,
   practice,
   picker,
+  specialtyName,
 }: PracticeAdminShellProps) {
-  const manifest = config.selectedSpecialty
-    ? getSpecialtyTemplate(config.selectedSpecialty)
-    : null;
 
   const enabled = config.enabledModalities ?? [];
   const disabled = config.disabledModalities ?? [];
@@ -193,7 +191,7 @@ export function PracticeAdminShell({
                   config.selectedSpecialty ? (
                     <span className="flex flex-col">
                       <span className="text-text">
-                        {manifest?.name ?? config.selectedSpecialty}
+                        {specialtyName ?? config.selectedSpecialty}
                       </span>
                       <code className="text-[11px] text-text-subtle bg-surface-muted px-1.5 py-0.5 rounded mt-1 self-start">
                         {config.selectedSpecialty}

--- a/src/lib/auth/audit-stub.ts
+++ b/src/lib/auth/audit-stub.ts
@@ -1,16 +1,24 @@
-// EMR-428 — Controller mutation audit log (stub).
+// EMR-470: name retained as 'audit-stub' for import-path stability across the storm. Body is now real persistence.
 //
 // Every mutation on the Practice Onboarding Controller surface (templates,
 // configs, wizard saves, publish/rollback, etc.) MUST call
-// `logControllerAction()` so we have a record of who-did-what once the
-// AuditLog persistence lands in EMR-470.
+// `logControllerAction()` so we have a record of who-did-what. Rows land in
+// `ControllerAuditLog` (see prisma/schema.prisma). The table is append-only
+// at the DB grant + trigger level — see
+// `prisma/migrations/20260505120000_add_controller_audit_log/append-only.sql`.
 //
-// Today this just emits a structured `console.log` line. The signature is
-// stable: when EMR-470 lands, only the body of this function changes — call
-// sites stay put.
+// Failure mode: a single insert. If it fails (DB down, schema drift, etc.)
+// we `console.error` and resolve — a missing audit row never blocks a
+// controller mutation. v1 trades durability for write availability.
+//
+// TODO(EMR-470 follow-up): wrap the insert in a durable queue so we can
+// retry on transient failures without coupling controller latency to audit
+// writes.
 
 import "server-only";
 
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
 import type { AuthedUser } from "./session";
 
 /**
@@ -42,33 +50,64 @@ export interface ControllerAuditEntry {
 }
 
 /**
- * Record a controller mutation. Stub today; persisted in EMR-470.
+ * Record a controller mutation to `ControllerAuditLog`.
  *
- * TODO(EMR-470): persist to AuditLog table once schema lands. The mapping is:
- *   - `actor.id`             → AuditLog.actorUserId
- *   - `actor.organizationId` → AuditLog.organizationId
- *   - `action`               → AuditLog.action
- *   - `"controller"`         → AuditLog.subjectType
- *   - `targetId`             → AuditLog.subjectId
- *   - `{ before, after, reason, actorRoles }` → AuditLog.metadata
+ * Mapping (kept identical to the stub's prior payload shape so call sites
+ * never had to change):
+ *   - `actor.id`             → ControllerAuditLog.actorUserId
+ *   - `actor.email`          → ControllerAuditLog.actorEmail
+ *   - `actor.roles`          → ControllerAuditLog.actorRoles
+ *   - `actor.organizationId` → ControllerAuditLog.organizationId
+ *   - `action`               → ControllerAuditLog.action
+ *   - `"controller"`         → ControllerAuditLog.subjectType
+ *   - `targetId`             → ControllerAuditLog.subjectId
+ *   - `before` / `after`     → ControllerAuditLog.before / .after (Json)
+ *   - `reason`               → ControllerAuditLog.reason
  */
 export async function logControllerAction(entry: ControllerAuditEntry): Promise<void> {
-  // Keep the payload shape identical to the eventual AuditLog row so call
-  // sites never have to change once EMR-470 lands.
-  const payload = {
-    at: new Date().toISOString(),
-    actorUserId: entry.actor.id,
-    actorEmail: entry.actor.email,
-    actorRoles: entry.actor.roles,
-    organizationId: entry.actor.organizationId,
-    action: entry.action,
-    subjectType: "controller",
-    subjectId: entry.targetId,
-    before: entry.before ?? null,
-    after: entry.after ?? null,
-    reason: entry.reason ?? null,
-  };
+  // Json columns: Prisma's `JsonNull` is the in-DB JSON null; `DbNull`
+  // leaves the column SQL NULL. We use SQL NULL when the caller didn't
+  // supply a snapshot — keeps the column index-friendly and matches the
+  // "absent" semantics callers expect.
+  const before: Prisma.InputJsonValue | typeof Prisma.DbNull =
+    entry.before == null ? Prisma.DbNull : (entry.before as Prisma.InputJsonValue);
+  const after: Prisma.InputJsonValue | typeof Prisma.DbNull =
+    entry.after == null ? Prisma.DbNull : (entry.after as Prisma.InputJsonValue);
 
-  // eslint-disable-next-line no-console -- intentional stub; EMR-470 swaps for prisma.auditLog.create
-  console.log("[audit:controller]", JSON.stringify(payload));
+  try {
+    await prisma.controllerAuditLog.create({
+      data: {
+        actorUserId: entry.actor.id,
+        actorEmail: entry.actor.email ?? null,
+        actorRoles: entry.actor.roles ?? [],
+        organizationId: entry.actor.organizationId ?? null,
+        action: entry.action,
+        subjectType: "controller",
+        subjectId: entry.targetId,
+        before,
+        after,
+        reason: entry.reason ?? null,
+      },
+    });
+  } catch (err) {
+    // Compliance-relevant: prefer write availability of the controller over
+    // write durability of the audit row. v1 ticket scope explicitly excludes
+    // a queue/retry. Surface enough context for ops to reconstruct.
+    const fallback = {
+      at: new Date().toISOString(),
+      actorUserId: entry.actor.id,
+      actorEmail: entry.actor.email ?? null,
+      actorRoles: entry.actor.roles ?? [],
+      organizationId: entry.actor.organizationId ?? null,
+      action: entry.action,
+      subjectType: "controller",
+      subjectId: entry.targetId,
+      before: entry.before ?? null,
+      after: entry.after ?? null,
+      reason: entry.reason ?? null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    // eslint-disable-next-line no-console -- intentional fallback path
+    console.error("[audit:controller:persist_failed]", JSON.stringify(fallback));
+  }
 }

--- a/src/lib/migration/profile-types.ts
+++ b/src/lib/migration/profile-types.ts
@@ -1,0 +1,186 @@
+/**
+ * EMR-453 — MigrationProfile shapes + default-seed helper.
+ *
+ * The MigrationProfile row stores its per-domain plan as a JSON array under
+ * the `categories` column. This module is the single source of truth for the
+ * TypeScript shape of that array, and exposes a pure helper that derives the
+ * default seed from a specialty manifest's `migration_mapping_defaults`.
+ *
+ * Architecture invariant: LeafJourney is specialty-adaptive. This file does
+ * NOT branch on a specialty slug. The behaviour difference between
+ * Pain Management, Internal Medicine, and Cannabis Medicine comes entirely
+ * from each manifest's own `migration_mapping_defaults` object — never from
+ * code that reads `manifest.slug`.
+ *
+ * Scope notes:
+ *   - Field-mapping detail (the strict shape of `fieldMappings`/`transforms`)
+ *     lands in EMR-454.
+ *   - Runtime import execution lands in EMR-456.
+ *   - This file deliberately keeps `fieldMappings`/`transforms` as
+ *     `Record<string, unknown>` so EMR-454 can tighten them without a
+ *     breaking schema migration.
+ */
+
+/**
+ * Canonical kebab-case category slugs the migration profile understands.
+ *
+ * Universal slugs are seeded for every profile regardless of manifest. The
+ * "Pain Management additions" group is opt-in: a manifest only seeds those
+ * slugs if its `migration_mapping_defaults` lists the corresponding key.
+ */
+export type MigrationCategorySlug =
+  | "demographics"
+  | "medications"
+  | "allergies"
+  | "problem-list"
+  | "notes"
+  | "imaging-refs"
+  | "procedures"
+  | "appointments"
+  | "documents"
+  | "patient-reported-outcomes"
+  // Pain Management additions
+  | "pain-scores"
+  | "pain-location"
+  | "prior-procedures"
+  | "imaging-history"
+  | "medication-history"
+  | "functional-limitations"
+  | "prior-treatment-response";
+
+export type MigrationCategory = {
+  slug: MigrationCategorySlug;
+  enabled: boolean;
+  /** Optional source-format hint per category (overrides profile-level sourceType). */
+  sourceFormat?: string;
+  /** Free-form mapping object — strict shape lands when EMR-454 ships. */
+  fieldMappings?: Record<string, unknown>;
+  /** Free-form transform definitions — strict shape lands when EMR-454 ships. */
+  transforms?: Record<string, unknown>;
+};
+
+export type MigrationProfileStatus =
+  | "draft"
+  | "configured"
+  | "completed"
+  | "archived";
+
+export type MigrationProfile = {
+  id: string;
+  configurationId: string;
+  sourceType: string | null;
+  categories: MigrationCategory[];
+  status: MigrationProfileStatus;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+};
+
+/**
+ * The universal set of categories every profile starts with, regardless of
+ * which specialty manifest is in play. Listed here as a single readonly
+ * tuple so callers can iterate it without re-deriving the list.
+ */
+export const UNIVERSAL_CATEGORY_SLUGS = [
+  "demographics",
+  "medications",
+  "allergies",
+  "problem-list",
+  "notes",
+  "imaging-refs",
+  "procedures",
+  "appointments",
+  "documents",
+  "patient-reported-outcomes",
+] as const satisfies ReadonlyArray<MigrationCategorySlug>;
+
+/**
+ * Whitelist of category slugs the helper is allowed to seed from a manifest.
+ * Anything not in this set is silently ignored — manifests are free to
+ * declare mapping keys for downstream tooling that the profile itself does
+ * not yet model.
+ */
+const REGISTERED_CATEGORY_SLUGS = new Set<MigrationCategorySlug>([
+  ...UNIVERSAL_CATEGORY_SLUGS,
+  "pain-scores",
+  "pain-location",
+  "prior-procedures",
+  "imaging-history",
+  "medication-history",
+  "functional-limitations",
+  "prior-treatment-response",
+]);
+
+/**
+ * Manifests use snake_case keys (e.g. `pain_score`) while the canonical
+ * profile slug union is kebab-case (e.g. `pain-scores`). This map captures
+ * the cases where the key→slug rewrite is non-trivial (singular vs. plural,
+ * compound aliasing). Keys that are already a kebab-case match for a
+ * registered slug after a simple `_`→`-` swap don't need an entry here.
+ */
+const MANIFEST_KEY_ALIASES: Record<string, MigrationCategorySlug> = {
+  pain_score: "pain-scores",
+  pain_scores: "pain-scores",
+  pain_location: "pain-location",
+  prior_procedures: "prior-procedures",
+  imaging_history: "imaging-history",
+  medication_history: "medication-history",
+  functional_limitations: "functional-limitations",
+  prior_treatment_response: "prior-treatment-response",
+  problem_list: "problem-list",
+  medication_list: "medications",
+  allergy_list: "allergies",
+  imaging_results: "imaging-refs",
+  imaging_refs: "imaging-refs",
+};
+
+function manifestKeyToSlug(key: string): MigrationCategorySlug | null {
+  if (key in MANIFEST_KEY_ALIASES) {
+    return MANIFEST_KEY_ALIASES[key];
+  }
+  const candidate = key.replace(/_/g, "-") as MigrationCategorySlug;
+  return REGISTERED_CATEGORY_SLUGS.has(candidate) ? candidate : null;
+}
+
+/**
+ * Pure helper. Reads a specialty manifest's `migration_mapping_defaults` and
+ * produces a default `MigrationCategory[]` seed.
+ *
+ * Behaviour:
+ *   1. The universal set (demographics, medications, allergies, problem-list,
+ *      notes, imaging-refs, procedures, appointments, documents,
+ *      patient-reported-outcomes) is always included as `enabled: true`.
+ *   2. Every key in `migration_mapping_defaults` that resolves to a
+ *      registered category slug is added (or merged) as `enabled: true`.
+ *      Manifest keys that don't match any registered slug are silently
+ *      ignored — they're harmless metadata for downstream tools.
+ *   3. The returned list is de-duplicated by slug. Universal categories
+ *      always appear first, in declaration order; manifest-derived extras
+ *      follow in the order the manifest emitted them.
+ *
+ * This function MUST stay pure: no I/O, no Date.now(), no manifest registry
+ * lookups. Callers fetch the manifest themselves and pass it in.
+ */
+export function buildDefaultProfileFromManifest(manifest: {
+  slug: string;
+  migration_mapping_defaults: Record<string, unknown>;
+}): MigrationCategory[] {
+  const out: MigrationCategory[] = [];
+  const seen = new Set<MigrationCategorySlug>();
+
+  for (const slug of UNIVERSAL_CATEGORY_SLUGS) {
+    out.push({ slug, enabled: true });
+    seen.add(slug);
+  }
+
+  for (const key of Object.keys(manifest.migration_mapping_defaults)) {
+    const slug = manifestKeyToSlug(key);
+    if (slug === null) continue;
+    if (seen.has(slug)) continue;
+    out.push({ slug, enabled: true });
+    seen.add(slug);
+  }
+
+  return out;
+}

--- a/src/lib/modality/__tests__/registry.test.ts
+++ b/src/lib/modality/__tests__/registry.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Modality registry + isModalityEnabled tests — EMR-410
+ *
+ * Acceptance:
+ *   1. Unpublished practice → all modalities resolve false.
+ *   2. Pain Management published config → cannabis-medicine is false.
+ *   3. Cannabis Medicine published config → cannabis-medicine is true.
+ *   4. Disabling cannabis-medicine cascades to commerce-leafmart (off even
+ *      when commerce is in enabledModalities).
+ *
+ * The Prisma client is mocked via `vi.mock` so these run pure-unit, no DB.
+ */
+
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  applyTemplateDefaults,
+} from "@/lib/specialty-templates/registry";
+
+// `server-only` is a Next.js-runtime guard that throws when imported from a
+// client module. Vitest doesn't run inside Next, so we stub it to a no-op for
+// the duration of this file. Without this, every import of ./server.ts fails.
+vi.mock("server-only", () => ({}));
+
+// ────────────────────────────────────────────────────────────────────────────
+// Prisma mock — replaces `@/lib/db/prisma` for the duration of this file.
+// ────────────────────────────────────────────────────────────────────────────
+
+type PublishedRow = {
+  id: string;
+  version: number;
+  enabledModalities: string[];
+  disabledModalities: string[];
+} | null;
+
+const findFirstMock = vi.fn<() => Promise<PublishedRow>>();
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    practiceConfiguration: {
+      findFirst: (..._args: unknown[]) => findFirstMock(),
+    },
+  },
+}));
+
+// React's `cache()` memoizes per call site for the lifetime of the module.
+// Each test wants a fresh result, so we re-import the server module after
+// resetting the mock to defeat the cache between cases.
+async function loadServer() {
+  vi.resetModules();
+  return await import("@/lib/modality/server");
+}
+
+beforeEach(() => {
+  findFirstMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Registry shape sanity
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("modality registry shape", () => {
+  it("MODALITY_META covers every REGISTERED_MODALITIES entry", async () => {
+    const { MODALITY_META, listModalities } = await import(
+      "@/lib/modality/registry"
+    );
+    const { REGISTERED_MODALITIES } = await import(
+      "@/lib/specialty-templates/manifest-schema"
+    );
+
+    expect(Object.keys(MODALITY_META).sort()).toEqual(
+      [...REGISTERED_MODALITIES].sort(),
+    );
+    // listModalities returns one meta per registered slug
+    expect(listModalities()).toHaveLength(REGISTERED_MODALITIES.length);
+  });
+
+  it("commerce-leafmart requires cannabis-medicine (v1 dependency)", async () => {
+    const { MODALITY_META } = await import("@/lib/modality/registry");
+    expect(MODALITY_META["commerce-leafmart"].requires).toEqual([
+      "cannabis-medicine",
+    ]);
+    // Inverse map populated.
+    expect(MODALITY_META["cannabis-medicine"].dependents).toContain(
+      "commerce-leafmart",
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// isModalityEnabled
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("isModalityEnabled", () => {
+  it("returns false for an unpublished practice (no config row)", async () => {
+    findFirstMock.mockResolvedValue(null);
+    const { isModalityEnabled } = await loadServer();
+
+    expect(await isModalityEnabled("practice-empty", "cannabis-medicine")).toBe(
+      false,
+    );
+    expect(await isModalityEnabled("practice-empty", "medications")).toBe(false);
+  });
+
+  it("returns false for cannabis-medicine on a Pain Management published config", async () => {
+    // Use the canonical Pain Management seed so the test fails if the
+    // manifest's bleed gate ever regresses.
+    const seed = applyTemplateDefaults("pain-management-non-cannabis");
+    findFirstMock.mockResolvedValue({
+      id: "cfg-pain",
+      version: 3,
+      enabledModalities: seed.enabledModalities ?? [],
+      disabledModalities: seed.disabledModalities ?? [],
+    });
+
+    const { isModalityEnabled } = await loadServer();
+    expect(await isModalityEnabled("practice-pain", "cannabis-medicine")).toBe(
+      false,
+    );
+    // Sanity: a modality that IS enabled in the seed reports true.
+    expect(await isModalityEnabled("practice-pain", "procedures")).toBe(true);
+  });
+
+  it("returns true for cannabis-medicine on a Cannabis Medicine published config", async () => {
+    const seed = applyTemplateDefaults("cannabis-medicine");
+    findFirstMock.mockResolvedValue({
+      id: "cfg-cb",
+      version: 1,
+      enabledModalities: seed.enabledModalities ?? [],
+      disabledModalities: seed.disabledModalities ?? [],
+    });
+
+    const { isModalityEnabled } = await loadServer();
+    expect(await isModalityEnabled("practice-cb", "cannabis-medicine")).toBe(
+      true,
+    );
+    expect(await isModalityEnabled("practice-cb", "commerce-leafmart")).toBe(
+      true,
+    );
+  });
+
+  it("disabling cannabis-medicine cascades to commerce-leafmart", async () => {
+    // commerce-leafmart is in enabledModalities, but cannabis-medicine is
+    // explicitly disabled — the cascade must turn commerce off.
+    findFirstMock.mockResolvedValue({
+      id: "cfg-cascade",
+      version: 1,
+      enabledModalities: ["commerce-leafmart", "patient-reported-outcomes"],
+      disabledModalities: ["cannabis-medicine"],
+    });
+
+    const { isModalityEnabled } = await loadServer();
+    expect(await isModalityEnabled("practice-cascade", "commerce-leafmart")).toBe(
+      false,
+    );
+    expect(
+      await isModalityEnabled("practice-cascade", "cannabis-medicine"),
+    ).toBe(false);
+    // Independent modality still reports true.
+    expect(
+      await isModalityEnabled("practice-cascade", "patient-reported-outcomes"),
+    ).toBe(true);
+  });
+
+  it("commerce-leafmart enabled without cannabis-medicine in either list still cascades off", async () => {
+    // Belt-and-suspenders: even when cannabis-medicine is silently absent
+    // (neither enabled nor explicitly disabled), the requires-edge fails.
+    findFirstMock.mockResolvedValue({
+      id: "cfg-missing",
+      version: 1,
+      enabledModalities: ["commerce-leafmart"],
+      disabledModalities: [],
+    });
+
+    const { isModalityEnabled } = await loadServer();
+    expect(await isModalityEnabled("practice-missing", "commerce-leafmart")).toBe(
+      false,
+    );
+  });
+
+  it("returns false when practiceId is empty", async () => {
+    const { isModalityEnabled } = await loadServer();
+    expect(await isModalityEnabled("", "medications")).toBe(false);
+    // findFirst should not have been called for empty practiceId.
+    expect(findFirstMock).not.toHaveBeenCalled();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// requireModalityEnabled / withModalityErrors
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("requireModalityEnabled", () => {
+  it("throws MODALITY_DISABLED:<slug> when off", async () => {
+    findFirstMock.mockResolvedValue(null);
+    vi.resetModules();
+    const { requireModalityEnabled } = await import(
+      "@/lib/modality/api-guard"
+    );
+
+    await expect(
+      requireModalityEnabled("practice-x", "cannabis-medicine"),
+    ).rejects.toThrowError("MODALITY_DISABLED:cannabis-medicine");
+  });
+
+  it("resolves silently when on", async () => {
+    findFirstMock.mockResolvedValue({
+      id: "cfg-on",
+      version: 1,
+      enabledModalities: ["cannabis-medicine"],
+      disabledModalities: [],
+    });
+    vi.resetModules();
+    const { requireModalityEnabled } = await import(
+      "@/lib/modality/api-guard"
+    );
+
+    await expect(
+      requireModalityEnabled("practice-on", "cannabis-medicine"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("withModalityErrors translates MODALITY_DISABLED to 403 JSON", async () => {
+    findFirstMock.mockResolvedValue(null);
+    vi.resetModules();
+    const { requireModalityEnabled, withModalityErrors } = await import(
+      "@/lib/modality/api-guard"
+    );
+
+    const response = await withModalityErrors(async () => {
+      await requireModalityEnabled("practice-y", "commerce-leafmart");
+      return new Response("unreachable");
+    });
+
+    // Vitest doesn't fully mock NextResponse — we just assert it's a Response
+    // with the expected status + body.
+    expect((response as Response).status).toBe(403);
+    const body = await (response as Response).json();
+    expect(body).toEqual({
+      error: "modality_disabled",
+      modality: "commerce-leafmart",
+    });
+  });
+});

--- a/src/lib/modality/api-guard.ts
+++ b/src/lib/modality/api-guard.ts
@@ -1,0 +1,82 @@
+/**
+ * Modality API Guard — EMR-410
+ *
+ * Server-only helper for use at the top of route handlers that touch a
+ * modality. Throws `Error("MODALITY_DISABLED:<slug>")` when the modality is
+ * off for the practice; the caller's error wrapper translates that to a 403
+ * JSON response (see `withModalityErrors` below).
+ *
+ * Usage:
+ *
+ *   export async function POST(req, { params }) {
+ *     return withModalityErrors(async () => {
+ *       await requireModalityEnabled(params.practiceId, "cannabis-medicine");
+ *       // ...handler logic...
+ *       return NextResponse.json({ ok: true });
+ *     });
+ *   }
+ *
+ * The convention mirrors the existing `withAuthErrors` helper in
+ * src/app/api/configs/_helpers.ts so the two can compose.
+ */
+
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { isModalityEnabled } from "@/lib/modality/server";
+import type { ModalityId } from "@/lib/modality/registry";
+
+const ERROR_PREFIX = "MODALITY_DISABLED:";
+
+/**
+ * Throws when the modality is disabled for the practice. Resolves silently
+ * when enabled. Composes with `withModalityErrors` for the JSON response.
+ */
+export async function requireModalityEnabled(
+  practiceId: string,
+  modality: ModalityId,
+): Promise<void> {
+  const enabled = await isModalityEnabled(practiceId, modality);
+  if (!enabled) {
+    throw new Error(`${ERROR_PREFIX}${modality}`);
+  }
+}
+
+/**
+ * Test whether an Error from `requireModalityEnabled` carries the disabled
+ * marker, and which modality it referenced. Useful for callers that want to
+ * customize the response shape.
+ */
+export function parseModalityError(
+  err: unknown,
+): { modality: string } | null {
+  if (!(err instanceof Error)) return null;
+  if (!err.message.startsWith(ERROR_PREFIX)) return null;
+  return { modality: err.message.slice(ERROR_PREFIX.length) };
+}
+
+/**
+ * Wrap a route handler body so that a thrown `MODALITY_DISABLED:<slug>` error
+ * becomes a 403 JSON response of shape
+ *   { error: "modality_disabled", modality: "<slug>" }
+ *
+ * Other errors re-throw — pair with `withAuthErrors` (EMR-435) when the
+ * handler also runs auth.
+ */
+export async function withModalityErrors<T>(
+  fn: () => Promise<T>,
+): Promise<T | NextResponse> {
+  try {
+    return await fn();
+  } catch (err) {
+    const parsed = parseModalityError(err);
+    if (parsed) {
+      return NextResponse.json(
+        { error: "modality_disabled", modality: parsed.modality },
+        { status: 403 },
+      );
+    }
+    throw err;
+  }
+}

--- a/src/lib/modality/client.tsx
+++ b/src/lib/modality/client.tsx
@@ -1,0 +1,118 @@
+/**
+ * <ModalityGate /> — EMR-410
+ *
+ * Renders `children` only when the named modality is enabled for the current
+ * practice; renders `fallback` (or null) otherwise.
+ *
+ * Two flavors live in this module:
+ *
+ * 1. `ModalityGate` (server) — the preferred form. Looks up the practice
+ *    from the EMR-411 PracticeContext when that lands; until then, accepts
+ *    `practiceId` as a prop. Hits Prisma via `isModalityEnabled()` which is
+ *    per-request cached, so multiple gates in one render don't fan out.
+ *
+ * 2. `ClientModalityGate` (client) — same API but reads from a snapshot
+ *    handed down from the server tree. Use this inside client components
+ *    where awaiting a server fetch isn't possible. Wrap the subtree in
+ *    `<ModalitySnapshotProvider snapshot={...} />` from a server component.
+ *
+ * Both flavors fail closed: missing practice id, missing snapshot, or
+ * disabled modality all render `fallback` — never the children.
+ */
+
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+import {
+  MODALITY_META,
+  isModalityId,
+  type ModalityId,
+} from "@/lib/modality/registry";
+import type { ModalitySnapshotDTO } from "@/lib/modality/server";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Client-side context + hook
+// ────────────────────────────────────────────────────────────────────────────
+
+const ModalitySnapshotContext = createContext<ModalitySnapshotDTO | null>(null);
+
+/**
+ * Provide a server-fetched snapshot to a client subtree. Place at the top of
+ * any client island that needs to consult the modality state — typically the
+ * shell renderer (EMR-411).
+ */
+export function ModalitySnapshotProvider(props: {
+  snapshot: ModalitySnapshotDTO | null;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <ModalitySnapshotContext.Provider value={props.snapshot}>
+      {props.children}
+    </ModalitySnapshotContext.Provider>
+  );
+}
+
+/**
+ * Read the current modality snapshot in a client component. Returns `null`
+ * when no snapshot is in scope — callers should treat that as fail-closed
+ * (no modality is enabled).
+ */
+export function useModalityState(): ModalitySnapshotDTO | null {
+  return useContext(ModalitySnapshotContext);
+}
+
+/**
+ * Pure check against an in-hand snapshot. Mirrors `resolveModality` in
+ * ./server.ts but operates over the DTO shape (arrays, not Sets).
+ */
+function resolveFromDTO(
+  snapshot: ModalitySnapshotDTO | null,
+  modality: ModalityId,
+): boolean {
+  if (!snapshot) return false;
+  if (!snapshot.enabled.includes(modality)) return false;
+
+  for (const dep of MODALITY_META[modality].requires) {
+    if (snapshot.disabled.includes(dep)) return false;
+    if (!snapshot.enabled.includes(dep)) return false;
+  }
+  return true;
+}
+
+/**
+ * Hook form: ask whether a modality is enabled given the current snapshot.
+ * Returns `false` when no provider is in scope.
+ */
+export function useIsModalityEnabled(modality: ModalityId): boolean {
+  const snapshot = useModalityState();
+  return resolveFromDTO(snapshot, modality);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gate components
+// ────────────────────────────────────────────────────────────────────────────
+
+export type ModalityGateProps = {
+  /** Modality slug — must be a registered modality id. */
+  modality: ModalityId;
+  /**
+   * Optional explicit practiceId. Required until EMR-411's PracticeContext
+   * lands. When EMR-411 is wired, the server gate falls back to context.
+   */
+  practiceId?: string;
+  /** Rendered when the modality is disabled. Defaults to `null`. */
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * Client-side gate. Reads from `useModalityState()`. Use inside client
+ * components that already live under a `<ModalitySnapshotProvider />`.
+ */
+export function ClientModalityGate(props: ModalityGateProps): JSX.Element {
+  const { modality, fallback = null, children } = props;
+  const enabled = useIsModalityEnabled(modality);
+  if (!isModalityId(modality)) return <>{fallback}</>;
+  return <>{enabled ? children : fallback}</>;
+}

--- a/src/lib/modality/gate.tsx
+++ b/src/lib/modality/gate.tsx
@@ -1,0 +1,42 @@
+/**
+ * <ModalityGate /> server component — EMR-410
+ *
+ * Async server component that resolves the modality snapshot via Prisma and
+ * renders children only when enabled. Pair with `ClientModalityGate` (from
+ * ./client.tsx) inside client subtrees.
+ *
+ * Until EMR-411's PracticeContext lands, callers must pass `practiceId`
+ * explicitly. When neither context nor prop is available, the gate renders
+ * `fallback` — fail closed by design.
+ */
+
+import "server-only";
+
+import type { ReactNode } from "react";
+
+import { isModalityEnabled } from "@/lib/modality/server";
+import { isModalityId, type ModalityId } from "@/lib/modality/registry";
+
+export type ModalityGateProps = {
+  modality: ModalityId;
+  /**
+   * Required until EMR-411 lands a PracticeContext. Once the context exists,
+   * this prop becomes optional and overrides the contextual value.
+   */
+  practiceId?: string;
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+
+export async function ModalityGate(
+  props: ModalityGateProps,
+): Promise<JSX.Element> {
+  const { modality, practiceId, fallback = null, children } = props;
+
+  if (!isModalityId(modality)) return <>{fallback}</>;
+  // TODO(EMR-411): replace with PracticeContext lookup once that lands.
+  if (!practiceId) return <>{fallback}</>;
+
+  const enabled = await isModalityEnabled(practiceId, modality);
+  return <>{enabled ? children : fallback}</>;
+}

--- a/src/lib/modality/registry.ts
+++ b/src/lib/modality/registry.ts
@@ -1,0 +1,343 @@
+/**
+ * Modality Registry — EMR-410
+ *
+ * The modality registry is the canonical capability map for LeafJourney.
+ * Every clinical or commerce capability that can be turned on/off per practice
+ * is a modality. This registry hardcodes the metadata + dependency graph; the
+ * per-practice on/off state lives on PracticeConfiguration.enabledModalities /
+ * disabledModalities and is read via ./server.ts.
+ *
+ * Architecture invariants (HARD constraints — see CLAUDE.md / Epic 2):
+ *   - LeafJourney is specialty-adaptive, NOT cannabis-first. The dependency
+ *     graph below treats cannabis-medicine as one modality among many. The
+ *     ONLY hard-wired dependency in v1 is: commerce-leafmart REQUIRES
+ *     cannabis-medicine (because the v1 Leafmart catalog is exclusively
+ *     cannabis SKUs — once Leafmart carries non-cannabis SKUs the requirement
+ *     is removed and replaced with per-SKU modality tagging).
+ *   - Adding a new modality means: add the slug to REGISTERED_MODALITIES in
+ *     ../specialty-templates/manifest-schema.ts AND add a META entry below.
+ *     The boot-time assertion on REGISTERED_MODALITIES keeps these in sync.
+ *   - The registry never branches on a specific slug at runtime. Code that
+ *     wants to gate on cannabis-medicine uses <ModalityGate /> or
+ *     isModalityEnabled() — never `if (slug === 'cannabis-medicine')`.
+ */
+
+import {
+  REGISTERED_MODALITIES,
+  type RegisteredModality,
+} from "@/lib/specialty-templates/manifest-schema";
+
+/** A modality id is one of the registered slugs. */
+export type ModalityId = RegisteredModality;
+
+/**
+ * Surfaces a modality may toggle when on/off. Used by EMR-411 (shell render),
+ * EMR-423 (toggle wizard), and EMR-445/447 (mission-control + portal cards) to
+ * decide which slots to render. New surfaces are added here and consumed
+ * elsewhere — the registry is the single source of truth.
+ */
+export type ModalitySurface =
+  | "physician-nav"
+  | "physician-mission-control"
+  | "physician-chart"
+  | "physician-cds"
+  | "patient-portal"
+  | "patient-education"
+  | "patient-commerce"
+  | "intake-questions"
+  | "shop";
+
+export type ModalityMeta = {
+  id: ModalityId;
+  label: string;
+  description: string;
+  /** Which surfaces this modality affects when toggled. */
+  surfaces: ModalitySurface[];
+  /** Other modalities required by this one (acyclic). */
+  requires: ModalityId[];
+  /** Modalities that depend on this one (computed inverse of requires). */
+  dependents: ModalityId[];
+};
+
+/**
+ * Authored metadata. `dependents` is filled in below by deriving it from
+ * `requires` so author-time edits cannot drift between the two directions.
+ */
+type AuthoredMeta = Omit<ModalityMeta, "dependents">;
+
+const AUTHORED: Record<ModalityId, AuthoredMeta> = {
+  medications: {
+    id: "medications",
+    label: "Medications",
+    description:
+      "General medication list, prescribing, refill management, and " +
+      "med reconciliation. Required by most longitudinal care models.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+      "physician-cds",
+      "patient-portal",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  "pain-medications": {
+    id: "pain-medications",
+    label: "Pain Medications",
+    description:
+      "Pain-specific medication workflows: opioid agreements, PDMP " +
+      "checks, controlled-substance refill cadence, and risk scoring.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+      "physician-cds",
+      "patient-portal",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  labs: {
+    id: "labs",
+    label: "Labs",
+    description:
+      "Lab orders, result review, abnormal-flag follow-up, and patient " +
+      "lab portal cards.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+      "patient-portal",
+    ],
+    requires: [],
+  },
+  imaging: {
+    id: "imaging",
+    label: "Imaging",
+    description:
+      "Imaging orders, radiology report review, and image-driven " +
+      "procedure planning.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+    ],
+    requires: [],
+  },
+  referrals: {
+    id: "referrals",
+    label: "Referrals",
+    description:
+      "Outbound referrals to specialists, status tracking, and " +
+      "loop-closure follow-up.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+    ],
+    requires: [],
+  },
+  procedures: {
+    id: "procedures",
+    label: "Procedures",
+    description:
+      "Procedure scheduling, procedure notes, and post-procedure " +
+      "follow-up workflows.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+      "patient-portal",
+    ],
+    requires: [],
+  },
+  lifestyle: {
+    id: "lifestyle",
+    label: "Lifestyle",
+    description:
+      "Lifestyle modalities: nutrition, sleep, stress, exercise. " +
+      "Patient-facing tracking and clinician guidance content.",
+    surfaces: [
+      "physician-chart",
+      "patient-portal",
+      "patient-education",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  "physical-therapy": {
+    id: "physical-therapy",
+    label: "Physical Therapy",
+    description:
+      "PT referral workflows, exercise plan delivery, and progress " +
+      "tracking.",
+    surfaces: [
+      "physician-nav",
+      "physician-chart",
+      "patient-portal",
+    ],
+    requires: [],
+  },
+  "functional-pain": {
+    id: "functional-pain",
+    label: "Functional Pain",
+    description:
+      "Functional outcome measures specific to chronic pain: PEG, ODI, " +
+      "Roland-Morris. Drives the pain-mgmt patient portal cards.",
+    surfaces: [
+      "physician-mission-control",
+      "physician-chart",
+      "patient-portal",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  "patient-reported-outcomes": {
+    id: "patient-reported-outcomes",
+    label: "Patient-Reported Outcomes",
+    description:
+      "Generic PROM collection: per-visit and longitudinal scales " +
+      "(emoji + 1-10) feeding the research/efficacy data layer.",
+    surfaces: [
+      "physician-mission-control",
+      "physician-chart",
+      "patient-portal",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  "cannabis-medicine": {
+    id: "cannabis-medicine",
+    label: "Cannabis Medicine",
+    description:
+      "Cannabis recommendations, certifications, dosing titration, " +
+      "post-dose check-ins, and the cannabis-specific charting templates. " +
+      "Disabled by default in non-cannabis specialties — practices opt in " +
+      "explicitly via the modality toggle.",
+    surfaces: [
+      "physician-nav",
+      "physician-mission-control",
+      "physician-chart",
+      "physician-cds",
+      "patient-portal",
+      "patient-education",
+      "intake-questions",
+    ],
+    requires: [],
+  },
+  "commerce-leafmart": {
+    id: "commerce-leafmart",
+    label: "Leafmart Commerce",
+    description:
+      "Patient-facing storefront integration: product catalog, cart, " +
+      "checkout, and recommendation → order linkage. v1 catalog is " +
+      "cannabis-only, so this modality requires cannabis-medicine.",
+    surfaces: [
+      "patient-portal",
+      "patient-commerce",
+      "shop",
+    ],
+    // v1 invariant: Leafmart SKUs are cannabis. Until the catalog carries
+    // non-cannabis goods we hard-require cannabis-medicine so a practice
+    // can't accidentally enable a storefront they can't legally fulfill.
+    requires: ["cannabis-medicine"],
+  },
+};
+
+/**
+ * Compute the inverse `dependents` map at module-init so callers can ask
+ * "what cascades off if I disable cannabis-medicine?" in O(1).
+ */
+function buildMeta(): Record<ModalityId, ModalityMeta> {
+  // Verify AUTHORED covers every registered modality. This is the boot-time
+  // sync check that keeps manifest-schema and the modality registry from
+  // drifting silently.
+  for (const id of REGISTERED_MODALITIES) {
+    if (!(id in AUTHORED)) {
+      throw new Error(
+        `[modality/registry] missing META entry for "${id}". Add it to ` +
+          `AUTHORED in src/lib/modality/registry.ts.`,
+      );
+    }
+  }
+  for (const key of Object.keys(AUTHORED)) {
+    if (!(REGISTERED_MODALITIES as readonly string[]).includes(key)) {
+      throw new Error(
+        `[modality/registry] AUTHORED contains "${key}" which is not in ` +
+          `REGISTERED_MODALITIES. Either drop the entry or add the slug to ` +
+          `manifest-schema.ts.`,
+      );
+    }
+  }
+
+  // Every `requires` edge must point at a known modality.
+  for (const meta of Object.values(AUTHORED)) {
+    for (const dep of meta.requires) {
+      if (!(dep in AUTHORED)) {
+        throw new Error(
+          `[modality/registry] "${meta.id}" requires unknown modality "${dep}".`,
+        );
+      }
+    }
+  }
+
+  // Build inverse map: dep → [things that require dep].
+  const dependents: Record<ModalityId, ModalityId[]> = Object.fromEntries(
+    REGISTERED_MODALITIES.map((id) => [id, [] as ModalityId[]]),
+  ) as Record<ModalityId, ModalityId[]>;
+
+  for (const meta of Object.values(AUTHORED)) {
+    for (const dep of meta.requires) {
+      dependents[dep].push(meta.id);
+    }
+  }
+
+  // Acyclicity check (DFS). With v1 having a single edge this is a formality,
+  // but it's cheap and prevents future authors from introducing a cycle.
+  const WHITE = 0,
+    GRAY = 1,
+    BLACK = 2;
+  const color: Record<ModalityId, number> = Object.fromEntries(
+    REGISTERED_MODALITIES.map((id) => [id, WHITE]),
+  ) as Record<ModalityId, number>;
+
+  function visit(node: ModalityId, stack: ModalityId[]): void {
+    if (color[node] === GRAY) {
+      throw new Error(
+        `[modality/registry] dependency cycle: ${[...stack, node].join(" → ")}`,
+      );
+    }
+    if (color[node] === BLACK) return;
+    color[node] = GRAY;
+    for (const dep of AUTHORED[node].requires) {
+      visit(dep, [...stack, node]);
+    }
+    color[node] = BLACK;
+  }
+  for (const id of REGISTERED_MODALITIES) visit(id, []);
+
+  const out: Record<ModalityId, ModalityMeta> = {} as Record<
+    ModalityId,
+    ModalityMeta
+  >;
+  for (const id of REGISTERED_MODALITIES) {
+    out[id] = { ...AUTHORED[id], dependents: [...dependents[id]].sort() };
+  }
+  return out;
+}
+
+export const MODALITY_META: Record<ModalityId, ModalityMeta> = buildMeta();
+
+/** Type guard — checks at runtime that `value` is a registered modality slug. */
+export function isModalityId(value: unknown): value is ModalityId {
+  return (
+    typeof value === "string" &&
+    (REGISTERED_MODALITIES as readonly string[]).includes(value)
+  );
+}
+
+/** All registered modality ids in deterministic order. */
+export function listModalities(): ModalityMeta[] {
+  return REGISTERED_MODALITIES.map((id) => MODALITY_META[id]);
+}

--- a/src/lib/modality/server.ts
+++ b/src/lib/modality/server.ts
@@ -1,0 +1,166 @@
+/**
+ * Modality Server Helpers — EMR-410
+ *
+ * Server-only API for asking "is this modality enabled for this practice?"
+ *
+ * Architecture invariants:
+ *   - Reads the practice's *latest published* PracticeConfiguration directly
+ *     via Prisma. We do NOT route through `/api/configs/by-practice` — that
+ *     route is for clients; calling it from server code would round-trip
+ *     through the network and bypass the per-request cache.
+ *   - Cached with React's `cache()` per request so repeated checks within a
+ *     single render pass hit the DB once.
+ *   - Returns `false` (fail-closed) when no published config exists yet — a
+ *     practice that hasn't published cannot have any modality enabled.
+ *   - `requires` cascades: if `commerce-leafmart` requires `cannabis-medicine`
+ *     and `cannabis-medicine` is disabled, then `commerce-leafmart` is
+ *     reported disabled even if it appears in `enabledModalities`.
+ *   - NEVER branches on a specific slug. Cannabis-bleed prevention is enforced
+ *     by the manifest + modality data, not by code paths.
+ */
+
+import "server-only";
+
+import * as React from "react";
+
+import { prisma } from "@/lib/db/prisma";
+import {
+  MODALITY_META,
+  isModalityId,
+  type ModalityId,
+} from "@/lib/modality/registry";
+
+// React's `cache()` is only present in the React Server Components build
+// (Next provides it; the bare `react` package on npm 18.3.1 does not export
+// it). Fall back to identity when it's missing so this module can be
+// exercised in plain Node tests; under Next the per-request dedupe still
+// kicks in because `React.cache` is the canary export that Next ships.
+type CacheFn = <A extends unknown[], R>(
+  fn: (...args: A) => R,
+) => (...args: A) => R;
+const reactCache: CacheFn =
+  (React as unknown as { cache?: CacheFn }).cache ??
+  (((fn) => fn) as CacheFn);
+
+/**
+ * Snapshot of what's enabled / disabled for a practice. Computed from the
+ * latest published PracticeConfiguration. `null` when no published config
+ * exists.
+ */
+export type ModalitySnapshot = {
+  practiceId: string;
+  configurationId: string;
+  version: number;
+  enabled: ReadonlySet<ModalityId>;
+  disabled: ReadonlySet<ModalityId>;
+};
+
+/**
+ * Per-request cached fetch of the latest published config. Returns the bare
+ * row so callers can read both `enabledModalities` and `disabledModalities`.
+ */
+const getLatestPublishedRow = reactCache(async (practiceId: string) => {
+  if (!practiceId) return null;
+  return prisma.practiceConfiguration.findFirst({
+    where: { practiceId, status: "published" },
+    orderBy: { publishedAt: "desc" },
+    select: {
+      id: true,
+      version: true,
+      enabledModalities: true,
+      disabledModalities: true,
+    },
+  });
+});
+
+/**
+ * Per-request cached snapshot. Filters the persisted slug arrays to known
+ * modalities — an unknown string in the DB (e.g. a removed modality) is
+ * silently dropped. This keeps the system forward-compatible across modality
+ * deprecations.
+ */
+export const getModalitySnapshot = reactCache(
+  async (practiceId: string): Promise<ModalitySnapshot | null> => {
+    const row = await getLatestPublishedRow(practiceId);
+    if (!row) return null;
+
+    const enabled = new Set<ModalityId>();
+    for (const slug of row.enabledModalities) {
+      if (isModalityId(slug)) enabled.add(slug);
+    }
+    const disabled = new Set<ModalityId>();
+    for (const slug of row.disabledModalities) {
+      if (isModalityId(slug)) disabled.add(slug);
+    }
+
+    return {
+      practiceId,
+      configurationId: row.id,
+      version: row.version,
+      enabled,
+      disabled,
+    };
+  },
+);
+
+/**
+ * Resolve effective enablement for a modality given an in-memory snapshot.
+ * Pure — no I/O. Used by the client gate too (see ./client.tsx).
+ */
+export function resolveModality(
+  snapshot: ModalitySnapshot | null,
+  modality: ModalityId,
+): boolean {
+  if (!snapshot) return false;
+  if (!snapshot.enabled.has(modality)) return false;
+
+  // Cascade: any required modality being disabled (or not enabled) cascades
+  // into this one being effectively off, regardless of what
+  // `enabledModalities` says.
+  for (const dep of MODALITY_META[modality].requires) {
+    if (snapshot.disabled.has(dep)) return false;
+    if (!snapshot.enabled.has(dep)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * `true` only when the modality is in `enabledModalities` AND none of its
+ * `requires` are disabled. Returns `false` for an unpublished practice or
+ * when `practiceId` is empty.
+ */
+export async function isModalityEnabled(
+  practiceId: string,
+  modality: ModalityId,
+): Promise<boolean> {
+  const snapshot = await getModalitySnapshot(practiceId);
+  return resolveModality(snapshot, modality);
+}
+
+/**
+ * Snapshot projection suitable for handing to client components — plain
+ * arrays instead of Sets so it serializes cleanly across the
+ * server/client boundary. Pair with `useModalityState()` from ./client.tsx.
+ */
+export type ModalitySnapshotDTO = {
+  practiceId: string;
+  configurationId: string;
+  version: number;
+  enabled: ModalityId[];
+  disabled: ModalityId[];
+};
+
+export async function getModalitySnapshotDTO(
+  practiceId: string,
+): Promise<ModalitySnapshotDTO | null> {
+  const snap = await getModalitySnapshot(practiceId);
+  if (!snap) return null;
+  return {
+    practiceId: snap.practiceId,
+    configurationId: snap.configurationId,
+    version: snap.version,
+    enabled: [...snap.enabled].sort(),
+    disabled: [...snap.disabled].sort(),
+  };
+}

--- a/src/lib/onboarding/draft-summary.ts
+++ b/src/lib/onboarding/draft-summary.ts
@@ -1,0 +1,88 @@
+// EMR-427 — Shared draft summary helper for the wizard preview & publish steps.
+//
+// Pure projection of the in-progress draft + the active specialty manifest
+// into a stable, display-friendly shape. Steps 12–15 share this helper so
+// the "what's about to be published" recap is identical everywhere it shows.
+//
+// Specialty-adaptive: this function never branches on a specific slug; the
+// values surfaced come straight from the draft and the supplied manifest.
+
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+
+export type DraftSummary = {
+  specialty: { slug: string; name: string };
+  careModel: string;
+  enabledModalities: string[];
+  disabledModalities: string[];
+  templates: { workflows: number; charting: number; roles: number };
+  shells: { patient: string | null; physician: string | null };
+  migration: { mode: "greenfield" | "migrate"; categories: number };
+};
+
+/**
+ * Reduce a draft (plus its active specialty manifest, if known) to a
+ * `DraftSummary`. Pure — no IO.
+ *
+ * The function tolerates a `null` manifest because steps 12–15 may render
+ * before the registry has been consulted on the client; in that case the
+ * specialty name falls back to its slug.
+ *
+ * Migration mode is "migrate" when the draft has either a `migrationProfileId`
+ * or any `migration_mapping_defaults` from the manifest; otherwise "greenfield".
+ * `categories` counts the number of mapping keys (data categories) the
+ * downstream import will touch.
+ */
+export function summarizeDraft(
+  draft: Partial<PracticeConfiguration>,
+  manifest: SpecialtyManifest | null,
+): DraftSummary {
+  const slug = (draft.selectedSpecialty as string | null | undefined) ?? "";
+  const specialty = {
+    slug,
+    name: manifest?.name ?? slug ?? "—",
+  };
+
+  const enabled = Array.isArray(draft.enabledModalities)
+    ? [...draft.enabledModalities]
+    : [];
+  const disabled = Array.isArray(draft.disabledModalities)
+    ? [...draft.disabledModalities]
+    : [];
+
+  const workflows = Array.isArray(draft.workflowTemplateIds)
+    ? draft.workflowTemplateIds.length
+    : 0;
+  const charting = Array.isArray(draft.chartingTemplateIds)
+    ? draft.chartingTemplateIds.length
+    : 0;
+  const roles = Array.isArray(draft.rolePermissionTemplateIds)
+    ? draft.rolePermissionTemplateIds.length
+    : 0;
+
+  const physicianShell =
+    (draft.physicianShellTemplateId as string | null | undefined) ?? null;
+  const patientShell =
+    (draft.patientShellTemplateId as string | null | undefined) ?? null;
+
+  const mappingDefaults = manifest?.migration_mapping_defaults ?? {};
+  const mappingCategories = Object.keys(mappingDefaults).length;
+  const hasProfile =
+    typeof draft.migrationProfileId === "string" &&
+    draft.migrationProfileId.length > 0;
+
+  const migration: DraftSummary["migration"] =
+    hasProfile || mappingCategories > 0
+      ? { mode: "migrate", categories: mappingCategories }
+      : { mode: "greenfield", categories: 0 };
+
+  return {
+    specialty,
+    careModel: (draft.careModel as string | null | undefined) ?? "",
+    enabledModalities: enabled,
+    disabledModalities: disabled,
+    templates: { workflows, charting, roles },
+    shells: { patient: patientShell, physician: physicianShell },
+    migration,
+  };
+}

--- a/src/lib/onboarding/known-shell-templates.ts
+++ b/src/lib/onboarding/known-shell-templates.ts
@@ -1,0 +1,277 @@
+// Known shell template catalog — EMR-425.
+//
+// The Practice Onboarding wizard's steps 9 (patient portal) and 10 (physician
+// Mission Control) ask the admin to pick a shell *template*. A template is a
+// preset bundle of cards / surfaces that the patient or clinician will see
+// once the configuration publishes (the actual rendering is owned by
+// EMR-411 / EMR-412 — this file only describes the picker options).
+//
+// Specialty-adaptive rule: the templates listed here are *generic* presets,
+// not specialty-specific. A specialty's manifest can also derive its own
+// "Recommended for <specialty>" template at runtime by mapping
+// `manifest.default_patient_portal_cards` /
+// `manifest.default_mission_control_cards` into a `ShellTemplateOption`.
+// We never branch on `slug === 'cannabis-medicine'` here.
+
+export type ShellTemplateOption = {
+  /** Stable id — persisted as `patientShellTemplateId` /
+   * `physicianShellTemplateId` on the PracticeConfiguration row. */
+  id: string;
+  label: string;
+  description: string;
+  /** Ordered list of card identifiers this template renders. The order is
+   * the canonical render order of the shell. The physician picker lets the
+   * admin reorder; the patient picker shows the order as a preview. */
+  cards: string[];
+};
+
+/**
+ * Patient portal shell templates. Card ids match the ones declared in
+ * specialty manifests' `default_patient_portal_cards` so the same render
+ * pipeline (EMR-411) can resolve any of them.
+ *
+ * Keep at least three options so the picker is meaningful and the UI doesn't
+ * collapse to a single-card "are you sure?" page.
+ */
+export const PATIENT_SHELL_TEMPLATES: ShellTemplateOption[] = [
+  {
+    id: "patient-shell-essentials",
+    label: "Essentials",
+    description:
+      "A minimal portal: appointments, messages, and educational resources. " +
+      "Best for practices that want a clean, low-friction patient experience.",
+    cards: [
+      "welcome",
+      "upcoming-appointments",
+      "messages",
+      "education",
+    ],
+  },
+  {
+    id: "patient-shell-longitudinal-care",
+    label: "Longitudinal care",
+    description:
+      "Adds labs, medications, and billing on top of the essentials. " +
+      "The default for primary-care and chronic-disease practices.",
+    cards: [
+      "welcome",
+      "upcoming-appointments",
+      "lab-results",
+      "medications",
+      "messages",
+      "education",
+      "billing",
+    ],
+  },
+  {
+    id: "patient-shell-outcome-tracking",
+    label: "Outcome tracking",
+    description:
+      "Per-visit check-ins, weekly outcome scales, and goal progress. Best " +
+      "for specialties that rely on patient-reported outcomes.",
+    cards: [
+      "welcome",
+      "upcoming-appointments",
+      "post-visit-checkins",
+      "weekly-outcome-scales",
+      "goal-progress",
+      "messages",
+      "education",
+    ],
+  },
+  {
+    id: "patient-shell-procedural",
+    label: "Procedural",
+    description:
+      "Optimised for procedure-heavy practices: pre-op instructions, " +
+      "consent forms, and a pain or recovery diary.",
+    cards: [
+      "welcome",
+      "upcoming-appointments",
+      "pre-op-instructions",
+      "consent-forms",
+      "pain-diary",
+      "functional-goals",
+      "messages",
+      "billing",
+    ],
+  },
+];
+
+/**
+ * Physician Mission Control shell templates. Card ids match
+ * `default_mission_control_cards` from specialty manifests.
+ *
+ * The order in `cards` is significant — it's the rendered order of the
+ * Mission Control dashboard. Step 10 lets the admin reorder via up/down
+ * buttons (no drag library is currently installed; see EMR-425 ticket).
+ */
+export const PHYSICIAN_SHELL_TEMPLATES: ShellTemplateOption[] = [
+  {
+    id: "physician-shell-clinic-day",
+    label: "Clinic day",
+    description:
+      "Schedule-first dashboard for a typical outpatient clinic day. Open " +
+      "charts and the inbox sit alongside today's schedule.",
+    cards: [
+      "todays-schedule",
+      "open-charts",
+      "messages-inbox",
+      "refill-requests",
+    ],
+  },
+  {
+    id: "physician-shell-longitudinal-care",
+    label: "Longitudinal care",
+    description:
+      "Adds lab and imaging review queues for primary-care and chronic-care " +
+      "workflows. The default for longitudinal practices.",
+    cards: [
+      "todays-schedule",
+      "open-charts",
+      "lab-results-pending-review",
+      "imaging-pending-review",
+      "messages-inbox",
+      "refill-requests",
+    ],
+  },
+  {
+    id: "physician-shell-procedural",
+    label: "Procedural",
+    description:
+      "Procedure board first. Best for interventional and pain-management " +
+      "practices that batch procedure days.",
+    cards: [
+      "todays-schedule",
+      "procedure-board",
+      "open-charts",
+      "imaging-pending-review",
+      "controlled-substance-monitoring",
+      "messages-inbox",
+      "refill-requests",
+    ],
+  },
+  {
+    id: "physician-shell-certification",
+    label: "Certification + follow-up",
+    description:
+      "Certification queue and outcome check-ins surfaced for specialties " +
+      "with a recurring qualifying-visit cadence.",
+    cards: [
+      "todays-schedule",
+      "open-charts",
+      "certifications-due",
+      "outcome-checkins",
+      "messages-inbox",
+    ],
+  },
+];
+
+/**
+ * Look up a patient template by id. Returns null when not found — callers
+ * (the wizard step) render a recoverable empty state rather than throwing.
+ */
+export function getPatientShellTemplate(
+  id: string | null | undefined,
+): ShellTemplateOption | null {
+  if (!id) return null;
+  return PATIENT_SHELL_TEMPLATES.find((t) => t.id === id) ?? null;
+}
+
+/** Look up a physician template by id. */
+export function getPhysicianShellTemplate(
+  id: string | null | undefined,
+): ShellTemplateOption | null {
+  if (!id) return null;
+  return PHYSICIAN_SHELL_TEMPLATES.find((t) => t.id === id) ?? null;
+}
+
+/**
+ * Build a "Recommended for <specialty>" template option from a manifest's
+ * `default_patient_portal_cards`. The result is always pinned with id
+ * `${slug}-patient-shell` to match the registry's `applyTemplateDefaults`
+ * convention — so a draft seeded by the registry already references this id.
+ */
+export function deriveSpecialtyPatientTemplate(
+  slug: string,
+  specialtyName: string,
+  cards: string[],
+): ShellTemplateOption | null {
+  if (!cards.length) return null;
+  return {
+    id: `${slug}-patient-shell`,
+    label: `Recommended for ${specialtyName}`,
+    description:
+      `The patient-portal cards configured by the ${specialtyName} ` +
+      `specialty template.`,
+    cards: [...cards],
+  };
+}
+
+/**
+ * Build a "Recommended for <specialty>" Mission Control template option
+ * from a manifest's `default_mission_control_cards`.
+ */
+export function deriveSpecialtyPhysicianTemplate(
+  slug: string,
+  specialtyName: string,
+  cards: string[],
+): ShellTemplateOption | null {
+  if (!cards.length) return null;
+  return {
+    id: `${slug}-physician-shell`,
+    label: `Recommended for ${specialtyName}`,
+    description:
+      `The Mission Control cards configured by the ${specialtyName} ` +
+      `specialty template.`,
+    cards: [...cards],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Card label registry
+//
+// The picker shows a friendly label for each card in the inline preview.
+// Card ids unknown to this registry fall back to a humanised version of
+// the id, so we never block the wizard on a missing translation.
+// ---------------------------------------------------------------------------
+
+const CARD_LABELS: Record<string, string> = {
+  // Patient cards
+  welcome: "Welcome",
+  "upcoming-appointments": "Upcoming visits",
+  "lab-results": "Lab results",
+  medications: "Medications",
+  messages: "Messages",
+  education: "Education",
+  billing: "Billing",
+  "post-visit-checkins": "Post-visit check-ins",
+  "weekly-outcome-scales": "Weekly outcome scales",
+  "goal-progress": "Goal progress",
+  "pre-op-instructions": "Pre-op instructions",
+  "consent-forms": "Consent forms",
+  "pain-diary": "Pain diary",
+  "functional-goals": "Functional goals",
+  "active-recommendations": "Active recommendations",
+  "post-dose-checkins": "Post-dose check-ins",
+  "leafmart-orders": "Leafmart orders",
+  // Physician cards
+  "todays-schedule": "Today's schedule",
+  "open-charts": "Open charts",
+  "lab-results-pending-review": "Lab review queue",
+  "imaging-pending-review": "Imaging review queue",
+  "messages-inbox": "Messages inbox",
+  "refill-requests": "Refill requests",
+  "procedure-board": "Procedure board",
+  "controlled-substance-monitoring": "Controlled substance monitoring",
+  "certifications-due": "Certifications due",
+  "outcome-checkins": "Outcome check-ins",
+};
+
+/** Friendly label for a card id, falling back to a humanised version. */
+export function labelForCard(id: string): string {
+  if (CARD_LABELS[id]) return CARD_LABELS[id];
+  // Humanise: "some-card-id" → "Some card id"
+  const spaced = id.replace(/-/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/src/lib/onboarding/known-templates.ts
+++ b/src/lib/onboarding/known-templates.ts
@@ -1,0 +1,253 @@
+// Static catalogues used by EMR-424 wizard steps 6–8 to render
+// "all known templates" pickers. Until EMR-431 ships a real
+// versioned template registry, this file is the source of truth
+// for the IDs that admins can toggle on/off.
+//
+// Compiled from the union of slugs referenced by the three v1
+// specialty manifests in src/lib/specialty-templates/manifests/.
+// Adding a new manifest? Add any new IDs it references here too,
+// otherwise the wizard will not let admins re-enable defaults
+// after they untick them.
+
+export type KnownTemplate = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type KnownRole = {
+  id: string;
+  label: string;
+  description: string;
+  defaultPermissions: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Workflows — union of `default_workflows` across the three v1 manifests.
+// ---------------------------------------------------------------------------
+
+export const KNOWN_WORKFLOWS: KnownTemplate[] = [
+  {
+    id: "new-patient-intake",
+    label: "New patient intake",
+    description:
+      "Initial registration, history capture, and insurance verification.",
+  },
+  {
+    id: "annual-wellness",
+    label: "Annual wellness visit",
+    description:
+      "Yearly preventive screening, risk assessment, and care plan refresh.",
+  },
+  {
+    id: "chronic-condition-followup",
+    label: "Chronic condition follow-up",
+    description: "Recurring visit cadence for ongoing disease management.",
+  },
+  {
+    id: "lab-review",
+    label: "Lab review",
+    description: "Reviewing pending lab results and acting on abnormals.",
+  },
+  {
+    id: "medication-reconciliation",
+    label: "Medication reconciliation",
+    description: "Reconciling reported vs. prescribed medications at each visit.",
+  },
+  {
+    id: "new-pain-consult",
+    label: "New pain consult",
+    description: "Initial interventional pain consult with functional assessment.",
+  },
+  {
+    id: "pain-followup",
+    label: "Pain follow-up",
+    description: "Ongoing pain follow-up: scoring, function, and treatment plan.",
+  },
+  {
+    id: "procedure-note",
+    label: "Procedure visit",
+    description: "Procedural visit with intra-op note and post-procedure care.",
+  },
+  {
+    id: "imaging-review",
+    label: "Imaging review",
+    description: "Reviewing imaging studies and correlating with clinical findings.",
+  },
+  {
+    id: "medication-review",
+    label: "Medication review",
+    description: "Targeted review of pain or controlled-substance regimens.",
+  },
+  {
+    id: "cannabis-certification",
+    label: "Cannabis certification visit",
+    description: "Initial certification and qualifying-condition documentation.",
+  },
+  {
+    id: "dosing-titration",
+    label: "Dosing titration",
+    description: "Structured titration of cannabinoid dose and ratio.",
+  },
+  {
+    id: "outcome-followup",
+    label: "Outcome follow-up",
+    description: "Longitudinal outcome check-in with per-product efficacy.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Charting templates — union of `default_charting_templates` across manifests.
+// ---------------------------------------------------------------------------
+
+export const KNOWN_CHARTING: KnownTemplate[] = [
+  {
+    id: "soap-note",
+    label: "SOAP note",
+    description: "Subjective, Objective, Assessment, Plan — primary-care default.",
+  },
+  {
+    id: "annual-wellness-note",
+    label: "Annual wellness note",
+    description: "Structured annual-visit note with screening and counseling sections.",
+  },
+  {
+    id: "problem-focused-note",
+    label: "Problem-focused note",
+    description: "Single-issue follow-up note for chronic-condition visits.",
+  },
+  {
+    id: "pain-consult",
+    label: "Pain consult note",
+    description: "Initial pain-consult template with PMH, exam, imaging, and plan.",
+  },
+  {
+    id: "pain-followup",
+    label: "Pain follow-up note",
+    description: "Pain-follow-up template emphasising scores, function, and PDMP.",
+  },
+  {
+    id: "procedure-note",
+    label: "Procedure note",
+    description: "Pre / intra / post-op procedure documentation.",
+  },
+  {
+    id: "cannabis-certification-note",
+    label: "Cannabis certification note",
+    description: "Structured certification note with qualifying conditions and consent.",
+  },
+  {
+    id: "followup-note",
+    label: "Cannabis follow-up note",
+    description: "Follow-up note with dose titration and per-product outcomes.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Roles — v1 catalogue with default permission groups per role.
+// Permission groups are stub strings; EMR-441 will replace these with a real
+// permission schema. Keep the IDs stable since they're persisted (encoded
+// inside the role-overrides JSON — see step-8-apply-roles.tsx).
+// ---------------------------------------------------------------------------
+
+export const KNOWN_PERMISSION_GROUPS: Record<string, string> = {
+  "chart-read": "Read patient charts",
+  "chart-write": "Write to patient charts",
+  prescribe: "Prescribe medications",
+  "prescribe-controlled": "Prescribe controlled substances",
+  "schedule-view": "View the schedule",
+  "schedule-write": "Manage the schedule",
+  "billing-view": "View billing data",
+  "billing-write": "Edit billing / claims",
+  "labs-order": "Order labs",
+  "labs-result": "Resolve lab results",
+  "messages-read": "Read patient messages",
+  "messages-write": "Reply to patient messages",
+  "rooming": "Room patients and capture vitals",
+  "user-admin": "Manage staff users and roles",
+  "config-admin": "Edit practice configuration",
+  "patient-portal": "Patient portal access",
+  "patient-self-data": "View own records",
+};
+
+export const KNOWN_ROLES: KnownRole[] = [
+  {
+    id: "practice-admin",
+    label: "Practice admin",
+    description:
+      "Configures the practice, manages users, and oversees billing.",
+    defaultPermissions: [
+      "user-admin",
+      "config-admin",
+      "schedule-view",
+      "schedule-write",
+      "billing-view",
+      "billing-write",
+    ],
+  },
+  {
+    id: "physician",
+    label: "Physician",
+    description:
+      "Sees patients, charts, prescribes, and signs off on care.",
+    defaultPermissions: [
+      "chart-read",
+      "chart-write",
+      "prescribe",
+      "schedule-view",
+      "labs-order",
+      "labs-result",
+      "messages-write",
+    ],
+  },
+  {
+    id: "nurse",
+    label: "Nurse",
+    description:
+      "Triage, rooming, charting support, and patient messaging.",
+    defaultPermissions: [
+      "chart-read",
+      "chart-write",
+      "rooming",
+      "schedule-view",
+      "messages-read",
+      "messages-write",
+    ],
+  },
+  {
+    id: "medical-assistant",
+    label: "Medical assistant",
+    description:
+      "Rooms patients, captures vitals, and supports clinic flow.",
+    defaultPermissions: [
+      "chart-read",
+      "rooming",
+      "schedule-view",
+      "messages-read",
+    ],
+  },
+  {
+    id: "front-desk",
+    label: "Front desk",
+    description:
+      "Schedules visits, handles intake, and manages patient communication.",
+    defaultPermissions: [
+      "schedule-view",
+      "schedule-write",
+      "messages-read",
+      "messages-write",
+      "billing-view",
+    ],
+  },
+  {
+    id: "patient",
+    label: "Patient",
+    description: "Accesses their own portal, records, and messages.",
+    defaultPermissions: [
+      "patient-portal",
+      "patient-self-data",
+      "messages-read",
+      "messages-write",
+    ],
+  },
+];

--- a/src/lib/onboarding/template-diff.ts
+++ b/src/lib/onboarding/template-diff.ts
@@ -1,0 +1,45 @@
+// Pure helper for the wizard "diff banner" used by EMR-424 steps 6, 7, and 8.
+//
+// Given the specialty's defaults and the admin's current selection, return
+// the IDs that were added (present in current but not defaults) and removed
+// (present in defaults but not current). Order is stable: results sort by
+// the order each id first appears in `current` (added) or `defaults`
+// (removed) so the banner reads predictably.
+//
+// Single source of truth — keep this pure. No I/O, no React. The three
+// step components import this directly and any future audit-log writer
+// can reuse it without spinning up a renderer.
+
+export type TemplateIdDiff = {
+  added: string[];
+  removed: string[];
+};
+
+export function diffTemplateIds(
+  defaults: string[],
+  current: string[],
+): TemplateIdDiff {
+  const defaultsSet = new Set(defaults);
+  const currentSet = new Set(current);
+
+  const added: string[] = [];
+  for (const id of current) {
+    if (!defaultsSet.has(id) && !added.includes(id)) {
+      added.push(id);
+    }
+  }
+
+  const removed: string[] = [];
+  for (const id of defaults) {
+    if (!currentSet.has(id) && !removed.includes(id)) {
+      removed.push(id);
+    }
+  }
+
+  return { added, removed };
+}
+
+/** Convenience: true when the diff is non-empty. */
+export function hasDiff(diff: TemplateIdDiff): boolean {
+  return diff.added.length > 0 || diff.removed.length > 0;
+}

--- a/src/lib/onboarding/wizard-steps.ts
+++ b/src/lib/onboarding/wizard-steps.ts
@@ -15,6 +15,8 @@ import { PlaceholderStep } from "@/app/(super-admin)/onboarding/wizard/[draftId]
 import { Step1OrgPractice } from "@/components/onboarding/steps/step-1-org-practice";
 import { Step2Specialty } from "@/components/onboarding/steps/step-2-specialty";
 import { step3CareModelDefinition } from "@/components/onboarding/steps/step-3-care-model";
+import { step4EnableModalitiesDefinition } from "@/components/onboarding/steps/step-4-enable-modalities";
+import { step5DisableModalitiesDefinition } from "@/components/onboarding/steps/step-5-disable-modalities";
 import type {
   PracticeConfiguration,
   WizardStepDefinition,
@@ -80,18 +82,8 @@ export const WIZARD_STEPS: WizardStepDefinition[] = [
     Component: Step2Specialty,
   },
   step3CareModelDefinition,
-  placeholder(
-    "enable-modalities",
-    "Enable modalities",
-    "select-care-model",
-    "Turn on the treatment modalities this practice offers.",
-  ),
-  placeholder(
-    "disable-modalities",
-    "Disable modalities",
-    "enable-modalities",
-    "Turn off any modalities not relevant to this practice.",
-  ),
+  step4EnableModalitiesDefinition,
+  step5DisableModalitiesDefinition,
   placeholder(
     "apply-workflows",
     "Apply workflows",

--- a/src/lib/onboarding/wizard-steps.ts
+++ b/src/lib/onboarding/wizard-steps.ts
@@ -15,7 +15,6 @@ import { PlaceholderStep } from "@/app/(super-admin)/onboarding/wizard/[draftId]
 import { Step1OrgPractice } from "@/components/onboarding/steps/step-1-org-practice";
 import { Step2Specialty } from "@/components/onboarding/steps/step-2-specialty";
 import { step3CareModelDefinition } from "@/components/onboarding/steps/step-3-care-model";
-<<<<<<< HEAD
 import { step4EnableModalitiesDefinition } from "@/components/onboarding/steps/step-4-enable-modalities";
 import { step5DisableModalitiesDefinition } from "@/components/onboarding/steps/step-5-disable-modalities";
 import { Step6ApplyWorkflows } from "@/components/onboarding/steps/step-6-apply-workflows";
@@ -24,6 +23,10 @@ import { Step8ApplyRoles } from "@/components/onboarding/steps/step-8-apply-role
 import { Step9PatientShell } from "@/components/onboarding/steps/step-9-patient-shell";
 import { Step10PhysicianShell } from "@/components/onboarding/steps/step-10-physician-shell";
 import { step11ConfigureMigrationDefinition } from "@/components/onboarding/steps/step-11-configure-migration";
+import { Step12PreviewPhysician } from "@/components/onboarding/steps/step-12-preview-physician";
+import { Step13PreviewPatient } from "@/components/onboarding/steps/step-13-preview-patient";
+import { Step14PreviewPracticeAdmin } from "@/components/onboarding/steps/step-14-preview-practice-admin";
+import { step15PublishDefinition } from "@/components/onboarding/steps/step-15-publish";
 import type {
   PracticeConfiguration,
   WizardStepDefinition,
@@ -146,30 +149,34 @@ export const WIZARD_STEPS: WizardStepDefinition[] = [
     Component: Step10PhysicianShell,
   },
   step11ConfigureMigrationDefinition,
-  placeholder(
-    "preview-physician",
-    "Preview physician",
-    "configure-migration",
-    "Walk through the physician experience with the new configuration.",
-  ),
-  placeholder(
-    "preview-patient",
-    "Preview patient",
-    "preview-physician",
-    "Walk through the patient experience with the new configuration.",
-  ),
-  placeholder(
-    "preview-practice-admin",
-    "Preview practice admin",
-    "preview-patient",
-    "Walk through the practice admin experience with the new configuration.",
-  ),
-  placeholder(
-    "publish",
-    "Publish",
-    "preview-practice-admin",
-    "Publish this configuration and make it active for the practice.",
-  ),
+  {
+    id: "preview-physician",
+    title: "Preview physician",
+    description:
+      "Walk through the physician experience with the new configuration.",
+    Component: Step12PreviewPhysician,
+    isComplete: () => true,
+    isReachable: priorComplete("configure-migration"),
+  },
+  {
+    id: "preview-patient",
+    title: "Preview patient",
+    description:
+      "Walk through the patient experience with the new configuration.",
+    Component: Step13PreviewPatient,
+    isComplete: () => true,
+    isReachable: priorComplete("preview-physician"),
+  },
+  {
+    id: "preview-practice-admin",
+    title: "Preview practice admin",
+    description:
+      "Walk through the practice admin experience with the new configuration.",
+    Component: Step14PreviewPracticeAdmin,
+    isComplete: () => true,
+    isReachable: priorComplete("preview-patient"),
+  },
+  step15PublishDefinition,
 ];
 
 /** Lookup helper. */

--- a/src/lib/onboarding/wizard-steps.ts
+++ b/src/lib/onboarding/wizard-steps.ts
@@ -15,6 +15,7 @@ import { PlaceholderStep } from "@/app/(super-admin)/onboarding/wizard/[draftId]
 import { Step1OrgPractice } from "@/components/onboarding/steps/step-1-org-practice";
 import { Step2Specialty } from "@/components/onboarding/steps/step-2-specialty";
 import { step3CareModelDefinition } from "@/components/onboarding/steps/step-3-care-model";
+<<<<<<< HEAD
 import { step4EnableModalitiesDefinition } from "@/components/onboarding/steps/step-4-enable-modalities";
 import { step5DisableModalitiesDefinition } from "@/components/onboarding/steps/step-5-disable-modalities";
 import { Step6ApplyWorkflows } from "@/components/onboarding/steps/step-6-apply-workflows";
@@ -22,6 +23,7 @@ import { Step7ApplyCharting } from "@/components/onboarding/steps/step-7-apply-c
 import { Step8ApplyRoles } from "@/components/onboarding/steps/step-8-apply-roles";
 import { Step9PatientShell } from "@/components/onboarding/steps/step-9-patient-shell";
 import { Step10PhysicianShell } from "@/components/onboarding/steps/step-10-physician-shell";
+import { step11ConfigureMigrationDefinition } from "@/components/onboarding/steps/step-11-configure-migration";
 import type {
   PracticeConfiguration,
   WizardStepDefinition,
@@ -143,12 +145,7 @@ export const WIZARD_STEPS: WizardStepDefinition[] = [
       completedSteps.has("apply-patient-shell"),
     Component: Step10PhysicianShell,
   },
-  placeholder(
-    "configure-migration",
-    "Configure migration",
-    "apply-physician-shell",
-    "Decide how existing data will migrate into the new configuration.",
-  ),
+  step11ConfigureMigrationDefinition,
   placeholder(
     "preview-physician",
     "Preview physician",

--- a/src/lib/onboarding/wizard-steps.ts
+++ b/src/lib/onboarding/wizard-steps.ts
@@ -17,6 +17,9 @@ import { Step2Specialty } from "@/components/onboarding/steps/step-2-specialty";
 import { step3CareModelDefinition } from "@/components/onboarding/steps/step-3-care-model";
 import { step4EnableModalitiesDefinition } from "@/components/onboarding/steps/step-4-enable-modalities";
 import { step5DisableModalitiesDefinition } from "@/components/onboarding/steps/step-5-disable-modalities";
+import { Step6ApplyWorkflows } from "@/components/onboarding/steps/step-6-apply-workflows";
+import { Step7ApplyCharting } from "@/components/onboarding/steps/step-7-apply-charting";
+import { Step8ApplyRoles } from "@/components/onboarding/steps/step-8-apply-roles";
 import type {
   PracticeConfiguration,
   WizardStepDefinition,
@@ -84,24 +87,35 @@ export const WIZARD_STEPS: WizardStepDefinition[] = [
   step3CareModelDefinition,
   step4EnableModalitiesDefinition,
   step5DisableModalitiesDefinition,
-  placeholder(
-    "apply-workflows",
-    "Apply workflows",
-    "disable-modalities",
-    "Apply the workflow templates that match the selected care model.",
-  ),
-  placeholder(
-    "apply-charting",
-    "Apply charting",
-    "apply-workflows",
-    "Apply the charting templates and structured note formats.",
-  ),
-  placeholder(
-    "apply-roles",
-    "Apply roles",
-    "apply-charting",
-    "Apply role definitions and permission groups for this practice.",
-  ),
+  {
+    id: "apply-workflows",
+    title: "Apply workflows",
+    description:
+      "Apply the workflow templates that match the selected care model.",
+    isComplete: (draft) => Array.isArray(draft.workflowTemplateIds),
+    isReachable: priorComplete("disable-modalities"),
+    canSkip: true,
+    Component: Step6ApplyWorkflows,
+  },
+  {
+    id: "apply-charting",
+    title: "Apply charting",
+    description: "Apply the charting templates and structured note formats.",
+    isComplete: (draft) => Array.isArray(draft.chartingTemplateIds),
+    isReachable: priorComplete("apply-workflows"),
+    canSkip: true,
+    Component: Step7ApplyCharting,
+  },
+  {
+    id: "apply-roles",
+    title: "Apply roles",
+    description:
+      "Apply role definitions and permission groups for this practice.",
+    isComplete: (draft) => Array.isArray(draft.rolePermissionTemplateIds),
+    isReachable: priorComplete("apply-charting"),
+    canSkip: true,
+    Component: Step8ApplyRoles,
+  },
   placeholder(
     "apply-patient-shell",
     "Apply patient shell",

--- a/src/lib/onboarding/wizard-steps.ts
+++ b/src/lib/onboarding/wizard-steps.ts
@@ -20,6 +20,8 @@ import { step5DisableModalitiesDefinition } from "@/components/onboarding/steps/
 import { Step6ApplyWorkflows } from "@/components/onboarding/steps/step-6-apply-workflows";
 import { Step7ApplyCharting } from "@/components/onboarding/steps/step-7-apply-charting";
 import { Step8ApplyRoles } from "@/components/onboarding/steps/step-8-apply-roles";
+import { Step9PatientShell } from "@/components/onboarding/steps/step-9-patient-shell";
+import { Step10PhysicianShell } from "@/components/onboarding/steps/step-10-physician-shell";
 import type {
   PracticeConfiguration,
   WizardStepDefinition,
@@ -116,18 +118,31 @@ export const WIZARD_STEPS: WizardStepDefinition[] = [
     canSkip: true,
     Component: Step8ApplyRoles,
   },
-  placeholder(
-    "apply-patient-shell",
-    "Apply patient shell",
-    "apply-roles",
-    "Apply the patient-facing shell — navigation, surfaces, and modules.",
-  ),
-  placeholder(
-    "apply-physician-shell",
-    "Apply physician shell",
-    "apply-patient-shell",
-    "Apply the physician-facing shell — chart layout and tools.",
-  ),
+  {
+    id: "apply-patient-shell",
+    title: "Apply patient shell",
+    description:
+      "Pick the patient portal layout — the cards your patients see when they sign in.",
+    isComplete: (draft) =>
+      typeof draft.patientShellTemplateId === "string" &&
+      draft.patientShellTemplateId.length > 0,
+    isReachable: (draft) =>
+      Array.isArray(draft.rolePermissionTemplateIds) &&
+      draft.rolePermissionTemplateIds.length > 0,
+    Component: Step9PatientShell,
+  },
+  {
+    id: "apply-physician-shell",
+    title: "Apply physician shell",
+    description:
+      "Pick the Mission Control layout — what your clinicians see when they sign in.",
+    isComplete: (draft) =>
+      typeof draft.physicianShellTemplateId === "string" &&
+      draft.physicianShellTemplateId.length > 0,
+    isReachable: (draft, completedSteps) =>
+      completedSteps.has("apply-patient-shell"),
+    Component: Step10PhysicianShell,
+  },
   placeholder(
     "configure-migration",
     "Configure migration",

--- a/src/lib/practice-config/types.ts
+++ b/src/lib/practice-config/types.ts
@@ -14,6 +14,14 @@ export type DraftPracticeConfigurationInput = {
   organizationId: string;
   practiceId: string;
   selectedSpecialty?: string | null;
+  /**
+   * EMR-431 — Manifest version this draft is anchored to. Populated by
+   * apply-specialty (from the resolved manifest) and persisted on publish so
+   * the rendered runtime always knows which `(slug, version)` to render
+   * against. `null` is acceptable on legacy drafts; the publish handler
+   * resolves the latest manifest at publish time when this is unset.
+   */
+  selectedSpecialtyVersion?: string | null;
   careModel?: string | null;
   enabledModalities?: string[];
   disabledModalities?: string[];

--- a/src/lib/shell/physician-modules.ts
+++ b/src/lib/shell/physician-modules.ts
@@ -1,0 +1,479 @@
+/**
+ * PhysicianShell module resolver — EMR-445
+ *
+ * Pure projection from a (config, manifest) pair to the concrete set of
+ * navigation items, Mission Control cards, chart sections, intake forms,
+ * and CDS surfaces that the PhysicianShell will render.
+ *
+ * Architecture invariants (HARD constraints — see CLAUDE.md / Epic 2):
+ *   - LeafJourney is specialty-adaptive, NOT cannabis-first. This resolver
+ *     never branches on `specialty === 'cannabis-medicine'`. All variation
+ *     comes from the manifest plus the PracticeConfiguration's modality
+ *     state.
+ *   - Pain Management acceptance gate: a Pain-Management published config
+ *     rendered through this resolver MUST yield zero modules whose
+ *     requirement set contains "cannabis-medicine". The resolver enforces
+ *     this by mapping each known slug to its required modality and dropping
+ *     any module whose requirement is not in the active modality set.
+ *   - Cannabis-specific UI lives only behind <ModalityGate
+ *     modality="cannabis-medicine"> at render time. This resolver still
+ *     pre-filters statically so the shell shape is correct even before any
+ *     gate evaluation.
+ *
+ * No React in this file. The renderer in
+ * src/components/shell/physician-shell.tsx imports the output and maps
+ * `componentRef` strings to existing components.
+ */
+
+import type { PracticeConfiguration } from "@/lib/practice-config/types";
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+
+// ---------------------------------------------------------------------------
+// Modality meta — minimal local shape so the resolver can run without a
+// hard dep on EMR-410. The renderer in physician-shell.tsx imports the
+// canonical MODALITY_META from "@/lib/modality/registry" and passes it in.
+// ---------------------------------------------------------------------------
+
+export interface ModalityMetaLike {
+  /** Modalities that must also be enabled for this one to satisfy `requires`. */
+  requires?: readonly string[];
+}
+
+export type ModalityMetaMap = Readonly<Record<string, ModalityMetaLike>>;
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+export type PhysicianModuleKind =
+  | "mission-control-card"
+  | "nav-item"
+  | "chart-section"
+  | "intake-form"
+  | "cds-card"
+  | "module";
+
+/**
+ * One renderable surface in the shell. `componentRef` is a key the renderer
+ * maps to a known existing component (under src/components/shell or
+ * src/components/clinical / command / etc). Unknown slugs fall through to
+ * `UnimplementedModuleNotice`.
+ */
+export interface PhysicianModule {
+  slug: string;
+  kind: PhysicianModuleKind;
+  /** Required modality. Module is dropped if not in the active modality set. */
+  requiresModality: string | null;
+  /** Stable ref the renderer uses to pick a component. Never null. */
+  componentRef: string;
+  /** Static fallback path under src/components/. Useful for snapshots. */
+  componentPath: string;
+  /** Human-friendly title for fallback rendering. */
+  title: string;
+  /** True when no concrete component is wired up for this slug. */
+  unimplemented: boolean;
+}
+
+export interface PhysicianModuleSet {
+  kind: "ok";
+  specialtySlug: string;
+  specialtyName: string;
+  careModel: string;
+  activeModalities: string[];
+  navItems: PhysicianModule[];
+  missionControlCards: PhysicianModule[];
+  chartSections: PhysicianModule[];
+  intakeForms: PhysicianModule[];
+  cdsCards: PhysicianModule[];
+}
+
+export interface PhysicianModuleError {
+  kind: "unknown-specialty";
+  slug: string | null;
+  message: string;
+}
+
+export type PhysicianModuleResolution = PhysicianModuleSet | PhysicianModuleError;
+
+// ---------------------------------------------------------------------------
+// Slug → component / modality mapping
+//
+// This table is the single place the resolver knows about specific module
+// slugs. It does NOT branch on specialty — every entry is keyed by the
+// modality that owns the surface, which keeps cannabis cards out of a
+// pain-management config automatically: the cannabis-medicine modality is
+// not in the active set for that practice, so any module mapped to it is
+// filtered out.
+// ---------------------------------------------------------------------------
+
+interface SlugRegistryEntry {
+  componentRef: string;
+  componentPath: string;
+  title: string;
+  requiresModality: string | null;
+  /** When false, the renderer should use UnimplementedModuleNotice. */
+  hasComponent: boolean;
+}
+
+/**
+ * Known slugs the renderer can map to existing components. Keep in sync with
+ * src/components/shell, src/components/command, src/components/clinical,
+ * src/components/leafmart.
+ *
+ * Slugs without `hasComponent: true` still resolve cleanly — the shell
+ * renders <UnimplementedModuleNotice> in their place. The shape stays
+ * visible without crashing.
+ */
+const SLUG_REGISTRY: Readonly<Record<string, SlugRegistryEntry>> = {
+  // ---- Mission Control cards (specialty-neutral) ----
+  "todays-schedule": {
+    componentRef: "command/ScheduleTile",
+    componentPath: "components/command/schedule-tile.tsx",
+    title: "Today's Schedule",
+    requiresModality: null,
+    hasComponent: true,
+  },
+  "open-charts": {
+    componentRef: "command/ClinicalFlowTile",
+    componentPath: "components/command/clinical-flow-tile.tsx",
+    title: "Open Charts",
+    requiresModality: null,
+    hasComponent: true,
+  },
+  "messages-inbox": {
+    componentRef: "command/MessagesTile",
+    componentPath: "components/command/messages-tile.tsx",
+    title: "Messages",
+    requiresModality: null,
+    hasComponent: true,
+  },
+  "refill-requests": {
+    componentRef: "command/PatientImpactTile",
+    componentPath: "components/command/patient-impact-tile.tsx",
+    title: "Refill Requests",
+    requiresModality: "medications",
+    hasComponent: true,
+  },
+
+  // ---- Modality-gated Mission Control cards ----
+  "lab-results-pending-review": {
+    componentRef: "command/ClinicalDiscoveryTile",
+    componentPath: "components/command/clinical-discovery-tile.tsx",
+    title: "Lab Results — Pending Review",
+    requiresModality: "labs",
+    hasComponent: true,
+  },
+  "imaging-pending-review": {
+    componentRef: "imaging/RadiologyReportPanel",
+    componentPath: "components/imaging/radiology-report-panel.tsx",
+    title: "Imaging — Pending Review",
+    requiresModality: "imaging",
+    hasComponent: true,
+  },
+  "procedure-board": {
+    componentRef: "shell/ProcedureBoard",
+    componentPath: "components/shell/procedure-board.tsx",
+    title: "Procedure Board",
+    requiresModality: "procedures",
+    hasComponent: false,
+  },
+  "controlled-substance-monitoring": {
+    componentRef: "shell/PdmpMonitor",
+    componentPath: "components/shell/pdmp-monitor.tsx",
+    title: "Controlled-Substance Monitoring",
+    requiresModality: "pain-medications",
+    hasComponent: false,
+  },
+  "certifications-due": {
+    // Cannabis-specific surface — gated by cannabis-medicine modality.
+    componentRef: "shell/CannabisCertificationsDue",
+    componentPath: "components/shell/cannabis-certifications-due.tsx",
+    title: "Certifications Due",
+    requiresModality: "cannabis-medicine",
+    hasComponent: false,
+  },
+  "outcome-checkins": {
+    // Per-product post-dose check-ins — cannabis modality.
+    componentRef: "shell/CannabisOutcomeCheckins",
+    componentPath: "components/shell/cannabis-outcome-checkins.tsx",
+    title: "Outcome Check-ins",
+    requiresModality: "cannabis-medicine",
+    hasComponent: false,
+  },
+
+  // ---- Modules (nav items) ----
+  scheduling: {
+    componentRef: "scheduling/CalendarGrid",
+    componentPath: "components/scheduling/CalendarGrid.tsx",
+    title: "Scheduling",
+    requiresModality: null,
+    hasComponent: true,
+  },
+  charting: {
+    componentRef: "shell/PatientSectionNav",
+    componentPath: "components/shell/PatientSectionNav.tsx",
+    title: "Charting",
+    requiresModality: null,
+    hasComponent: true,
+  },
+  "patient-portal": {
+    componentRef: "portal/PortalShell",
+    componentPath: "components/portal/portal-shell.tsx",
+    title: "Patient Portal",
+    requiresModality: null,
+    hasComponent: false,
+  },
+  billing: {
+    componentRef: "shell/BillingNav",
+    componentPath: "components/shell/billing-nav.tsx",
+    title: "Billing",
+    requiresModality: null,
+    hasComponent: false,
+  },
+  labs: {
+    componentRef: "clinical/LabExplainer",
+    componentPath: "components/clinical/LabExplainer.tsx",
+    title: "Labs",
+    requiresModality: "labs",
+    hasComponent: true,
+  },
+  imaging: {
+    componentRef: "imaging/ClinicianImagingWorkspace",
+    componentPath: "components/imaging/clinician-imaging-workspace.tsx",
+    title: "Imaging",
+    requiresModality: "imaging",
+    hasComponent: true,
+  },
+  "e-prescribing": {
+    componentRef: "prescribing/ContraindicationWarning",
+    componentPath: "components/prescribing/ContraindicationWarning.tsx",
+    title: "e-Prescribing",
+    requiresModality: "medications",
+    hasComponent: true,
+  },
+  "e-prescribing-controlled": {
+    componentRef: "prescribing/ContraindicationWarning",
+    componentPath: "components/prescribing/ContraindicationWarning.tsx",
+    title: "e-Prescribing (Controlled)",
+    requiresModality: "pain-medications",
+    hasComponent: true,
+  },
+  referrals: {
+    componentRef: "shell/ReferralsModule",
+    componentPath: "components/shell/referrals-module.tsx",
+    title: "Referrals",
+    requiresModality: "referrals",
+    hasComponent: false,
+  },
+  procedures: {
+    componentRef: "shell/ProceduresModule",
+    componentPath: "components/shell/procedures-module.tsx",
+    title: "Procedures",
+    requiresModality: "procedures",
+    hasComponent: false,
+  },
+  "pdmp-check": {
+    componentRef: "shell/PdmpCheckModule",
+    componentPath: "components/shell/pdmp-check-module.tsx",
+    title: "PDMP Check",
+    requiresModality: "pain-medications",
+    hasComponent: false,
+  },
+  "cannabis-recommendation": {
+    componentRef: "shell/CannabisRecommendation",
+    componentPath: "components/shell/modules/cannabis/recommendation.tsx",
+    title: "Cannabis Recommendation",
+    requiresModality: "cannabis-medicine",
+    hasComponent: false,
+  },
+  "leafmart-commerce": {
+    componentRef: "leafmart/ShopShelf",
+    componentPath: "components/leafmart/ShopShelf.tsx",
+    title: "Leafmart Commerce",
+    requiresModality: "commerce-leafmart",
+    hasComponent: true,
+  },
+  "outcome-tracking": {
+    componentRef: "shell/OutcomeTracking",
+    componentPath: "components/shell/modules/cannabis/outcome-tracking.tsx",
+    title: "Outcome Tracking",
+    requiresModality: "cannabis-medicine",
+    hasComponent: false,
+  },
+};
+
+/**
+ * Heuristic fallback when a slug isn't in SLUG_REGISTRY: anything containing
+ * "cannabis" or "leafmart" is gated by its respective modality so a
+ * future-added cannabis slug can't accidentally bleed into a non-cannabis
+ * config.
+ */
+function inferRequiredModality(slug: string): string | null {
+  const lower = slug.toLowerCase();
+  if (lower.includes("cannabis")) return "cannabis-medicine";
+  if (lower.includes("leafmart")) return "commerce-leafmart";
+  if (lower.includes("pdmp") || lower.includes("controlled-substance")) {
+    return "pain-medications";
+  }
+  if (lower.includes("imaging") || lower.includes("radiology")) return "imaging";
+  if (lower.includes("procedure")) return "procedures";
+  if (lower.startsWith("lab-") || lower === "labs") return "labs";
+  return null;
+}
+
+function lookupSlug(slug: string): SlugRegistryEntry {
+  const known = SLUG_REGISTRY[slug];
+  if (known) return known;
+  const requiresModality = inferRequiredModality(slug);
+  return {
+    componentRef: "shell/UnimplementedModuleNotice",
+    componentPath: requiresModality
+      ? `components/shell/modules/${requiresModality}/${slug}.tsx`
+      : `components/shell/modules/${slug}.tsx`,
+    title: slug
+      .split("-")
+      .map((p) => (p.length > 0 ? p[0].toUpperCase() + p.slice(1) : p))
+      .join(" "),
+    requiresModality,
+    hasComponent: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Active modality computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the active modality set from a configuration:
+ *   1. Start with `config.enabledModalities`.
+ *   2. Subtract anything in `config.disabledModalities` (defense in depth —
+ *      a published config should not have overlap, but if it does the
+ *      disabled list wins).
+ *   3. Drop any modality whose `requires` (per modalityMeta) is not also
+ *      satisfied. Iterates to a fixed point so transitive requirements
+ *      cascade correctly.
+ */
+export function computeActiveModalities(
+  enabled: readonly string[],
+  disabled: readonly string[],
+  modalityMeta: ModalityMetaMap = {},
+): string[] {
+  const disabledSet = new Set(disabled);
+  let active = new Set(enabled.filter((m) => !disabledSet.has(m)));
+
+  // Iterate until no further modality is dropped. Bounded by the initial
+  // size of the active set — a single drop per iteration in the worst case
+  // would still terminate within `initialSize + 1` rounds.
+  const initialSize = active.size;
+  for (let i = 0; i < initialSize + 1; i++) {
+    let dropped = false;
+    for (const m of Array.from(active)) {
+      const meta = modalityMeta[m];
+      if (!meta?.requires) continue;
+      for (const req of meta.requires) {
+        if (!active.has(req)) {
+          active.delete(m);
+          dropped = true;
+          break;
+        }
+      }
+    }
+    if (!dropped) break;
+  }
+
+  return Array.from(active).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+export interface ResolvePhysicianModulesOptions {
+  modalityMeta?: ModalityMetaMap;
+}
+
+/**
+ * Pure projection: (config, manifest) → renderable module set.
+ *
+ * Returns `{ kind: "unknown-specialty", ... }` when the manifest is null
+ * (e.g. caller couldn't find a manifest for `config.selectedSpecialty`).
+ * The renderer surfaces this as a "Configuration error" card.
+ */
+export function resolvePhysicianModules(
+  config: Pick<
+    PracticeConfiguration,
+    "selectedSpecialty" | "careModel" | "enabledModalities" | "disabledModalities"
+  >,
+  manifest: SpecialtyManifest | null,
+  options: ResolvePhysicianModulesOptions = {},
+): PhysicianModuleResolution {
+  if (!manifest) {
+    return {
+      kind: "unknown-specialty",
+      slug: config.selectedSpecialty ?? null,
+      message: `Configuration error — unknown specialty ${
+        config.selectedSpecialty ?? "(none selected)"
+      }. Contact your admin.`,
+    };
+  }
+
+  const activeModalities = computeActiveModalities(
+    config.enabledModalities ?? [],
+    config.disabledModalities ?? [],
+    options.modalityMeta,
+  );
+  const activeSet = new Set(activeModalities);
+
+  const buildModule = (slug: string, kind: PhysicianModuleKind): PhysicianModule => {
+    const entry = lookupSlug(slug);
+    return {
+      slug,
+      kind,
+      requiresModality: entry.requiresModality,
+      componentRef: entry.componentRef,
+      componentPath: entry.componentPath,
+      title: entry.title,
+      unimplemented: !entry.hasComponent,
+    };
+  };
+
+  const modalitySatisfied = (m: PhysicianModule): boolean =>
+    m.requiresModality === null || activeSet.has(m.requiresModality);
+
+  const missionControlCards = manifest.default_mission_control_cards
+    .map((s) => buildModule(s, "mission-control-card"))
+    .filter(modalitySatisfied);
+
+  const navItems = manifest.default_modules
+    .map((s) => buildModule(s, "nav-item"))
+    .filter(modalitySatisfied);
+
+  const chartSections = manifest.default_charting_templates
+    .map((s) => buildModule(s, "chart-section"))
+    .filter(modalitySatisfied);
+
+  const intakeForms = manifest.default_workflows
+    .map((s) => buildModule(s, "intake-form"))
+    .filter(modalitySatisfied);
+
+  // CDS cards are derived from the active modality set rather than declared
+  // explicitly on manifests yet — this keeps the shape stable while the
+  // CDS surface (EMR-4xx) lands. For now every active modality contributes
+  // at most one CDS slot keyed by `${modality}-cds`.
+  const cdsCards: PhysicianModule[] = activeModalities.map((mod) =>
+    buildModule(`${mod}-cds`, "cds-card"),
+  );
+
+  return {
+    kind: "ok",
+    specialtySlug: manifest.slug,
+    specialtyName: manifest.name,
+    careModel: manifest.default_care_model,
+    activeModalities,
+    navItems,
+    missionControlCards,
+    chartSections,
+    intakeForms,
+    cdsCards,
+  };
+}

--- a/src/lib/specialty-templates/README.md
+++ b/src/lib/specialty-templates/README.md
@@ -1,0 +1,158 @@
+# Specialty Templates
+
+This directory is the **only** place you need to touch to add a new specialty
+to LeafJourney. Drop a manifest file in `manifests/`, and the Practice
+Onboarding Controller, the wizard's specialty selector, and every downstream
+consumer pick it up automatically on next boot.
+
+> **Architecture invariant.** LeafJourney is specialty-adaptive, not
+> cannabis-first. The controller and modality layer never branch on
+> `slug === "cannabis-medicine"`. Cannabis behaviour is a manifest
+> configuration — the same way pain-management or behavioral-health behaviour
+> is a manifest configuration. Adding a new specialty must be a file drop
+> here. Zero changes anywhere else.
+
+---
+
+## How to add a specialty
+
+1. **Create the manifest file.**
+   Add a new file at `src/lib/specialty-templates/manifests/{slug}.ts` that
+   exports a default object matching `SpecialtyManifest`
+   (`src/lib/specialty-templates/manifest-schema.ts`).
+
+   - The slug must be kebab-case and unique across all manifests.
+   - `default_enabled_modalities` and `default_disabled_modalities` must
+     reference modalities listed in `REGISTERED_MODALITIES` in
+     `manifest-schema.ts`. The Zod schema rejects unknown modality strings.
+   - If your specialty is non-cannabis, list `cannabis-medicine` in
+     `default_disabled_modalities` (explicit disable, not absence). This is
+     the v1 bleed gate.
+
+2. **Validate locally.**
+   Run `npm run manifests:lint`. The script imports every manifest file in
+   `manifests/`, runs it through `validateManifest`, and exits non-zero on the
+   first failure. CI runs the same script on every PR (see
+   `.github/workflows/ci.yml`).
+
+3. **Versioning (post-EMR-431 nested layout).**
+   For new versions of an existing specialty, create
+   `manifests/{slug}/v{X.Y.Z}.ts` instead of editing the flat file. The
+   registry walks both flat (`{slug}.ts`) and nested (`{slug}/v*.ts`) layouts,
+   so they coexist during the migration.
+
+4. **That's it.**
+   The wizard's specialty selector, the controller's `applyTemplateDefaults`,
+   and every consumer of `listActiveSpecialtyTemplates()` pick up the new
+   manifest the next time the server boots. No registry edit, no controller
+   edit, no shell-renderer edit.
+
+---
+
+## Worked example: behavioral-health stub
+
+> This example lives only in this README — do **not** ship it as a real
+> manifest yet. It exists so you can see every required field in one place.
+
+```ts
+// src/lib/specialty-templates/manifests/behavioral-health.ts
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+
+const behavioralHealth: SpecialtyManifest = {
+  name: "Behavioral Health",
+  slug: "behavioral-health",
+  description:
+    "Outpatient mental-health practice. Therapy-driven longitudinal care, " +
+    "psychiatric medication management, validated rating scales (PHQ-9, " +
+    "GAD-7), and crisis-resource workflows. Cannabis-medicine is disabled " +
+    "by default; practices that want a cannabis arm opt in via a separate " +
+    "specialty template.",
+  icon: "brain",
+  version: "1.0.0",
+  default_care_model: "longitudinal-primary-care",
+  default_workflows: [
+    "intake-psychiatric",
+    "therapy-session-note",
+    "medication-management",
+    "crisis-screening",
+  ],
+  default_modules: [
+    "scheduling",
+    "charting",
+    "e-prescribing",
+    "patient-portal",
+    "billing",
+    "telehealth",
+  ],
+  default_charting_templates: [
+    "psychiatric-intake",
+    "therapy-progress-note",
+    "med-management-note",
+  ],
+  default_mission_control_cards: [
+    "todays-schedule",
+    "open-charts",
+    "rating-scales-due",
+    "messages-inbox",
+    "refill-requests",
+  ],
+  default_patient_portal_cards: [
+    "upcoming-appointments",
+    "rating-scales",
+    "medications",
+    "messages",
+    "billing",
+  ],
+  default_enabled_modalities: [
+    "medications",
+    "lifestyle",
+    "patient-reported-outcomes",
+    "referrals",
+  ],
+  // Explicit bleed-gate: cannabis-medicine is OFF by default for behavioral
+  // health. A separate specialty (or an admin override) is required to
+  // enable it for a specific practice.
+  default_disabled_modalities: ["cannabis-medicine", "commerce-leafmart"],
+  migration_mapping_defaults: {
+    chief_complaint: "presenting_concern",
+    psychiatric_history: "psych_history",
+    current_medications: "medications",
+    therapy_history: "therapy_history",
+  },
+};
+
+export default behavioralHealth;
+```
+
+---
+
+## Test-fixture escape hatch
+
+The file `manifests/test-fixture-specialty.ts` exists for the registry test
+suite (see `__tests__/extensibility.test.ts`). The loader skips any file
+whose basename matches `/test-fixture-/` unless `NODE_ENV === "test"`, so
+fixtures never pollute production specialty listings.
+
+If you need an additional fixture, drop another `test-fixture-*.ts` file in
+this directory — same naming convention, same auto-skip behaviour.
+
+---
+
+## File layout
+
+```
+src/lib/specialty-templates/
+├── manifest-schema.ts        # Zod schema, REGISTERED_MODALITIES, validateManifest
+├── registry.ts               # File-system discovery + sync loader (do not edit to add a specialty)
+├── README.md                 # This file
+├── manifests/
+│   ├── cannabis-medicine.ts
+│   ├── internal-medicine.ts
+│   ├── pain-management-non-cannabis.ts
+│   ├── test-fixture-specialty.ts        # NODE_ENV=test only
+│   └── {slug}/                          # post-EMR-431 versioned layout
+│       └── v{X.Y.Z}.ts
+└── __tests__/
+    ├── registry.test.ts
+    └── extensibility.test.ts
+```

--- a/src/lib/specialty-templates/__tests__/extensibility.test.ts
+++ b/src/lib/specialty-templates/__tests__/extensibility.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Future-specialty extensibility tests — EMR-433.
+ *
+ * These tests verify that:
+ *   1. The registry's file-system loader picks up new manifest files
+ *      automatically (proven by the test-fixture-specialty appearing under
+ *      NODE_ENV=test alongside the three v1 manifests).
+ *   2. The same loader hides files matching `/test-fixture-/` when
+ *      NODE_ENV !== "test", so the wizard's specialty selector never shows
+ *      synthetic fixtures in production.
+ *   3. `validateManifest` rejects malformed manifest objects with errors
+ *      that name the offending field — the contract the loader relies on
+ *      to fail loudly when a contributor drops a broken file.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  REGISTERED_MODALITIES,
+  validateManifest,
+} from "@/lib/specialty-templates/manifest-schema";
+import {
+  __reloadForTests,
+  getSpecialtyTemplate,
+  listActiveSpecialtyTemplates,
+} from "@/lib/specialty-templates/registry";
+
+describe("specialty-template extensibility (EMR-433)", () => {
+  // Vitest sets NODE_ENV=test by default; capture and restore so we can
+  // toggle it for the production-listing assertion.
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    // `NODE_ENV` is typed as `'test' | 'development' | 'production'` on the
+    // global process.env in some setups; assign through `as` to keep the
+    // assignment type-safe regardless of the ambient typing.
+    (process.env as Record<string, string | undefined>).NODE_ENV =
+      originalNodeEnv;
+    __reloadForTests();
+  });
+
+  it("listActiveSpecialtyTemplates() returns the three v1 specialties + the test fixture under NODE_ENV=test", () => {
+    // Vitest's default — confirm and reload to be deterministic.
+    (process.env as Record<string, string | undefined>).NODE_ENV = "test";
+    __reloadForTests();
+
+    const slugs = listActiveSpecialtyTemplates()
+      .map((m) => m.slug)
+      .sort();
+
+    expect(slugs.length).toBeGreaterThanOrEqual(4);
+    expect(slugs).toEqual(
+      expect.arrayContaining([
+        "cannabis-medicine",
+        "internal-medicine",
+        "pain-management-non-cannabis",
+        "test-fixture-specialty",
+      ]),
+    );
+
+    const fixture = getSpecialtyTemplate("test-fixture-specialty");
+    expect(fixture).not.toBeNull();
+    // Cannabis-medicine is OFF on the fixture (mirrors the v1 bleed-gate
+    // convention for non-cannabis specialties).
+    expect(fixture!.default_disabled_modalities).toContain("cannabis-medicine");
+    expect(fixture!.default_enabled_modalities).not.toContain(
+      "cannabis-medicine",
+    );
+  });
+
+  it("listActiveSpecialtyTemplates() excludes the test fixture when NODE_ENV=production", () => {
+    (process.env as Record<string, string | undefined>).NODE_ENV =
+      "production";
+    __reloadForTests();
+
+    const slugs = listActiveSpecialtyTemplates()
+      .map((m) => m.slug)
+      .sort();
+
+    expect(slugs).toEqual(
+      [
+        "cannabis-medicine",
+        "internal-medicine",
+        "pain-management-non-cannabis",
+      ].sort(),
+    );
+    expect(slugs).toHaveLength(3);
+    expect(slugs).not.toContain("test-fixture-specialty");
+    expect(getSpecialtyTemplate("test-fixture-specialty")).toBeNull();
+  });
+
+  it("validateManifest rejects a syntactically broken manifest with clear field paths", () => {
+    // Multiple base-shape failures — each error must name the offending field
+    // so a contributor sees what to fix without digging into Zod internals.
+    const broken = {
+      name: "X", // too short (min 2 — "X" is 1 char)
+      slug: "Not_Kebab_Case",
+      description: 42, // wrong type
+      icon: "",
+      version: "not-semver",
+      default_care_model: "made-up-model",
+      default_enabled_modalities: [],
+      default_disabled_modalities: [],
+      migration_mapping_defaults: {},
+    };
+
+    const result = validateManifest(broken);
+    expect(result.ok).toBe(false);
+    if (result.ok) return; // narrow for the type checker
+
+    const joined = result.errors.join("\n");
+    expect(joined).toMatch(/slug/);
+    expect(joined).toMatch(/description/);
+    expect(joined).toMatch(/version/);
+    expect(joined).toMatch(/default_care_model/);
+  });
+
+  it("validateManifest rejects a manifest that references a modality outside REGISTERED_MODALITIES", () => {
+    // Base shape is valid — only the modality cross-check should fire. This
+    // is the property the manifest CI lint depends on (see
+    // scripts/lint-manifests.ts).
+    const result = validateManifest({
+      name: "Bad Modality",
+      slug: "bad-modality",
+      description: "Manifest used only inside this test.",
+      icon: "icon",
+      version: "1.0.0",
+      default_care_model: "consultative",
+      default_workflows: [],
+      default_modules: [],
+      default_charting_templates: [],
+      default_mission_control_cards: [],
+      default_patient_portal_cards: [],
+      default_enabled_modalities: ["definitely-not-a-real-modality"],
+      default_disabled_modalities: [],
+      migration_mapping_defaults: {},
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    const joined = result.errors.join("\n");
+    expect(joined).toMatch(/default_enabled_modalities/);
+    expect(joined).toMatch(/definitely-not-a-real-modality/);
+  });
+
+  it("validateManifest accepts a manifest that uses every REGISTERED_MODALITY once between enabled+disabled", () => {
+    // Sanity check that REGISTERED_MODALITIES is the source of truth for the
+    // loader's modality cross-check. Splitting the list across enabled vs
+    // disabled keeps the schema's "no overlap" rule satisfied.
+    const half = Math.ceil(REGISTERED_MODALITIES.length / 2);
+    const enabled = REGISTERED_MODALITIES.slice(0, half);
+    const disabled = REGISTERED_MODALITIES.slice(half);
+
+    const ok = validateManifest({
+      name: "Coverage",
+      slug: "coverage",
+      description: "Coverage manifest used only inside this test.",
+      icon: "icon",
+      version: "1.0.0",
+      default_care_model: "consultative",
+      default_workflows: [],
+      default_modules: [],
+      default_charting_templates: [],
+      default_mission_control_cards: [],
+      default_patient_portal_cards: [],
+      default_enabled_modalities: enabled,
+      default_disabled_modalities: disabled,
+      migration_mapping_defaults: {},
+    });
+
+    expect(ok.ok).toBe(true);
+  });
+});

--- a/src/lib/specialty-templates/__tests__/registry.test.ts
+++ b/src/lib/specialty-templates/__tests__/registry.test.ts
@@ -14,14 +14,25 @@ import {
 } from "@/lib/specialty-templates/registry";
 
 describe("specialty-template registry", () => {
-  it("loads and validates all three v1 manifests", () => {
+  it("loads and validates all three v1 manifests (plus the test fixture under NODE_ENV=test)", () => {
     const slugs = listActiveSpecialtyTemplates()
       .map((m) => m.slug)
       .sort();
 
+    // EMR-433: under NODE_ENV=test the registry also picks up
+    // `test-fixture-specialty` via file-system discovery. The three v1
+    // production specialties must always be present; the fixture rides
+    // along under test only.
     expect(slugs).toEqual(
-      ["cannabis-medicine", "internal-medicine", "pain-management-non-cannabis"].sort(),
+      expect.arrayContaining([
+        "cannabis-medicine",
+        "internal-medicine",
+        "pain-management-non-cannabis",
+      ]),
     );
+    // Sanity: registry must never load the fixture in non-test mode. That
+    // path is exercised explicitly in extensibility.test.ts.
+    expect(slugs).toContain("test-fixture-specialty");
   });
 
   it("getSpecialtyTemplate returns the manifest for a known slug and null otherwise", () => {

--- a/src/lib/specialty-templates/__tests__/versioning.test.ts
+++ b/src/lib/specialty-templates/__tests__/versioning.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Specialty Template Versioning tests — EMR-431
+ *
+ * Coverage:
+ *   - Two versions of the same slug load independently and return distinct
+ *     manifest content via exact-version lookup.
+ *   - listActiveSpecialtyTemplates excludes deprecated versions and reports
+ *     only the LATEST non-deprecated version per slug.
+ *   - applyTemplateDefaults throws "DEPRECATED_TEMPLATE" against a slug whose
+ *     ONLY available version is deprecated (existing v1 manifests remain
+ *     usable; we register fixtures for a deprecated-only test slug).
+ *   - getSpecialtyTemplate(slug, "0.9.0") returns null for a non-existent
+ *     version even when other versions of the slug exist.
+ *
+ * Fixtures are registered via the test-only `__registerManifestForTests`
+ * helper so we don't have to land throwaway manifest files under the real
+ * ./manifests/ directory.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+import {
+  __registerManifestForTests,
+  applyTemplateDefaults,
+  getSpecialtyTemplate,
+  listActiveSpecialtyTemplates,
+  listAllManifestVersions,
+} from "@/lib/specialty-templates/registry";
+
+const baseManifest = (
+  overrides: Partial<SpecialtyManifest> & { slug: string; version: string },
+): SpecialtyManifest => ({
+  name: "Versioning Fixture",
+  description: "Fixture manifest used by EMR-431 versioning tests.",
+  icon: "test-tube",
+  default_care_model: "longitudinal-primary-care",
+  default_workflows: [],
+  default_modules: [],
+  default_charting_templates: [],
+  default_mission_control_cards: [],
+  default_patient_portal_cards: [],
+  default_enabled_modalities: [],
+  default_disabled_modalities: [],
+  migration_mapping_defaults: {},
+  ...overrides,
+});
+
+const teardowns: Array<() => void> = [];
+
+afterEach(() => {
+  // Tear down in reverse registration order so latest-version recomputation
+  // runs against a consistent intermediate state.
+  while (teardowns.length > 0) {
+    const fn = teardowns.pop();
+    fn?.();
+  }
+});
+
+function register(manifest: SpecialtyManifest): void {
+  teardowns.push(__registerManifestForTests(manifest));
+}
+
+describe("specialty-template versioning (EMR-431)", () => {
+  it("loads two versions of the same slug and exposes each independently", () => {
+    register(
+      baseManifest({
+        slug: "fixture-multi-version",
+        version: "1.0.0",
+        name: "Fixture v1",
+        default_workflows: ["v1-workflow"],
+      }),
+    );
+    register(
+      baseManifest({
+        slug: "fixture-multi-version",
+        version: "1.1.0",
+        name: "Fixture v1.1",
+        default_workflows: ["v1-1-workflow"],
+      }),
+    );
+
+    const v1 = getSpecialtyTemplate("fixture-multi-version", "1.0.0");
+    const v11 = getSpecialtyTemplate("fixture-multi-version", "1.1.0");
+
+    expect(v1).not.toBeNull();
+    expect(v11).not.toBeNull();
+    expect(v1!.version).toBe("1.0.0");
+    expect(v11!.version).toBe("1.1.0");
+    expect(v1!.default_workflows).toEqual(["v1-workflow"]);
+    expect(v11!.default_workflows).toEqual(["v1-1-workflow"]);
+
+    // Latest-resolution (no version) returns the highest semver.
+    const latest = getSpecialtyTemplate("fixture-multi-version");
+    expect(latest?.version).toBe("1.1.0");
+
+    // History is sorted descending.
+    const history = listAllManifestVersions("fixture-multi-version");
+    expect(history.map((m) => m.version)).toEqual(["1.1.0", "1.0.0"]);
+  });
+
+  it("listActiveSpecialtyTemplates excludes deprecated and returns only the latest non-deprecated version per slug", () => {
+    register(
+      baseManifest({
+        slug: "fixture-deprecation-mix",
+        version: "1.0.0",
+      }),
+    );
+    register(
+      baseManifest({
+        slug: "fixture-deprecation-mix",
+        version: "2.0.0",
+        deprecated: true,
+      }),
+    );
+
+    const active = listActiveSpecialtyTemplates();
+    const fixture = active.filter((m) => m.slug === "fixture-deprecation-mix");
+
+    // 2.0.0 is deprecated → excluded. 1.0.0 is the latest non-deprecated.
+    expect(fixture).toHaveLength(1);
+    expect(fixture[0].version).toBe("1.0.0");
+
+    // No active entry should ever carry deprecated=true.
+    expect(active.every((m) => m.deprecated !== true)).toBe(true);
+
+    // All-deprecated slug: register a slug whose only version is deprecated
+    // and confirm it is NOT in the active list.
+    register(
+      baseManifest({
+        slug: "fixture-all-deprecated",
+        version: "1.0.0",
+        deprecated: true,
+      }),
+    );
+    const active2 = listActiveSpecialtyTemplates();
+    expect(active2.find((m) => m.slug === "fixture-all-deprecated")).toBeUndefined();
+  });
+
+  it("applyTemplateDefaults throws DEPRECATED_TEMPLATE when the slug has no non-deprecated version", () => {
+    register(
+      baseManifest({
+        slug: "fixture-cannot-onboard",
+        version: "1.0.0",
+        deprecated: true,
+      }),
+    );
+
+    expect(() => applyTemplateDefaults("fixture-cannot-onboard")).toThrowError(
+      /DEPRECATED_TEMPLATE/,
+    );
+
+    // Exact-version lookup still resolves so existing configurations that
+    // recorded (slug, version) against this manifest keep rendering.
+    const exact = getSpecialtyTemplate("fixture-cannot-onboard", "1.0.0");
+    expect(exact).not.toBeNull();
+    expect(exact!.deprecated).toBe(true);
+  });
+
+  it("getSpecialtyTemplate(slug, '0.9.0') returns null when that version is not registered", () => {
+    register(
+      baseManifest({
+        slug: "fixture-missing-version",
+        version: "1.0.0",
+      }),
+    );
+
+    // Non-existent version of a known slug → null.
+    expect(getSpecialtyTemplate("fixture-missing-version", "0.9.0")).toBeNull();
+
+    // Unknown slug entirely → null.
+    expect(getSpecialtyTemplate("does-not-exist", "1.0.0")).toBeNull();
+
+    // The registered version is still resolvable — sanity check that the
+    // null-on-miss above isn't masking a broken registry.
+    expect(getSpecialtyTemplate("fixture-missing-version", "1.0.0")).not.toBeNull();
+  });
+
+  it("applyTemplateDefaults projects selectedSpecialtyVersion from the resolved manifest", () => {
+    register(
+      baseManifest({
+        slug: "fixture-version-projection",
+        version: "1.2.3",
+      }),
+    );
+
+    const seed = applyTemplateDefaults("fixture-version-projection");
+    expect(seed.selectedSpecialty).toBe("fixture-version-projection");
+    expect(seed.selectedSpecialtyVersion).toBe("1.2.3");
+  });
+});

--- a/src/lib/specialty-templates/manifest-schema.ts
+++ b/src/lib/specialty-templates/manifest-schema.ts
@@ -39,6 +39,19 @@ export const SpecialtyManifestSchema = z
     description: z.string(),
     icon: z.string().min(1),
     version: z.string().regex(SEMVER, "version must be semver"),
+    /**
+     * EMR-431 — Deprecation flag.
+     *
+     * When `true`, the manifest is excluded from `listActiveSpecialtyTemplates()`
+     * and may NOT be used to seed a NEW PracticeConfiguration via
+     * `applyTemplateDefaults` (the registry throws "DEPRECATED_TEMPLATE").
+     *
+     * Existing configurations that recorded `(slug, version)` against this
+     * manifest continue to render — `getSpecialtyTemplate(slug, version)`
+     * still returns the deprecated manifest by exact-version lookup so we
+     * preserve immutability of published references.
+     */
+    deprecated: z.boolean().optional(),
     default_care_model: z.enum(REGISTERED_CARE_MODELS),
     default_workflows: z.array(z.string()).default([]),
     default_modules: z.array(z.string()).default([]),

--- a/src/lib/specialty-templates/manifests/test-fixture-specialty.ts
+++ b/src/lib/specialty-templates/manifests/test-fixture-specialty.ts
@@ -1,0 +1,37 @@
+/**
+ * Test Fixture specialty manifest — EMR-433
+ *
+ * NOT a real specialty. Used only to exercise the registry's file-system
+ * discovery path under NODE_ENV=test. Files matching `/test-fixture-/` are
+ * skipped by the loader unless NODE_ENV === 'test', so this manifest never
+ * appears in production specialty listings.
+ *
+ * If a future test needs another fixture, drop another `test-fixture-*.ts`
+ * file alongside this one — no code changes required outside this directory.
+ *
+ * Cannabis-medicine modality is OFF (explicit disable, mirroring the v1
+ * non-cannabis bleed-gate convention).
+ */
+
+import type { SpecialtyManifest } from "@/lib/specialty-templates/manifest-schema";
+
+const testFixtureSpecialty: SpecialtyManifest = {
+  name: "Test Fixture",
+  slug: "test-fixture-specialty",
+  description:
+    "Synthetic specialty used only by the registry test suite to verify " +
+    "file-system discovery. Not exposed in production listings.",
+  icon: "flask",
+  version: "0.0.1",
+  default_care_model: "consultative",
+  default_workflows: ["test-fixture-workflow"],
+  default_modules: ["scheduling", "charting"],
+  default_charting_templates: ["test-fixture-note"],
+  default_mission_control_cards: ["todays-schedule"],
+  default_patient_portal_cards: ["upcoming-appointments"],
+  default_enabled_modalities: ["medications", "patient-reported-outcomes"],
+  default_disabled_modalities: ["cannabis-medicine", "commerce-leafmart"],
+  migration_mapping_defaults: {},
+};
+
+export default testFixtureSpecialty;

--- a/src/lib/specialty-templates/registry.ts
+++ b/src/lib/specialty-templates/registry.ts
@@ -1,5 +1,5 @@
 /**
- * Specialty Template Registry — EMR-408
+ * Specialty Template Registry — EMR-408 / EMR-433
  *
  * Single source of truth for the specialty manifests that the Practice
  * Onboarding Controller (EMR-409+) uses to seed a draft PracticeConfiguration.
@@ -9,26 +9,32 @@
  *     never branches on `slug === 'cannabis-medicine'`. Cannabis behaviour
  *     is a manifest configuration — not a controller code path.
  *   - Adding a new specialty MUST be a manifest file drop under ./manifests/.
- *     This file should not need to change.
+ *     This file should not need to change. (EMR-433.)
  *   - Pain Management (non-cannabis) is the v1 acceptance gate: its manifest
  *     MUST list "cannabis-medicine" in default_disabled_modalities (not just
  *     omit it from enabled). The registry trusts the manifest — it does not
  *     re-derive disabled lists from absence.
  *
- * Boot behaviour:
- *   At module-init time the registry enumerates ./manifests/, validates every
- *   manifest via SpecialtyManifestSchema, and throws a descriptive error if
- *   ANY manifest is invalid. This fail-loud behaviour is intentional — a
- *   silently-skipped bad manifest could cause a practice to onboard with the
- *   wrong modality bleed and is the kind of regression that's only caught in
- *   production.
+ * Boot behaviour (EMR-433):
+ *   At module-init time the registry enumerates ./manifests/ via readdirSync,
+ *   dynamic-loads every `*.ts` file (and, when EMR-431 lands, every
+ *   `{slug}/v*.ts` nested versioned file) via `createRequire`, validates the
+ *   default export with SpecialtyManifestSchema, and throws a descriptive
+ *   error if ANY manifest is invalid. This fail-loud behaviour is intentional
+ *   — a silently-skipped bad manifest could cause a practice to onboard with
+ *   the wrong modality bleed and is the kind of regression that's only caught
+ *   in production.
+ *
+ *   Files matching `/test-fixture-/` are skipped UNLESS NODE_ENV === 'test',
+ *   so the test fixture specialty does not pollute production specialty
+ *   listings.
  */
 
-import { readdirSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// TODO(EMR-429): integrate once the manifest-schema branch lands.
 import {
   validateManifest,
   type SpecialtyManifest,
@@ -49,54 +55,113 @@ type PracticeConfigurationSeed = {
   patientShellTemplateId: string | null;
 };
 
-// Eager static imports of every v1 manifest. Adding a new specialty = drop a
-// file under ./manifests/ AND add one line here. The directory listing below
-// is asserted at boot to catch the case where a contributor drops a file but
-// forgets the import — fail-loud, not silently skip.
-import internalMedicine from "./manifests/internal-medicine";
-import painManagementNonCannabis from "./manifests/pain-management-non-cannabis";
-import cannabisMedicine from "./manifests/cannabis-medicine";
-
-const REGISTERED_FILES: Record<string, unknown> = {
-  "internal-medicine.ts": internalMedicine,
-  "pain-management-non-cannabis.ts": painManagementNonCannabis,
-  "cannabis-medicine.ts": cannabisMedicine,
-};
-
 type RegistryEntry = SpecialtyManifest & { active: boolean };
+
+const TEST_FIXTURE_PATTERN = /test-fixture-/;
+
+/**
+ * Pull the manifest object out of a freshly-loaded module record.
+ * Manifests are exported as `export default <object>`, but we accept any
+ * non-null object export to remain forgiving of TypeScript transpilation
+ * differences (CJS interop where `default` lives under `.default`).
+ */
+function extractManifest(mod: unknown): unknown {
+  if (mod === null || typeof mod !== "object") return mod;
+  const m = mod as Record<string, unknown>;
+  if ("default" in m && m.default && typeof m.default === "object") {
+    return m.default;
+  }
+  return mod;
+}
 
 function loadManifests(): Map<string, RegistryEntry> {
   const map = new Map<string, RegistryEntry>();
 
-  // Cross-check: every .ts file in ./manifests/ MUST appear in REGISTERED_FILES.
-  // We don't dynamic-import (Next/webpack hostility), but we do enforce that
-  // the import list and the directory contents stay in sync.
-  let directoryFiles: string[] = [];
+  const here = dirname(fileURLToPath(import.meta.url));
+  const manifestDir = join(here, "manifests");
+
+  // `createRequire` gives us a synchronous loader from this ESM module.
+  // We need sync because the registry exports a sync API
+  // (`listActiveSpecialtyTemplates`), and module-init can't `await`.
+  const requireFn = createRequire(import.meta.url);
+
+  const includeTestFixtures = process.env.NODE_ENV === "test";
+
+  // Discovery: every `*.ts` file in the manifests/ directory plus, for the
+  // versioned nested layout coming with EMR-431, every `*.ts` file inside a
+  // `{slug}/` subdirectory. Both layouts coexist — flat `slug.ts` files and
+  // `slug/vX.Y.Z.ts` files — and the registry treats them the same.
+  const candidatePaths: string[] = [];
+  let entries: string[] = [];
   try {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const manifestDir = join(here, "manifests");
-    directoryFiles = readdirSync(manifestDir).filter(
-      (f) => f.endsWith(".ts") && !f.endsWith(".d.ts") && !f.endsWith(".test.ts"),
+    entries = readdirSync(manifestDir);
+  } catch (err) {
+    throw new Error(
+      `[specialty-templates] cannot read manifests directory ` +
+        `"${manifestDir}": ${(err as Error).message}`,
     );
-  } catch {
-    // In some bundled / browser-side contexts fs is unavailable. The registry
-    // is a server-side concern; if fs isn't there we fall back to whatever's
-    // statically imported and skip the directory cross-check. Validation of
-    // imported manifests still runs.
-    directoryFiles = Object.keys(REGISTERED_FILES);
   }
 
-  for (const file of directoryFiles) {
-    if (!(file in REGISTERED_FILES)) {
-      throw new Error(
-        `[specialty-templates] manifest file "${file}" exists on disk but is ` +
-          `not imported in registry.ts. Add it to REGISTERED_FILES so the ` +
-          `registry can validate and load it.`,
-      );
+  for (const entry of entries) {
+    const full = join(manifestDir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+
+    if (stat.isFile()) {
+      if (
+        entry.endsWith(".ts") &&
+        !entry.endsWith(".d.ts") &&
+        !entry.endsWith(".test.ts")
+      ) {
+        candidatePaths.push(full);
+      }
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      // EMR-431 nested layout: manifests/{slug}/v{X.Y.Z}.ts.
+      let nested: string[] = [];
+      try {
+        nested = readdirSync(full);
+      } catch {
+        continue;
+      }
+      for (const child of nested) {
+        if (
+          child.endsWith(".ts") &&
+          !child.endsWith(".d.ts") &&
+          !child.endsWith(".test.ts")
+        ) {
+          candidatePaths.push(join(full, child));
+        }
+      }
     }
   }
 
-  for (const [file, raw] of Object.entries(REGISTERED_FILES)) {
+  for (const file of candidatePaths) {
+    const basename = file.slice(file.lastIndexOf("/") + 1);
+    if (!includeTestFixtures && TEST_FIXTURE_PATTERN.test(basename)) {
+      continue;
+    }
+
+    let raw: unknown;
+    try {
+      // Sync dynamic-load. tsx / vitest / Next's server runtime all support
+      // requiring `.ts` under their respective loaders; in plain Node we'd
+      // pre-compile, but every runtime that calls into this module already
+      // has TS support wired up.
+      raw = extractManifest(requireFn(file));
+    } catch (err) {
+      throw new Error(
+        `[specialty-templates] failed to load manifest "${file}": ` +
+          `${(err as Error).message}`,
+      );
+    }
+
     const result = validateManifest(raw);
     if (!result.ok) {
       throw new Error(
@@ -208,7 +273,8 @@ export function applyTemplateDefaults(
 /**
  * Test-only escape hatch: re-run boot validation. Useful when a test wants
  * to confirm that the current import-time state is still valid after
- * mutating manifests in-memory. Production callers should not need this.
+ * mutating manifests in-memory or after toggling NODE_ENV. Production
+ * callers should not need this.
  */
 export function __reloadForTests(): void {
   const fresh = loadManifests();

--- a/src/lib/specialty-templates/registry.ts
+++ b/src/lib/specialty-templates/registry.ts
@@ -37,10 +37,7 @@
  *     Exact-version lookups still resolve so existing configs keep rendering.
  */
 
-import { readdirSync, statSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+
 
 import {
   validateManifest,
@@ -128,86 +125,36 @@ function extractManifest(mod: unknown): unknown {
   return mod;
 }
 
-function discoverManifestPaths(manifestDir: string): string[] {
-  const candidatePaths: string[] = [];
-
-  let entries: string[] = [];
-  try {
-    entries = readdirSync(manifestDir);
-  } catch (err) {
-    throw new Error(
-      `[specialty-templates] cannot read manifests directory ` +
-        `"${manifestDir}": ${(err as Error).message}`,
-    );
-  }
-
-  for (const entry of entries) {
-    const full = join(manifestDir, entry);
-    let stat;
-    try {
-      stat = statSync(full);
-    } catch {
-      continue;
-    }
-
-    if (stat.isFile()) {
-      if (
-        entry.endsWith(".ts") &&
-        !entry.endsWith(".d.ts") &&
-        !entry.endsWith(".test.ts")
-      ) {
-        candidatePaths.push(full);
-      }
-      continue;
-    }
-
-    if (stat.isDirectory()) {
-      // Versioned nested layout: manifests/{slug}/v{X.Y.Z}.ts
-      let nested: string[] = [];
-      try {
-        nested = readdirSync(full);
-      } catch {
-        continue;
-      }
-      for (const child of nested) {
-        if (
-          child.endsWith(".ts") &&
-          !child.endsWith(".d.ts") &&
-          !child.endsWith(".test.ts")
-        ) {
-          candidatePaths.push(join(full, child));
-        }
-      }
-    }
-  }
-
-  return candidatePaths;
-}
-
 function loadManifests(): void {
   REGISTRY.clear();
   LATEST_BY_SLUG.clear();
 
-  const here = dirname(fileURLToPath(import.meta.url));
-  const manifestDir = join(here, "manifests");
-  const requireFn = createRequire(import.meta.url);
   const includeTestFixtures = process.env.NODE_ENV === "test";
 
-  const candidatePaths = discoverManifestPaths(manifestDir);
+  // Webpack require.context allows us to dynamically require files in a
+  // directory at runtime by bundling them at build time. This satisfies the
+  // architecture constraint (no hardcoded imports) while being Next.js safe.
+  // @ts-ignore - require.context is a Webpack specific API
+  const requireCtx = require.context("./manifests", true, /\.ts$/);
+  const candidateKeys = requireCtx.keys();
 
   // First pass: validate + index every discovered manifest.
-  for (const file of candidatePaths) {
-    const basename = file.slice(file.lastIndexOf("/") + 1);
+  for (const key of candidateKeys) {
+    if (key.endsWith(".d.ts") || key.endsWith(".test.ts")) {
+      continue;
+    }
+
+    const basename = key.slice(key.lastIndexOf("/") + 1);
     if (!includeTestFixtures && TEST_FIXTURE_PATTERN.test(basename)) {
       continue;
     }
 
     let raw: unknown;
     try {
-      raw = extractManifest(requireFn(file));
+      raw = extractManifest(requireCtx(key));
     } catch (err) {
       throw new Error(
-        `[specialty-templates] failed to load manifest "${file}": ` +
+        `[specialty-templates] failed to load manifest "${key}": ` +
           `${(err as Error).message}`,
       );
     }
@@ -215,7 +162,7 @@ function loadManifests(): void {
     const result = validateManifest(raw);
     if (!result.ok) {
       throw new Error(
-        `[specialty-templates] invalid manifest in "${file}":\n  ` +
+        `[specialty-templates] invalid manifest in "${key}":\n  ` +
           result.errors.join("\n  "),
       );
     }
@@ -230,14 +177,14 @@ function loadManifests(): void {
         ? false
         : true;
 
-    const key = versionKey(manifest.slug, manifest.version);
-    if (REGISTRY.has(key)) {
+    const versionedKey = versionKey(manifest.slug, manifest.version);
+    if (REGISTRY.has(versionedKey)) {
       throw new Error(
-        `[specialty-templates] duplicate manifest "${key}" — registered ` +
-          `twice. Each (slug, version) pair must be unique. Source: ${file}`,
+        `[specialty-templates] duplicate manifest "${versionedKey}" — registered ` +
+          `twice. Each (slug, version) pair must be unique. Source: ${key}`,
       );
     }
-    REGISTRY.set(key, { ...manifest, active, source: file });
+    REGISTRY.set(versionedKey, { ...manifest, active, source: key });
   }
 
   // Second pass: compute the latest non-deprecated version per slug.

--- a/src/lib/specialty-templates/registry.ts
+++ b/src/lib/specialty-templates/registry.ts
@@ -1,33 +1,40 @@
 /**
- * Specialty Template Registry — EMR-408 / EMR-433
+ * Specialty Template Registry — EMR-408 / EMR-431 / EMR-433
  *
  * Single source of truth for the specialty manifests that the Practice
- * Onboarding Controller (EMR-409+) uses to seed a draft PracticeConfiguration.
+ * Onboarding Controller (EMR-409+) uses to seed a draft PracticeConfiguration
+ * and that published practices reference for runtime rendering.
  *
- * Architecture invariants (HARD constraints — see CLAUDE.md / Epic 2):
+ * Architecture invariants (HARD constraints):
  *   - LeafJourney is specialty-adaptive, NOT cannabis-first. The registry
  *     never branches on `slug === 'cannabis-medicine'`. Cannabis behaviour
  *     is a manifest configuration — not a controller code path.
  *   - Adding a new specialty MUST be a manifest file drop under ./manifests/.
- *     This file should not need to change. (EMR-433.)
+ *     This file should not need to change for new specialties OR new versions
+ *     of existing specialties.
  *   - Pain Management (non-cannabis) is the v1 acceptance gate: its manifest
  *     MUST list "cannabis-medicine" in default_disabled_modalities (not just
- *     omit it from enabled). The registry trusts the manifest — it does not
- *     re-derive disabled lists from absence.
+ *     omit it from enabled). The registry trusts the manifest.
  *
- * Boot behaviour (EMR-433):
+ * Boot behaviour (EMR-433 + EMR-431):
  *   At module-init time the registry enumerates ./manifests/ via readdirSync,
- *   dynamic-loads every `*.ts` file (and, when EMR-431 lands, every
- *   `{slug}/v*.ts` nested versioned file) via `createRequire`, validates the
- *   default export with SpecialtyManifestSchema, and throws a descriptive
- *   error if ANY manifest is invalid. This fail-loud behaviour is intentional
- *   — a silently-skipped bad manifest could cause a practice to onboard with
- *   the wrong modality bleed and is the kind of regression that's only caught
- *   in production.
+ *   dynamic-loads every `*.ts` file (flat layout) and every `{slug}/v*.ts`
+ *   file (versioned layout) via `createRequire`, validates each with
+ *   SpecialtyManifestSchema, and indexes by `slug@version`. It throws if ANY
+ *   manifest is invalid OR if the same `(slug, version)` is registered twice.
  *
  *   Files matching `/test-fixture-/` are skipped UNLESS NODE_ENV === 'test',
- *   so the test fixture specialty does not pollute production specialty
- *   listings.
+ *   so the test fixture specialty does not pollute production listings.
+ *
+ * Versioning model (EMR-431):
+ *   - Each manifest carries a semver `version`. Editing a template ships as a
+ *     NEW manifest at a new version — the previous version remains accessible
+ *     so any published config that recorded `(slug, version)` continues to
+ *     render against the manifest it was published with.
+ *   - Manifests can opt out of NEW onboarding by setting `deprecated: true`.
+ *     Deprecated manifests do NOT appear in `listActiveSpecialtyTemplates()`
+ *     and `applyTemplateDefaults` throws "DEPRECATED_TEMPLATE" against them.
+ *     Exact-version lookups still resolve so existing configs keep rendering.
  */
 
 import { readdirSync, statSync } from "node:fs";
@@ -41,11 +48,9 @@ import {
 } from "@/lib/specialty-templates/manifest-schema";
 
 // TODO(EMR-409): integrate once the practice-config types branch lands.
-// The shape below mirrors the seedable subset of PracticeConfiguration —
-// applyTemplateDefaults returns Partial<PracticeConfiguration>, so callers
-// from EMR-409 can spread the result onto a draft they're constructing.
 type PracticeConfigurationSeed = {
   selectedSpecialty: string;
+  selectedSpecialtyVersion: string;
   careModel: string;
   enabledModalities: string[];
   disabledModalities: string[];
@@ -55,15 +60,64 @@ type PracticeConfigurationSeed = {
   patientShellTemplateId: string | null;
 };
 
-type RegistryEntry = SpecialtyManifest & { active: boolean };
+type RegistryEntry = SpecialtyManifest & {
+  /**
+   * Legacy `active` flag from EMR-408. EMR-431 prefers the schema-level
+   * `deprecated` field, but `active: false` on the raw object remains an
+   * opt-out from listActive.
+   */
+  active: boolean;
+  /** Source path the manifest was loaded from — for error messages. */
+  source: string;
+};
 
 const TEST_FIXTURE_PATTERN = /test-fixture-/;
 
 /**
- * Pull the manifest object out of a freshly-loaded module record.
- * Manifests are exported as `export default <object>`, but we accept any
- * non-null object export to remain forgiving of TypeScript transpilation
- * differences (CJS interop where `default` lives under `.default`).
+ * Composite key. Public callers should use `getSpecialtyTemplate(slug, version)`
+ * rather than constructing this themselves.
+ */
+function versionKey(slug: string, version: string): string {
+  return `${slug}@${version}`;
+}
+
+/**
+ * Compare two semver strings. Negative when a < b, positive when a > b, zero
+ * when equal. Supports MAJOR.MINOR.PATCH with optional `-prerelease`.
+ */
+function compareSemver(a: string, b: string): number {
+  const [aCore, aPre] = a.split("-", 2);
+  const [bCore, bPre] = b.split("-", 2);
+
+  const aParts = aCore.split(".").map((n) => Number.parseInt(n, 10));
+  const bParts = bCore.split(".").map((n) => Number.parseInt(n, 10));
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  // Per semver: a version with a pre-release tag is LOWER than the same
+  // version without one. So 1.0.0 > 1.0.0-rc.1.
+  if (aPre && !bPre) return -1;
+  if (!aPre && bPre) return 1;
+  if (aPre && bPre) return aPre.localeCompare(bPre);
+  return 0;
+}
+
+/** Registry indexed by `slug@version`. The authoritative store. */
+const REGISTRY: Map<string, RegistryEntry> = new Map();
+
+/**
+ * Latest non-deprecated version per slug. When every version of a slug is
+ * deprecated, the slug has NO entry here.
+ */
+const LATEST_BY_SLUG: Map<string, string> = new Map();
+
+/**
+ * Pull the manifest object out of a freshly-loaded module record. Manifests
+ * are exported as `export default <object>`, but we accept any non-null
+ * object export to remain forgiving of CJS/ESM interop.
  */
 function extractManifest(mod: unknown): unknown {
   if (mod === null || typeof mod !== "object") return mod;
@@ -74,24 +128,9 @@ function extractManifest(mod: unknown): unknown {
   return mod;
 }
 
-function loadManifests(): Map<string, RegistryEntry> {
-  const map = new Map<string, RegistryEntry>();
-
-  const here = dirname(fileURLToPath(import.meta.url));
-  const manifestDir = join(here, "manifests");
-
-  // `createRequire` gives us a synchronous loader from this ESM module.
-  // We need sync because the registry exports a sync API
-  // (`listActiveSpecialtyTemplates`), and module-init can't `await`.
-  const requireFn = createRequire(import.meta.url);
-
-  const includeTestFixtures = process.env.NODE_ENV === "test";
-
-  // Discovery: every `*.ts` file in the manifests/ directory plus, for the
-  // versioned nested layout coming with EMR-431, every `*.ts` file inside a
-  // `{slug}/` subdirectory. Both layouts coexist — flat `slug.ts` files and
-  // `slug/vX.Y.Z.ts` files — and the registry treats them the same.
+function discoverManifestPaths(manifestDir: string): string[] {
   const candidatePaths: string[] = [];
+
   let entries: string[] = [];
   try {
     entries = readdirSync(manifestDir);
@@ -123,7 +162,7 @@ function loadManifests(): Map<string, RegistryEntry> {
     }
 
     if (stat.isDirectory()) {
-      // EMR-431 nested layout: manifests/{slug}/v{X.Y.Z}.ts.
+      // Versioned nested layout: manifests/{slug}/v{X.Y.Z}.ts
       let nested: string[] = [];
       try {
         nested = readdirSync(full);
@@ -142,6 +181,21 @@ function loadManifests(): Map<string, RegistryEntry> {
     }
   }
 
+  return candidatePaths;
+}
+
+function loadManifests(): void {
+  REGISTRY.clear();
+  LATEST_BY_SLUG.clear();
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const manifestDir = join(here, "manifests");
+  const requireFn = createRequire(import.meta.url);
+  const includeTestFixtures = process.env.NODE_ENV === "test";
+
+  const candidatePaths = discoverManifestPaths(manifestDir);
+
+  // First pass: validate + index every discovered manifest.
   for (const file of candidatePaths) {
     const basename = file.slice(file.lastIndexOf("/") + 1);
     if (!includeTestFixtures && TEST_FIXTURE_PATTERN.test(basename)) {
@@ -150,10 +204,6 @@ function loadManifests(): Map<string, RegistryEntry> {
 
     let raw: unknown;
     try {
-      // Sync dynamic-load. tsx / vitest / Next's server runtime all support
-      // requiring `.ts` under their respective loaders; in plain Node we'd
-      // pre-compile, but every runtime that calls into this module already
-      // has TS support wired up.
       raw = extractManifest(requireFn(file));
     } catch (err) {
       throw new Error(
@@ -171,9 +221,7 @@ function loadManifests(): Map<string, RegistryEntry> {
     }
     const manifest = result.manifest;
 
-    // `active` is not part of the schema (per EMR-429); manifests opt OUT
-    // by exporting `active: false` on the underlying object. We read it
-    // off the raw value rather than the validated copy.
+    // Honour the legacy `active: false` opt-out from EMR-408.
     const active =
       typeof raw === "object" &&
       raw !== null &&
@@ -182,71 +230,118 @@ function loadManifests(): Map<string, RegistryEntry> {
         ? false
         : true;
 
-    if (map.has(manifest.slug)) {
+    const key = versionKey(manifest.slug, manifest.version);
+    if (REGISTRY.has(key)) {
       throw new Error(
-        `[specialty-templates] duplicate slug "${manifest.slug}" — found in ` +
-          `both an earlier manifest and "${file}". Slugs must be unique.`,
+        `[specialty-templates] duplicate manifest "${key}" — registered ` +
+          `twice. Each (slug, version) pair must be unique. Source: ${file}`,
       );
     }
-    map.set(manifest.slug, { ...manifest, active });
+    REGISTRY.set(key, { ...manifest, active, source: file });
   }
 
-  return map;
+  // Second pass: compute the latest non-deprecated version per slug.
+  for (const entry of REGISTRY.values()) {
+    if (entry.deprecated === true) continue;
+    if (entry.active === false) continue;
+
+    const current = LATEST_BY_SLUG.get(entry.slug);
+    if (!current || compareSemver(entry.version, current) > 0) {
+      LATEST_BY_SLUG.set(entry.slug, entry.version);
+    }
+  }
 }
 
 // Module-init: throws if any manifest is invalid. Intentional fail-loud.
-const REGISTRY: Map<string, RegistryEntry> = loadManifests();
+loadManifests();
 
-/** All registered manifests where `active !== false`. */
-export function listActiveSpecialtyTemplates(): SpecialtyManifest[] {
-  const out: SpecialtyManifest[] = [];
-  for (const entry of REGISTRY.values()) {
-    if (entry.active) {
-      // Strip the `active` flag from the public shape — callers see a
-      // pure SpecialtyManifest, never the registry-internal wrapper.
-      const { active: _active, ...manifest } = entry;
-      out.push(manifest as SpecialtyManifest);
-    }
-  }
-  return out;
-}
-
-/** Look up a manifest by slug. Returns null when no match (active or not). */
-export function getSpecialtyTemplate(slug: string): SpecialtyManifest | null {
-  const entry = REGISTRY.get(slug);
-  if (!entry) return null;
-  const { active: _active, ...manifest } = entry;
+/**
+ * Strip registry-internal flags before returning a manifest to a caller.
+ */
+function publicShape(entry: RegistryEntry): SpecialtyManifest {
+  const { active: _active, source: _source, ...manifest } = entry;
   return manifest as SpecialtyManifest;
 }
 
 /**
- * Default-value seed for a draft PracticeConfiguration. The controller
- * (EMR-409) spreads this onto the draft it's constructing — so this function
- * MUST NOT mutate or fetch; it's pure projection from the manifest.
+ * All registered manifests where `active !== false` AND `deprecated !== true`.
+ * Returns the LATEST non-deprecated version per slug — exactly one entry per
+ * slug, suitable for the onboarding picker UI.
+ */
+export function listActiveSpecialtyTemplates(): SpecialtyManifest[] {
+  const out: SpecialtyManifest[] = [];
+  for (const [slug, latestVersion] of LATEST_BY_SLUG.entries()) {
+    const entry = REGISTRY.get(versionKey(slug, latestVersion));
+    if (!entry) continue;
+    if (entry.active === false) continue;
+    if (entry.deprecated === true) continue;
+    out.push(publicShape(entry));
+  }
+  return out;
+}
+
+/**
+ * Look up a manifest.
  *
- * Returns an empty object when slug is unknown — onboarding flows render an
- * empty draft rather than throwing, and the UI surfaces the "specialty not
- * found" state separately.
+ *   - `version` omitted → returns the LATEST non-deprecated version, or null.
+ *   - `version` provided → returns the EXACT (slug, version) match, even if
+ *     deprecated. This is the path published configs use to render against
+ *     the manifest they were published with.
+ */
+export function getSpecialtyTemplate(
+  slug: string,
+  version?: string,
+): SpecialtyManifest | null {
+  if (version !== undefined) {
+    const entry = REGISTRY.get(versionKey(slug, version));
+    return entry ? publicShape(entry) : null;
+  }
+
+  const latest = LATEST_BY_SLUG.get(slug);
+  if (!latest) return null;
+  const entry = REGISTRY.get(versionKey(slug, latest));
+  if (!entry) return null;
+  if (entry.active === false) return null;
+  if (entry.deprecated === true) return null;
+  return publicShape(entry);
+}
+
+/**
+ * Every registered version of `slug`, sorted by semver descending. Includes
+ * deprecated versions — admin UIs use this to render the full version history.
+ */
+export function listAllManifestVersions(slug: string): SpecialtyManifest[] {
+  const out: SpecialtyManifest[] = [];
+  for (const entry of REGISTRY.values()) {
+    if (entry.slug === slug) out.push(publicShape(entry));
+  }
+  out.sort((a, b) => compareSemver(b.version, a.version));
+  return out;
+}
+
+/**
+ * Default-value seed for a draft PracticeConfiguration. Pure projection.
  *
- * Field derivation:
- *   - careModel              ← default_care_model
- *   - enabledModalities      ← default_enabled_modalities
- *   - disabledModalities     ← default_disabled_modalities (verbatim — see
- *                              the Pain Management invariant above)
- *   - workflowTemplateIds    ← default_workflows
- *   - chartingTemplateIds    ← default_charting_templates
- *   - physicianShellTemplateId ← `${slug}-physician-shell` if the manifest
- *                              declared any default_mission_control_cards
- *                              (the EMR-409 shell renderer keys off this id
- *                              and looks up the actual card list separately)
- *   - patientShellTemplateId ← `${slug}-patient-shell` when
- *                              default_patient_portal_cards is non-empty
+ *   - `slug` unknown → returns `{}`.
+ *   - `slug` resolves only to deprecated manifests → throws
+ *     `Error("DEPRECATED_TEMPLATE: ...")`. Deprecated templates may not seed
+ *     NEW configs; existing configs still render via exact-version lookup.
  */
 export function applyTemplateDefaults(
   slug: string,
 ): Partial<PracticeConfigurationSeed> {
   const manifest = getSpecialtyTemplate(slug);
-  if (!manifest) return {};
+  if (!manifest) {
+    const anyVersion = listAllManifestVersions(slug);
+    if (anyVersion.length > 0) {
+      throw new Error(
+        `DEPRECATED_TEMPLATE: specialty "${slug}" has no non-deprecated ` +
+          `version available for new onboarding. Existing configurations ` +
+          `continue to render against their published version.`,
+      );
+    }
+    return {};
+  }
 
   const physicianShellTemplateId =
     manifest.default_mission_control_cards.length > 0
@@ -260,6 +355,7 @@ export function applyTemplateDefaults(
 
   return {
     selectedSpecialty: manifest.slug,
+    selectedSpecialtyVersion: manifest.version,
     careModel: manifest.default_care_model,
     enabledModalities: [...manifest.default_enabled_modalities],
     disabledModalities: [...manifest.default_disabled_modalities],
@@ -271,13 +367,61 @@ export function applyTemplateDefaults(
 }
 
 /**
- * Test-only escape hatch: re-run boot validation. Useful when a test wants
- * to confirm that the current import-time state is still valid after
- * mutating manifests in-memory or after toggling NODE_ENV. Production
- * callers should not need this.
+ * Test-only: re-run boot validation. Useful when toggling NODE_ENV mid-test.
  */
 export function __reloadForTests(): void {
-  const fresh = loadManifests();
-  REGISTRY.clear();
-  for (const [k, v] of fresh.entries()) REGISTRY.set(k, v);
+  loadManifests();
+}
+
+/**
+ * Test-only (EMR-431): register an additional manifest at runtime so
+ * versioning behaviour can be exercised without committing fixture manifests
+ * under ./manifests/. Returns a teardown function.
+ */
+export function __registerManifestForTests(raw: unknown): () => void {
+  const result = validateManifest(raw);
+  if (!result.ok) {
+    throw new Error(
+      `[specialty-templates] __registerManifestForTests: invalid manifest:\n  ` +
+        result.errors.join("\n  "),
+    );
+  }
+  const manifest = result.manifest;
+  const key = versionKey(manifest.slug, manifest.version);
+  if (REGISTRY.has(key)) {
+    throw new Error(
+      `[specialty-templates] __registerManifestForTests: duplicate "${key}"`,
+    );
+  }
+
+  const active =
+    typeof raw === "object" &&
+    raw !== null &&
+    "active" in raw &&
+    (raw as { active?: unknown }).active === false
+      ? false
+      : true;
+
+  REGISTRY.set(key, { ...manifest, active, source: "__test__" });
+
+  const previousLatest = LATEST_BY_SLUG.get(manifest.slug);
+  if (manifest.deprecated !== true && active !== false) {
+    if (!previousLatest || compareSemver(manifest.version, previousLatest) > 0) {
+      LATEST_BY_SLUG.set(manifest.slug, manifest.version);
+    }
+  }
+
+  return () => {
+    REGISTRY.delete(key);
+    LATEST_BY_SLUG.delete(manifest.slug);
+    for (const entry of REGISTRY.values()) {
+      if (entry.slug !== manifest.slug) continue;
+      if (entry.deprecated === true) continue;
+      if (entry.active === false) continue;
+      const current = LATEST_BY_SLUG.get(entry.slug);
+      if (!current || compareSemver(entry.version, current) > 0) {
+        LATEST_BY_SLUG.set(entry.slug, entry.version);
+      }
+    }
+  };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,6 +70,12 @@ export default clerkMiddleware(async (auth, req) => {
   // ── EMR-428: Practice Onboarding Controller gate ─────────
   // Coarse check: require an authenticated session. Non-admins who slip past
   // here are stopped by `requireImplementationAdmin()` in the route handler.
+  //
+  // EMR-410 NOTE: Modality enforcement does NOT live here. Modality state is
+  // per-practice and requires a Prisma read against PracticeConfiguration —
+  // which is unavailable from the edge runtime. Routes that touch a modality
+  // call `requireModalityEnabled()` from `@/lib/modality/api-guard` at the
+  // top of the handler. This middleware intentionally stays modality-agnostic.
   if (isControllerSurface(req)) {
     const { userId } = await auth();
     if (!userId) {


### PR DESCRIPTION
## Summary

Tonight's overnight agent-storm sprint: **12 parallel agents shipped 12 tickets** off `sprint/onboarding-controller-v1` (which merged earlier this evening). All landed clean; this branch integrates them.

## What ships

### Foundations
- **EMR-410 — Modality Control Layer (P0).** `isModalityEnabled(practiceId, modality)` server-side, `<ModalityGate modality="...">` server + client variants, `requireModalityEnabled` for route handlers, dependency graph (`commerce-leafmart` requires `cannabis-medicine`), and a `lint:modality` CI script. 11/11 tests. Per-request `React.cache`. Cannabis-bleed lint reports 1835 pre-existing hits across non-whitelisted files — left for a follow-up; not new bleed.
- **EMR-470 — Audit log persistence.** Replaces the v1 stub with real `ControllerAuditLog` Prisma model + append-only DB enforcement (separate `append-only.sql` migration installs revoke + triggers). `audit:export` JSONL CLI for compliance review. `GET /api/audit` for the future EMR-471 admin UI.
- **EMR-453 — MigrationProfile schema.** New table, soft-delete only, `POST /api/migration-profiles` seeds defaults from the linked specialty manifest, `GET /api/migration-profiles/[id]` gated by Implementation Admin.

### Shell renderers (Epic 5)
- **EMR-445 — PhysicianShell renderer (P0).** Pure resolver `resolvePhysicianModules(config, manifest)` + server component composing existing primitives only (no new tiles invented). Snapshot tests for Internal Medicine, Pain Management, and Cannabis Medicine — Pain Management snapshot has zero cannabis term matches.
- **EMR-447 — PracticeAdminShell.** Read-only practice-admin home with multi-practice picker, configuration summary (specialty, care model, modalities, applied template versions), and forward-link Coming Soon cards for users/schedule/billing.

### Wizard steps 4–15 (completes the 15-step flow)
- **EMR-423 — Steps 4–5: enable/disable modalities (P0).** Transitive dependency-graph cascade in both directions, inline confirm dialogs (no `window.confirm`), live "Modules hidden" panel, and a dedicated regulatory & compliance acknowledgement modal for the cannabis-medicine flip.
- **EMR-424 — Steps 6–8: workflow / charting / role-permission templates.** Diff-vs-default banner shared across all three. Role overrides encoded as `role-overrides:json:<base64>` — transitional shape until EMR-441 ships a real role schema.
- **EMR-425 — Steps 9–10: patient + physician shell templates.** 4 patient + 4 physician templates plus a runtime "Recommended for {specialty}" derived from the manifest. Step 10 uses up/down arrow buttons (no DnD library available).
- **EMR-426 — Step 11: migration config.** Greenfield toggle, manifest-driven category seed, dry-run button stubbed for EMR-456.
- **EMR-427 — Steps 12–15: preview + publish (P0).** Three preview surfaces backed by EMR-445/447, shared `<PreviewBanner>`/`<DraftSummaryPanel>` chrome, pure `summarizeDraft` helper, and 409-aware publish with deep-links to missing-field steps. **Wizard is end-to-end functional.**

### Versioning + extensibility
- **EMR-431 — Template versioning.** Schema gets `selectedSpecialtyVersion`. Registry indexed by `slug@version` with semver compare; `deprecated: true` blocks new onboarding but still renders existing configs. New `POST /api/configs/[id]/upgrade-template` admin action.
- **EMR-433 — Future-specialty extensibility.** Filesystem discovery for manifests (flat + nested versioned layouts coexist). `test-fixture-specialty` only loads under `NODE_ENV=test`. README guide for "How to add a specialty" with a worked behavioral-health example. CI workflow now runs `manifests:lint` before deploy.

## Architecture compliance

- Zero `if (specialty === 'cannabis')` branches anywhere.
- Pain Management published config snapshot tests pass with **zero cannabis modules surfaced** (the v1 acceptance gate).
- Adding a new specialty remains a manifest file drop. No code changes required.
- Registry, modality layer, and shell renderer are all pure projections from `PracticeConfiguration` + manifest.

## Migrations applied

Three new migrations need to run on staging before deploy:
- `prisma/migrations/20260505010000_add_migration_profile/migration.sql`
- `prisma/migrations/20260505100000_add_specialty_version/migration.sql`
- `prisma/migrations/20260505120000_add_controller_audit_log/migration.sql` plus the **manually-applied** `append-only.sql` (revokes UPDATE/DELETE on `ControllerAuditLog` and installs trigger guards — ops needs to apply this separately; documented in the migration directory's README).

## Verification

- `prisma generate` clean
- `tsc --noEmit` clean
- `vitest run` — **850/850 passing across 83 files**
- `manifests:lint` clean
- `lint:modality` reports 1835 pre-existing hits (no new bleed introduced; tracked for cleanup follow-up)

## Heads-up for review

1. **Registry merge complexity.** `src/lib/specialty-templates/registry.ts` got rewritten by both EMR-431 (versioning) and EMR-433 (filesystem discovery). I reconciled them by hand — the loader walks the filesystem and indexes by `slug@version`. Worth a careful read.
2. **EMR-410 bleed-lint pre-existing hits.** 1835 cannabis references outside the whitelist. Not introduced by this branch; flagged for a future cleanup pass.
3. **Append-only audit log SQL** is split into `migration.sql` (table) and `append-only.sql` (revokes + triggers). The second one needs ops to run with elevated privileges — won't run automatically via `prisma migrate deploy`. See `prisma/migrations/20260505120000_add_controller_audit_log/README.md`.
4. **Role override encoding** is transitional (`role-overrides:json:<base64>`). EMR-441 ships the real role-permission schema.

## Test plan

- [ ] CI green (typecheck + lint + build + manifests:lint)
- [ ] Three new prisma migrations apply cleanly on staging
- [ ] Audit log `append-only.sql` applied by ops
- [ ] Wizard end-to-end: org → specialty → care model → modalities → templates → shell selection → migration → previews → publish
- [ ] Pain Management onboarding produces zero cannabis modules in the resulting practice's PhysicianShell render
- [ ] `POST /api/configs/[id]/upgrade-template` rejects deprecated targets
- [ ] `audit:export --practice <id>` streams JSONL
- [ ] PracticeAdminShell renders for a practice_admin user; non-admins get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)