### PR TITLE
db(perf): 5 chart-tab indexes (CREATE INDEX CONCURRENTLY) — index audit pass 1

### DIFF
--- a/docs/audit/INDEX_AUDIT_2026-05-09.md
+++ b/docs/audit/INDEX_AUDIT_2026-05-09.md
@@ -1,0 +1,76 @@
+# Index audit — patient detail page hot paths
+
+**Scope:** every `findMany`/`findFirst`/`count` invoked from
+`src/app/(clinician)/clinic/patients/[id]/page.tsx` cross-referenced
+against existing `@@index` declarations in `prisma/schema.prisma`.
+
+**Method:**
+1. Enumerate Prisma calls in the patient page and the `where` /
+   `orderBy` shapes.
+2. For each, compute the index that would cover the filter + sort.
+3. Compare against existing indexes.
+4. Recommend additions where coverage is missing OR where the
+   query's sort column is not the trailing column of an otherwise-
+   matching index.
+
+This audit was static — `EXPLAIN ANALYZE` against a live database
+will refine the priority order. The 5 indexes added in this migration
+are conservative coverages of obvious gaps; further tuning is a
+follow-up after the migration is in prod and pg_stat_statements has
+data.
+
+## Patient page query inventory
+
+| # | Query | Where | Order | Coverage status |
+|---|---|---|---|---|
+| 1 | `note.findMany` | encounter.patientId + organizationId | createdAt desc | OK via Encounter indexes |
+| 2 | `messageThread.findMany` | patientId | lastMessageAt desc | ✅ exact `(patientId, lastMessageAt)` |
+| 3 | `assessmentResponse.findMany` | patientId | submittedAt desc | ✅ exact `(patientId, submittedAt)` |
+| 4 | `dosingRegimen.findMany` | patientId | startDate desc | 🆕 add `(patientId, startDate)` |
+| 5 | `doseLog.findMany` | patientId | loggedAt desc | ✅ exact `(patientId, loggedAt)` |
+| 6 | `cannabisProduct.findMany` | organizationId, active | name asc | small set, OK |
+| 7 | `patientMedication.findMany` | patientId, active | name asc | covered, name sort small |
+| 8 | `patientMemory.findMany` | patientId, validUntil null | createdAt desc | OK via `(patientId, createdAt)` |
+| 9 | `clinicalObservation.findMany` | patientId | createdAt desc | 🆕 add `(patientId, createdAt)` — existing indexes require category/severity predicate |
+| 10 | `claim.findMany` | patientId | serviceDate desc | ✅ exact `(patientId, serviceDate)` |
+| 11 | `claim.count` | patientId, status IN (...) | — | 🆕 add `(patientId, status)` — existing indexes don't lead with `(patientId, status)` |
+| 12 | `task.findMany` | patientId, status='open' | dueAt asc | 🆕 add `(patientId, status, dueAt)` — existing indexes lead with org or assignee |
+| 13 | `encounter.findMany` (recentCharted) | organizationId, charting timestamps not null | chartingCompletedAt desc | 🆕 add `(organizationId, chartingCompletedAt)` |
+
+## Indexes added by the migration
+
+```
+ClinicalObservation_patientId_createdAt_idx          (patientId, createdAt)
+Claim_patientId_status_idx                           (patientId, status)
+Task_patientId_status_dueAt_idx                      (patientId, status, dueAt)
+Encounter_organizationId_chartingCompletedAt_idx     (organizationId, chartingCompletedAt)
+DosingRegimen_patientId_startDate_idx                (patientId, startDate)
+```
+
+All five use `CREATE INDEX CONCURRENTLY` so they don't take an
+`ACCESS EXCLUSIVE` lock on their table — required for prod
+deployment against live tenant data.
+
+## What this audit did NOT cover
+
+- Other clinician pages (clinic dashboard, billing surfaces, ops dashboards)
+- Patient portal pages
+- Agent fan-out queries
+- Cron job queries
+- Marketplace / Leafmart commerce queries
+
+Each is a separate audit pass. EPIC 2.4 budgets 5 days for the full
+sweep — this PR closes the highest-traffic surface (the chart tab
+that every clinician opens dozens of times per day).
+
+## Follow-up
+
+After this migration deploys:
+1. Enable `pg_stat_statements` if not already on
+2. Take a baseline of the 5 affected query shapes' mean and p95
+   latency
+3. Land the migration
+4. Compare 24h and 7d post-migration. Document the actual win in
+   this file.
+5. Repeat for the next page (clinic dashboard) using the same
+   methodology.

