### PR TITLE
feat(marketplace): EMR-282 grow-accessory cultivation legality + disclaimer

### DIFF
--- a/src/app/(patient)/portal/shop/products/[slug]/page.tsx
+++ b/src/app/(patient)/portal/shop/products/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { RatingStars } from "@/components/marketplace/RatingStars";
 import { ProductGrid } from "@/components/marketplace/ProductGrid";
+import { GrowAccessoryDisclaimer } from "@/components/marketplace/GrowAccessoryDisclaimer";
 import { getCurrentUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import {
@@ -400,6 +401,11 @@ export default async function ProductDetailPage({ params }: SlugPageProps) {
           <Badge tone="success" className="text-sm px-3 py-1">
             Beginner Friendly
           </Badge>
+        )}
+
+        {/* EMR-282 — grow-accessory legal disclaimer */}
+        {product.growAccessory && (
+          <GrowAccessoryDisclaimer state={patient?.state ?? null} className="mt-6" />
         )}
       </section>
 

--- a/src/components/marketplace/GrowAccessoryDisclaimer.tsx
+++ b/src/components/marketplace/GrowAccessoryDisclaimer.tsx
@@ -1,0 +1,107 @@
+// EMR-282 — Grow-accessory legal disclaimer.
+//
+// Shown on the PDP of any product flagged growAccessory=true (e.g. lights,
+// tents, fans, fertilizer, trim shears). Conveys two things in order:
+//   1. Per-state legality summary (from cultivation-legality.ts) when the
+//      patient's state is on file. Generic "verify with your state" when not.
+//   2. Hard "you are solely responsible" disclaimer covering both state and
+//      federal jurisdictions. Required regardless of the per-state lookup.
+//
+// We intentionally never claim authority over the legality determination —
+// the lookup is convenience, the disclaimer is the floor.
+
+import {
+  getCultivationRule,
+  statusLabel,
+  statusTone,
+  type StateCultivationRule,
+} from "@/lib/marketplace/cultivation-legality";
+
+interface Props {
+  /** Customer's 2-letter state code, or null/undefined if unknown. */
+  state?: string | null;
+  className?: string;
+}
+
+const TONE_CLASS: Record<ReturnType<typeof statusTone>, string> = {
+  success: "bg-emerald-50 border-emerald-200 text-emerald-900",
+  warning: "bg-amber-50 border-amber-200 text-amber-900",
+  danger: "bg-red-50 border-red-200 text-red-900",
+  neutral: "bg-[var(--surface-muted)] border-[var(--border)] text-text",
+};
+
+function StateBanner({ rule }: { rule: StateCultivationRule }) {
+  const tone = statusTone(rule.status);
+  return (
+    <div className={`rounded-2xl border p-5 ${TONE_CLASS[tone]}`} role="region" aria-label={`Cultivation legality in ${rule.stateName}`}>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] mb-1 opacity-80">
+        Cultivation in {rule.stateName}
+      </p>
+      <p className="text-[15px] font-semibold mb-1.5">{statusLabel(rule.status)}</p>
+      <p className="text-[13.5px] leading-relaxed opacity-90">{rule.summary}</p>
+      {rule.regulatorUrl && (
+        <a
+          href={rule.regulatorUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-[12.5px] font-medium underline underline-offset-2 opacity-80 hover:opacity-100"
+        >
+          Read the official guidance →
+        </a>
+      )}
+    </div>
+  );
+}
+
+function UnknownStateBanner() {
+  return (
+    <div className={`rounded-2xl border p-5 ${TONE_CLASS.neutral}`} role="region" aria-label="Cultivation legality">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] mb-1 opacity-80">
+        Cultivation legality
+      </p>
+      <p className="text-[15px] font-semibold mb-1.5">Verify with your state</p>
+      <p className="text-[13.5px] leading-relaxed opacity-90">
+        We don&apos;t have your state on file, so we can&apos;t give a tailored summary.
+        Cannabis cultivation laws vary widely by state, county, and municipality.
+        Check your state&apos;s cannabis regulator before purchasing or planting.
+      </p>
+    </div>
+  );
+}
+
+export function GrowAccessoryDisclaimer({ state, className }: Props) {
+  const rule = getCultivationRule(state);
+
+  return (
+    <div className={`space-y-4 ${className ?? ""}`}>
+      {rule ? <StateBanner rule={rule} /> : <UnknownStateBanner />}
+
+      <div className="rounded-2xl border border-[var(--border)] bg-white p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-text-subtle mb-2">
+          Your responsibility
+        </p>
+        <p className="text-[13.5px] text-text leading-relaxed mb-2">
+          Cannabis cultivation is regulated at the state and federal level, and
+          legality changes — sometimes overnight. The information above is a
+          convenience summary, not legal advice. You are solely responsible for
+          confirming that growing cannabis is legal in your state, county, and
+          municipality, and for staying within plant counts, locations, and any
+          registration or licensing requirements that apply to you.
+        </p>
+        <p className="text-[13.5px] text-text leading-relaxed mb-2">
+          Federal law continues to classify cannabis as a controlled substance.
+          Purchasing grow accessories from this site does not authorize you to
+          cultivate cannabis, and Leafjourney makes no representation that doing
+          so is legal in your jurisdiction.
+        </p>
+        <p className="text-[13.5px] font-semibold text-text leading-relaxed">
+          Leafjourney is not liable for any legal consequences arising from your
+          cultivation activities. If you are uncertain, consult a licensed
+          attorney in your state before growing.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default GrowAccessoryDisclaimer;

--- a/src/lib/marketplace/cultivation-legality.ts
+++ b/src/lib/marketplace/cultivation-legality.ts
@@ -1,0 +1,136 @@
+// EMR-282 — per-state cannabis cultivation legality lookup.
+//
+// This data is curated, not authoritative. It maps each US state/territory
+// to a short status descriptor and a plain-language summary that the PDP
+// shows to patients alongside grow-accessory products.
+//
+// Patients are ALWAYS told to verify with their state's regulator before
+// purchasing — the disclaimer is mandatory, this lookup is convenience.
+//
+// Status levels:
+//   - allowed_recreational: adult-use home cultivation allowed
+//   - allowed_medical: medical patients only
+//   - registered_caregiver: only by registered caregivers/patients
+//   - prohibited: home cultivation not allowed (medical or recreational)
+//   - unknown: no data on file — fall back to "verify with your state"
+//
+// Dates and plant counts encoded here should be reviewed periodically;
+// states amend cultivation laws frequently.
+
+export type CultivationStatus =
+  | "allowed_recreational"
+  | "allowed_medical"
+  | "registered_caregiver"
+  | "prohibited"
+  | "unknown";
+
+export interface StateCultivationRule {
+  state: string; // 2-letter postal code
+  stateName: string;
+  status: CultivationStatus;
+  /** Plain-language summary safe to interpolate into the PDP banner. */
+  summary: string;
+  /** Plant count limit if applicable, otherwise null. */
+  plantLimit?: number | null;
+  /** URL of the state regulator's cultivation guidance, if public. */
+  regulatorUrl?: string | null;
+}
+
+// Curated state-by-state status. Personal-cultivation laws as of early 2026.
+// Where a state has multiple thresholds (e.g., per household vs per adult),
+// the summary uses the more permissive number and notes the household cap.
+const RULES: StateCultivationRule[] = [
+  { state: "AK", stateName: "Alaska", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants (3 mature) per household.", plantLimit: 6 },
+  { state: "AL", stateName: "Alabama", status: "prohibited", summary: "Home cultivation is prohibited, including for medical patients." },
+  { state: "AR", stateName: "Arkansas", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use licensed dispensaries." },
+  { state: "AZ", stateName: "Arizona", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants per adult, capped at 12 per household.", plantLimit: 12 },
+  { state: "CA", stateName: "California", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants per residence indoors; outdoor cultivation may be restricted locally.", plantLimit: 6 },
+  { state: "CO", stateName: "Colorado", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants (3 flowering), capped at 12 per residence.", plantLimit: 12 },
+  { state: "CT", stateName: "Connecticut", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants per person, 12 per household.", plantLimit: 12 },
+  { state: "DC", stateName: "District of Columbia", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants (3 mature) per household.", plantLimit: 6 },
+  { state: "DE", stateName: "Delaware", status: "prohibited", summary: "Home cultivation is prohibited under current state law." },
+  { state: "FL", stateName: "Florida", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use licensed dispensaries." },
+  { state: "GA", stateName: "Georgia", status: "prohibited", summary: "Home cultivation is prohibited; only low-THC oil is legal for qualified medical patients." },
+  { state: "HI", stateName: "Hawaii", status: "allowed_medical", summary: "Registered medical patients may cultivate up to 10 plants at one site.", plantLimit: 10 },
+  { state: "IA", stateName: "Iowa", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "ID", stateName: "Idaho", status: "prohibited", summary: "Cannabis cultivation is prohibited under any circumstance." },
+  { state: "IL", stateName: "Illinois", status: "allowed_medical", summary: "Medical patients may cultivate up to 5 plants; recreational home grow is not legal.", plantLimit: 5 },
+  { state: "IN", stateName: "Indiana", status: "prohibited", summary: "Home cultivation is prohibited under state law." },
+  { state: "KS", stateName: "Kansas", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "KY", stateName: "Kentucky", status: "prohibited", summary: "Home cultivation is prohibited; medical program limits use to non-smokable forms." },
+  { state: "LA", stateName: "Louisiana", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use authorized pharmacies." },
+  { state: "MA", stateName: "Massachusetts", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants per person, 12 per household.", plantLimit: 12 },
+  { state: "MD", stateName: "Maryland", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 2 plants per household.", plantLimit: 2 },
+  { state: "ME", stateName: "Maine", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 3 mature, 12 immature, and unlimited seedlings.", plantLimit: 3 },
+  { state: "MI", stateName: "Michigan", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 12 plants per household.", plantLimit: 12 },
+  { state: "MN", stateName: "Minnesota", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 8 plants (4 mature) per residence.", plantLimit: 8 },
+  { state: "MO", stateName: "Missouri", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 flowering plants, 6 nonflowering, and 6 clones.", plantLimit: 18 },
+  { state: "MS", stateName: "Mississippi", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "MT", stateName: "Montana", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 4 mature and 4 seedlings per household.", plantLimit: 8 },
+  { state: "NC", stateName: "North Carolina", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "ND", stateName: "North Dakota", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "NE", stateName: "Nebraska", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "NH", stateName: "New Hampshire", status: "registered_caregiver", summary: "Cultivation is restricted to therapeutic alternative treatment centers." },
+  { state: "NJ", stateName: "New Jersey", status: "prohibited", summary: "Home cultivation remains prohibited even under recreational legalization." },
+  { state: "NM", stateName: "New Mexico", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 mature and 6 immature plants per person, 12 mature per household.", plantLimit: 12 },
+  { state: "NV", stateName: "Nevada", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants, 12 per household — only if 25+ miles from a dispensary.", plantLimit: 12 },
+  { state: "NY", stateName: "New York", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 3 mature and 3 immature plants per person, 12 per household.", plantLimit: 12 },
+  { state: "OH", stateName: "Ohio", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 6 plants per adult, 12 per household.", plantLimit: 12 },
+  { state: "OK", stateName: "Oklahoma", status: "allowed_medical", summary: "Medical patients may cultivate up to 6 mature plants and 6 seedlings.", plantLimit: 12 },
+  { state: "OR", stateName: "Oregon", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 4 plants per household regardless of number of adults.", plantLimit: 4 },
+  { state: "PA", stateName: "Pennsylvania", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use dispensaries." },
+  { state: "RI", stateName: "Rhode Island", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 3 mature and 3 immature plants.", plantLimit: 6 },
+  { state: "SC", stateName: "South Carolina", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "SD", stateName: "South Dakota", status: "allowed_medical", summary: "Medical patients without nearby dispensary access may cultivate up to 3 plants.", plantLimit: 3 },
+  { state: "TN", stateName: "Tennessee", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "TX", stateName: "Texas", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "UT", stateName: "Utah", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use licensed pharmacies." },
+  { state: "VA", stateName: "Virginia", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 4 plants per household.", plantLimit: 4 },
+  { state: "VT", stateName: "Vermont", status: "allowed_recreational", summary: "Adults 21+ may cultivate up to 2 mature and 4 immature plants per household.", plantLimit: 6 },
+  { state: "WA", stateName: "Washington", status: "allowed_medical", summary: "Medical patients may cultivate up to 6 plants (15 with extra authorization); recreational home grow is not legal.", plantLimit: 6 },
+  { state: "WI", stateName: "Wisconsin", status: "prohibited", summary: "Home cultivation is prohibited." },
+  { state: "WV", stateName: "West Virginia", status: "prohibited", summary: "Home cultivation is prohibited; medical patients must use dispensaries." },
+  { state: "WY", stateName: "Wyoming", status: "prohibited", summary: "Cannabis cultivation is prohibited." },
+];
+
+const BY_CODE: Record<string, StateCultivationRule> = Object.fromEntries(
+  RULES.map((r) => [r.state, r]),
+);
+
+/** Look up a state's cultivation rule by 2-letter postal code (case-insensitive).
+ *  Unknown / non-US states return null so callers can fall back to the
+ *  generic "verify with your state" disclaimer. */
+export function getCultivationRule(state: string | null | undefined): StateCultivationRule | null {
+  if (!state) return null;
+  const key = state.trim().toUpperCase();
+  return BY_CODE[key] ?? null;
+}
+
+export function statusLabel(status: CultivationStatus): string {
+  switch (status) {
+    case "allowed_recreational":
+      return "Permitted (adults 21+)";
+    case "allowed_medical":
+      return "Permitted for medical patients";
+    case "registered_caregiver":
+      return "Restricted to caregivers";
+    case "prohibited":
+      return "Prohibited";
+    case "unknown":
+      return "Verify with your state";
+  }
+}
+
+export function statusTone(status: CultivationStatus): "success" | "warning" | "danger" | "neutral" {
+  switch (status) {
+    case "allowed_recreational":
+      return "success";
+    case "allowed_medical":
+    case "registered_caregiver":
+      return "warning";
+    case "prohibited":
+      return "danger";
+    case "unknown":
+      return "neutral";
+  }
+}

--- a/src/lib/marketplace/types.ts
+++ b/src/lib/marketplace/types.ts
@@ -29,6 +29,11 @@ export interface MarketplaceProduct {
   onsetTime?: string;
   duration?: string;
 
+  // EMR-282 — grow-accessory products (lights, tents, fans, fertilizer,
+  // trim tools) trigger a state-aware cultivation legality banner + hard
+  // disclaimer on the PDP.
+  growAccessory?: boolean;
+
   // Dosage
   dosageGuidance?: string;
   beginnerFriendly: boolean;


### PR DESCRIPTION
## Summary
Fixes [EMR-282](https://linear.app/emr-project/issue/EMR-282) — adds the **legal protections** for selling grow accessories: a state-aware cultivation legality summary plus a hard "you are solely responsible" disclaimer.

## What ships
- **\`src/lib/marketplace/cultivation-legality.ts\`** (new) — curated 50-state + DC lookup of personal-cultivation rules. Five status levels (\`allowed_recreational\`, \`allowed_medical\`, \`registered_caregiver\`, \`prohibited\`, \`unknown\`); each state ships with a plain-language summary and plant-count cap where applicable. Helper exports: \`getCultivationRule\`, \`statusLabel\`, \`statusTone\`.
- **\`src/components/marketplace/GrowAccessoryDisclaimer.tsx\`** (new) — two-panel disclaimer:
  1. **State banner** — tailored summary when the patient's state is on file (color-coded: green=permitted, amber=medical-only, red=prohibited). Generic "Verify with your state" banner when not.
  2. **Hard liability section** — covers federal scheduling, no-authorization-implied, and explicit no-liability statement.
- **\`MarketplaceProduct\`** — adds optional \`growAccessory?: boolean\` flag.
- **\`/portal/shop/products/[slug]\`** — when \`product.growAccessory === true\`, renders the disclaimer below the product info using the patient's state from their profile.

## What's intentionally **not** shipped here
- A grow-accessory **category page** / catalog seed — that requires actual products to display. The compliance machinery ships first so any future product can be safely flagged \`growAccessory: true\` and immediately get the right banner.
- AI-generated state summaries — the curated table is more accurate and reviewable. The data lives in one file and can be reviewed periodically as states change laws.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] Flag a test product \`growAccessory: true\` and view as a patient with \`state: "CA"\` — green banner with the 6-plant rule appears.
- [ ] Same product, patient with \`state: "TX"\` — red banner with "Home cultivation is prohibited."
- [ ] No state on file — neutral "Verify with your state" banner.
- [ ] Liability disclaimer renders in all three cases; final paragraph is bold.
- [ ] Non-grow products: no banner appears (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)