### PR TITLE
ci(security): gitleaks secret-scan on PRs and main

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,35 @@
+name: Security — Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Block merging PRs that introduce hardcoded secrets. Runs gitleaks against
+# the full diff on a PR, and against the full history on push-to-main as a
+# defence-in-depth check.
+#
+# False-positive workflow: add a rule allowlist entry to .gitleaks.toml,
+# scoped narrowly to the file/path. Do NOT add commit-SHA exceptions —
+# secrets need to be rotated, not allowlisted in place.
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout (full history for diff scan)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,63 @@
+# gitleaks rule config for the Leafjourney monorepo.
+#
+# Strategy: extend gitleaks's defaults (no [extend] disabling means defaults
+# run) and add three local concerns:
+#   1. Untracked-file patterns we've seen leak into the repo root
+#      (prod_dump.sql, env*.json, payload*.json) — make these blocking.
+#   2. Allowlists for known placeholder values so the scanner doesn't
+#      choke on .env.example or seed demo strings.
+#   3. Path allowlists for docs that intentionally show example tokens.
+#
+# False-positive workflow: add to [allowlist] with a narrow path or regex.
+# NEVER add commit-SHA-based allowlists — leaked secrets must be rotated,
+# not whitelisted in place.
+
+title = "Leafjourney gitleaks config"
+
+[extend]
+useDefault = true
+
+# ── Custom rules ─────────────────────────────────────────────────
+
+[[rules]]
+id = "leafjourney-prod-dump"
+description = "Production database dump committed to repo"
+regex = '''(?i)prod[_-]?dump[_-]?\d*\.sql'''
+path = '''.*'''
+tags = ["secret", "high"]
+
+[[rules]]
+id = "leafjourney-env-payload-json"
+description = "env or payload JSON file at repo root"
+regex = '''^(env|payload)([_-][a-z0-9]+)?\.json$'''
+path = '''^(env|payload)([_-][a-z0-9]+)?\.json$'''
+tags = ["secret", "high"]
+
+[[rules]]
+id = "leafjourney-render-secret-id"
+description = "Render envvar lookup with literal secret ID"
+regex = '''rnd_[A-Za-z0-9]{20,}'''
+tags = ["secret", "render"]
+
+# ── Allowlists (be narrow) ───────────────────────────────────────
+
+[allowlist]
+description = "Repo-wide false-positive pre-emption"
+
+paths = [
+  '''(?i)\.env\.example$''',
+  '''(?i)readme\.md$''',
+  '''^docs/security/.*\.md$''',
+  '''^docs/runbooks/.*\.md$''',
+]
+
+regexes = [
+  '''PASTE_YOUR_LINEAR_API_KEY_HERE''',
+  '''replace[_-]me''',
+  '''YOUR[_-][A-Z0-9_]+[_-]HERE''',
+  '''pk_test_[A-Za-z0-9]+''',
+  '''pk_live_[A-Za-z0-9]+''',
+  '''pk_(test|live)_[a-zA-Z0-9_-]+''',
+]
+
+commits = []


### PR DESCRIPTION
## Summary
Tonight's audit found multiple sensitive files present at the repo root over the course of recent agent work: \`prod_dump.sql\`, \`env.json\`, \`env_cron.json\`, \`env_worker.json\`, \`payload*.json\`, \`update_render_env.js\`. None ended up committed (they were untracked or in \`.gitignore\`) but **nothing in CI was preventing the next one from making it through**.

Adds gitleaks scanning on every PR + every push to main.

## Files
- \`.github/workflows/security-scan.yml\` — gitleaks-action@v2, full-history checkout, fails the build on hits
- \`.gitleaks.toml\` — extends gitleaks defaults with three custom rules:
  - \`leafjourney-prod-dump\` — matches \`prod_dump*.sql\`
  - \`leafjourney-env-payload-json\` — matches \`env*.json\`/\`payload*.json\` at repo root
  - \`leafjourney-render-secret-id\` — matches Render-style \`rnd_*\` IDs in code
  - Plus narrow allowlists for \`.env.example\`, \`README\`, \`docs/security/**\`, and known placeholder strings (\`PASTE_YOUR_*_HERE\`, Stripe/Clerk \`pk_*\` public keys)

## False-positive policy (in the config comment)
- Add narrow path or regex allowlists
- **Never** commit-SHA-based exceptions — leaked secrets must be rotated, not whitelisted in place

## Test plan
- [ ] Open this PR — gitleaks runs against the diff, finds nothing, passes
- [ ] Sanity test: create a throwaway branch with a fake \`AWS_SECRET_ACCESS_KEY=AKIA...\` line in code, open PR — gitleaks should fail
- [ ] Verify allowlist works: a \`.env.example\` line with \`PASTE_YOUR_LINEAR_API_KEY_HERE\` does not flag

## Pre-merge ops
- [ ] No GitHub Action setup needed (gitleaks-action is public)
- [ ] If gitleaks fires on the initial scan against \`main\` history, **rotate the surfaced secret first** before allowlisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)