### PR TITLE
fix(cron/reminders): burn @ts-nocheck, fix Dr. undefined bug, tighten secret

### DIFF
--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,27 +1,74 @@
-// @ts-nocheck
+// /api/cron/reminders
+//
+// Inbound cron tick (Render background worker or Vercel Cron). Looks at
+// encounters scheduled in the 24-48h window and emits reminder messages.
+//
+// Auth model: shared-secret in the Authorization header. Production
+// requires a match against CRON_SECRET — fail closed. Non-production
+// allows any header (dev convenience) but logs the call so it's visible
+// in dev tooling. There is no fallback default secret in code; CRON_SECRET
+// must be set in any env where this route is callable.
+//
+// Per docs/security/route-auth.yaml — auth: needs_review (review_due
+// 2026-05-16). This file ALSO previously carried `@ts-nocheck`. This PR
+// burns down the `@ts-nocheck` and tightens the secret check; the
+// review-due ticket can decide whether to additionally require Vercel's
+// CRON_SECRET injection or move to a queue-based scheduler.
+
 import { NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 
-// Render background workers or Vercel Cron will hit this endpoint daily
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const REMINDER_BATCH_CAP = 500;
+
+/**
+ * Shape of the JSON we read from / write back to Encounter.briefingContext.
+ * Stored as Prisma.JsonValue at rest, but the cron only cares about a
+ * single `reminderSentAt` field.
+ */
+type BriefingContext = Record<string, unknown> & {
+  reminderSentAt?: string;
+};
+
+function readBriefingContext(value: Prisma.JsonValue | null): BriefingContext {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as BriefingContext;
+  }
+  return {};
+}
 
 export async function GET(req: Request) {
-  // Validate standard cron auth header (replace with real secret validation in prod)
-  const authHeader = req.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET || 'dev-secret'}`) {
-    if (process.env.NODE_ENV === 'production') {
+  // Auth: production must validate the secret. Non-prod logs and falls
+  // through so dev tooling can hit the route without the env var.
+  const authHeader = req.headers.get("authorization") ?? "";
+  const secret = process.env.CRON_SECRET ?? "";
+  const expected = secret ? `Bearer ${secret}` : null;
+
+  if (process.env.NODE_ENV === "production") {
+    if (!expected || authHeader !== expected) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
+  } else if (!expected || authHeader !== expected) {
+    // Dev: accept but log. Helps catch "we shipped to staging without
+    // setting CRON_SECRET" before it bites prod.
+    // eslint-disable-next-line no-console
+    console.warn("[cron/reminders] non-prod call without valid CRON_SECRET");
   }
 
   // Find appointments scheduled between 24 and 48 hours from now
   const tomorrowStart = new Date();
   tomorrowStart.setHours(tomorrowStart.getHours() + 24);
-  
+
   const tomorrowEnd = new Date();
   tomorrowEnd.setHours(tomorrowEnd.getHours() + 48);
 
   try {
+    // Cap the read — a busy multi-org cron should not pull every
+    // scheduled encounter into one Lambda. Above this cap, ops needs to
+    // know the cron is over budget.
     const upcomingEncounters = await prisma.encounter.findMany({
       where: {
         status: "scheduled",
@@ -36,44 +83,73 @@ export async function GET(req: Request) {
             firstName: true,
             email: true,
             phone: true,
-          }
+          },
         },
+        // Provider rows don't carry firstName/lastName directly — those
+        // live on the related User (Provider.user). Reach through.
         provider: {
           select: {
-            firstName: true,
-            lastName: true,
-          }
-        }
-      }
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+      take: REMINDER_BATCH_CAP,
     });
+
+    if (upcomingEncounters.length === REMINDER_BATCH_CAP) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[cron/reminders] batch hit cap (${REMINDER_BATCH_CAP}) — tail of window may be skipped this run`,
+      );
+    }
 
     let sentCount = 0;
 
     for (const encounter of upcomingEncounters) {
       if (!encounter.scheduledFor) continue;
+      if (!encounter.patient?.email) continue;
 
-      const timeString = new Date(encounter.scheduledFor).toLocaleTimeString('en-US', {
-        hour: 'numeric',
-        minute: '2-digit',
+      const scheduledFor = encounter.scheduledFor;
+      const timeString = scheduledFor.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
       });
-      const providerName = encounter.provider ? `Dr. ${encounter.provider.lastName}` : "your care provider";
-      const modalityText = encounter.modality === "video" ? "telehealth video" : 
-                           encounter.modality === "phone" ? "phone" : "in-person";
+      const providerLastName = encounter.provider?.user?.lastName ?? null;
+      const providerName = providerLastName
+        ? `Dr. ${providerLastName}`
+        : "your care provider";
+      const modalityText =
+        encounter.modality === "video"
+          ? "telehealth video"
+          : encounter.modality === "phone"
+            ? "phone"
+            : "in-person";
 
-      // Mock sending email / SMS via Twilio/SendGrid
-      console.log(`[CRON] Sending reminder to ${encounter.patient.email}:`);
-      console.log(`Hi ${encounter.patient.firstName}, just a reminder about your upcoming ${modalityText} visit with ${providerName} tomorrow at ${timeString}. Please complete any pending intake forms in your portal.`);
-      
-      // Update briefingContext to mark reminder as sent to avoid duplicates
-      const currentContext = (encounter.briefingContext as any) || {};
+      // TODO(EMR-XXX): replace with the real Twilio/SendGrid path once
+      // the messaging-provider abstraction lands. For now this is a
+      // structured log line so ops can verify the cron is firing
+      // against the right rows.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[cron/reminders] would-send to=${encounter.patient.email} ` +
+          `firstName=${encounter.patient.firstName ?? ""} ` +
+          `at=${timeString} provider=${providerName} modality=${modalityText}`,
+      );
+
+      const currentContext = readBriefingContext(encounter.briefingContext);
       await prisma.encounter.update({
         where: { id: encounter.id },
         data: {
           briefingContext: {
             ...currentContext,
             reminderSentAt: new Date().toISOString(),
-          }
-        }
+          },
+        },
       });
 
       sentCount++;
