### PR TITLE
feat(super-admin): chrome with sign-out across console, practices, wizard

### DIFF
--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -2,16 +2,46 @@ import { redirect } from "next/navigation";
 import { requireUser } from "@/lib/auth/session";
 import { requireSuperAdmin } from "@/lib/auth/super-admin";
 import { bootstrapSuperAdminIfAllowlisted } from "@/lib/auth/super-admin-bootstrap";
+import { AppShell, type NavSection } from "@/components/shell/AppShell";
+import { ROLE_LABELS } from "@/lib/rbac/roles";
 
 export const dynamic = "force-dynamic";
+
+const SUPER_ADMIN_SECTIONS: NavSection[] = [
+  {
+    pillar: "onboarding",
+    icon: "clipboard-check",
+    label: "Onboarding",
+    items: [{ label: "Onboarding", href: "/onboarding" }],
+  },
+  {
+    pillar: "practices",
+    icon: "building",
+    label: "Practices",
+    items: [{ label: "Practices", href: "/practices" }],
+  },
+  {
+    pillar: "templates",
+    icon: "layout-grid",
+    label: "Templates",
+    items: [{ label: "Templates", href: "/templates" }],
+  },
+  {
+    pillar: "admin",
+    icon: "settings",
+    label: "Admin",
+    items: [{ label: "Console", href: "/admin" }],
+  },
+];
 
 export default async function SuperAdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  let user;
   try {
-    const user = await requireUser();
+    user = await requireUser();
     await bootstrapSuperAdminIfAllowlisted(user);
     await requireSuperAdmin();
   } catch (err) {
@@ -19,5 +49,16 @@ export default async function SuperAdminLayout({
     if (code === "UNAUTHORIZED") redirect("/sign-in");
     redirect("/");
   }
-  return <>{children}</>;
+
+  return (
+    <AppShell
+      user={user}
+      activeRole="super_admin"
+      sections={SUPER_ADMIN_SECTIONS}
+      roleLabel={ROLE_LABELS.super_admin}
+      showNavPrefs={false}
+    >
+      {children}
+    </AppShell>
+  );
 }

--- a/src/app/(super-admin)/onboarding/wizard/[draftId]/wizard-shell.tsx
+++ b/src/app/(super-admin)/onboarding/wizard/[draftId]/wizard-shell.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { Check, ChevronLeft, ChevronRight } from "lucide-react";
+import { SignOutButton } from "@clerk/nextjs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -286,6 +287,11 @@ export function WizardShell({
             >
               Exit
             </Button>
+            <SignOutButton redirectUrl="/sign-in">
+              <Button variant="ghost" size="sm">
+                Sign out
+              </Button>
+            </SignOutButton>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Wraps the `(super-admin)` route group in `AppShell` with four pillars — **Onboarding · Practices · Templates · Admin** — so the rail's identity menu (with Clerk `SignOutButton` → `/sign-in`) is reachable from every super-admin surface, including the focused onboarding wizard.
- Adds an explicit **Sign out** button beside **Exit** in the wizard header so testers can drop the session without hunting in the rail mid-flow.
- Promotes the existing `/practices` fleet landing (live KPIs, drafts, summary stats) to a first-class pillar in the nav.

## Why
While testing the onboarding flow for a new practice, there was no way to sign out from the super-admin layer — the route group rendered children directly with no chrome, so the Clerk session felt like it persisted indefinitely. This was both a UX gap and a testing/QA blocker.

## Test plan
- [ ] Visit `/onboarding` as a super-admin — confirm the left rail shows four pillars and the avatar identity menu offers **Sign out**.
- [ ] Click into a draft `/onboarding/wizard/[draftId]` — confirm both the rail identity menu *and* the inline header **Sign out** button work and land on `/sign-in`.
- [ ] Verify `/practices` and `/templates` and `/admin` all render inside the shell with active-pillar highlighting.
- [ ] Sign out, hard-refresh — verify you're bounced to `/sign-in` (no lingering session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)