### PR TITLE
feat(clinic): EMR-604 WhatsApp-style call record bubbles in the Smart Inbox thread

### DIFF
--- a/src/app/(clinician)/clinic/messages/call-bubble.tsx
+++ b/src/app/(clinician)/clinic/messages/call-bubble.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { cn } from "@/lib/utils/cn";
+import { formatRelative } from "@/lib/utils/format";
+import { launchCallAction } from "@/lib/communications/calls";
+
+// EMR-604 — WhatsApp-style in-thread call record bubble. Renders the same
+// info pattern as WhatsApp's missed-call cards: type, outcome, duration,
+// timestamp. The bubble is itself the redial trigger.
+
+export interface CallLogData {
+  id: string;
+  channel: string;       // "phone" | "video" | "sms" | "secure_message"
+  direction: string;     // "inbound" | "outbound"
+  status: string;        // "initiated" | "in_progress" | "completed" | "missed" | "no_answer" | "failed"
+  startedAt: string;
+  endedAt: string | null;
+  durationSeconds: number | null;
+}
+
+interface Props {
+  call: CallLogData;
+  patientId: string;
+  threadId: string;
+}
+
+function formatDuration(seconds: number | null): string | null {
+  if (seconds == null || seconds <= 0) return null;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0) return `${s} s`;
+  if (s === 0) return `${m} min`;
+  return `${m} min ${s} s`;
+}
+
+function bubbleLabel(call: CallLogData): string {
+  const typeWord = call.channel === "video" ? "video call" : "audio call";
+  const isMissed =
+    call.status === "missed" ||
+    call.status === "no_answer" ||
+    call.status === "failed";
+  if (isMissed) {
+    const verb = call.direction === "outbound" ? "Unanswered" : "Missed";
+    return `${verb} ${typeWord}`;
+  }
+  const dur = formatDuration(call.durationSeconds);
+  if (dur) {
+    return `${typeWord[0].toUpperCase()}${typeWord.slice(1)} · ${dur}`;
+  }
+  return `${typeWord[0].toUpperCase()}${typeWord.slice(1)}`;
+}
+
+function isMissed(call: CallLogData): boolean {
+  return (
+    call.status === "missed" ||
+    call.status === "no_answer" ||
+    call.status === "failed"
+  );
+}
+
+function VideoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="1" y="3.5" width="8" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M9 6.5L13 4.5V9.5L9 7.5V6.5Z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function PhoneIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M3 2C2.4 2 2 2.4 2 3v1.5C2 8.6 5.4 12 9.5 12H11c.6 0 1-.4 1-1V9.5c0-.5-.4-.9-.9-1L9.6 8.2c-.4-.1-.8 0-1.1.3L7.9 9.1c-1.6-.7-2.9-2-3.7-3.6l.6-.6c.3-.3.4-.7.3-1.1L4.5 2.9C4.4 2.4 4 2 3.5 2H3z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function CallBubble({ call, patientId, threadId }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const missed = isMissed(call);
+  const Icon = call.channel === "video" ? VideoIcon : PhoneIcon;
+
+  function redial() {
+    setError(null);
+    const fd = new FormData();
+    // Map our stored channel back to the launch action's expected value.
+    fd.set("channel", call.channel === "video" ? "video" : "phone");
+    fd.set("patientId", patientId);
+    fd.set("messageThreadId", threadId);
+    startTransition(async () => {
+      const result = await launchCallAction(fd);
+      if (!result.ok) {
+        setError(result.error ?? "Could not start call");
+      }
+    });
+  }
+
+  return (
+    <div className="flex justify-center">
+      <button
+        type="button"
+        onClick={redial}
+        disabled={pending}
+        aria-label={`Redial — ${bubbleLabel(call)}`}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-full px-3.5 py-1.5",
+          "text-xs leading-none border transition-colors",
+          missed
+            ? "bg-danger-soft/40 text-danger border-danger/30 hover:bg-danger-soft/60"
+            : "bg-surface-muted text-text-muted border-border/60 hover:bg-surface-raised hover:text-text",
+          "disabled:opacity-60 disabled:cursor-wait",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        )}
+      >
+        <Icon
+          className={cn(
+            "shrink-0",
+            missed ? "text-danger" : "text-text-subtle",
+          )}
+        />
+        <span className="font-medium">{bubbleLabel(call)}</span>
+        <span className="text-text-subtle">·</span>
+        <span className="text-text-subtle">{formatRelative(call.startedAt)}</span>
+      </button>
+      {error && (
+        <span className="ml-2 text-xs text-danger" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/messages/page.tsx
+++ b/src/app/(clinician)/clinic/messages/page.tsx
@@ -35,6 +35,20 @@ export default async function ClinicMessagesPage({
           },
         },
       },
+      // EMR-604 — pull call records so the thread view can interleave them
+      // chronologically as WhatsApp-style bubbles.
+      callLogs: {
+        select: {
+          id: true,
+          channel: true,
+          direction: true,
+          status: true,
+          startedAt: true,
+          endedAt: true,
+          durationSeconds: true,
+        },
+        orderBy: { startedAt: "asc" },
+      },
     },
     take: 50,
   });
