### PR TITLE
fix(security): close payabli webhook signature-bypass + fail-closed gateway resolver

### DIFF
--- a/src/app/api/webhooks/payabli/route.ts
+++ b/src/app/api/webhooks/payabli/route.ts
@@ -30,25 +30,65 @@ import { resolvePaymentGateway } from "@/lib/payments";
 const SIGNATURE_HEADER = "x-payabli-signature";
 
 export async function POST(req: Request) {
-  // Read raw body for signature verification
+  // Read raw body for signature verification (signature is computed over
+  // raw bytes; parsing JSON first would corrupt the comparison).
   const rawBody = await req.text();
   const signature = req.headers.get(SIGNATURE_HEADER) ?? "";
 
   const gateway = resolvePaymentGateway();
 
-  // Verify signature — refuse anything that doesn't check out
-  if (gateway.name === "payabli") {
-    const valid = gateway.verifyWebhookSignature({ signature, rawBody });
-    if (!valid) {
-      console.warn("[webhook/payabli] invalid signature", {
-        signaturePresent: !!signature,
-        bodyLength: rawBody.length,
-      });
+  // Fail closed when the live gateway isn't wired. The previous gate
+  // (\`if (gateway.name === "payabli")\`) skipped verification entirely
+  // whenever the env resolved to the stub gateway — which silently happens
+  // when PAYMENT_GATEWAY is unset OR when Payabli init throws and falls
+  // back to stub (see resolvePaymentGateway). In production that meant any
+  // unsigned POST to this route mutated the financial ledger.
+  //
+  // In production we require the real Payabli gateway. In non-prod, we
+  // still require signature verification — the stub's \`verifyWebhookSignature\`
+  // returns true for everything, so this also catches "we shipped a stub
+  // to staging and forgot to reconfigure."
+  const isProd = process.env.NODE_ENV === "production";
+  if (gateway.name !== "payabli") {
+    if (isProd) {
+      console.error(
+        "[webhook/payabli] refusing webhook — production must use the payabli gateway",
+        { gatewayName: gateway.name },
+      );
       return NextResponse.json(
-        { ok: false, error: "invalid signature" },
-        { status: 401 },
+        { ok: false, error: "gateway_misconfigured" },
+        { status: 503 },
       );
     }
+    // Non-prod with stub gateway: still refuse so dev environments don't
+    // build muscle memory of unverified webhook flows. Set
+    // PAYABLI_DEV_BYPASS=1 to opt in for local testing only.
+    if (process.env.PAYABLI_DEV_BYPASS !== "1") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "gateway_not_payabli",
+          hint: "Set PAYMENT_GATEWAY=payabli, or PAYABLI_DEV_BYPASS=1 in dev only.",
+        },
+        { status: 503 },
+      );
+    }
+  }
+
+  // Always verify signature — even with the dev-bypass flag, the stub's
+  // verifyWebhookSignature returns true so this is a no-op in dev. In
+  // prod (gateway.name === "payabli") this is the only thing standing
+  // between a forged ledger event and a financial mutation.
+  const valid = gateway.verifyWebhookSignature({ signature, rawBody });
+  if (!valid) {
+    console.warn("[webhook/payabli] invalid signature", {
+      signaturePresent: !!signature,
+      bodyLength: rawBody.length,
+    });
+    return NextResponse.json(
+      { ok: false, error: "invalid signature" },
+      { status: 401 },
+    );
   }
 
   // Parse the event

--- a/src/lib/payments/index.ts
+++ b/src/lib/payments/index.ts
@@ -26,10 +26,20 @@ export function resolvePaymentGateway(): PaymentGateway {
       cached = new PayabliGateway();
       return cached;
     } catch (err) {
-      console.error(
-        "[payments] Payabli gateway failed to initialize, falling back to stub:",
-        err instanceof Error ? err.message : err,
-      );
+      const msg =
+        "[payments] Payabli gateway failed to initialize: " +
+        (err instanceof Error ? err.message : String(err));
+
+      // Production: refuse to silently fall back. Crashing here is
+      // preferable to running the financial flow against a stub that
+      // accepts every signature (\`verifyWebhookSignature\` returns true).
+      // Earlier behaviour silently demoted to stub and was a forgery
+      // vector for /api/webhooks/payabli.
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(msg);
+      }
+
+      console.error(msg, "— falling back to stub (non-production only)");
       cached = new StubPaymentGateway();
       return cached;
     }


