### PR TITLE
feat(leafmart): EMR-281 Amazon-style autocomplete search bar on homepage

### DIFF
--- a/src/app/leafmart/page.tsx
+++ b/src/app/leafmart/page.tsx
@@ -4,8 +4,10 @@ import { ProductSilhouette } from "@/components/leafmart/ProductSilhouette";
 import { LeafmartProductGrid } from "@/components/leafmart/LeafmartProductCard";
 import { Portrait } from "@/components/leafmart/PortraitPlaceholder";
 import { CategoryIcon } from "@/components/leafmart/CategoryIcon";
+import { HeroSearchBar } from "@/components/leafmart/HeroSearchBar";
 import { TESTIMONIALS, TRUST_STEPS } from "@/components/leafmart/demo-data";
 import { getProducts, getCategories, getVendors } from "@/lib/leafmart/products";
+import { buildSuggestions } from "@/lib/leafmart/search-suggestions";
 
 export const metadata: Metadata = {
   title: "Leafmart — Physician-curated cannabis wellness",
@@ -64,6 +66,8 @@ export default async function LeafmartHomePage() {
     getCategories(),
     getVendors(),
   ]);
+  // EMR-281 — hero search suggestion universe.
+  const searchSuggestions = buildSuggestions(products);
 
   return (
     <>
@@ -134,6 +138,17 @@ export default async function LeafmartHomePage() {
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* ── SEARCH (EMR-281) ─────────────────────────────── */}
+      <section className="px-4 sm:px-6 lg:px-14 pb-8 sm:pb-10 max-w-[1440px] mx-auto -mt-4 sm:-mt-6 relative z-10">
+        <div className="flex flex-col items-center gap-3">
+          <HeroSearchBar suggestions={searchSuggestions} />
+          <p className="text-[12.5px] text-[var(--text-subtle)] text-center max-w-md">
+            Try &ldquo;sleep&rdquo;, &ldquo;CBD tincture&rdquo;, &ldquo;limonene&rdquo;,
+            or a brand name. We&apos;ll surface products, symptoms, terpenes, and more.
+          </p>
         </div>
       </section>
 

--- a/src/components/leafmart/HeroSearchBar.tsx
+++ b/src/components/leafmart/HeroSearchBar.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+// EMR-281 — Amazon-style search bar with autocomplete for the Leafmart
+// homepage hero. Suggests across multiple axes:
+//   - products (name + brand)
+//   - symptoms / use-cases
+//   - cannabinoid names (THC, CBD, CBG, CBN, THCv, etc.)
+//   - terpene names (myrcene, limonene, pinene, etc.)
+//   - strain types (indica / sativa / hybrid)
+//   - delivery formats (tincture, edible, topical, etc.)
+//
+// On selection or Enter, navigates to /leafmart/search?q=<term>. The
+// search page already supports the same q parameter and filter set,
+// so this component is purely a discovery accelerator.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export type SuggestionKind =
+  | "product"
+  | "symptom"
+  | "cannabinoid"
+  | "terpene"
+  | "strain"
+  | "format"
+  | "accessory";
+
+export interface Suggestion {
+  kind: SuggestionKind;
+  label: string;
+  /** Optional secondary line shown faintly under the label. */
+  detail?: string;
+  /** Optional href override. Defaults to /leafmart/search?q=<label>. */
+  href?: string;
+}
+
+export interface HeroSearchBarProps {
+  /** Pre-built suggestion universe. Resolved server-side from the catalog. */
+  suggestions: Suggestion[];
+  /** How many suggestions to show in the dropdown. */
+  limit?: number;
+  placeholder?: string;
+  className?: string;
+}
+
+const KIND_LABEL: Record<SuggestionKind, string> = {
+  product: "Product",
+  symptom: "Symptom",
+  cannabinoid: "Cannabinoid",
+  terpene: "Terpene",
+  strain: "Strain",
+  format: "Format",
+  accessory: "Accessory",
+};
+
+const KIND_TONE: Record<SuggestionKind, string> = {
+  product: "bg-[var(--leaf)]/10 text-[var(--leaf)]",
+  symptom: "bg-amber-100 text-amber-800",
+  cannabinoid: "bg-emerald-100 text-emerald-800",
+  terpene: "bg-sky-100 text-sky-800",
+  strain: "bg-violet-100 text-violet-800",
+  format: "bg-rose-100 text-rose-800",
+  accessory: "bg-stone-100 text-stone-800",
+};
+
+function rankSuggestions(query: string, pool: Suggestion[], limit: number): Suggestion[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const scored: { s: Suggestion; score: number }[] = [];
+  for (const s of pool) {
+    const label = s.label.toLowerCase();
+    const detail = (s.detail ?? "").toLowerCase();
+    let score = 0;
+    if (label === q) score += 100;
+    else if (label.startsWith(q)) score += 40;
+    else if (label.includes(q)) score += 20;
+    if (detail.includes(q)) score += 5;
+    // Boost products slightly so the first results are clickable items, not taxonomies.
+    if (s.kind === "product" && score > 0) score += 3;
+    if (score > 0) scored.push({ s, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map((x) => x.s);
+}
+
+export function HeroSearchBar({
+  suggestions,
+  limit = 8,
+  placeholder = "Search products, symptoms, cannabinoids, terpenes…",
+  className,
+}: HeroSearchBarProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const matches = useMemo(
+    () => rankSuggestions(query, suggestions, limit),
+    [query, suggestions, limit],
+  );
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    window.addEventListener("mousedown", onClick);
+    return () => window.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const navigate = (term: string, href?: string) => {
+    if (href) {
+      router.push(href);
+      return;
+    }
+    const q = term.trim();
+    if (!q) return;
+    router.push(`/leafmart/search?q=${encodeURIComponent(q)}`);
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const target = matches[highlight];
+      if (target) navigate(target.label, target.href);
+      else navigate(query);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className={`relative w-full max-w-2xl ${className ?? ""}`}>
+      <div className="relative">
+        <span
+          aria-hidden="true"
+          className="absolute left-5 top-1/2 -translate-y-1/2 text-[var(--leaf)] pointer-events-none"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <circle cx="9" cy="9" r="6" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M13.7 13.7L17 17" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          </svg>
+        </span>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setHighlight(0);
+            setOpen(e.target.value.trim().length > 0);
+          }}
+          onFocus={() => {
+            if (query.trim().length > 0) setOpen(true);
+          }}
+          onKeyDown={handleKey}
+          placeholder={placeholder}
+          aria-label="Search Leafmart"
+          aria-autocomplete="list"
+          aria-expanded={open}
+          autoComplete="off"
+          className="w-full h-14 pl-14 pr-32 rounded-full bg-white text-[var(--ink)] placeholder:text-[var(--text-subtle)] border border-[var(--border)] focus:outline-none focus:border-[var(--leaf)] focus:ring-2 focus:ring-[var(--leaf)]/20 shadow-sm transition-colors"
+        />
+        <button
+          type="button"
+          onClick={() => navigate(query)}
+          className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center px-5 h-11 rounded-full bg-[var(--ink)] text-[var(--bg,#fff)] text-sm font-medium hover:bg-[var(--leaf)] transition-colors"
+        >
+          Search
+        </button>
+      </div>
+
+      {open && matches.length > 0 && (
+        <ul
+          role="listbox"
+          aria-label="Search suggestions"
+          className="absolute z-30 mt-2 w-full max-h-[420px] overflow-y-auto rounded-2xl bg-white border border-[var(--border)] shadow-xl divide-y divide-[var(--border)]"
+        >
+          {matches.map((s, i) => {
+            const isActive = i === highlight;
+            return (
+              <li key={`${s.kind}:${s.label}`} role="option" aria-selected={isActive}>
+                <button
+                  type="button"
+                  onMouseEnter={() => setHighlight(i)}
+                  onClick={() => navigate(s.label, s.href)}
+                  className={`w-full flex items-center justify-between gap-3 px-4 py-3 text-left transition-colors ${
+                    isActive ? "bg-[var(--surface-muted)]" : "hover:bg-[var(--surface-muted)]/60"
+                  }`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-[14px] font-medium text-[var(--ink)] truncate">
+                      {s.label}
+                    </div>
+                    {s.detail && (
+                      <div className="text-[12px] text-[var(--text-subtle)] truncate">{s.detail}</div>
+                    )}
+                  </div>
+                  <span
+                    className={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-md ${KIND_TONE[s.kind]}`}
+                  >
+                    {KIND_LABEL[s.kind]}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {open && matches.length === 0 && query.trim().length > 0 && (
+        <div className="absolute z-30 mt-2 w-full rounded-2xl bg-white border border-[var(--border)] shadow-xl px-4 py-6 text-center">
+          <p className="text-sm text-[var(--text-soft)]">
+            Nothing matches &ldquo;<span className="font-medium text-[var(--ink)]">{query}</span>&rdquo;.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate(query)}
+            className="mt-2 text-[13px] font-medium text-[var(--leaf)] hover:underline"
+          >
+            Search anyway →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default HeroSearchBar;

--- a/src/lib/leafmart/search-suggestions.ts
+++ b/src/lib/leafmart/search-suggestions.ts
@@ -1,0 +1,63 @@
+// EMR-281 — Build the suggestion universe for the Leafmart hero search bar.
+//
+// Server-side: pulls product names from the catalog and combines them with
+// static cannabis taxonomies (symptoms, cannabinoids, terpenes, strains,
+// delivery formats). The result is ranked client-side as the user types.
+
+import type { Suggestion } from "@/components/leafmart/HeroSearchBar";
+import type { LeafmartProduct } from "@/components/leafmart/LeafmartProductCard";
+
+const SYMPTOMS = [
+  "sleep", "insomnia", "anxiety", "pain", "chronic pain", "back pain",
+  "migraine", "headache", "nausea", "depression", "ptsd", "stress",
+  "appetite", "inflammation", "muscle recovery", "focus", "energy",
+  "menstrual cramps", "neuropathy", "fatigue",
+];
+
+const CANNABINOIDS = [
+  "THC", "CBD", "CBG", "CBN", "THCv", "CBC", "CBDa", "THCa",
+];
+
+const TERPENES = [
+  "myrcene", "limonene", "linalool", "pinene", "alpha-pinene",
+  "beta-pinene", "caryophyllene", "humulene", "terpinolene", "ocimene",
+  "bisabolol", "eucalyptol",
+];
+
+const STRAINS = ["indica", "sativa", "hybrid"];
+
+const FORMATS = [
+  "tincture", "edible", "topical", "beverage", "capsule", "vape",
+  "serum", "flower",
+];
+
+const ACCESSORIES = [
+  "grow light", "grow tent", "vape battery", "rolling tray",
+  "storage jar", "grinder", "fertilizer", "trimming shears",
+];
+
+export function buildSuggestions(products: LeafmartProduct[]): Suggestion[] {
+  const out: Suggestion[] = [];
+
+  // Products — name + brand context. De-duplicate by slug.
+  const seen = new Set<string>();
+  for (const p of products) {
+    if (seen.has(p.slug)) continue;
+    seen.add(p.slug);
+    out.push({
+      kind: "product",
+      label: p.name,
+      detail: `${p.partner} · ${p.formatLabel}`,
+      href: `/leafmart/products/${p.slug}`,
+    });
+  }
+
+  for (const s of SYMPTOMS) out.push({ kind: "symptom", label: s });
+  for (const c of CANNABINOIDS) out.push({ kind: "cannabinoid", label: c });
+  for (const t of TERPENES) out.push({ kind: "terpene", label: t });
+  for (const s of STRAINS) out.push({ kind: "strain", label: s });
+  for (const f of FORMATS) out.push({ kind: "format", label: f });
+  for (const a of ACCESSORIES) out.push({ kind: "accessory", label: a });
+
+  return out;
+}


### PR DESCRIPTION
## Summary
Fixes [EMR-281](https://linear.app/emr-project/issue/EMR-281) — adds the always-visible homepage search bar with cross-axis autocomplete (products, symptoms, cannabinoids, terpenes, strains, formats, accessories).

## What ships
- **\`HeroSearchBar.tsx\`** (new, client) — pill-shaped input + embedded Search button + autocomplete dropdown:
  - Up to 8 ranked suggestions, each labeled with a typed tag (Product / Symptom / Cannabinoid / Terpene / Strain / Format / Accessory).
  - Keyboard nav: arrow keys cycle highlight, Enter selects, Escape closes; outside-click closes.
  - Selection routes either to a product detail page (when a product suggestion includes an href) or to \`/leafmart/search?q=<term>\` — both endpoints already exist.
  - "Search anyway →" CTA when nothing matches.
- **\`search-suggestions.ts\`** (new) — server-side builder that fuses the product catalog with curated cannabis taxonomies:
  - Cannabinoids: THC, CBD, CBG, CBN, THCv, CBC, CBDa, THCa
  - Terpenes: myrcene, limonene, pinene, linalool, caryophyllene, humulene, terpinolene, etc.
  - Strain types: indica / sativa / hybrid
  - Symptoms: sleep, anxiety, pain, migraine, nausea, depression, PTSD, etc.
  - Delivery formats: tincture, edible, topical, beverage, capsule, vape, serum, flower
  - Accessories: grow light, grow tent, vape battery, rolling tray, etc.
- **\`leafmart/page.tsx\`** — runs \`buildSuggestions(products)\` server-side at request time and renders \`<HeroSearchBar>\` in a discrete section overlapping the hero radius (-mt-4 sm:-mt-6).

Ranking is deterministic (exact match → prefix → substring, with a small product boost). No external AI dependency for v1 — a model-backed re-ranker can be swapped in later without changing the component API.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] /leafmart shows the search bar right under the hero
- [ ] Type "sleep" → dropdown surfaces the "sleep" symptom + any products matching sleep + the relevant cannabinoid (CBN) if it ranks
- [ ] Type "CBD" → cannabinoid tag at top, then any CBD products
- [ ] Type "myrcene" → terpene suggestion appears
- [ ] Type a brand name → product suggestion routes to the PDP
- [ ] Keyboard: ↓/↑ navigate, Enter selects, Esc closes
- [ ] No-match query shows "Nothing matches" with Search-anyway CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)