### PR TITLE
fix(security): auth + rate-limit 3 LLM agent endpoints; close cfo/generate auth hole

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -164,24 +164,21 @@ routes:
   # ── Agents (LLM-backed, $$ implications) ─────────────────
   agents/pharmacology:
     methods: [POST]
-    auth: needs_review
+    auth: required
     owner: agents
-    review_due: 2026-05-16
-    notes: "🚨 LLM agent endpoint, no auth detected. Unmetered prompt = unmetered cost. Must require auth + rate-limit before any prod traffic."
+    notes: "Closed 2026-05-09: requireApiAuth + agentInvocationLimiter (30/min/actor). Bucket: agent.pharmacology. Streams SSE; gate runs BEFORE the body is consumed."
 
   cindy:
     methods: [POST]
-    auth: needs_review
+    auth: required
     owner: agents
-    review_due: 2026-05-16
-    notes: "🚨 LLM agent endpoint, no auth detected. Same risk as agents/pharmacology."
+    notes: "Closed 2026-05-09: requireApiAuth + agentInvocationLimiter (30/min/actor). Bucket: agent.cindy."
 
   cfo/generate:
     methods: [GET, POST]
-    auth: needs_review
+    auth: cron
     owner: agents
-    review_due: 2026-05-16
-    notes: "🚨 CFO report generation, no auth detected. Both LLM cost and PHI/financial-data exposure risk."
+    notes: "Cron-style. POST validates Bearer CRON_SECRET, fail-closed in prod when env unset (PR S — same hardening pattern as cron/reminders). Org fan-out capped at 250."
 
   feedback/whisper:
     methods: [GET, POST]

--- a/src/app/api/agents/pharmacology/route.ts
+++ b/src/app/api/agents/pharmacology/route.ts
@@ -2,6 +2,8 @@ import {
   isModelError,
   resolveModelClient,
 } from "@/lib/orchestration/model-client";
