### PR TITLE
feat(security): Phase 9 Track 4 — Security & Admin tickets (EMR-064/065/081/082/084/088/094)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -440,3 +440,24 @@ routes:
     auth: public
     owner: marketing
     notes: "Public contact form submission route."
+
+  audit/report:
+    methods: [GET]
+    auth: needs_review
+    owner: platform-security
+    review_due: 2026-05-30
+    notes: "Scaffolded route for audit reporting."
+
+  foundation/grants:
+    methods: [GET, POST]
+    auth: needs_review
+    owner: marketing
+    review_due: 2026-05-30
+    notes: "Scaffolded route for foundation grants."
+
+  integrations/test-garmin:
+    methods: [POST]
+    auth: needs_review
+    owner: integrations
+    review_due: 2026-05-30
+    notes: "Scaffolded route for testing Garmin integration."

--- a/src/app/api/audit/report/route.ts
+++ b/src/app/api/audit/report/route.ts
@@ -1,0 +1,132 @@
+// EMR-064 — Audit log PDF / CSV export endpoint.
+//
+// GET /api/audit/report?subjectId=&organizationId=&since=&until=&action=&format=html|csv
+//
+// Gated by `requireImplementationAdmin` (super_admin or implementation_admin).
+// Returns a print-ready HTML document (which the browser can save as PDF
+// via Cmd-P) or a CSV download for spreadsheet analysis.
+//
+// This endpoint does NOT page — by design, compliance exports want the
+// entire result set in one artifact. Caller is responsible for choosing
+// a reasonable date window. We do still cap at MAX_ROWS as a guardrail
+// against accidental practice-wide pulls.
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireImplementationAdmin } from "@/lib/auth/super-admin";
+import {
+  renderAuditLogReportCsv,
+  renderAuditLogReportHtml,
+  type AuditLogReportRow,
+} from "@/lib/compliance/audit-log-report";
+
+export const runtime = "nodejs";
+
+const MAX_ROWS = 5000;
+
+const queryInput = z.object({
+  subjectId: z.string().min(1).optional(),
+  organizationId: z.string().min(1).optional(),
+  actorUserId: z.string().min(1).optional(),
+  action: z.string().min(1).optional(),
+  since: z
+    .string()
+    .refine((s) => !Number.isNaN(Date.parse(s)), "invalid ISO date")
+    .optional(),
+  until: z
+    .string()
+    .refine((s) => !Number.isNaN(Date.parse(s)), "invalid ISO date")
+    .optional(),
+  format: z.enum(["html", "csv"]).optional(),
+});
+
+function asError(status: number, error: string): NextResponse {
+  return NextResponse.json({ error }, { status });
+}
+
+export async function GET(req: Request): Promise<NextResponse | Response> {
+  try {
+    await requireImplementationAdmin();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "UNAUTHORIZED") return asError(401, "unauthorized");
+    if (msg === "FORBIDDEN") return asError(403, "forbidden");
+    throw err;
+  }
+
+  const url = new URL(req.url);
+  const raw = Object.fromEntries(url.searchParams.entries());
+  const parsed = queryInput.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid_input", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { subjectId, organizationId, actorUserId, action, since, until } =
+    parsed.data;
+  const format = parsed.data.format ?? "html";
+
+  const where: Prisma.AuditLogWhereInput = {};
+  if (subjectId) where.subjectId = subjectId;
+  if (organizationId) where.organizationId = organizationId;
+  if (actorUserId) where.actorUserId = actorUserId;
+  if (action) where.action = action;
+  if (since || until) {
+    where.createdAt = {};
+    if (since) where.createdAt.gte = new Date(since);
+    if (until) where.createdAt.lte = new Date(until);
+  }
+
+  const dbRows = await prisma.auditLog.findMany({
+    where,
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: MAX_ROWS,
+  });
+
+  const rows: AuditLogReportRow[] = dbRows.map((r) => ({
+    id: r.id,
+    at: r.createdAt,
+    organizationId: r.organizationId,
+    actorUserId: r.actorUserId,
+    actorAgent: r.actorAgent,
+    action: r.action,
+    subjectType: r.subjectType,
+    subjectId: r.subjectId,
+    metadata: (r.metadata ?? null) as Record<string, unknown> | null,
+  }));
+
+  if (format === "csv") {
+    const csv = renderAuditLogReportCsv(rows);
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        "content-type": "text/csv; charset=utf-8",
+        "content-disposition": `attachment; filename="audit-log-${new Date().toISOString().slice(0, 10)}.csv"`,
+      },
+    });
+  }
+
+  const html = renderAuditLogReportHtml({
+    rows,
+    filters: {
+      organizationId: organizationId ?? null,
+      actorUserId: actorUserId ?? null,
+      action: action ?? null,
+      subjectId: subjectId ?? null,
+      since: since ?? null,
+      until: until ?? null,
+    },
+    generatedAt: new Date(),
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+    },
+  });
+}

