### PR TITLE
Practice fleet landing page with expandable KPI cards

### DIFF
--- a/src/app/(super-admin)/practices/loaders.ts
+++ b/src/app/(super-admin)/practices/loaders.ts
@@ -7,81 +7,15 @@
 
 import { prisma } from "@/lib/db/prisma";
 import { LEAFJOURNEY_HQ_SLUG } from "@/lib/auth/super-admin-bootstrap";
+import {
+  ZERO_KPI,
+  type PracticeCardData,
+  type PracticeKpi,
+  type PracticeStakeholder,
+} from "./types";
 
-export type PracticeStakeholder = {
-  userId: string;
-  name: string;
-  email: string;
-  role: string;
-  title?: string | null;
-};
-
-export type PracticeKpi = {
-  providerCount: number;
-  activeProviderCount: number;
-  patientCount: number;
-  claimCount: number;
-  claimsLast30: number;
-  billedCents: number;
-  paidCents: number;
-  gatewayChargeCents: number;
-  encounterCount: number;
-  encountersLast30: number;
-};
-
-export type PracticeCardData = {
-  practiceId: string | null;
-  configId: string | null;
-  organizationId: string;
-  organizationName: string;
-  practiceName: string;
-  brandName: string | null;
-  legalName: string | null;
-  city: string | null;
-  state: string | null;
-  timeZone: string | null;
-  primaryContactName: string | null;
-  primaryContactEmail: string | null;
-  specialty: string | null;
-  specialtyVersion: string | null;
-  careModel: string | null;
-  enabledModalities: string[];
-  status: string;
-  publishedAt: string | null;
-  updatedAt: string | null;
-  officeManagers: PracticeStakeholder[];
-  leadProviders: PracticeStakeholder[];
-  kpi: PracticeKpi;
-};
-
-const ZERO_KPI: PracticeKpi = {
-  providerCount: 0,
-  activeProviderCount: 0,
-  patientCount: 0,
-  claimCount: 0,
-  claimsLast30: 0,
-  billedCents: 0,
-  paidCents: 0,
-  gatewayChargeCents: 0,
-  encounterCount: 0,
-  encountersLast30: 0,
-};
-
-/** Pretty-print a slug like "primary-care@1" → "Primary care". */
-export function humanizeSpecialty(slug: string | null | undefined): string {
-  if (!slug) return "Specialty not selected";
-  const base = slug.split("@")[0] ?? slug;
-  return base
-    .split("-")
-    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
-    .join(" ");
-}
-
-/** Pretty-print a care-model slug like "in_person" → "In person". */
-export function humanizeCareModel(value: string | null | undefined): string {
-  if (!value) return "—";
-  return value.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
-}
+export type { PracticeCardData, PracticeKpi, PracticeStakeholder } from "./types";
+export { humanizeCareModel, humanizeSpecialty } from "./types";
 
 /**
  * Top-level loader. Returns one card per published-or-in-flight
@@ -126,7 +60,6 @@ export async function loadPracticeLandingCards(): Promise<PracticeCardData[]> {
     providers,
     claimsGroup,
     claimsLast30Group,
-    paymentsRaw,
     chargesGroup,
     encountersGroup,
     encountersLast30Group,
@@ -209,10 +142,6 @@ export async function loadPracticeLandingCards(): Promise<PracticeCardData[]> {
       },
       _count: { _all: true },
     }),
-    prisma.payment.findMany({
-      where: { claim: { organizationId: { in: orgIds } } },
-      select: { amountCents: true, claim: { select: { organizationId: true } } },
-    }),
     prisma.charge.groupBy({
       by: ["organizationId"],
       where: { organizationId: { in: orgIds } },
@@ -283,10 +212,6 @@ export async function loadPracticeLandingCards(): Promise<PracticeCardData[]> {
   }
   for (const row of claimsLast30Group) {
     ensureKpi(row.organizationId).claimsLast30 = row._count._all;
-  }
-  for (const row of paymentsRaw) {
-    if (!row.claim?.organizationId) continue;
-    ensureKpi(row.claim.organizationId).paidCents += row.amountCents;
   }
   for (const row of chargesGroup) {
     ensureKpi(row.organizationId).gatewayChargeCents = row._sum.feeAmountCents ?? 0;

--- a/src/app/(super-admin)/practices/loaders.ts
+++ b/src/app/(super-admin)/practices/loaders.ts
@@ -1,0 +1,346 @@
+// Server-side loader for the post-onboarding Practice Landing dashboard.
+//
+// Joins PracticeConfiguration → Practice → Organization and computes a
+// per-organization KPI rollup (provider count, claims volume, billed/paid
+// totals, charges run through the gateway). One round-trip per dimension
+// is grouped so this stays fast even at hundreds of practices.
+
+import { prisma } from "@/lib/db/prisma";
+import { LEAFJOURNEY_HQ_SLUG } from "@/lib/auth/super-admin-bootstrap";
+
+export type PracticeStakeholder = {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  title?: string | null;
+};
+
+export type PracticeKpi = {
+  providerCount: number;
+  activeProviderCount: number;
+  patientCount: number;
+  claimCount: number;
+  claimsLast30: number;
+  billedCents: number;
+  paidCents: number;
+  gatewayChargeCents: number;
+  encounterCount: number;
+  encountersLast30: number;
+};
+
+export type PracticeCardData = {
+  practiceId: string | null;
+  configId: string | null;
+  organizationId: string;
+  organizationName: string;
+  practiceName: string;
+  brandName: string | null;
+  legalName: string | null;
+  city: string | null;
+  state: string | null;
+  timeZone: string | null;
+  primaryContactName: string | null;
+  primaryContactEmail: string | null;
+  specialty: string | null;
+  specialtyVersion: string | null;
+  careModel: string | null;
+  enabledModalities: string[];
+  status: string;
+  publishedAt: string | null;
+  updatedAt: string | null;
+  officeManagers: PracticeStakeholder[];
+  leadProviders: PracticeStakeholder[];
+  kpi: PracticeKpi;
+};
+
+const ZERO_KPI: PracticeKpi = {
+  providerCount: 0,
+  activeProviderCount: 0,
+  patientCount: 0,
+  claimCount: 0,
+  claimsLast30: 0,
+  billedCents: 0,
+  paidCents: 0,
+  gatewayChargeCents: 0,
+  encounterCount: 0,
+  encountersLast30: 0,
+};
+
+/** Pretty-print a slug like "primary-care@1" → "Primary care". */
+export function humanizeSpecialty(slug: string | null | undefined): string {
+  if (!slug) return "Specialty not selected";
+  const base = slug.split("@")[0] ?? slug;
+  return base
+    .split("-")
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+/** Pretty-print a care-model slug like "in_person" → "In person". */
+export function humanizeCareModel(value: string | null | undefined): string {
+  if (!value) return "—";
+  return value.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+}
+
+/**
+ * Top-level loader. Returns one card per published-or-in-flight
+ * PracticeConfiguration, plus a small set of org-level KPIs joined in.
+ */
+export async function loadPracticeLandingCards(): Promise<PracticeCardData[]> {
+  // 1. PracticeConfigurations — the source of truth for "which practices
+  //    have been configured." We include drafts so the landing page also
+  //    surfaces in-flight onboardings (the card badge distinguishes them).
+  const configsRaw = await prisma.practiceConfiguration.findMany({
+    orderBy: [{ updatedAt: "desc" }],
+    select: {
+      id: true,
+      organizationId: true,
+      practiceId: true,
+      selectedSpecialty: true,
+      selectedSpecialtyVersion: true,
+      careModel: true,
+      enabledModalities: true,
+      status: true,
+      publishedAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (configsRaw.length === 0) return [];
+
+  const orgIds = Array.from(new Set(configsRaw.map((c) => c.organizationId)));
+  const practiceIds = Array.from(
+    new Set(
+      configsRaw.map((c) => c.practiceId).filter((x): x is string => !!x),
+    ),
+  );
+
+  // 2. Pull all the related rows we need in parallel.
+  const since30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const [
+    orgs,
+    practices,
+    memberships,
+    providers,
+    claimsGroup,
+    claimsLast30Group,
+    paymentsRaw,
+    chargesGroup,
+    encountersGroup,
+    encountersLast30Group,
+    patientsGroup,
+  ] = await Promise.all([
+    prisma.organization.findMany({
+      where: { id: { in: orgIds } },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        legalName: true,
+        brandName: true,
+        primaryContactName: true,
+        primaryContactEmail: true,
+      },
+    }),
+    practiceIds.length
+      ? prisma.practice.findMany({
+          where: { id: { in: practiceIds } },
+          select: {
+            id: true,
+            organizationId: true,
+            name: true,
+            city: true,
+            state: true,
+            timeZone: true,
+          },
+        })
+      : Promise.resolve([] as Array<{
+          id: string;
+          organizationId: string;
+          name: string;
+          city: string | null;
+          state: string | null;
+          timeZone: string | null;
+        }>),
+    prisma.membership.findMany({
+      where: {
+        organizationId: { in: orgIds },
+        role: { in: ["practice_admin", "operator", "practice_owner"] },
+      },
+      select: {
+        organizationId: true,
+        role: true,
+        user: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+      },
+    }),
+    prisma.provider.findMany({
+      where: { organizationId: { in: orgIds } },
+      select: {
+        id: true,
+        organizationId: true,
+        title: true,
+        active: true,
+        user: {
+          select: { id: true, firstName: true, lastName: true, email: true },
+        },
+      },
+      orderBy: [{ active: "desc" }, { createdAt: "asc" }],
+    }),
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: { organizationId: { in: orgIds } },
+      _count: { _all: true },
+      _sum: { billedAmountCents: true, paidAmountCents: true },
+    }),
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        createdAt: { gte: since30 },
+      },
+      _count: { _all: true },
+    }),
+    prisma.payment.findMany({
+      where: { claim: { organizationId: { in: orgIds } } },
+      select: { amountCents: true, claim: { select: { organizationId: true } } },
+    }),
+    prisma.charge.groupBy({
+      by: ["organizationId"],
+      where: { organizationId: { in: orgIds } },
+      _sum: { feeAmountCents: true },
+    }),
+    prisma.encounter.groupBy({
+      by: ["organizationId"],
+      where: { organizationId: { in: orgIds } },
+      _count: { _all: true },
+    }),
+    prisma.encounter.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        createdAt: { gte: since30 },
+      },
+      _count: { _all: true },
+    }),
+    prisma.patient.groupBy({
+      by: ["organizationId"],
+      where: { organizationId: { in: orgIds }, deletedAt: null },
+      _count: { _all: true },
+    }),
+  ]);
+
+  // 3. Index everything by organizationId so the per-card build is O(1).
+  const orgById = new Map(orgs.map((o) => [o.id, o]));
+  const practiceById = new Map(practices.map((p) => [p.id, p]));
+
+  const officeManagersByOrg = new Map<string, PracticeStakeholder[]>();
+  for (const m of memberships) {
+    const arr = officeManagersByOrg.get(m.organizationId) ?? [];
+    arr.push({
+      userId: m.user.id,
+      name: `${m.user.firstName} ${m.user.lastName}`.trim(),
+      email: m.user.email,
+      role: m.role,
+    });
+    officeManagersByOrg.set(m.organizationId, arr);
+  }
+
+  const providersByOrg = new Map<string, PracticeStakeholder[]>();
+  for (const p of providers) {
+    const arr = providersByOrg.get(p.organizationId) ?? [];
+    arr.push({
+      userId: p.user.id,
+      name: `${p.user.firstName} ${p.user.lastName}`.trim(),
+      email: p.user.email,
+      role: "provider",
+      title: p.title,
+    });
+    providersByOrg.set(p.organizationId, arr);
+  }
+
+  const kpiByOrg = new Map<string, PracticeKpi>();
+  function ensureKpi(orgId: string): PracticeKpi {
+    const existing = kpiByOrg.get(orgId);
+    if (existing) return existing;
+    const fresh = { ...ZERO_KPI };
+    kpiByOrg.set(orgId, fresh);
+    return fresh;
+  }
+  for (const row of claimsGroup) {
+    const k = ensureKpi(row.organizationId);
+    k.claimCount = row._count._all;
+    k.billedCents = row._sum.billedAmountCents ?? 0;
+    k.paidCents = row._sum.paidAmountCents ?? 0;
+  }
+  for (const row of claimsLast30Group) {
+    ensureKpi(row.organizationId).claimsLast30 = row._count._all;
+  }
+  for (const row of paymentsRaw) {
+    if (!row.claim?.organizationId) continue;
+    ensureKpi(row.claim.organizationId).paidCents += row.amountCents;
+  }
+  for (const row of chargesGroup) {
+    ensureKpi(row.organizationId).gatewayChargeCents = row._sum.feeAmountCents ?? 0;
+  }
+  for (const row of encountersGroup) {
+    ensureKpi(row.organizationId).encounterCount = row._count._all;
+  }
+  for (const row of encountersLast30Group) {
+    ensureKpi(row.organizationId).encountersLast30 = row._count._all;
+  }
+  for (const row of patientsGroup) {
+    ensureKpi(row.organizationId).patientCount = row._count._all;
+  }
+  for (const orgId of orgIds) {
+    const orgProviders = providers.filter((p) => p.organizationId === orgId);
+    const k = ensureKpi(orgId);
+    k.providerCount = orgProviders.length;
+    k.activeProviderCount = orgProviders.filter((p) => p.active).length;
+  }
+
+  // 4. Build the final card rows.
+  return configsRaw
+    // Drop the synthetic HQ org — it's an internal carrier, not a real practice.
+    .filter((c) => orgById.get(c.organizationId)?.slug !== LEAFJOURNEY_HQ_SLUG)
+    .map((c): PracticeCardData => {
+      const org = orgById.get(c.organizationId);
+      const practice = c.practiceId ? practiceById.get(c.practiceId) : undefined;
+      const orgManagers = officeManagersByOrg.get(c.organizationId) ?? [];
+      const orgProviders = providersByOrg.get(c.organizationId) ?? [];
+
+      return {
+        practiceId: practice?.id ?? null,
+        configId: c.id,
+        organizationId: c.organizationId,
+        organizationName: org?.name ?? "(unknown organization)",
+        practiceName:
+          practice?.name ?? org?.brandName ?? org?.name ?? "Untitled practice",
+        brandName: org?.brandName ?? null,
+        legalName: org?.legalName ?? null,
+        city: practice?.city ?? null,
+        state: practice?.state ?? null,
+        timeZone: practice?.timeZone ?? null,
+        primaryContactName: org?.primaryContactName ?? null,
+        primaryContactEmail: org?.primaryContactEmail ?? null,
+        specialty: c.selectedSpecialty ?? null,
+        specialtyVersion: c.selectedSpecialtyVersion ?? null,
+        careModel: c.careModel ?? null,
+        enabledModalities: c.enabledModalities ?? [],
+        status: String(c.status),
+        publishedAt: c.publishedAt ? c.publishedAt.toISOString() : null,
+        updatedAt: c.updatedAt ? c.updatedAt.toISOString() : null,
+        officeManagers: orgManagers.slice(0, 3),
+        leadProviders: orgProviders.slice(0, 4),
+        kpi: kpiByOrg.get(c.organizationId) ?? { ...ZERO_KPI },
+      };
+    });
+}