+import { requireApiAuth } from "@/lib/auth/api-gate";
+import { agentInvocationLimiter } from "@/lib/auth/rate-limit";
 
 /**
  * POST /api/agents/pharmacology
@@ -236,6 +238,17 @@ async function pumpView(
 }
 
 export async function POST(request: Request) {
+  // Auth + rate limit BEFORE we touch the body — an unauthed caller
+  // shouldn't even consume the request stream, let alone reach the
+  // upstream LLM that this endpoint fans out to.
+  const gate = await requireApiAuth({
+    rateLimit: {
+      limiter: agentInvocationLimiter,
+      bucket: "agent.pharmacology",
+    },
+  });
+  if (gate.error) return gate.error;
+
   let body: { diagnosis?: unknown; icd10?: unknown };
   try {
     body = (await request.json()) as typeof body;

--- a/src/app/api/cfo/generate/route.ts
+++ b/src/app/api/cfo/generate/route.ts
@@ -24,15 +24,41 @@ const bodySchema = z.object({
   inline: z.boolean().optional(),
 });
 
-function authorized(req: Request) {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) return true; // dev: open
-  const header = req.headers.get("authorization");
-  return header === `Bearer ${expected}`;
+// Auth: cron-style shared-secret in the Authorization header. Production
+// requires a match against CRON_SECRET — fail closed even if the env var
+// itself is missing (the previous version returned `true` when CRON_SECRET
+// was unset, which silently opened the endpoint in any env where the var
+// hadn't been provisioned). Non-production logs and falls through so dev
+// tooling can hit the route without the env var.
+function authorized(req: Request): { ok: true } | { ok: false; reason: string } {
+  const expected = process.env.CRON_SECRET ?? "";
+  const header = req.headers.get("authorization") ?? "";
+  const wanted = expected ? `Bearer ${expected}` : null;
+
+  if (process.env.NODE_ENV === "production") {
+    if (!wanted) return { ok: false, reason: "cron_secret_not_configured" };
+    if (header !== wanted) return { ok: false, reason: "bad_authorization" };
+    return { ok: true };
+  }
+
+  // Non-prod: accept but warn so missing CRON_SECRET in staging is visible.
+  if (!wanted || header !== wanted) {
+    // eslint-disable-next-line no-console
+    console.warn("[cfo/generate] non-prod call without valid CRON_SECRET");
+  }
+  return { ok: true };
 }
 
+const ORG_FANOUT_CAP = 250;
+
 export async function POST(req: Request) {
-  if (!authorized(req)) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  const auth = authorized(req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      { ok: false, error: "Unauthorized", reason: auth.reason },
+      { status: 401 },
+    );
+  }
 
   const json = await req.json().catch(() => ({}));
   const parsed = bodySchema.safeParse(json);
@@ -44,8 +70,22 @@ export async function POST(req: Request) {
   if (organizationId) {
     orgIds = [organizationId];
   } else {
-    const orgs = await prisma.organization.findMany({ select: { id: true } });
+    // Cap the cron fan-out — a multi-hundred-org tenant base would
+    // otherwise dispatch the CFO agent across every row in one tick,
+    // which is both an LLM cost spike and an N-way DB hammer. Above
+    // this cap, ops needs to shard the cron by tenant slice.
+    const orgs = await prisma.organization.findMany({
+      select: { id: true },
+      orderBy: { createdAt: "asc" },
+      take: ORG_FANOUT_CAP,
+    });
     orgIds = orgs.map((o) => o.id);
+    if (orgIds.length === ORG_FANOUT_CAP) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[cfo/generate] org fan-out hit cap (${ORG_FANOUT_CAP}); shard the cron`,
+      );
+    }
   }
 
   if (inline) {

--- a/src/app/api/cindy/route.ts
+++ b/src/app/api/cindy/route.ts
@@ -2,13 +2,24 @@
 // a server action; this route exists so external surfaces (a future
 // browser extension, a partner site embed) can call Cindy without a
 // Next.js server-action context.
+//
+// Auth (added per docs/security/route-auth.yaml needs_review entry):
+// any signed-in user, rate-limited by agentInvocationLimiter so an
+// abusive caller can't unbounded-spend on the upstream LLM.
 
 import { NextResponse } from "next/server";
 import { askCindy, askCindyInput } from "@/lib/agents/cindy";
+import { requireApiAuth } from "@/lib/auth/api-gate";
+import { agentInvocationLimiter } from "@/lib/auth/rate-limit";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
+  const gate = await requireApiAuth({
+    rateLimit: { limiter: agentInvocationLimiter, bucket: "agent.cindy" },
+  });
+  if (gate.error) return gate.error;
+
   let body: unknown;
   try {
     body = await req.json();


### PR DESCRIPTION
## Summary
Closes 3 of the 🚨 \`needs_review\` entries from the route-auth manifest (PR #241). Each LLM-backed endpoint was reachable without auth AND without rate limit — every call is a paid upstream LLM call, and \"unmetered prompt = unmetered cost\" is exactly the abuse vector these routes attract.

## Changes

### \`/api/cindy\` (29 → 41 lines)
- \`requireApiAuth\` (any signed-in user)
- \`agentInvocationLimiter\` (30/min/actor)
- Manifest: \`needs_review\` → \`required\`

### \`/api/agents/pharmacology\` (318 lines, SSE stream)
- \`requireApiAuth\` + \`agentInvocationLimiter\` 
- Gate runs **before** the body is consumed — an unauthed caller can't even start the SSE stream, let alone reach the upstream LLM
- Manifest: \`needs_review\` → \`required\`

### \`/api/cfo/generate\` (real bug fixed)
The previous \`authorized()\` helper had this hole:
\`\`\`ts
function authorized(req: Request) {
  const expected = process.env.CRON_SECRET;
  if (!expected) return true; // dev: open
  // ...
}
\`\`\`
**A missing \`CRON_SECRET\` in any environment (including prod) returned \`true\` and silently opened the endpoint.** Same bug pattern PR Q fixed in \`cron/reminders\`.

Now:
- Production refuses if \`CRON_SECRET\` is missing or wrong
- Non-prod still falls through but logs so missing-env-var in staging is visible before it bites prod
- Org fan-out capped at 250 (was unbounded \`findMany\` across every org)
- Manifest: \`needs_review\` → \`cron\`

## Not in this PR
\`/api/feedback/whisper\` — public-by-design (FAB feedback from signed-out marketing visitors). Needs IP-keyed rate limit, which is a different design from the user-keyed limiter. Stays in \`needs_review\` with a separate ticket.

## Manifest impact
\`\`\`
before: 62 routes / 20 pending review
after:  62 routes / 17 pending review
\`\`\`

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] \`node scripts/check-route-auth-manifest.mjs\` passes
- [ ] Local: \`curl -X POST /api/cindy -d '{}'\` (no auth) → 401
- [ ] Local: signed-in burst of 35 cindy POSTs → 31st returns 429 with Retry-After
- [ ] Local: \`curl -X POST /api/cfo/generate\` (no auth) with NODE_ENV=production → 401
- [ ] Local: \`CRON_SECRET=foo curl -H 'Authorization: Bearer foo' /api/cfo/generate\` → 200
- [ ] Verify SSE pharmacology endpoint still streams correctly when authed

## Pre-merge ops
- [ ] Confirm \`CRON_SECRET\` set in Render staging + prod for \`/api/cfo/generate\`. Hardened auth = missing env var is now a 401 instead of an open door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)