### PR TITLE
feat(shell): unify Owner + Clinician nav with icon-rail pillars

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -102,21 +102,30 @@ export default async function ClinicianLayout({
     {
       label: "Today",
       pillar: "today",
+      icon: "clipboard-check",
       items: [
-        { label: "Today", href: "/clinic" },
+        { label: "Overview", href: "/clinic" },
         { label: "Command Center", href: "/clinic/command" },
         { label: "Schedule", href: "/clinic/schedule" },
         { label: "Telehealth", href: "/telehealth" },
-        { label: "Roster", href: "/clinic/patients" },
-        { label: "Inbox", href: "/clinic/messages" },
       ],
     },
     {
-      label: "Review",
+      label: "Patients",
+      pillar: "patients",
+      icon: "users",
       items: [
+        { label: "Roster", href: "/clinic/patients" },
+      ],
+    },
+    {
+      label: "Inbox",
+      pillar: "inbox",
+      icon: "inbox",
+      items: [
+        { label: "Messages", href: "/clinic/messages" },
         // EMR-165: unified sign-off queue rolls up labs + refills +
-        // notes + messages. Pinned to the top of the Review section so
-        // a doctor can clear the day's signatures from one place.
+        // notes + messages — clinician's single place to clear the day.
         { label: "Sign-off", href: "/clinic/sign-off" },
         {
           label: "Approvals",
@@ -140,21 +149,23 @@ export default async function ClinicianLayout({
     },
     {
       label: "Reference",
+      pillar: "reference",
+      icon: "book-open",
       items: [
         { label: "Providers", href: "/clinic/providers" },
         { label: "Research", href: "/clinic/research" },
         { label: "Library", href: "/clinic/library" },
         { label: "Communications", href: "/clinic/communications" },
       ],
-      defaultCollapsed: true,
     },
     {
       label: "Admin",
+      pillar: "admin",
+      icon: "settings",
       items: [
         { label: "Audit", href: "/clinic/audit-trail" },
         { label: "Brief", href: "/clinic/morning-brief" },
       ],
-      defaultCollapsed: true,
     },
   ];
 
@@ -171,6 +182,7 @@ export default async function ClinicianLayout({
       activeRole="clinician"
       sections={sections}
       roleLabel="Provider"
+      showNavPrefs={false}
     >
       <QuoteWelcomeModal userName={user.firstName} />
       <BreathingBreak />

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -125,6 +125,7 @@ export default async function OperatorLayout({
     {
       label: "Overview",
       pillar: "overview",
+      icon: "home",
       items: [
         { label: "Overview", href: "/ops" },
         { label: "Mission Control", href: "/ops/mission-control" },
@@ -135,22 +136,25 @@ export default async function OperatorLayout({
     },
     {
       label: "Billing",
+      pillar: "billing",
+      icon: "dollar",
       items: [
-        { label: "Billing", href: "/ops/billing" },
+        { label: "Overview", href: "/ops/billing" },
         { label: "Scrub", href: "/ops/scrub" },
         { label: "Denials", href: "/ops/denials", badge: denialsBadge },
         { label: "Aging", href: "/ops/aging", badge: agingBadge },
-        { label: "Agents", href: "/ops/billing-agents" },
-        { label: "Revenue", href: "/ops/revenue" },
         { label: "Eligibility", href: "/ops/eligibility" },
         { label: "Mail / Fax OCR", href: "/ops/mail-fax" },
+        { label: "Agents", href: "/ops/billing-agents" },
+        { label: "Revenue", href: "/ops/revenue" },
       ],
     },
     {
-      label: "Office of the CFO",
+      label: "Finance",
       pillar: "cfo",
+      icon: "chart",
       items: [
-        { label: "CFO overview", href: "/ops/cfo" },
+        { label: "Overview", href: "/ops/cfo" },
         { label: "P&L", href: "/ops/cfo/pnl" },
         { label: "Cash flow", href: "/ops/cfo/cash-flow" },
         { label: "Balance sheet", href: "/ops/cfo/balance-sheet" },
@@ -165,6 +169,8 @@ export default async function OperatorLayout({
     },
     {
       label: "Operations",
+      pillar: "operations",
+      icon: "building",
       items: [
         { label: "Staff schedule", href: "/ops/staff-schedule" },
         { label: "Time clock", href: "/ops/time-clock" },
@@ -177,33 +183,36 @@ export default async function OperatorLayout({
         { label: "Marketing", href: "/ops/marketing" },
         { label: "Announcements", href: "/ops/announcements" },
       ],
-      defaultCollapsed: true,
     },
     {
-      label: "Practice Setup",
+      label: "Insights",
+      pillar: "insights",
+      icon: "layout-grid",
+      items: [
+        { label: "Analytics", href: "/ops/analytics" },
+        { label: "Analytics Lab", href: "/ops/analytics-lab" },
+        { label: "Population", href: "/ops/population" },
+      ],
+    },
+    {
+      label: "Setup",
+      pillar: "setup",
+      icon: "clipboard-check",
       items: [
         { label: "Onboarding", href: "/ops/onboarding" },
         { label: "Practice launch", href: "/ops/launch" },
         { label: "Intake Builder", href: "/ops/intake-builder" },
         { label: "Export", href: "/ops/export" },
       ],
-      defaultCollapsed: true,
-    },
-    {
-      label: "Intelligence",
-      items: [
-        { label: "Analytics", href: "/ops/analytics" },
-        { label: "Analytics Lab", href: "/ops/analytics-lab" },
-        { label: "Population", href: "/ops/population" },
-      ],
-      defaultCollapsed: true,
     },
     {
       label: "Platform",
+      pillar: "platform",
+      icon: "server",
       items: [
         { label: "Modules", href: "/ops/platform/modules" },
-        { label: "Licensing menu", href: "/ops/platform/licensing" },
-        { label: "Pricing comparator", href: "/ops/platform/pricing" },
+        { label: "Licensing", href: "/ops/platform/licensing" },
+        { label: "Pricing", href: "/ops/platform/pricing" },
         { label: "Business plan", href: "/ops/platform/business-plan" },
         { label: "FHIR bridge", href: "/ops/platform/fhir-bridge" },
         { label: "MIPS console", href: "/ops/platform/mips" },
@@ -211,10 +220,11 @@ export default async function OperatorLayout({
         { label: "FDA Rx + Cannabis", href: "/ops/platform/fda-rx" },
         { label: "15-day launch", href: "/ops/platform/launch-15-day" },
       ],
-      defaultCollapsed: true,
     },
     {
       label: "System",
+      pillar: "system",
+      icon: "settings",
       items: [
         { label: "AI Config", href: "/ops/settings/ai-config" },
         { label: "Webhooks", href: "/ops/webhooks" },
@@ -239,6 +249,7 @@ export default async function OperatorLayout({
       activeRole="operator"
       sections={sections}
       roleLabel="Practice ops"
+      showNavPrefs={false}
     >
       <CommandPalette role="operator" />
       {children}

--- a/src/components/shell/RailIdentityMenu.tsx
+++ b/src/components/shell/RailIdentityMenu.tsx
@@ -42,7 +42,7 @@ export function RailIdentityMenu({
       {open && (
         <div
           role="menu"
-          aria-label="Patient identity menu"
+          aria-label={`${roleLabel} identity menu`}
           className={cn(
             "absolute bottom-12 left-12 z-50 w-64 rounded-xl border border-border",
             "liquid-glass bg-surface-raised p-3 shadow-xl",
@@ -76,9 +76,9 @@ export function RailIdentityMenu({
 
       <button
         type="button"
-        aria-label="Open patient ID menu"
+        aria-label={`Open ${roleLabel} menu`}
         aria-expanded={open}
-        title="Patient ID"
+        title={roleLabel}
         onClick={() => setOpen((value) => !value)}
         className={cn(
           "flex h-11 w-11 items-center justify-center rounded-xl transition-colors",


### PR DESCRIPTION
## Summary
- Brings the **operator (Owner)** and **clinician** shells in line with the patient nav overhaul ([PR #72](https://github.com/scwayman1/EMR/pull/72)). Both layouts now opt into PillarNav by giving every section a `pillar` + `icon`, replacing the flat 60-item / 16-item sidebars with contextual icon-rail navigation.
- **Clinician (5 pillars):** Today (clipboard-check) / Patients (users) / Inbox (inbox) / Reference (book-open) / Admin (settings). Queues consolidated under Inbox; badges preserved on Approvals / Labs / Refills.
- **Owner / operator (8 pillars):** Overview (home) / Billing (dollar) / Finance (chart, was "Office of the CFO") / Operations (building) / Insights (layout-grid) / Setup (clipboard-check) / Platform (server) / System (settings). Pillar-name-duplicate first items renamed to "Overview".
- **RailIdentityMenu:** drop hardcoded "patient" aria/title strings, use the passed-in `roleLabel` so the menu reads correctly across roles.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run src/components/shell src/app` — 41/41 pass
- [ ] Visual QA on staging: clinician icon rail engages and pillars open contextual drawer
- [ ] Visual QA on staging: owner icon rail engages with all 8 pillars
- [ ] Mobile: hamburger drawer renders sections correctly (uses NavSections, no rail)
- [ ] Identity menu reads "Provider" for clinician, "Practice ops" for owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)