### PR TITLE
fix(education): EMR-299 route Education > Learn topics to the Educational Library

### DIFF
--- a/src/app/(patient)/portal/learn/page.tsx
+++ b/src/app/(patient)/portal/learn/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -28,9 +29,26 @@ const EVIDENCE_TONE: Record<string, "success" | "info" | "warning" | "neutral"> 
   anecdotal: "neutral",
 };
 
+const TAB_VALUES: readonly Tab[] = ["conditions", "cannabinoids", "terpenes", "delivery"];
+
+function parseTab(raw: string | null): Tab | null {
+  if (!raw) return null;
+  return (TAB_VALUES as readonly string[]).includes(raw) ? (raw as Tab) : null;
+}
+
 export default function LearnPage() {
-  const [tab, setTab] = useState<Tab>("conditions");
+  const searchParams = useSearchParams();
+  const initialTab = parseTab(searchParams.get("tab")) ?? "conditions";
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [search, setSearch] = useState("");
+
+  // Re-sync tab when the user navigates between deep links from
+  // the Education hub without a full page reload.
+  useEffect(() => {
+    const next = parseTab(searchParams.get("tab"));
+    if (next && next !== tab) setTab(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   const searchResults = useMemo(() => {
     if (search.length < 2) return null;

--- a/src/components/education/LearnTab.tsx
+++ b/src/components/education/LearnTab.tsx
@@ -8,56 +8,58 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FileText, ArrowRight, Video, Sparkles, HelpCircle, Activity, ShieldCheck } from "lucide-react";
 
+// Every topic deep-links into the Educational Library (/portal/learn).
+// The library page reads ?tab to preselect the right section.
 const LEARN_TOPICS = [
-  { 
-    title: "What is CBD?", 
-    desc: "A beginner's guide to cannabidiol — the non-psychoactive cannabinoid changing medicine.", 
-    href: "/portal/education",
+  {
+    title: "What is CBD?",
+    desc: "A beginner's guide to cannabidiol — the non-psychoactive cannabinoid changing medicine.",
+    href: "/portal/learn?tab=cannabinoids",
     icon: Sparkles,
     color: "text-leaf",
     bg: "bg-mint",
     border: "border-mint"
   },
-  { 
-    title: "How to dose cannabis", 
-    desc: "Start low, go slow. Learn the principles of safe, effective cannabis dosing.", 
-    href: "/portal/dosing",
+  {
+    title: "How to dose cannabis",
+    desc: "Start low, go slow. Learn the principles of safe, effective cannabis dosing.",
+    href: "/portal/learn?tab=conditions",
     icon: Activity,
     color: "text-leaf",
     bg: "bg-sage",
     border: "border-sage"
   },
-  { 
-    title: "Routes of administration", 
-    desc: "Oral, sublingual, inhaled, topical — which delivery method is right for you?", 
-    href: "/portal/education",
+  {
+    title: "Routes of administration",
+    desc: "Oral, sublingual, inhaled, topical — which delivery method is right for you?",
+    href: "/portal/learn?tab=delivery",
     icon: FileText,
     color: "text-ink",
     bg: "bg-lilac",
     border: "border-lilac"
   },
-  { 
-    title: "Understanding terpenes", 
-    desc: "The aromatic compounds that shape each strain's unique therapeutic effects.", 
-    href: "/portal/education",
+  {
+    title: "Understanding terpenes",
+    desc: "The aromatic compounds that shape each strain's unique therapeutic effects.",
+    href: "/portal/learn?tab=terpenes",
     icon: Sparkles,
     color: "text-highlight-hover",
     bg: "bg-butter",
     border: "border-butter"
   },
-  { 
-    title: "Cannabis & your medications", 
-    desc: "Important drug interactions every patient and caregiver should know.", 
-    href: "/portal/education",
+  {
+    title: "Cannabis & your medications",
+    desc: "Important drug interactions every patient and caregiver should know.",
+    href: "/portal/learn?tab=conditions",
     icon: ShieldCheck,
     color: "text-danger",
     bg: "bg-rose",
     border: "border-rose"
   },
-  { 
-    title: "Legal considerations", 
-    desc: "State laws, federal status, and what it means for your workplace and travel.", 
-    href: "/portal/qa",
+  {
+    title: "Legal considerations",
+    desc: "State laws, federal status, and what it means for your workplace and travel.",
+    href: "/portal/learn",
     icon: HelpCircle,
     color: "text-text-muted",
     bg: "bg-peach",
@@ -151,7 +153,7 @@ export function LearnTab() {
       </Card>
       
       <div className="text-center pt-8">
-        <Link href="/portal/education">
+        <Link href="/portal/learn">
           <Button variant="secondary" size="lg" className="rounded-xl font-bold border-2 text-text hover:bg-surface-muted">
             Browse Full Library
             <ArrowRight className="w-5 h-5 ml-2" />


### PR DESCRIPTION
## Summary
Fixes [EMR-299](https://linear.app/emr-project/issue/EMR-299) — Dr. Patel reported that clicking topics under **Education > Learn** ("What is CBD?", "How to dose cannabis", etc.) navigated to the personalized Care Guide (\`/portal/education\`) or Dosing Recommendations (\`/portal/dosing\`) instead of the Educational Library.

## What changed
- **\`src/components/education/LearnTab.tsx\`** — every topic card now links to \`/portal/learn\` with a \`?tab=\` hint for deep linking:
  - What is CBD? → \`/portal/learn?tab=cannabinoids\`
  - How to dose cannabis → \`/portal/learn?tab=conditions\`
  - Routes of administration → \`/portal/learn?tab=delivery\`
  - Understanding terpenes → \`/portal/learn?tab=terpenes\`
  - Cannabis & your medications → \`/portal/learn?tab=conditions\`
  - Legal considerations → \`/portal/learn\`
  - "Browse Full Library" CTA also now points at \`/portal/learn\`.
- **\`src/app/(patient)/portal/learn/page.tsx\`** — reads \`?tab\` from the URL on mount and re-syncs on \`searchParams\` change, so deep links open the right section.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] Patient portal: Education > Learn > click each of the 6 topics; verify each lands in the Educational Library on the correct tab
- [ ] Hitting \`/portal/learn?tab=terpenes\` directly opens the Terpenes tab
- [ ] Invalid tab values (\`?tab=foo\`) fall back to the Conditions tab without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)