### PR TITLE
feat(leafmart): EMR-398 age-gate consent checkbox + T&C/Privacy hyperlinks + audit log

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -293,6 +293,12 @@ routes:
     owner: leafmart
     notes: "Public vendor application form. Rate-limit recommended."
 
+  leafmart/age-gate/consent:
+    methods: [POST]
+    auth: public
+    owner: leafmart
+    notes: "EMR-398. Storefront is anonymous; this audit-logs the 21+/T&C consent (IP + timestamp + UA) so we have compliance evidence without storing PII at rest."
+
   leafmart/signout:
     methods: [POST]
     auth: establishes_auth

--- a/src/app/api/leafmart/age-gate/consent/route.ts
+++ b/src/app/api/leafmart/age-gate/consent/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/observability/log";
+
+// EMR-398 — compliance audit trail for the Leafmart age-gate consent
+// checkbox. The storefront is anonymous, so this route is intentionally
+// public; the IP + timestamp + user-agent line in server logs is the
+// evidence we keep for regulators. We never store this in the database
+// (no schema change in this PR), so there is no PII at rest beyond the
+// existing log infrastructure.
+
+function getClientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  const xri = req.headers.get("x-real-ip");
+  if (xri) return xri.trim();
+  return "unknown";
+}
+
+type ConsentPayload = {
+  confirmedAt?: string;
+};
+
+export async function POST(request: Request) {
+  let body: ConsentPayload = {};
+  try {
+    body = (await request.json()) as ConsentPayload;
+  } catch {
+    // Empty body is fine — server adds receivedAt regardless.
+  }
+
+  logger.info({
+    event: "leafmart.age_gate.consent",
+    ip: getClientIp(request),
+    userAgent: request.headers.get("user-agent") ?? "unknown",
+    clientConfirmedAt: body.confirmedAt ?? null,
+    receivedAt: new Date().toISOString(),
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/components/leafmart/AgeGateModal.tsx
+++ b/src/components/leafmart/AgeGateModal.tsx
@@ -97,6 +97,17 @@ export function AgeGateModal({
 
   const handleConfirm = useCallback(() => {
     confirmAgeOver21();
+    // Fire-and-forget audit log — server records IP + timestamp + UA. EMR-398.
+    if (typeof window !== "undefined") {
+      void fetch("/api/leafmart/age-gate/consent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmedAt: new Date().toISOString() }),
+        keepalive: true,
+      }).catch(() => {
+        /* best-effort audit; failure must not block the user */
+      });
+    }
     onConfirmed?.();
     onClose();
   }, [onConfirmed, onClose]);
@@ -193,6 +204,9 @@ function PromptView({
   onConfirm: () => void;
   onDeny: () => void;
 }) {
+  const consentId = useId();
+  const [consented, setConsented] = useState(false);
+
   return (
     <>
       <div className="flex justify-center mb-5">
@@ -213,12 +227,50 @@ function PromptView({
         and agree to use these products responsibly.
       </p>
 
-      <div className="mt-7 flex flex-col gap-2.5">
+      <label
+        htmlFor={consentId}
+        className="mt-6 flex items-start gap-2.5 cursor-pointer select-none"
+      >
+        <input
+          id={consentId}
+          type="checkbox"
+          checked={consented}
+          onChange={(e) => setConsented(e.target.checked)}
+          className="mt-[3px] h-4 w-4 shrink-0 cursor-pointer rounded border-[var(--border)] text-[var(--leaf)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+        />
+        <span className="text-[12.5px] leading-relaxed text-[var(--muted)]">
+          I have read and agree to the{" "}
+          <Link
+            href="/legal/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-[var(--leaf)] underline underline-offset-2 hover:text-[var(--ink)]"
+          >
+            Terms of Service
+          </Link>{" "}
+          and{" "}
+          <Link
+            href="/legal/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-[var(--leaf)] underline underline-offset-2 hover:text-[var(--ink)]"
+          >
+            Privacy Policy
+          </Link>
+          .
+        </span>
+      </label>
+
+      <div className="mt-5 flex flex-col gap-2.5">
         <button
           ref={primaryRef}
           type="button"
           onClick={onConfirm}
-          className="w-full rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+          disabled={!consented}
+          aria-disabled={!consented}
+          className="w-full rounded-full bg-[var(--ink)] text-[var(--bg)] py-3.5 text-[14px] font-medium tracking-wide hover:bg-[var(--leaf)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--leaf)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[var(--ink)]"
         >
           I am 21 or older
         </button>


### PR DESCRIPTION
## Summary

Dr. Patel **PRIORITY**, compliance-adjacent. Adds a required consent checkbox to the Leafmart age-gate so the storefront can't be entered without explicit T&C acceptance.

- **UI** — `AgeGateModal.PromptView` now renders a checkbox above the action buttons with the label *"I have read and agree to the Terms of Service and Privacy Policy."* Both clauses are hyperlinks to the existing `/legal/terms` and `/legal/privacy` pages (open in a new tab so the gate state isn't lost). The "I am 21 or older" button is `disabled` until the box is ticked.
- **Audit trail** — On confirm, the modal POSTs (`keepalive: true`) to a new public `/api/leafmart/age-gate/consent` route. The route extracts the client IP from `x-forwarded-for` / `x-real-ip`, captures the user-agent, and emits a structured `leafmart.age_gate.consent` log line. No DB write — log line is the compliance evidence, matching the pattern other storefront audit endpoints use (`/api/contact`, `/api/leafmart/vendor-apply`, etc.).
- **Manifest** — New route registered as `auth: public` in `docs/security/route-auth.yaml` so the route-auth manifest gate stays green.

## Why no database write

Mirrors the existing storefront audit pattern (see `/api/contact/route.ts`) where the log line *is* the record. Avoids introducing PII at rest, avoids a schema migration, and keeps this PR strictly within the overnight triage rules. If legal later wants persisted records, a follow-up can wire a `ComplianceAuditLog` model.

## Per-project memory

The gate is served from EMR (not the Design System) per the user's standing memory; all changes are local to this repo.

## Test plan
- [x] `npx tsc --noEmit` — clean (unrelated pre-existing failures only)
- [x] `next lint` on changed files — clean
- [x] `node scripts/check-route-auth-manifest.mjs` — manifest in sync (69 routes)
- [ ] Manual: open Leafmart in incognito → gate appears → "I am 21 or older" is dimmed/disabled → tick checkbox → button enables → click → server logs `leafmart.age_gate.consent` with IP + UA.
- [ ] Manual: click Terms / Privacy links → opens in new tab; gate persists in the original tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)