### PR TITLE
refactor(super-admin): drop redundant inline sign-out from wizard header

### DIFF
--- a/src/app/(super-admin)/onboarding/wizard/[draftId]/wizard-shell.tsx
+++ b/src/app/(super-admin)/onboarding/wizard/[draftId]/wizard-shell.tsx
@@ -23,7 +23,6 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { Check, ChevronLeft, ChevronRight } from "lucide-react";
-import { SignOutButton } from "@clerk/nextjs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -287,11 +286,6 @@ export function WizardShell({
             >
               Exit
             </Button>
-            <SignOutButton redirectUrl="/sign-in">
-              <Button variant="ghost" size="sm">
-                Sign out
-              </Button>
-            </SignOutButton>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Removes the inline **Sign out** button from the onboarding wizard header (added in #316).
- The `AppShell` wrap from #316 already places a Clerk `SignOutButton` in the rail's identity menu on every super-admin surface — including the focused wizard — so the inline control was duplicative.

## Why
Follow-up to #316. The wizard's step bar is intentionally minimal (just **Draft** + **Exit**); the duplicate sign-out added visual noise without adding capability.

## Test plan
- [ ] Visit `/onboarding/wizard/[draftId]` as a super-admin — confirm only **Draft · Exit** in the header.
- [ ] Click the avatar in the lower-left rail — confirm **Sign out** still appears in the identity menu and lands on `/sign-in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)