### PR TITLE
feat(security): rate-limit admin mutations via requireApiAuth + Upstash swap point

### DIFF
--- a/src/app/api/admin/practices/[id]/switch-specialty/route.ts
+++ b/src/app/api/admin/practices/[id]/switch-specialty/route.ts
@@ -22,6 +22,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireApiAuth } from "@/lib/auth/api-gate";
+import { adminMutationLimiter } from "@/lib/auth/rate-limit";
 import { applyTemplateDefaults } from "@/lib/specialty-templates/registry";
 import { logControllerAction } from "@/lib/auth/audit-stub";
 
@@ -37,7 +38,10 @@ export async function POST(
   req: Request,
   { params }: { params: { id: string } },
 ) {
-  const gate = await requireApiAuth({ role: "super_admin" });
+  const gate = await requireApiAuth({
+    role: "super_admin",
+    rateLimit: { limiter: adminMutationLimiter, bucket: "admin.config.switch_specialty" },
+  });
   if (gate.error) return gate.error;
   const actor = gate.actor;
 

--- a/src/app/api/admin/super-admins/[userId]/route.ts
+++ b/src/app/api/admin/super-admins/[userId]/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { requireApiAuth } from "@/lib/auth/api-gate";
+import { adminMutationLimiter } from "@/lib/auth/rate-limit";
 import { logControllerAction } from "@/lib/auth/audit-stub";
 
 export const runtime = "nodejs";
@@ -21,7 +22,10 @@ export async function DELETE(
   _req: Request,
   { params }: { params: { userId: string } },
 ) {
-  const gate = await requireApiAuth({ role: "super_admin" });
+  const gate = await requireApiAuth({
+    role: "super_admin",
+    rateLimit: { limiter: adminMutationLimiter, bucket: "admin.super_admin.revoke" },
+  });
   if (gate.error) return gate.error;
   const actor = gate.actor;
 

--- a/src/app/api/admin/super-admins/route.ts
+++ b/src/app/api/admin/super-admins/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireApiAuth } from "@/lib/auth/api-gate";
+import { adminMutationLimiter } from "@/lib/auth/rate-limit";
 import { ensureLeafjourneyHq } from "@/lib/auth/super-admin-bootstrap";
 import { logControllerAction } from "@/lib/auth/audit-stub";
 
@@ -68,7 +69,10 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const gate = await requireApiAuth({ role: "super_admin" });
+  const gate = await requireApiAuth({
+    role: "super_admin",
+    rateLimit: { limiter: adminMutationLimiter, bucket: "admin.super_admin.grant" },
+  });
   if (gate.error) return gate.error;
   const actor = gate.actor;
 

--- a/src/lib/auth/api-gate.ts
+++ b/src/lib/auth/api-gate.ts
@@ -50,6 +50,22 @@ export interface RequireApiAuthOptions {
    * Set explicitly to override.
    */
   bootstrapSuperAdmin?: boolean;
+
+  /**
+   * Optional rate-limit gate. Runs AFTER successful authN/authZ and
+   * keys the limiter on the resolved actor's id. Returns 429 with
+   * Retry-After when the actor is over budget.
+   *
+   * Pass one of the pre-configured limiters from
+   * `src/lib/auth/rate-limit.ts` (adminMutationLimiter,
+   * agentInvocationLimiter) or a custom one — the helper only sees
+   * the RateLimiter shape.
+   */
+  rateLimit?: {
+    limiter: { check(id: string): { allowed: boolean; resetAt: number } };
+    /** Bucket label included in the 429 response — for client-side debugging. */
+    bucket?: string;
+  };
 }
 
 export type RequireApiAuthResult =
@@ -107,6 +123,30 @@ export async function requireApiAuth(
         { status: 403 },
       ),
     };
+  }
+
+  if (options.rateLimit) {
+    const result = options.rateLimit.limiter.check(user.id);
+    if (!result.allowed) {
+      const retryAfterSec = Math.max(
+        1,
+        Math.ceil((result.resetAt - Date.now()) / 1000),
+      );
+      return {
+        actor: null,
+        error: NextResponse.json(
+          {
+            error: "RATE_LIMITED",
+            bucket: options.rateLimit.bucket ?? null,
+            retryAfter: retryAfterSec,
+          },
+          {
+            status: 429,
+            headers: { "Retry-After": String(retryAfterSec) },
+          },
+        ),
+      };
+    }
   }
 
   return { actor: user, error: null };

