### PR TITLE
fix(db): remove CONCURRENTLY from index migrations

### DIFF
--- a/prisma/migrations/20260509000000_chart_tab_indexes/migration.sql
+++ b/prisma/migrations/20260509000000_chart_tab_indexes/migration.sql
@@ -20,21 +20,21 @@
 --    Read: where patientId, orderBy createdAt desc. Existing compound
 --    indexes start with patientId but require a category/severity
 --    predicate to be useful. This one covers the bare patientId+order.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "ClinicalObservation_patientId_createdAt_idx"
+CREATE INDEX IF NOT EXISTS "ClinicalObservation_patientId_createdAt_idx"
   ON "ClinicalObservation" ("patientId", "createdAt");
 
 -- 2. Claim open-claim count for the chart tab.
 --    Read: count where patientId AND status IN (...). Existing
 --    patientId+serviceDate index doesn't cover a status filter when
 --    serviceDate isn't in the predicate.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Claim_patientId_status_idx"
+CREATE INDEX IF NOT EXISTS "Claim_patientId_status_idx"
   ON "Claim" ("patientId", "status");
 
 -- 3. Task chart-tab open-task list.
 --    Read: where patientId AND status='open', orderBy dueAt asc.
 --    Existing indexes are on (organizationId, status) and
 --    (assigneeUserId, status) — neither leads with patientId.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Task_patientId_status_dueAt_idx"
+CREATE INDEX IF NOT EXISTS "Task_patientId_status_dueAt_idx"
   ON "Task" ("patientId", "status", "dueAt");
 
 -- 4. Encounter charting-time benchmark.
@@ -42,12 +42,12 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "Task_patientId_status_dueAt_idx"
 --    chartingCompletedAt IS NOT NULL, orderBy chartingCompletedAt desc.
 --    Existing organizationId+status+createdAt index is on the wrong
 --    sort column.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_chartingCompletedAt_idx"
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_chartingCompletedAt_idx"
   ON "Encounter" ("organizationId", "chartingCompletedAt");
 
 -- 5. DosingRegimen chart-tab history.
 --    Read: where patientId, orderBy startDate desc. Existing
 --    patientId+active index doesn't cover the ordering when `active`
 --    isn't in the predicate.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "DosingRegimen_patientId_startDate_idx"
+CREATE INDEX IF NOT EXISTS "DosingRegimen_patientId_startDate_idx"
   ON "DosingRegimen" ("patientId", "startDate");

--- a/prisma/migrations/20260510000000_clinic_dashboard_indexes/migration.sql
+++ b/prisma/migrations/20260510000000_clinic_dashboard_indexes/migration.sql
@@ -17,12 +17,12 @@
 -- 1. Encounter (organizationId, scheduledFor)
 --    Covers: today's calendar, this-week count, 7-day sparkline
 --    (3 queries on the dashboard).
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_scheduledFor_idx"
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_scheduledFor_idx"
   ON "Encounter" ("organizationId", "scheduledFor");
 
 -- 2. Encounter (organizationId, status, completedAt)
 --    Covers: "recent completed encounters" activity feed widget.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_status_completedAt_idx"
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_status_completedAt_idx"
   ON "Encounter" ("organizationId", "status", "completedAt");
 
 -- 3. Note (status, finalizedAt)
@@ -30,23 +30,23 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "Encounter_organizationId_status_complet
 --    scope is enforced by joining through encounter, so the index
 --    is global on (status, finalizedAt) and the query plan does the
 --    encounter-org filter as a second step.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Note_status_finalizedAt_idx"
+CREATE INDEX IF NOT EXISTS "Note_status_finalizedAt_idx"
   ON "Note" ("status", "finalizedAt");
 
 -- 4. AgentJob (organizationId, status, completedAt)
 --    Covers: fleet-bridge widget. Filters org + status IN [...] +
 --    completedAt > 24h, orders by completedAt desc.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "AgentJob_organizationId_status_completedAt_idx"
+CREATE INDEX IF NOT EXISTS "AgentJob_organizationId_status_completedAt_idx"
   ON "AgentJob" ("organizationId", "status", "completedAt");
 
 -- 5. ChartSummary (patientId)
 --    The model previously had ZERO indexes. Dashboard's
 --    avg-readiness widget reads every active patient's score; the
 --    join was sequential-scanning the table.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "ChartSummary_patientId_idx"
+CREATE INDEX IF NOT EXISTS "ChartSummary_patientId_idx"
   ON "ChartSummary" ("patientId");
 
 -- 6. Document (organizationId, deletedAt, createdAt)
 --    Covers: "recent documents" activity feed widget.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "Document_organizationId_deletedAt_createdAt_idx"
+CREATE INDEX IF NOT EXISTS "Document_organizationId_deletedAt_createdAt_idx"
   ON "Document" ("organizationId", "deletedAt", "createdAt");


### PR DESCRIPTION
Prisma migrate deploy wraps migrations in a transaction by default, causing `CREATE INDEX CONCURRENTLY` to crash with `ERROR: CREATE INDEX CONCURRENTLY cannot run inside a transaction block`. This has been blocking all deployments on Render for the last 12 hours. This PR removes CONCURRENTLY from the two pending index migrations to unblock the staging/prod pipelines. Given the current table size, the brief AccessExclusiveLock is acceptable.