### PR TITLE
feat(marketplace): EMR-278 add Effect tile next to Onset and Duration

### DIFF
--- a/src/app/(patient)/portal/shop/products/[slug]/page.tsx
+++ b/src/app/(patient)/portal/shop/products/[slug]/page.tsx
@@ -369,9 +369,9 @@ export default async function ProductDetailPage({ params }: SlugPageProps) {
           </Card>
         )}
 
-        {/* Onset & Duration */}
-        {(product.onsetTime || product.duration) && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Onset · Duration · Effect (EMR-278) */}
+        {(product.onsetTime || product.duration || (product.effectTags && product.effectTags.length > 0)) && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             {product.onsetTime && (
               <div className="rounded-lg border border-border bg-surface p-4">
                 <p className="text-xs uppercase tracking-wide text-text-subtle mb-1">
@@ -390,6 +390,23 @@ export default async function ProductDetailPage({ params }: SlugPageProps) {
                 <p className="text-sm font-medium text-text">
                   {product.duration}
                 </p>
+              </div>
+            )}
+            {product.effectTags && product.effectTags.length > 0 && (
+              <div className="rounded-lg border border-border bg-surface p-4">
+                <p className="text-xs uppercase tracking-wide text-text-subtle mb-2">
+                  Effect
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {product.effectTags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center rounded-full bg-[var(--accent)]/10 text-[var(--accent)] text-[11.5px] font-medium px-2 py-0.5 capitalize"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/src/lib/marketplace/effects.ts
+++ b/src/lib/marketplace/effects.ts
@@ -1,0 +1,148 @@
+// EMR-278 — derive a small set of "effect" descriptors for a product based
+// on its strain type, cannabinoid loading, and dominant terpenes.
+//
+// Per the ticket, the eventual implementation should incorporate AI synthesis
+// of reviews + the cannabinoid/terpene profile. This module provides a clean,
+// deterministic v1 that ships today: rule-based mapping over the same data
+// the AI would consume. The output shape is wire-compatible with whatever
+// model-driven implementation replaces it.
+
+export type StrainType = "indica" | "sativa" | "hybrid" | "n/a";
+
+export interface EffectDerivationInput {
+  strainType?: StrainType;
+  thcContent?: number;
+  cbdContent?: number;
+  cbnContent?: number;
+  terpeneProfile?: Record<string, number>;
+  /** Optional product use-cases / symptoms — bias the effect set toward
+   *  benefit framing when present (e.g., "anxiety" → "calming"). */
+  symptoms?: string[];
+  useCases?: string[];
+}
+
+// Tag preference order — when we have to truncate, keep the most
+// informative descriptor first. Curated to feel natural reading L-to-R.
+const TAG_PRIORITY: string[] = [
+  "relaxing",
+  "uplifting",
+  "calming",
+  "soothing",
+  "energizing",
+  "focused",
+  "creative",
+  "cerebral",
+  "mellow",
+  "sedating",
+  "euphoric",
+  "balanced",
+  "couch lock",
+  "giggly",
+];
+
+const TERPENE_EFFECTS: Record<string, string[]> = {
+  myrcene: ["sedating", "mellow"],
+  limonene: ["uplifting", "euphoric"],
+  linalool: ["calming", "soothing"],
+  pinene: ["focused", "cerebral"],
+  caryophyllene: ["soothing"],
+  humulene: ["mellow"],
+  terpinolene: ["uplifting", "creative"],
+  ocimene: ["uplifting"],
+  bisabolol: ["calming"],
+  eucalyptol: ["cerebral"],
+};
+
+const SYMPTOM_BIAS: Record<string, string[]> = {
+  anxiety: ["calming", "soothing"],
+  insomnia: ["sedating", "mellow"],
+  sleep: ["sedating", "mellow"],
+  pain: ["soothing", "relaxing"],
+  inflammation: ["soothing"],
+  fatigue: ["energizing", "uplifting"],
+  depression: ["uplifting", "euphoric"],
+  focus: ["focused", "cerebral"],
+  adhd: ["focused"],
+  appetite: ["giggly"],
+};
+
+const MAX_TAGS = 5;
+
+export function deriveEffectTags(input: EffectDerivationInput): string[] {
+  const pool = new Set<string>();
+
+  // Strain backbone
+  switch (input.strainType) {
+    case "indica":
+      pool.add("relaxing");
+      pool.add("sedating");
+      pool.add("mellow");
+      break;
+    case "sativa":
+      pool.add("uplifting");
+      pool.add("energizing");
+      pool.add("creative");
+      break;
+    case "hybrid":
+      pool.add("balanced");
+      break;
+    // "n/a" / undefined → no strain contribution
+  }
+
+  // Cannabinoid loading. Numbers are percentage points; treat falsy as 0.
+  const thc = input.thcContent ?? 0;
+  const cbd = input.cbdContent ?? 0;
+  const cbn = input.cbnContent ?? 0;
+
+  if (thc >= 20) {
+    pool.add("euphoric");
+    pool.add("cerebral");
+  } else if (thc >= 12) {
+    pool.add("uplifting");
+  }
+  if (cbd >= 10) {
+    pool.add("calming");
+    pool.add("soothing");
+  }
+  if (cbn >= 1) {
+    pool.add("sedating");
+  }
+
+  // CBD-dominant (CBD ≥ 2× THC) products feel calming first, regardless of
+  // any THC-driven euphoric flags we already added.
+  if (cbd > 0 && thc > 0 && cbd >= 2 * thc) {
+    pool.delete("euphoric");
+    pool.delete("cerebral");
+    pool.add("calming");
+  }
+
+  // Dominant terpenes (top 2 by concentration).
+  const terps = input.terpeneProfile ?? {};
+  const ranked = Object.entries(terps)
+    .filter(([, v]) => typeof v === "number" && v > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2);
+  for (const [name] of ranked) {
+    const effects = TERPENE_EFFECTS[name.toLowerCase()];
+    if (effects) effects.forEach((e) => pool.add(e));
+  }
+
+  // Symptom / use-case bias
+  const hints = [
+    ...(input.symptoms ?? []),
+    ...(input.useCases ?? []),
+  ].map((s) => s.toLowerCase());
+  for (const h of hints) {
+    for (const [key, effects] of Object.entries(SYMPTOM_BIAS)) {
+      if (h.includes(key)) effects.forEach((e) => pool.add(e));
+    }
+  }
+
+  // Sort by curated priority, then truncate.
+  const ordered = TAG_PRIORITY.filter((t) => pool.has(t));
+  // Fold in any remaining tags not yet in the priority list (defensive).
+  for (const t of pool) {
+    if (!ordered.includes(t)) ordered.push(t);
+  }
+  return ordered.slice(0, MAX_TAGS);
+}

--- a/src/lib/marketplace/public-queries.ts
+++ b/src/lib/marketplace/public-queries.ts
@@ -20,6 +20,7 @@ import type {
   ProductVariant,
   ProductReview,
 } from "./types";
+import { deriveEffectTags } from "./effects";
 
 const publicProductInclude = {
   variants: { orderBy: { sortOrder: "asc" } },
@@ -89,6 +90,15 @@ function mapPublicProduct(p: PublicProductRow): MarketplaceProduct {
     useCases: p.useCases,
     onsetTime: p.onsetTime ?? undefined,
     duration: p.duration ?? undefined,
+    effectTags: deriveEffectTags({
+      strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+      thcContent: p.thcContent ?? undefined,
+      cbdContent: p.cbdContent ?? undefined,
+      cbnContent: p.cbnContent ?? undefined,
+      terpeneProfile: terpene,
+      symptoms: p.symptoms,
+      useCases: p.useCases,
+    }),
     // Dosage guidance intentionally stripped on the public surface —
     // surface it only in authenticated portal contexts.
     dosageGuidance: undefined,

--- a/src/lib/marketplace/queries.ts
+++ b/src/lib/marketplace/queries.ts
@@ -13,6 +13,7 @@ import type {
   ProductReview,
   ProductFormat,
 } from "./types";
+import { deriveEffectTags } from "./effects";
 
 const productInclude = {
   variants: { orderBy: { sortOrder: "asc" } },
@@ -72,6 +73,15 @@ function mapProduct(p: ProductRow): MarketplaceProduct {
     useCases: p.useCases,
     onsetTime: p.onsetTime ?? undefined,
     duration: p.duration ?? undefined,
+    effectTags: deriveEffectTags({
+      strainType: (p.strainType ?? undefined) as MarketplaceProduct["strainType"],
+      thcContent: p.thcContent ?? undefined,
+      cbdContent: p.cbdContent ?? undefined,
+      cbnContent: p.cbnContent ?? undefined,
+      terpeneProfile: terpene,
+      symptoms: p.symptoms,
+      useCases: p.useCases,
+    }),
     dosageGuidance: p.dosageGuidance ?? undefined,
     beginnerFriendly: p.beginnerFriendly,
     labVerified: p.labVerified,

--- a/src/lib/marketplace/types.ts
+++ b/src/lib/marketplace/types.ts
@@ -28,6 +28,10 @@ export interface MarketplaceProduct {
   useCases: string[];
   onsetTime?: string;
   duration?: string;
+  // EMR-278 — descriptive effect tags ("uplifting", "relaxing", "cerebral").
+  // Optional; PDP falls back to deriving from strain/cannabinoid/terpene
+  // profile when missing.
+  effectTags?: string[];
 
   // Dosage
   dosageGuidance?: string;


### PR DESCRIPTION
## Summary
Fixes [EMR-278](https://linear.app/emr-project/issue/EMR-278) — Dr. Patel asked for an Effect tile alongside Onset and Duration on each PDP, populated with descriptors like "uplifting", "relaxing", "cerebral", etc.

## What changed
- **\`src/lib/marketplace/effects.ts\`** (new) — \`deriveEffectTags()\` rule-based mapper over the product's existing fields (strainType, THC/CBD/CBN, terpeneProfile, symptoms, useCases). Output: an ordered \`string[]\` of up to 5 descriptors picked from a curated priority list. The signature is wire-compatible with a future AI-driven impl so the eventual review-synthesis swap is a one-liner in queries.
- **\`types.ts\`** — adds optional \`effectTags?: string[]\` to \`MarketplaceProduct\`.
- **\`queries.ts\`** and **\`public-queries.ts\`** — populate \`effectTags\` via the mapper using fields already on the row. No DB migration.
- **\`/portal/shop/products/[slug]/page.tsx\`** — the Onset/Duration block becomes a 3-column grid; Effect tile renders pill chips. The whole row hides when none of the three fields have content.

## Derivation rules (v1)
- Strain: indica → relaxing/sedating/mellow; sativa → uplifting/energizing/creative; hybrid → balanced.
- Cannabinoids: THC ≥ 20% → euphoric/cerebral; THC ≥ 12% → uplifting; CBD ≥ 10% → calming/soothing; CBN ≥ 1% → sedating. CBD-dominant (CBD ≥ 2×THC) overrides toward calming.
- Top-2 dominant terpenes: limonene→uplifting/euphoric, linalool→calming/soothing, myrcene→sedating/mellow, pinene→focused/cerebral, etc.
- Symptom bias: anxiety→calming, insomnia→sedating, pain→soothing, focus→focused, etc.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] PDP with full profile (THC + terpenes + symptoms): Effect tile shows 3-5 chips
- [ ] PDP missing strain/cannabinoid data: tile gracefully renders only what can be derived (or hides entirely)
- [ ] Indica + myrcene-dominant product: tags lead with "relaxing", "sedating", "mellow"
- [ ] CBD-dominant tincture: tags include "calming", "soothing"; no "euphoric"

🤖 Generated with [Claude Code](https://claude.com/claude-code)