--- a/src/app/(super-admin)/practices/page.tsx
+++ b/src/app/(super-admin)/practices/page.tsx
@@ -81,7 +81,7 @@ export default async function PracticesLandingPage({
             value={`$${(totalPaidCents / 100).toLocaleString(undefined, {
               maximumFractionDigits: 0,
             })}`}
-            sub="Sum of payments"
+            sub="Posted to claims"
           />
         </div>
       )}

--- a/src/app/(super-admin)/practices/page.tsx
+++ b/src/app/(super-admin)/practices/page.tsx
@@ -1,0 +1,185 @@
+// Post-onboarding Practice Landing dashboard.
+//
+// Renders one horizontal card per practice (PracticeConfiguration) with a
+// click-to-expand drawer showing KPIs (provider count, claims volume,
+// billed/paid, gateway GM, encounters). Visited after Step 15 publishes a
+// configuration; also reachable from the super-admin nav so the user can
+// audit the full fleet at a glance.
+
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Eyebrow, EmptyIllustration } from "@/components/ui/ornament";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+
+import { loadPracticeLandingCards } from "./loaders";
+import { PracticeCard } from "./practice-card";
+import { PublishedBanner } from "./published-banner";
+
+export const metadata: Metadata = {
+  title: "Practices — Leafjourney",
+  description: "Fleet overview of every onboarded practice on Leafjourney.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function PracticesLandingPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ published?: string }>;
+}) {
+  const params = (await searchParams) ?? {};
+  const justPublished = params.published === "1";
+  const practices = await loadPracticeLandingCards();
+
+  const published = practices.filter((p) => p.publishedAt);
+  const drafts = practices.filter((p) => !p.publishedAt);
+
+  const totalProviders = practices.reduce(
+    (sum, p) => sum + p.kpi.activeProviderCount,
+    0,
+  );
+  const totalClaims = practices.reduce((sum, p) => sum + p.kpi.claimCount, 0);
+  const totalPaidCents = practices.reduce((sum, p) => sum + p.kpi.paidCents, 0);
+
+  return (
+    <PageShell maxWidth="max-w-[1280px]">
+      <PageHeader
+        eyebrow="Leafjourney HQ"
+        title="Practices"
+        description="Every practice you've configured, with live KPIs. Click any card to expand."
+        actions={
+          <Link href="/onboarding">
+            <Button>Onboard a practice</Button>
+          </Link>
+        }
+      />
+
+      {justPublished && <PublishedBanner />}
+
+      {practices.length > 0 && (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-8">
+          <SummaryStat
+            label="Practices"
+            value={String(practices.length)}
+            sub={`${published.length} live · ${drafts.length} draft`}
+          />
+          <SummaryStat
+            label="Active providers"
+            value={String(totalProviders)}
+            sub="Across all practices"
+          />
+          <SummaryStat
+            label="Claims volume"
+            value={totalClaims.toLocaleString()}
+            sub="Lifetime"
+          />
+          <SummaryStat
+            label="Collected"
+            value={`$${(totalPaidCents / 100).toLocaleString(undefined, {
+              maximumFractionDigits: 0,
+            })}`}
+            sub="Sum of payments"
+          />
+        </div>
+      )}
+
+      {practices.length === 0 ? (
+        <Card tone="outlined">
+          <CardContent className="py-16 flex flex-col items-center text-center">
+            <EmptyIllustration size={140} className="mb-6 opacity-80" />
+            <Eyebrow className="mb-2">No practices yet</Eyebrow>
+            <h2 className="font-display text-xl text-text">
+              Onboard your first practice
+            </h2>
+            <p className="text-sm text-text-muted mt-2 max-w-md">
+              The onboarding wizard walks you through specialty, care model,
+              providers, and modalities. Once you publish, the practice will
+              appear here with live KPIs.
+            </p>
+            <div className="mt-6">
+              <Link href="/onboarding">
+                <Button>Start onboarding</Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-8">
+          {published.length > 0 && (
+            <section>
+              <SectionHeader
+                title="Live practices"
+                count={published.length}
+              />
+              <div className="grid gap-3">
+                {published.map((p) => (
+                  <PracticeCard key={p.configId ?? p.organizationId} practice={p} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {drafts.length > 0 && (
+            <section>
+              <SectionHeader
+                title="In flight"
+                count={drafts.length}
+                hint="Drafts and pending publishes"
+              />
+              <div className="grid gap-3">
+                {drafts.map((p) => (
+                  <PracticeCard key={p.configId ?? p.organizationId} practice={p} />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <Card tone="ambient" className="px-5 py-4">
+      <div className="text-[11px] uppercase tracking-wider text-text-muted">
+        {label}
+      </div>
+      <div className="font-display text-2xl text-text tracking-tight mt-1">
+        {value}
+      </div>
+      {sub && <div className="text-[11px] text-text-muted mt-0.5">{sub}</div>}
+    </Card>
+  );
+}
+
+function SectionHeader({
+  title,
+  count,
+  hint,
+}: {
+  title: string;
+  count: number;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between mb-3">
+      <h2 className="font-display text-lg text-text tracking-tight">
+        {title}{" "}
+        <span className="text-text-muted text-sm font-normal">({count})</span>
+      </h2>
+      {hint && <span className="text-[12px] text-text-muted">{hint}</span>}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/practice-card.tsx
+++ b/src/app/(super-admin)/practices/practice-card.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+// Horizontal practice card with a click-to-expand KPI drawer.
+//
+// Collapsed: practice name + specialty + key people + location chips.
+// Expanded: KPI grid (providers, patients, claims volume, billed, paid,
+// gateway GM, encounters) + tag list + activity strip.
+//
+// The card body is a button so the whole row is keyboard-activatable; the
+// drawer toggles aria-expanded for screen readers.
+
+import * as React from "react";
+import { ChevronDown, MapPin, Users, Stethoscope, Mail } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils/cn";
+import type { PracticeCardData } from "./loaders";
+import { humanizeCareModel, humanizeSpecialty } from "./loaders";
+
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  if (dollars >= 1_000_000) return `$${(dollars / 1_000_000).toFixed(1)}M`;
+  if (dollars >= 1_000) return `$${(dollars / 1_000).toFixed(1)}K`;
+  return `$${dollars.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .slice(0, 2)
+    .join("");
+}
+
+function StatusBadge({ status, publishedAt }: { status: string; publishedAt: string | null }) {
+  if (publishedAt) return <Badge tone="success">Live</Badge>;
+  if (status === "draft") return <Badge tone="neutral">Draft</Badge>;
+  if (status === "archived") return <Badge tone="warning">Archived</Badge>;
+  return <Badge tone="info">{status}</Badge>;
+}
+
+function PersonChip({ name, sub }: { name: string; sub?: string }) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <div className="h-7 w-7 rounded-full bg-accent-soft text-accent text-[11px] font-medium flex items-center justify-center shrink-0">
+        {initials(name) || "?"}
+      </div>
+      <div className="min-w-0">
+        <div className="text-[13px] text-text truncate leading-tight">{name}</div>
+        {sub && (
+          <div className="text-[11px] text-text-muted truncate leading-tight">{sub}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Kpi({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-surface px-4 py-3">
+      <div className="text-[11px] uppercase tracking-wide text-text-muted">{label}</div>
+      <div className="font-display text-xl text-text tracking-tight mt-1">{value}</div>
+      {sub && <div className="text-[11px] text-text-muted mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+export function PracticeCard({ practice }: { practice: PracticeCardData }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const drawerId = React.useId();
+
+  const specialtyLabel = humanizeSpecialty(practice.specialty);
+  const careModelLabel = humanizeCareModel(practice.careModel);
+  const location = [practice.city, practice.state].filter(Boolean).join(", ");
+
+  const officeManager = practice.officeManagers[0];
+  const leadProvider = practice.leadProviders[0];
+
+  return (
+    <Card tone={expanded ? "raised" : "default"} className="transition-all">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={drawerId}
+        className="w-full text-left px-6 py-5 flex items-center gap-6 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-xl"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h3 className="font-display text-lg text-text tracking-tight truncate">
+              {practice.practiceName}
+            </h3>
+            <StatusBadge status={practice.status} publishedAt={practice.publishedAt} />
+            <Badge tone="accent">{specialtyLabel}</Badge>
+            {practice.careModel && <Badge tone="neutral">{careModelLabel}</Badge>}
+          </div>
+          {practice.organizationName !== practice.practiceName && (
+            <div className="text-[12px] text-text-muted mt-1 truncate">
+              {practice.organizationName}
+            </div>
+          )}
+          <div className="flex items-center gap-5 mt-3 text-[12px] text-text-muted flex-wrap">
+            {location && (
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="h-3.5 w-3.5" />
+                {location}
+              </span>
+            )}
+            <span className="inline-flex items-center gap-1.5">
+              <Stethoscope className="h-3.5 w-3.5" />
+              {practice.kpi.activeProviderCount} provider
+              {practice.kpi.activeProviderCount === 1 ? "" : "s"}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" />
+              {formatNumber(practice.kpi.patientCount)} patients
+            </span>
+          </div>
+        </div>
+
+        <div className="hidden md:flex items-center gap-6 shrink-0 pr-2">
+          {officeManager && (
+            <div className="min-w-[160px]">
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1.5">
+                Office manager
+              </div>
+              <PersonChip name={officeManager.name} sub={officeManager.email} />
+            </div>
+          )}
+          {leadProvider && (
+            <div className="min-w-[160px]">
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1.5">
+                Lead provider
+              </div>
+              <PersonChip
+                name={leadProvider.name}
+                sub={leadProvider.title ?? "Provider"}
+              />
+            </div>
+          )}
+          <div className="text-right min-w-[110px]">
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">
+              Claims
+            </div>
+            <div className="font-display text-lg text-text tracking-tight">
+              {formatNumber(practice.kpi.claimCount)}
+            </div>
+            <div className="text-[11px] text-text-muted">
+              {practice.kpi.claimsLast30} in last 30d
+            </div>
+          </div>
+          <div className="text-right min-w-[110px]">
+            <div className="text-[10px] uppercase tracking-wider text-text-muted">
+              Paid
+            </div>
+            <div className="font-display text-lg text-text tracking-tight">
+              {formatDollars(practice.kpi.paidCents)}
+            </div>
+            <div className="text-[11px] text-text-muted">collected</div>
+          </div>
+        </div>
+
+        <ChevronDown
+          className={cn(
+            "h-5 w-5 text-text-muted shrink-0 transition-transform",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div
+          id={drawerId}
+          className="px-6 pb-6 pt-1 border-t border-border/60 mt-1 grid gap-6"
+        >
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <Kpi
+              label="Active providers"
+              value={String(practice.kpi.activeProviderCount)}
+              sub={`${practice.kpi.providerCount} total on roster`}
+            />
+            <Kpi
+              label="Patients"
+              value={formatNumber(practice.kpi.patientCount)}
+              sub="Non-archived"
+            />
+            <Kpi
+              label="Claims volume"
+              value={formatNumber(practice.kpi.claimCount)}
+              sub={`${practice.kpi.claimsLast30} created last 30d`}
+            />
+            <Kpi
+              label="Encounters"
+              value={formatNumber(practice.kpi.encounterCount)}
+              sub={`${practice.kpi.encountersLast30} in last 30d`}
+            />
+            <Kpi
+              label="Billed (lifetime)"
+              value={formatDollars(practice.kpi.billedCents)}
+            />
+            <Kpi
+              label="Collected"
+              value={formatDollars(practice.kpi.paidCents)}
+              sub="Sum of payments"
+            />
+            <Kpi
+              label="Gateway GM"
+              value={formatDollars(practice.kpi.gatewayChargeCents)}
+              sub="Charges run through gateway"
+            />
+            <Kpi
+              label="Specialty"
+              value={specialtyLabel}
+              sub={
+                practice.specialtyVersion
+                  ? `v${practice.specialtyVersion}`
+                  : undefined
+              }
+            />
+          </div>
+
+          {practice.enabledModalities.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+                Enabled modalities
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {practice.enabledModalities.map((m) => (
+                  <Badge key={m} tone="neutral">
+                    {m.replace(/_/g, " ")}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+                Practice details
+              </div>
+              <dl className="text-[13px] grid gap-1.5">
+                {practice.legalName && (
+                  <Row label="Legal" value={practice.legalName} />
+                )}
+                {practice.brandName && (
+                  <Row label="Brand" value={practice.brandName} />
+                )}
+                {location && <Row label="Location" value={location} />}
+                {practice.timeZone && (
+                  <Row label="Time zone" value={practice.timeZone} />
+                )}
+                {practice.primaryContactName && (
+                  <Row
+                    label="Primary contact"
+                    value={
+                      practice.primaryContactEmail
+                        ? `${practice.primaryContactName} · ${practice.primaryContactEmail}`
+                        : practice.primaryContactName
+                    }
+                  />
+                )}
+                <Row label="Care model" value={careModelLabel} />
+                {practice.publishedAt && (
+                  <Row
+                    label="Published"
+                    value={new Date(practice.publishedAt).toLocaleDateString()}
+                  />
+                )}
+              </dl>
+            </div>
+
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+                Office managers & operators
+              </div>
+              {practice.officeManagers.length === 0 ? (
+                <div className="text-[12px] text-text-muted italic">
+                  None invited yet.
+                </div>
+              ) : (
+                <ul className="grid gap-2.5">
+                  {practice.officeManagers.map((m) => (
+                    <li key={m.userId}>
+                      <PersonChip
+                        name={m.name}
+                        sub={`${m.role.replace(/_/g, " ")} · ${m.email}`}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+                Key providers
+              </div>
+              {practice.leadProviders.length === 0 ? (
+                <div className="text-[12px] text-text-muted italic">
+                  No providers onboarded yet.
+                </div>
+              ) : (
+                <ul className="grid gap-2.5">
+                  {practice.leadProviders.map((p) => (
+                    <li key={p.userId}>
+                      <PersonChip name={p.name} sub={p.title ?? "Provider"} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between pt-2 border-t border-border/60 text-[12px] text-text-muted">
+            <div className="inline-flex items-center gap-1.5">
+              <Mail className="h-3.5 w-3.5" />
+              {practice.primaryContactEmail ?? "No primary contact email"}
+            </div>
+            <div>
+              Updated{" "}
+              {practice.updatedAt
+                ? new Date(practice.updatedAt).toLocaleDateString()
+                : "—"}
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="text-text-muted w-28 shrink-0 text-[11px] uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd className="text-text">{value}</dd>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/practice-card.tsx
+++ b/src/app/(super-admin)/practices/practice-card.tsx
@@ -15,8 +15,8 @@ import { ChevronDown, MapPin, Users, Stethoscope, Mail } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils/cn";
-import type { PracticeCardData } from "./loaders";
-import { humanizeCareModel, humanizeSpecialty } from "./loaders";
+import type { PracticeCardData } from "./types";
+import { humanizeCareModel, humanizeSpecialty } from "./types";
 
 function formatDollars(cents: number): string {
   const dollars = cents / 100;
@@ -208,7 +208,7 @@ export function PracticeCard({ practice }: { practice: PracticeCardData }) {
             <Kpi
               label="Collected"
               value={formatDollars(practice.kpi.paidCents)}
-              sub="Sum of payments"
+              sub="Posted to claims"
             />
             <Kpi
               label="Gateway GM"

--- a/src/app/(super-admin)/practices/published-banner.tsx
+++ b/src/app/(super-admin)/practices/published-banner.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// Success banner shown after Step 15 redirects with ?published=1. Auto-clears
+// the query param after mount so a refresh doesn't keep showing the banner.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, X } from "lucide-react";
+
+export function PublishedBanner() {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(true);
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => {
+      router.replace("/practices");
+    }, 6000);
+    return () => window.clearTimeout(timer);
+  }, [router]);
+
+  if (!open) return null;
+
+  return (
+    <div className="mb-6 flex items-start gap-3 rounded-xl border border-[color:var(--success)]/30 bg-[color:var(--accent-soft)] px-4 py-3">
+      <CheckCircle2 className="h-5 w-5 text-success shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <div className="font-display text-sm text-text">
+          Practice published 🎉
+        </div>
+        <p className="text-[13px] text-text-muted mt-0.5">
+          Your new configuration is live. Click any card below to drill into
+          its KPIs.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(false);
+          router.replace("/practices");
+        }}
+        className="text-text-muted hover:text-text"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/types.ts
+++ b/src/app/(super-admin)/practices/types.ts
@@ -1,0 +1,78 @@
+// Pure types and presentation helpers for the practices landing page.
+// Kept free of any server-only imports so it can be consumed by both the
+// server loader and the client card component.
+
+export type PracticeStakeholder = {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  title?: string | null;
+};
+
+export type PracticeKpi = {
+  providerCount: number;
+  activeProviderCount: number;
+  patientCount: number;
+  claimCount: number;
+  claimsLast30: number;
+  billedCents: number;
+  paidCents: number;
+  gatewayChargeCents: number;
+  encounterCount: number;
+  encountersLast30: number;
+};
+
+export type PracticeCardData = {
+  practiceId: string | null;
+  configId: string | null;
+  organizationId: string;
+  organizationName: string;
+  practiceName: string;
+  brandName: string | null;
+  legalName: string | null;
+  city: string | null;
+  state: string | null;
+  timeZone: string | null;
+  primaryContactName: string | null;
+  primaryContactEmail: string | null;
+  specialty: string | null;
+  specialtyVersion: string | null;
+  careModel: string | null;
+  enabledModalities: string[];
+  status: string;
+  publishedAt: string | null;
+  updatedAt: string | null;
+  officeManagers: PracticeStakeholder[];
+  leadProviders: PracticeStakeholder[];
+  kpi: PracticeKpi;
+};
+
+export const ZERO_KPI: PracticeKpi = {
+  providerCount: 0,
+  activeProviderCount: 0,
+  patientCount: 0,
+  claimCount: 0,
+  claimsLast30: 0,
+  billedCents: 0,
+  paidCents: 0,
+  gatewayChargeCents: 0,
+  encounterCount: 0,
+  encountersLast30: 0,
+};
+
+/** Pretty-print a slug like "primary-care@1" → "Primary care". */
+export function humanizeSpecialty(slug: string | null | undefined): string {
+  if (!slug) return "Specialty not selected";
+  const base = slug.split("@")[0] ?? slug;
+  return base
+    .split("-")
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+/** Pretty-print a care-model slug like "in_person" → "In person". */
+export function humanizeCareModel(value: string | null | undefined): string {
+  if (!value) return "—";
+  return value.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+}

--- a/src/components/onboarding/steps/step-15-publish.tsx
+++ b/src/components/onboarding/steps/step-15-publish.tsx
@@ -8,8 +8,9 @@
 //
 // On click:
 //   POST /api/configs/[draftId]/publish
-//     200 → redirect to /practice-admin/dashboard?published=1 (EMR-447's
-//           dashboard reads the query param and shows the success banner)
+//     200 → redirect to /practices?published=1 — the super-admin fleet
+//           landing page surfaces a success banner and renders the newly
+//           published practice as an expandable KPI card.
 //     409 → server returned `{ missing: [...] }` — surface inline with
 //           deep-links back to the relevant earlier step.
 //
@@ -106,7 +107,7 @@ export function Step15Publish({ draft, goBack }: WizardStepProps) {
       );
 
       if (res.ok) {
-        router.push("/practice-admin/dashboard?published=1");
+        router.push("/practices?published=1");
         return;
       }
 


### PR DESCRIPTION
## Summary

- New super-admin route `/practices` that lists every onboarded practice as a horizontal card and serves as the post-onboarding landing page.
- Each card collapses to name, status, specialty/care-model chips, location, office manager, lead provider, and headline claim/payment numbers; clicking expands a drawer with an 8-tile KPI grid (active providers, patients, claims lifetime + last 30d, encounters, billed, collected, gateway GM, specialty version), enabled modalities, full stakeholder roster, and practice details.
- Server loader joins PracticeConfiguration → Practice → Organization → Membership / Provider / Claim / Payment / Charge / Encounter / Patient in a single parallel batch. Synthetic Leafjourney HQ org is filtered out. Membership roles `practice_admin` / `operator` / `practice_owner` are surfaced as "office managers" since the schema has no dedicated office_manager role.
- Step 15 of the onboarding wizard now redirects to `/practices?published=1` (was `/practice-admin/dashboard?published=1`); landing page shows a dismissable success banner when that param is present.
- Summary strip at the top of `/practices` totals practices, active providers, claims volume, and collected revenue across the fleet.

## Test plan

- [ ] Visit `/practices` as a super-admin with no published configs — empty state renders with "Start onboarding" CTA.
- [ ] Run the onboarding wizard through Step 15 → confirm redirect lands on `/practices?published=1` with the success banner, and the new practice appears under "Live practices".
- [ ] Click a practice card — drawer expands with KPI tiles, modality chips, and three-column detail panel. Click again — collapses.
- [ ] Seed a few claims + payments + charges + encounters against an org and confirm KPI tiles reflect the totals (lifetime + last 30d).
- [ ] Visit as a non-super-admin — `(super-admin)/layout.tsx` redirects to `/sign-in` or `/`.
- [ ] `tsc --noEmit` and `next lint` pass on the new files.

https://claude.ai/code/session_012DAVaggx66rjU6QtDgsWhd

---
_Generated by [Claude Code](https://claude.ai/code/session_012DAVaggx66rjU6QtDgsWhd)_