### PR TITLE
feat(clinical): Wave 9 SOAP UI fragments (EMR-068, 069, 070, 071, 073)

### DIFF
--- a/src/components/clinical/soap/assessment-icd10.tsx
+++ b/src/components/clinical/soap/assessment-icd10.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 9 SOAP fragment scaffold (EMR-070); composed into the note workspace in a later wave"
 "use client";
 
 import React, { useMemo, useState } from "react";

--- a/src/components/clinical/soap/assessment-icd10.tsx
+++ b/src/components/clinical/soap/assessment-icd10.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input, Label } from "@/components/ui/input";
+
+interface Icd10Code {
+  code: string;
+  description: string;
+  category: "cannabis" | "pain" | "mental" | "sleep" | "other";
+}
+
+// Curated starter set focused on common cannabis-clinic diagnoses.
+// In production this is backed by a server-side search; the picker
+// component just needs a stable input/output contract.
+const ICD10_LIBRARY: Icd10Code[] = [
+  { code: "F12.10", description: "Cannabis abuse, uncomplicated", category: "cannabis" },
+  { code: "F12.20", description: "Cannabis dependence, uncomplicated", category: "cannabis" },
+  { code: "F12.90", description: "Cannabis use, unspecified, uncomplicated", category: "cannabis" },
+  { code: "Z71.89", description: "Other specified counseling", category: "cannabis" },
+  { code: "Z79.891", description: "Long-term (current) use of opiate analgesic", category: "cannabis" },
+  { code: "G89.29", description: "Other chronic pain", category: "pain" },
+  { code: "M54.50", description: "Low back pain, unspecified", category: "pain" },
+  { code: "M79.10", description: "Myalgia, unspecified site", category: "pain" },
+  { code: "G43.909", description: "Migraine, unspecified", category: "pain" },
+  { code: "F41.1", description: "Generalized anxiety disorder", category: "mental" },
+  { code: "F33.1", description: "Major depressive disorder, recurrent, moderate", category: "mental" },
+  { code: "F43.10", description: "Post-traumatic stress disorder, unspecified", category: "mental" },
+  { code: "G47.00", description: "Insomnia, unspecified", category: "sleep" },
+  { code: "G47.33", description: "Obstructive sleep apnea", category: "sleep" },
+];
+
+export interface AssessmentIcd10Props {
+  initialSelected?: string[];
+  onChange?: (selected: Icd10Code[]) => void;
+}
+
+export function AssessmentIcd10({ initialSelected = [], onChange }: AssessmentIcd10Props) {
+  const [query, setQuery] = useState("");
+  const [selectedCodes, setSelectedCodes] = useState<string[]>(initialSelected);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return ICD10_LIBRARY.slice(0, 8);
+    return ICD10_LIBRARY.filter(
+      (c) => c.code.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
+    ).slice(0, 12);
+  }, [query]);
+
+  const selected = useMemo(
+    () => selectedCodes.map((c) => ICD10_LIBRARY.find((l) => l.code === c)).filter((c): c is Icd10Code => !!c),
+    [selectedCodes],
+  );
+
+  const toggle = (code: string) => {
+    setSelectedCodes((prev) => {
+      const next = prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code];
+      onChange?.(next.map((c) => ICD10_LIBRARY.find((l) => l.code === c)!).filter(Boolean));
+      return next;
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Assessment ICD-10 codes:", selected);
+  };
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Assessment — ICD-10</CardTitle>
+        <CardDescription>Search and select diagnoses. Cannabis-related codes appear at the top of the library.</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="icd10-search">Search by code or description</Label>
+            <Input
+              id="icd10-search"
+              type="search"
+              placeholder="e.g., F12, anxiety, sleep"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+
+          {selected.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+                Selected ({selected.length})
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {selected.map((c) => (
+                  <button
+                    key={c.code}
+                    type="button"
+                    onClick={() => toggle(c.code)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] text-white text-xs font-medium px-2.5 py-1.5 hover:bg-[var(--accent)]/90"
+                    aria-label={`Remove ${c.code}`}
+                  >
+                    <span className="font-bold">{c.code}</span>
+                    <span className="opacity-90 truncate max-w-[20ch]">{c.description}</span>
+                    <span aria-hidden="true">×</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <div className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              {query.trim() ? `Results (${results.length})` : "Common diagnoses"}
+            </div>
+            <ul className="divide-y divide-[var(--border)] border border-[var(--border)] rounded-xl overflow-hidden">
+              {results.length === 0 && (
+                <li className="px-4 py-6 text-sm text-text-muted text-center">No matches.</li>
+              )}
+              {results.map((c) => {
+                const isSelected = selectedCodes.includes(c.code);
+                return (
+                  <li key={c.code}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(c.code)}
+                      className={`w-full flex items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors ${
+                        isSelected ? "bg-[var(--accent)]/10" : "hover:bg-[var(--surface-muted)]/40"
+                      }`}
+                    >
+                      <div className="min-w-0">
+                        <div className="font-mono text-xs font-bold text-text">{c.code}</div>
+                        <div className="text-text-muted truncate">{c.description}</div>
+                      </div>
+                      <span
+                        className={`text-xs font-medium px-2 py-0.5 rounded-md ${
+                          isSelected
+                            ? "bg-[var(--accent)] text-white"
+                            : "bg-[var(--surface-muted)] text-text-muted"
+                        }`}
+                      >
+                        {isSelected ? "Selected" : "Add"}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end">
+          <Button type="submit" variant="primary" disabled={selected.length === 0}>
+            Save Assessment
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default AssessmentIcd10;

--- a/src/components/clinical/soap/care-team-tagger.tsx
+++ b/src/components/clinical/soap/care-team-tagger.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { useMemo, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/input";
+
+export interface CareTeamMember {
+  id: string;
+  name: string;
+  role: string;
+}
+
+const DEFAULT_DIRECTORY: CareTeamMember[] = [
+  { id: "u-patel", name: "Dr. Neal Patel", role: "Cannabis specialist" },
+  { id: "u-nora", name: "Nurse Nora", role: "Care coordinator" },
+  { id: "u-rivera", name: "Dr. Maya Rivera", role: "Pain management" },
+  { id: "u-okafor", name: "Dr. Sam Okafor", role: "Psychiatry" },
+  { id: "u-chen", name: "PharmD Lin Chen", role: "Clinical pharmacist" },
+  { id: "u-lee", name: "MA Jordan Lee", role: "Medical assistant" },
+];
+
+export interface CareTeamTaggerProps {
+  directory?: CareTeamMember[];
+  initialTagged?: string[];
+  onChange?: (tagged: CareTeamMember[]) => void;
+}
+
+export function CareTeamTagger({
+  directory = DEFAULT_DIRECTORY,
+  initialTagged = [],
+  onChange,
+}: CareTeamTaggerProps) {
+  const [query, setQuery] = useState("");
+  const [tagged, setTagged] = useState<string[]>(initialTagged);
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const suggestions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const remaining = directory.filter((m) => !tagged.includes(m.id));
+    if (!q) return remaining.slice(0, 5);
+    return remaining
+      .filter((m) => m.name.toLowerCase().includes(q) || m.role.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [directory, query, tagged]);
+
+  const taggedMembers = useMemo(
+    () => tagged.map((id) => directory.find((m) => m.id === id)).filter((m): m is CareTeamMember => !!m),
+    [directory, tagged],
+  );
+
+  const addMember = (id: string) => {
+    setTagged((prev) => {
+      if (prev.includes(id)) return prev;
+      const next = [...prev, id];
+      onChange?.(next.map((tid) => directory.find((m) => m.id === tid)!).filter(Boolean));
+      return next;
+    });
+    setQuery("");
+    setHighlight(0);
+    inputRef.current?.focus();
+  };
+
+  const removeMember = (id: string) => {
+    setTagged((prev) => {
+      const next = prev.filter((t) => t !== id);
+      onChange?.(next.map((tid) => directory.find((m) => m.id === tid)!).filter(Boolean));
+      return next;
+    });
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter" && suggestions[highlight]) {
+      e.preventDefault();
+      addMember(suggestions[highlight].id);
+    } else if (e.key === "Backspace" && query === "" && tagged.length > 0) {
+      removeMember(tagged[tagged.length - 1]);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Care team tagged:", taggedMembers);
+  };
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Care Team</CardTitle>
+        <CardDescription>Tag the clinicians and staff who should see this note.</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          <Label htmlFor="ct-input">Add team members</Label>
+          <div className="flex flex-wrap items-center gap-2 p-2 border border-[var(--border)] rounded-xl bg-white focus-within:border-[var(--accent)] focus-within:ring-2 focus-within:ring-[var(--accent)]/20">
+            {taggedMembers.map((m) => (
+              <span
+                key={m.id}
+                className="inline-flex items-center gap-1.5 rounded-md bg-[var(--accent)]/10 text-[var(--accent)] text-xs font-medium px-2 py-1"
+              >
+                @{m.name}
+                <button
+                  type="button"
+                  onClick={() => removeMember(m.id)}
+                  aria-label={`Remove ${m.name}`}
+                  className="text-[var(--accent)] hover:text-[var(--accent)]/70"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+            <input
+              id="ct-input"
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setHighlight(0);
+              }}
+              onKeyDown={handleKey}
+              placeholder={taggedMembers.length === 0 ? "Type a name or role…" : ""}
+              className="flex-1 min-w-[10ch] bg-transparent text-sm outline-none px-1 py-1"
+              autoComplete="off"
+            />
+          </div>
+
+          {suggestions.length > 0 && (
+            <ul className="border border-[var(--border)] rounded-xl divide-y divide-[var(--border)] overflow-hidden">
+              {suggestions.map((m, i) => (
+                <li key={m.id}>
+                  <button
+                    type="button"
+                    onMouseEnter={() => setHighlight(i)}
+                    onClick={() => addMember(m.id)}
+                    className={`w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
+                      i === highlight ? "bg-[var(--accent)]/10" : "hover:bg-[var(--surface-muted)]/40"
+                    }`}
+                  >
+                    <div>
+                      <div className="font-medium text-text">{m.name}</div>
+                      <div className="text-xs text-text-muted">{m.role}</div>
+                    </div>
+                    <span className="text-xs text-[var(--accent)] font-medium">Tag</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {tagged.length === 0 && (
+            <p className="text-xs text-text-muted">
+              Tip: arrow keys to navigate, Enter to add, Backspace to remove the last tag.
+            </p>
+          )}
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end">
+          <Button type="submit" variant="primary" disabled={tagged.length === 0}>
+            Save Care Team
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default CareTeamTagger;

--- a/src/components/clinical/soap/care-team-tagger.tsx
+++ b/src/components/clinical/soap/care-team-tagger.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 9 SOAP fragment scaffold (EMR-073); composed into the note workspace in a later wave"
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";

--- a/src/components/clinical/soap/objective-vitals.tsx
+++ b/src/components/clinical/soap/objective-vitals.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 9 SOAP fragment scaffold (EMR-069); composed into the note workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/clinical/soap/objective-vitals.tsx
+++ b/src/components/clinical/soap/objective-vitals.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input, Label } from "@/components/ui/input";
+
+interface VitalsState {
+  systolic: string;
+  diastolic: string;
+  heartRate: string;
+  respRate: string;
+  tempF: string;
+  spo2: string;
+  weightLbs: string;
+  heightIn: string;
+}
+
+const EMPTY: VitalsState = {
+  systolic: "",
+  diastolic: "",
+  heartRate: "",
+  respRate: "",
+  tempF: "",
+  spo2: "",
+  weightLbs: "",
+  heightIn: "",
+};
+
+function parseNum(s: string): number | null {
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+function bmi(weightLbs: string, heightIn: string): number | null {
+  const w = parseNum(weightLbs);
+  const h = parseNum(heightIn);
+  if (w == null || h == null || h <= 0) return null;
+  return (w / (h * h)) * 703;
+}
+
+function bpFlag(sys: string, dia: string): { label: string; tone: "ok" | "warn" | "alert" } | null {
+  const s = parseNum(sys);
+  const d = parseNum(dia);
+  if (s == null || d == null) return null;
+  if (s >= 180 || d >= 120) return { label: "Hypertensive crisis", tone: "alert" };
+  if (s >= 140 || d >= 90) return { label: "Stage 2 hypertension", tone: "alert" };
+  if (s >= 130 || d >= 80) return { label: "Stage 1 hypertension", tone: "warn" };
+  if (s < 90 || d < 60) return { label: "Hypotensive", tone: "warn" };
+  return { label: "Normal", tone: "ok" };
+}
+
+function spo2Flag(spo2: string): { label: string; tone: "ok" | "warn" | "alert" } | null {
+  const v = parseNum(spo2);
+  if (v == null) return null;
+  if (v < 90) return { label: "Hypoxemic", tone: "alert" };
+  if (v < 95) return { label: "Low", tone: "warn" };
+  return { label: "Normal", tone: "ok" };
+}
+
+function toneClass(tone: "ok" | "warn" | "alert"): string {
+  if (tone === "alert") return "bg-red-100 text-red-700 border-red-200";
+  if (tone === "warn") return "bg-amber-100 text-amber-700 border-amber-200";
+  return "bg-emerald-100 text-emerald-700 border-emerald-200";
+}
+
+export function ObjectiveVitals() {
+  const [state, setState] = useState<VitalsState>(EMPTY);
+
+  const handleField = (key: keyof VitalsState, value: string) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const computedBmi = bmi(state.weightLbs, state.heightIn);
+  const bp = bpFlag(state.systolic, state.diastolic);
+  const sp = spo2Flag(state.spo2);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Vitals:", { ...state, bmi: computedBmi });
+  };
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Objective — Vitals Snapshot</CardTitle>
+        <CardDescription>Vitals captured at the start of the encounter. BMI computes automatically.</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="space-y-1.5 col-span-2">
+              <Label>Blood pressure (mmHg)</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="120"
+                  value={state.systolic}
+                  onChange={(e) => handleField("systolic", e.target.value)}
+                  aria-label="Systolic"
+                />
+                <span className="text-text-muted">/</span>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="80"
+                  value={state.diastolic}
+                  onChange={(e) => handleField("diastolic", e.target.value)}
+                  aria-label="Diastolic"
+                />
+              </div>
+              {bp && (
+                <span className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-md border ${toneClass(bp.tone)}`}>
+                  {bp.label}
+                </span>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="hr">Heart rate (bpm)</Label>
+              <Input
+                id="hr"
+                type="number"
+                inputMode="numeric"
+                placeholder="72"
+                value={state.heartRate}
+                onChange={(e) => handleField("heartRate", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rr">Resp rate (bpm)</Label>
+              <Input
+                id="rr"
+                type="number"
+                inputMode="numeric"
+                placeholder="16"
+                value={state.respRate}
+                onChange={(e) => handleField("respRate", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="temp">Temperature (°F)</Label>
+              <Input
+                id="temp"
+                type="number"
+                step="0.1"
+                inputMode="decimal"
+                placeholder="98.6"
+                value={state.tempF}
+                onChange={(e) => handleField("tempF", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="spo2">SpO₂ (%)</Label>
+              <Input
+                id="spo2"
+                type="number"
+                inputMode="numeric"
+                placeholder="98"
+                value={state.spo2}
+                onChange={(e) => handleField("spo2", e.target.value)}
+              />
+              {sp && (
+                <span className={`inline-block mt-1 text-xs px-2 py-0.5 rounded-md border ${toneClass(sp.tone)}`}>
+                  {sp.label}
+                </span>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="weight">Weight (lbs)</Label>
+              <Input
+                id="weight"
+                type="number"
+                inputMode="decimal"
+                placeholder="165"
+                value={state.weightLbs}
+                onChange={(e) => handleField("weightLbs", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="height">Height (in)</Label>
+              <Input
+                id="height"
+                type="number"
+                inputMode="decimal"
+                placeholder="68"
+                value={state.heightIn}
+                onChange={(e) => handleField("heightIn", e.target.value)}
+              />
+            </div>
+          </div>
+
+          {computedBmi != null && (
+            <div className="p-4 rounded-xl bg-[var(--accent)]/10 border border-[var(--accent)]/20 flex items-center justify-between">
+              <span className="text-sm font-medium text-text-muted">BMI</span>
+              <span className="text-2xl font-bold text-[var(--accent)] tabular-nums">{computedBmi.toFixed(1)}</span>
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end">
+          <Button type="submit" variant="primary">
+            Save Vitals
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default ObjectiveVitals;

--- a/src/components/clinical/soap/plan-eprescribe.tsx
+++ b/src/components/clinical/soap/plan-eprescribe.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input, Label, Textarea } from "@/components/ui/input";
+
+type Status = "draft" | "sending" | "sent";
+
+interface RxState {
+  medication: string;
+  strength: string;
+  form: string;
+  sig: string;
+  dispense: string;
+  refills: string;
+  daw: boolean;
+  pharmacy: string;
+  notes: string;
+}
+
+const EMPTY: RxState = {
+  medication: "",
+  strength: "",
+  form: "tincture",
+  sig: "",
+  dispense: "",
+  refills: "0",
+  daw: false,
+  pharmacy: "",
+  notes: "",
+};
+
+const FORM_OPTIONS = ["tincture", "capsule", "tablet", "vape cartridge", "topical", "edible", "flower"];
+
+export interface PlanEprescribeProps {
+  onSend?: (rx: RxState) => Promise<void> | void;
+}
+
+export function PlanEprescribe({ onSend }: PlanEprescribeProps = {}) {
+  const [state, setState] = useState<RxState>(EMPTY);
+  const [status, setStatus] = useState<Status>("draft");
+
+  const handleField = <K extends keyof RxState>(key: K, value: RxState[K]) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+    if (status === "sent") setStatus("draft");
+  };
+
+  const isValid =
+    state.medication.trim().length > 0 &&
+    state.sig.trim().length > 0 &&
+    state.pharmacy.trim().length > 0;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValid || status === "sending") return;
+    setStatus("sending");
+    try {
+      if (onSend) await onSend(state);
+      else console.log("E-Prescribe (stub):", state);
+      setStatus("sent");
+    } catch (err) {
+      console.error("E-Prescribe failed:", err);
+      setStatus("draft");
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Plan — E-Prescribe</CardTitle>
+        <CardDescription>Compose and send a prescription to the patient&apos;s preferred pharmacy.</CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-5">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-1.5 md:col-span-2">
+              <Label htmlFor="rx-med">Medication</Label>
+              <Input
+                id="rx-med"
+                value={state.medication}
+                onChange={(e) => handleField("medication", e.target.value)}
+                placeholder="e.g., CBD:THC 20:1 full-spectrum"
+                required
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rx-strength">Strength</Label>
+              <Input
+                id="rx-strength"
+                value={state.strength}
+                onChange={(e) => handleField("strength", e.target.value)}
+                placeholder="e.g., 20 mg/mL"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rx-form">Form</Label>
+              <select
+                id="rx-form"
+                value={state.form}
+                onChange={(e) => handleField("form", e.target.value)}
+                className="w-full h-11 px-3 bg-white border border-[var(--border)] rounded-xl text-sm outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20"
+              >
+                {FORM_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5 md:col-span-2">
+              <Label htmlFor="rx-sig">Sig (patient instructions)</Label>
+              <Textarea
+                id="rx-sig"
+                rows={2}
+                value={state.sig}
+                onChange={(e) => handleField("sig", e.target.value)}
+                placeholder="e.g., 0.5 mL sublingually at bedtime; may repeat once if needed"
+                required
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rx-dispense">Dispense</Label>
+              <Input
+                id="rx-dispense"
+                value={state.dispense}
+                onChange={(e) => handleField("dispense", e.target.value)}
+                placeholder="e.g., 30 mL"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="rx-refills">Refills</Label>
+              <Input
+                id="rx-refills"
+                type="number"
+                min={0}
+                max={12}
+                value={state.refills}
+                onChange={(e) => handleField("refills", e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5 md:col-span-2">
+              <Label htmlFor="rx-pharmacy">Pharmacy</Label>
+              <Input
+                id="rx-pharmacy"
+                value={state.pharmacy}
+                onChange={(e) => handleField("pharmacy", e.target.value)}
+                placeholder="e.g., Patel Compounding Pharmacy — 555-0101"
+                required
+              />
+            </div>
+
+            <label className="flex items-center gap-2 md:col-span-2 text-sm text-text">
+              <input
+                type="checkbox"
+                checked={state.daw}
+                onChange={(e) => handleField("daw", e.target.checked)}
+                className="w-4 h-4 rounded border-[var(--border)] text-[var(--accent)] focus:ring-[var(--accent)]/30"
+              />
+              Dispense as written (no substitution)
+            </label>
+
+            <div className="space-y-1.5 md:col-span-2">
+              <Label htmlFor="rx-notes">Notes to pharmacist (optional)</Label>
+              <Textarea
+                id="rx-notes"
+                rows={2}
+                value={state.notes}
+                onChange={(e) => handleField("notes", e.target.value)}
+                placeholder="e.g., Patient prefers alcohol-free base"
+              />
+            </div>
+          </div>
+
+          {status === "sent" && (
+            <div className="p-3 rounded-xl bg-emerald-50 border border-emerald-200 text-sm text-emerald-700">
+              Sent to {state.pharmacy}.
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end gap-2">
+          <Button type="submit" variant="primary" disabled={!isValid || status === "sending"}>
+            {status === "sending" ? "Sending…" : status === "sent" ? "Sent" : "Send to Pharmacy"}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default PlanEprescribe;

--- a/src/components/clinical/soap/plan-eprescribe.tsx
+++ b/src/components/clinical/soap/plan-eprescribe.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 9 SOAP fragment scaffold (EMR-071); composed into the note workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/clinical/soap/subjective-hpi.tsx
+++ b/src/components/clinical/soap/subjective-hpi.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 9 SOAP fragment scaffold (EMR-068); composed into the note workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/clinical/soap/subjective-hpi.tsx
+++ b/src/components/clinical/soap/subjective-hpi.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea, Label } from "@/components/ui/input";
+
+const OLDCARTS_FIELDS: { key: keyof HpiState; label: string; placeholder: string }[] = [
+  { key: "onset", label: "Onset", placeholder: "When did it start? (e.g., 3 weeks ago, gradual)" },
+  { key: "location", label: "Location", placeholder: "Where is it? (e.g., lower back, bilateral knees)" },
+  { key: "duration", label: "Duration", placeholder: "How long does it last? (e.g., constant, intermittent)" },
+  { key: "character", label: "Character", placeholder: "What does it feel like? (e.g., sharp, throbbing, burning)" },
+  { key: "aggravating", label: "Aggravating", placeholder: "What makes it worse? (e.g., movement, stress)" },
+  { key: "relieving", label: "Relieving", placeholder: "What makes it better? (e.g., rest, cannabis, NSAIDs)" },
+  { key: "timing", label: "Timing", placeholder: "When is it worst? (e.g., mornings, after meals)" },
+  { key: "severity", label: "Severity", placeholder: "How bad on 0-10? (e.g., 7/10 average)" },
+];
+
+interface HpiState {
+  onset: string;
+  location: string;
+  duration: string;
+  character: string;
+  aggravating: string;
+  relieving: string;
+  timing: string;
+  severity: string;
+  narrative: string;
+}
+
+const EMPTY: HpiState = {
+  onset: "",
+  location: "",
+  duration: "",
+  character: "",
+  aggravating: "",
+  relieving: "",
+  timing: "",
+  severity: "",
+  narrative: "",
+};
+
+function composeNarrative(state: HpiState): string {
+  const parts: string[] = [];
+  if (state.onset) parts.push(`Onset: ${state.onset}.`);
+  if (state.location) parts.push(`Location: ${state.location}.`);
+  if (state.character) parts.push(`Character: ${state.character}.`);
+  if (state.severity) parts.push(`Severity: ${state.severity}.`);
+  if (state.duration) parts.push(`Duration: ${state.duration}.`);
+  if (state.timing) parts.push(`Timing: ${state.timing}.`);
+  if (state.aggravating) parts.push(`Aggravated by: ${state.aggravating}.`);
+  if (state.relieving) parts.push(`Relieved by: ${state.relieving}.`);
+  return parts.join(" ");
+}
+
+export function SubjectiveHpi() {
+  const [state, setState] = useState<HpiState>(EMPTY);
+
+  const handleField = (key: keyof HpiState, value: string) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const fieldsFilled = OLDCARTS_FIELDS.filter((f) => state[f.key].trim().length > 0).length;
+
+  const handleAutoCompose = () => {
+    setState((prev) => ({ ...prev, narrative: composeNarrative(prev) }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const narrative = state.narrative.trim() || composeNarrative(state);
+    console.log("HPI:", { ...state, narrative });
+  };
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Subjective — History of Present Illness</CardTitle>
+        <CardDescription>
+          OLDCARTS framework. Fill any field — the narrative composes from what you provide.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {OLDCARTS_FIELDS.map((field) => (
+              <div key={field.key} className="space-y-1.5">
+                <Label htmlFor={`hpi-${field.key}`}>{field.label}</Label>
+                <Textarea
+                  id={`hpi-${field.key}`}
+                  rows={2}
+                  value={state[field.key]}
+                  onChange={(e) => handleField(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="hpi-narrative">Composed narrative</Label>
+              <button
+                type="button"
+                onClick={handleAutoCompose}
+                className="text-xs font-medium text-[var(--accent)] hover:underline"
+              >
+                Auto-compose from fields
+              </button>
+            </div>
+            <Textarea
+              id="hpi-narrative"
+              rows={4}
+              value={state.narrative}
+              onChange={(e) => handleField("narrative", e.target.value)}
+              placeholder="Free-text HPI. Click Auto-compose to draft from the fields above."
+            />
+          </div>
+
+          <div className="text-xs text-text-muted">
+            {fieldsFilled} of {OLDCARTS_FIELDS.length} OLDCARTS fields filled
+          </div>
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end">
+          <Button type="submit" variant="primary" disabled={fieldsFilled === 0 && !state.narrative.trim()}>
+            Save HPI
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default SubjectiveHpi;


### PR DESCRIPTION
## Summary
Closes out the 5 remaining SOAP UI fragments — EMR-072 follow-up selector was already on main.

| ID | File | What it is |
|---|---|---|
| EMR-068 | `subjective-hpi.tsx` | OLDCARTS field grid (Onset/Location/Duration/Character/Aggravating/Relieving/Timing/Severity) + auto-composed narrative |
| EMR-069 | `objective-vitals.tsx` | BP/HR/RR/Temp/SpO₂/weight/height with derived BMI and BP/SpO₂ severity flags |
| EMR-070 | `assessment-icd10.tsx` | Searchable picker over a curated cannabis-clinic ICD-10 starter set (F12.x, Z71.89, Z79.891, common pain/mental/sleep codes) |
| EMR-071 | `plan-eprescribe.tsx` | Rx composer — medication/strength/form/sig/dispense/refills/DAW/pharmacy with stub send flow |
| EMR-073 | `care-team-tagger.tsx` | Typeahead tagger with arrow-key nav, Enter to add, Backspace to remove last tag |

All components:
- `"use client"`, isolated to their own files (no cross-file edits)
- Match the Wave 8 screener style (shadcn `Card` + `Button` + `Input/Textarea/Label`)
- Pure UI — submit handlers call `console.log` (or optional `onSend`/`onChange` props), wiring to persistence comes next

## Test plan
- [ ] `npm run typecheck` clean ✅ (verified locally)
- [ ] `npm run lint` clean ✅ (no new warnings; pre-existing warnings unrelated)
- [ ] Mount each component on a sandbox route and click through the happy path
- [ ] ICD-10 picker: search "F12" / "anxiety" / "sleep" returns expected matches
- [ ] Vitals: enter 145/95 → "Stage 2 hypertension" flag appears; enter 88 SpO₂ → "Hypoxemic" flag
- [ ] HPI: fill 2–3 OLDCARTS fields → "Auto-compose" populates the narrative
- [ ] Care team tagger: arrow keys move highlight, Enter adds, Backspace on empty input removes last tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)