### PR TITLE
fix(prisma): cap unbounded findMany on clinician-facing pages

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -249,6 +249,9 @@ export default async function ClinicHomePage() {
     //    Exclude encounters whose patient has been soft-deleted — otherwise
     //    the card would render with a ghost patient and the Prepare button
     //    would 404 downstream.
+    // Today's encounters — bounded by calendar day. 200/day is well past
+    // any realistic single-clinician schedule and serves as a defensive
+    // ceiling for multi-provider orgs sharing this dashboard view.
     prisma.encounter.findMany({
       where: {
         organizationId,
@@ -257,6 +260,7 @@ export default async function ClinicHomePage() {
       },
       include: { patient: { include: { chartSummary: true } } },
       orderBy: { scheduledFor: "asc" },
+      take: 200,
     }),
 
     // 2. Draft notes count
@@ -377,10 +381,13 @@ export default async function ClinicHomePage() {
       take: 5,
     }),
 
-    // 14. Chart summaries for avg readiness
+    // 14. Chart summaries for avg readiness. Cap matches the patient roster
+    // ceiling — past 500 active patients per org we should be sampling
+    // server-side, not dumping every score into memory for an average.
     prisma.chartSummary.findMany({
       where: { patient: { organizationId, status: "active" } },
       select: { completenessScore: true },
+      take: 500,
     }),
 
     // 15. Daily encounter counts for sparkline (last 7 days)
@@ -415,7 +422,10 @@ export default async function ClinicHomePage() {
       take: 50,
     }),
 
-    // 18. Pending AI drafts (fleet bridge — approval count per agent)
+    // 18. Pending AI drafts (fleet bridge — approval count per agent).
+    // Cap at 500 — if the queue is bigger than that the count widget
+    // should show "500+" and ops needs a real backlog dashboard, not a
+    // dropdown render dumping the full backlog.
     prisma.message.findMany({
       where: {
         status: "draft",
@@ -423,6 +433,7 @@ export default async function ClinicHomePage() {
         thread: { patient: { organizationId } },
       },
       select: { senderAgent: true },
+      take: 500,
     }),
 
     // 19. Recent unacknowledged clinical observations

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -97,7 +97,10 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
         },
       },
     }),
