### PR TITLE
fix(clinic/members): burn @ts-nocheck, fix 'FORBIDDEN on every request' bug + 4 others

### DIFF
--- a/src/app/(clinician)/[orgId]/settings/members/page.tsx
+++ b/src/app/(clinician)/[orgId]/settings/members/page.tsx
@@ -1,29 +1,67 @@
-// @ts-nocheck
 import { prisma } from "@/lib/db/prisma";
-import { requireRole } from "@/lib/auth/session";
+import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { MoreHorizontal, Plus, Shield, User } from "lucide-react";
-import { notFound } from "next/navigation";
+import { MoreHorizontal, Plus, Shield, User as UserIcon } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
 
 export const metadata = { title: "Team Members" };
 
-export default async function MembersPage({ params }: { params: { orgId: string } }) {
-  const user = await requireRole(["admin", "provider"]);
+const PROVIDER_LIST_CAP = 200;
+
+// Role-display gate. Any signed-in clinician or practice admin may view
+// the roster; mutation handlers (invite/remove) gate on practice_admin.
+const VIEWER_ROLES = ["clinician", "practice_admin", "super_admin"] as const;
+
+function initials(firstName: string | null, lastName: string | null): string {
+  const a = (firstName ?? "").trim().charAt(0).toUpperCase();
+  const b = (lastName ?? "").trim().charAt(0).toUpperCase();
+  return a + b || "?";
+}
+
+export default async function MembersPage({
+  params,
+}: {
+  params: { orgId: string };
+}) {
+  // EMR-?? bugfix: the previous handler called requireRole(["admin",
+  // "provider"]) — both wrong: requireRole takes a single Role enum
+  // value, and "admin"/"provider" aren't members of the Role enum
+  // (it's clinician / practice_admin / super_admin / etc). With
+  // @ts-nocheck on top, the broken call shipped; every request to
+  // this page threw FORBIDDEN at the role gate. Replaced with the
+  // explicit "any of these roles" check below.
+  const user = await requireUser();
+  if (!user.roles.some((r) => (VIEWER_ROLES as readonly string[]).includes(r))) {
+    redirect("/clinic");
+  }
 
   const organization = await prisma.organization.findUnique({
     where: { id: params.orgId },
     include: {
-      providers: true,
-      // In a real schema we might have an OrganizationMember bridging table.
-      // For V1, we list the providers assigned to this org.
-    }
+      providers: {
+        where: { active: true },
+        orderBy: { createdAt: "asc" },
+        take: PROVIDER_LIST_CAP,
+        include: {
+          // Provider does not carry firstName/lastName — those live on
+          // the related User. The previous version accessed
+          // provider.firstName.charAt(0) which threw at runtime when
+          // @ts-nocheck wasn't preventing the type error.
+          user: {
+            select: { firstName: true, lastName: true, lastLoginAt: true },
+          },
+        },
+      },
+    },
   });
 
   if (!organization) {
     notFound();
   }
+
+  const providers = organization.providers;
 
   return (
     <PageShell maxWidth="max-w-[1000px]">
@@ -52,47 +90,73 @@ export default async function MembersPage({ params }: { params: { orgId: string 
               </tr>
             </thead>
             <tbody className="divide-y divide-[var(--border)]">
-              {organization.providers.map((provider) => (
-                <tr key={provider.id} className="hover:bg-[var(--surface-muted)]/50 transition-colors">
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-[var(--accent)]/10 text-[var(--accent)] flex items-center justify-center font-medium">
-                        {provider.firstName.charAt(0)}{provider.lastName.charAt(0)}
-                      </div>
-                      <div>
-                        <div className="font-medium text-text">
-                          Dr. {provider.firstName} {provider.lastName}
+              {providers.map((provider) => {
+                const firstName = provider.user.firstName ?? "";
+                const lastName = provider.user.lastName ?? "";
+                const specialtyLabel =
+                  provider.specialties[0] ?? provider.title ?? "Provider";
+                // TODO: surface the provider's actual platform role by
+                // joining Membership(role) for this user × this org.
+                // Showing "Clinician" universally is honest given today's
+                // schema doesn't stash a per-provider admin flag — better
+                // than the fake `id.endsWith("a")` heuristic the prior
+                // version used.
+                const isAdmin = false;
+                const lastLoginAt = provider.user.lastLoginAt
+                  ? provider.user.lastLoginAt.toLocaleString()
+                  : "—";
+                return (
+                  <tr
+                    key={provider.id}
+                    className="hover:bg-[var(--surface-muted)]/50 transition-colors"
+                  >
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 rounded-full bg-[var(--accent)]/10 text-[var(--accent)] flex items-center justify-center font-medium">
+                          {initials(firstName, lastName)}
                         </div>
-                        <div className="text-text-muted text-xs">
-                          {provider.specialty || "Provider"}
+                        <div>
+                          <div className="font-medium text-text">
+                            Dr. {firstName} {lastName}
+                          </div>
+                          <div className="text-text-muted text-xs">
+                            {specialtyLabel}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-1.5 text-text-muted">
-                      {/* For demo purposes, we randomly assign roles */}
-                      {provider.id.endsWith("a") ? (
-                        <><Shield className="w-3.5 h-3.5" /> Admin</>
-                      ) : (
-                        <><User className="w-3.5 h-3.5" /> Clinician</>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4">
-                    <Badge tone="success" className="text-[10px]">Active</Badge>
-                  </td>
-                  <td className="px-6 py-4 text-text-muted">
-                    Just now
-                  </td>
-                  <td className="px-6 py-4 text-right">
-                    <Button variant="ghost" size="icon" className="h-8 w-8 text-text-muted">
-                      <MoreHorizontal className="w-4 h-4" />
-                      <span className="sr-only">Actions</span>
-                    </Button>
-                  </td>
-                </tr>
-              ))}
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-1.5 text-text-muted">
+                        {isAdmin ? (
+                          <>
+                            <Shield className="w-3.5 h-3.5" /> Admin
+                          </>
+                        ) : (
+                          <>
+                            <UserIcon className="w-3.5 h-3.5" /> Clinician
+                          </>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <Badge tone="success" className="text-[10px]">
+                        Active
+                      </Badge>
+                    </td>
+                    <td className="px-6 py-4 text-text-muted">{lastLoginAt}</td>
+                    <td className="px-6 py-4 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-text-muted"
+                        aria-label="Actions"
+                      >
+                        <MoreHorizontal className="w-4 h-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
Third \`@ts-nocheck\` burn-down. Worst yet — \`/clinic/[orgId]/settings/members\` was **throwing FORBIDDEN on every request** because \`@ts-nocheck\` was hiding an auth gate that couldn't possibly succeed.

## The cardinal bug

\`\`\`ts
const user = await requireRole([\"admin\", \"provider\"]);
\`\`\`

Four problems compounded:
1. \`requireRole(role: Role)\` takes a **single** Role enum value, not an array
2. Passing an array short-circuits \`user.roles.includes(arr)\` to \`false\` — gate always throws
3. \"admin\" and \"provider\" aren't even members of the Role enum (which has \`clinician\`, \`practice_admin\`, \`super_admin\`, etc.)
4. \`@ts-nocheck\` let all three slip through review and shipped

**Fix:** \`requireUser()\` then \`roles.some\` against an explicit allowlist \`[clinician, practice_admin, super_admin]\`. Anyone outside that set is redirected to \`/clinic\`.

## Other bugs surfaced
| # | Bug | Cause |
|---|---|---|
| 2 | \`provider.firstName.charAt(0)\` would TypeError | Provider has firstName/lastName on its related \`user\`, not on itself (same as PR Q's Dr. undefined) |
| 3 | \`provider.specialty\` rendered undefined → fallback "Provider" | Schema has \`specialties: String[]\` (plural, array). Code read singular |
| 4 | Role detection was \`provider.id.endsWith(\"a\")\` | Literal demo placeholder. Removed with TODO to wire up Membership(role) |
| 5 | \`<Button size=\"icon\">\` doesn't typecheck | Real sizes are sm/md/lg |

Plus: capped \`providers\` at 200 (was unbounded), real \`lastLoginAt\` rendering instead of hardcoded "Just now".

## Pattern observation
Three \`@ts-nocheck\` files burnt down so far. **Three real bugs each**:
- PR Q (cron/reminders): "Dr. undefined" in every reminder + open-secret in non-prod
- PR T (portal/orders): "undefined × \$NaN" on every order line + missing relations
- PR W (clinic/members): every request 500'd at the auth gate + Provider relation bugs

That's an undefeated 3-for-3 on \`@ts-nocheck\` files producing user-visible bugs. **4 to go.**

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Local: as a clinician, render \`/clinic/[orgId]/settings/members\` → no longer 500/FORBIDDEN, table shows real provider names
- [ ] Provider initials render from real firstName/lastName (e.g. "JS" not crash)
- [ ] Specialty cell shows the first \`specialties\` entry or \`title\`, never "undefined"
- [ ] Last-active column shows real \`lastLoginAt\` or "—"
- [ ] As a patient or operator, redirected to /clinic instead of seeing a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)