### PR TITLE
feat(observability): logger-sweep slice 2 — src/lib/agents/ (8 console calls migrated)

### DIFF
--- a/src/lib/agents/corpus-book-indexer.ts
+++ b/src/lib/agents/corpus-book-indexer.ts
@@ -1,9 +1,10 @@
 /**
  * EMR-038: Cannabis Book Integration (Justin Kander)
  */
+import { logger } from "@/lib/observability/log";
 export class CorpusBookIndexer {
   async ingestBookContent(pdfPath: string) {
-    console.log(`[Indexer] Ingesting book from ${pdfPath}...`);
+    logger.info({ event: "agent.indexer.ingest", pdfPath });
     // AI vectorization pipeline for RAG integration
     return {
       vectorsCreated: 15420,

--- a/src/lib/agents/insurance-billing-agent.ts
+++ b/src/lib/agents/insurance-billing-agent.ts
@@ -1,9 +1,10 @@
 /**
  * EMR-045: Insurance Billing AI Agents
  */
+import { logger } from "@/lib/observability/log";
 export class InsuranceBillingAgent {
   async optimizeCoding(encounterId: string, chartNotes: string) {
-    console.log(`[BillingAgent] Optimizing CPT/ICD-10 codes for ${encounterId}`);
+    logger.info({ event: "agent.billing.code_optimize", encounterId });
     
     // AI analysis to maximize reimbursement within CMS guidelines
     return {

--- a/src/lib/agents/memory/agent-feedback.ts
+++ b/src/lib/agents/memory/agent-feedback.ts
@@ -13,6 +13,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import type { AgentFeedback, FeedbackAction } from "@prisma/client";
+import { logger } from "@/lib/observability/log";
 
 export interface RecordFeedbackInput {
   agentName: string;
@@ -47,10 +48,11 @@ export async function recordFeedback(
       },
     });
   } catch (err) {
-    console.warn("[agent-feedback] persist failed", {
+    logger.warn({
+      event: "agent.feedback.persist_failed",
       agentName: input.agentName,
       action: input.action,
-      error: err instanceof Error ? err.message : String(err),
+      err,
     });
     return null;
   }

--- a/src/lib/agents/memory/agent-reasoning.ts
+++ b/src/lib/agents/memory/agent-reasoning.ts
@@ -28,6 +28,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import type { AgentReasoning } from "@prisma/client";
+import { logger } from "@/lib/observability/log";
 
 export interface ReasoningStep {
   step: string;
@@ -110,9 +111,10 @@ export function startReasoning(
         // Reasoning persistence is best-effort. A failure here should
         // NEVER take down the agent run. The trace is a nice-to-have
         // for transparency; the actual output has already been produced.
-        console.warn("[agent-reasoning] persist failed", {
+        logger.warn({
+          event: "agent.reasoning.persist_failed",
           agentName,
-          error: err instanceof Error ? err.message : String(err),
+          err,
         });
         return null;
       }

--- a/src/lib/agents/patient-explainer.ts
+++ b/src/lib/agents/patient-explainer.ts
@@ -1,9 +1,10 @@
 /**
  * Patient Explainer Agent (EMR-009)
- * 
+ *
  * This agent translates complex clinical notes, diagnoses, and medical jargon
  * into a highly accessible, 3rd-grade reading level explanation for patients.
  */
+import { logger } from "@/lib/observability/log";
 
 export interface ExplainerRequest {
   clinicalText: string;
@@ -25,7 +26,7 @@ export class PatientExplainerAgent {
    */
   async explainClinicalNotes(request: ExplainerRequest): Promise<ExplainerResponse> {
     // Scaffold: Simulated LLM call
-    console.log(`[Explainer Agent] Processing notes for ${request.patientAge}yo patient...`);
+    logger.info({ event: "agent.explainer.processing", patientAge: request.patientAge });
     
     // Simulate API delay
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/lib/agents/pre-visit-intelligence-agent.ts
+++ b/src/lib/agents/pre-visit-intelligence-agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "@/lib/observability/log";
 import { prisma } from "@/lib/db/prisma";
 import type { Agent } from "@/lib/orchestration/types";
 import { writeAgentAudit } from "@/lib/orchestration/context";
@@ -51,7 +52,7 @@ function daysAgo(date: Date): number {
  * contract is to return the briefing to the caller; persistence is a
  * side-effect that lets downstream surfaces (Schedule tile brief line, scribe
  * pre-seed) read it without re-running the agent. On failure we log via
- * `console.warn` with a clear prefix so the issue surfaces in server logs
+ * `logger.warn` with a structured event so the issue surfaces in server logs
  * without breaking the calling flow.
  */
 async function persistBriefingToEncounter(
@@ -65,11 +66,11 @@ async function persistBriefingToEncounter(
       data: { briefingContext: briefing as any },
     });
   } catch (err) {
-    console.warn(
-      "[preVisitIntelligence] persistence failed:",
-      err instanceof Error ? err.message : String(err),
-      { encounterId },
-    );
+    logger.warn({
+      event: "agent.previsit.persist_failed",
+      encounterId,
+      err,
+    });
   }
 }
 

--- a/src/lib/agents/research/pubmed-citation-service.ts
+++ b/src/lib/agents/research/pubmed-citation-service.ts
@@ -11,6 +11,7 @@ import {
   type PubMedArticle,
 } from "@/lib/domain/pubmed";
 import type { Citation, StudyType, EvidenceLevel } from "@/lib/domain/chatcb";
+import { logger } from "@/lib/observability/log";
 
 export interface FetchCitationsOptions {
   /** Max number of PubMed records to return. Defaults to 5. */
@@ -61,7 +62,7 @@ export async function fetchPubMedCitations(
   try {
     searchResult = await searchPubMed(trimmed, maxResults);
   } catch (err) {
-    console.error("[pubmed-citation-service] searchPubMed failed:", err);
+    logger.error({ event: "agent.pubmed.search_failed", query: trimmed, err });
     return { query: trimmed, totalResults: 0, citations: [], searchTime: 0 };
   }
 


### PR DESCRIPTION
## Summary
Slice 2 of the \`console.*\` → structured logger migration. Slice 1 was \`src/lib/auth/\` in PR #249. This slice covers all 8 \`console.*\` calls across 7 files in \`src/lib/agents/\`.

## Migrated event names (dot-namespaced under \`agent.*\`)

| Old call | New event |
|---|---|
| \`[Explainer Agent] Processing notes for ...\` | \`agent.explainer.processing\` |
| \`[BillingAgent] Optimizing CPT/ICD-10 codes for ...\` | \`agent.billing.code_optimize\` |
| \`[Indexer] Ingesting book from ...\` | \`agent.indexer.ingest\` |
| \`[preVisitIntelligence] persistence failed:\` | \`agent.previsit.persist_failed\` |
| \`[pubmed-citation-service] searchPubMed failed:\` | \`agent.pubmed.search_failed\` |
| \`[agent-reasoning] persist failed\` | \`agent.reasoning.persist_failed\` |
| \`[agent-feedback] persist failed\` | \`agent.feedback.persist_failed\` |

## Side benefit: error stack traces are preserved
Previously the calls passed \`err instanceof Error ? err.message : String(err)\` inline, which **lost stack traces on genuine Errors**. The logger module's PHI-aware redact treats Error objects as a discriminated case (preserves \`name\` + \`message\` + \`stack\`), so failures in agent persist paths now surface their stacks in the structured log line.

## What this is NOT
- Not pino — still using \`console\` under the logger interface. pino lands in EPIC 4.1 follow-up.
- Not the full sweep. Remaining slices documented in the commit message.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] No \`console.*\` calls remaining in \`src/lib/agents/\` (verified via grep)
- [ ] Trigger an agent persist failure locally → verify NDJSON log line contains \`event: agent.*.persist_failed\` with full error stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)