@@ -85,7 +161,8 @@ export async function GET(req: Request) {
       sent: sentCount,
     });
   } catch (error) {
-    console.error("[CRON] Failed to run appointment reminders:", error);
+    // eslint-disable-next-line no-console
+    console.error("[cron/reminders] failed:", error);
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
First of 7 \`@ts-nocheck\` burn-downs (EPIC 3.1). \`/api/cron/reminders\` had TS turned off on a file that mutates encounter rows and reads patient PII for messaging — exactly where you can't afford TS to be off.

The previous code had a real, latent bug that \`@ts-nocheck\` was hiding.

## Bug found while removing \`@ts-nocheck\`

Original code:
\`\`\`ts
include: {
  provider: {
    select: { firstName: true, lastName: true },
  },
}
// ...
\`Dr. \${encounter.provider.lastName}\`
\`\`\`

\`Provider\` doesn't have \`firstName\`/\`lastName\` — those live on the related \`User\` (\`Provider.user\`). At runtime this returned \`undefined\` and the rendered reminder said **"Dr. undefined"**. With \`@ts-nocheck\`, TypeScript didn't catch it.

Fix: traverse correctly through the \`user\` relation.
\`\`\`ts
provider: { select: { user: { select: { firstName, lastName } } } }
// ...
encounter.provider?.user?.lastName
\`\`\`

## Other issues addressed in the same file

| Issue | Before | After |
|---|---|---|
| Hardcoded fallback secret | \`Bearer \${CRON_SECRET \|\| 'dev-secret'}\` | Prod refuses if \`CRON_SECRET\` is unset; dev logs |
| Unbounded \`findMany\` | every encounter in 24–48h window | \`take: 500\` + warn-log on cap hit |
| \`(briefingContext as any)\` | bypass JSON typing | typed \`readBriefingContext\` helper |
| Missing \`dynamic = "force-dynamic"\` | could be cached at edge | added |

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Local: \`curl /api/cron/reminders\` without auth header → 401 in production, fall-through-with-log in dev
- [ ] Local: \`CRON_SECRET=foo curl -H 'Authorization: Bearer foo' /api/cron/reminders\` → 200
- [ ] Reminder log line now includes a real provider lastName, not "undefined"
- [ ] When patient.email is null, the encounter is skipped (not crash)
- [ ] \`take: 500\` cap warning fires on a synthetic 600-encounter window

## Pre-merge ops
- [ ] Confirm \`CRON_SECRET\` is set in Render staging + prod env. The hardcoded fallback is gone — missing env var = 401.

## What this unblocks
6 more \`@ts-nocheck\` burn-downs, each its own small PR:
- \`src/app/(clinician)/[orgId]/settings/members/page.tsx\` (102 lines)
- \`src/app/features/page.tsx\` (115 lines)
- \`src/app/(patient)/portal/orders/page.tsx\` (116 lines)
- \`src/app/leafmart/refer/page.tsx\` (119 lines)
- \`src/app/education/[slug]/page.tsx\` (126 lines)
- \`src/app/book-demo/page.tsx\` (186 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)