### PR TITLE
feat(legal): EMR-555 /terms TOC + scroll-spy + print polish

### DIFF
--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { TermsSection } from "./terms-section";
 import { TermsSignature } from "./terms-signature";
+import { TermsLayout } from "./terms-layout";
 
 export const metadata: Metadata = { title: "Terms of Service" };
 
@@ -211,44 +212,60 @@ const SECTIONS: { id: string; title: string; summary: string; body: React.ReactN
 ];
 
 export default function TermsPage() {
+  const tocSections = SECTIONS.map((s) => ({ id: s.id, title: s.title }));
+
   return (
-    <>
-      <h1>Terms of Service</h1>
-      <p>
-        Last updated: 2026-05-09 (Draft v2 — pending outside-counsel review)
-      </p>
-      <p>
-        These Terms govern the practice&apos;s use of Leafjourney as an
-        electronic medical record system, AI clinical workflow tool, and
-        connected marketplace. They are based on standard EMR contracting
-        practice and the Office of the National Coordinator&apos;s{" "}
-        <a
-          href="https://healthit.gov/wp-content/uploads/2025/03/EHR_Contracts_Untangled.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          EHR Contracts Untangled
-        </a>{" "}
-        guide.
-      </p>
+    <div id="terms-top" className="max-w-[1100px] mx-auto px-4 sm:px-6 py-10 print:px-0 print:py-0">
+      <header className="mb-10 print:mb-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--leaf,#2d8b5e)] mb-2">
+          Legal
+        </p>
+        <h1 className="font-display text-[32px] sm:text-[40px] font-normal tracking-[-1px] leading-[1.05] text-[var(--ink)]">
+          Terms of Service
+        </h1>
+        <p className="mt-3 text-[13px] text-[var(--text-subtle)]">
+          Last updated: 2026-05-09 (Draft v2 — pending outside-counsel review)
+        </p>
+        <p className="mt-4 text-[14.5px] leading-relaxed text-[var(--text-soft)] max-w-[640px]">
+          These Terms govern the practice&apos;s use of Leafjourney as an
+          electronic medical record system, AI clinical workflow tool, and
+          connected marketplace. They are based on standard EMR contracting
+          practice and the Office of the National Coordinator&apos;s{" "}
+          <a
+            href="https://healthit.gov/wp-content/uploads/2025/03/EHR_Contracts_Untangled.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--leaf,#2d8b5e)] underline-offset-2 hover:underline"
+          >
+            EHR Contracts Untangled
+          </a>{" "}
+          guide.
+        </p>
+      </header>
 
-      {SECTIONS.map((s) => (
-        <TermsSection key={s.id} id={s.id} title={s.title} summary={s.summary}>
-          {s.body}
-        </TermsSection>
-      ))}
+      <TermsLayout sections={tocSections}>
+        {SECTIONS.map((s) => (
+          <TermsSection key={s.id} id={s.id} title={s.title} summary={s.summary}>
+            {s.body}
+          </TermsSection>
+        ))}
 
-      <h2>Total summary</h2>
-      <p>
-        AI summary: You and Leafjourney both promise to take HIPAA seriously.
-        We provide the software and the AI; you provide the clinical judgment
-        and the patient consent. You own your data and can leave with it. The
-        platform is a tool, not a replacement for a clinician — and either
-        side can end the relationship cleanly with 90 days&apos; notice plus
-        a 30-day export window.
-      </p>
+        <section id="total-summary" className="not-prose mt-12 mb-10 rounded-2xl border border-[var(--border)] bg-[var(--surface-muted,#fafaf7)] p-6 print:bg-transparent print:border-0 print:p-0">
+          <h2 className="font-display text-[20px] font-medium text-[var(--ink)] mb-2">
+            Total summary
+          </h2>
+          <p className="text-[14.5px] leading-relaxed text-[var(--text-soft)]">
+            You and Leafjourney both promise to take HIPAA seriously. We
+            provide the software and the AI; you provide the clinical judgment
+            and the patient consent. You own your data and can leave with it.
+            The platform is a tool, not a replacement for a clinician — and
+            either side can end the relationship cleanly with 90 days&apos;
+            notice plus a 30-day export window.
+          </p>
+        </section>
 
-      <TermsSignature />
-    </>
+        <TermsSignature />
+      </TermsLayout>
+    </div>
   );
 }

