### PR TITLE
db(perf): 6 clinic dashboard indexes — pass 2 (ChartSummary had ZERO indexes)

### DIFF
--- a/docs/audit/INDEX_AUDIT_2026-05-10.md
+++ b/docs/audit/INDEX_AUDIT_2026-05-10.md
@@ -1,0 +1,82 @@
+# Index audit pass 2 — clinic dashboard hot paths
+
+**Scope:** every \`findMany\`/\`findFirst\`/\`count\` invoked from
+\`src/app/(clinician)/clinic/page.tsx\` (the mission-control
+dashboard, ~17 fan-out queries per render). Pass 1 (PR #248)
+covered the patient detail page; this is the second highest-traffic
+clinician surface.
+
+## Method
+
+Same as pass 1: enumerate Prisma calls, identify their `where` /
+`orderBy` shapes, compare against existing `@@index` declarations,
+recommend additions where coverage is missing.
+
+This audit was static — `EXPLAIN ANALYZE` against a live database
+will refine the priority order. The 6 indexes added are conservative
+covers of obvious gaps; further tuning waits for `pg_stat_statements`
+data after deploy.
+
+## Dashboard query inventory
+
+| # | Query | Where | Order | Coverage |
+|---|---|---|---|---|
+| 1 | `encounter.findMany` (today) | org + scheduledFor range | scheduledFor asc | 🆕 add `(org, scheduledFor)` |
+| 2 | `note.count` (drafts) | status + encounter.org | — | join through encounter; OK |
+| 3 | `note.findMany` (review queue) | status IN + encounter.org | updatedAt desc | not addressed (low volume) |
+| 4 | `agentJob.count` (approval queue) | org + status | — | covered by `(org, status)` |
+| 5 | `messageThread.count` | patient.org + messages.some | — | covered |
+| 6 | `patient.count` | org + status | — | covered by `(org, status)` |
+| 7 | `encounter.count` (this week) | org + scheduledFor range | — | 🆕 same as #1 |
+| 8 | `note.count` (finalized this week) | status + finalizedAt range + encounter.org | — | 🆕 covered by `(status, finalizedAt)` |
+| 9 | `encounter.findMany` (recent complete) | org + status='complete' | completedAt desc | 🆕 add `(org, status, completedAt)` |
+| 10 | `note.findMany` (recent finalized) | status='finalized' + encounter.org | finalizedAt desc | 🆕 covered by `(status, finalizedAt)` |
+| 11 | `assessmentResponse.findMany` | patient.org | submittedAt desc | covered |
+| 12 | `message.findMany` (recent) | status='sent' + thread.patient.org | createdAt desc | covered |
+| 13 | `document.findMany` (recent) | org + deletedAt=null | createdAt desc | 🆕 add `(org, deletedAt, createdAt)` |
+| 14 | `chartSummary.findMany` (avg readiness) | patient.org + patient.status='active' | — | 🆕 add `patientId` (model had ZERO indexes) |
+| 15 | `encounter.count` ×7 (sparkline) | org + scheduledFor day-window | — | 🆕 same as #1 |
+| 16 | `agentJob.findMany` (fleet bridge) | org + status IN + completedAt > 24h | completedAt desc | 🆕 add `(org, status, completedAt)` |
+| 17 | `message.findMany` (pending drafts) | status='draft' + aiDrafted + thread.patient.org | — | covered |
+| 18 | `clinicalObservation.findMany` (recent) | patient.org + acknowledgedAt=null + createdAt > 7d | createdAt desc | covered by pass-1 `(patientId, createdAt)` |
+
+## Indexes added
+
+```
+Encounter_organizationId_scheduledFor_idx                        (organizationId, scheduledFor)
+Encounter_organizationId_status_completedAt_idx                  (organizationId, status, completedAt)
+Note_status_finalizedAt_idx                                      (status, finalizedAt)
+AgentJob_organizationId_status_completedAt_idx                   (organizationId, status, completedAt)
+ChartSummary_patientId_idx                                       (patientId)
+Document_organizationId_deletedAt_createdAt_idx                  (organizationId, deletedAt, createdAt)
+```
+
+All six use `CREATE INDEX CONCURRENTLY` — no ACCESS EXCLUSIVE lock,
+safe for prod deployment.
+
+## Highlight: ChartSummary had ZERO indexes
+
+The dashboard's avg-readiness widget reads every active patient's
+score (capped at 500 by PR #228) and joins through `Patient`. Without
+even a `patientId` index on `ChartSummary`, that join was a sequential
+scan over the entire `ChartSummary` table on every dashboard render —
+on a 10k-patient tenant, that's a 10k-row scan per dashboard load
+multiplied by N concurrent clinicians.
+
+This is the single biggest perf win in the audit.
+
+## Cumulative: pass 1 + pass 2 indexes
+
+Pass 1 (PR #248) added 5 indexes for the patient detail page.
+Pass 2 adds 6 more for the clinic dashboard. **11 indexes total**
+covering the two highest-traffic clinician surfaces.
+
+## Follow-up
+
+After this migration deploys:
+1. Confirm `pg_stat_statements` enabled on the prod Postgres
+2. Capture baseline mean / p95 for the 17 dashboard query shapes
+3. Land migration during a low-traffic window
+4. Compare 24h + 7d post-migration latency
+5. Append actuals to this file
+6. Move to next surface — likely `(operator)/ops/revenue/page.tsx` (938-line aggregate-heavy dashboard)

--- a/prisma/migrations/20260510000000_clinic_dashboard_indexes/migration.sql
+++ b/prisma/migrations/20260510000000_clinic_dashboard_indexes/migration.sql
@@ -1,0 +1,52 @@
+-- Index audit pass 2 — clinic dashboard hot paths.
+--
+-- Cross-references findMany / count shapes in
+-- src/app/(clinician)/clinic/page.tsx (the "mission control"
+-- dashboard that every clinician opens dozens of times per day,
+-- ~17 fan-out queries per render) against existing indexes. Adds
+-- 5 covers for queries that were either full-scanning or relying on
+-- ill-fitting composite leads.
+--
+-- All five use CREATE INDEX CONCURRENTLY so the migration does NOT
+-- take an ACCESS EXCLUSIVE lock on the table — required for safe
+-- prod deployment against live tenant data.
+--
+-- See docs/audit/INDEX_AUDIT_2026-05-10.md for the per-query analysis.
+-- Pairs with PR #248 (chart-tab indexes pass 1).
+
+-- 1. Encounter (organizationId, scheduledFor)
+--    Covers: today's calendar, this-week count, 7-day sparkline
+--    (3 queries on the dashboard).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_scheduledFor_idx"
+  ON "Encounter" ("organizationId", "scheduledFor");
+
+-- 2. Encounter (organizationId, status, completedAt)
+--    Covers: "recent completed encounters" activity feed widget.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_status_completedAt_idx"
+  ON "Encounter" ("organizationId", "status", "completedAt");
+
+-- 3. Note (status, finalizedAt)
+--    Covers: "recently finalized notes" activity feed widget. Org
+--    scope is enforced by joining through encounter, so the index
+--    is global on (status, finalizedAt) and the query plan does the
+--    encounter-org filter as a second step.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Note_status_finalizedAt_idx"
+  ON "Note" ("status", "finalizedAt");
+
+-- 4. AgentJob (organizationId, status, completedAt)
+--    Covers: fleet-bridge widget. Filters org + status IN [...] +
+--    completedAt > 24h, orders by completedAt desc.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "AgentJob_organizationId_status_completedAt_idx"
+  ON "AgentJob" ("organizationId", "status", "completedAt");
+
+-- 5. ChartSummary (patientId)
+--    The model previously had ZERO indexes. Dashboard's
+--    avg-readiness widget reads every active patient's score; the
+--    join was sequential-scanning the table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ChartSummary_patientId_idx"
+  ON "ChartSummary" ("patientId");
+
+-- 6. Document (organizationId, deletedAt, createdAt)
+--    Covers: "recent documents" activity feed widget.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Document_organizationId_deletedAt_createdAt_idx"
+  ON "Document" ("organizationId", "deletedAt", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -368,7 +368,11 @@ model ChartSummary {
   generatedBy       String // agent name:version
   generatedAt       DateTime @default(now())
 
-  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)  // ChartSummary has no indexes today. The clinic dashboard reads
+  // every active patient's score for the avg-readiness widget.
+  // Without an index on patientId the join sequential-scans every
+  // ChartSummary row. Index audit pass 2 2026-05-10.
+  @@index([patientId])
 }
 
 // --------------------------------------------------------------
@@ -410,6 +414,10 @@ model Document {
 
   @@index([patientId, kind])
   @@index([organizationId, needsReview])
+  // Clinic dashboard "recent documents" activity feed (clinic/page.tsx).
+  // Filters by org + deletedAt=null, orders by createdAt desc.
+  // Index audit pass 2 2026-05-10.
+  @@index([organizationId, deletedAt, createdAt])
 }
 
 // --------------------------------------------------------------
@@ -457,6 +465,14 @@ model Encounter {
   // Filters by organizationId + nulls-not-null on charting timestamps, orders
   // by chartingCompletedAt. Index audit 2026-05-09.
   @@index([organizationId, chartingCompletedAt])
+  // Clinic dashboard "today's calendar", "this week's count", and the
+  // 7-day per-day sparkline (clinic/page.tsx). All filter by org +
+  // scheduledFor range. Index audit pass 2 2026-05-10.
+  @@index([organizationId, scheduledFor])
+  // Clinic dashboard "recent completed encounters" activity feed.
+  // Filters by org + status='complete', orders by completedAt desc.
+  // Index audit pass 2 2026-05-10.
+  @@index([organizationId, status, completedAt])
 }
 
 enum NoteStatus {
@@ -484,6 +500,10 @@ model Note {
   codingSuggestion CodingSuggestion?
 
   @@index([encounterId, status])
+  // Clinic dashboard "recently finalized notes" activity feed
+  // (clinic/page.tsx). Filters status='finalized', orders by
+  // finalizedAt desc. Index audit pass 2 2026-05-10.
+  @@index([status, finalizedAt])
 }
 
 model CodingSuggestion {
@@ -1670,6 +1690,10 @@ model AgentJob {
   @@index([status, runAfter])
   @@index([organizationId, status])
   @@index([workflowName, status])
+  // Clinic dashboard "fleet bridge" recent-jobs widget (clinic/page.tsx).
+  // Filters org + status IN [...] + completedAt > 24h, orders by
+  // completedAt desc. Index audit pass 2 2026-05-10.
+  @@index([organizationId, status, completedAt])
 }
 
 // --------------------------------------------------------------


### PR DESCRIPTION
## Summary
Pass 2 of EPIC 2.4 (index audit). Pass 1 was PR #248 (patient detail page). This pass covers \`src/app/(clinician)/clinic/page.tsx\` — the mission-control dashboard, **~17 fan-out queries per render**, opened dozens of times per day per clinician.

## The biggest win

\`ChartSummary\` had **zero indexes**. The dashboard's avg-readiness widget joins through Patient and reads \`completenessScore\` for every active patient. Without even a \`patientId\` index, that join was a **sequential scan over the entire ChartSummary table on every dashboard render**.

On a 10k-patient tenant: 10k-row scan per dashboard load × N concurrent clinicians.

## Indexes added

| Model | Index | Covers |
|---|---|---|
| \`Encounter\` | \`(organizationId, scheduledFor)\` | today's calendar + this-week count + 7-day sparkline (3 queries) |
| \`Encounter\` | \`(organizationId, status, completedAt)\` | recent-completed activity feed |
| \`Note\` | \`(status, finalizedAt)\` | recently-finalized notes feed |
| \`AgentJob\` | \`(organizationId, status, completedAt)\` | fleet bridge widget |
| \`ChartSummary\` | \`(patientId)\` | **previously zero indexes — see above** |
| \`Document\` | \`(organizationId, deletedAt, createdAt)\` | recent documents feed |

All six use \`CREATE INDEX CONCURRENTLY\` — no ACCESS EXCLUSIVE lock, safe for prod deploy.

## Cumulative
- Pass 1 (#248): 5 indexes for patient detail page
- Pass 2 (this): 6 indexes for clinic dashboard
- **Total: 11 indexes covering the 2 highest-traffic clinician surfaces**

## Test plan
- [ ] Local: \`npx prisma migrate dev --create-only\` confirms migration applies cleanly
- [ ] \`\\d \"ChartSummary\"\` in psql shows the new index post-apply
- [ ] No ACCESS EXCLUSIVE lock during apply (\`SELECT * FROM pg_locks\` mid-migration on test load)

## Pre-merge ops
- [ ] Capture baseline dashboard P50/P95 BEFORE merge
- [ ] Confirm \`pg_stat_statements\` on prod Postgres
- [ ] Deploy during low-traffic window (CONCURRENTLY scans every row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)