--- a/src/lib/auth/rate-limit.ts
+++ b/src/lib/auth/rate-limit.ts
@@ -98,3 +98,46 @@ export const signupLimiter = createRateLimiter({
   windowMs: 60 * 60 * 1000,
   max: 3,
 });
+
+/**
+ * /api/admin/** mutation rate limit. Applied via requireApiAuth's
+ * `rateLimit` option. 10 per minute per actor — fast enough for any
+ * realistic admin workflow (grant + revoke + practice switch are
+ * each one click), slow enough that a stolen super-admin session
+ * can't drain through the entire org membership table at speed.
+ */
+export const adminMutationLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  max: 10,
+});
+
+/**
+ * Agent invocation rate limit. LLM endpoints (cindy, cfo/generate,
+ * agents/pharmacology, feedback/whisper) call paid upstream APIs —
+ * an unbounded request rate is an unbounded cost vector. 30 per
+ * minute per actor is conservative; production should refine these
+ * per-agent based on observed usage + budget.
+ */
+export const agentInvocationLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  max: 30,
+});
+
+// ---------------------------------------------------------------------------
+// Roadmap: REDIS_URL / UPSTASH_REDIS_REST_URL backed limiter
+// ---------------------------------------------------------------------------
+//
+// The in-memory limiter above is correct for a single-process Render
+// service. Once we run multiple instances or move to a serverless
+// platform that horizontally scales, each instance will have its own
+// counters and the effective rate is `max × instances` — useless for
+// abuse prevention.
+//
+// Swap point: when UPSTASH_REDIS_REST_URL is set, `createRateLimiter`
+// should return an instance backed by `@upstash/ratelimit`. Same
+// interface, real distributed counters. The constants above are env-
+// agnostic; only the implementation under the hood changes.
+//
+// Tracked as a follow-up to keep this PR focused on the abstraction
+// + initial application surface.
+


### PR DESCRIPTION
## Summary
Adds rate limiting to the admin mutation surface and the optional \`rateLimit\` parameter to \`requireApiAuth\`. Stolen-super-admin-session is not an outlandish threat model — without a rate limit, an attacker can drain the membership table at request speed.

## Pre-configured limiters
\`\`\`ts
adminMutationLimiter      // 10/min/actor — admin grant/revoke/switch
agentInvocationLimiter    // 30/min/actor — LLM cost containment
loginLimiter              // 5 / 15min/actor — pre-existing
signupLimiter             // 3 / hour/actor — pre-existing
\`\`\`

## Helper integration
\`\`\`ts
const gate = await requireApiAuth({
  role: \"super_admin\",
  rateLimit: { limiter: adminMutationLimiter, bucket: \"admin.super_admin.grant\" },
});
if (gate.error) return gate.error;  // 401, 403, or 429 — single envelope
\`\`\`

429 responses carry a \`Retry-After\` header (seconds), the \`RATE_LIMITED\` error code, and the bucket label for client-side debugging.

## Applied to
- \`POST /api/admin/super-admins\` (grant)
- \`DELETE /api/admin/super-admins/[userId]\` (revoke)
- \`POST /api/admin/practices/[id]/switch-specialty\`

\`GET\` admin endpoints **intentionally NOT** rate-limited — they're read-only and the admin console refreshes them on its own cadence. Limiting them risks breaking the console UX without a corresponding security gain.

## What this is NOT (yet)
- **Not Upstash-backed.** The limiter is in-memory — correct for a single-process Render service. The rate-limit module documents the swap point when this goes multi-instance. Tracked as follow-up to keep this PR focused.
- **Not applied to the LLM agent endpoints yet.** Those (cindy, cfo/generate, agents/pharmacology, feedback/whisper) are flagged \`needs_review\` in the route-auth manifest with a 2026-05-16 due date. Each gets its own PR adding both auth AND \`agentInvocationLimiter\`.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] \`for i in {1..15}; do curl -X POST /api/admin/super-admins ...; done\` — 11th call returns 429 with \`Retry-After: 60\`
- [ ] After waiting 60s, next call returns 200/4xx based on auth, not 429
- [ ] GET endpoints continue to work without limit during a burst
- [ ] No regression on PRs #239 (auth gate) or #234 (bootstrap)

## Follow-ups
1. Swap to \`@upstash/ratelimit\` when \`UPSTASH_REDIS_REST_URL\` is set
2. Apply \`agentInvocationLimiter\` to the 4 LLM endpoints in the same PR that closes their needs_review classification
3. Add structured log on every 429 so abuse patterns are queryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)