### PR TITLE
feat(clinic): EMR-570 /clinic landing — Search button + partial-match URL seed

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -614,13 +614,20 @@ export default async function ClinicHomePage() {
 
           {/* Right: Quick actions */}
           <div className="flex items-center gap-3 shrink-0">
-            <form action="/clinic/patients" method="get" className="hidden md:block">
+            <form
+              action="/clinic/patients"
+              method="get"
+              className="hidden md:flex items-center gap-2"
+            >
               <input
                 type="search"
                 name="q"
-                placeholder="Search patients..."
-                className="h-9 w-48 rounded-md border border-border bg-surface px-3 text-sm text-text placeholder:text-text-subtle focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50 transition-colors"
+                placeholder="Search name, DOB, or phone..."
+                className="h-9 w-56 rounded-md border border-border bg-surface px-3 text-sm text-text placeholder:text-text-subtle focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50 transition-colors"
               />
+              <Button type="submit" variant="secondary" size="sm">
+                Search
+              </Button>
             </form>
             <Link href="/clinic/patients?new=1">
               <Button size="sm">New visit</Button>

--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -8,7 +8,11 @@ import { logger } from "@/lib/observability/log";
 
 export const metadata = { title: "Patient Roster" };
 
-export default async function PatientsPage() {
+export default async function PatientsPage({
+  searchParams,
+}: {
+  searchParams: { q?: string };
+}) {
   const user = await requireUser();
   const orgId = user.organizationId!;
 
@@ -163,6 +167,7 @@ export default async function PatientsPage() {
         patients={serialized}
         statusCounts={statusCounts}
         avgReadiness={avgReadiness}
+        initialSearch={searchParams.q ?? ""}
       />
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -40,6 +40,7 @@ interface Props {
   patients: PatientRow[];
   statusCounts: StatusCounts;
   avgReadiness: number;
+  initialSearch?: string;
 }
 
 /* ------------------------------------------------------------------ */
@@ -217,8 +218,9 @@ export function PatientListClient({
   patients,
   statusCounts,
   avgReadiness,
+  initialSearch = "",
 }: Props) {
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(initialSearch);
   const [powerFilter, setPowerFilter] = useState<PowerFilter>("all");
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
 


### PR DESCRIPTION
## Summary

- Adds a visible **Search** button to the `/clinic` mission-control header, sitting to the right of the input and to the left of the existing **New visit** button (per the EMR-570 spec). Pressing Enter still submits — the button just makes the action discoverable.
- Updates the placeholder to `Search name, DOB, or phone...` so the clinician knows the scope of the search.
- Submits to `/clinic/patients?q=<query>`; the roster page now reads `q` from the URL and seeds the partial-match search box introduced in EMR-599, so the clinician lands on a list already filtered.

## Why no new API route

Matching reuses the helper from EMR-599 (`@/lib/search/patient-search`). The clinic landing form is now a thin redirect into the roster, which is already cached/optimized. Adding a typeahead would require a 20th query in the existing 19-way `Promise.all` on `/clinic` — explicitly called out as risky in the project context.

## Stacked on EMR-599

This PR depends on #323 (EMR-599) because:
1. It calls the helper at `src/lib/search/patient-search.ts`.
2. It relies on `/clinic/patients` accepting partial-match queries.

If #323 lands first, this PR's diff against `main` will collapse to just the three lines that change in `/clinic/page.tsx` plus the small `initialSearch` plumbing. If #323 doesn't land first, rebase this branch after the merge.

## Test plan
- [x] `npx tsc --noEmit` — clean (pre-existing unrelated failures only)
- [x] `next lint` on changed files — clean
- [ ] Manual: from `/clinic`, type `john` → press **Search** → land on `/clinic/patients?q=john` with the search field pre-populated and the list filtered.
- [ ] Manual: same with `555-123`, `1980`, `5/17/1980` — all match the right patients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)