--- a/src/components/clinical/SensitiveRecordWall.tsx
+++ b/src/components/clinical/SensitiveRecordWall.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils/cn";
+import {
+  buildAccessAudit,
+  CATEGORY_LABEL,
+  decideAccess,
+  type AccessAttempt,
+  type BreakGlassAttestation,
+  type SensitiveAccessAudit,
+  type SensitivityClassification,
+  type ViewerRole,
+} from "@/lib/clinical/mental-health-access";
+
+/**
+ * EMR-094 — Sensitive-record access wall.
+ *
+ * Renders a HIPAA / 42 CFR Part 2 break-glass form between a clinician
+ * and a sensitive record (psychotherapy notes, SUD treatment, suicidal
+ * ideation, reproductive care, etc.). Drives the same `decideAccess`
+ * state machine the audit agent watches, so on-screen behavior and
+ * audit records are guaranteed to agree.
+ */
+
+interface Props {
+  classification: SensitivityClassification;
+  viewerRole: ViewerRole;
+  viewerUserId: string;
+  resource: { type: string; id: string; patientId: string };
+  /** True when the viewer is the patient (bypasses wall for self-view). */
+  isViewingOwnRecord?: boolean;
+  hasTreatmentRelationship?: boolean;
+  onUnlock: (audit: SensitiveAccessAudit) => void;
+  onDeny?: (reason: string) => void;
+}
+
+export function SensitiveRecordWall({
+  classification,
+  viewerRole,
+  viewerUserId,
+  resource,
+  isViewingOwnRecord,
+  hasTreatmentRelationship,
+  onUnlock,
+  onDeny,
+}: Props) {
+  const [reason, setReason] = React.useState("");
+  const [name, setName] = React.useState("");
+  const [clinicalAck, setClinicalAck] = React.useState(false);
+  const [redisclosureAck, setRedisclosureAck] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const baseAttempt = React.useMemo<AccessAttempt>(
+    () => ({
+      viewerRole,
+      isViewingOwnRecord,
+      hasTreatmentRelationship,
+    }),
+    [viewerRole, isViewingOwnRecord, hasTreatmentRelationship],
+  );
+
+  // Pre-attestation decision — drives whether we even render the form.
+  const initialDecision = React.useMemo(
+    () => decideAccess(classification, baseAttempt),
+    [classification, baseAttempt],
+  );
+
+  // Fire onUnlock / onDeny side effects when the upstream decision is
+  // already final (treating clinician, self-view, hard deny).
+  React.useEffect(() => {
+    if (!classification.isSensitive) return;
+    if (initialDecision.kind === "allow") {
+      const audit = buildAccessAudit(
+        classification,
+        baseAttempt,
+        { ...resource, viewerUserId },
+        initialDecision,
+      );
+      onUnlock(audit);
+    } else if (initialDecision.kind === "deny") {
+      onDeny?.(initialDecision.reason);
+    }
+    // We deliberately depend only on the inputs that change the decision.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classification, baseAttempt, initialDecision.kind]);
+
+  if (!classification.isSensitive) return null;
+  if (initialDecision.kind === "allow") return null;
+
+  if (initialDecision.kind === "deny") {
+    return (
+      <Card tone="outlined" className={cn("max-w-xl mx-auto p-6")}>
+        <CardHeader>
+          <CardTitle>Access blocked</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-text-muted">{initialDecision.reason}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const handleUnlock = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    const attestation: BreakGlassAttestation = {
+      reason,
+      clinicianAttestation: name,
+      acknowledgedClinicalPurpose: clinicalAck,
+      acknowledgedRedisclosureRules: redisclosureAck,
+    };
+    const attempt: AccessAttempt = {
+      ...baseAttempt,
+      breakGlassAttestation: attestation,
+    };
+    const decision = decideAccess(classification, attempt);
+    if (decision.kind !== "allow") {
+      setError(
+        "Attestation incomplete. Provide a 20+ character clinical reason, your typed full name, and acknowledge both check-boxes.",
+      );
+      return;
+    }
+    const audit = buildAccessAudit(
+      classification,
+      attempt,
+      { ...resource, viewerUserId },
+      decision,
+    );
+    onUnlock(audit);
+  };
+
+  return (
+    <Card tone="raised" className="max-w-2xl mx-auto p-6 ring-2 ring-amber-300">
+      <CardHeader>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center rounded-full bg-amber-600 text-white text-xs font-semibold uppercase tracking-wide px-2.5 py-1">
+            Protected record
+          </span>
+          {classification.categories.map((c) => (
+            <span
+              key={c}
+              className="inline-flex items-center rounded-full bg-amber-50 text-amber-900 text-xs font-medium px-2 py-0.5 border border-amber-200"
+            >
+              {CATEGORY_LABEL[c]}
+            </span>
+          ))}
+        </div>
+        <CardTitle className="mt-2">Confirm clinical purpose before viewing</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-text-muted">{classification.rationale}</p>
+        <form onSubmit={handleUnlock} className="mt-4 space-y-4">
+          <label className="block text-sm">
+            <span className="font-medium">Clinical purpose for this access</span>
+            <textarea
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm focus:ring-2 focus:ring-accent/40"
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="At least 20 characters. Describe the specific clinical reason you need this record."
+              required
+              minLength={20}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="font-medium">Type your full name (e-signature)</span>
+            <input
+              type="text"
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm focus:ring-2 focus:ring-accent/40"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </label>
+
+          <div className="space-y-2 text-sm">
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={clinicalAck}
+                onChange={(e) => setClinicalAck(e.target.checked)}
+                className="mt-0.5"
+                required
+              />
+              <span>
+                I am NOT the patient and I have a clinical purpose for accessing this record.
+              </span>
+            </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={redisclosureAck}
+                onChange={(e) => setRedisclosureAck(e.target.checked)}
+                className="mt-0.5"
+                required
+              />
+              <span>
+                I acknowledge 42 CFR Part 2 and applicable state mental-health redisclosure rules.
+              </span>
+            </label>
+          </div>
+
+          {error && (
+            <p className="text-sm text-rose-700 bg-rose-50 border border-rose-200 rounded-md px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end">
+            <Button type="submit" variant="primary">
+              Unlock record
+            </Button>
+          </div>
+          <p className="text-[11px] text-text-muted">
+            This access is recorded in the immutable audit log and reviewed weekly by the privacy officer.
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/clinical/SensitiveRecordWall.tsx
+++ b/src/components/clinical/SensitiveRecordWall.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Unintegrated scaffold (track-9)"
 "use client";
 
 import * as React from "react";

--- a/src/lib/clinical/contraindication-check.test.ts
+++ b/src/lib/clinical/contraindication-check.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOverrideAudit,
+  runContraindicationCheck,
+  validateOverride,
+} from "./contraindication-check";
+
+describe("runContraindicationCheck", () => {
+  it("returns a clear gate for a patient with no flags", () => {
+    const r = runContraindicationCheck({
+      icd10Codes: ["M54.12"],
+      historyText: "Chronic neck pain.",
+    });
+    expect(r.gate).toBe("clear");
+    expect(r.matches).toEqual([]);
+    expect(r.overrideRequired).toBe(false);
+    expect(r.topSeverity).toBeNull();
+  });
+
+  it("blocks when a schizophrenia ICD prefix is present", () => {
+    const r = runContraindicationCheck({ icd10Codes: ["F20.9"] });
+    expect(r.gate).toBe("block");
+    expect(r.topSeverity).toBe("absolute");
+    expect(r.overrideRequired).toBe(true);
+    expect(r.headline).toMatch(/Absolute contraindication/);
+  });
+
+  it("blocks on pregnancy keyword in free-text history", () => {
+    const r = runContraindicationCheck({
+      historyText: "Patient is currently pregnant, third trimester.",
+    });
+    expect(r.gate).toBe("block");
+    expect(r.matches[0].contraindication.id).toBe("pregnancy");
+  });
+
+  it("warns for relative-severity flags (e.g. severe CV disease)", () => {
+    const r = runContraindicationCheck({
+      historyText: "History of recent MI and unstable angina.",
+    });
+    // CV disease is "relative" — should warn, not block.
+    expect(r.gate).toBe("warn");
+    expect(r.topSeverity).toBe("relative");
+  });
+
+  it("ranks absolute above relative when both are present", () => {
+    const r = runContraindicationCheck({
+      icd10Codes: ["F20.9", "I25.10"],
+      historyText: "Recent MI.",
+    });
+    expect(r.gate).toBe("block");
+    expect(r.matches[0].contraindication.severity).toBe("absolute");
+  });
+
+  it("surfaces a multi-flag count in the headline", () => {
+    const r = runContraindicationCheck({
+      icd10Codes: ["F20.9", "F31.0"],
+    });
+    expect(r.headline).toMatch(/\+1 more/);
+  });
+});
+
+describe("validateOverride", () => {
+  const blocking = runContraindicationCheck({ icd10Codes: ["F20.9"] });
+
+  it("approves a clear check trivially", () => {
+    const r = validateOverride(
+      {
+        reason: "",
+        clinicianAttestation: "",
+        patientCounseledAcknowledged: false,
+        alternativesConsideredAcknowledged: false,
+      },
+      runContraindicationCheck({}),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a too-short reason", () => {
+    const r = validateOverride(
+      {
+        reason: "fine",
+        clinicianAttestation: "Dr. Park",
+        patientCounseledAcknowledged: true,
+        alternativesConsideredAcknowledged: true,
+      },
+      blocking,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.join(" ")).toMatch(/at least 30 characters/);
+  });
+
+  it("requires the clinician attestation", () => {
+    const r = validateOverride(
+      {
+        reason:
+          "Patient has stable schizophrenia on clozapine; risk of pain non-treatment outweighs cannabis risk.",
+        clinicianAttestation: "",
+        patientCounseledAcknowledged: true,
+        alternativesConsideredAcknowledged: true,
+      },
+      blocking,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.join(" ")).toMatch(/attestation/);
+  });
+
+  it("requires both acknowledgement checkboxes", () => {
+    const r = validateOverride(
+      {
+        reason:
+          "Patient with schizophrenia has stable mood on clozapine. Long discussion with patient.",
+        clinicianAttestation: "Dr. Park",
+        patientCounseledAcknowledged: false,
+        alternativesConsideredAcknowledged: false,
+      },
+      blocking,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("requires the reason to reference the flag keyword for absolute contraindications", () => {
+    const r = validateOverride(
+      {
+        // 30+ chars but no mention of "schizophrenia" or related keyword.
+        reason:
+          "Risk benefit weighed. Continuing with prescribing per shared decision-making.",
+        clinicianAttestation: "Dr. Park",
+        patientCounseledAcknowledged: true,
+        alternativesConsideredAcknowledged: true,
+      },
+      blocking,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.join(" ")).toMatch(/reference the specific flagged condition/);
+  });
+
+  it("accepts a complete override on an absolute contraindication", () => {
+    const r = validateOverride(
+      {
+        reason:
+          "Patient with schizophrenia has been stable on clozapine for 4 years; pain is severe and untreated alternatives exhausted.",
+        clinicianAttestation: "Dr. Park",
+        patientCounseledAcknowledged: true,
+        alternativesConsideredAcknowledged: true,
+      },
+      blocking,
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("buildOverrideAudit", () => {
+  it("captures the severity, matched flags, and attestation", () => {
+    const check = runContraindicationCheck({ icd10Codes: ["F20.9"] });
+    const audit = buildOverrideAudit(
+      {
+        reason:
+          "Patient with schizophrenia stable on clozapine; pain severe and alternatives tried.",
+        clinicianAttestation: "Dr. Park",
+        patientCounseledAcknowledged: true,
+        alternativesConsideredAcknowledged: true,
+      },
+      check,
+    );
+    expect(audit.action).toBe("rx.contraindication.override");
+    expect(audit.severity).toBe("absolute");
+    expect(audit.contraindicationIds).toContain("schizophrenia");
+    expect(audit.matchedOn[0]).toMatch(/ICD-10 F20\.9/);
+    expect(audit.acknowledgements.patientCounseled).toBe(true);
+  });
+
+  it("throws when called on a clear check", () => {
+    const clear = runContraindicationCheck({});
+    expect(() =>
+      buildOverrideAudit(
+        {
+          reason: "—",
+          clinicianAttestation: "—",
+          patientCounseledAcknowledged: true,
+          alternativesConsideredAcknowledged: true,
+        },
+        clear,
+      ),
+    ).toThrow(/clear check/);
+  });
+});

--- a/src/lib/clinical/mental-health-access.test.ts
+++ b/src/lib/clinical/mental-health-access.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAccessAudit,
+  classifySensitivity,
+  decideAccess,
+  type AccessAttempt,
+  type BreakGlassAttestation,
+} from "./mental-health-access";
+
+const VALID_ATTESTATION: BreakGlassAttestation = {
+  reason:
+    "Patient is being co-managed for chronic pain; need access to behavioral-health plan to reconcile medications.",
+  clinicianAttestation: "Dr. Helen Park",
+  acknowledgedClinicalPurpose: true,
+  acknowledgedRedisclosureRules: true,
+};
+
+describe("classifySensitivity", () => {
+  it("flags substance-use ICD codes (42 CFR Part 2)", () => {
+    const c = classifySensitivity({ icd10Codes: ["F11.20"] });
+    expect(c.isSensitive).toBe(true);
+    expect(c.categories).toContain("substance_use");
+    expect(c.primary).toBe("substance_use");
+  });
+
+  it("flags psychotherapy note types via CPT codes", () => {
+    const c = classifySensitivity({ cptCodes: ["90837"] });
+    expect(c.primary).toBe("psychotherapy_notes");
+  });
+
+  it("flags suicidal-ideation language", () => {
+    const c = classifySensitivity({
+      text: "Patient verbalized that she wants to die.",
+    });
+    expect(c.categories).toContain("suicidal_ideation");
+  });
+
+  it("ranks psychotherapy notes above substance use (precedence)", () => {
+    const c = classifySensitivity({
+      icd10Codes: ["F11.20"],
+      cptCodes: ["90837"],
+    });
+    expect(c.primary).toBe("psychotherapy_notes");
+  });
+
+  it("flags reproductive-care ICD prefix O04", () => {
+    const c = classifySensitivity({ icd10Codes: ["O04.5"] });
+    expect(c.categories).toContain("reproductive_care");
+  });
+
+  it("returns empty classification for a routine note", () => {
+    const c = classifySensitivity({
+      noteType: "follow_up",
+      text: "Blood pressure improved on lisinopril.",
+      icd10Codes: ["I10"],
+    });
+    expect(c.isSensitive).toBe(false);
+    expect(c.categories).toEqual([]);
+    expect(c.primary).toBeNull();
+  });
+
+  it("respects an explicit flaggedConfidential override", () => {
+    const c = classifySensitivity({ flaggedConfidential: true });
+    expect(c.isSensitive).toBe(true);
+    expect(c.categories).toContain("general_mental_health");
+  });
+});
+
+describe("decideAccess", () => {
+  const sudClass = classifySensitivity({ icd10Codes: ["F11.20"] });
+  const pyschoClass = classifySensitivity({ cptCodes: ["90837"] });
+  const generalMh = classifySensitivity({ icd10Codes: ["F32.1"] });
+
+  it("allows access to non-sensitive records without a wall", () => {
+    const r = decideAccess(classifySensitivity({}), {
+      viewerRole: "ma_or_front_desk",
+    });
+    expect(r.kind).toBe("allow");
+  });
+
+  it("lets a treating clinician through with no e-signature", () => {
+    const r = decideAccess(generalMh, {
+      viewerRole: "treating_clinician",
+      hasTreatmentRelationship: true,
+    });
+    expect(r.kind).toBe("allow");
+  });
+
+  it("walls off non-treating clinicians until they break-glass", () => {
+    const r = decideAccess(generalMh, { viewerRole: "covering_clinician" });
+    expect(r.kind).toBe("wall");
+  });
+
+  it("denies billing access to SUD records (42 CFR Part 2)", () => {
+    const r = decideAccess(sudClass, {
+      viewerRole: "billing_or_back_office",
+    });
+    expect(r.kind).toBe("deny");
+  });
+
+  it("denies external viewers — they must go through ROI", () => {
+    const r = decideAccess(generalMh, { viewerRole: "external" });
+    expect(r.kind).toBe("deny");
+  });
+
+  it("allows patients to view their own non-process records", () => {
+    const r = decideAccess(generalMh, {
+      viewerRole: "patient_self",
+      isViewingOwnRecord: true,
+    });
+    expect(r.kind).toBe("allow");
+  });
+
+  it("denies patients access to their own psychotherapy process notes", () => {
+    const r = decideAccess(pyschoClass, {
+      viewerRole: "patient_self",
+      isViewingOwnRecord: true,
+    });
+    expect(r.kind).toBe("deny");
+  });
+
+  it("accepts a complete break-glass attestation for a covering clinician", () => {
+    const r = decideAccess(generalMh, {
+      viewerRole: "covering_clinician",
+      breakGlassAttestation: VALID_ATTESTATION,
+    });
+    expect(r.kind).toBe("allow");
+  });
+
+  it("re-walls when the break-glass reason is too short", () => {
+    const r = decideAccess(generalMh, {
+      viewerRole: "covering_clinician",
+      breakGlassAttestation: { ...VALID_ATTESTATION, reason: "covering" },
+    });
+    expect(r.kind).toBe("wall");
+  });
+
+  it("re-walls when acknowledgements are not checked", () => {
+    const r = decideAccess(generalMh, {
+      viewerRole: "covering_clinician",
+      breakGlassAttestation: {
+        ...VALID_ATTESTATION,
+        acknowledgedClinicalPurpose: false,
+      },
+    });
+    expect(r.kind).toBe("wall");
+  });
+});
+
+describe("buildAccessAudit", () => {
+  const sudClass = classifySensitivity({ icd10Codes: ["F11.20"] });
+
+  it("uses the break_glass action when allow + attestation are both present", () => {
+    const attempt: AccessAttempt = {
+      viewerRole: "covering_clinician",
+      breakGlassAttestation: VALID_ATTESTATION,
+    };
+    const decision = decideAccess(sudClass, attempt);
+    const audit = buildAccessAudit(sudClass, attempt, {
+      type: "Note",
+      id: "note_1",
+      patientId: "p_1",
+      viewerUserId: "u_1",
+    }, decision);
+    expect(audit.action).toBe("phi.sensitive.break_glass");
+    expect(audit.outcome).toBe("allowed");
+    expect(audit.breakGlass?.clinicianAttestation).toBe("Dr. Helen Park");
+  });
+
+  it("uses the viewed action when no attestation was supplied", () => {
+    const attempt: AccessAttempt = {
+      viewerRole: "treating_clinician",
+      hasTreatmentRelationship: true,
+    };
+    const decision = decideAccess(sudClass, attempt);
+    const audit = buildAccessAudit(sudClass, attempt, {
+      type: "Note",
+      id: "note_1",
+      patientId: "p_1",
+      viewerUserId: "u_1",
+    }, decision);
+    expect(audit.action).toBe("phi.sensitive.viewed");
+    expect(audit.outcome).toBe("allowed");
+    expect(audit.breakGlass).toBeUndefined();
+  });
+
+  it("records 'blocked' outcome when the wall fired", () => {
+    const attempt: AccessAttempt = {
+      viewerRole: "covering_clinician",
+    };
+    const decision = decideAccess(sudClass, attempt);
+    const audit = buildAccessAudit(sudClass, attempt, {
+      type: "Note",
+      id: "note_1",
+      patientId: "p_1",
+      viewerUserId: "u_1",
+    }, decision);
+    expect(audit.outcome).toBe("blocked");
+  });
+});

--- a/src/lib/clinical/ocr-chart-merge.test.ts
+++ b/src/lib/clinical/ocr-chart-merge.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { ExtractedField } from "./ocr-extract";
+import { planMerge, type ChartSnapshot } from "./ocr-chart-merge";
+
+function field(path: string, value: string, confidence = 0.9): ExtractedField {
+  return {
+    kind: path.startsWith("vital")
+      ? "vital"
+      : path === "dob" || path === "phone" || path === "externalMrn"
+        ? "demographic"
+        : path === "medication"
+          ? "medication"
+          : path === "allergy"
+            ? "allergy"
+            : path === "problem.icd10"
+              ? "problem"
+              : "note",
+    path,
+    source: `${path}: ${value}`,
+    value,
+    confidence,
+  };
+}
+
+describe("planMerge", () => {
+  it("buckets a fresh chart's fields as 'add'", () => {
+    const plan = planMerge(
+      [field("dob", "1982-03-14"), field("phone", "(555) 123-4567")],
+      {},
+    );
+    expect(plan.autoApply).toHaveLength(2);
+    expect(plan.needsReview).toHaveLength(0);
+    expect(plan.duplicates).toHaveLength(0);
+  });
+
+  it("flags DOB conflict when the chart has a different DOB", () => {
+    const plan = planMerge(
+      [field("dob", "1982-03-14")],
+      { dob: "1981-12-01" },
+    );
+    expect(plan.items[0].decision).toBe("conflict");
+    expect(plan.items[0].existingValue).toBe("1981-12-01");
+  });
+
+  it("flags an identical DOB as duplicate (no action needed)", () => {
+    const plan = planMerge(
+      [field("dob", "1982-03-14")],
+      { dob: "1982-03-14" },
+    );
+    expect(plan.items[0].decision).toBe("duplicate");
+    expect(plan.duplicates).toHaveLength(1);
+  });
+
+  it("marks low-confidence fields for review even when chart is empty", () => {
+    const plan = planMerge(
+      [field("phone", "(555) 999-0000", 0.4)],
+      {},
+    );
+    expect(plan.items[0].decision).toBe("review");
+    expect(plan.needsReview).toHaveLength(1);
+  });
+
+  it("treats medications as conflicts when name matches but dose differs", () => {
+    const plan = planMerge(
+      [field("medication", "Lisinopril 20mg")],
+      {
+        medications: [{ name: "Lisinopril", doseDisplay: "10mg" }],
+      } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("conflict");
+    expect(plan.items[0].existingValue).toBe("Lisinopril 10mg");
+  });
+
+  it("treats medications as duplicate when name + dose match", () => {
+    const plan = planMerge(
+      [field("medication", "Lisinopril 10mg")],
+      {
+        medications: [{ name: "Lisinopril", doseDisplay: "10mg" }],
+      } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("duplicate");
+  });
+
+  it("dedupes allergies (case-insensitive)", () => {
+    const plan = planMerge(
+      [field("allergy", "Penicillin")],
+      { allergies: [{ substance: "penicillin" }] } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("duplicate");
+  });
+
+  it("ignores allergies not yet on the chart", () => {
+    const plan = planMerge(
+      [field("allergy", "Sulfa")],
+      { allergies: [{ substance: "Penicillin" }] } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("add");
+  });
+
+  it("dedupes ICD-10 problems already on the active list", () => {
+    const plan = planMerge(
+      [field("problem.icd10", "E11.9")],
+      { problems: [{ icd10: "E11.9" }] } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("duplicate");
+  });
+
+  it("vitals never conflict — every measurement is a new row", () => {
+    const plan = planMerge(
+      [field("vital.bp", "124/78")],
+      { vitals: { bp: "138/90" } } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("add");
+  });
+
+  it("vital duplicate when newest value already matches OCR", () => {
+    const plan = planMerge(
+      [field("vital.bp", "124/78")],
+      { vitals: { bp: "124/78" } } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("duplicate");
+  });
+
+  it("payer conflict surfaces existing vs incoming payer", () => {
+    const plan = planMerge(
+      [field("insurance.payer", "Aetna POS")],
+      { insurance: { payer: "Blue Cross" } } as ChartSnapshot,
+    );
+    expect(plan.items[0].decision).toBe("conflict");
+    expect(plan.items[0].existingValue).toBe("Blue Cross");
+  });
+});

--- a/src/lib/clinical/ocr-chart-merge.ts
+++ b/src/lib/clinical/ocr-chart-merge.ts
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Unintegrated scaffold (track-9)"
 /**
  * EMR-081 — Merge OCR-extracted fields into an existing chart.
  *

--- a/src/lib/clinical/ocr-chart-merge.ts
+++ b/src/lib/clinical/ocr-chart-merge.ts
@@ -1,0 +1,191 @@
+/**
+ * EMR-081 — Merge OCR-extracted fields into an existing chart.
+ *
+ * The raw OCR extractor returns ExtractedField rows. Before we write any
+ * of them to the chart we need to know which fields would COLLIDE with
+ * an existing value, which would simply ADD, and which would DUPLICATE
+ * (no-op). The clinician then sees a single review screen instead of
+ * one decision per field.
+ *
+ * Pure function — no I/O. Caller supplies a snapshot of the current
+ * chart and we return a planned merge.
+ */
+
+import type { ExtractedField } from "./ocr-extract";
+
+export interface ChartSnapshot {
+  dob?: string | null;
+  phone?: string | null;
+  externalMrn?: string | null;
+  medications?: Array<{ name: string; doseDisplay?: string | null }> | null;
+  allergies?: Array<{ substance: string }> | null;
+  problems?: Array<{ icd10: string }> | null;
+  vitals?: {
+    bp?: string | null;
+    hr?: string | null;
+    weight_lbs?: string | null;
+    height_in?: string | null;
+    temp_f?: string | null;
+  } | null;
+  insurance?: { payer?: string | null } | null;
+}
+
+export type MergeDecision = "add" | "duplicate" | "conflict" | "review";
+
+export interface MergePlanItem {
+  field: ExtractedField;
+  decision: MergeDecision;
+  /** Existing chart value the OCR field collides with (if any). */
+  existingValue?: string;
+  /** Short rationale shown to the clinician. */
+  rationale: string;
+}
+
+export interface MergePlan {
+  items: MergePlanItem[];
+  /** Items the clinician should apply with one click — already deduped. */
+  autoApply: MergePlanItem[];
+  /** Items requiring explicit review (conflicts or low-confidence). */
+  needsReview: MergePlanItem[];
+  /** Items the clinician can safely ignore (already in the chart). */
+  duplicates: MergePlanItem[];
+}
+
+const AUTO_APPLY_CONFIDENCE = 0.8;
+
+function normalize(s: string | null | undefined): string {
+  return (s ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function medicationKey(value: string): string {
+  // Drop dose to compare med identity. "Lisinopril 10mg" vs "Lisinopril 20mg"
+  // should still be detectable as a conflict on the same medication.
+  return normalize(value).split(/\s+/)[0];
+}
+
+function planFor(field: ExtractedField, chart: ChartSnapshot): MergePlanItem {
+  const lowConfidence = field.confidence < AUTO_APPLY_CONFIDENCE;
+  const baseReview: Pick<MergePlanItem, "decision" | "rationale"> = lowConfidence
+    ? { decision: "review", rationale: "Low confidence — clinician confirmation required." }
+    : { decision: "add", rationale: "New value; no existing chart entry." };
+
+  switch (field.path) {
+    case "dob": {
+      const existing = chart.dob;
+      if (!existing) return { field, ...baseReview };
+      if (normalize(existing) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: existing, rationale: "Chart already records the same DOB." };
+      }
+      return {
+        field,
+        decision: "conflict",
+        existingValue: existing,
+        rationale: "DOB on chart differs from the OCR'd document.",
+      };
+    }
+    case "phone": {
+      const existing = chart.phone;
+      if (!existing) return { field, ...baseReview };
+      if (normalize(existing) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: existing, rationale: "Chart already has this phone number." };
+      }
+      return {
+        field,
+        decision: "conflict",
+        existingValue: existing,
+        rationale: "Phone on file differs from the OCR'd document.",
+      };
+    }
+    case "externalMrn": {
+      const existing = chart.externalMrn;
+      if (!existing) return { field, ...baseReview };
+      if (normalize(existing) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: existing, rationale: "External MRN already linked." };
+      }
+      return {
+        field,
+        decision: "conflict",
+        existingValue: existing,
+        rationale: "An external MRN is already linked — adding another requires review.",
+      };
+    }
+    case "vital.bp":
+    case "vital.hr":
+    case "vital.weight_lbs":
+    case "vital.height_in":
+    case "vital.temp_f": {
+      // Vitals are time-series — every measurement is a new row, never
+      // a conflict. We only mark them "duplicate" if the latest known
+      // value matches verbatim.
+      const key = field.path.split(".")[1] as keyof NonNullable<ChartSnapshot["vitals"]>;
+      const existing = chart.vitals?.[key] ?? null;
+      if (existing && normalize(existing) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: existing, rationale: "Latest recorded vital equals the OCR value." };
+      }
+      return { field, ...baseReview };
+    }
+    case "medication": {
+      const key = medicationKey(field.value);
+      const match = (chart.medications ?? []).find(
+        (m) => medicationKey(m.name) === key,
+      );
+      if (!match) return { field, ...baseReview };
+      const matchDisplay = `${match.name}${match.doseDisplay ? ` ${match.doseDisplay}` : ""}`;
+      if (normalize(matchDisplay) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: matchDisplay, rationale: "Same medication + dose already on the med list." };
+      }
+      return {
+        field,
+        decision: "conflict",
+        existingValue: matchDisplay,
+        rationale: "Medication is on the list with a different dose — confirm which is current.",
+      };
+    }
+    case "allergy": {
+      const existing = (chart.allergies ?? []).find(
+        (a) => normalize(a.substance) === normalize(field.value),
+      );
+      if (existing) {
+        return { field, decision: "duplicate", existingValue: existing.substance, rationale: "Allergy already on the chart." };
+      }
+      return { field, ...baseReview };
+    }
+    case "problem.icd10": {
+      const existing = (chart.problems ?? []).find(
+        (p) => normalize(p.icd10) === normalize(field.value),
+      );
+      if (existing) {
+        return { field, decision: "duplicate", existingValue: existing.icd10, rationale: "Problem already on the active list." };
+      }
+      return { field, ...baseReview };
+    }
+    case "insurance.payer": {
+      const existing = chart.insurance?.payer;
+      if (!existing) return { field, ...baseReview };
+      if (normalize(existing) === normalize(field.value)) {
+        return { field, decision: "duplicate", existingValue: existing, rationale: "Payer already on file." };
+      }
+      return {
+        field,
+        decision: "conflict",
+        existingValue: existing,
+        rationale: "Payer differs from the chart — confirm the active plan.",
+      };
+    }
+    default:
+      return { field, ...baseReview };
+  }
+}
+
+export function planMerge(
+  fields: ExtractedField[],
+  chart: ChartSnapshot,
+): MergePlan {
+  const items = fields.map((f) => planFor(f, chart));
+  const autoApply = items.filter((i) => i.decision === "add");
+  const needsReview = items.filter(
+    (i) => i.decision === "conflict" || i.decision === "review",
+  );
+  const duplicates = items.filter((i) => i.decision === "duplicate");
+  return { items, autoApply, needsReview, duplicates };
+}

--- a/src/lib/clinical/ocr-extract.test.ts
+++ b/src/lib/clinical/ocr-extract.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { extractFromOcr, toChartPatch } from "./ocr-extract";
+
+const SAMPLE_INTAKE = `
+PATIENT INTAKE FORM
+Name: Jane Doe
+DOB: 03/14/1982
+Phone: (555) 123-4567
+MRN: ABC-12345
+
+VITALS
+BP: 124/78
+HR: 72
+Temp: 98.6
+Wt: 165 lbs
+Ht: 5'7
+
+ALLERGIES: Penicillin, Sulfa, latex
+
+MEDICATIONS
+- Lisinopril 10 mg daily
+- Metformin 500mg twice daily
+- Atorvastatin 20 mg nightly
+
+PROBLEMS
+E11.9
+I10
+J45.40
+
+Insurance: Aetna POS plan
+`;
+
+describe("extractFromOcr", () => {
+  it("pulls DOB, MRN, and phone from intake form", () => {
+    const r = extractFromOcr({ text: SAMPLE_INTAKE });
+    const dob = r.fields.find((f) => f.path === "dob");
+    expect(dob?.value).toBe("1982-03-14");
+    const mrn = r.fields.find((f) => f.path === "externalMrn");
+    expect(mrn?.value).toBe("ABC-12345");
+    const phone = r.fields.find((f) => f.path === "phone");
+    expect(phone?.value).toBe("(555) 123-4567");
+  });
+
+  it("pulls vitals (BP, HR, weight in lbs, height in inches)", () => {
+    const r = extractFromOcr({ text: SAMPLE_INTAKE });
+    expect(r.fields.find((f) => f.path === "vital.bp")?.value).toBe("124/78");
+    expect(r.fields.find((f) => f.path === "vital.hr")?.value).toBe("72");
+    expect(r.fields.find((f) => f.path === "vital.weight_lbs")?.value).toBe(
+      "165",
+    );
+    expect(r.fields.find((f) => f.path === "vital.height_in")?.value).toBe(
+      "67",
+    );
+  });
+
+  it("converts kg weight to lbs", () => {
+    const r = extractFromOcr({ text: "Wt: 75 kg" });
+    const weight = r.fields.find((f) => f.path === "vital.weight_lbs");
+    expect(weight).toBeDefined();
+    expect(parseFloat(weight!.value)).toBeCloseTo(165.3, 1);
+  });
+
+  it("splits allergies on comma / semicolon / 'and'", () => {
+    const r = extractFromOcr({
+      text: "Allergies: Penicillin, Sulfa and latex",
+    });
+    const allergens = r.fields
+      .filter((f) => f.kind === "allergy")
+      .map((f) => f.value);
+    expect(allergens).toEqual(
+      expect.arrayContaining(["Penicillin", "Sulfa", "latex"]),
+    );
+  });
+
+  it("records NKDA when allergies line says no known", () => {
+    const r = extractFromOcr({ text: "Allergies: NKDA" });
+    const allergen = r.fields.find((f) => f.kind === "allergy");
+    expect(allergen?.value).toBe("NKDA");
+  });
+
+  it("extracts medication name + dose with unit", () => {
+    const r = extractFromOcr({ text: "Lisinopril 10 mg daily" });
+    const med = r.fields.find((f) => f.kind === "medication");
+    expect(med?.value).toBe("Lisinopril 10mg");
+  });
+
+  it("deduplicates repeated ICD-10 codes", () => {
+    const r = extractFromOcr({ text: "E11.9 E11.9 I10" });
+    const icds = r.fields
+      .filter((f) => f.path === "problem.icd10")
+      .map((f) => f.value);
+    expect(icds.sort()).toEqual(["E11.9", "I10"]);
+  });
+
+  it("captures insurance line", () => {
+    const r = extractFromOcr({ text: "Insurance: Blue Cross Blue Shield" });
+    const ins = r.fields.find((f) => f.path === "insurance.payer");
+    expect(ins?.value).toContain("Blue Cross Blue Shield");
+  });
+
+  it("flags low-confidence fields for review", () => {
+    const r = extractFromOcr({ text: SAMPLE_INTAKE });
+    for (const f of r.needsReview) {
+      expect(f.confidence).toBeLessThan(0.7);
+    }
+  });
+
+  it("returns residual text for anything unclaimed", () => {
+    const r = extractFromOcr({
+      text: "DOB: 03/14/1982\nFree text the patient wrote about themselves.",
+    });
+    expect(r.residual).toMatch(/Free text the patient wrote/);
+    expect(r.residual).not.toMatch(/03\/14\/1982/);
+  });
+});
+
+describe("toChartPatch", () => {
+  it("buckets fields into auto-apply vs needs-review", () => {
+    const r = extractFromOcr({ text: SAMPLE_INTAKE });
+    const patch = toChartPatch(r);
+    for (const f of patch.autoApply) expect(f.confidence).toBeGreaterThanOrEqual(0.7);
+    for (const f of patch.review) expect(f.confidence).toBeLessThan(0.7);
+  });
+
+  it("returns an empty note addendum when there is no residual text", () => {
+    const r = extractFromOcr({ text: "DOB: 03/14/1982" });
+    const patch = toChartPatch(r);
+    expect(patch.noteAddendum).toBe("");
+  });
+
+  it("includes residual text in the note addendum", () => {
+    const r = extractFromOcr({ text: "DOB: 03/14/1982\nNon-structured prose." });
+    const patch = toChartPatch(r);
+    expect(patch.noteAddendum).toMatch(/Non-structured prose/);
+    expect(patch.noteAddendum).toMatch(/OCR import — unparsed residual/);
+  });
+});

--- a/src/lib/clinical/ocr-extract.ts
+++ b/src/lib/clinical/ocr-extract.ts
@@ -64,7 +64,7 @@ const BP_RE = /\b(?:bp|blood pressure)[:\s]*(\d{2,3})\s*\/\s*(\d{2,3})/i;
 const HR_RE = /\b(?:hr|heart rate|pulse)[:\s]*(\d{2,3})/i;
 const TEMP_RE = /\b(?:temp|temperature)[:\s]*(\d{2,3}(?:\.\d)?)\s*°?\s*[fF]?/;
 const WEIGHT_RE = /\b(?:wt|weight)[:\s]*(\d{2,3}(?:\.\d)?)\s*(lbs?|kg)/i;
-const HEIGHT_RE = /\b(?:ht|height)[:\s]*(\d)['ʹ]\s*(\d{1,2})/;
+const HEIGHT_RE = /\b(?:ht|height)[:\s]*(\d)['ʹ]\s*(\d{1,2})/i;
 const ALLERGY_LINE_RE = /\b(?:allerg(?:y|ies))[:\s]*([^\n]{0,180})/i;
 const MED_LINE_RE =
   /^\s*[-•*]?\s*([A-Z][a-zA-Z][a-zA-Z\-]+(?:\s+[A-Z]?[a-zA-Z\-]+)?)\s+(\d+(?:\.\d+)?)\s*(mg|mcg|g|ml|units?|iu)\b/m;

--- a/src/lib/clinical/record-release-workflow.test.ts
+++ b/src/lib/clinical/record-release-workflow.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyProviderDecision,
+  canTransition,
+  evaluatePolicy,
+  markSent,
+  validatePatientSignature,
+} from "./record-release-workflow";
+import type { RecordReleaseRequest } from "@/lib/domain/record-release";
+
+function release(over: Partial<RecordReleaseRequest> = {}): RecordReleaseRequest {
+  return {
+    id: "roi_1",
+    patientId: "p_1",
+    createdAt: "2026-05-01T08:00:00Z",
+    updatedAt: "2026-05-01T08:00:00Z",
+    status: "submitted",
+    recipient: { fullName: "Dr. Smith", practice: "Pain Clinic of Orange County" },
+    scope: "everything",
+    categories: ["notes", "labs", "medications"],
+    patientSignatureName: "Jane Doe",
+    patientSignedAt: "2026-05-01T08:00:00Z",
+    expiresAt: "2027-05-01T08:00:00Z",
+    ...over,
+  };
+}
+
+describe("evaluatePolicy", () => {
+  it("buckets default categories correctly", () => {
+    const p = evaluatePolicy(release({ categories: ["labs", "notes", "billing"] }));
+    expect(p.autoReleasable).toEqual(["labs"]);
+    expect(p.needsProviderReview).toEqual(expect.arrayContaining(["notes", "billing"]));
+    expect(p.requiresReview).toBe(true);
+    expect(p.hasForbidden).toBe(false);
+  });
+
+  it("honors per-practice policy overrides", () => {
+    const p = evaluatePolicy(
+      release({ categories: ["notes"] }),
+      { notes: "forbidden" },
+    );
+    expect(p.forbidden).toEqual(["notes"]);
+    expect(p.hasForbidden).toBe(true);
+  });
+});
+
+describe("validatePatientSignature", () => {
+  it("accepts a signature that matches the patient's legal name", () => {
+    const v = validatePatientSignature(
+      release({ patientSignatureName: "Jane Doe" }),
+      "Jane Doe",
+      new Date("2026-05-05T00:00:00Z"),
+    );
+    expect(v.ok).toBe(true);
+    expect(v.errors).toEqual([]);
+  });
+
+  it("rejects empty signatures", () => {
+    const v = validatePatientSignature(
+      release({ patientSignatureName: "" }),
+      "Jane Doe",
+      new Date("2026-05-05T00:00:00Z"),
+    );
+    expect(v.ok).toBe(false);
+  });
+
+  it("rejects when authorization has expired", () => {
+    const v = validatePatientSignature(
+      release({ expiresAt: "2026-04-01T00:00:00Z" }),
+      "Jane Doe",
+      new Date("2026-05-05T00:00:00Z"),
+    );
+    expect(v.errors).toContain("Authorization has expired.");
+  });
+
+  it("flags a signature that doesn't match the legal name", () => {
+    const v = validatePatientSignature(
+      release({ patientSignatureName: "John Smith" }),
+      "Jane Doe",
+      new Date("2026-05-05T00:00:00Z"),
+    );
+    expect(v.ok).toBe(false);
+    expect(v.errors.join(" ")).toMatch(/does not match the legal name/);
+  });
+
+  it("accepts a signature with first-name match (initial-style)", () => {
+    const v = validatePatientSignature(
+      release({ patientSignatureName: "Jane" }),
+      "Jane Marie Doe",
+      new Date("2026-05-05T00:00:00Z"),
+    );
+    expect(v.ok).toBe(true);
+  });
+});
+
+describe("canTransition", () => {
+  it("permits submitted -> approved", () => {
+    expect(canTransition("submitted", "approved")).toBe(true);
+  });
+  it("permits approved -> sent", () => {
+    expect(canTransition("approved", "sent")).toBe(true);
+  });
+  it("blocks sent -> approved", () => {
+    expect(canTransition("sent", "approved")).toBe(false);
+  });
+  it("blocks declined -> approved (terminal)", () => {
+    expect(canTransition("declined", "approved")).toBe(false);
+  });
+  it("permits any -> revoked except from terminal states", () => {
+    expect(canTransition("approved", "revoked")).toBe(true);
+    expect(canTransition("declined", "revoked")).toBe(false);
+  });
+});
+
+describe("applyProviderDecision (approve)", () => {
+  it("transitions submitted to approved with provider signature", () => {
+    const { next, audit } = applyProviderDecision({
+      request: release(),
+      providerUserId: "dr_1",
+      providerSignatureName: "Dr. Helen Park",
+      action: "approve",
+    });
+    expect(next.status).toBe("approved");
+    expect(audit.action).toBe("record_release.approved");
+    expect(audit.providerUserId).toBe("dr_1");
+  });
+
+  it("requires a provider signature on approval", () => {
+    expect(() =>
+      applyProviderDecision({
+        request: release(),
+        providerUserId: "dr_1",
+        providerSignatureName: "",
+        action: "approve",
+      }),
+    ).toThrow(/signature is required/i);
+  });
+
+  it("records categories withheld when only a subset is released", () => {
+    const { next, audit } = applyProviderDecision({
+      request: release({ categories: ["notes", "labs", "billing"] }),
+      providerUserId: "dr_1",
+      providerSignatureName: "Dr. Park",
+      action: "approve",
+      releaseCategories: ["labs"],
+    });
+    expect(next.categories).toEqual(["labs"]);
+    expect(audit.categoriesReleased).toEqual(["labs"]);
+    expect(audit.categoriesWithheld?.sort()).toEqual(["billing", "notes"]);
+  });
+
+  it("rejects approval when a forbidden category is in the request", () => {
+    expect(() =>
+      applyProviderDecision({
+        request: release({ categories: ["notes"] }),
+        providerUserId: "dr_1",
+        providerSignatureName: "Dr. Park",
+        action: "approve",
+        policyOverrides: { notes: "forbidden" },
+      }),
+    ).toThrow(/forbidden/);
+  });
+});
+
+describe("applyProviderDecision (decline)", () => {
+  it("transitions to declined with required reason", () => {
+    const { next, audit } = applyProviderDecision({
+      request: release(),
+      providerUserId: "dr_1",
+      providerSignatureName: "Dr. Park",
+      action: "decline",
+      reason: "Recipient cannot be verified.",
+    });
+    expect(next.status).toBe("declined");
+    expect(audit.action).toBe("record_release.declined");
+    expect(audit.categoriesWithheld).toEqual(["notes", "labs", "medications"]);
+  });
+
+  it("requires a reason on decline", () => {
+    expect(() =>
+      applyProviderDecision({
+        request: release(),
+        providerUserId: "dr_1",
+        providerSignatureName: "Dr. Park",
+        action: "decline",
+      }),
+    ).toThrow(/reason is required/i);
+  });
+});
+
+describe("markSent", () => {
+  it("transitions approved -> sent", () => {
+    const { next, audit } = markSent(release({ status: "approved" }), "dr_1");
+    expect(next.status).toBe("sent");
+    expect(audit.action).toBe("record_release.sent");
+  });
+
+  it("refuses to send when status is not approved", () => {
+    expect(() => markSent(release({ status: "submitted" }), "dr_1")).toThrow(
+      /Cannot mark sent/,
+    );
+  });
+});

--- a/src/lib/clinical/record-release-workflow.ts
+++ b/src/lib/clinical/record-release-workflow.ts
@@ -1,0 +1,324 @@
+/**
+ * EMR-082 — Provider-side workflow for record-release requests.
+ *
+ * The patient-facing form (see `src/components/portal/record-release-form.tsx`)
+ * captures recipient, scope, e-signature, and submits a request. The
+ * provider review screen needs to:
+ *
+ *   1. Verify the patient e-signature is valid and not expired.
+ *   2. Apply the practice's release-of-information policy: which
+ *      categories are released without manual review, which require
+ *      provider sign-off, which are forbidden.
+ *   3. Drive the state machine: submitted → approved → sent  OR
+ *      submitted → declined  OR  any → revoked.
+ *   4. Produce a structured audit payload for AuditLog.
+ *
+ * Pure TS — the storage layer remains pluggable.
+ */
+
+import {
+  RECORD_CATEGORY_LABELS,
+  type RecordCategory,
+  type RecordReleaseRequest,
+  type RecordReleaseStatus,
+} from "@/lib/domain/record-release";
+
+export type ReviewPolicy = "auto_release" | "needs_provider_review" | "forbidden";
+
+/**
+ * Default ROI policy. Most categories release automatically once the
+ * patient has signed; mental-health-adjacent categories and billing
+ * records require provider review; psychotherapy process notes are
+ * never released through the standard ROI surface.
+ */
+export const DEFAULT_CATEGORY_POLICY: Record<RecordCategory, ReviewPolicy> = {
+  notes: "needs_provider_review",
+  labs: "auto_release",
+  imaging: "auto_release",
+  medications: "auto_release",
+  immunizations: "auto_release",
+  problem_list: "auto_release",
+  allergies: "auto_release",
+  billing: "needs_provider_review",
+};
+
+export interface PolicyDecision {
+  categories: Array<{
+    category: RecordCategory;
+    label: string;
+    policy: ReviewPolicy;
+  }>;
+  /** True iff any category requires provider sign-off before sending. */
+  requiresReview: boolean;
+  /** True iff any category is forbidden under the policy. */
+  hasForbidden: boolean;
+  /** Categories the provider may release without further review. */
+  autoReleasable: RecordCategory[];
+  /** Categories that need provider sign-off. */
+  needsProviderReview: RecordCategory[];
+  /** Forbidden categories — must be dropped before sending. */
+  forbidden: RecordCategory[];
+}
+
+export function evaluatePolicy(
+  request: Pick<RecordReleaseRequest, "categories">,
+  overrides: Partial<Record<RecordCategory, ReviewPolicy>> = {},
+): PolicyDecision {
+  const policy = { ...DEFAULT_CATEGORY_POLICY, ...overrides };
+  const categories = request.categories.map((c) => ({
+    category: c,
+    label: RECORD_CATEGORY_LABELS[c],
+    policy: policy[c],
+  }));
+  const autoReleasable = categories
+    .filter((c) => c.policy === "auto_release")
+    .map((c) => c.category);
+  const needsProviderReview = categories
+    .filter((c) => c.policy === "needs_provider_review")
+    .map((c) => c.category);
+  const forbidden = categories
+    .filter((c) => c.policy === "forbidden")
+    .map((c) => c.category);
+  return {
+    categories,
+    autoReleasable,
+    needsProviderReview,
+    forbidden,
+    requiresReview: needsProviderReview.length > 0,
+    hasForbidden: forbidden.length > 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Patient e-signature validation
+// ---------------------------------------------------------------------------
+
+export interface SignatureValidation {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Permissive normalization for name-vs-name comparison. */
+function normalizeName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function validatePatientSignature(
+  request: Pick<
+    RecordReleaseRequest,
+    "patientSignatureName" | "patientSignedAt" | "expiresAt"
+  >,
+  patientLegalName: string,
+  now: Date = new Date(),
+): SignatureValidation {
+  const errors: string[] = [];
+  if (!request.patientSignatureName?.trim()) {
+    errors.push("Patient signature is missing.");
+  }
+  if (!request.patientSignedAt) {
+    errors.push("Signature timestamp is missing.");
+  }
+  if (request.expiresAt && new Date(request.expiresAt).getTime() < now.getTime()) {
+    errors.push("Authorization has expired.");
+  }
+  if (request.patientSignatureName && patientLegalName) {
+    const sigTokens = new Set(
+      normalizeName(request.patientSignatureName).split(" "),
+    );
+    const nameTokens = new Set(normalizeName(patientLegalName).split(" "));
+    let overlap = 0;
+    for (const t of sigTokens) {
+      if (t.length >= 2 && nameTokens.has(t)) overlap += 1;
+    }
+    if (overlap === 0) {
+      errors.push(
+        "Patient signature does not match the legal name on file. Confirm identity before approving.",
+      );
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// State transitions
+// ---------------------------------------------------------------------------
+
+const ALLOWED_TRANSITIONS: Record<RecordReleaseStatus, RecordReleaseStatus[]> = {
+  draft: ["submitted", "revoked"],
+  submitted: ["approved", "declined", "revoked"],
+  approved: ["sent", "declined", "revoked"],
+  sent: ["revoked"],
+  declined: [],
+  revoked: [],
+};
+
+export function canTransition(
+  from: RecordReleaseStatus,
+  to: RecordReleaseStatus,
+): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+export interface ProviderDecisionInput {
+  request: RecordReleaseRequest;
+  /** Provider performing the action. */
+  providerUserId: string;
+  providerSignatureName: string;
+  /** "approve" releases all approved categories; "decline" rejects. */
+  action: "approve" | "decline";
+  /** Subset to release. Defaults to all requested categories. */
+  releaseCategories?: RecordCategory[];
+  /** Free-text decision reason (required on decline; optional on approve). */
+  reason?: string;
+  /** Optional policy overrides applied for this practice. */
+  policyOverrides?: Partial<Record<RecordCategory, ReviewPolicy>>;
+}
+
+export interface ProviderDecisionResult {
+  next: RecordReleaseRequest;
+  audit: RecordReleaseAuditPayload;
+}
+
+export interface RecordReleaseAuditPayload {
+  action:
+    | "record_release.submitted"
+    | "record_release.approved"
+    | "record_release.declined"
+    | "record_release.sent"
+    | "record_release.revoked";
+  at: string;
+  releaseId: string;
+  patientId: string;
+  providerUserId?: string;
+  recipientName: string;
+  scope: RecordReleaseRequest["scope"];
+  categoriesReleased?: RecordCategory[];
+  categoriesWithheld?: RecordCategory[];
+  reason?: string;
+}
+
+/**
+ * Apply a provider review decision and return the next request + audit.
+ * Throws when the transition would violate the state machine or policy.
+ */
+export function applyProviderDecision(
+  input: ProviderDecisionInput,
+): ProviderDecisionResult {
+  const { request, action, providerUserId, providerSignatureName, reason } = input;
+  if (action === "decline") {
+    if (!canTransition(request.status, "declined")) {
+      throw new Error(
+        `Cannot decline request in status "${request.status}".`,
+      );
+    }
+    if (!reason?.trim()) {
+      throw new Error("A reason is required to decline a record release.");
+    }
+    const next: RecordReleaseRequest = {
+      ...request,
+      status: "declined",
+      updatedAt: new Date().toISOString(),
+      reason,
+    };
+    return {
+      next,
+      audit: {
+        action: "record_release.declined",
+        at: next.updatedAt,
+        releaseId: request.id,
+        patientId: request.patientId,
+        providerUserId,
+        recipientName: request.recipient.fullName,
+        scope: request.scope,
+        categoriesWithheld: request.categories,
+        reason,
+      },
+    };
+  }
+
+  // action === "approve"
+  if (!canTransition(request.status, "approved")) {
+    throw new Error(
+      `Cannot approve request in status "${request.status}".`,
+    );
+  }
+  if (!providerSignatureName.trim()) {
+    throw new Error("Provider signature is required to approve a release.");
+  }
+
+  const policy = evaluatePolicy(request, input.policyOverrides);
+  if (policy.hasForbidden) {
+    throw new Error(
+      `Cannot approve: requested categories include forbidden items (${policy.forbidden.join(", ")}). Drop them or decline the request.`,
+    );
+  }
+
+  const released =
+    input.releaseCategories ?? request.categories.filter((c) =>
+      [...policy.autoReleasable, ...policy.needsProviderReview].includes(c),
+    );
+  // Any requested-but-not-released categories are recorded as withheld.
+  const withheld = request.categories.filter((c) => !released.includes(c));
+
+  const next: RecordReleaseRequest = {
+    ...request,
+    status: "approved",
+    categories: released,
+    updatedAt: new Date().toISOString(),
+    reason: reason ?? request.reason,
+  };
+
+  return {
+    next,
+    audit: {
+      action: "record_release.approved",
+      at: next.updatedAt,
+      releaseId: request.id,
+      patientId: request.patientId,
+      providerUserId,
+      recipientName: request.recipient.fullName,
+      scope: request.scope,
+      categoriesReleased: released,
+      categoriesWithheld: withheld.length > 0 ? withheld : undefined,
+      reason,
+    },
+  };
+}
+
+/**
+ * Mark an approved release as sent. The actual transmission (Direct Trust,
+ * fax, encrypted email) is out of band — this just records that the
+ * artifact left our system.
+ */
+export function markSent(
+  request: RecordReleaseRequest,
+  providerUserId: string,
+): ProviderDecisionResult {
+  if (!canTransition(request.status, "sent")) {
+    throw new Error(
+      `Cannot mark sent from status "${request.status}".`,
+    );
+  }
+  const next: RecordReleaseRequest = {
+    ...request,
+    status: "sent",
+    updatedAt: new Date().toISOString(),
+  };
+  return {
+    next,
+    audit: {
+      action: "record_release.sent",
+      at: next.updatedAt,
+      releaseId: request.id,
+      patientId: request.patientId,
+      providerUserId,
+      recipientName: request.recipient.fullName,
+      scope: request.scope,
+      categoriesReleased: request.categories,
+    },
+  };
+}

--- a/src/lib/compliance/audit-log-report.test.ts
+++ b/src/lib/compliance/audit-log-report.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AuditLogReportRow,
+  renderAuditLogReportCsv,
+  renderAuditLogReportHtml,
+  summarizeAuditRows,
+} from "./audit-log-report";
+
+function row(over: Partial<AuditLogReportRow>): AuditLogReportRow {
+  return {
+    id: "log_" + Math.random().toString(36).slice(2, 8),
+    at: new Date("2026-05-01T12:00:00Z"),
+    organizationId: "org_1",
+    actorUserId: "u1",
+    actorEmail: "alice@clinic.test",
+    action: "chart.viewed",
+    subjectType: "patient",
+    subjectId: "p1",
+    ...over,
+  };
+}
+
+describe("summarizeAuditRows", () => {
+  it("counts rows, actors, and unique actions", () => {
+    const s = summarizeAuditRows([
+      row({}),
+      row({ actorEmail: "bob@clinic.test", action: "note.finalized" }),
+      row({ action: "note.finalized" }),
+    ]);
+    expect(s.rowCount).toBe(3);
+    expect(s.actorCount).toBe(2);
+    expect(s.uniqueActions).toBe(2);
+  });
+
+  it("ranks top actors by event count", () => {
+    const s = summarizeAuditRows([
+      row({ actorEmail: "alice@clinic.test" }),
+      row({ actorEmail: "alice@clinic.test" }),
+      row({ actorEmail: "bob@clinic.test" }),
+    ]);
+    expect(s.topActors[0]).toEqual({
+      actor: "alice@clinic.test",
+      count: 2,
+    });
+    expect(s.topActors[1]).toEqual({
+      actor: "bob@clinic.test",
+      count: 1,
+    });
+  });
+
+  it("buckets known sensitive actions into exception counters", () => {
+    const s = summarizeAuditRows([
+      row({ action: "phi.sensitive.break_glass" }),
+      row({ action: "phi.sensitive.viewed" }),
+      row({ action: "rx.contraindication.override" }),
+      row({ action: "auth.login.failed" }),
+      row({ action: "auth.mfa.failed" }),
+      row({ action: "document.downloaded" }),
+      row({ action: "research.export" }),
+    ]);
+    expect(s.exceptions).toEqual({
+      breakGlass: 1,
+      sensitiveAccess: 1,
+      contraindicationOverride: 1,
+      authFailure: 2,
+      bulkExport: 2,
+    });
+  });
+
+  it("computes earliest/latest span", () => {
+    const s = summarizeAuditRows([
+      row({ at: new Date("2026-01-01T00:00:00Z") }),
+      row({ at: new Date("2026-02-01T00:00:00Z") }),
+      row({ at: new Date("2026-03-01T00:00:00Z") }),
+    ]);
+    expect(s.span).toEqual({
+      earliest: "2026-01-01T00:00:00.000Z",
+      latest: "2026-03-01T00:00:00.000Z",
+    });
+  });
+
+  it("returns a null span when there are zero rows", () => {
+    expect(summarizeAuditRows([]).span).toBeNull();
+  });
+
+  it("falls back to actorUserId / actorAgent when no email is present", () => {
+    const s = summarizeAuditRows([
+      row({ actorEmail: null, actorUserId: "u1", actorAgent: null }),
+      row({ actorEmail: null, actorUserId: null, actorAgent: "agent:scribe@1.0" }),
+      row({ actorEmail: null, actorUserId: null, actorAgent: null }),
+    ]);
+    const labels = s.topActors.map((a) => a.actor).sort();
+    expect(labels).toEqual(["agent:scribe@1.0", "u1", "unknown"]);
+  });
+});
+
+describe("renderAuditLogReportHtml", () => {
+  it("includes cover heading, filter values, and detail rows", () => {
+    const html = renderAuditLogReportHtml({
+      rows: [row({})],
+      filters: {
+        organizationId: "org_1",
+        organizationName: "Greenleaf Clinic",
+        patientLabel: "Jane Doe",
+        patientId: "p1",
+        actorUserId: "alice@clinic.test",
+        action: "chart.viewed",
+        since: "2026-04-01T00:00:00Z",
+        until: "2026-05-01T00:00:00Z",
+      },
+      generatedAt: new Date("2026-05-12T15:00:00Z"),
+      practiceLabel: "Greenleaf Clinic",
+    });
+    expect(html).toMatch(/Audit Log Report/);
+    expect(html).toMatch(/Greenleaf Clinic/);
+    expect(html).toMatch(/Jane Doe/);
+    expect(html).toMatch(/2026-05-12 15:00:00Z/);
+    expect(html).toMatch(/chart\.viewed/);
+    expect(html).toMatch(/45 CFR §164\.312\(b\)/);
+  });
+
+  it("escapes user-supplied HTML in actor names + actions", () => {
+    const html = renderAuditLogReportHtml({
+      rows: [
+        row({
+          actorEmail: '<script>alert("x")</script>',
+          action: "<img onerror=1>",
+        }),
+      ],
+      filters: { organizationName: "Org & Co." },
+      generatedAt: "2026-05-12T15:00:00Z",
+    });
+    expect(html).not.toMatch(/<script>alert\("x"\)<\/script>/);
+    expect(html).not.toMatch(/<img onerror=1>/);
+    expect(html).toMatch(/&lt;script&gt;/);
+    expect(html).toMatch(/&lt;img onerror=1&gt;/);
+    expect(html).toMatch(/Org &amp; Co\./);
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const html = renderAuditLogReportHtml({
+      rows: [],
+      filters: {},
+      generatedAt: "2026-05-12T15:00:00Z",
+    });
+    expect(html).toMatch(/No events match the filter/);
+    expect(html).toMatch(/No events in window/);
+  });
+
+  it("flags exception counts > 0 with the .flag class", () => {
+    const html = renderAuditLogReportHtml({
+      rows: [row({ action: "phi.sensitive.break_glass" })],
+      filters: {},
+      generatedAt: "2026-05-12T15:00:00Z",
+    });
+    expect(html).toMatch(/class="num flag"/);
+  });
+});
+
+describe("renderAuditLogReportCsv", () => {
+  it("produces a header row + one row per event", () => {
+    const csv = renderAuditLogReportCsv([
+      row({ metadata: { reason: "test" } }),
+      row({ actorEmail: "bob@clinic.test", action: "note.finalized" }),
+    ]);
+    const lines = csv.trim().split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/^at,organizationId,actorUserId,actorEmail/);
+  });
+
+  it("quotes cells that contain commas, quotes, or newlines", () => {
+    const csv = renderAuditLogReportCsv([
+      row({ reason: 'with, comma and "quote"' }),
+    ]);
+    expect(csv).toMatch(/"with, comma and ""quote"""/);
+  });
+
+  it("serializes metadata as stable JSON (keys sorted)", () => {
+    const csv = renderAuditLogReportCsv([
+      row({ metadata: { z: 1, a: 2 } }),
+    ]);
+    // Quoted because it has a comma — but keys must be alphabetical.
+    expect(csv).toMatch(/"\{""a"":2,""z"":1\}"/);
+  });
+});

--- a/src/lib/compliance/audit-log-report.ts
+++ b/src/lib/compliance/audit-log-report.ts
@@ -1,0 +1,441 @@
+/**
+ * EMR-064 — Audit Log PDF Export
+ *
+ * Renders a print-ready HTML report from a filtered set of `AuditLog`
+ * rows. Browsers turn this into a PDF via the standard print pipeline
+ * (`window.print()` or a server-side Chromium headless renderer), so we
+ * don't need a heavy PDF SDK dependency for v1.
+ *
+ * The renderer is pure: it takes already-fetched rows + filter metadata
+ * and returns an HTML string. The route handler (or CLI) handles
+ * authorization, pagination, and the actual response/file write.
+ *
+ * Report sections:
+ *   1. Cover — practice name, filter window, generated-at, row count.
+ *   2. Filter summary — actor, subject, action, date range, etc.
+ *   3. Aggregate roll-up — top actors, top actions, exception counts.
+ *   4. Detailed row table — every event with timestamp, actor, action,
+ *      subject, IP / agent, metadata flags.
+ *   5. Compliance footnote — references the HIPAA controls this
+ *      satisfies and the integrity hash chain (when available).
+ *
+ * HIPAA §164.312(b) requires the ability to record AND examine activity
+ * in PHI systems — this is the "examine" surface in a portable form
+ * auditors can take with them.
+ */
+
+export interface AuditLogReportRow {
+  id: string;
+  at: Date | string;
+  organizationId?: string | null;
+  actorUserId?: string | null;
+  actorEmail?: string | null;
+  actorAgent?: string | null;
+  actorRoles?: string[] | null;
+  action: string;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  reason?: string | null;
+  /** Optional row hash from the tamper-evident chain. */
+  rowHash?: string | null;
+}
+
+export interface AuditLogReportFilters {
+  organizationId?: string | null;
+  organizationName?: string | null;
+  actorUserId?: string | null;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  patientId?: string | null;
+  patientLabel?: string | null;
+  action?: string | null;
+  since?: Date | string | null;
+  until?: Date | string | null;
+}
+
+export interface AuditLogReportSummary {
+  rowCount: number;
+  actorCount: number;
+  uniqueActions: number;
+  topActors: Array<{ actor: string; count: number }>;
+  topActions: Array<{ action: string; count: number }>;
+  /** Counts of well-known sensitive-action categories. */
+  exceptions: {
+    breakGlass: number;
+    contraindicationOverride: number;
+    bulkExport: number;
+    authFailure: number;
+    sensitiveAccess: number;
+  };
+  /** Spans the from/to of the rendered rows; null when no rows. */
+  span: { earliest: string; latest: string } | null;
+}
+
+const SENSITIVE_ACTIONS = new Set([
+  "phi.sensitive.viewed",
+  "phi.sensitive.break_glass",
+  "rx.contraindication.override",
+  "auth.login.failed",
+  "auth.mfa.failed",
+  "export.generated",
+  "document.downloaded",
+  "research.export",
+]);
+
+function asIso(d: Date | string | null | undefined): string | null {
+  if (d == null) return null;
+  if (typeof d === "string") return d;
+  return d.toISOString();
+}
+
+function fmtDateTime(d: Date | string): string {
+  const date = typeof d === "string" ? new Date(d) : d;
+  // Match the audit-table convention used elsewhere in the EMR: ISO-ish,
+  // human-readable, no microseconds. Always UTC so the report doesn't
+  // shift when downloaded across time zones.
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const yyyy = date.getUTCFullYear();
+  const mm = pad(date.getUTCMonth() + 1);
+  const dd = pad(date.getUTCDate());
+  const hh = pad(date.getUTCHours());
+  const mi = pad(date.getUTCMinutes());
+  const ss = pad(date.getUTCSeconds());
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}Z`;
+}
+
+function bucketAction(action: string): keyof AuditLogReportSummary["exceptions"] | null {
+  if (action === "phi.sensitive.break_glass") return "breakGlass";
+  if (action === "rx.contraindication.override") return "contraindicationOverride";
+  if (
+    action === "export.generated" ||
+    action === "document.downloaded" ||
+    action === "research.export"
+  ) {
+    return "bulkExport";
+  }
+  if (action === "auth.login.failed" || action === "auth.mfa.failed") {
+    return "authFailure";
+  }
+  if (action === "phi.sensitive.viewed") return "sensitiveAccess";
+  return null;
+}
+
+export function summarizeAuditRows(
+  rows: AuditLogReportRow[],
+): AuditLogReportSummary {
+  const actorCount = new Map<string, number>();
+  const actionCount = new Map<string, number>();
+  const exceptions = {
+    breakGlass: 0,
+    contraindicationOverride: 0,
+    bulkExport: 0,
+    authFailure: 0,
+    sensitiveAccess: 0,
+  };
+  let earliest: Date | null = null;
+  let latest: Date | null = null;
+
+  for (const r of rows) {
+    const actor = r.actorEmail ?? r.actorUserId ?? r.actorAgent ?? "unknown";
+    actorCount.set(actor, (actorCount.get(actor) ?? 0) + 1);
+    actionCount.set(r.action, (actionCount.get(r.action) ?? 0) + 1);
+
+    const bucket = bucketAction(r.action);
+    if (bucket) exceptions[bucket] += 1;
+
+    const t = typeof r.at === "string" ? new Date(r.at) : r.at;
+    if (!earliest || t < earliest) earliest = t;
+    if (!latest || t > latest) latest = t;
+  }
+
+  const sortDesc = <T extends { count: number }>(arr: T[]) =>
+    [...arr].sort((a, b) => b.count - a.count);
+  const topActors = sortDesc(
+    [...actorCount.entries()].map(([actor, count]) => ({ actor, count })),
+  ).slice(0, 10);
+  const topActions = sortDesc(
+    [...actionCount.entries()].map(([action, count]) => ({ action, count })),
+  ).slice(0, 10);
+
+  return {
+    rowCount: rows.length,
+    actorCount: actorCount.size,
+    uniqueActions: actionCount.size,
+    topActors,
+    topActions,
+    exceptions,
+    span: earliest && latest
+      ? { earliest: earliest.toISOString(), latest: latest.toISOString() }
+      : null,
+  };
+}
+
+export interface RenderAuditLogReportInput {
+  rows: AuditLogReportRow[];
+  filters: AuditLogReportFilters;
+  /** ISO timestamp the report was generated. Caller supplies for determinism. */
+  generatedAt: Date | string;
+  /** "PRACTICE_NAME" on the cover. Defaults to the org id. */
+  practiceLabel?: string;
+}
+
+export function renderAuditLogReportHtml(
+  input: RenderAuditLogReportInput,
+): string {
+  const { rows, filters, generatedAt, practiceLabel } = input;
+  const summary = summarizeAuditRows(rows);
+  const since = asIso(filters.since ?? null);
+  const until = asIso(filters.until ?? null);
+  const generated =
+    typeof generatedAt === "string" ? generatedAt : generatedAt.toISOString();
+
+  const exceptionRows = (
+    [
+      ["Break-glass overrides (sensitive records)", summary.exceptions.breakGlass],
+      ["Contraindication overrides", summary.exceptions.contraindicationOverride],
+      ["Sensitive PHI views", summary.exceptions.sensitiveAccess],
+      ["Bulk exports / downloads", summary.exceptions.bulkExport],
+      ["Auth failures", summary.exceptions.authFailure],
+    ] as Array<[string, number]>
+  )
+    .map(
+      ([label, count]) => `
+      <tr>
+        <td>${escapeHtml(label)}</td>
+        <td class="num ${count > 0 ? "flag" : ""}">${count}</td>
+      </tr>`,
+    )
+    .join("");
+
+  const detailRows = rows
+    .map((r) => {
+      const actor =
+        r.actorEmail ?? r.actorUserId ?? r.actorAgent ?? "(unknown)";
+      const subject =
+        r.subjectType && r.subjectId
+          ? `${r.subjectType}/${r.subjectId}`
+          : r.subjectType ?? r.subjectId ?? "—";
+      const metadata = r.metadata
+        ? escapeHtml(stableStringify(r.metadata)).slice(0, 320)
+        : "";
+      return `
+      <tr>
+        <td class="ts">${escapeHtml(fmtDateTime(r.at))}</td>
+        <td>${escapeHtml(actor)}</td>
+        <td>${escapeHtml(r.action)}</td>
+        <td>${escapeHtml(subject)}</td>
+        <td class="meta">${metadata}</td>
+      </tr>`;
+    })
+    .join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Audit Log Report — ${escapeHtml(practiceLabel ?? filters.organizationName ?? filters.organizationId ?? "Leafjourney")}</title>
+  <style>
+    @page { size: Letter; margin: 0.6in; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif; color: #1a1a1a; font-size: 10pt; line-height: 1.4; }
+    h1 { font-size: 22pt; margin: 0 0 0.2em; }
+    h2 { font-size: 13pt; margin: 1.5em 0 0.4em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; }
+    h3 { font-size: 11pt; margin: 1em 0 0.3em; color: #555; }
+    .cover { padding: 1em 0 2em; border-bottom: 2px solid #2e7d32; }
+    .cover .sub { color: #666; font-style: italic; }
+    .meta-row { display: flex; gap: 2em; flex-wrap: wrap; margin-top: 0.8em; font-size: 9.5pt; }
+    .meta-row .k { color: #888; text-transform: uppercase; font-size: 8pt; letter-spacing: 0.04em; }
+    table { width: 100%; border-collapse: collapse; font-size: 9pt; }
+    th, td { text-align: left; padding: 0.3em 0.5em; border-bottom: 1px solid #eee; vertical-align: top; }
+    th { background: #f7f7f7; font-weight: 600; border-bottom: 1.5px solid #ccc; }
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    td.num.flag { color: #b71c1c; font-weight: 600; }
+    td.ts { white-space: nowrap; font-variant-numeric: tabular-nums; color: #555; }
+    td.meta { font-family: ui-monospace, SF Mono, Menlo, monospace; font-size: 8pt; color: #555; word-break: break-all; }
+    .footnote { margin-top: 2em; font-size: 8.5pt; color: #666; border-top: 1px solid #ccc; padding-top: 0.6em; }
+    .summary-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.8em; margin: 0.4em 0 0.8em; }
+    .summary-grid .card { border: 1px solid #eee; border-radius: 4px; padding: 0.5em 0.7em; background: #fafafa; }
+    .summary-grid .card .num { font-size: 16pt; font-weight: bold; color: #2e7d32; }
+    .summary-grid .card .lbl { font-size: 8pt; color: #888; text-transform: uppercase; letter-spacing: 0.04em; }
+  </style>
+</head>
+<body>
+  <section class="cover">
+    <h1>Audit Log Report</h1>
+    <p class="sub">${escapeHtml(practiceLabel ?? filters.organizationName ?? "Leafjourney EMR")}</p>
+    <div class="meta-row">
+      <div>
+        <div class="k">Generated</div>
+        ${escapeHtml(fmtDateTime(generated))}
+      </div>
+      <div>
+        <div class="k">From</div>
+        ${since ? escapeHtml(fmtDateTime(since)) : "—"}
+      </div>
+      <div>
+        <div class="k">Through</div>
+        ${until ? escapeHtml(fmtDateTime(until)) : "—"}
+      </div>
+      <div>
+        <div class="k">Rows</div>
+        ${summary.rowCount.toLocaleString()}
+      </div>
+      <div>
+        <div class="k">Actors</div>
+        ${summary.actorCount}
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Filters applied</h2>
+    <table>
+      <tbody>
+        ${filterRow("Organization", filters.organizationName ?? filters.organizationId)}
+        ${filterRow("Patient", filters.patientLabel ?? filters.patientId)}
+        ${filterRow("Actor", filters.actorUserId)}
+        ${filterRow("Subject", filters.subjectType && filters.subjectId ? `${filters.subjectType}/${filters.subjectId}` : filters.subjectType ?? filters.subjectId ?? null)}
+        ${filterRow("Action", filters.action)}
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Summary</h2>
+    <div class="summary-grid">
+      <div class="card"><div class="num">${summary.rowCount.toLocaleString()}</div><div class="lbl">Total events</div></div>
+      <div class="card"><div class="num">${summary.actorCount}</div><div class="lbl">Unique actors</div></div>
+      <div class="card"><div class="num">${summary.uniqueActions}</div><div class="lbl">Unique actions</div></div>
+      <div class="card"><div class="num">${(summary.exceptions.breakGlass + summary.exceptions.contraindicationOverride + summary.exceptions.authFailure).toLocaleString()}</div><div class="lbl">Exceptions</div></div>
+    </div>
+
+    <h3>Exception counts</h3>
+    <table>
+      <thead><tr><th>Event class</th><th class="num">Count</th></tr></thead>
+      <tbody>${exceptionRows}</tbody>
+    </table>
+
+    <h3>Top actors</h3>
+    <table>
+      <thead><tr><th>Actor</th><th class="num">Events</th></tr></thead>
+      <tbody>
+        ${
+          summary.topActors
+            .map(
+              (a) => `<tr><td>${escapeHtml(a.actor)}</td><td class="num">${a.count}</td></tr>`,
+            )
+            .join("") || `<tr><td colspan="2"><em>No events in window.</em></td></tr>`
+        }
+      </tbody>
+    </table>
+
+    <h3>Top actions</h3>
+    <table>
+      <thead><tr><th>Action</th><th class="num">Count</th></tr></thead>
+      <tbody>
+        ${
+          summary.topActions
+            .map(
+              (a) => `<tr><td>${escapeHtml(a.action)}</td><td class="num">${a.count}</td></tr>`,
+            )
+            .join("") || `<tr><td colspan="2"><em>No events in window.</em></td></tr>`
+        }
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Detailed events (${rows.length})</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Timestamp (UTC)</th>
+          <th>Actor</th>
+          <th>Action</th>
+          <th>Subject</th>
+          <th>Metadata</th>
+        </tr>
+      </thead>
+      <tbody>${detailRows || `<tr><td colspan="5"><em>No events match the filter.</em></td></tr>`}</tbody>
+    </table>
+  </section>
+
+  <footer class="footnote">
+    Satisfies HIPAA 45 CFR §164.312(b) audit controls — records and examines activity in systems that contain PHI.
+    Report generated by Leafjourney Compliance Surface.
+  </footer>
+</body>
+</html>`;
+}
+
+/** Helper for the renderer — emits a key/value row if value is set. */
+function filterRow(label: string, value: string | null | undefined): string {
+  if (!value) return "";
+  return `<tr><td><strong>${escapeHtml(label)}</strong></td><td>${escapeHtml(value)}</td></tr>`;
+}
+
+/** Stable JSON for metadata. Avoids ordering wobble between runs. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Convenience: render the report as a CSV for back-office analytics
+ * that prefer spreadsheets. CSV is a single sheet of detailed events
+ * (the summary lives in the HTML/PDF variant).
+ */
+export function renderAuditLogReportCsv(rows: AuditLogReportRow[]): string {
+  const header = [
+    "at",
+    "organizationId",
+    "actorUserId",
+    "actorEmail",
+    "actorAgent",
+    "actorRoles",
+    "action",
+    "subjectType",
+    "subjectId",
+    "reason",
+    "metadata",
+  ];
+  const lines = [header.join(",")];
+  for (const r of rows) {
+    const cells = [
+      fmtDateTime(r.at),
+      r.organizationId ?? "",
+      r.actorUserId ?? "",
+      r.actorEmail ?? "",
+      r.actorAgent ?? "",
+      (r.actorRoles ?? []).join(";"),
+      r.action,
+      r.subjectType ?? "",
+      r.subjectId ?? "",
+      r.reason ?? "",
+      r.metadata ? stableStringify(r.metadata) : "",
+    ];
+    lines.push(cells.map(csvCell).join(","));
+  }
+  return lines.join("\n") + "\n";
+}
+
+function csvCell(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/src/lib/compliance/note-compliance-check.test.ts
+++ b/src/lib/compliance/note-compliance-check.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkNoteCompliance,
+  summarizeBatch,
+  type NoteForComplianceCheck,
+} from "./note-compliance-check";
+
+function note(over: Partial<NoteForComplianceCheck>): NoteForComplianceCheck {
+  return {
+    noteId: "n_" + Math.random().toString(36).slice(2, 8),
+    noteType: "office_visit",
+    chiefComplaint: "Chronic neck pain — follow up",
+    hpi: "Patient reports pain stable on current regimen.",
+    exam: "Neck: tender to palpation at C5-6, ROM mildly reduced.",
+    assessment:
+      "Cervical radiculopathy stable. Continue current cannabis tincture regimen.",
+    icd10Codes: ["M54.12"],
+    cptCodes: ["99213"],
+    mdmLevel: "moderate",
+    signed: true,
+    signedAt: "2026-05-01T13:00:00Z",
+    encounterAt: "2026-05-01T12:00:00Z",
+    treatmentPlanDocumented: true,
+    patientCounseled: true,
+    controlledSubstancePrescribed: false,
+    pdmpQueried: null,
+    ...over,
+  };
+}
+
+describe("checkNoteCompliance", () => {
+  it("passes for a well-formed office visit note", () => {
+    const r = checkNoteCompliance(note({}));
+    expect(r.findings).toEqual([]);
+    expect(r.passes).toBe(true);
+    expect(r.topSeverity).toBeNull();
+  });
+
+  it("flags missing chief complaint as critical", () => {
+    const r = checkNoteCompliance(note({ chiefComplaint: "" }));
+    const f = r.findings.find((x) => x.id === "jc.rc01.cc");
+    expect(f).toBeDefined();
+    expect(f?.severity).toBe("critical");
+    expect(r.passes).toBe(false);
+  });
+
+  it("flags missing assessment as critical", () => {
+    const r = checkNoteCompliance(note({ assessment: "ok" }));
+    expect(r.findings.some((f) => f.id === "cms.em.assessment")).toBe(true);
+  });
+
+  it("flags missing ICD-10 codes as critical", () => {
+    const r = checkNoteCompliance(note({ icd10Codes: [] }));
+    expect(r.findings.some((f) => f.id === "cms.diagnosis.code")).toBe(true);
+  });
+
+  it("warns when high-complexity CPT is billed but MDM is low", () => {
+    const r = checkNoteCompliance(
+      note({ cptCodes: ["99215"], mdmLevel: "low" }),
+    );
+    const f = r.findings.find((x) => x.id === "cms.em.mdm-mismatch");
+    expect(f?.severity).toBe("warning");
+  });
+
+  it("does NOT warn when MDM matches the billed level", () => {
+    const r = checkNoteCompliance(
+      note({ cptCodes: ["99215"], mdmLevel: "high" }),
+    );
+    expect(r.findings.some((f) => f.id === "cms.em.mdm-mismatch")).toBe(false);
+  });
+
+  it("flags controlled-substance Rx without PDMP query as critical", () => {
+    const r = checkNoteCompliance(
+      note({ controlledSubstancePrescribed: true, pdmpQueried: false }),
+    );
+    expect(r.findings.some((f) => f.id === "cms.pdmp")).toBe(true);
+  });
+
+  it("warns when controlled substance is prescribed alongside SUD diagnosis", () => {
+    const r = checkNoteCompliance(
+      note({
+        controlledSubstancePrescribed: true,
+        pdmpQueried: true,
+        icd10Codes: ["F11.20"],
+      }),
+    );
+    expect(r.findings.some((f) => f.id === "cms.sud-controlled")).toBe(true);
+  });
+
+  it("flags unsigned notes as critical", () => {
+    const r = checkNoteCompliance(note({ signed: false, signedAt: null }));
+    expect(r.findings.some((f) => f.id === "jc.rc02.signed")).toBe(true);
+  });
+
+  it("warns when signing is more than 24h after the encounter", () => {
+    const r = checkNoteCompliance(
+      note({
+        encounterAt: "2026-05-01T08:00:00Z",
+        signedAt: "2026-05-03T08:00:00Z",
+      }),
+    );
+    expect(r.findings.some((f) => f.id === "cms.482.24.signing-window")).toBe(
+      true,
+    );
+  });
+
+  it("does NOT warn for same-day signing within 24h", () => {
+    const r = checkNoteCompliance(
+      note({
+        encounterAt: "2026-05-01T08:00:00Z",
+        signedAt: "2026-05-01T22:00:00Z",
+      }),
+    );
+    expect(r.findings.some((f) => f.id === "cms.482.24.signing-window")).toBe(
+      false,
+    );
+  });
+
+  it("orders findings critical -> warning -> info", () => {
+    const r = checkNoteCompliance(
+      note({
+        chiefComplaint: "",
+        cptCodes: ["99215"],
+        mdmLevel: "low",
+        patientCounseled: false,
+      }),
+    );
+    const sev = r.findings.map((f) => f.severity);
+    expect(sev.indexOf("critical")).toBeLessThan(sev.indexOf("warning"));
+    expect(sev.indexOf("warning")).toBeLessThan(sev.indexOf("info"));
+  });
+});
+
+describe("summarizeBatch", () => {
+  it("aggregates rule counts across reports", () => {
+    const r1 = checkNoteCompliance(note({ chiefComplaint: "" }));
+    const r2 = checkNoteCompliance(note({ chiefComplaint: "" }));
+    const r3 = checkNoteCompliance(note({}));
+    const summary = summarizeBatch([r1, r2, r3]);
+    expect(summary.notesScanned).toBe(3);
+    expect(summary.notesWithFindings).toBe(2);
+    expect(summary.notesWithCritical).toBe(2);
+    const cc = summary.byRule.find((r) => r.ruleId === "jc.rc01.cc");
+    expect(cc?.count).toBe(2);
+  });
+
+  it("orders rules critical first, then by count", () => {
+    const r1 = checkNoteCompliance(note({ patientCounseled: false }));
+    const r2 = checkNoteCompliance(note({ chiefComplaint: "" }));
+    const summary = summarizeBatch([r1, r2]);
+    expect(summary.byRule[0].severity).toBe("critical");
+  });
+});

--- a/src/lib/compliance/note-compliance-check.ts
+++ b/src/lib/compliance/note-compliance-check.ts
@@ -1,0 +1,358 @@
+/**
+ * EMR-065 — Note-level compliance check.
+ *
+ * The orchestration-side `complianceAuditAgent` looks at activity patterns
+ * (off-hours access, bulk exports, etc.). This module is the OTHER half:
+ * it audits a single clinical note for documentation gaps that CMS, the
+ * Joint Commission, and major commercial insurers (Aetna, BCBS, UHC,
+ * Cigna, Humana, Medicare, Medicaid) flag during chart reviews.
+ *
+ * Rule sources:
+ *   - CMS — 1995 / 1997 E/M Documentation Guidelines, MDM table
+ *   - Joint Commission RC.01.01.01 — record contains enough information
+ *     to identify the patient, support the diagnosis, justify treatment,
+ *     and promote continuity
+ *   - Aetna / UHC clinical-payment-policy: medical-necessity statement
+ *   - 42 CFR §482.24 — Medical records (Conditions of Participation)
+ *
+ * Pure function. The caller hands us a structured note + visit context;
+ * we hand back a list of findings ranked critical / warning / info. The
+ * `complianceAuditAgent` calls this on every finalized note and surfaces
+ * any "critical" finding as a high-severity audit event.
+ */
+
+export interface NoteForComplianceCheck {
+  noteId: string;
+  noteType?: string | null;
+  authorRole?: string | null;
+  /** Chief complaint or "reason for visit" — required by JC RC.01.01.01. */
+  chiefComplaint?: string | null;
+  /** History of present illness narrative. */
+  hpi?: string | null;
+  /** Physical exam narrative or structured findings. */
+  exam?: string | null;
+  /** Free-text assessment / plan section. */
+  assessment?: string | null;
+  /** ICD-10 codes attached to the encounter. */
+  icd10Codes?: string[] | null;
+  /** CPT codes billed for the encounter. */
+  cptCodes?: string[] | null;
+  /** Medical decision-making complexity level when present. */
+  mdmLevel?: "straightforward" | "low" | "moderate" | "high" | null;
+  /** True iff the clinician has signed the note. */
+  signed?: boolean | null;
+  signedAt?: string | Date | null;
+  /** When the visit occurred — used for 24h-signing rule. */
+  encounterAt?: string | Date | null;
+  /** True iff a controlled substance was prescribed at this visit. */
+  controlledSubstancePrescribed?: boolean | null;
+  /** True iff PDMP / state CURES was queried before prescribing. */
+  pdmpQueried?: boolean | null;
+  /** True iff a treatment plan was documented (justifies the encounter). */
+  treatmentPlanDocumented?: boolean | null;
+  /** True iff the patient was counseled about risks / alternatives. */
+  patientCounseled?: boolean | null;
+}
+
+export type ComplianceFindingSeverity = "critical" | "warning" | "info";
+
+export interface ComplianceFinding {
+  id: string;
+  severity: ComplianceFindingSeverity;
+  /** Authority + citation that drives the rule. */
+  citation: string;
+  title: string;
+  detail: string;
+  remediation: string;
+}
+
+export interface NoteComplianceReport {
+  noteId: string;
+  findings: ComplianceFinding[];
+  /** "passes" iff no critical findings were emitted. */
+  passes: boolean;
+  /** Highest severity emitted; null when no findings. */
+  topSeverity: ComplianceFindingSeverity | null;
+  /** Quick counts the dashboard can render without re-filtering. */
+  counts: Record<ComplianceFindingSeverity, number>;
+}
+
+const NOTE_TYPES_REQUIRING_EXAM = new Set([
+  "office_visit",
+  "follow_up",
+  "initial_consult",
+  "annual_wellness",
+]);
+
+const SEVERITY_RANK: Record<ComplianceFindingSeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
+const HOURS_24 = 24 * 60 * 60 * 1000;
+
+function toDate(v: string | Date | null | undefined): Date | null {
+  if (!v) return null;
+  const d = typeof v === "string" ? new Date(v) : v;
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function isBlank(value: string | null | undefined, min = 1): boolean {
+  return !value || value.trim().length < min;
+}
+
+const HIGH_COMPLEXITY_CPT = new Set([
+  "99204",
+  "99205",
+  "99214",
+  "99215",
+  "99244",
+  "99245",
+]);
+
+const CONTROLLED_SUBSTANCE_ICD_HINTS = ["F11", "F13", "F19"];
+
+export function checkNoteCompliance(
+  note: NoteForComplianceCheck,
+): NoteComplianceReport {
+  const findings: ComplianceFinding[] = [];
+
+  // ------------------------------------------------------------------
+  // Joint Commission RC.01.01.01 — record must identify the reason for
+  // the encounter and justify the treatment.
+  // ------------------------------------------------------------------
+  if (isBlank(note.chiefComplaint)) {
+    findings.push({
+      id: "jc.rc01.cc",
+      severity: "critical",
+      citation: "Joint Commission RC.01.01.01",
+      title: "Chief complaint missing",
+      detail:
+        "Every encounter note must record the reason for the visit. Joint Commission considers the absence of a chief complaint a documentation deficiency.",
+      remediation:
+        "Add a chief complaint or reason-for-visit statement to the note header before finalizing.",
+    });
+  }
+
+  if (isBlank(note.assessment, 10)) {
+    findings.push({
+      id: "cms.em.assessment",
+      severity: "critical",
+      citation: "CMS E/M Documentation Guidelines",
+      title: "Assessment missing or trivial",
+      detail:
+        "The assessment section must articulate the diagnosis or differential. CMS chart reviewers downgrade or deny billed levels when the assessment is blank or boilerplate.",
+      remediation:
+        "Write a substantive assessment summarizing the diagnostic impression and rationale.",
+    });
+  }
+
+  if ((note.icd10Codes?.length ?? 0) === 0) {
+    findings.push({
+      id: "cms.diagnosis.code",
+      severity: "critical",
+      citation: "42 CFR §482.24",
+      title: "No diagnosis code attached",
+      detail:
+        "Every billed encounter must carry at least one ICD-10 diagnosis code that supports medical necessity.",
+      remediation: "Attach the primary ICD-10 diagnosis before finalizing.",
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // CMS 1995/1997 E/M — exam component
+  // ------------------------------------------------------------------
+  if (
+    note.noteType &&
+    NOTE_TYPES_REQUIRING_EXAM.has(note.noteType) &&
+    isBlank(note.exam, 5)
+  ) {
+    findings.push({
+      id: "cms.em.exam",
+      severity: "warning",
+      citation: "CMS 1995/1997 E/M Documentation Guidelines",
+      title: "Physical exam section is empty",
+      detail:
+        "Office visits and follow-ups require an exam component to justify the billed E/M level. Documentation reviewers downcode when this is blank.",
+      remediation: "Document at least the focused-system exam findings for this visit.",
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // High-complexity codes need high MDM + assessment
+  // ------------------------------------------------------------------
+  if (note.cptCodes?.some((c) => HIGH_COMPLEXITY_CPT.has(c))) {
+    if (!note.mdmLevel || note.mdmLevel === "straightforward" || note.mdmLevel === "low") {
+      findings.push({
+        id: "cms.em.mdm-mismatch",
+        severity: "warning",
+        citation: "CMS E/M Code Selection",
+        title: "Billed E/M level exceeds documented MDM",
+        detail:
+          `Billed CPT ${[...new Set(note.cptCodes!.filter((c) => HIGH_COMPLEXITY_CPT.has(c)))].join(", ")} but medical decision-making is documented as ${note.mdmLevel ?? "unspecified"}.`,
+        remediation:
+          "Either downgrade the code or update MDM to reflect the data reviewed, problems addressed, and risk.",
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Treatment plan + counseling — Aetna / UHC medical-necessity reviews
+  // ------------------------------------------------------------------
+  if (note.treatmentPlanDocumented === false) {
+    findings.push({
+      id: "payer.tx-plan",
+      severity: "warning",
+      citation: "Aetna / UHC Clinical Payment Policy",
+      title: "Treatment plan not documented",
+      detail:
+        "Commercial payers require a documented plan (medications, follow-up interval, referrals) to demonstrate medical necessity.",
+      remediation: "Add a Plan section identifying interventions and follow-up timing.",
+    });
+  }
+
+  if (note.patientCounseled === false) {
+    findings.push({
+      id: "payer.counseling",
+      severity: "info",
+      citation: "BCBS / Cigna Medical Necessity",
+      title: "Patient counseling not documented",
+      detail:
+        "When risks and alternatives are not documented as discussed with the patient, payers sometimes deny coverage.",
+      remediation:
+        "Note that risks, benefits, and alternatives were discussed and the patient consented to the plan.",
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Controlled substances — PDMP query required in most states.
+  // ------------------------------------------------------------------
+  const sudIcd = note.icd10Codes?.some((c) =>
+    CONTROLLED_SUBSTANCE_ICD_HINTS.some((p) => c.startsWith(p)),
+  );
+  if (note.controlledSubstancePrescribed && note.pdmpQueried === false) {
+    findings.push({
+      id: "cms.pdmp",
+      severity: "critical",
+      citation: "CMS / SUPPORT Act / State PDMP Mandate",
+      title: "PDMP query not documented before controlled-substance Rx",
+      detail:
+        "Federal and most state laws require providers to check the prescription-drug monitoring program before prescribing a controlled substance.",
+      remediation:
+        "Query CURES / state PDMP and attach the result to the note before finalizing the prescription.",
+    });
+  }
+  if (sudIcd && note.controlledSubstancePrescribed) {
+    findings.push({
+      id: "cms.sud-controlled",
+      severity: "warning",
+      citation: "42 CFR Part 2",
+      title: "Controlled substance prescribed alongside SUD diagnosis",
+      detail:
+        "Patient carries an active substance-use diagnosis (F11/F13/F19). Documented clinical justification is required for any controlled-substance Rx.",
+      remediation:
+        "Document the medical-necessity rationale and patient counseling for this prescribing decision.",
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Signature + timeliness — JC RC.02.01.07 / CMS 482.24(c)(1)
+  // ------------------------------------------------------------------
+  if (!note.signed) {
+    findings.push({
+      id: "jc.rc02.signed",
+      severity: "critical",
+      citation: "Joint Commission RC.02.01.07",
+      title: "Note not signed",
+      detail:
+        "Unsigned notes are not part of the legal record and cannot be billed.",
+      remediation: "Sign the note before exporting or billing.",
+    });
+  } else {
+    const encounter = toDate(note.encounterAt ?? null);
+    const signedAt = toDate(note.signedAt ?? null);
+    if (encounter && signedAt && signedAt.getTime() - encounter.getTime() > HOURS_24) {
+      findings.push({
+        id: "cms.482.24.signing-window",
+        severity: "warning",
+        citation: "CMS 42 CFR §482.24(c)(1)",
+        title: "Note signed more than 24 hours after the encounter",
+        detail:
+          "CMS Conditions of Participation expect entries to be authenticated promptly. Notes signed days after the visit are flagged in chart reviews.",
+        remediation:
+          "Sign visit notes within 24 hours. If delayed, document the reason in the note.",
+      });
+    }
+  }
+
+  // Sort by severity (critical first), preserving rule order within tier.
+  findings.sort(
+    (a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity],
+  );
+
+  const counts: Record<ComplianceFindingSeverity, number> = {
+    critical: 0,
+    warning: 0,
+    info: 0,
+  };
+  for (const f of findings) counts[f.severity] += 1;
+  const topSeverity =
+    findings.length === 0 ? null : findings[0].severity;
+
+  return {
+    noteId: note.noteId,
+    findings,
+    passes: counts.critical === 0,
+    topSeverity,
+    counts,
+  };
+}
+
+/**
+ * Roll up a batch of per-note reports into one practice-wide summary.
+ * Used by the compliance dashboard's "notes that need attention" tile.
+ */
+export interface BatchComplianceReport {
+  notesScanned: number;
+  notesWithFindings: number;
+  notesWithCritical: number;
+  byRule: Array<{ ruleId: string; severity: ComplianceFindingSeverity; count: number }>;
+}
+
+export function summarizeBatch(
+  reports: NoteComplianceReport[],
+): BatchComplianceReport {
+  const ruleCount = new Map<string, { sev: ComplianceFindingSeverity; n: number }>();
+  let withFindings = 0;
+  let withCritical = 0;
+
+  for (const rep of reports) {
+    if (rep.findings.length > 0) withFindings += 1;
+    if (rep.counts.critical > 0) withCritical += 1;
+    for (const f of rep.findings) {
+      const cur = ruleCount.get(f.id);
+      if (cur) cur.n += 1;
+      else ruleCount.set(f.id, { sev: f.severity, n: 1 });
+    }
+  }
+
+  const byRule = [...ruleCount.entries()]
+    .map(([ruleId, { sev, n }]) => ({
+      ruleId,
+      severity: sev,
+      count: n,
+    }))
+    .sort(
+      (a, b) =>
+        SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] ||
+        b.count - a.count,
+    );
+
+  return {
+    notesScanned: reports.length,
+    notesWithFindings: withFindings,
+    notesWithCritical: withCritical,
+    byRule,
+  };
+}

--- a/src/lib/security/encryption-framework.test.ts
+++ b/src/lib/security/encryption-framework.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { randomBytes } from "node:crypto";
+import {
+  COMPLIANCE_CONTROLS,
+  EnvironmentKeyResolver,
+  FRAMEWORK_DOC_PATH,
+  FRAMEWORK_VERSION,
+  decryptString,
+  deidentify,
+  deriveSubKey,
+  encryptString,
+  hashPassword,
+  hmacSha256,
+  parseEnvelope,
+  serializeEnvelope,
+  setKeyResolver,
+  sha256Hex,
+  verifyPassword,
+} from "./encryption-framework";
+
+beforeAll(() => {
+  // Tests need a stable KEK. Generate a 32-byte key and base64url-encode it.
+  process.env.EMR_PHI_KEK = randomBytes(32).toString("base64url");
+  setKeyResolver(new EnvironmentKeyResolver("EMR_PHI_KEK"));
+});
+
+describe("envelope serialization", () => {
+  it("round-trips through parse/serialize", () => {
+    const env = {
+      version: 1 as const,
+      iv: "iv",
+      tag: "tag",
+      wrappedDek: "wrapped",
+      ciphertext: "ct",
+    };
+    const s = serializeEnvelope(env);
+    expect(s.startsWith("v1:")).toBe(true);
+    expect(parseEnvelope(s)).toEqual(env);
+  });
+
+  it("rejects an envelope with the wrong number of segments", () => {
+    expect(() => parseEnvelope("v1:a:b")).toThrow(/wrong segment count/);
+  });
+
+  it("rejects an unsupported version", () => {
+    expect(() => parseEnvelope("v2:a:b:c:d")).toThrow(/Unsupported envelope/);
+  });
+});
+
+describe("encryptString / decryptString", () => {
+  it("round-trips a plaintext string", async () => {
+    const env = await encryptString("hello world", { purpose: "phi-field" });
+    const out = await decryptString(env, { purpose: "phi-field" });
+    expect(out).toBe("hello world");
+  });
+
+  it("produces a different ciphertext on every call (fresh IV + DEK)", async () => {
+    const a = await encryptString("hello", { purpose: "phi-field" });
+    const b = await encryptString("hello", { purpose: "phi-field" });
+    expect(a).not.toBe(b);
+  });
+
+  it("fails decryption with a mismatched purpose (HKDF derivation differs)", async () => {
+    const env = await encryptString("secret", { purpose: "phi-field" });
+    await expect(
+      decryptString(env, { purpose: "msg-body" }),
+    ).rejects.toThrow();
+  });
+
+  it("binds additional-authenticated-data and rejects tampered AAD", async () => {
+    const env = await encryptString("secret", {
+      purpose: "phi-field",
+      aad: "record-id-123",
+    });
+    await expect(
+      decryptString(env, { purpose: "phi-field", aad: "record-id-999" }),
+    ).rejects.toThrow();
+    const ok = await decryptString(env, {
+      purpose: "phi-field",
+      aad: "record-id-123",
+    });
+    expect(ok).toBe("secret");
+  });
+
+  it("rejects when the auth tag is tampered with", async () => {
+    const env = await encryptString("secret", { purpose: "phi-field" });
+    // Flip a character in the tag segment.
+    const parts = env.split(":");
+    const tag = Buffer.from(parts[2], "base64url");
+    tag[0] ^= 0xff;
+    parts[2] = tag.toString("base64url");
+    const tampered = parts.join(":");
+    await expect(
+      decryptString(tampered, { purpose: "phi-field" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("deriveSubKey", () => {
+  it("produces deterministic but purpose-distinct keys", () => {
+    const kek = randomBytes(32);
+    const a1 = deriveSubKey(kek, "phi");
+    const a2 = deriveSubKey(kek, "phi");
+    const b = deriveSubKey(kek, "msg");
+    expect(a1.equals(a2)).toBe(true);
+    expect(a1.equals(b)).toBe(false);
+  });
+});
+
+describe("password hashing", () => {
+  it("verifies a correct password", () => {
+    const stored = hashPassword("correct horse battery staple");
+    expect(verifyPassword("correct horse battery staple", stored)).toBe(true);
+  });
+
+  it("rejects an incorrect password", () => {
+    const stored = hashPassword("hunter2");
+    expect(verifyPassword("hunter3", stored)).toBe(false);
+  });
+
+  it("rejects when the stored algo is unknown", () => {
+    const stored = hashPassword("test");
+    const broken = { ...stored, algo: "md5" as const };
+    // @ts-expect-error — purposely passing a non-scrypt algo.
+    expect(verifyPassword("test", broken)).toBe(false);
+  });
+});
+
+describe("digests + integrity", () => {
+  it("hashes deterministically with SHA-256", () => {
+    expect(sha256Hex("abc")).toBe(sha256Hex("abc"));
+    expect(sha256Hex("abc")).not.toBe(sha256Hex("abcd"));
+  });
+
+  it("HMAC depends on the key", () => {
+    const a = hmacSha256(Buffer.alloc(32, 1), "x");
+    const b = hmacSha256(Buffer.alloc(32, 2), "x");
+    expect(a.equals(b)).toBe(false);
+  });
+});
+
+describe("deidentify", () => {
+  it("produces stable de-identification hashes for the same value", async () => {
+    const a = await deidentify("scott@example.com");
+    const b = await deidentify("scott@example.com");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes hash when the purpose changes", async () => {
+    const a = await deidentify("scott@example.com", "research");
+    const b = await deidentify("scott@example.com", "billing");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("EnvironmentKeyResolver", () => {
+  it("throws when EMR_PHI_KEK is missing", async () => {
+    const prev = process.env.EMR_PHI_KEK;
+    delete process.env.EMR_PHI_KEK;
+    const r = new EnvironmentKeyResolver("EMR_PHI_KEK");
+    await expect(r.getKek()).rejects.toThrow(/refusing to encrypt PHI/);
+    if (prev) process.env.EMR_PHI_KEK = prev;
+  });
+
+  it("throws when EMR_PHI_KEK is the wrong length", async () => {
+    const prev = process.env.EMR_PHI_KEK;
+    process.env.EMR_PHI_KEK = "short";
+    const r = new EnvironmentKeyResolver("EMR_PHI_KEK");
+    await expect(r.getKek()).rejects.toThrow(/must be 32 bytes/);
+    if (prev) process.env.EMR_PHI_KEK = prev;
+  });
+});
+
+describe("COMPLIANCE_CONTROLS catalog", () => {
+  it("publishes at least the HIPAA encryption + audit controls", () => {
+    const ids = COMPLIANCE_CONTROLS.map((c) => c.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "HIPAA-164.312(a)(2)(iv)",
+        "HIPAA-164.312(b)",
+        "HIPAA-Safe-Harbor",
+      ]),
+    );
+  });
+
+  it("references the companion docs path", () => {
+    expect(FRAMEWORK_DOC_PATH).toBe("docs/compliance/encryption.md");
+    expect(FRAMEWORK_VERSION).toBe(1);
+  });
+});

--- a/src/lib/security/licensing-framework.test.ts
+++ b/src/lib/security/licensing-framework.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPLIANCE_ATTESTATIONS,
+  INTELLECTUAL_PROPERTY,
+  LICENSEE_TIERS,
+  SAMPLE_CONTRACTS,
+  buildFrameworkSummary,
+} from "./licensing-framework";
+
+describe("licensing framework data", () => {
+  it("declares every required licensee tier", () => {
+    const kinds = LICENSEE_TIERS.map((t) => t.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        "outpatient_clinic",
+        "specialty_practice",
+        "hospital",
+        "health_system",
+        "ehr_vendor_partner",
+        "research_institution",
+      ]),
+    );
+  });
+
+  it("never lists a tier with negative pricing", () => {
+    for (const t of LICENSEE_TIERS) {
+      expect(t.startingPricePerProvider).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("includes patent + trademark + trade-secret claims", () => {
+    const kinds = new Set(INTELLECTUAL_PROPERTY.map((c) => c.kind));
+    expect(kinds.has("patent_pending")).toBe(true);
+    expect(kinds.has("trademark")).toBe(true);
+    expect(kinds.has("trade_secret")).toBe(true);
+  });
+
+  it("publishes BAA + MSA + DPA contract templates", () => {
+    const kinds = SAMPLE_CONTRACTS.map((c) => c.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        "master_services_agreement",
+        "business_associate_agreement",
+        "data_processing_addendum",
+      ]),
+    );
+  });
+
+  it("references HIPAA, 42 CFR Part 2, and Joint Commission in attestations", () => {
+    const frameworks = COMPLIANCE_ATTESTATIONS.map((a) => a.framework);
+    expect(frameworks).toEqual(
+      expect.arrayContaining(["HIPAA", "42 CFR Part 2", "Joint Commission"]),
+    );
+  });
+
+  it("each attestation lists at least one evidence artifact", () => {
+    for (const a of COMPLIANCE_ATTESTATIONS) {
+      expect(a.evidenceArtifacts.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("buildFrameworkSummary", () => {
+  it("counts IP claims by kind", () => {
+    const s = buildFrameworkSummary();
+    const total =
+      s.ipCounts.patent_pending +
+      s.ipCounts.patent_filed +
+      s.ipCounts.trademark +
+      s.ipCounts.trade_secret +
+      s.ipCounts.copyright;
+    expect(total).toBe(INTELLECTUAL_PROPERTY.length);
+  });
+
+  it("sets hasPatentPending iff there's at least one patent-pending claim", () => {
+    const s = buildFrameworkSummary();
+    expect(s.hasPatentPending).toBe(s.ipCounts.patent_pending > 0);
+  });
+
+  it("returns all attestation frameworks for the badge row", () => {
+    const s = buildFrameworkSummary();
+    expect(s.attestationFrameworks.length).toBe(COMPLIANCE_ATTESTATIONS.length);
+  });
+});

--- a/src/lib/security/licensing-framework.ts
+++ b/src/lib/security/licensing-framework.ts
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Unintegrated scaffold (track-9)"
 /**
  * EMR-084 — Licensing + IP framework.
  *

--- a/src/lib/security/licensing-framework.ts
+++ b/src/lib/security/licensing-framework.ts
@@ -1,0 +1,406 @@
+/**
+ * EMR-084 — Licensing + IP framework.
+ *
+ * The encryption side of EMR-084 lives in `./encryption-framework.ts`. This
+ * companion module is the *legal / commercial* surface: the set of
+ * artifacts a sales engineer or counsel needs when pitching Leafjourney
+ * to a hospital system, Epic / Cerner partner, or PT/OT chain.
+ *
+ * The data is intentionally static and version-controlled here (rather
+ * than living in a CMS) so:
+ *   1. Changes are reviewed alongside code.
+ *   2. The licensing brochure endpoint can re-render deterministically.
+ *   3. The compliance audit page can show "what we license, against
+ *      which claims, with which sample contract."
+ *
+ * Counsel reviewed shape:
+ *   - LICENSEE_TIERS         — outpatient → hospital pricing buckets
+ *   - INTELLECTUAL_PROPERTY  — patent + trademark claim inventory
+ *   - COMPLIANCE_ATTESTATIONS — what Leafjourney represents to a buyer
+ *   - SAMPLE_CONTRACTS       — boilerplate MSA + DPA + BAA templates
+ */
+
+export type LicenseeKind =
+  | "outpatient_clinic"
+  | "specialty_practice"
+  | "hospital"
+  | "health_system"
+  | "ehr_vendor_partner"
+  | "research_institution";
+
+export interface LicenseeTier {
+  kind: LicenseeKind;
+  label: string;
+  description: string;
+  /** Indicative starting list price per provider per month. */
+  startingPricePerProvider: number;
+  /** Typical revenue share when bundled by an EHR partner. */
+  partnerRevenueSharePct?: number;
+  /** Service levels available for this tier (SLA targets). */
+  uptimeTarget: number;
+  /** Whether on-prem deployment is contractually supported. */
+  onPremiseAvailable: boolean;
+}
+
+export const LICENSEE_TIERS: LicenseeTier[] = [
+  {
+    kind: "outpatient_clinic",
+    label: "Outpatient clinic",
+    description: "Independent or small-group practices (1–10 providers).",
+    startingPricePerProvider: 199,
+    uptimeTarget: 99.5,
+    onPremiseAvailable: false,
+  },
+  {
+    kind: "specialty_practice",
+    label: "Specialty practice",
+    description:
+      "PT/OT, pain, behavioral-health, cannabis-medicine clinics with specialty workflows.",
+    startingPricePerProvider: 249,
+    uptimeTarget: 99.5,
+    onPremiseAvailable: false,
+  },
+  {
+    kind: "hospital",
+    label: "Hospital (single facility)",
+    description:
+      "Community hospitals adopting Leafjourney for outpatient + ambulatory floors.",
+    startingPricePerProvider: 349,
+    uptimeTarget: 99.9,
+    onPremiseAvailable: true,
+  },
+  {
+    kind: "health_system",
+    label: "Multi-facility health system",
+    description:
+      "Networks running Leafjourney across multiple sites, integrating with an enterprise EHR.",
+    startingPricePerProvider: 449,
+    uptimeTarget: 99.95,
+    onPremiseAvailable: true,
+  },
+  {
+    kind: "ehr_vendor_partner",
+    label: "EHR vendor partner",
+    description:
+      "Epic, Cerner, Athena, etc. embedding Leafjourney modules under their own UI.",
+    startingPricePerProvider: 0,
+    partnerRevenueSharePct: 30,
+    uptimeTarget: 99.9,
+    onPremiseAvailable: true,
+  },
+  {
+    kind: "research_institution",
+    label: "Research institution",
+    description:
+      "Academic medical centers + CROs running de-identified cohort analytics.",
+    startingPricePerProvider: 129,
+    uptimeTarget: 99.5,
+    onPremiseAvailable: false,
+  },
+];
+
+export type IpClaimKind = "patent_pending" | "patent_filed" | "trademark" | "trade_secret" | "copyright";
+
+export interface IpClaim {
+  id: string;
+  kind: IpClaimKind;
+  title: string;
+  description: string;
+  /** What part of the system the claim covers. */
+  surface: string;
+  /** Reference number where applicable. */
+  reference?: string;
+}
+
+export const INTELLECTUAL_PROPERTY: IpClaim[] = [
+  {
+    id: "ip.envelope-encryption",
+    kind: "trade_secret",
+    title: "Envelope-encryption PHI store with per-record DEKs",
+    description:
+      "HKDF-derived per-purpose wrap keys, per-record DEKs wrapped under a customer-controlled KEK; auditable, key-rotatable PHI at rest.",
+    surface: "src/lib/security/encryption-framework.ts",
+  },
+  {
+    id: "ip.sensitivity-classifier",
+    kind: "patent_pending",
+    title: "Mental-health sensitivity classifier with break-glass workflow",
+    description:
+      "Multi-signal classifier (CPT, ICD-10, note-type, free-text) ranks PHI sensitivity and conditionally requires a recorded clinician attestation before disclosure.",
+    surface: "src/lib/clinical/mental-health-access.ts",
+  },
+  {
+    id: "ip.cannabis-contraindication",
+    kind: "patent_pending",
+    title: "Cannabis-specific contraindication override engine",
+    description:
+      "Codified absolute / relative / caution contraindications with override gating, attestation, and audit-coupled prescribing.",
+    surface: "src/lib/clinical/contraindication-check.ts",
+  },
+  {
+    id: "ip.compliance-agent",
+    kind: "trade_secret",
+    title: "Activity-pattern compliance audit agent",
+    description:
+      "Rule-driven sweeper that ranks off-hours access, snooping, bulk-export, auth-anomaly and break-glass behaviors into a privacy-officer triage queue.",
+    surface: "src/lib/agents/compliance-audit-agent.ts",
+  },
+  {
+    id: "ip.leafjourney-mark",
+    kind: "trademark",
+    title: "Leafjourney® word + leaf-burst logo",
+    description:
+      "Cannabis-medicine EMR brand mark, registered in classes 9 (software) and 44 (medical services).",
+    surface: "Brand surface",
+    reference: "USPTO Class 9 / 44",
+  },
+  {
+    id: "ip.cannabis-search-chatcb",
+    kind: "trademark",
+    title: "ChatCB™ conversational cannabis search",
+    description:
+      "Conversational cannabis evidence search trained on PubMed cannabinoid-disease pairs and our outcome registry.",
+    surface: "src/app/(public)/education/chatcb",
+  },
+  {
+    id: "ip.michelin-licensing-menu",
+    kind: "copyright",
+    title: "Michelin-style modular licensing brochure",
+    description:
+      "Editorial framing of the platform as a star-rated modular menu, with tiered comparison matrix and à la carte pricing.",
+    surface: "src/lib/platform/licensing.ts",
+  },
+];
+
+export type AttestationFramework =
+  | "HIPAA"
+  | "HITECH"
+  | "SOC 2 Type II"
+  | "HITRUST CSF"
+  | "Joint Commission"
+  | "CMS Conditions of Participation"
+  | "42 CFR Part 2"
+  | "NIST SP 800-66"
+  | "NIST SP 800-53"
+  | "GDPR";
+
+export interface ComplianceAttestation {
+  framework: AttestationFramework;
+  scope: string;
+  /** Single-sentence summary of how Leafjourney meets the framework. */
+  statement: string;
+  evidenceArtifacts: string[];
+}
+
+export const COMPLIANCE_ATTESTATIONS: ComplianceAttestation[] = [
+  {
+    framework: "HIPAA",
+    scope: "PHI at rest, in transit, and at the access boundary.",
+    statement:
+      "AES-256-GCM with per-record DEKs, TLS 1.2+, role-based access controls, signed BAA, audit logs satisfying §164.312(b).",
+    evidenceArtifacts: [
+      "src/lib/security/encryption-framework.ts",
+      "src/lib/clinical/mental-health-access.ts",
+      "scripts/export-audit-log.ts",
+    ],
+  },
+  {
+    framework: "42 CFR Part 2",
+    scope: "Substance-use disorder treatment records.",
+    statement:
+      "Sensitive-record overlay restricts SUD records to roles with a documented treatment relationship; disclosures require patient-specific consent.",
+    evidenceArtifacts: [
+      "src/lib/clinical/mental-health-access.ts",
+      "src/lib/clinical/record-release-workflow.ts",
+    ],
+  },
+  {
+    framework: "Joint Commission",
+    scope: "Clinical documentation completeness (RC.01.01.01).",
+    statement:
+      "Note compliance checker validates chief complaint, assessment, signature, and diagnosis-code attachment before a note can be finalized.",
+    evidenceArtifacts: [
+      "src/lib/compliance/note-compliance-check.ts",
+    ],
+  },
+  {
+    framework: "CMS Conditions of Participation",
+    scope: "Medical record timeliness (42 CFR §482.24).",
+    statement:
+      "Compliance checker flags notes signed more than 24 hours after the encounter and PDMP queries missing on controlled-substance prescribing.",
+    evidenceArtifacts: [
+      "src/lib/compliance/note-compliance-check.ts",
+    ],
+  },
+  {
+    framework: "SOC 2 Type II",
+    scope: "Security, availability, and confidentiality.",
+    statement:
+      "Append-only ControllerAuditLog, RBAC across surfaces, encrypted backups, and incident-response runbooks underpin the trust services criteria.",
+    evidenceArtifacts: [
+      "src/lib/auth/audit-stub.ts",
+      "src/lib/rbac/*",
+    ],
+  },
+];
+
+/**
+ * Sample contract templates the sales team can hand to counsel for
+ * redlines. These are NOT a substitute for legal review — they exist so
+ * a counterparty has something concrete to negotiate from on day one.
+ */
+export type SampleContractKind =
+  | "master_services_agreement"
+  | "business_associate_agreement"
+  | "data_processing_addendum"
+  | "ehr_partner_agreement"
+  | "research_data_use_agreement";
+
+export interface SampleContract {
+  kind: SampleContractKind;
+  title: string;
+  description: string;
+  /** Counterparty profile this template is tuned for. */
+  audience: LicenseeKind[];
+  /** Headline clauses the buyer should expect. */
+  keyClauses: string[];
+  /** Default terms the sales engineer should pre-fill. */
+  defaultTerms: {
+    termYears: number;
+    autoRenewYears: number;
+    noticeDays: number;
+    feeStructure: string;
+  };
+}
+
+export const SAMPLE_CONTRACTS: SampleContract[] = [
+  {
+    kind: "master_services_agreement",
+    title: "Leafjourney Master Services Agreement (MSA)",
+    description:
+      "Anchor contract covering subscription term, fees, SLAs, IP allocation, indemnification, and termination.",
+    audience: ["outpatient_clinic", "specialty_practice", "hospital", "health_system"],
+    keyClauses: [
+      "Subscription scope + named-provider seat counts",
+      "Service-level commitments (uptime, support response, breach notification)",
+      "IP ownership: licensee owns its data; Leafjourney retains platform IP",
+      "Indemnification for IP infringement and gross negligence",
+      "Termination for cause + transition-services obligation",
+    ],
+    defaultTerms: {
+      termYears: 3,
+      autoRenewYears: 1,
+      noticeDays: 90,
+      feeStructure: "Per-provider monthly subscription, billed annually",
+    },
+  },
+  {
+    kind: "business_associate_agreement",
+    title: "HIPAA Business Associate Agreement (BAA)",
+    description:
+      "Required for any covered-entity licensee. Imposes HIPAA Security and Privacy obligations on Leafjourney.",
+    audience: ["outpatient_clinic", "specialty_practice", "hospital", "health_system"],
+    keyClauses: [
+      "Permitted uses + disclosures of PHI",
+      "Safeguards: administrative, physical, technical (§164.308–.312)",
+      "Breach notification within 60 days",
+      "Sub-contractor flow-down obligations",
+      "Return / destruction of PHI on termination",
+    ],
+    defaultTerms: {
+      termYears: 3,
+      autoRenewYears: 1,
+      noticeDays: 30,
+      feeStructure: "Bundled with MSA — no separate fee",
+    },
+  },
+  {
+    kind: "data_processing_addendum",
+    title: "Data Processing Addendum (DPA)",
+    description:
+      "GDPR / state-privacy-law processor obligations. Required for any licensee with EU patients or California-resident patients.",
+    audience: ["outpatient_clinic", "specialty_practice", "hospital", "health_system", "research_institution"],
+    keyClauses: [
+      "Processor obligations under GDPR Art. 28",
+      "International data-transfer mechanism (SCCs)",
+      "Sub-processor list + change-notification window",
+      "Data-subject rights support obligations",
+    ],
+    defaultTerms: {
+      termYears: 3,
+      autoRenewYears: 1,
+      noticeDays: 30,
+      feeStructure: "Bundled with MSA",
+    },
+  },
+  {
+    kind: "ehr_partner_agreement",
+    title: "EHR Vendor Partner Agreement",
+    description:
+      "Distribution + revenue-share contract for embedding Leafjourney modules into Epic / Cerner / Athena.",
+    audience: ["ehr_vendor_partner"],
+    keyClauses: [
+      "License grant to embed Leafjourney modules under partner UI",
+      "Co-branding + trademark usage limits",
+      "Revenue share + reconciliation cadence",
+      "Joint customer support runbook",
+    ],
+    defaultTerms: {
+      termYears: 5,
+      autoRenewYears: 2,
+      noticeDays: 180,
+      feeStructure: "Revenue share (30% default) on partner-sourced licensees",
+    },
+  },
+  {
+    kind: "research_data_use_agreement",
+    title: "Research Data Use Agreement (DUA)",
+    description:
+      "Governs access to the de-identified outcome registry for academic research and CRO partnerships.",
+    audience: ["research_institution"],
+    keyClauses: [
+      "De-identification standard (HIPAA Safe Harbor)",
+      "Permitted research purposes + IRB requirement",
+      "No re-identification covenant",
+      "Publication review + acknowledgement obligations",
+    ],
+    defaultTerms: {
+      termYears: 2,
+      autoRenewYears: 1,
+      noticeDays: 60,
+      feeStructure: "Per-study access fee + revenue share on commercial use",
+    },
+  },
+];
+
+/**
+ * Build the framework summary the operator surface renders on
+ * /ops/platform/licensing → "IP & Compliance" panel.
+ */
+export interface LicensingFrameworkSummary {
+  tiers: LicenseeTier[];
+  ipCounts: Record<IpClaimKind, number>;
+  attestationFrameworks: AttestationFramework[];
+  contractCount: number;
+  /** True iff there's at least one patent-pending claim — drives the badge. */
+  hasPatentPending: boolean;
+}
+
+export function buildFrameworkSummary(): LicensingFrameworkSummary {
+  const ipCounts: Record<IpClaimKind, number> = {
+    patent_pending: 0,
+    patent_filed: 0,
+    trademark: 0,
+    trade_secret: 0,
+    copyright: 0,
+  };
+  for (const c of INTELLECTUAL_PROPERTY) ipCounts[c.kind] += 1;
+
+  return {
+    tiers: LICENSEE_TIERS,
+    ipCounts,
+    attestationFrameworks: COMPLIANCE_ATTESTATIONS.map((a) => a.framework),
+    contractCount: SAMPLE_CONTRACTS.length,
+    hasPatentPending: ipCounts.patent_pending > 0,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 9 Track 4 — Security/Admin track. Implements the remaining
compliance, audit, and security surfaces with full vitest coverage.

- **EMR-064 (Audit Log PDF Export)** — print-ready HTML + CSV renderer + `/api/audit/report` endpoint
- **EMR-065 (AI Compliance Audit Agent)** — note-level compliance checker covering CMS E/M, JC RC.01.01.01, 42 CFR §482.24, PDMP requirements
- **EMR-081 (OCR Scan + Auto-Populate)** — chart-merge planner with add/duplicate/conflict/review bucketing; height-regex bug fix
- **EMR-082 (Provider Record Release)** — workflow engine: policy evaluation, e-sig validation, state machine, audit payloads
- **EMR-084 (Encryption + Licensing IP Framework)** — encryption-framework tests + new licensing-framework module (LICENSEE_TIERS, INTELLECTUAL_PROPERTY, COMPLIANCE_ATTESTATIONS, SAMPLE_CONTRACTS)
- **EMR-088 (Cannabis Contraindication Override)** — full gate/override/audit test coverage
- **EMR-094 (Mental Health Chart Security Overlay)** — full test coverage + new `<SensitiveRecordWall />` break-glass component

### Tests

- **151 new vitest cases** across 12 test files, all passing.
- Pre-existing test failures (`specialty-templates` extensibility, several `server-only` import shims) are unchanged.
- `tsc --noEmit` clean.

## Test plan

- [x] `npm test` — 151 new tests pass; only pre-existing failures remain
- [x] `npx tsc --noEmit` — clean
- [ ] Manually exercise `/api/audit/report?format=html` (requires auth)
- [ ] Manually exercise `/api/audit/report?format=csv` (requires auth)
- [ ] Smoke-render `<SensitiveRecordWall />` in a chart route
- [ ] Operator licensing page picks up new `buildFrameworkSummary()` data