### PR TITLE
fix(notes): harden note detail render against malformed blocks

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -92,15 +92,23 @@ export function NoteEditor({
   // JSON never reaches here.
   const [refineErrors, setRefineErrors] = useState<Record<number, string>>({});
   const [blocks, setBlocks] = useState<NoteBlock[]>(() => {
+    // Defensive: a malformed JSON payload could deliver a non-array here
+    // (the parent already filters `_guardrails`, but we don't trust the
+    // wire shape). Treat anything non-array as empty so the editor renders
+    // an empty state rather than crashing the patient chart.
+    const safe: NoteBlock[] = Array.isArray(initialBlocks) ? initialBlocks : [];
     // Sort initial blocks in APSO order
-    const sorted = [...initialBlocks].sort((a, b) => {
+    const sorted = [...safe].sort((a, b) => {
       const aIdx = a.type ? APSO_ORDER.indexOf(a.type) : APSO_ORDER.length;
       const bIdx = b.type ? APSO_ORDER.indexOf(b.type) : APSO_ORDER.length;
       return (aIdx === -1 ? APSO_ORDER.length : aIdx) - (bIdx === -1 ? APSO_ORDER.length : bIdx);
     });
-    // Apply APSO display labels to headings
+    // Apply APSO display labels to headings + coerce `body` to a string so
+    // downstream `body.split` / template-string concatenation never hit
+    // null/undefined.
     return sorted.map((block) => ({
       ...block,
+      body: typeof block.body === "string" ? block.body : "",
       heading: block.type && NOTE_BLOCK_LABELS[block.type]
         ? NOTE_BLOCK_LABELS[block.type]
         : block.heading,

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -38,15 +38,27 @@ export default async function NoteDetailPage({ params }: PageProps) {
 
   const patient = note.encounter.patient;
 
-  // Parse blocks — they are stored as JSON
-  const blocks: { heading: string; body: string }[] = Array.isArray(note.blocks)
-    ? (note.blocks as { heading: string; body: string }[])
-    : [];
+  // Parse blocks — they are stored as JSON. Strip the internal `_guardrails`
+  // metadata block planted by the scribe agent: it carries hallucination /
+  // redaction metadata for the finalize-time snapshot, not display content,
+  // and rendering it as a regular block exposes internals to the clinician.
+  const rawBlocks: unknown[] = Array.isArray(note.blocks) ? note.blocks : [];
+  const blocks = rawBlocks.filter(
+    (b): b is { heading: string; body: string } =>
+      !!b &&
+      typeof b === "object" &&
+      typeof (b as { heading?: unknown }).heading === "string" &&
+      (b as { heading: string }).heading !== "_guardrails",
+  );
 
-  // Parse coding suggestion
+  // Parse coding suggestion. `icd10` is a JSON column — runtime-validate
+  // that it's actually an array before handing it to the client, otherwise
+  // a legacy/malformed row will crash the editor on render.
   const codingSuggestion = note.codingSuggestion
     ? {
-        icd10: note.codingSuggestion.icd10 as { code: string; label: string; confidence: number }[],
+        icd10: Array.isArray(note.codingSuggestion.icd10)
+          ? (note.codingSuggestion.icd10 as { code: string; label: string; confidence: number }[])
+          : [],
         emLevel: note.codingSuggestion.emLevel,
         rationale: note.codingSuggestion.rationale,
       }


### PR DESCRIPTION
## Summary

Defensive fix for the patient-chart error boundary crashing with `h.map is not a function` when opening a note detail page (reported while testing voice dictation on `/clinic/patients/{id}/notes/{noteId}`).

Targets the three most likely shapes of bad data — without a stack trace from the production deploy, this is a best-effort harden of the render path rather than a confirmed root-cause fix.

- **Strip `_guardrails` block at the page level** — the scribe agent plants an internal block (`heading: "_guardrails"`, type `"metadata"`, plus `metadata.guardrails` payload) into `note.blocks` so the finalize-time snapshot can hash provenance. It was leaking into the editor as a real section, and any nested-array shape on it would crash a `.map`. Filter it out before passing to the client.
- **Runtime-validate `CodingSuggestion.icd10`** — the column is `Json` in Prisma. The page was relying on a TS cast (`as { code, label, confidence }[]`) with no runtime check. Now we `Array.isArray`-guard it and fall back to `[]` if the row is malformed.
- **Coerce block `body` to string in the editor's lazy initializer** — defends `body.split("\n")` (textarea row count) and the dictation concat path against null/undefined bodies.

## What I'm not sure about

The minified `h.map` doesn't pin to a single line, so I can't say for certain this fixes the exact production crash. It does eliminate the most plausible failure modes I found while reading the render tree, and removes a real UX bug (the `_guardrails` block being visible to clinicians).

If the crash repros after this deploys, the patient-level `error.tsx` already logs `[patient chart] error:` with the stack — grabbing that from the browser console will pin the offending line and I can do a targeted follow-up.

## Test plan

- [ ] Type-check passes (verified locally)
- [ ] Open a finalized note created via voice intake and confirm the `_guardrails` section no longer renders
- [ ] Open the failing note URL on the deploy and confirm the page loads
- [ ] Dictate into a section and confirm text appends correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)