### PR TITLE
feat(clinical): EMR-174 wire Clinical Note Templates into the note editor

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -18,6 +18,8 @@ import { APSO_ORDER, NOTE_BLOCK_LABELS } from "@/lib/domain/notes";
 import type { NoteBlockType } from "@/lib/domain/notes";
 import { LeafSprig } from "@/components/ui/ornament";
 import { DictateButton } from "@/components/ui/dictation";
+import { NoteTemplatePicker, type PickerBlock } from "@/components/clinical/note-template-picker";
+import { NOTE_BLOCK_LABELS as NB_LABELS } from "@/lib/domain/notes";
 
 interface NoteBlock {
   type?: NoteBlockType;
@@ -145,6 +147,26 @@ export function NoteEditor({
     });
   }
 
+  // EMR-174 — applying a template overwrites the current blocks. Picker
+  // shows a confirm dialog before calling this when there's content to
+  // preserve, so we trust the call here. APSO-sort and APSO-label, same
+  // as the initial mount.
+  function applyTemplate(_templateName: string, incoming: PickerBlock[]) {
+    const sorted = [...incoming].sort((a, b) => {
+      const aIdx = a.type ? APSO_ORDER.indexOf(a.type) : APSO_ORDER.length;
+      const bIdx = b.type ? APSO_ORDER.indexOf(b.type) : APSO_ORDER.length;
+      return (aIdx === -1 ? APSO_ORDER.length : aIdx) - (bIdx === -1 ? APSO_ORDER.length : bIdx);
+    });
+    setBlocks(
+      sorted.map((b) => ({
+        type: b.type,
+        body: b.body,
+        heading: b.type && NB_LABELS[b.type] ? NB_LABELS[b.type] : b.heading,
+      })),
+    );
+    setSaveMessage(null);
+  }
+
   function handleSave() {
     startTransition(async () => {
       const result = await saveNoteBlocks(noteId, blocks);
@@ -243,26 +265,33 @@ export function NoteEditor({
         </Card>
       )}
 
-      {/* Status + AI badges */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <Badge
-          tone={
-            currentStatus === "finalized"
-              ? "success"
-              : currentStatus === "needs_review"
-                ? "warning"
-                : "neutral"
-          }
-        >
-          {currentStatus}
-        </Badge>
-        {aiDrafted && <Badge tone="highlight">AI-drafted</Badge>}
-        {aiConfidence !== null && (
-          <Badge tone="info">
-            Confidence {Math.round(aiConfidence * 100)}%
+      {/* Status + AI badges + template picker (EMR-174) */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge
+            tone={
+              currentStatus === "finalized"
+                ? "success"
+                : currentStatus === "needs_review"
+                  ? "warning"
+                  : "neutral"
+            }
+          >
+            {currentStatus}
           </Badge>
-        )}
-        {fromBriefing && <Badge tone="accent">Briefing-seeded</Badge>}
+          {aiDrafted && <Badge tone="highlight">AI-drafted</Badge>}
+          {aiConfidence !== null && (
+            <Badge tone="info">
+              Confidence {Math.round(aiConfidence * 100)}%
+            </Badge>
+          )}
+          {fromBriefing && <Badge tone="accent">Briefing-seeded</Badge>}
+        </div>
+        <NoteTemplatePicker
+          disabled={!isEditable}
+          hasExistingContent={blocks.some((b) => b.body.trim().length > 0)}
+          onApply={(template, incoming) => applyTemplate(template.name, incoming)}
+        />
       </div>
 
       {/* Emotional vitals — EMR-134: emoji demeanor scale persisted to encounter */}

--- a/src/components/clinical/note-template-picker.tsx
+++ b/src/components/clinical/note-template-picker.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+// EMR-174 — clinical note template picker.
+//
+// Drop-in surface for the note editor. Renders an inline dropdown trigger
+// that opens a menu of pre-built templates (Cannabis Initiation, Pain
+// Follow-up, Mental Health Check-In, Medication Adjustment, etc.). On
+// selection it emits a normalized `NoteBlock[]` so the editor can
+// `setBlocks(...)` directly. Templates already contain the AI-friendly
+// `[bracketed]` placeholders that the refine flow expands per-section.
+
+import { useEffect, useRef, useState } from "react";
+import {
+  NOTE_TEMPLATES,
+  type NoteTemplate,
+} from "@/lib/domain/note-templates";
+import type { NoteBlockType } from "@/lib/domain/notes";
+
+export interface PickerBlock {
+  type?: NoteBlockType;
+  heading: string;
+  body: string;
+}
+
+interface Props {
+  onApply: (template: NoteTemplate, blocks: PickerBlock[]) => void;
+  /** When true, the picker is disabled. Editor passes !isEditable. */
+  disabled?: boolean;
+  /** When true, the patient already has content; the picker shows a
+   *  confirm step before replacing. Editor passes blocks.length > 0. */
+  hasExistingContent?: boolean;
+  className?: string;
+}
+
+const NOTE_BLOCK_TYPES: ReadonlySet<NoteBlockType> = new Set([
+  "subjective",
+  "objective",
+  "assessment",
+  "plan",
+] as NoteBlockType[]);
+
+function asBlockType(raw: string): NoteBlockType | undefined {
+  return NOTE_BLOCK_TYPES.has(raw as NoteBlockType) ? (raw as NoteBlockType) : undefined;
+}
+
+export function NoteTemplatePicker({
+  onApply,
+  disabled,
+  hasExistingContent,
+  className,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState<NoteTemplate | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open && !confirming) return;
+    function onClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+        setConfirming(null);
+      }
+    }
+    window.addEventListener("mousedown", onClick);
+    return () => window.removeEventListener("mousedown", onClick);
+  }, [open, confirming]);
+
+  const applyTemplate = (template: NoteTemplate) => {
+    const blocks: PickerBlock[] = template.blocks.map((b) => ({
+      type: asBlockType(b.type),
+      heading: b.heading,
+      body: b.body,
+    }));
+    onApply(template, blocks);
+    setOpen(false);
+    setConfirming(null);
+  };
+
+  const handlePick = (template: NoteTemplate) => {
+    if (hasExistingContent) {
+      setConfirming(template);
+      return;
+    }
+    applyTemplate(template);
+  };
+
+  return (
+    <div ref={containerRef} className={`relative inline-block ${className ?? ""}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg text-[13px] font-medium border border-[var(--border)] bg-white hover:border-[var(--accent)] hover:text-[var(--accent)] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+      >
+        <span aria-hidden="true">📝</span>
+        Apply template
+        <span aria-hidden="true" className={`transition-transform ${open ? "rotate-180" : ""}`}>
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute z-30 mt-2 w-[320px] rounded-xl bg-white border border-[var(--border)] shadow-xl overflow-hidden"
+        >
+          <div className="px-4 py-2.5 border-b border-[var(--border)] bg-[var(--surface-muted)]/60">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+              Templates
+            </p>
+            <p className="text-[11px] text-text-muted mt-0.5">
+              AI fills the bracketed placeholders per section after you apply.
+            </p>
+          </div>
+          <ul className="max-h-[360px] overflow-y-auto divide-y divide-[var(--border)]">
+            {NOTE_TEMPLATES.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => handlePick(t)}
+                  className="w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-[var(--surface-muted)]/40 transition-colors"
+                >
+                  <span className="text-lg leading-none mt-0.5" aria-hidden="true">{t.emoji}</span>
+                  <div className="min-w-0">
+                    <p className="text-[13.5px] font-medium text-text leading-tight">{t.name}</p>
+                    <p className="text-[11.5px] text-text-muted mt-0.5">
+                      {t.visitType} · {t.blocks.length} sections
+                    </p>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {confirming && (
+        <div className="absolute z-30 mt-2 w-[360px] rounded-xl bg-white border border-amber-300 shadow-xl p-4">
+          <p className="text-[12px] font-semibold text-amber-700 mb-1">Replace current note?</p>
+          <p className="text-[13px] text-text leading-snug mb-3">
+            Applying <strong>{confirming.name}</strong> will overwrite the current
+            blocks. Your AI refinements will be lost.
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirming(null)}
+              className="text-[13px] px-3 h-8 rounded-lg border border-[var(--border)] hover:bg-[var(--surface-muted)]/40"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => applyTemplate(confirming)}
+              className="text-[13px] px-3 h-8 rounded-lg bg-amber-500 text-white hover:bg-amber-600 font-medium"
+            >
+              Replace
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NoteTemplatePicker;


### PR DESCRIPTION
## Summary
Fixes [EMR-174](https://linear.app/emr-project/issue/EMR-174) — the note templates library at \`src/lib/domain/note-templates.ts\` was orphaned (five ready templates: Cannabis Initiation, Pain Follow-Up, Mental Health Check-In, Medication Adjustment, etc.), but no UI consumed it. This ships the clinician-facing surface.

## What's added
- **\`components/clinical/note-template-picker.tsx\`** (new) — popover trigger + menu listing every template by emoji, name, visit type, and section count. Closes on outside click. When the editor already has body content, picking a template shows a confirm step ("Replace current note?") before overwriting; otherwise it applies directly.
- **\`note-editor.tsx\`** — mounts the picker in the status-badge row, right-justified. The \`applyTemplate()\` callback:
  - APSO-sorts the incoming blocks (Assessment → Plan → Subjective → Objective)
  - Relabels headings via \`NOTE_BLOCK_LABELS\` — same normalization the initial-mount does, so the Refine flow behaves identically on template-applied vs hand-typed blocks
  - Resets the save banner so the editor isn't stuck on stale "Saved successfully"
  - Picker is disabled when the note isn't editable

No new server actions, no model wiring. Templates feed into the same edit/save/refine pipeline a hand-typed note already uses. The existing per-section AI Refine handles the \`[bracketed]\` placeholders.

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] Open a draft note → see "📝 Apply template ▾" button in the badge row
- [ ] Click → menu shows 5+ templates with emoji and section count
- [ ] Pick "Cannabis Initiation Visit" on an empty note → blocks populate immediately, APSO-ordered, headings relabeled
- [ ] Pick another template on a note with content → confirm dialog "Replace current note?" appears; Cancel preserves content, Replace overwrites
- [ ] On a finalized note, the picker is disabled
- [ ] Refine button on a templated block expands \`[bracketed]\` placeholders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)