### PR TITLE
ci(deploy): wait for staging /api/health to report current SHA

### DIFF
--- a/.github/workflows/staging-to-prod.yml
+++ b/.github/workflows/staging-to-prod.yml
@@ -31,6 +31,7 @@ jobs:
     name: Deploy to Staging
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: Staging
     steps:
       - name: Trigger Render Staging Deploy
@@ -40,8 +41,39 @@ jobs:
           method: 'POST'
           customHeaders: '{"Content-Type": "application/json"}'
           timeout: '60000'
-      - name: Wait for Staging Deploy
-        run: echo "Waiting for staging deploy to finish..." && sleep 180
+
+      - name: Wait for staging /api/health to report this commit
+        env:
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Poll /api/health until commit == github.sha. This replaces the
+          # old "sleep 180" which raced the Render build and made every
+          # deploy a coin flip. Hard cap at ~12 minutes to avoid hung jobs.
+          MAX_ATTEMPTS=72   # 72 * 10s = 12 minutes
+          INTERVAL=10
+          ATTEMPT=0
+          LAST_COMMIT=""
+
+          echo "Waiting for staging to report commit ${EXPECTED_SHA}..."
+          while [ "${ATTEMPT}" -lt "${MAX_ATTEMPTS}" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            BODY="$(curl -fsS --max-time 8 "${STAGING_URL%/}/api/health" || true)"
+            if [ -n "${BODY}" ]; then
+              LAST_COMMIT="$(printf '%s' "${BODY}" | jq -r '.commit // empty' 2>/dev/null || true)"
+              if [ "${LAST_COMMIT}" = "${EXPECTED_SHA}" ]; then
+                echo "Staging is on ${EXPECTED_SHA} (attempt ${ATTEMPT})."
+                exit 0
+              fi
+            fi
+            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: live commit=${LAST_COMMIT:-<none>}; sleeping ${INTERVAL}s..."
+            sleep "${INTERVAL}"
+          done
+
+          echo "::error::Staging did not report commit ${EXPECTED_SHA} after $((MAX_ATTEMPTS * INTERVAL))s. Last seen: ${LAST_COMMIT:-<none>}."
+          exit 1
 
   test_staging:
     name: Automated Tests (Staging)
@@ -65,5 +97,3 @@ jobs:
           BASE_URL: ${{ secrets.STAGING_URL }}
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-
-

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,13 +1,28 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db/prisma";
 
+// Render injects RENDER_GIT_COMMIT at build time. Other hosts use different
+// names; we read the first that's set so the field works locally and on
+// Vercel/Render/Fly without ceremony. Keeping the response shape additive
+// so the existing smoke test (which asserts ok / db / service) is untouched.
+function deployedCommit(): string | null {
+  return (
+    process.env.RENDER_GIT_COMMIT ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.GIT_COMMIT ||
+    process.env.COMMIT_SHA ||
+    null
+  );
+}
+
 export async function GET() {
+  const commit = deployedCommit();
   try {
     await prisma.$queryRaw`SELECT 1`;
-    return NextResponse.json({ ok: true, service: "web", db: "ok" });
+    return NextResponse.json({ ok: true, service: "web", db: "ok", commit });
   } catch (err) {
     return NextResponse.json(
-      { ok: false, service: "web", db: "down", error: String(err) },
+      { ok: false, service: "web", db: "down", commit, error: String(err) },
       { status: 503 }
     );
   }


### PR DESCRIPTION
## Summary
- Replace the blind `sleep 180` after the Render staging deploy hook with a poll loop on `/api/health` that waits until `.commit` matches the `github.sha` triggering the workflow.
- Add `commit` to the `/api/health` response, sourced from `RENDER_GIT_COMMIT` (Render injects this automatically; falls back to `VERCEL_GIT_COMMIT_SHA` / `GIT_COMMIT` / `COMMIT_SHA` for portability).
- Hard cap at ~12 minutes (72 attempts × 10s).

## Why
Next.js builds on Render typically take 4–8 minutes. The 3-minute sleep raced the build, so Playwright kept hitting the *previous* deploy. Every commit landed on main since #226 has been red on Staging & Production Pipeline — including the marketing makeover (#256) and the `<main>` landmark fix (#265) — even though the deploys themselves eventually succeeded. This makes the gate deterministic instead of timing-dependent.

## Test plan
- [ ] After merge, the new `Wait for staging /api/health to report this commit` step passes within 10 minutes.
- [ ] `Automated Tests (Staging)` runs against the freshly-deployed code.
- [ ] On a future broken deploy, the step fails with `Staging did not report commit X after 720s` instead of silently testing stale code.
- [ ] `/api/health` still returns `ok: true`, `db: "ok"`, `service: "web"` (the existing smoke-test contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)