--- a/prisma/migrations/20260509000000_chart_tab_indexes/migration.sql
+++ b/prisma/migrations/20260509000000_chart_tab_indexes/migration.sql
@@ -1,0 +1,53 @@
+-- Index audit 2026-05-09 — patient detail page hot paths.
+--
+-- Adds 5 composite indexes that cover findMany shapes in
+-- src/app/(clinician)/clinic/patients/[id]/page.tsx. Cross-referenced
+-- against existing indexes per docs/audit/INDEX_AUDIT_2026-05-09.md.
+-- Each is small (composite on already-cardinal columns), low storage
+-- cost, real read benefit on chart-tab loads.
+--
+-- All five use CREATE INDEX CONCURRENTLY so the migration does not
+-- take an ACCESS EXCLUSIVE lock on the table — required for prod
+-- deployment against live tenant data. Postgres requires
+-- CONCURRENTLY indexes to live OUTSIDE a transaction; Prisma's
+-- migrate runner handles each statement individually so this is
+-- safe.
+--
+-- Rollback: each index is independently DROP-able with
+--   DROP INDEX CONCURRENTLY IF EXISTS "<name>";
+
+-- 1. ClinicalObservation chart-tab unfiltered list.
+--    Read: where patientId, orderBy createdAt desc. Existing compound
+--    indexes start with patientId but require a category/severity
+--    predicate to be useful. This one covers the bare patientId+order.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ClinicalObservation_patientId_createdAt_idx"
+  ON "ClinicalObservation" ("patientId", "createdAt");
+
+-- 2. Claim open-claim count for the chart tab.
+--    Read: count where patientId AND status IN (...). Existing
+--    patientId+serviceDate index doesn't cover a status filter when
+--    serviceDate isn't in the predicate.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Claim_patientId_status_idx"
+  ON "Claim" ("patientId", "status");
+
+-- 3. Task chart-tab open-task list.
+--    Read: where patientId AND status='open', orderBy dueAt asc.
+--    Existing indexes are on (organizationId, status) and
+--    (assigneeUserId, status) — neither leads with patientId.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Task_patientId_status_dueAt_idx"
+  ON "Task" ("patientId", "status", "dueAt");
+
+-- 4. Encounter charting-time benchmark.
+--    Read: where organizationId AND startedAt IS NOT NULL AND
+--    chartingCompletedAt IS NOT NULL, orderBy chartingCompletedAt desc.
+--    Existing organizationId+status+createdAt index is on the wrong
+--    sort column.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_chartingCompletedAt_idx"
+  ON "Encounter" ("organizationId", "chartingCompletedAt");
+
+-- 5. DosingRegimen chart-tab history.
+--    Read: where patientId, orderBy startDate desc. Existing
+--    patientId+active index doesn't cover the ordering when `active`
+--    isn't in the predicate.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "DosingRegimen_patientId_startDate_idx"
+  ON "DosingRegimen" ("patientId", "startDate");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -453,6 +453,10 @@ model Encounter {
   @@index([patientId, status])
   @@index([providerId, scheduledFor])
   @@index([organizationId, status, createdAt])
+  // EMR-132 charting-time benchmark (clinic/patients/[id]/page.tsx#recentCharted).
+  // Filters by organizationId + nulls-not-null on charting timestamps, orders
+  // by chartingCompletedAt. Index audit 2026-05-09.
+  @@index([organizationId, chartingCompletedAt])
 }
 
 enum NoteStatus {
@@ -584,6 +588,10 @@ model Claim {
   @@index([patientId, serviceDate])
   @@index([providerId, serviceDate])
   @@index([status, timelyFilingDeadline])
+  // Chart-tab open-claim count (clinic/patients/[id]/page.tsx#openClaimCount).
+  // The existing patientId+serviceDate index doesn't cover a status filter
+  // efficiently when serviceDate is not in the predicate. Index audit 2026-05-09.
+  @@index([patientId, status])
 }
 
 enum PaymentSource {
@@ -1612,6 +1620,10 @@ model Task {
 
   @@index([organizationId, status])
   @@index([assigneeUserId, status])
+  // Chart-tab open-task list (clinic/patients/[id]/page.tsx#openTasks).
+  // Filters by patientId+status, orders by dueAt — covered by this composite.
+  // Index audit 2026-05-09.
+  @@index([patientId, status, dueAt])
 }
 
 // --------------------------------------------------------------
@@ -1836,6 +1848,11 @@ model ClinicalObservation {
   @@index([patientId, acknowledgedAt])
   @@index([patientId, category, createdAt])
   @@index([patientId, severity, createdAt])
+  // Chart-tab unfiltered observation list (clinic/patients/[id]/page.tsx).
+  // Existing compound indexes start with patientId but the chart tab
+  // doesn't filter by category or severity, so neither covers the
+  // ordering. Index audit 2026-05-09.
+  @@index([patientId, createdAt])
 }
 
 model AgentReasoning {
@@ -1995,6 +2012,10 @@ model DosingRegimen {
   doseLogs DoseLog[]
 
   @@index([patientId, active])
+  // Chart-tab regimen history (clinic/patients/[id]/page.tsx#dosingRegimens).
+  // Read does not filter on `active`, orders by startDate desc.
+  // Index audit 2026-05-09.
+  @@index([patientId, startDate])
 }
 
 model DoseLog {


### PR DESCRIPTION
## Summary
First pass of EPIC 2.4 (index audit on hot paths). Cross-references every \`findMany\`/\`findFirst\`/\`count\` in \`src/app/(clinician)/clinic/patients/[id]/page.tsx\` (the 2,043-line patient chart that every clinician opens dozens of times per day) against existing \`@@index\` declarations. Adds 5 indexes covering obvious gaps.

## Indexes added

| Model | Index | Why |
|---|---|---|
| \`ClinicalObservation\` | \`(patientId, createdAt)\` | Chart-tab unfiltered list; existing compound indexes require category/severity in the predicate to be useful |
| \`Claim\` | \`(patientId, status)\` | Open-claim count; existing patientId+serviceDate doesn't cover a status filter when serviceDate isn't in the predicate |
| \`Task\` | \`(patientId, status, dueAt)\` | Chart-tab open-task list; existing indexes lead with org or assignee, not patient |
| \`Encounter\` | \`(organizationId, chartingCompletedAt)\` | EMR-132 charting-time benchmark; existing org index sorts on createdAt |
| \`DosingRegimen\` | \`(patientId, startDate)\` | Regimen history; existing patientId+active doesn't cover an unfiltered read ordered by startDate |

## Migration safety

All 5 use **\`CREATE INDEX CONCURRENTLY\`** so the migration does **not** take an \`ACCESS EXCLUSIVE\` lock on the table — required for safe prod deployment against live tenant data. Postgres requires \`CONCURRENTLY\` indexes to live outside a transaction; Prisma's migrate runner handles each statement individually so this is safe.

Rollback: each index is independently \`DROP INDEX CONCURRENTLY IF EXISTS\` -able.

## What this audit was NOT

- **Not based on \`EXPLAIN ANALYZE\`.** The 5 indexes are conservative coverages of obvious gaps based on schema review. The real win/loss numbers come from \`pg_stat_statements\` after deploy.
- **Not the full sweep.** Other clinician pages, patient portal, agent fan-outs, cron, leafmart — each is a separate audit slice. EPIC 2.4 budgets 5 days for the full pass; this PR closes the highest-traffic single surface.

## Follow-up plan
1. Enable \`pg_stat_statements\` if not already on
2. Capture baseline mean/p95 for the 5 query shapes BEFORE merge
3. Land the migration
4. Compare 24h + 7d post-migration; record actuals in \`docs/audit/INDEX_AUDIT_2026-05-09.md\`
5. Move to the clinic-dashboard page next (~13 more hot queries)

## Test plan
- [ ] \`npx prisma format\` passes (schema is well-formed)
- [ ] \`npx prisma migrate dev --create-only\` against a local dev DB confirms the migration applies
- [ ] After applying: \`\\d "ClinicalObservation"\` in psql shows the new index
- [ ] No table-level \`ACCESS EXCLUSIVE\` lock during apply (verify via \`SELECT * FROM pg_locks\` mid-migration on a test load)
- [ ] Rollback by dropping each index individually works

## Pre-merge checklist
- [ ] Confirm Render staging can run \`prisma migrate deploy\` against the new migration without timing out
- [ ] Capture baseline query latencies on staging before merge
- [ ] Schedule deploy in a low-traffic window — even \`CONCURRENTLY\` adds I/O load proportional to table size

🤖 Generated with [Claude Code](https://claude.com/claude-code)