### PR TITLE
fix(security): gate /api/reports/competitive-analysis to super_admin

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -427,10 +427,9 @@ routes:
 
   reports/competitive-analysis:
     methods: [GET]
-    auth: needs_review
+    auth: required
     owner: research
-    review_due: 2026-05-16
-    notes: "🚨 'Competitive analysis report' generated without auth. Likely should be admin-only."
+    notes: "Closed 2026-05-12 via PR fix/competitive-analysis-route-auth. Find-and-fix pass 4 confirmed full report was returned unauthed. Now gated requireApiAuth({role:'super_admin'})."
 
   dispensary/ingest:
     methods: [POST]

--- a/src/app/api/reports/competitive-analysis/route.ts
+++ b/src/app/api/reports/competitive-analysis/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/auth/api-gate";
 
 // ---------------------------------------------------------------------------
 // Competitive Analysis Report: Leafjourney vs ArfinnMed
@@ -103,6 +104,12 @@ const COMPARISON: FeatureComparison[] = [
 ];
 
 export async function GET() {
+  // Internal competitive analysis — admin-only. Find-and-fix pass 4
+  // found this route returning the full report to anonymous callers,
+  // exposing our internal feature scoring against competitors.
+  const gate = await requireApiAuth({ role: "super_admin" });
+  if (gate.error) return gate.error;
+
   // Compute summary stats
   const total = COMPARISON.length;
   const ourYes = COMPARISON.filter((c) => c.leafjourney === "yes").length;


### PR DESCRIPTION
## Summary
Find-and-fix pass 4 (PR #277) caught this route returning the **full competitive analysis report** — 58 features × competitor scoring + internal "CRITICAL GAP" annotations — to anonymous callers.

\`\`\`
$ curl http://localhost:3000/api/reports/competitive-analysis
{\"title\":\"Competitive Analysis: Leafjourney vs ArfinnMed\",
 \"summary\":{\"totalFeaturesCompared\":58, ...},
 \"comparison\":[ ... 58 entries with notes like \"CRITICAL GAP — needed for compliance.\" ... ]}
\`\`\`

This is internal competitive intel. Every "CRITICAL GAP" annotation tells a competitor exactly where to attack.

## Fix
\`requireApiAuth({ role: \"super_admin\" })\` at the top of the handler.

## Manifest
\`reports/competitive-analysis\` flipped from \`needs_review\` → \`required\`.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Authed super-admin: 200 with the report
- [ ] Authed clinician: 403 FORBIDDEN
- [ ] Unauthed: 401 UNAUTHORIZED

🤖 Generated with [Claude Code](https://claude.com/claude-code)