### PR TITLE
ci(deadcode): block PRs introducing zero-importer components/lib files

### DIFF
--- a/.github/workflows/no-orphan-components.yml
+++ b/.github/workflows/no-orphan-components.yml
@@ -1,0 +1,39 @@
+name: Code Health — No Orphan Components
+
+on:
+  pull_request:
+    branches: [main]
+
+# Fails when a PR introduces new src/components/** or src/lib/** files
+# with zero non-test importers in the same diff.
+#
+# Pairs with docs/audit/DEAD_CODE_2026-05-09.md (PR #236): 22 of 22
+# files added by the 2026-05-08 swarm had zero importers and shipped to
+# main as bundle bloat with no user value. This rule prevents recurrence.
+#
+# Allowlist escape: a new file can carry
+#   // SAFE: dead-export-allowed reason="<short justification>"
+# in its first 10 lines and the rule passes. PR reviewers scrutinize
+# those.
+
+jobs:
+  check-no-orphans:
+    name: no-orphan-components
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (need merge-base)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate
+        env:
+          BASE: origin/${{ github.base_ref }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          node scripts/check-no-orphan-components.mjs

--- a/scripts/check-no-orphan-components.mjs
+++ b/scripts/check-no-orphan-components.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Fails when a PR introduces new src/components/** or src/lib/** files
+// with zero non-test importers in the same diff or in main.
+//
+// This is the gate from PR #236 (dead-code audit) — 22 of 22 swarm
+// deliveries were unimported scaffolds. Without this rule, the next
+// agent storm reproduces the same problem.
+//
+// Strategy:
+//   1. Diff this commit/PR against the merge base.
+//   2. For every NEW file under src/components/** or src/lib/**:
+//      - Skip __tests__/, .test.ts, .spec.ts, .stories.tsx
+//      - Skip index.ts re-exports
+//      - Compute the "import basename" (filename without extension)
+//      - Grep for that basename anywhere in src/ excluding the new
+//        file itself and any test files
+//   3. If grep finds zero hits, fail with a per-file list.
+//
+// Allowlist escape hatch: a new file can carry the comment
+//   // SAFE: dead-export-allowed reason="<short justification>"
+// on its first 5 lines and the rule passes for that file. PR review
+// scrutinizes those.
+//
+// Usage:
+//   BASE=origin/main node scripts/check-no-orphan-components.mjs
+//   (BASE defaults to origin/main when running in CI; falls back to
+//   HEAD~1 locally if origin/main isn't fetched.)
+
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { join, basename, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+function git(args) {
+  return execSync(`git ${args}`, { cwd: ROOT, encoding: "utf8" });
+}
+
+function resolveBase() {
+  if (process.env.BASE) return process.env.BASE;
+  // CI passes GITHUB_BASE_REF
+  if (process.env.GITHUB_BASE_REF) return `origin/${process.env.GITHUB_BASE_REF}`;
+  try {
+    git("rev-parse origin/main");
+    return "origin/main";
+  } catch {
+    return "HEAD~1";
+  }
+}
+
+const BASE = resolveBase();
+
+const newFiles = git(`diff --name-only --diff-filter=A ${BASE}...HEAD`)
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .filter((f) => /^src\/(components|lib)\//.test(f))
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .filter((f) => !/__tests__\/|\.test\.|\.spec\.|\.stories\./.test(f))
+  .filter((f) => basename(f) !== "index.ts" && basename(f) !== "index.tsx");
+
+if (newFiles.length === 0) {
+  console.log("✓ no new component / lib files in this diff");
+  process.exit(0);
+}
+
+const SAFE_RE =
+  /\/\/\s*SAFE:\s*dead-export-allowed\b.*?reason\s*=\s*"([^"]+)"/i;
+
+const orphans = [];
+for (const f of newFiles) {
+  const path = join(ROOT, f);
+  if (!existsSync(path)) continue; // file may have been deleted in a later commit
+
+  // Allowlist comment in first 10 lines
+  const first10 = readFileSync(path, "utf8").split("\n").slice(0, 10).join("\n");
+  if (SAFE_RE.test(first10)) continue;
+
+  const base = basename(f, extname(f));
+  let importers = 0;
+  try {
+    const out = execSync(
+      `grep -rl --include='*.ts' --include='*.tsx' '/${base}' src/ 2>/dev/null || true`,
+      { cwd: ROOT, encoding: "utf8" },
+    );
+    importers = out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((p) => p !== f) // not the file itself
+      .filter((p) => !/__tests__\/|\.test\.|\.spec\./.test(p)).length;
+  } catch {
+    // grep returns 1 when no matches — treat as 0
+    importers = 0;
+  }
+
+  if (importers === 0) orphans.push({ file: f, base });
+}
+
+if (orphans.length === 0) {
+  console.log(`✓ all ${newFiles.length} new component/lib files have at least one importer`);
+  process.exit(0);
+}
+
+console.error(
+  `\n✗ ${orphans.length} new file(s) added with zero non-test importers:\n`,
+);
+for (const o of orphans) {
+  console.error(`    ${o.file}`);
+}
+console.error(
+  `\n  Each new component/lib file must be imported somewhere in the same PR,\n` +
+    `  OR carry the allowlist comment in its first 10 lines:\n\n` +
+    `      // SAFE: dead-export-allowed reason="<short justification>"\n\n` +
+    `  Background: docs/audit/DEAD_CODE_2026-05-09.md (PR #236) found that\n` +
+    `  22 of 22 swarm-delivered files were unintegrated scaffolds. This rule\n` +
+    `  is the gate that prevents the next batch from doing the same.\n`,
+);
+process.exit(1);


### PR DESCRIPTION
## Summary
Pairs with PR #236 (audit) and PR #237 (Bucket-A drop). The 2026-05-08 swarm shipped 22 files with zero importers — this rule prevents the next batch from doing the same.

## How it works
On every PR:
1. Diff against the merge base
2. Find new files under \`src/components/**\` or \`src/lib/**\` (skip tests, stories, \`index.ts\` re-exports)
3. For each, grep \`src/\` for the basename, excluding the file itself + tests
4. Zero importers → fail with a per-file list

## Allowlist escape (use sparingly)
\`\`\`ts
// SAFE: dead-export-allowed reason=\"<short justification>\"
\`\`\`
in the first 10 lines of the new file. PR review scrutinizes the justification.

This is for legitimate cases like a public re-export landing in a separate PR from its first consumer. **Not** for the swarm pattern of "ship a scaffold and hope someone wires it up later."

## Test plan
- [ ] CI workflow runs on this PR (no new component files → passes)
- [ ] Sanity test (don't merge): add an unimported \`src/components/foo/bar.tsx\` to a throwaway PR, confirm CI fails
- [ ] Sanity test: add the SAFE allowlist comment to that file, confirm CI passes

## What this catches
- Swarm-style "agents wrote 30 features" deliveries where most files are scaffolds
- Forgotten WIP files left over from refactors
- Components landed in advance of their integration without a tracking comment

## What this does NOT catch
- Dead code that was wired up at one point and is no longer reached (use the audit doc + manual sweeps for that)
- Modifications that delete the only importer of an existing file (separate rule, future work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)