### PR TITLE
feat(telehealth): EMR-598 pre-visit checklist — live browser probes with leaf indicators

### DIFF
--- a/src/app/(clinician)/telehealth/page.tsx
+++ b/src/app/(clinician)/telehealth/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { PreVisitChecklistClient } from "./pre-visit-checklist-client";
 
 export const metadata = { title: "Telehealth" };
 
@@ -292,20 +293,7 @@ export default async function TelehealthDashboardPage() {
               <CardTitle className="text-base">Pre-visit checklist</CardTitle>
             </CardHeader>
             <CardContent>
-              <ul className="space-y-2 text-sm text-text-muted">
-                <li className="flex gap-2">
-                  <span className="text-accent">•</span>Confirm camera and microphone
-                </li>
-                <li className="flex gap-2">
-                  <span className="text-accent">•</span>Verify a stable connection
-                </li>
-                <li className="flex gap-2">
-                  <span className="text-accent">•</span>Use a private, quiet room
-                </li>
-                <li className="flex gap-2">
-                  <span className="text-accent">•</span>Have current medications nearby
-                </li>
-              </ul>
+              <PreVisitChecklistClient />
             </CardContent>
           </Card>
         </div>

--- a/src/app/(clinician)/telehealth/pre-visit-checklist-client.tsx
+++ b/src/app/(clinician)/telehealth/pre-visit-checklist-client.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { LeafSprig } from "@/components/ui/ornament";
+import { Button } from "@/components/ui/button";
+
+// EMR-598 — every bullet must map to a real probe the browser can run.
+// Static "Use a private, quiet room" bullets are gone; they were never
+// verifiable.
+type ProbeState = "pending" | "pass" | "fail";
+
+interface Probe {
+  key: string;
+  label: string;
+  detail: string;
+  state: ProbeState;
+}
+
+const INITIAL_PROBES: Probe[] = [
+  {
+    key: "camera",
+    label: "Camera available",
+    detail: "Checking…",
+    state: "pending",
+  },
+  {
+    key: "microphone",
+    label: "Microphone available",
+    detail: "Checking…",
+    state: "pending",
+  },
+  {
+    key: "network",
+    label: "Internet reachable",
+    detail: "Checking…",
+    state: "pending",
+  },
+  {
+    key: "webrtc",
+    label: "Video calling supported in this browser",
+    detail: "Checking…",
+    state: "pending",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Probe implementations                                              */
+/* ------------------------------------------------------------------ */
+
+async function probePermission(
+  name: "camera" | "microphone",
+): Promise<{ state: ProbeState; detail: string }> {
+  if (typeof navigator === "undefined" || !navigator.permissions) {
+    return { state: "fail", detail: "Permissions API unsupported" };
+  }
+  try {
+    // `camera` and `microphone` are valid PermissionName values in the
+    // Permissions API spec but aren't in the DOM lib's narrow union, so we
+    // cast to keep TS happy without disabling the check site-wide.
+    const status = await navigator.permissions.query({
+      name: name as PermissionName,
+    });
+    if (status.state === "granted") {
+      return { state: "pass", detail: "Permission granted" };
+    }
+    if (status.state === "denied") {
+      return { state: "fail", detail: "Permission denied in browser settings" };
+    }
+    return { state: "fail", detail: "Not yet granted — allow on join" };
+  } catch {
+    return { state: "fail", detail: "Could not query permission" };
+  }
+}
+
+async function probeNetwork(): Promise<{ state: ProbeState; detail: string }> {
+  if (typeof navigator === "undefined") {
+    return { state: "fail", detail: "Navigator unavailable" };
+  }
+  if (!navigator.onLine) {
+    return { state: "fail", detail: "Browser reports offline" };
+  }
+  // Self-hosted favicon request — tiny, same-origin, cached. We don't trust
+  // the response body; reaching the server at all is the signal.
+  try {
+    const res = await fetch("/favicon.ico", {
+      method: "HEAD",
+      cache: "no-store",
+    });
+    if (res.ok || res.status === 304) {
+      return { state: "pass", detail: "Connection reachable" };
+    }
+    return { state: "fail", detail: `Origin replied ${res.status}` };
+  } catch {
+    return { state: "fail", detail: "Network probe failed" };
+  }
+}
+
+function probeWebRTC(): { state: ProbeState; detail: string } {
+  if (typeof window === "undefined") {
+    return { state: "fail", detail: "No window" };
+  }
+  if (typeof window.RTCPeerConnection === "undefined") {
+    return { state: "fail", detail: "Browser doesn't support WebRTC" };
+  }
+  return { state: "pass", detail: "RTCPeerConnection available" };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function PreVisitChecklistClient() {
+  const [probes, setProbes] = useState<Probe[]>(INITIAL_PROBES);
+  const [running, setRunning] = useState(false);
+
+  const runProbes = useCallback(async () => {
+    setRunning(true);
+    setProbes(INITIAL_PROBES);
+
+    const [camera, microphone, network] = await Promise.all([
+      probePermission("camera"),
+      probePermission("microphone"),
+      probeNetwork(),
+    ]);
+    const webrtc = probeWebRTC();
+
+    setProbes([
+      { key: "camera", label: "Camera available", ...camera },
+      { key: "microphone", label: "Microphone available", ...microphone },
+      { key: "network", label: "Internet reachable", ...network },
+      {
+        key: "webrtc",
+        label: "Video calling supported in this browser",
+        ...webrtc,
+      },
+    ]);
+    setRunning(false);
+  }, []);
+
+  useEffect(() => {
+    void runProbes();
+  }, [runProbes]);
+
+  return (
+    <ul className="space-y-2.5 text-sm">
+      {probes.map((p) => (
+        <li key={p.key} className="flex items-start gap-2.5">
+          <LeafIndicator state={p.state} />
+          <div className="min-w-0 flex-1">
+            <p className={textClass(p.state)}>{p.label}</p>
+            <p className="text-xs text-text-subtle mt-0.5">{p.detail}</p>
+          </div>
+        </li>
+      ))}
+      <li className="pt-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => void runProbes()}
+          disabled={running}
+        >
+          {running ? "Re-checking…" : "Re-run checks"}
+        </Button>
+      </li>
+    </ul>
+  );
+}
+
+function LeafIndicator({ state }: { state: ProbeState }) {
+  // `text-success` / `text-danger` are CSS-variable utilities the design
+  // system already exposes; both clear WCAG AA against the surface bg in
+  // light and dark themes.
+  const color =
+    state === "pass"
+      ? "text-success"
+      : state === "fail"
+        ? "text-[color:var(--leaf-dry,#8b5a2b)]"
+        : "text-text-subtle";
+  // A withered leaf reads as "broken" — drop the opacity and skew the
+  // veins so it visibly droops vs. the upright healthy leaf.
+  return (
+    <span
+      className={`mt-0.5 shrink-0 ${color} ${state === "fail" ? "opacity-80 rotate-12" : ""}`}
+    >
+      <LeafSprig size={14} className="text-current" />
+    </span>
+  );
+}
+
+function textClass(state: ProbeState): string {
+  if (state === "pass") return "text-success font-medium";
+  if (state === "fail") return "text-danger font-medium";
+  return "text-text-muted";
+}


### PR DESCRIPTION
## Summary

The pre-visit checklist on `/telehealth` used to be four static bullets — "Confirm camera and microphone", "Verify a stable connection", "Use a private, quiet room", "Have current medications nearby" — that the EMR couldn't actually verify. This PR replaces them with four real browser probes that update live:

| Probe | How |
|---|---|
| Camera available | `navigator.permissions.query({ name: "camera" })` |
| Microphone available | `navigator.permissions.query({ name: "microphone" })` |
| Internet reachable | `navigator.onLine` + a same-origin `HEAD /favicon.ico` |
| Video calling supported | `typeof window.RTCPeerConnection !== "undefined"` |

Each row renders the existing `LeafSprig` icon:

- **Pass** → `text-success` token (green leaf + green, bold label)
- **Fail** → `text-danger` label + an amber/brown, slightly rotated leaf (reads as "withered")
- **Pending** → muted text + a subtle leaf

A **Re-run checks** button re-probes on demand — useful after the clinician grants permission in the browser permission dialog.

## Design system reuse

- No new icon assets. The withered/dried leaf is the existing `LeafSprig` recolored to amber (`var(--leaf-dry, #8b5a2b)` fallback) and rotated 12° — readable as broken without bloating the asset bundle.
- `text-success` and `text-danger` already clear WCAG AA in both light and dark themes via the design-system CSS variables.

## Test plan
- [x] `npx tsc --noEmit` — clean (pre-existing unrelated failures only)
- [x] `next lint` on changed files — clean
- [ ] Manual (Chrome, fresh profile): visit `/telehealth`. The four bullets should appear with leaves while pending, then resolve. Denying camera permission in browser settings should flip that row to red+brown. Going offline (Network panel) and pressing "Re-run checks" should flip the network row to red+brown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)