### PR TITLE
chore: low-effort batch 1 (EMR-372, EMR-86, EMR-291)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
 
 const FOUNDERS = [
   {
-    name: "Dr. Neal H. Patel",
+    name: "Dr. Neal H. Patel, D.O.",
     title: "Co-Founder & CEO",
     bio: "Physician, innovator, and cannabis medicine pioneer. Dr. Patel combines decades of clinical experience with a fearless vision for patient-centered care. A true shaman of modern medicine — blending evidence-based practice with deep compassion for every patient's journey.",
     initials: "NP",
@@ -82,7 +82,7 @@ export default function AboutPage() {
       {/* Founders */}
       <section className="max-w-[1280px] mx-auto px-6 lg:px-12 pb-20">
         <div className="max-w-2xl mb-14">
-          <Eyebrow className="mb-4">The team</Eyebrow>
+          <Eyebrow className="mb-4">Meet our team</Eyebrow>
           <h2 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.1]">
             Built by people who live this every day.
           </h2>
@@ -291,7 +291,7 @@ const EXECS: {
   {
     role: "CEO",
     title: "Chief Executive Officer",
-    name: "Dr. Neal H. Patel",
+    name: "Dr. Neal H. Patel, D.O.",
     initials: "NP",
     filled: true,
     focus: "Clinical vision, partnerships, and patient-centered strategy.",

--- a/src/app/about/team/page.tsx
+++ b/src/app/about/team/page.tsx
@@ -27,7 +27,7 @@ const EXECS: Executive[] = [
   {
     role: "CEO",
     title: "Chief Executive Officer",
-    name: "Dr. Neal H. Patel",
+    name: "Dr. Neal H. Patel, D.O.",
     initials: "NP",
     filled: true,
     bio: "Physician, innovator, and cannabis medicine pioneer. Decades of clinical experience, a fearless vision for patient-centered care, and the founding voice behind Leafjourney's clinical strategy.",

--- a/src/app/leafmart/checkout/page.tsx
+++ b/src/app/leafmart/checkout/page.tsx
@@ -524,13 +524,20 @@ export default function CheckoutPage() {
           <ul className="divide-y divide-[var(--border)]">
             {confirmedSnapshot.items.map(({ product, quantity }) => (
               <li key={product.slug} className="py-4 flex items-center gap-4">
-                <div className="w-14 h-14 rounded-xl flex-shrink-0 overflow-hidden">
+                <Link
+                  href={`/leafmart/products/${product.slug}`}
+                  aria-label={`View ${product.name}`}
+                  className="w-14 h-14 rounded-xl flex-shrink-0 overflow-hidden focus:outline-none focus:ring-2 focus:ring-[var(--leaf)]"
+                >
                   <ProductSilhouette shape={product.shape} bg={product.bg} deep={product.deep} height={56} />
-                </div>
+                </Link>
                 <div className="flex-1 min-w-0">
-                  <p className="font-display text-[15px] font-medium text-[var(--ink)] truncate">
+                  <Link
+                    href={`/leafmart/products/${product.slug}`}
+                    className="font-display text-[15px] font-medium text-[var(--ink)] truncate block hover:text-[var(--leaf)] transition-colors"
+                  >
                     {product.name}
-                  </p>
+                  </Link>
                   <p className="text-[12px] text-[var(--muted)]">
                     {product.dose} · Qty {quantity}
                   </p>
@@ -933,16 +940,23 @@ export default function CheckoutPage() {
           <ul className="divide-y divide-[var(--border)] mb-5">
             {items.map(({ product, quantity }) => (
               <li key={product.slug} className="py-3 flex items-center gap-3">
-                <div className="w-12 h-12 rounded-xl flex-shrink-0 overflow-hidden relative">
+                <Link
+                  href={`/leafmart/products/${product.slug}`}
+                  aria-label={`View ${product.name}`}
+                  className="w-12 h-12 rounded-xl flex-shrink-0 overflow-hidden relative block focus:outline-none focus:ring-2 focus:ring-[var(--leaf)]"
+                >
                   <ProductSilhouette shape={product.shape} bg={product.bg} deep={product.deep} height={48} />
                   <span className="absolute -top-1.5 -right-1.5 bg-[var(--ink)] text-[var(--bg)] text-[10px] font-semibold rounded-full w-5 h-5 flex items-center justify-center tabular-nums">
                     {quantity}
                   </span>
-                </div>
+                </Link>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13.5px] font-medium text-[var(--ink)] truncate leading-tight">
+                  <Link
+                    href={`/leafmart/products/${product.slug}`}
+                    className="text-[13.5px] font-medium text-[var(--ink)] truncate leading-tight block hover:text-[var(--leaf)] transition-colors"
+                  >
                     {product.name}
-                  </p>
+                  </Link>
                   <p className="text-[11.5px] text-[var(--muted)] mt-0.5">{product.dose}</p>
                 </div>
                 <span className="text-[13px] font-medium text-[var(--ink)] tabular-nums">

--- a/src/components/lifestyle/MindfulnessTracker.tsx
+++ b/src/components/lifestyle/MindfulnessTracker.tsx
@@ -21,6 +21,13 @@ export const MINDFULNESS_PRACTICES = [
     nudge: "Three slow breaths count.",
   },
   {
+    id: "silence",
+    emoji: "\u{1F92B}",
+    label: "Silence",
+    minDuration: "2 min",
+    nudge: "Two minutes of quiet — phone face-down.",
+  },
+  {
     id: "gratitude",
     emoji: "\u{1F64F}",
     label: "Gratitude",
@@ -33,6 +40,13 @@ export const MINDFULNESS_PRACTICES = [
     label: "Journaling",
     minDuration: "1 line",
     nudge: "What did today feel like in one sentence?",
+  },
+  {
+    id: "sunlight",
+    emoji: "\u{2600}\u{FE0F}",
+    label: "Sunlight",
+    minDuration: "5 min",
+    nudge: "Step outside, look at something further than your screen.",
   },
   {
     id: "breathing",


### PR DESCRIPTION
## Summary

Three small wins from the backlog, plus two that were already done and two that turned out not to be low-effort.

- **EMR-372** — Cart line-item images now link to the PDP on the two checkout surfaces (post-purchase confirmation, in-checkout sidebar). The CartDrawer and `/leafmart/cart` already had it; this just makes the click target consistent everywhere a cart line item appears. Cart state is preserved by the persistent cart store.
- **EMR-86** — Added `silence` + `sunlight` to `MINDFULNESS_PRACTICES`. Meditation and journaling were already there, so all four categories named in the ticket are now present.
- **EMR-291** — About page: "The team" → "Meet our team" eyebrow; "Dr. Neal H. Patel" → "Dr. Neal H. Patel, D.O." on `/about` and `/about/team`. Mission Statement section already existed. Kept Wayman's title as Chief Product & Technology Officer rather than the ticket's older "CIO/CTO" phrasing — assumed CPTO is the current intentional title.

## Already done — closed without code

- **EMR-373** (cannabis shop outcome page emoji row) — `SentimentRow` with 😞/😐/😊 mapped to ratings 2/3/5 was already shipped at `src/app/leafmart/account/outcomes/page.tsx:16-23`.

## Not actually low-effort — left open

- **EMR-70** (warmer Vitals wording → "Your numbers") — no patient-facing Vitals section exists in the portal; the only "Vitals" code is `EmotionalVitals` for clinical APSO notes. Would need to build a new patient page from scratch.
- **EMR-80** (verify iOS portrait nav across pages) — pure manual QA. The portrait infrastructure exists (`MobileNav`, `MobilePortraitNav`, `PatientSectionNav` has an explicit EMR-117 fix) but a code review can't replace a sweep on actual iOS Safari.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Visit `/leafmart/cart`, add items, navigate to checkout — click line-item image and product name in the sidebar; should route to the PDP. Browser back retains the cart.
- [ ] Complete a checkout (demo data) — on the confirmation page, click line-item image / name; should route to the PDP.
- [ ] If the `MindfulnessTracker` is wired into a route, verify the new silence (🤫) and sunlight (☀️) tiles appear; toggle and confirm streak math is unchanged.
- [ ] Visit `/about` — eyebrow reads "Meet our team", Patel card shows "Dr. Neal H. Patel, D.O.". Same on `/about/team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)