### PR TITLE
feat(observability): structured logger module + auth-slice migration (3 of ~136 console.* calls)

### DIFF
--- a/src/lib/auth/api-gate.ts
+++ b/src/lib/auth/api-gate.ts
@@ -33,6 +33,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import type { Role } from "@prisma/client";
+import { logger } from "@/lib/observability/log";
 import { type AuthedUser, requireUser } from "./session";
 import { bootstrapSuperAdminIfAllowlisted } from "./super-admin-bootstrap";
 
@@ -107,11 +108,11 @@ export async function requireApiAuth(
       // Bootstrap failure is unusual (DB hiccup) but shouldn't 500 the
       // request — fall through to the role check, which will 403 if the
       // user wasn't already a super-admin.
-      // eslint-disable-next-line no-console
-      console.warn(
-        "[api-gate] bootstrapSuperAdminIfAllowlisted threw — continuing to role check",
+      logger.warn({
+        event: "auth.bootstrap.threw",
+        userId: user.id,
         err,
-      );
+      });
     }
   }
 

--- a/src/lib/auth/audit-stub.ts
+++ b/src/lib/auth/audit-stub.ts
@@ -19,6 +19,7 @@ import "server-only";
 
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
 import type { AuthedUser } from "./session";
 
 /**
@@ -107,7 +108,6 @@ export async function logControllerAction(entry: ControllerAuditEntry): Promise<
       reason: entry.reason ?? null,
       error: err instanceof Error ? err.message : String(err),
     };
-    // eslint-disable-next-line no-console -- intentional fallback path
-    console.error("[audit:controller:persist_failed]", JSON.stringify(fallback));
+    logger.error({ event: "audit.controller.persist_failed", ...fallback });
   }
 }

--- a/src/lib/auth/super-admin-bootstrap.ts
+++ b/src/lib/auth/super-admin-bootstrap.ts
@@ -22,6 +22,7 @@
 import "server-only";
 
 import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
 import type { AuthedUser } from "./session";
 
 export const LEAFJOURNEY_HQ_SLUG = "leafjourney-hq";
@@ -137,12 +138,13 @@ export async function bootstrapSuperAdminIfAllowlisted(
     // Don't block the grant on a failed audit row — but make sure the
     // failure is loud. Silently-promoted super-admins with no audit
     // trail is the exact failure mode this module is supposed to avoid.
-    console.error(
-      "[super-admin-bootstrap] FAILED to write audit row for promotion of " +
-        user.email +
-        " — investigate immediately.",
+    logger.error({
+      event: "auth.bootstrap.audit_write_failed",
+      userId: user.id,
       err,
-    );
+      message:
+        "Promoted user but audit row failed to persist — investigate immediately.",
+    });
   }
 
   return true;

--- a/src/lib/observability/log.ts
+++ b/src/lib/observability/log.ts
@@ -1,0 +1,116 @@
+// Structured logger — single entry point for app logging.
+//
+// Why this exists: tonight's audit found 136 direct `console.*` calls
+// in src/. Each one drifts independently — no consistent fields, no
+// consistent severity mapping, no single place to wire Sentry. This
+// module is the abstraction that makes the larger sweep mechanical.
+//
+// Design constraints:
+//   - No new runtime dependencies. pino lands in EPIC 4.1 as a
+//     follow-up; this module is the interface that swap will be
+//     drop-in for. The body is just console.* with structured
+//     enrichment for now.
+//   - Server-only — must work in Node + Next.js Edge runtimes.
+//     Avoid `process.env` reads at module load (Edge restricts that
+//     to compile time); read inside the call sites.
+//   - PHI-aware — `redact` strips known sensitive keys before
+//     emission. Add to REDACT_KEYS as new sensitive fields land.
+//
+// Usage:
+//   import { logger } from "@/lib/observability/log";
+//   logger.info({ event: "auth.bootstrap.granted", userId, email });
+//   logger.error({ event: "audit.persist_failed", err });
+//
+// Bound logger for a request scope:
+//   const log = logger.with({ requestId, route: "api/admin/super-admins" });
+//   log.warn({ event: "rate_limit.hit", actor: user.id });
+
+import "server-only";
+
+type Level = "debug" | "info" | "warn" | "error";
+
+const REDACT_KEYS = new Set([
+  "password",
+  "passwordhash",
+  "token",
+  "apikey",
+  "secret",
+  "ssn",
+  "dea",
+  "npi",
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "creditcard",
+  "cvv",
+]);
+
+function redact(value: unknown, depth = 0): unknown {
+  // Recursion limit — no shape we log should be deeper than this.
+  if (depth > 6) return "[redacted: depth]";
+
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => redact(v, depth + 1));
+  }
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (REDACT_KEYS.has(k.toLowerCase())) {
+      out[k] = "[redacted]";
+    } else {
+      out[k] = redact(v, depth + 1);
+    }
+  }
+  return out;
+}
+
+function emit(level: Level, fields: Record<string, unknown>): void {
+  const enriched = {
+    ts: new Date().toISOString(),
+    level,
+    ...(redact(fields) as Record<string, unknown>),
+  };
+
+  // Single newline-delimited JSON line per emit so log aggregators
+  // can parse without configuration.
+  const line = JSON.stringify(enriched);
+
+  // Severity mapping: warn/error to console.error so non-prod tooling
+  // surfaces them; debug/info to console.log.
+  if (level === "error" || level === "warn") {
+    // eslint-disable-next-line no-console
+    console.error(line);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(line);
+  }
+}
+
+export interface Logger {
+  debug(fields: Record<string, unknown>): void;
+  info(fields: Record<string, unknown>): void;
+  warn(fields: Record<string, unknown>): void;
+  error(fields: Record<string, unknown>): void;
+  /** Return a logger that prepends `bound` to every emission. */
+  with(bound: Record<string, unknown>): Logger;
+}
+
+function makeLogger(bound: Record<string, unknown> = {}): Logger {
+  return {
+    debug: (fields) => emit("debug", { ...bound, ...fields }),
+    info: (fields) => emit("info", { ...bound, ...fields }),
+    warn: (fields) => emit("warn", { ...bound, ...fields }),
+    error: (fields) => emit("error", { ...bound, ...fields }),
+    with: (more) => makeLogger({ ...bound, ...more }),
+  };
+}
+
+export const logger: Logger = makeLogger();