### PR DESCRIPTION
## Summary
The clinical-billing Payabli webhook had **two combined bugs that allowed unsigned attacker-supplied payloads to mutate financial ledger rows**.

## The vulnerability

### Bug 1 — \`src/app/api/webhooks/payabli/route.ts:40\`
Signature verification was gated on the resolved gateway:
\`\`\`ts
if (gateway.name === \"payabli\") {
  const valid = gateway.verifyWebhookSignature(...);
  if (!valid) return 401;
}
// fall through, process event
\`\`\`
When the resolver returned anything else (stub gateway, mock, etc.), **the entire signature check was skipped** and the handler proceeded to write \`FinancialEvent\` rows and update \`Claim.paidAmountCents\` based on the unverified body.

### Bug 2 — \`src/lib/payments/index.ts:27-35\`
\`resolvePaymentGateway()\` silently fell back to \`StubPaymentGateway\` when \`PayabliGateway\` initialization threw (e.g., missing API token). Combined with bug 1, **dropping \`PAYABLI_API_TOKEN\` from prod env silently disabled signature verification** instead of failing the deploy.

## Fix

### \`src/app/api/webhooks/payabli/route.ts\`
- Production must use the \`payabli\` gateway. If not, return **503 gateway_misconfigured** and refuse to process.
- Non-prod still rejects unless \`PAYABLI_DEV_BYPASS=1\` is set (dev opt-in only).
- Signature verification now runs unconditionally — even with the dev bypass, the stub's \`verifyWebhookSignature\` returns \`true\` so dev keeps working but the call site is correct.

### \`src/lib/payments/index.ts\`
- \`resolvePaymentGateway()\` **throws** in production when \`PayabliGateway\` init fails. No more silent demotion to stub.
- Stub fallback is preserved in non-production for local dev / tests.

## Other webhooks audited
| Route | Status |
|---|---|
| \`/api/webhooks/clerk\` | ✅ svix signature verified, fail-closed on missing secret, fail-closed on missing headers |
| \`/api/webhooks/payabli/marketplace\` | ✅ HMAC verified independent of gateway, fail-closed on missing secret |
| \`/api/webhooks/payabli\` | 🔴 **fixed by this PR** |

## Pre-merge ops checklist
- [ ] Confirm prod env has \`PAYMENT_GATEWAY=payabli\`
- [ ] Confirm prod env has \`PAYABLI_API_TOKEN\` and \`PAYABLI_ENTRY_POINT\`
- [ ] Confirm prod env has \`PAYABLI_WEBHOOK_SECRET\` (already required for sig verification — verify it's set)
- [ ] After merge: monitor \`/api/webhooks/payabli\` 503 rate. A spike means env vars are missing — fail-closed will block real traffic until fixed.

## Risk if not merged
Any attacker who knows the URL can post arbitrary \`payment.captured\`, \`payment.failed\`, \`payment.refunded\`, or \`chargeback.opened\` events to \`/api/webhooks/payabli\` and get them written to the \`FinancialEvent\` ledger if any of these conditions hold:
- \`PAYMENT_GATEWAY\` env is unset / wrong
- \`PAYABLI_API_TOKEN\` is missing or invalid (init throws → silent stub)
- The deploy ever runs without one of these set

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Local: \`PAYMENT_GATEWAY=stub\` + POST to \`/api/webhooks/payabli\` returns 503 \`gateway_not_payabli\`
- [ ] Local: \`PAYABLI_DEV_BYPASS=1 PAYMENT_GATEWAY=stub\` + POST returns 200 (dev opt-in)
- [ ] Local: \`PAYMENT_GATEWAY=payabli\` without token → server fails to start
- [ ] Staging: post a forged payload without signature → 401 invalid_signature
- [ ] Staging: post a real Payabli-signed payload → 200, ledger updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)