### PR TITLE
feat(clinic): EMR-599 patient roster — smart name/DOB/phone search; drop status filters

### DIFF
--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -8,11 +8,7 @@ import { logger } from "@/lib/observability/log";
 
 export const metadata = { title: "Patient Roster" };
 
-export default async function PatientsPage({
-  searchParams,
-}: {
-  searchParams: { status?: string };
-}) {
+export default async function PatientsPage() {
   const user = await requireUser();
   const orgId = user.organizationId!;
 
@@ -121,14 +117,14 @@ export default async function PatientsPage({
     firstName: p.firstName,
     lastName: p.lastName,
     status: p.status as string,
+    dob: p.dateOfBirth?.toISOString() ?? null,
+    phone: p.phone,
     presentingConcerns: p.presentingConcerns,
     completenessScore: p.chartSummary?.completenessScore ?? null,
     updatedAt: p.updatedAt.toISOString(),
     lastVisit: lastVisitByPatient.get(p.id) ?? null,
     painTrend: painByPatient.get(p.id)?.reverse() ?? [], // chronological order
   }));
-
-  const activeStatus = searchParams.status ?? "all";
 
   return (
     <PageShell maxWidth="max-w-[1280px]">
@@ -167,7 +163,6 @@ export default async function PatientsPage({
         patients={serialized}
         statusCounts={statusCounts}
         avgReadiness={avgReadiness}
-        initialStatus={activeStatus}
       />
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -10,6 +9,7 @@ import { MetricTile } from "@/components/ui/metric-tile";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { patientMatchesQuery } from "@/lib/search/patient-search";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -20,6 +20,8 @@ interface PatientRow {
   firstName: string;
   lastName: string;
   status: string;
+  dob: string | null;
+  phone: string | null;
   presentingConcerns: string | null;
   completenessScore: number | null;
   updatedAt: string;
@@ -38,19 +40,7 @@ interface Props {
   patients: PatientRow[];
   statusCounts: StatusCounts;
   avgReadiness: number;
-  initialStatus: string;
 }
-
-/* ------------------------------------------------------------------ */
-/*  Status filter config                                               */
-/* ------------------------------------------------------------------ */
-
-const STATUS_FILTERS: { key: string; label: string; countKey: keyof StatusCounts }[] = [
-  { key: "all", label: "All", countKey: "all" },
-  { key: "active", label: "Active", countKey: "active" },
-  { key: "prospect", label: "In Intake", countKey: "prospect" },
-  { key: "inactive", label: "Inactive", countKey: "inactive" },
-];
 
 /* ------------------------------------------------------------------ */
 /*  Power filter chips (EMR-clinician power-tools)                     */
@@ -227,14 +217,10 @@ export function PatientListClient({
   patients,
   statusCounts,
   avgReadiness,
-  initialStatus,
 }: Props) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const [search, setSearch] = useState("");
   const [powerFilter, setPowerFilter] = useState<PowerFilter>("all");
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
-  const activeStatus = searchParams.get("status") ?? initialStatus;
 
   /* Hydrate saved views from localStorage -------------------------- */
   useEffect(() => {
@@ -278,28 +264,17 @@ export function PatientListClient({
   const filtered = useMemo(() => {
     let list = patients;
 
-    // Status filter
-    if (activeStatus !== "all") {
-      list = list.filter((p) => p.status === activeStatus);
-    }
-
     // Power filter
     list = list.filter(matchesPowerFilter);
 
-    // Name search
-    const q = search.toLowerCase().trim();
-    if (q) {
-      list = list.filter(
-        (p) =>
-          p.firstName.toLowerCase().includes(q) ||
-          p.lastName.toLowerCase().includes(q) ||
-          `${p.firstName} ${p.lastName}`.toLowerCase().includes(q)
-      );
+    // Partial-match search (name / DOB / phone) — see EMR-599.
+    if (search.trim()) {
+      list = list.filter((p) => patientMatchesQuery(p, search));
     }
 
     return list;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [patients, activeStatus, search, powerFilter]);
+  }, [patients, search, powerFilter]);
 
   /* Save/load views ------------------------------------------------ */
   function handleSaveView() {
@@ -333,17 +308,6 @@ export function PatientListClient({
     } catch {
       /* ignore */
     }
-  }
-
-  /* Status pill navigation ----------------------------------------- */
-  function setStatus(key: string) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (key === "all") {
-      params.delete("status");
-    } else {
-      params.set("status", key);
-    }
-    router.push(`?${params.toString()}`, { scroll: false });
   }
 
   /* ---------------------------------------------------------------- */
@@ -431,33 +395,6 @@ export function PatientListClient({
         </div>
       )}
 
-      {/* Status filter strip */}
-      <div className="flex items-center gap-2 flex-wrap">
-        {STATUS_FILTERS.map((f) => {
-          const isActive = activeStatus === f.key;
-          return (
-            <button
-              key={f.key}
-              onClick={() => setStatus(f.key)}
-              className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium rounded-full border transition-colors duration-200 ${
-                isActive
-                  ? "bg-accent text-accent-ink border-accent shadow-sm"
-                  : "bg-surface-raised text-text-muted border-border hover:bg-surface-muted hover:border-border-strong"
-              }`}
-            >
-              {f.label}
-              <span
-                className={`tabular-nums ${
-                  isActive ? "text-accent-ink/70" : "text-text-subtle"
-                }`}
-              >
-                {statusCounts[f.countKey]}
-              </span>
-            </button>
-          );
-        })}
-      </div>
-
       {/* Patient list card */}
       <Card tone="raised" className="overflow-hidden">
         {/* Search bar */}
@@ -470,7 +407,7 @@ export function PatientListClient({
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search by name..."
+              placeholder="Search name, DOB, or phone..."
               className="pl-9"
             />
           </div>

--- a/src/lib/search/patient-search.test.ts
+++ b/src/lib/search/patient-search.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { patientMatchesQuery, type SearchablePatient } from "./patient-search";
+
+const ALICE: SearchablePatient = {
+  firstName: "Alice",
+  lastName: "Anderson",
+  dob: "1980-05-17",
+  phone: "(555) 123-4567",
+};
+
+const BOB: SearchablePatient = {
+  firstName: "Bob",
+  lastName: "Bouchard",
+  dob: "1975-11-03T00:00:00.000Z",
+  phone: null,
+};
+
+const CARMEN: SearchablePatient = {
+  firstName: "Carmen",
+  lastName: "Costa",
+  dob: null,
+  phone: "555.987.6543",
+};
+
+describe("patientMatchesQuery", () => {
+  it("empty query matches everyone", () => {
+    expect(patientMatchesQuery(ALICE, "")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "   ")).toBe(true);
+  });
+
+  it("partial first-name match (case-insensitive)", () => {
+    expect(patientMatchesQuery(ALICE, "ali")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "ALICE")).toBe(true);
+  });
+
+  it("partial last-name match", () => {
+    expect(patientMatchesQuery(ALICE, "ander")).toBe(true);
+  });
+
+  it("matches across first + last", () => {
+    expect(patientMatchesQuery(ALICE, "ce ande")).toBe(true);
+  });
+
+  it("phone match ignores separators in stored value and query", () => {
+    expect(patientMatchesQuery(ALICE, "555-123")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "(555) 123")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "1234567")).toBe(true);
+    expect(patientMatchesQuery(CARMEN, "9876543")).toBe(true);
+  });
+
+  it("phone match requires at least 2 digits to avoid spurious matches", () => {
+    // CARMEN has no DOB; firstName/lastName have no digits, so a single
+    // digit query must not match via the phone path on its own.
+    expect(patientMatchesQuery(CARMEN, "5")).toBe(false);
+  });
+
+  it("DOB matches across formats", () => {
+    expect(patientMatchesQuery(ALICE, "5/17/1980")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "05-17-1980")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "1980-05-17")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "05.17.1980")).toBe(true);
+  });
+
+  it("DOB partial match (year only, month/day fragment)", () => {
+    expect(patientMatchesQuery(ALICE, "1980")).toBe(true);
+    expect(patientMatchesQuery(ALICE, "5/17")).toBe(true);
+  });
+
+  it("handles full ISO timestamps as DOB", () => {
+    expect(patientMatchesQuery(BOB, "11/3/1975")).toBe(true);
+    expect(patientMatchesQuery(BOB, "1975-11-03")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(patientMatchesQuery(ALICE, "zzz")).toBe(false);
+    expect(patientMatchesQuery(BOB, "9999")).toBe(false);
+  });
+
+  it("null phone and null DOB don't crash", () => {
+    expect(patientMatchesQuery(BOB, "555")).toBe(false);
+    expect(patientMatchesQuery(CARMEN, "1980")).toBe(false);
+  });
+});

--- a/src/lib/search/patient-search.ts
+++ b/src/lib/search/patient-search.ts
@@ -1,0 +1,72 @@
+// Smart partial-match for clinician patient search boxes.
+// Shared by EMR-599 (/clinic/patients) and EMR-570 (/clinic landing) so the
+// behaviour is identical in both places.
+//
+// A single query string is matched (case-insensitive) against the patient's
+// first name, last name, date of birth, and phone number. DOB is compared
+// across the separator styles a clinician is likely to type
+// (`5/17/1980`, `05-17-1980`, `1980-05-17`, etc.) and phone is compared
+// digits-only so hyphens and parens don't matter.
+
+export interface SearchablePatient {
+  firstName: string;
+  lastName: string;
+  /** ISO 8601 date or full timestamp; only the YYYY-MM-DD portion is used. */
+  dob: string | null;
+  /** Raw stored phone — may contain separators, country codes, etc. */
+  phone: string | null;
+}
+
+function digitsOnly(s: string): string {
+  return s.replace(/\D/g, "");
+}
+
+function dobVariants(iso: string | null): string[] {
+  if (!iso) return [];
+  const date = iso.slice(0, 10);
+  const [y, m, d] = date.split("-");
+  if (!y || !m || !d) return [];
+  const mTrim = String(parseInt(m, 10));
+  const dTrim = String(parseInt(d, 10));
+  return [
+    `${y}-${m}-${d}`,
+    `${m}/${d}/${y}`,
+    `${mTrim}/${dTrim}/${y}`,
+    `${m}-${d}-${y}`,
+    `${mTrim}-${dTrim}-${y}`,
+    `${m}.${d}.${y}`,
+    `${mTrim}.${dTrim}.${y}`,
+    `${y}${m}${d}`,
+    `${m}${d}${y}`,
+  ];
+}
+
+export function patientMatchesQuery(
+  p: SearchablePatient,
+  rawQuery: string,
+): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+
+  const first = p.firstName.toLowerCase();
+  const last = p.lastName.toLowerCase();
+  if (
+    first.includes(q) ||
+    last.includes(q) ||
+    `${first} ${last}`.includes(q)
+  ) {
+    return true;
+  }
+
+  const qDigits = digitsOnly(q);
+  if (qDigits.length >= 2 && p.phone) {
+    const phoneDigits = digitsOnly(p.phone);
+    if (phoneDigits.includes(qDigits)) return true;
+  }
+
+  for (const v of dobVariants(p.dob)) {
+    if (v.includes(q)) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

- Removes the Active / Inactive / In Intake / All filter strip on `/clinic/patients` per the EMR-599 spec ("These are removed entirely — not hidden behind a setting"). The count tiles at the top of the page stay, so totals remain visible.
- Upgrades the single search box to partial-match across **first name, last name, DOB, and phone**:
  - **DOB** matches across the separator styles a clinician is likely to type — `5/17/1980`, `05-17-1980`, `1980-05-17`, `05.17.1980` — plus partial fragments (`1980`, `5/17`).
  - **Phone** compares digits-only, so the stored value's hyphens/parens/spaces don't matter and the query can include or omit any of them.
- The matching logic is extracted into `src/lib/search/patient-search.ts` so the upcoming `/clinic` landing (EMR-570) and `/clinic/providers` (EMR-613) search boxes will share identical behaviour without copy/paste drift.
- Unit-tested in `src/lib/search/patient-search.test.ts` (11 cases covering each separator style, phone normalization, null DOB/phone, and the "≥2 digits" phone-match guard).

## Test plan
- [x] `npx vitest run src/lib/search/patient-search.test.ts` — 11 / 11 pass
- [x] `npx tsc --noEmit` — no errors introduced by this PR (the pre-existing failures in `src/lib/billing/{eligibility-client,scrub}.test.ts` and `src/lib/referrals/state-machine*.ts` are unrelated)
- [x] `next lint` on changed files — clean
- [x] `scripts/check-no-orphan-components.mjs` — `patient-search.ts` has an importer in the same diff
- [ ] Manual: visit `/clinic/patients`, confirm the four status pills are gone, the layout reflows without a gap, and search with each of: partial first name, partial last name, `5/17/1980`, `1980`, `(555) 123-4567`, `5551234`, all return the expected patient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)