### PR TITLE
feat(telehealth+scheduling): Wave 10 UI components (EMR-074..EMR-079)

### DIFF
--- a/docs/superpowers/specs/2026-05-13-wearables-cds-engine-design.md
+++ b/docs/superpowers/specs/2026-05-13-wearables-cds-engine-design.md
@@ -1,0 +1,43 @@
+# Wearables Sync & CDS Engine Design
+
+## Overview
+A unified background architecture to continuously ingest biometric data from connected wearables (Whoop, Garmin, Dexcom, etc.) and run it through a Clinical Decision Support (CDS) Rules Engine to proactively alert providers of clinically significant events.
+
+## 1. The Sync Daemon (Data Liquidity)
+**Purpose:** Fetch recent data from wearable APIs and normalize it into the database.
+* **Trigger:** An external cron scheduler calling a secured Next.js API route (e.g., `/api/cron/sync-wearables`) hourly.
+* **Flow:**
+  1. Query DB for all patients with active wearable integration tokens.
+  2. Iterate through each patient and device type.
+  3. Call the respective client (e.g., `whoopClient.syncPatientData()`) to pull the last 24 hours of data.
+  4. Write normalized data to `OutcomeLog` and `ClinicalObservation`.
+* **Error Handling:** If an API call fails or a token is expired, the system writes to `AuditLog` (or logs a failed `AgentJob`) and continues to the next patient to ensure the queue doesn't stall.
+
+## 2. The Clinical Decision Support (CDS) Engine
+**Purpose:** Evaluate fresh data against clinical rules to detect concerning trends.
+* **Component:** `src/lib/cds/engine.ts`
+* **Flow:** 
+  1. Once data is saved, the Sync Daemon triggers `evaluatePatientCDS(patientId)`.
+  2. The engine retrieves the patient's recent `OutcomeLog` and `ClinicalObservation` records (last 24-48 hours).
+  3. It runs a suite of pure functions ("Rules") against this data.
+* **Example Rules:**
+  * **Overtraining / Burnout Risk:** Whoop Strain > 16 AND Recovery < 40%.
+  * **Sustained Sleep Debt:** Sleep `OutcomeLog` < 6 hours for 3 consecutive days.
+  * **Hypoglycemia Risk:** Dexcom reading < 70 mg/dL.
+* **Output:** If a rule evaluates to `true`, it returns a `CDSTrigger` object.
+
+## 3. Provider Alert Routing (Inbox Integration)
+**Purpose:** Route `CDSTrigger` events to the provider without causing alert fatigue.
+* **Component:** `src/lib/cds/alerts.ts`
+* **Flow:**
+  1. Receives a `CDSTrigger` from the CDS Engine.
+  2. Checks for deduplication: *Does an open Task already exist for this specific patient and this specific rule within the last 24 hours?*
+  3. If no duplicate exists, it creates a `Task` assigned to the patient's care team.
+* **Task Details:**
+  * Priority maps to rule severity (e.g., Hypoglycemia = "Urgent").
+  * Title and description explain the trigger context.
+  * Includes a deep link to the patient's chart/biometrics tab.
+
+## Testing Strategy
+* **Rules Engine:** Since rules are pure functions, they will be comprehensively unit-tested using mock arrays of `OutcomeLog` and `ClinicalObservation` data to verify triggers fire accurately.
+* **Alert Routing:** Unit tests to verify the 24-hour deduplication logic prevents duplicate Task creation.

