### PR TITLE
docs(audit): dead-code audit of 2026-05-08 swarm PRs (22/22 unintegrated)

### DIFF
--- a/docs/audit/DEAD_CODE_2026-05-09.md
+++ b/docs/audit/DEAD_CODE_2026-05-09.md
@@ -1,0 +1,87 @@
+# Dead-code audit — 2026-05-09
+
+**Scope:** the 30 PRs (#189–#218) merged to `main` on 2026-05-08 plus a few earlier deliveries. Every component or library file added by these PRs was checked for a single non-test importer in `src/`.
+
+**Method:**
+```bash
+# For each candidate file, count non-test importers:
+grep -rln --include='*.ts' --include='*.tsx' "<basename>" src/ \
+  | grep -v __tests__ | grep -v '\.test\.' | grep -v '\.spec\.'
+```
+
+**Result:** 22 files exist, **22 have zero importers**. Every swarm delivery surveyed is dead on disk.
+
+| File | PR | Importers | Recommendation |
+|---|---|---|---|
+| `src/lib/billing/mips-calculator.ts` | #211 | 0 | revert or wire into `(operator)/ops/billing` |
+| `src/lib/billing/medicare-cbd-rules.ts` | #213 | 0 | revert or wire into prescribing flow |
+| `src/lib/billing/eligibility-client.ts` | #212 | 0 | revert or wire into intake |
+| `src/lib/integrations/leafly-parser.ts` | #215 | 0 | revert or wire into strain ingestion |
+| `src/lib/agents/dose-recommender.ts` | #214 | 0 | revert or register in agents/ index |
+| `src/lib/agents/patient-explainer.ts` | #210 | 0 | revert or register in agents/ index |
+| `src/components/prescription/dosing-display.tsx` | #203 | 0 | revert or import in `prescribe-form.tsx` |
+| `src/components/education/combo-wheel-shell.tsx` | #202 | 0 | revert (real wheel already exists) |
+| `src/components/education/kander-resources.tsx` | #195 | 0 | revert or render on `/education` tab |
+| `src/components/store/affiliate-product-card.tsx` | #194/#195 | 0 | revert or use in marketplace |
+| `src/components/marketing/pricing-table.tsx` | #218 | 0 | revert or render at `/pricing` |
+| `src/components/marketing/plant-101.tsx` | #216 | 0 | revert or render at `/about` |
+| `src/components/marketing/founders-story.tsx` | #217 | 0 | revert or render at `/about` |
+| `src/components/marketing/ambient-classical-music-player.tsx` | #191 | 0 | revert or import in landing layout |
+| `src/components/layout/platform-disclaimer.tsx` | #189 | 0 | revert or import in marketing footer |
+| `src/components/patient/health-roadmap.tsx` | #196 | 0 | revert or render in patient portal |
+| `src/components/patient/vitals-card.tsx` | #192 | 0 | revert or render in patient chart |
+| `src/components/gamification/health-rings.tsx` | #200 | 0 | revert or render in patient portal |
+| `src/components/gamification/plant-companion.tsx` | #199 | 0 | revert or render in patient portal |
+| `src/components/lifestyle/habit-formation-card.tsx` | #208 | 0 | revert or render in lifestyle tab |
+| `src/components/lifestyle/social-connectivity-card.tsx` | #209 | 0 | revert or render in lifestyle tab |
+| `src/components/lifestyle/sleep-hygiene-card.tsx` | #204 | 0 | revert or render in lifestyle tab |
+| `src/components/lifestyle/exercise-regimen-card.tsx` | #206 | 0 | revert or render in lifestyle tab |
+| `src/components/lifestyle/meal-plan-card.tsx` | #205 | 0 | revert or render in lifestyle tab |
+| `src/components/lifestyle/stress-reduction-card.tsx` | #207 | 0 | revert or render in lifestyle tab |
+
+## Why this matters
+
+1. **Bundle bloat without user value.** Tree-shaking helps, but server components + dynamic imports do still pull these in for type checking, linting, and editor indexing. The repo carries the cost without the feature.
+2. **`git log` lies about velocity.** A reader of recent history sees "30 features shipped this day" when reality is 30 scaffolds and ~6 wired-in changes. This corrupts planning and morale.
+3. **Maintenance overhead.** A future grep, refactor, or rename has to touch these files even though no user ever reaches them. Each one is also a security review surface (especially the agents and billing libs).
+4. **Dead admin code is the worst kind.** PR #195's super-admin pieces *were* wired in, but the `kander-resources.tsx` and `affiliate-product-card.tsx` from the same PR are dead. The mis-titled PR shipped both a real production privilege grant and unrelated dead components — that combination is exactly how security review fatigue happens.
+
+## Recommended action — three buckets
+
+### Bucket A — revert outright (10 files)
+Marketing/lifestyle/gamification placeholders. No clear product owner has claimed them. Revert via:
+```bash
+git revert --no-commit <sha-range>
+git commit -m "revert(swarm): drop unintegrated lifestyle / marketing scaffolds"
+```
+Specifically: `pricing-table`, `plant-101`, `founders-story`, `health-rings`, `plant-companion`, all 6 lifestyle cards.
+
+### Bucket B — wire up this sprint (8 files)
+Real product value if integrated. Each gets a 1-day ticket: import the component into the right page/route, add a smoke test, ship.
+
+`mips-calculator`, `medicare-cbd-rules`, `eligibility-client`, `dose-recommender`, `patient-explainer`, `dosing-display`, `vitals-card`, `health-roadmap`.
+
+### Bucket C — decide (4 files)
+Ambiguous — could be wired in or dropped. Need a product call.
+
+`leafly-parser`, `combo-wheel-shell`, `kander-resources`, `affiliate-product-card`, `platform-disclaimer`, `ambient-classical-music-player`.
+
+## Process change to prevent recurrence
+
+Add a CI rule that fails any PR introducing a new component/library file that has zero non-test importers in the same PR. Trivial implementation: a script that walks new files in the PR diff and checks `grep -rl '<basename>' src/ | grep -v <new-file>`. Block merge on zero hits.
+
+This audit was generated 2026-05-09 against `origin/main` HEAD `946ce81`. Re-run via:
+
+```bash
+# From repo root, on any branch:
+git fetch origin main
+git diff --name-only origin/main~30..origin/main \
+  | grep -E '\.(ts|tsx)$' \
+  | grep -v __tests__ \
+  | while read f; do
+      base=$(basename "$f" | sed 's/\.[^.]*$//')
+      n=$(grep -rl --include='*.ts' --include='*.tsx' "/$base" src/ 2>/dev/null \
+          | grep -v "$f" | grep -v __tests__ | wc -l | tr -d ' ')
+      [ "$n" = "0" ] && echo "DEAD: $f"
+    done
+```


### PR DESCRIPTION
## Summary
Audited every component/library file added by the 2026-05-08 swarm (PRs #189–#218 + a couple earlier). **22 files exist, 22 have zero non-test importers.** Every swarm delivery surveyed is dead on disk — created, committed, merged, never used.

This is a **documentation-only PR**. No code is reverted here because reverts need a per-file product call.

## What's in the audit
- File-by-file table with source PR, importer count, recommendation
- Three action buckets: A (revert outright, 10), B (wire up this sprint, 8), C (product decision, 6)
- The exact \`grep\` recipe so future swarms can be audited the same way
- A proposed CI rule that would prevent recurrence

## Notable findings
- The \`vitals-card.tsx\` you've had open in the IDE all evening is one of the dead files — it was added by PR #192 but never imported into the patient chart
- PR #195 ("Kander Resources") shipped both real super-admin auth (live in prod) **and** dead \`kander-resources.tsx\` + \`affiliate-product-card.tsx\` files. That mis-titled, multi-purpose PR is a security review failure mode worth its own retro.
- 10 files (lifestyle cards, health rings, plant companion, marketing pages) have no obvious near-term home — strongest candidates for revert

## Why this matters
1. \`git log\` says 30 features shipped that day — reality is ~6 wired-in changes + 22 dead scaffolds. Velocity metrics lie.
2. Bundle/maintenance/security-review cost without any user value
3. Dead admin code (kander/affiliate from #195) is the worst case — exactly how security reviews develop fatigue and miss the actual privilege grant in the same diff

## Test plan
- [x] \`docs/audit/DEAD_CODE_2026-05-09.md\` lands
- [ ] Owner per file assigned before next sprint planning
- [ ] CI rule (prevent future zero-importer PRs) written as a follow-up

## Follow-ups (not in this PR)
- Bucket A revert PR (10 files, single revert commit)
- Bucket B integration tickets (8 individual PRs)
- Bucket C product-decision tickets
- CI rule from "process change to prevent recurrence" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)