-    // Flatten notes via encounters (separate query to keep the patient query lean)
+    // Flatten notes via encounters (separate query to keep the patient query lean).
+    // Cap: a patient with a decade of weekly visits has ~500 notes; the chart
+    // tab paginates anyway. 200 is the most-recent slice the UI actually
+    // renders before the user has to scroll.
     prisma.note.findMany({
       where: {
         encounter: {
@@ -109,6 +112,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
         encounter: true,
       },
       orderBy: { createdAt: "desc" },
+      take: 200,
     }),
     prisma.messageThread.findMany({
       where: { patientId: params.id },
@@ -127,12 +131,16 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       where: { patientId: params.id },
       include: { assessment: true },
       orderBy: { submittedAt: "desc" },
+      take: 100,
     }),
-    // Cannabis dosing regimens with product info
+    // Cannabis dosing regimens with product info. 100 historical regimens
+    // is well past any realistic patient — capping protects against a row
+    // explosion without truncating real history.
     prisma.dosingRegimen.findMany({
       where: { patientId: params.id },
       include: { product: true },
       orderBy: { startDate: "desc" },
+      take: 100,
     }),
     // Recent dose logs
     prisma.doseLog.findMany({
@@ -141,15 +149,19 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       orderBy: { loggedAt: "desc" },
       take: 10,
     }),
-    // Organization's cannabis product formulary
+    // Organization's cannabis product formulary. 500 is a defensive ceiling
+    // for an active formulary on a single org — most are well under 100.
     prisma.cannabisProduct.findMany({
       where: { organizationId: user.organizationId!, active: true },
       orderBy: { name: "asc" },
+      take: 500,
     }),
-    // Patient's conventional medications
+    // Patient's conventional medications (active only). Cap at 100 — past
+    // that there's a polypharmacy review needed, not a render problem.
     prisma.patientMedication.findMany({
       where: { patientId: params.id, active: true },
       orderBy: { name: "asc" },
+      take: 100,
     }),
     // Agentic memory harness: longitudinal memories + recent observations
     prisma.patientMemory.findMany({

--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -16,14 +16,31 @@ export default async function PatientsPage({
   const orgId = user.organizationId!;
 
   // Fetch all non-deleted patients with chart summary
+  // EMR-debt: hard cap. A single render of the roster ships every row to
+  // the client; a 500+ patient org needs server-side pagination, not a page
+  // dump. 500 is a defensive ceiling — most orgs are well under it. When a
+  // practice grows past this we fail loud (the count below) and add proper
+  // pagination + filter UI.
+  const PATIENT_ROSTER_CAP = 500;
   const patients = await prisma.patient.findMany({
     where: { organizationId: orgId, deletedAt: null },
     include: { chartSummary: true },
     orderBy: { lastName: "asc" },
+    take: PATIENT_ROSTER_CAP,
   });
+  if (patients.length === PATIENT_ROSTER_CAP) {
+    // eslint-disable-next-line no-console -- intentional: ops-relevant signal
+    console.warn(
+      `[patients-roster] hit cap (${PATIENT_ROSTER_CAP}) for org ${orgId} — ` +
+        `add server-side pagination before this org grows further.`,
+    );
+  }
 
   // Fetch pain outcome logs (last 7 per patient) for sparklines
   const patientIds = patients.map((p) => p.id);
+  // 7 sparkline points per patient × up to 500 patients = 3500. Anything
+  // older isn't rendered anyway, so capping the read avoids dragging years
+  // of pain logs into memory just to throw most of them away.
   const outcomeLogs = patientIds.length
     ? await prisma.outcomeLog.findMany({
         where: {
@@ -36,6 +53,7 @@ export default async function PatientsPage({
           value: true,
           loggedAt: true,
         },
+        take: 7 * PATIENT_ROSTER_CAP,
       })
     : [];
 
@@ -50,6 +68,10 @@ export default async function PatientsPage({
   }
 
   // Fetch last encounter (completed) per patient for "last visit" date
+  // We only consume the FIRST completed encounter per patient (line 67
+  // breaks once each patient is mapped). Capping the read keeps a patient
+  // with 10 years of completed visits from dragging thousands of rows into
+  // a render that uses one date per patient.
   const lastEncounters = patientIds.length
     ? await prisma.encounter.findMany({
         where: {
@@ -61,6 +83,7 @@ export default async function PatientsPage({
           patientId: true,
           completedAt: true,
         },
+        take: PATIENT_ROSTER_CAP * 5,
       })
     : [];
 


### PR DESCRIPTION
## Summary
~232 \`findMany\` call sites across this codebase have no \`take:\` cap. On any tenant past a few hundred patients, the worst of them are a HIPAA blast-radius bomb — a single render dumps every row matching a patient/org filter into memory.

This PR doesn't fix all 232 — it caps the top-of-funnel clinician views (patient roster, patient chart, clinic dashboard) where the queries are reached on every clinician login.

## Changes — 3 files, 11 caps

### \`src/app/(clinician)/clinic/patients/page.tsx\` (patient roster)
| Query | Cap | Why |
|---|---|---|
| \`patient.findMany\` | **500** + \`console.warn\` when hit | A 500+ active-patient org needs server-side pagination, not a page dump |
| \`outcomeLog.findMany\` (pain sparkline) | 7 × roster cap | Only 7 points/patient are rendered |
| \`encounter.findMany\` (last visit) | roster cap × 5 | Only 1 row/patient is consumed |

### \`src/app/(clinician)/clinic/patients/[id]/page.tsx\` (patient chart, 2,043 lines)
| Query | Cap |
|---|---|
| \`note.findMany\` | 200 |
| \`assessmentResponse.findMany\` | 100 |
| \`dosingRegimen.findMany\` | 100 |
| \`cannabisProduct.findMany\` (org formulary) | 500 |
| \`patientMedication.findMany\` (active) | 100 |

### \`src/app/(clinician)/clinic/page.tsx\` (mission-control dashboard)
| Query | Cap |
|---|---|
| \`encounter.findMany\` (today) | 200 |
| \`chartSummary.findMany\` (avg readiness) | 500 |
| \`message.findMany\` (pending AI drafts) | 500 |

## What this is NOT
- Not real server-side pagination — that's the right long-term fix for the roster + chart tabs
- Not a sweep of all 232 uncapped sites — this targets the clinician shell only
- Not a tested-against-prod fix — caps are conservative ceilings; verify against your largest-tenant counts before assuming they're right

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Render the roster against a tenant with >500 patients; confirm \`console.warn\` fires
- [ ] Render a patient chart against a long-tenured patient; confirm note tab loads <200 most recent and the page renders
- [ ] Confirm dashboard widgets still populate against current staging data

## Follow-up tickets needed
1. Real pagination on \`/clinic/patients\` (with status filter + search)
2. Real pagination on the chart-tab note list
3. Sweep the remaining ~221 uncapped \`findMany\` sites — patient API routes, agent fan-outs, billing routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)