### PR TITLE
fix(marketing): add <main> landmark to homepage/about/education

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -43,6 +43,8 @@ export default function AboutPage() {
 
       <SiteHeader />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="max-w-[1280px] mx-auto px-6 lg:px-12 pt-12 pb-16">
         <Eyebrow className="mb-6">Our story</Eyebrow>
@@ -268,6 +270,8 @@ export default function AboutPage() {
           </div>
         </div>
       </section>
+
+      </main>
 
       <SiteFooter />
     </div>

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -58,6 +58,8 @@ export default function EducationPage() {
     <div className="min-h-screen bg-bg">
       <SiteHeader />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-16 pb-12 lg:pt-20 lg:pb-14 text-center animate-in fade-in slide-in-from-bottom-4 duration-700">
         <Eyebrow className="justify-center mb-6 text-accent">Evidence-based knowledge</Eyebrow>
@@ -104,6 +106,8 @@ export default function EducationPage() {
           );
         })}
       </div>
+
+      </main>
 
       <SiteFooter />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,8 @@ export default function HomePage() {
 
       <SiteHeader />
 
+      <main id="main-content">
+
       {/* ── Hero ─────────────────────────────────────────── */}
       <section className="relative max-w-[1320px] mx-auto px-6 lg:px-12 pt-16 pb-28">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-center">
@@ -567,6 +569,8 @@ export default function HomePage() {
           </div>
         </Reveal>
       </section>
+
+      </main>
 
       <SiteFooter />
     </div>


### PR DESCRIPTION
## Summary
- Wraps the homepage, About, and Education page bodies in `<main id="main-content">`.
- Unblocks the staging smoke test that's been red on every commit since #226 (it expects `page.locator('main')` to be visible on `/`).
- Bonus: the existing skip-link in `layout.tsx` (`href="#main-content"`) now actually lands on a target.

## Test plan
- [ ] Staging smoke test (`e2e/health.spec.ts › Homepage loads correctly`) passes.
- [ ] Visual check on `/`, `/about`, `/education` — no layout regressions.
- [ ] Skip-to-content link focuses the page body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)