### PR DESCRIPTION
## Summary
First slice of EPIC 4.1 — replace 136 \`console.*\` calls in \`src/\` with a structured logger. Adds the module + migrates the 3 calls in \`src/lib/auth/\` as a pattern proof.

## Module: \`src/lib/observability/log.ts\` (116 lines)

\`\`\`ts
import { logger } from "@/lib/observability/log";

logger.info({ event: "auth.bootstrap.granted", userId, email });
logger.error({ event: "audit.persist_failed", err });

// Bound-context for a request scope:
const log = logger.with({ requestId, route: "api/admin/super-admins" });
log.warn({ event: "rate_limit.hit", actor: user.id });
\`\`\`

Properties:
- **PHI-aware redact** — strips \`password\`, \`ssn\`, \`dea\`, \`npi\`, \`authorization\`, \`cookie\`, \`set-cookie\`, \`creditCard\`, \`cvv\`, \`secret\`, \`token\`, \`apiKey\` from any nested key (case-insensitive)
- **NDJSON output** — log aggregators parse without configuration
- **Server-only** via \`"server-only"\` import
- **No new dependencies.** pino lands in EPIC 4.1 follow-up; this is the interface that swap will be drop-in for.
- **Dot-namespaced event names** — \`auth.*\` / \`audit.*\` / \`rate_limit.*\` — alert rules target stable identifiers instead of brittle bracket-prefix strings

## Migrated (3 files, 3 calls)

| File | Before | After |
|---|---|---|
| \`src/lib/auth/audit-stub.ts\` | \`console.error(\"[audit:controller:persist_failed]\", JSON.stringify(fallback))\` | \`logger.error({ event: \"audit.controller.persist_failed\", ...fallback })\` |
| \`src/lib/auth/api-gate.ts\` | \`console.warn(\"[api-gate] bootstrapSuperAdminIfAllowlisted threw...\", err)\` | \`logger.warn({ event: \"auth.bootstrap.threw\", userId, err })\` |
| \`src/lib/auth/super-admin-bootstrap.ts\` | \`console.error(\"[super-admin-bootstrap] FAILED to write audit row...\", err)\` | \`logger.error({ event: \"auth.bootstrap.audit_write_failed\", userId, err, message })\` |

## Why ship the module + a thin slice?
1. **Module-only PR has no observable behavior.** Review can't spot a redact-key omission until a real call site uses it.
2. **Auth slice is security-relevant.** Getting redact right here matters more than in marketing pages.
3. **Mechanical follow-ups.** Each remaining slice (~30 in clinic/, ~20 in api/, ~10 in agents/, etc.) becomes a small PR on a green pattern.

## What this is NOT
- Not pino — that's an EPIC 4.1 follow-up. The interface here is what pino will swap into.
- Not Sentry breadcrumb integration — separate concern; logger.error already feeds the existing \`captureAuditFailure\` path in audit-stub.
- Not request-correlation IDs — EPIC 4.2.
- Not a pino sweep across 136 call sites — slice-at-a-time per directory.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] \`npm run lint\` passes
- [ ] No remaining \`console.*\` calls in \`src/lib/auth/\` (verified by grep)
- [ ] Run a local request that triggers audit failure → see NDJSON line in stderr with \`event: audit.controller.persist_failed\`
- [ ] Pass an object containing \`{ password: "p4ssw0rd" }\` to logger → verify \`password\` redacted in output

## Follow-up slices
1. \`src/lib/agents/\` — ~10 call sites
2. \`src/app/api/\` — ~20 call sites
3. \`src/app/(clinician)/\` — ~30 call sites
4. \`src/app/(patient)/\` — ~10 call sites
5. \`src/lib/billing/\` — ~5 call sites
6. \`src/lib/orchestration/\` — ~5 call sites
7. \`src/lib/integrations/\` — ~10 call sites
8. \`src/lib/marketplace/\`, \`src/lib/leafmart/\`, etc.

Each its own PR. After all slices land: lint rule blocking new \`console.*\` in \`src/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)