--- a/src/app/legal/terms/terms-layout.tsx
+++ b/src/app/legal/terms/terms-layout.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// EMR-555 — sticky-TOC + scroll-spy + print-friendly layout for /terms.
+// Renders a two-column grid on desktop (sticky TOC rail left, content right)
+// and stacks on mobile. IntersectionObserver tracks the active section so
+// the TOC stays in sync as the user scrolls. Print styles collapse the
+// chrome (TOC, "back to top") so the printed page reads as a clean document.
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import Link from "next/link";
+
+export interface TermsSectionEntry {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  sections: TermsSectionEntry[];
+  children: ReactNode;
+}
+
+export function TermsLayout({ sections, children }: Props) {
+  const [activeId, setActiveId] = useState<string | null>(sections[0]?.id ?? null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Observe section headings — fire on the topmost visible one.
+    const visible = new Map<string, IntersectionObserverEntry>();
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) visible.set(e.target.id, e);
+          else visible.delete(e.target.id);
+        }
+        // Pick the section closest to the top of the viewport.
+        let topId: string | null = null;
+        let topY = Infinity;
+        for (const [id, e] of visible) {
+          const y = e.boundingClientRect.top;
+          if (y >= 0 && y < topY) {
+            topY = y;
+            topId = id;
+          }
+        }
+        if (topId) setActiveId(topId);
+      },
+      // Bias toward sections in the top third of the viewport so the active
+      // pill flips before the section title hits the very top of the screen.
+      { rootMargin: "-15% 0% -65% 0%", threshold: [0, 0.25, 0.5, 1] },
+    );
+    observerRef.current = obs;
+    for (const s of sections) {
+      const el = document.getElementById(s.id);
+      if (el) obs.observe(el);
+    }
+    return () => obs.disconnect();
+  }, [sections]);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[220px_minmax(0,1fr)] gap-10 lg:gap-12">
+      {/* Sticky TOC (left rail) */}
+      <aside className="lg:sticky lg:top-24 lg:self-start print:hidden" aria-label="Table of contents">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-subtle)] mb-3">
+          On this page
+        </p>
+        <nav>
+          <ol className="space-y-1">
+            {sections.map((s) => {
+              const active = s.id === activeId;
+              return (
+                <li key={s.id}>
+                  <a
+                    href={`#${s.id}`}
+                    className={`block text-[12.5px] leading-snug py-1.5 pl-3 border-l-2 transition-colors ${
+                      active
+                        ? "border-[var(--leaf,#2d8b5e)] text-[var(--ink)] font-medium"
+                        : "border-transparent text-[var(--text-soft)] hover:text-[var(--ink)] hover:border-[var(--border)]"
+                    }`}
+                    aria-current={active ? "location" : undefined}
+                  >
+                    {s.title}
+                  </a>
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+        <div className="mt-6 pt-4 border-t border-[var(--border)] print:hidden">
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof window !== "undefined") window.print();
+            }}
+            className="text-[12px] font-medium text-[var(--leaf,#2d8b5e)] hover:underline"
+          >
+            Print these terms
+          </button>
+        </div>
+      </aside>
+
+      <div>{children}</div>
+    </div>
+  );
+}
+
+interface BackToTopProps {
+  className?: string;
+}
+
+export function BackToTop({ className }: BackToTopProps) {
+  return (
+    <a
+      href="#terms-top"
+      className={`inline-flex items-center gap-1 text-[12px] font-medium text-[var(--text-subtle)] hover:text-[var(--leaf,#2d8b5e)] print:hidden ${className ?? ""}`}
+    >
+      <span aria-hidden="true">↑</span>
+      Back to top
+    </a>
+  );
+}
+
+export default TermsLayout;

--- a/src/app/legal/terms/terms-section.tsx
+++ b/src/app/legal/terms/terms-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ReactNode } from "react";
 import { ChevronDown, Sparkles } from "lucide-react";
