### PR TITLE
feat(branding): EMR-277 replace star ratings with cannabis-leaf ratings

### DIFF
--- a/src/app/(operator)/ops/training/training-view.tsx
+++ b/src/app/(operator)/ops/training/training-view.tsx
@@ -89,7 +89,7 @@ export function TrainingView({ initialModules }: { initialModules: TrainingModul
               <div className="flex items-start justify-between gap-2 mb-2">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1.5">
-                    {m.required && <span className="text-amber-500" title="Required">★</span>}
+                    {m.required && <span className="text-[var(--leaf,#3a7d44)]" title="Required">🍃</span>}
                     <h3 className="font-medium text-text">{m.title}</h3>
                   </div>
                   <p className="text-xs text-text-muted mt-1">{m.description}</p>
@@ -171,7 +171,7 @@ export function TrainingView({ initialModules }: { initialModules: TrainingModul
 
       <div className="flex items-center justify-between">
         <p className="text-xs text-text-subtle">
-          Star (★) indicates a required module for all staff.
+          Leaf (🍃) indicates a required module for all staff.
         </p>
         <span className={cn("text-xs", progressPct === 100 ? "text-accent" : "text-text-subtle")}>
           {progressPct === 100 ? "All required training complete." : "Keep going!"}

--- a/src/app/(patient)/portal/survey/survey-form.tsx
+++ b/src/app/(patient)/portal/survey/survey-form.tsx
@@ -177,7 +177,7 @@ function NpsSelector({
   );
 }
 
-/* ── Star Rating ─────────────────────────────────── */
+/* ── Leaf Rating (EMR-277, was StarRating) ───────── */
 
 function StarRating({
   value,
@@ -191,27 +191,29 @@ function StarRating({
 
   return (
     <div className="flex items-center gap-1" onMouseLeave={() => setHovered(null)}>
-      {[1, 2, 3, 4, 5].map((star) => (
+      {[1, 2, 3, 4, 5].map((leaf) => (
         <button
-          key={star}
+          key={leaf}
           type="button"
-          onClick={() => onChange(star)}
-          onMouseEnter={() => setHovered(star)}
+          onClick={() => onChange(leaf)}
+          onMouseEnter={() => setHovered(leaf)}
+          aria-label={`${leaf} leaf${leaf === 1 ? "" : "s"}`}
           className="p-1 transition-transform hover:scale-110"
         >
           <svg
             width="28"
             height="28"
             viewBox="0 0 24 24"
-            fill={star <= displayValue ? "currentColor" : "none"}
+            fill={leaf <= displayValue ? "currentColor" : "none"}
             stroke="currentColor"
             strokeWidth="1.5"
+            strokeLinejoin="round"
             className={cn(
               "transition-colors",
-              star <= displayValue ? "text-amber-400" : "text-gray-300",
+              leaf <= displayValue ? "text-[var(--leaf,#3a7d44)]" : "text-gray-300",
             )}
           >
-            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+            <path d="M12 2C12 2 10 6 8 8C6 10 4 11 2 11C4 13 6 13 8 14C6 16 5 18 5 21C7 19 9 18 11 17C11 19 11 21 12 22C13 21 13 19 13 17C15 18 17 19 19 21C19 18 18 16 16 14C18 13 20 13 22 11C20 11 18 10 16 8C14 6 12 2 12 2Z" />
           </svg>
         </button>
       ))}

--- a/src/components/leafmart/LeafIcon.tsx
+++ b/src/components/leafmart/LeafIcon.tsx
@@ -1,0 +1,32 @@
+// EMR-277: shared cannabis-leaf icon used for ratings and decorative
+// callouts. Single source of truth so we don't drift between callers.
+
+interface Props {
+  size?: number;
+  /** Filled (solid) vs outlined. Defaults to filled. */
+  filled?: boolean;
+  className?: string;
+}
+
+const PATH =
+  "M12 2C12 2 10 6 8 8C6 10 4 11 2 11C4 13 6 13 8 14C6 16 5 18 5 21C7 19 9 18 11 17C11 19 11 21 12 22C13 21 13 19 13 17C15 18 17 19 19 21C19 18 18 16 16 14C18 13 20 13 22 11C20 11 18 10 16 8C14 6 12 2 12 2Z";
+
+export function LeafIcon({ size = 16, filled = true, className = "" }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={`shrink-0 ${className}`}
+    >
+      <path
+        d={PATH}
+        fill={filled ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/leafmart/ProductReviews.tsx
+++ b/src/components/leafmart/ProductReviews.tsx
@@ -505,7 +505,7 @@ function ReviewComposer({
             key={n}
             type="button"
             onClick={() => setRating(n)}
-            aria-label={`${n} star${n === 1 ? "" : "s"}`}
+            aria-label={`${n} leaf${n === 1 ? "" : "s"}`}
             className="p-0.5"
           >
             <svg
@@ -515,8 +515,11 @@ function ReviewComposer({
               className={n <= rating ? "text-[var(--leaf)]" : "text-[var(--border)]"}
             >
               <path
-                d="M12 2.5l2.95 6.13 6.55.87-4.78 4.59 1.18 6.5L12 17.6l-6.0 2.99 1.18-6.5L2.5 9.5l6.55-.87L12 2.5z"
+                d="M12 2C12 2 10 6 8 8C6 10 4 11 2 11C4 13 6 13 8 14C6 16 5 18 5 21C7 19 9 18 11 17C11 19 11 21 12 22C13 21 13 19 13 17C15 18 17 19 19 21C19 18 18 16 16 14C18 13 20 13 22 11C20 11 18 10 16 8C14 6 12 2 12 2Z"
                 fill="currentColor"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinejoin="round"
               />
             </svg>
           </button>

--- a/src/components/leafmart/ReviewSubmissionForm.tsx
+++ b/src/components/leafmart/ReviewSubmissionForm.tsx
@@ -153,7 +153,7 @@ export function ReviewSubmissionForm({ productSlug, onClose }: Props) {
             type="button"
             onClick={() => setRating(n)}
             className="p-0.5"
-            aria-label={`${n} stars`}
+            aria-label={`${n} leaves`}
           >
             <StarRating rating={n <= rating ? 5 : 0} size={22} />
           </button>

--- a/src/components/leafmart/StarRating.tsx
+++ b/src/components/leafmart/StarRating.tsx
@@ -1,32 +1,43 @@
 "use client";
 
+// EMR-277: Star ratings replaced with cannabis-leaf ratings per Dr. Patel.
+// The export name stays `StarRating` for backward compatibility with the
+// many call sites; `LeafRating` is the preferred forward-facing name.
+
 interface Props {
   rating: number;
   size?: number;
   className?: string;
 }
 
-/** Five-star row. Renders fractional fill via a clip-path so half-stars work. */
-export function StarRating({ rating, size = 16, className = "" }: Props) {
+/** Five-leaf rating row. Renders fractional fill via a clip-path so
+ *  half-leaves work the same way half-stars did. */
+export function LeafRating({ rating, size = 16, className = "" }: Props) {
   const clamped = Math.max(0, Math.min(5, rating));
   return (
     <span
       className={`inline-flex items-center gap-0.5 text-[var(--leaf)] ${className}`}
       role="img"
-      aria-label={`${clamped.toFixed(1)} out of 5 stars`}
+      aria-label={`${clamped.toFixed(1)} out of 5`}
     >
       {[0, 1, 2, 3, 4].map((i) => {
         const fill = Math.max(0, Math.min(1, clamped - i));
-        return <Star key={i} size={size} fill={fill} />;
+        return <Leaf key={i} size={size} fill={fill} />;
       })}
     </span>
   );
 }
 
-function Star({ size, fill }: { size: number; fill: number }) {
+// Backward-compat alias — many existing call sites import StarRating.
+export const StarRating = LeafRating;
+
+function Leaf({ size, fill }: { size: number; fill: number }) {
+  // 5-leaflet cannabis silhouette in a 24x24 viewBox. The path traces
+  // the outer leaflets first (left → top → right) then returns along
+  // the bottom stem so a single clip rect produces a clean partial fill.
   const path =
-    "M12 2.5l2.95 6.13 6.55.87-4.78 4.59 1.18 6.5L12 17.6l-6.0 2.99 1.18-6.5L2.5 9.5l6.55-.87L12 2.5z";
-  const id = `clip-${Math.random().toString(36).slice(2, 9)}`;
+    "M12 2C12 2 10 6 8 8C6 10 4 11 2 11C4 13 6 13 8 14C6 16 5 18 5 21C7 19 9 18 11 17C11 19 11 21 12 22C13 21 13 19 13 17C15 18 17 19 19 21C19 18 18 16 16 14C18 13 20 13 22 11C20 11 18 10 16 8C14 6 12 2 12 2Z";
+  const id = `leaf-clip-${Math.random().toString(36).slice(2, 9)}`;
   return (
     <svg
       width={size}

--- a/src/components/store/affiliate-product-card.tsx
+++ b/src/components/store/affiliate-product-card.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ExternalLink, Star, Tag, ShoppingBag } from "lucide-react";
+import { ExternalLink, Tag, ShoppingBag } from "lucide-react";
+import { LeafIcon } from "@/components/leafmart/LeafIcon";
 import { logPatientEngagement } from "@/app/(patient)/portal/wellness/actions";
 
 export interface AffiliateProductProps {
@@ -51,8 +52,8 @@ export function AffiliateProductCard({ product }: { product: AffiliateProductPro
             {product.brand}
           </span>
           {product.rating && (
-            <div className="flex items-center gap-1 text-amber-500">
-              <Star className="w-3.5 h-3.5 fill-current" />
+            <div className="flex items-center gap-1 text-[var(--leaf,#3a7d44)]">
+              <LeafIcon size={14} filled />
               <span className="text-xs font-medium text-neutral-600 dark:text-neutral-400">
                 {product.rating}
               </span>


### PR DESCRIPTION
## Summary
Fixes [EMR-277](https://linear.app/emr-project/issue/EMR-277) — every 5-star rating across the app becomes a 5-leaf rating per Dr. Patel.

## What changed
- **\`leafmart/StarRating.tsx\`** — re-implemented as \`LeafRating\` with a 5-leaflet cannabis-leaf SVG path. Fractional fill (half-leaf) still works via clip-path, same as the old half-star behavior. \`StarRating\` is re-exported as a back-compat alias so the dozen existing call sites keep working with no churn.
- **\`leafmart/LeafIcon.tsx\`** (new) — shared single-leaf icon for non-rating callouts (badges, indicators).
- **\`leafmart/ProductReviews.tsx\`** — inline "Write a review" star path swapped to leaf path; \`aria-label\` "N stars" → "N leaves".
- **\`leafmart/ReviewSubmissionForm.tsx\`** — \`aria-label\` "N stars" → "N leaves".
- **\`portal/survey/survey-form.tsx\`** — inline NPS-survey \`StarRating\` swapped to leaf path with leaf color + accessible label.
- **\`store/affiliate-product-card.tsx\`** — small lucide \`Star\` badge replaced with the new \`LeafIcon\`.
- **\`ops/training/training-view.tsx\`** — "★ required module" indicator → "🍃 required"; legend updated to match.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] LeafMart product card / detail page: ratings render as 5 cannabis leaves with correct fractional fill
- [ ] LeafMart "Write a review" form: clicking the leaves sets the rating, fills cleanly
- [ ] Patient survey form: NPS rating renders as 5 leaves
- [ ] Affiliate store card: small green leaf next to numeric rating
- [ ] Ops training view: required modules show a leaf, legend reads "Leaf (🍃) indicates a required module"
- [ ] Screen reader sees "N out of 5" / "N leaves" — no leftover "stars" copy in rating contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)