--- a/src/components/scheduling/sms-reminder-toggle.tsx
+++ b/src/components/scheduling/sms-reminder-toggle.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import React, { useState } from "react";
+
+export interface SmsReminderConfig {
+  enabled: boolean;
+  /** Minutes before appointment to send each reminder, ordered. */
+  offsetsMinutes: number[];
+}
+
+export interface SmsReminderToggleProps {
+  initial?: SmsReminderConfig;
+  patientPhone?: string;
+  onChange?: (config: SmsReminderConfig) => void;
+  className?: string;
+}
+
+interface OffsetOption {
+  minutes: number;
+  label: string;
+}
+
+const OFFSET_OPTIONS: OffsetOption[] = [
+  { minutes: 60 * 24 * 2, label: "2 days before" },
+  { minutes: 60 * 24, label: "1 day before" },
+  { minutes: 60 * 2, label: "2 hours before" },
+  { minutes: 30, label: "30 minutes before" },
+];
+
+const DEFAULT_CONFIG: SmsReminderConfig = {
+  enabled: true,
+  offsetsMinutes: [60 * 24, 60 * 2],
+};
+
+function maskPhone(raw?: string): string | null {
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length < 4) return raw;
+  const last4 = digits.slice(-4);
+  return `••• ••• ${last4}`;
+}
+
+export function SmsReminderToggle({
+  initial = DEFAULT_CONFIG,
+  patientPhone,
+  onChange,
+  className,
+}: SmsReminderToggleProps) {
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [offsets, setOffsets] = useState<number[]>(initial.offsetsMinutes);
+
+  const emit = (next: SmsReminderConfig) => {
+    onChange?.(next);
+  };
+
+  const toggleEnabled = () => {
+    const next = !enabled;
+    setEnabled(next);
+    emit({ enabled: next, offsetsMinutes: offsets });
+  };
+
+  const toggleOffset = (minutes: number) => {
+    setOffsets((prev) => {
+      const next = prev.includes(minutes) ? prev.filter((m) => m !== minutes) : [...prev, minutes].sort((a, b) => b - a);
+      emit({ enabled, offsetsMinutes: next });
+      return next;
+    });
+  };
+
+  const masked = maskPhone(patientPhone);
+
+  return (
+    <div
+      className={`rounded-2xl border border-[var(--border)] bg-white p-5 ${className ?? ""}`}
+      aria-labelledby="sms-reminder-title"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 id="sms-reminder-title" className="text-sm font-semibold text-text">
+            SMS reminders
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            {masked ? `Send to ${masked}` : "Text the patient before their appointment"}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={toggleEnabled}
+          className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${
+            enabled ? "bg-[var(--accent)]" : "bg-[var(--surface-muted)] border border-[var(--border)]"
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${
+              enabled ? "translate-x-[22px]" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+
+      <fieldset
+        disabled={!enabled}
+        className={`mt-4 transition-opacity ${enabled ? "opacity-100" : "opacity-50"}`}
+      >
+        <legend className="text-xs font-medium uppercase tracking-wider text-text-muted mb-2">
+          When to remind
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {OFFSET_OPTIONS.map((opt) => {
+            const active = offsets.includes(opt.minutes);
+            return (
+              <button
+                key={opt.minutes}
+                type="button"
+                onClick={() => toggleOffset(opt.minutes)}
+                aria-pressed={active}
+                className={`text-xs font-medium px-3 h-8 rounded-lg border transition-colors ${
+                  active
+                    ? "bg-[var(--accent)] text-white border-[var(--accent)]"
+                    : "bg-white text-text border-[var(--border)] hover:border-[var(--accent)]"
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+        {enabled && offsets.length === 0 && (
+          <p className="text-xs text-amber-700 mt-2">
+            Choose at least one reminder time, or disable SMS reminders entirely.
+          </p>
+        )}
+      </fieldset>
+    </div>
+  );
+}
+
+export default SmsReminderToggle;

--- a/src/components/scheduling/sms-reminder-toggle.tsx
+++ b/src/components/scheduling/sms-reminder-toggle.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 scheduling scaffold (EMR-078); mounted on the scheduling workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/scheduling/time-off-block.tsx
+++ b/src/components/scheduling/time-off-block.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 scheduling scaffold (EMR-079); mounted on the scheduling workspace in a later wave"
 "use client";
 
 import React, { useMemo, useState } from "react";

--- a/src/components/scheduling/time-off-block.tsx
+++ b/src/components/scheduling/time-off-block.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input, Label, Textarea } from "@/components/ui/input";
+
+export type TimeOffReason = "vacation" | "conference" | "sick" | "personal" | "cme" | "other";
+
+export interface TimeOffBlock {
+  providerId: string;
+  startDate: string;
+  endDate: string;
+  allDay: boolean;
+  startTime?: string;
+  endTime?: string;
+  reason: TimeOffReason;
+  notes?: string;
+}
+
+export interface TimeOffBlockProps {
+  providerId: string;
+  providerName?: string;
+  /** Number of appointments that fall in the proposed window. Shown to
+   *  the user as a warning when > 0; the scheduler reconciles them. */
+  affectedAppointments?: number;
+  initial?: Partial<TimeOffBlock>;
+  onSave?: (block: TimeOffBlock) => Promise<void> | void;
+}
+
+const REASON_OPTIONS: { value: TimeOffReason; label: string }[] = [
+  { value: "vacation", label: "Vacation" },
+  { value: "conference", label: "Conference" },
+  { value: "cme", label: "CME / training" },
+  { value: "sick", label: "Sick" },
+  { value: "personal", label: "Personal" },
+  { value: "other", label: "Other" },
+];
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function TimeOffBlockForm({
+  providerId,
+  providerName,
+  affectedAppointments = 0,
+  initial,
+  onSave,
+}: TimeOffBlockProps) {
+  const [startDate, setStartDate] = useState(initial?.startDate ?? todayIso());
+  const [endDate, setEndDate] = useState(initial?.endDate ?? todayIso());
+  const [allDay, setAllDay] = useState(initial?.allDay ?? true);
+  const [startTime, setStartTime] = useState(initial?.startTime ?? "09:00");
+  const [endTime, setEndTime] = useState(initial?.endTime ?? "17:00");
+  const [reason, setReason] = useState<TimeOffReason>(initial?.reason ?? "vacation");
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const dateError = useMemo(() => {
+    if (!startDate || !endDate) return null;
+    if (endDate < startDate) return "End date is before start date.";
+    if (!allDay && startDate === endDate && endTime <= startTime) {
+      return "End time must be after start time.";
+    }
+    return null;
+  }, [startDate, endDate, allDay, startTime, endTime]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (dateError) return;
+    const block: TimeOffBlock = {
+      providerId,
+      startDate,
+      endDate,
+      allDay,
+      startTime: allDay ? undefined : startTime,
+      endTime: allDay ? undefined : endTime,
+      reason,
+      notes: notes.trim() || undefined,
+    };
+    setSaving(true);
+    try {
+      if (onSave) await onSave(block);
+      else console.log("Time-off block:", block);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>Block time off</CardTitle>
+        <CardDescription>
+          {providerName ? `Hold time on ${providerName}'s calendar.` : "Hold time on the provider's calendar."} Existing appointments in this window will surface for rescheduling.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-5">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="to-start-date">Start date</Label>
+              <Input
+                id="to-start-date"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="to-end-date">End date</Label>
+              <Input
+                id="to-end-date"
+                type="date"
+                value={endDate}
+                min={startDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-text">
+            <input
+              type="checkbox"
+              checked={allDay}
+              onChange={(e) => setAllDay(e.target.checked)}
+              className="w-4 h-4 rounded border-[var(--border)] text-[var(--accent)] focus:ring-[var(--accent)]/30"
+            />
+            All day
+          </label>
+
+          {!allDay && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="to-start-time">Start time</Label>
+                <Input
+                  id="to-start-time"
+                  type="time"
+                  value={startTime}
+                  onChange={(e) => setStartTime(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="to-end-time">End time</Label>
+                <Input
+                  id="to-end-time"
+                  type="time"
+                  value={endTime}
+                  onChange={(e) => setEndTime(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="to-reason">Reason</Label>
+            <select
+              id="to-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value as TimeOffReason)}
+              className="w-full h-11 px-3 bg-white border border-[var(--border)] rounded-xl text-sm outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20"
+            >
+              {REASON_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="to-notes">Notes (optional)</Label>
+            <Textarea
+              id="to-notes"
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Visible to schedulers only"
+            />
+          </div>
+
+          {dateError && (
+            <div className="p-3 rounded-xl bg-red-50 border border-red-200 text-sm text-red-700">{dateError}</div>
+          )}
+
+          {!dateError && affectedAppointments > 0 && (
+            <div className="p-3 rounded-xl bg-amber-50 border border-amber-200 text-sm text-amber-800">
+              {affectedAppointments} existing appointment{affectedAppointments === 1 ? "" : "s"} fall in this window
+              and will need to be moved or canceled.
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-end">
+          <Button type="submit" variant="primary" disabled={saving || !!dateError}>
+            {saving ? "Saving…" : "Block time"}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+export default TimeOffBlockForm;

--- a/src/components/scheduling/waitlist-card.tsx
+++ b/src/components/scheduling/waitlist-card.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+
+export type WaitlistPriority = "routine" | "soon" | "urgent";
+
+export interface WaitlistEntry {
+  id: string;
+  patientName: string;
+  requestedRange: string;
+  reason: string;
+  priority: WaitlistPriority;
+  daysWaiting: number;
+  preferredProvider?: string;
+  contactMethod?: "phone" | "sms" | "email";
+}
+
+export interface WaitlistCardProps {
+  entry: WaitlistEntry;
+  onSchedule?: (entry: WaitlistEntry) => void;
+  onNotify?: (entry: WaitlistEntry) => void;
+  onRemove?: (entry: WaitlistEntry) => void;
+}
+
+const PRIORITY_STYLES: Record<WaitlistPriority, { label: string; tone: string }> = {
+  routine: { label: "Routine", tone: "bg-[var(--surface-muted)] text-text-muted border-[var(--border)]" },
+  soon: { label: "Soon", tone: "bg-amber-50 text-amber-700 border-amber-200" },
+  urgent: { label: "Urgent", tone: "bg-red-50 text-red-700 border-red-200" },
+};
+
+const CONTACT_LABEL: Record<NonNullable<WaitlistEntry["contactMethod"]>, string> = {
+  phone: "📞 Phone",
+  sms: "💬 SMS",
+  email: "✉️ Email",
+};
+
+export function WaitlistCard({ entry, onSchedule, onNotify, onRemove }: WaitlistCardProps) {
+  const priority = PRIORITY_STYLES[entry.priority];
+
+  return (
+    <article
+      className="w-full max-w-md rounded-2xl border border-[var(--border)] bg-white shadow-sm overflow-hidden"
+      aria-labelledby={`wl-${entry.id}-name`}
+    >
+      <div className="px-5 pt-4 pb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 id={`wl-${entry.id}-name`} className="text-base font-semibold text-text truncate">
+            {entry.patientName}
+          </h3>
+          <p className="text-xs text-text-muted truncate mt-0.5">{entry.requestedRange}</p>
+        </div>
+        <span className={`text-[11px] font-semibold uppercase tracking-wider px-2 py-1 rounded-md border whitespace-nowrap ${priority.tone}`}>
+          {priority.label}
+        </span>
+      </div>
+
+      <div className="px-5 pb-3 space-y-2 text-sm text-text">
+        <div className="flex items-start gap-2">
+          <span className="text-text-muted text-xs uppercase tracking-wider w-20 shrink-0 pt-0.5">Reason</span>
+          <span className="flex-1">{entry.reason}</span>
+        </div>
+        {entry.preferredProvider && (
+          <div className="flex items-start gap-2">
+            <span className="text-text-muted text-xs uppercase tracking-wider w-20 shrink-0 pt-0.5">Provider</span>
+            <span className="flex-1">{entry.preferredProvider}</span>
+          </div>
+        )}
+        <div className="flex items-start gap-2">
+          <span className="text-text-muted text-xs uppercase tracking-wider w-20 shrink-0 pt-0.5">Waiting</span>
+          <span className="flex-1">
+            {entry.daysWaiting} {entry.daysWaiting === 1 ? "day" : "days"}
+            {entry.contactMethod && (
+              <span className="ml-2 text-text-muted">{CONTACT_LABEL[entry.contactMethod]}</span>
+            )}
+          </span>
+        </div>
+      </div>
+
+      <div className="px-5 py-3 bg-[var(--surface-muted)]/40 border-t border-[var(--border)] flex flex-wrap items-center gap-2 justify-end">
+        <button
+          type="button"
+          onClick={() => onRemove?.(entry)}
+          className="text-xs font-medium text-text-muted hover:text-red-600 px-2 py-1"
+        >
+          Remove
+        </button>
+        <button
+          type="button"
+          onClick={() => onNotify?.(entry)}
+          className="text-xs font-medium px-3 h-8 rounded-lg border border-[var(--border)] bg-white hover:border-[var(--accent)]"
+        >
+          Notify
+        </button>
+        <button
+          type="button"
+          onClick={() => onSchedule?.(entry)}
+          className="text-xs font-medium px-3 h-8 rounded-lg bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+        >
+          Schedule
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export default WaitlistCard;

--- a/src/components/scheduling/waitlist-card.tsx
+++ b/src/components/scheduling/waitlist-card.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 scheduling scaffold (EMR-077); mounted on the scheduling workspace in a later wave"
 "use client";
 
 import React from "react";

--- a/src/components/telehealth/call-controls.tsx
+++ b/src/components/telehealth/call-controls.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 telehealth scaffold (EMR-075); mounted on the visit workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/telehealth/call-controls.tsx
+++ b/src/components/telehealth/call-controls.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState } from "react";
+
+export interface CallControlState {
+  micMuted: boolean;
+  cameraOff: boolean;
+  screenSharing: boolean;
+  chatOpen: boolean;
+}
+
+export interface CallControlsProps {
+  initial?: Partial<CallControlState>;
+  onChange?: (state: CallControlState) => void;
+  onLeave?: () => void;
+  unreadChatCount?: number;
+}
+
+const DEFAULTS: CallControlState = {
+  micMuted: false,
+  cameraOff: false,
+  screenSharing: false,
+  chatOpen: false,
+};
+
+interface ControlButtonProps {
+  label: string;
+  active: boolean;
+  danger?: boolean;
+  badge?: number;
+  onClick: () => void;
+  iconOn: string;
+  iconOff: string;
+}
+
+function ControlButton({ label, active, danger, badge, onClick, iconOn, iconOff }: ControlButtonProps) {
+  const tone = danger
+    ? "bg-red-500 text-white hover:bg-red-600 border-red-500"
+    : active
+      ? "bg-[var(--accent)] text-white border-[var(--accent)] hover:bg-[var(--accent)]/90"
+      : "bg-white text-text border-[var(--border)] hover:border-[var(--accent)]";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      className={`relative w-14 h-14 rounded-2xl border grid place-items-center text-xl transition-colors ${tone}`}
+    >
+      <span aria-hidden="true">{active ? iconOn : iconOff}</span>
+      {badge != null && badge > 0 && (
+        <span className="absolute -top-1 -right-1 min-w-[20px] h-5 px-1 rounded-full bg-red-500 text-white text-[10px] font-bold grid place-items-center">
+          {badge > 99 ? "99+" : badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function CallControls({ initial, onChange, onLeave, unreadChatCount = 0 }: CallControlsProps) {
+  const [state, setState] = useState<CallControlState>({ ...DEFAULTS, ...initial });
+
+  const update = <K extends keyof CallControlState>(key: K, value: CallControlState[K]) => {
+    setState((prev) => {
+      const next = { ...prev, [key]: value };
+      onChange?.(next);
+      return next;
+    });
+  };
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Call controls"
+      className="inline-flex items-center gap-3 bg-white border border-[var(--border)] rounded-3xl shadow-sm px-4 py-3"
+    >
+      <ControlButton
+        label={state.micMuted ? "Unmute microphone" : "Mute microphone"}
+        active={!state.micMuted}
+        onClick={() => update("micMuted", !state.micMuted)}
+        iconOn="🎙️"
+        iconOff="🔇"
+      />
+      <ControlButton
+        label={state.cameraOff ? "Turn camera on" : "Turn camera off"}
+        active={!state.cameraOff}
+        onClick={() => update("cameraOff", !state.cameraOff)}
+        iconOn="📷"
+        iconOff="🚫"
+      />
+      <ControlButton
+        label={state.screenSharing ? "Stop sharing screen" : "Share screen"}
+        active={state.screenSharing}
+        onClick={() => update("screenSharing", !state.screenSharing)}
+        iconOn="🖥️"
+        iconOff="🖥️"
+      />
+      <ControlButton
+        label={state.chatOpen ? "Close chat" : "Open chat"}
+        active={state.chatOpen}
+        badge={unreadChatCount}
+        onClick={() => update("chatOpen", !state.chatOpen)}
+        iconOn="💬"
+        iconOff="💬"
+      />
+      <div className="w-px h-10 bg-[var(--border)] mx-1" aria-hidden="true" />
+      <ControlButton
+        label="Leave call"
+        active={false}
+        danger
+        onClick={() => onLeave?.()}
+        iconOn="📞"
+        iconOff="📞"
+      />
+    </div>
+  );
+}
+
+export default CallControls;

--- a/src/components/telehealth/screen-share-btn.tsx
+++ b/src/components/telehealth/screen-share-btn.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 telehealth scaffold (EMR-076); mounted on the visit workspace in a later wave"
 "use client";
 
 import React, { useState } from "react";

--- a/src/components/telehealth/screen-share-btn.tsx
+++ b/src/components/telehealth/screen-share-btn.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React, { useState } from "react";
+
+export interface ScreenShareBtnProps {
+  isSharing?: boolean;
+  /** If true, prompt for confirmation before starting share. Default true. */
+  confirmBeforeShare?: boolean;
+  onStartShare?: () => Promise<void> | void;
+  onStopShare?: () => Promise<void> | void;
+  className?: string;
+}
+
+type Phase = "idle" | "confirming" | "starting" | "sharing" | "stopping";
+
+export function ScreenShareBtn({
+  isSharing = false,
+  confirmBeforeShare = true,
+  onStartShare,
+  onStopShare,
+  className,
+}: ScreenShareBtnProps) {
+  const [phase, setPhase] = useState<Phase>(isSharing ? "sharing" : "idle");
+
+  const handleClick = async () => {
+    if (phase === "starting" || phase === "stopping") return;
+    if (phase === "sharing") {
+      setPhase("stopping");
+      try {
+        await onStopShare?.();
+        setPhase("idle");
+      } catch {
+        setPhase("sharing");
+      }
+      return;
+    }
+    if (confirmBeforeShare && phase === "idle") {
+      setPhase("confirming");
+      return;
+    }
+    await beginShare();
+  };
+
+  const beginShare = async () => {
+    setPhase("starting");
+    try {
+      await onStartShare?.();
+      setPhase("sharing");
+    } catch {
+      setPhase("idle");
+    }
+  };
+
+  const cancelConfirm = () => setPhase("idle");
+
+  const isActive = phase === "sharing" || phase === "starting";
+  const label =
+    phase === "starting"
+      ? "Starting…"
+      : phase === "stopping"
+        ? "Stopping…"
+        : phase === "sharing"
+          ? "Stop sharing"
+          : "Share screen";
+
+  return (
+    <div className={`inline-block ${className ?? ""}`}>
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-pressed={isActive}
+        disabled={phase === "starting" || phase === "stopping"}
+        className={`inline-flex items-center gap-2 px-4 h-11 rounded-xl border text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-[var(--accent)] text-white border-[var(--accent)] hover:bg-[var(--accent)]/90"
+            : "bg-white text-text border-[var(--border)] hover:border-[var(--accent)]"
+        } disabled:opacity-60 disabled:cursor-not-allowed`}
+      >
+        <span aria-hidden="true">🖥️</span>
+        {label}
+        {isActive && phase === "sharing" && (
+          <span className="ml-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-wider font-semibold">
+            <span className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" />
+            Live
+          </span>
+        )}
+      </button>
+
+      {phase === "confirming" && (
+        <div
+          role="dialog"
+          aria-label="Confirm screen share"
+          className="mt-3 max-w-sm p-4 rounded-2xl border border-[var(--border)] bg-white shadow-md"
+        >
+          <p className="text-sm text-text">
+            You&apos;re about to share your screen. Only share what&apos;s relevant — close any windows
+            with PHI you don&apos;t intend to show.
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancelConfirm}
+              className="px-3 h-9 rounded-lg text-sm border border-[var(--border)] hover:bg-[var(--surface-muted)]/40"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={beginShare}
+              className="px-3 h-9 rounded-lg text-sm font-medium bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+            >
+              Share screen
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ScreenShareBtn;

--- a/src/components/telehealth/waiting-room.tsx
+++ b/src/components/telehealth/waiting-room.tsx
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Wave 10 telehealth scaffold (EMR-074); mounted on the visit workspace in a later wave"
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";

--- a/src/components/telehealth/waiting-room.tsx
+++ b/src/components/telehealth/waiting-room.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export type WaitingStatus = "waiting" | "provider_ready" | "in_call" | "ended";
+
+export interface WaitingRoomProps {
+  patientName: string;
+  providerName: string;
+  appointmentTimeIso: string;
+  queuePosition?: number;
+  status?: WaitingStatus;
+  onJoin?: () => void;
+  onLeave?: () => void;
+  onToggleMic?: (muted: boolean) => void;
+  onToggleCamera?: (off: boolean) => void;
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function WaitingRoom({
+  patientName,
+  providerName,
+  appointmentTimeIso,
+  queuePosition,
+  status = "waiting",
+  onJoin,
+  onLeave,
+  onToggleMic,
+  onToggleCamera,
+}: WaitingRoomProps) {
+  const [muted, setMuted] = useState(false);
+  const [cameraOff, setCameraOff] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (status === "ended") return;
+    const id = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  const statusBanner = useMemo(() => {
+    if (status === "provider_ready") {
+      return { label: "Your provider is ready", tone: "bg-emerald-50 text-emerald-700 border-emerald-200" };
+    }
+    if (status === "in_call") {
+      return { label: "Connected", tone: "bg-emerald-50 text-emerald-700 border-emerald-200" };
+    }
+    if (status === "ended") {
+      return { label: "Call ended", tone: "bg-[var(--surface-muted)] text-text-muted border-[var(--border)]" };
+    }
+    return { label: "Waiting for provider", tone: "bg-amber-50 text-amber-700 border-amber-200" };
+  }, [status]);
+
+  const handleMic = () => {
+    const next = !muted;
+    setMuted(next);
+    onToggleMic?.(next);
+  };
+
+  const handleCamera = () => {
+    const next = !cameraOff;
+    setCameraOff(next);
+    onToggleCamera?.(next);
+  };
+
+  const canJoin = status === "provider_ready" || status === "in_call";
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>Telehealth Waiting Room</CardTitle>
+        <CardDescription>
+          {patientName} • Visit with {providerName} at {formatTime(appointmentTimeIso)}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className={`text-sm font-medium px-3 py-2 rounded-lg border ${statusBanner.tone}`}>
+          {statusBanner.label}
+          {status === "waiting" && queuePosition != null && queuePosition > 1 && (
+            <span className="ml-2 text-text-muted">— position {queuePosition} in queue</span>
+          )}
+        </div>
+
+        <div className="aspect-video w-full rounded-2xl bg-[var(--surface-muted)] border border-[var(--border)] grid place-items-center text-text-muted">
+          {cameraOff ? (
+            <div className="text-center">
+              <div className="text-4xl mb-2" aria-hidden="true">📷</div>
+              <div className="text-sm">Camera off</div>
+            </div>
+          ) : (
+            <div className="text-center">
+              <div className="w-20 h-20 rounded-full bg-[var(--accent)]/20 grid place-items-center text-[var(--accent)] text-3xl font-bold mx-auto mb-2">
+                {patientName.charAt(0).toUpperCase()}
+              </div>
+              <div className="text-sm">{patientName}</div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-text-muted">
+          <span>Connection: stable</span>
+          <span className="tabular-nums">In room {formatElapsed(elapsed)}</span>
+        </div>
+
+        <div className="flex items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={handleMic}
+            className={`w-12 h-12 rounded-full border grid place-items-center transition-colors ${
+              muted
+                ? "bg-red-50 border-red-200 text-red-600"
+                : "bg-white border-[var(--border)] text-text hover:border-[var(--accent)]"
+            }`}
+            aria-pressed={muted}
+            aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+          >
+            {muted ? "🔇" : "🎙️"}
+          </button>
+          <button
+            type="button"
+            onClick={handleCamera}
+            className={`w-12 h-12 rounded-full border grid place-items-center transition-colors ${
+              cameraOff
+                ? "bg-red-50 border-red-200 text-red-600"
+                : "bg-white border-[var(--border)] text-text hover:border-[var(--accent)]"
+            }`}
+            aria-pressed={cameraOff}
+            aria-label={cameraOff ? "Turn camera on" : "Turn camera off"}
+          >
+            {cameraOff ? "🚫" : "📷"}
+          </button>
+        </div>
+      </CardContent>
+      <CardFooter className="pt-6 border-t border-[var(--border)] flex justify-between">
+        <Button type="button" variant="ghost" onClick={onLeave}>
+          Leave
+        </Button>
+        <Button type="button" variant="primary" disabled={!canJoin} onClick={onJoin}>
+          {status === "in_call" ? "In call" : canJoin ? "Join visit" : "Waiting…"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default WaitingRoom;


### PR DESCRIPTION
## Summary
Closes out Wave 10 — six isolated, client-only UI components.

| ID | File | What it is |
|---|---|---|
| EMR-074 | `telehealth/waiting-room.tsx` | Patient lobby with mic/camera toggles, queue-position indicator, provider-ready banner |
| EMR-075 | `telehealth/call-controls.tsx` | In-call toolbar: mic / camera / screen-share / chat (with unread badge) / leave |
| EMR-076 | `telehealth/screen-share-btn.tsx` | Standalone share toggle with PHI-aware confirm dialog and async start/stop |
| EMR-077 | `scheduling/waitlist-card.tsx` | Waitlist entry with priority pill (routine/soon/urgent), reason, days-waiting, schedule/notify/remove |
| EMR-078 | `scheduling/sms-reminder-toggle.tsx` | Appointment SMS reminder switch with multi-offset chips (2d / 1d / 2h / 30m) and masked phone display |
| EMR-079 | `scheduling/time-off-block.tsx` | Provider time-off form with all-day toggle, date/time validation, affected-appointment warning |

All match the Wave 8/9 style — `Card` + `Button` + `Input/Textarea/Label`, pure UI, props for `onSave` / `onChange` / `onLeave` callbacks.

## Test plan
- [ ] `npm run typecheck` clean ✅
- [ ] Mount each on a sandbox route, click through happy paths
- [ ] Time-off form: pick end-date before start-date → inline error appears; affected-appointments warning shows when count > 0
- [ ] SMS toggle: deselect all offsets while enabled → inline hint appears
- [ ] Screen-share button: first click → confirm dialog, second click on confirm → "Live" indicator
- [ ] Waitlist card: each of the three buttons fires its callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)