+import { BackToTop } from "./terms-layout";
 
 export function TermsSection({
   id,
@@ -17,17 +18,20 @@ export function TermsSection({
   const [showSummary, setShowSummary] = useState(true);
 
   return (
-    <section id={id} className="not-prose mb-10">
-      <h2 className="font-display text-[22px] font-medium mt-10 text-[var(--ink)]">
-        {title}
-      </h2>
+    <section id={id} className="not-prose mb-10 scroll-mt-24">
+      <div className="flex items-baseline justify-between gap-4">
+        <h2 className="font-display text-[22px] font-medium mt-10 text-[var(--ink)]">
+          {title}
+        </h2>
+        <BackToTop />
+      </div>
 
-      <div className="mt-3 mb-4 rounded-xl border border-[var(--border)] bg-[var(--accent-soft,rgba(45,139,94,0.06))] px-4 py-3">
+      <div className="mt-3 mb-4 rounded-xl border border-[var(--border)] bg-[var(--accent-soft,rgba(45,139,94,0.06))] px-4 py-3 print:bg-transparent print:border-0 print:px-0 print:py-1">
         <button
           type="button"
           onClick={() => setShowSummary((v) => !v)}
           aria-expanded={showSummary}
-          className="flex items-center gap-2 text-[12px] uppercase tracking-wider font-semibold text-[var(--leaf,#2d8b5e)]"
+          className="flex items-center gap-2 text-[12px] uppercase tracking-wider font-semibold text-[var(--leaf,#2d8b5e)] print:hidden"
         >
           <Sparkles className="w-3.5 h-3.5" />
           AI summary
@@ -37,7 +41,7 @@ export function TermsSection({
           />
         </button>
         {showSummary && (
-          <p className="mt-2 text-[13.5px] leading-relaxed text-[var(--text-soft)]">
+          <p className="mt-2 text-[13.5px] leading-relaxed text-[var(--text-soft)] print:text-[12px] print:italic print:mt-0">
             {summary.replace(/^AI summary:\s*/i, "")}
           </p>
         )}


### PR DESCRIPTION
## Summary
Fixes [EMR-555](https://linear.app/emr-project/issue/EMR-555) — brings \`/terms\` up to the leafjourney.com polish bar.

## What ships
- **\`terms-layout.tsx\`** (new, client) — two-column grid (sticky TOC rail on desktop, single column on mobile). \`IntersectionObserver\` tracks the topmost visible section and flips the active pill. "Print these terms" button at the bottom of the TOC.
- **\`terms-section.tsx\`** — adds \`<BackToTop />\` next to each section title; adds \`scroll-mt-24\` so anchor jumps clear the sticky header; collapses the AI-summary chrome on print (no eyebrow on the printed page; summary text remains as italic).
- **\`page.tsx\`** — wraps \`SECTIONS\` with \`<TermsLayout>\`, adds a polished header with eyebrow + display-font H1, an \`#terms-top\` anchor for the BackToTop targets, and a "Total summary" card with consistent styling.

## Acceptance vs ticket
- ✅ Sticky TOC, current section highlighted as the user scrolls
- ✅ Section anchors (already there, now navigable from the rail; deep-linking like \`/terms#data-ownership\` works)
- ✅ Each section: title, AI summary card, full body, "back to top"
- ✅ E-sign block at the bottom (\`<TermsSignature />\` mounted)
- ✅ Print-friendly stylesheet — \`print:hidden\` on TOC + back-to-top + AI-summary eyebrow; surface backgrounds collapse to transparent on print

## Test plan
- [ ] \`npm run typecheck\` ✅
- [ ] \`/terms\` desktop: TOC sticks on the left; active pill follows scroll
- [ ] Click a TOC entry → smooth scroll, section appears under the sticky header
- [ ] Hit \`/terms#liability-disclaimer\` directly → opens scrolled to that section, TOC reflects it active
- [ ] Click "Back to top" on any section → returns to \`#terms-top\`
- [ ] Cmd+P print preview shows a clean single-column document; TOC and "back to top" links are absent
- [ ] Mobile width: TOC stacks above content, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)