### PR TITLE
feat(wellness): EMR-19 toolkit redesign — drop ribbon, add wellness score

### DIFF
--- a/src/app/(patient)/portal/lifestyle/lifestyle-toolkit.tsx
+++ b/src/app/(patient)/portal/lifestyle/lifestyle-toolkit.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-// Wellness toolkit checkbox dropdown — EMR-191
-// Replaces the lifestyle-page domain pills with a vertical list of expandable
-// cards. Each card has a checkbox row per tip so the patient can mark which
-// ones they are working on this week. State is local to the device.
+// Wellness toolkit checkbox dropdown — EMR-191 + EMR-19
+//
+// EMR-19 redesign: the colored left-border "ribbon" on each card was
+// distracting and clashed with the rest of the wellness hub. It's gone,
+// replaced with a single tonal accent (a small dot beside the domain
+// icon). The checkboxes now feed a visible wellness score so the
+// patient can see their effort move the number — score lives at the
+// top of the toolkit, weighted by difficulty (easy=1, moderate=2,
+// challenging=3).
 
 import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
@@ -20,6 +25,29 @@ const DIFFICULTY_TONE: Record<
   moderate: "warning",
   challenging: "danger",
 };
+
+// EMR-19 — difficulty-weighted scoring. Encourages tackling harder items
+// without making easy ones feel pointless.
+const DIFFICULTY_WEIGHT: Record<LifestyleTip["difficulty"], number> = {
+  easy: 1,
+  moderate: 2,
+  challenging: 3,
+};
+
+function scoreColor(score: number): string {
+  if (score >= 75) return "text-emerald-600";
+  if (score >= 50) return "text-amber-600";
+  if (score >= 25) return "text-orange-600";
+  return "text-text-subtle";
+}
+
+function scoreLabel(score: number): string {
+  if (score >= 90) return "Thriving";
+  if (score >= 75) return "Strong";
+  if (score >= 50) return "Steady";
+  if (score >= 25) return "Building";
+  return "Getting started";
+}
 
 interface ToolkitProps {
   domains: LifestyleDomain[];
@@ -63,6 +91,24 @@ export function LifestyleToolkit({ domains, tips }: ToolkitProps) {
   );
   const checkedCount = Object.keys(checked).length;
 
+  // EMR-19 — difficulty-weighted wellness score (0–100). Each tip
+  // contributes its weight if checked; we normalize against the total
+  // available weight so the score is comparable across patients.
+  const wellnessScore = useMemo(() => {
+    let earned = 0;
+    let possible = 0;
+    for (const domain of domains) {
+      const domainTips = tips[domain.id] ?? [];
+      for (const tip of domainTips) {
+        const w = DIFFICULTY_WEIGHT[tip.difficulty];
+        possible += w;
+        if (checked[tipKey(domain.id, tip.title)]) earned += w;
+      }
+    }
+    if (possible === 0) return 0;
+    return Math.round((earned / possible) * 100);
+  }, [checked, domains, tips]);
+
   function toggle(key: string) {
     setChecked((prev) => {
       const next = { ...prev };
@@ -75,6 +121,54 @@ export function LifestyleToolkit({ domains, tips }: ToolkitProps) {
 
   return (
     <section>
+      {/* EMR-19 — wellness score header replaces the ribbon-styled card.
+           Score is the load-bearing visual cue; the active count is
+           secondary. */}
+      <div className="mb-5 rounded-2xl bg-surface border border-border/60 p-5 sm:p-6 flex items-center gap-5">
+        <div className="relative shrink-0">
+          <svg width="72" height="72" viewBox="0 0 72 72" aria-hidden="true">
+            <circle
+              cx="36"
+              cy="36"
+              r="30"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="6"
+              className="text-surface-muted"
+            />
+            <circle
+              cx="36"
+              cy="36"
+              r="30"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="6"
+              strokeDasharray={2 * Math.PI * 30}
+              strokeDashoffset={2 * Math.PI * 30 * (1 - wellnessScore / 100)}
+              strokeLinecap="round"
+              transform="rotate(-90 36 36)"
+              className={`transition-[stroke-dashoffset] duration-500 ${scoreColor(wellnessScore)}`}
+            />
+          </svg>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className={`font-display text-xl tabular-nums ${scoreColor(wellnessScore)}`}>
+              {wellnessScore}
+            </span>
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+            Wellness score
+          </p>
+          <p className="font-display text-xl text-text tracking-tight">
+            {scoreLabel(wellnessScore)}
+          </p>
+          <p className="text-xs text-text-muted mt-0.5">
+            {checkedCount} of {total} active · weighted by difficulty
+          </p>
+        </div>
+      </div>
+
       <div className="flex items-center justify-between mb-4">
         <h2 className="font-display text-2xl text-text tracking-tight">
           Pick what you are working on
@@ -97,12 +191,6 @@ export function LifestyleToolkit({ domains, tips }: ToolkitProps) {
               key={domain.id}
               tone="raised"
               className="overflow-hidden"
-              style={
-                {
-                  borderLeftWidth: "4px",
-                  borderLeftColor: domain.color,
-                } as React.CSSProperties
-              }
             >
               <button
                 type="button"
@@ -110,14 +198,20 @@ export function LifestyleToolkit({ domains, tips }: ToolkitProps) {
                 aria-expanded={isOpen}
                 className="w-full text-left px-5 py-4 flex items-center gap-3 hover:bg-surface-muted/40 transition-colors"
               >
+                {/* EMR-19 — domain color survives as a small dot in place of
+                     the old left-border ribbon. */}
                 <span
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl relative"
                   style={{
                     backgroundColor: `color-mix(in srgb, ${domain.color} 12%, transparent)`,
                   }}
                   aria-hidden="true"
                 >
                   {domain.icon}
+                  <span
+                    className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-surface"
+                    style={{ backgroundColor: domain.color }}
+                  />
                 </span>
                 <div className="flex-1 min-w-0">
                   <p className="font-medium text-text">{domain.label}</p>


### PR DESCRIPTION
## Summary
Fixes [EMR-19](https://linear.app/emr-project/issue/EMR-19) — Dr. Patel asked to remove the colored "ribbon" on every aspect of the lifestyle toolkit and have the checkbox state contribute to a visible health score.

## What changed (single file: \`lifestyle-toolkit.tsx\`)
- **Ribbon removed** — the 4px colored left-border on each domain card is gone. Domain color survives as a small accent dot beside the icon, so the visual identity stays without dominating.
- **Wellness-score header** added at the top of the toolkit:
  - Animated ring (0–100) that recomputes live as items are checked.
  - Ring color reflects the score band: emerald (≥75) → amber (≥50) → orange (≥25) → muted.
  - Labeled status: Getting started → Building → Steady → Strong → Thriving.
  - Subline: \`{checked}/{total} active · weighted by difficulty\`.
- **Difficulty-weighted scoring**: easy=1, moderate=2, challenging=3. Normalized against the total available weight so the number is comparable across patients.

No data-model changes — state is the same \`lj-lifestyle-checked\` localStorage key the toolkit already used. The score is a derived view, not a new persisted metric.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] \`/portal/wellness\` and \`/portal/lifestyle\`: domain cards no longer have a colored left-border stripe
- [ ] Score is 0 with no items checked; ring is muted gray
- [ ] Check one "easy" item: score rises by `1 / totalWeight × 100`
- [ ] Check one "challenging" item: score rises by `3 / totalWeight × 100`
- [ ] Score crosses 25/50/75: label and ring color update accordingly
- [ ] Each domain still shows its color via the small dot on the icon badge
- [ ] localStorage persists across reload; score recomputes from saved checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)