@@ -86,6 +100,7 @@ export default async function ClinicMessagesPage({
   // Serialize full thread messages for the detail view
   const threadMessages = threads.map((t) => ({
     threadId: t.id,
+    patientId: t.patient.id,
     patientName: `${t.patient.firstName} ${t.patient.lastName}`,
     subject: t.subject,
     messages: t.messages.map((m) => ({
@@ -99,6 +114,15 @@ export default async function ClinicMessagesPage({
         ? { firstName: m.sender.firstName, lastName: m.sender.lastName }
         : null,
       createdAt: m.createdAt.toISOString(),
+    })),
+    callLogs: t.callLogs.map((c) => ({
+      id: c.id,
+      channel: c.channel as string,
+      direction: c.direction as string,
+      status: c.status as string,
+      startedAt: c.startedAt.toISOString(),
+      endedAt: c.endedAt?.toISOString() ?? null,
+      durationSeconds: c.durationSeconds,
     })),
   }));
 

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/domain/smart-inbox";
 import { sendReply } from "./actions";
 import { CallLaunchButtons } from "@/components/communications/call-launch-buttons";
+import { CallBubble, type CallLogData } from "./call-bubble";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,9 +39,11 @@ interface MessageData {
 
 interface ThreadMessageData {
   threadId: string;
+  patientId: string;
   patientName: string;
   subject: string;
   messages: MessageData[];
+  callLogs: CallLogData[];
 }
 
 interface Props {
@@ -48,6 +51,25 @@ interface Props {
   threadMessages: ThreadMessageData[];
   currentUserId: string;
   initialThreadId?: string;
+}
+
+// EMR-604 — chronological timeline that interleaves messages and call records
+// so the WhatsApp-style call bubbles land in the right spot among the texts.
+type TimelineItem =
+  | { kind: "message"; ts: string; data: MessageData }
+  | { kind: "call"; ts: string; data: CallLogData };
+
+function buildTimeline(thread: ThreadMessageData): TimelineItem[] {
+  const items: TimelineItem[] = [
+    ...thread.messages.map(
+      (m): TimelineItem => ({ kind: "message", ts: m.createdAt, data: m }),
+    ),
+    ...thread.callLogs.map(
+      (c): TimelineItem => ({ kind: "call", ts: c.startedAt, data: c }),
+    ),
+  ];
+  items.sort((a, b) => a.ts.localeCompare(b.ts));
+  return items;
 }
 
 // ---------------------------------------------------------------------------
@@ -617,9 +639,21 @@ export function SmartInboxView({
                 </div>
               </div>
 
-              {/* Message history */}
+              {/* Message history — messages and call records interleaved
+                  chronologically. EMR-604. */}
               <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-                {[...selectedThread.messages].reverse().map((msg) => {
+                {buildTimeline(selectedThread).map((item) => {
+                  if (item.kind === "call") {
+                    return (
+                      <CallBubble
+                        key={`call-${item.data.id}`}
+                        call={item.data}
+                        patientId={selectedThread.patientId}
+                        threadId={selectedThread.threadId}
+                      />
+                    );
+                  }
+                  const msg = item.data;
                   const isOwn = msg.senderUserId === currentUserId;
                   const isAgent = !!msg.senderAgent;
                   const senderName = isOwn


### PR DESCRIPTION
## Summary

When a clinician launches an audio or video call from inside a patient thread, the resulting `CallLog` now renders as a centered pill bubble interleaved chronologically with text messages — the WhatsApp pattern the ticket linked to.

Each bubble shows the call type with a matching glyph plus an outcome line:

| Outcome | Renders as |
|---|---|
| Connected audio | `📞 Audio call · 4 min 12 s · 5 min ago` |
| Connected video | `🎥 Video call · 12 min · 5 min ago` |
| Missed (incoming) | `📞 Missed audio call · 5 min ago` (red tint) |
| Unanswered (outgoing) | `📞 Unanswered audio call · 5 min ago` (red tint) |

The bubble itself is the redial trigger — clicking it dispatches the same `launchCallAction` the top-of-thread `CallLaunchButtons` use, matched to the original call's channel.

## Why no schema change

`MessageThread.callLogs` and `CallLog.{channel,direction,status,startedAt,endedAt,durationSeconds}` already exist in `prisma/schema.prisma`. All EMR-604 needed was rendering.

## Files
- `page.tsx` — pull `callLogs` alongside messages, serialize them with `patientId` so the bubble can dispatch redial
- `smart-inbox.tsx` — type the new field, build a unified `TimelineItem[]` via `buildTimeline()`, and dispatch each item to either the existing message renderer or the new `CallBubble`
- `call-bubble.tsx` (new, colocated) — the bubble component, including the redial `onClick` via `launchCallAction`

## Test plan
- [x] `npx tsc --noEmit` — clean (only the pre-existing unrelated failures remain)
- [x] `next lint` on changed files — clean
- [ ] Manual: open `/clinic/messages`, select a thread, launch an audio call → end it → confirm the bubble appears in the message timeline at the correct position with duration. Click the bubble → confirm it re-initiates the same channel.
- [ ] Manual: simulate a missed call (DB insert with `status="missed"`) → confirm red tint and "Missed audio/video call" copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)