### PR TITLE
feat(clinic): EMR-613 provider directory search across name/specialty/address/hospital

### DIFF
--- a/prisma/migrations/20260514000000_emr_613_provider_directory_fields/migration.sql
+++ b/prisma/migrations/20260514000000_emr_613_provider_directory_fields/migration.sql
@@ -1,0 +1,8 @@
+-- EMR-613 — Provider directory search needs practiceAddress + hospital
+-- affiliations to be searchable. Existing rows backfill cleanly:
+-- practiceAddress is nullable, hospitalAffiliations defaults to an empty
+-- array. No data migration required.
+
+ALTER TABLE "Provider"
+  ADD COLUMN "practiceAddress"      TEXT,
+  ADD COLUMN "hospitalAffiliations" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -368,17 +368,21 @@ model ShippingAddress {
 }
 
 model Provider {
-  id             String   @id @default(cuid())
-  userId         String   @unique
-  organizationId String
-  title          String? // e.g. "MD, Integrative Oncology"
-  specialties    String[] @default([])
-  bio            String?
-  active         Boolean  @default(true)
+  id                   String   @id @default(cuid())
+  userId               String   @unique
+  organizationId       String
+  title                String? // e.g. "MD, Integrative Oncology"
+  specialties          String[] @default([])
+  bio                  String?
+  active               Boolean  @default(true)
   // EMR-220 — Production billing identifiers
-  npi            String? // 10-digit type-1 individual NPI; CMS-Luhn validated on write
-  taxonomyCode   String? // 10-char Healthcare Provider Taxonomy code (e.g. "207RI0008X")
-  createdAt      DateTime @default(now())
+  npi                  String? // 10-digit type-1 individual NPI; CMS-Luhn validated on write
+  taxonomyCode         String? // 10-char Healthcare Provider Taxonomy code (e.g. "207RI0008X")
+  // EMR-613 — directory search fields. Free-text address (multi-line ok);
+  // hospital affiliations modeled as a tag array, matching `specialties`.
+  practiceAddress      String?
+  hospitalAffiliations String[] @default([])
+  createdAt            DateTime @default(now())
 
   user         User          @relation("ProviderUser", fields: [userId], references: [id], onDelete: Cascade)
   organization Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)

--- a/src/app/(clinician)/clinic/providers/page.tsx
+++ b/src/app/(clinician)/clinic/providers/page.tsx
@@ -1,12 +1,20 @@
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
-import { Card, CardContent } from "@/components/ui/card";
-import { Avatar } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { logger } from "@/lib/observability/log";
+import {
+  ProvidersDirectoryClient,
+  type ProviderRow,
+} from "./providers-directory-client";
 
 export const metadata = { title: "Providers" };
+
+// EMR-613 — hard cap on the directory size. The ticket targets 5,000
+// contacts; we keep an explicit cap so a single render never balloons
+// past it and log loudly when an org grows past the ceiling (mirrors the
+// pattern in `src/app/(clinician)/clinic/patients/page.tsx`).
+const PROVIDER_DIRECTORY_CAP = 5_000;
 
 export default async function ProvidersPage() {
   const user = await requireUser();
@@ -22,23 +30,29 @@ export default async function ProvidersPage() {
       },
     },
     orderBy: { createdAt: "asc" },
+    take: PROVIDER_DIRECTORY_CAP,
   });
 
-  if (providers.length === 0) {
-    return (
-      <PageShell>
-        <PageHeader
-          eyebrow="Providers"
-          title="Provider directory"
-          description="View and contact providers in your organization."
-        />
-        <EmptyState
-          title="No providers found"
-          description="There are no active providers in your organization yet."
-        />
-      </PageShell>
-    );
+  if (providers.length === PROVIDER_DIRECTORY_CAP) {
+    logger.warn({
+      event: "clinic.providers_directory.cap_hit",
+      cap: PROVIDER_DIRECTORY_CAP,
+      orgId: user.organizationId,
+      message:
+        "Add server-side pagination + filtered search before this org grows further.",
+    });
   }
+
+  const rows: ProviderRow[] = providers.map((p) => ({
+    id: p.id,
+    firstName: p.user.firstName,
+    lastName: p.user.lastName,
+    title: p.title,
+    specialties: p.specialties,
+    practiceAddress: p.practiceAddress,
+    hospitalAffiliations: p.hospitalAffiliations,
+    bio: p.bio,
+  }));
 
   return (
     <PageShell>
@@ -47,60 +61,14 @@ export default async function ProvidersPage() {
         title="Provider directory"
         description="View and contact providers in your organization."
       />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {providers.map((provider) => (
-          <Card key={provider.id} className="card-hover">
-            <CardContent className="pt-6">
-              <div className="flex items-start gap-4">
-                <Avatar
-                  firstName={provider.user.firstName}
-                  lastName={provider.user.lastName}
-                  size="lg"
-                  className="shrink-0"
-                />
-                <div className="min-w-0 flex-1">
-                  <h3 className="font-display text-lg font-medium text-text tracking-tight truncate">
-                    {provider.user.firstName} {provider.user.lastName}
-                  </h3>
-                  {provider.title && (
-                    <p className="text-sm text-text-muted mt-0.5 truncate">
-                      {provider.title}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {provider.specialties.length > 0 && (
-                <div className="flex flex-wrap gap-1.5 mt-4">
-                  {provider.specialties.map((specialty) => (
-                    <Badge key={specialty} tone="accent">
-                      {specialty}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-
-              {provider.bio && (
-                <p className="text-xs text-text-subtle mt-3 line-clamp-2 leading-relaxed">
-                  {provider.bio}
-                </p>
-              )}
-
-              <div className="mt-4 pt-3 border-t border-border/60">
-                <a
-                  href="/clinic/providers/messages"
-                  className="flex items-center justify-center gap-2 w-full text-sm font-medium text-accent py-2 rounded-md border border-accent/30 bg-accent/5 hover:bg-accent/10 transition-colors"
-                >
-                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="text-accent">
-                    <path d="M12 1H2C1.45 1 1 1.45 1 2V9.5C1 10.05 1.45 10.5 2 10.5H4L7 13L10 10.5H12C12.55 10.5 13 10.05 13 9.5V2C13 1.45 12.55 1 12 1Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"/>
-                  </svg>
-                  Secure message
-                </a>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No providers found"
+          description="There are no active providers in your organization yet."
+        />
+      ) : (
+        <ProvidersDirectoryClient providers={rows} />
+      )}
     </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
+++ b/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import {
+  providerMatchesQuery,
+  type SearchableProvider,
+} from "@/lib/search/provider-search";
+
+// EMR-613 — client wrapper for the provider directory. Owns the search
+// box; filters the server-supplied list in-memory (the page hard-caps at
+// `PROVIDER_DIRECTORY_CAP` so the filter stays sub-millisecond well past
+// the ticket's 5,000-contact performance target).
+
+export interface ProviderRow extends SearchableProvider {
+  id: string;
+  bio: string | null;
+}
+
+interface Props {
+  providers: ProviderRow[];
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      className="text-text-subtle"
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.3" />
+      <path
+        d="M10.5 10.5L14 14"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function ProvidersDirectoryClient({ providers }: Props) {
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return providers;
+    return providers.filter((p) => providerMatchesQuery(p, search));
+  }, [providers, search]);
+
+  return (
+    <div className="space-y-5">
+      <div className="relative max-w-md">
+        <div className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
+          <SearchIcon />
+        </div>
+        <Input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search name, specialty, address, or hospital..."
+          className="pl-9"
+          aria-label="Search providers"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          title="No providers match your search"
+          description="Try a different name, specialty, address, or hospital affiliation."
+        />
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((provider) => (
+            <Card key={provider.id} className="card-hover">
+              <CardContent className="pt-6">
+                <div className="flex items-start gap-4">
+                  <Avatar
+                    firstName={provider.firstName}
+                    lastName={provider.lastName}
+                    size="lg"
+                    className="shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-display text-lg font-medium text-text tracking-tight truncate">
+                      {provider.firstName} {provider.lastName}
+                    </h3>
+                    {provider.title && (
+                      <p className="text-sm text-text-muted mt-0.5 truncate">
+                        {provider.title}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {provider.specialties.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-4">
+                    {provider.specialties.map((specialty) => (
+                      <Badge key={specialty} tone="accent">
+                        {specialty}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+
+                {provider.hospitalAffiliations.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {provider.hospitalAffiliations.map((h) => (
+                      <Badge key={h} tone="neutral">
+                        {h}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+
+                {provider.practiceAddress && (
+                  <p className="text-xs text-text-subtle mt-3 leading-relaxed whitespace-pre-line">
+                    {provider.practiceAddress}
+                  </p>
+                )}
+
+                {provider.bio && (
+                  <p className="text-xs text-text-subtle mt-3 line-clamp-2 leading-relaxed">
+                    {provider.bio}
+                  </p>
+                )}
+
+                <div className="mt-4 pt-3 border-t border-border/60">
+                  <a
+                    href="/clinic/providers/messages"
+                    className="flex items-center justify-center gap-2 w-full text-sm font-medium text-accent py-2 rounded-md border border-accent/30 bg-accent/5 hover:bg-accent/10 transition-colors"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                      className="text-accent"
+                    >
+                      <path
+                        d="M12 1H2C1.45 1 1 1.45 1 2V9.5C1 10.05 1.45 10.5 2 10.5H4L7 13L10 10.5H12C12.55 10.5 13 10.05 13 9.5V2C13 1.45 12.55 1 12 1Z"
+                        stroke="currentColor"
+                        strokeWidth="1.2"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    Secure message
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/search/provider-search.test.ts
+++ b/src/lib/search/provider-search.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  providerMatchesQuery,
+  type SearchableProvider,
+} from "./provider-search";
+
+const ALICE: SearchableProvider = {
+  firstName: "Alice",
+  lastName: "Anderson",
+  title: "MD, Integrative Oncology",
+  specialties: ["Oncology", "Palliative care"],
+  practiceAddress: "100 Healing Way, Asheville, NC 28801",
+  hospitalAffiliations: ["Mission Hospital", "UNC Health"],
+};
+
+const BOB: SearchableProvider = {
+  firstName: "Bob",
+  lastName: "Bouchard",
+  title: null,
+  specialties: [],
+  practiceAddress: null,
+  hospitalAffiliations: [],
+};
+
+describe("providerMatchesQuery", () => {
+  it("empty query matches everyone", () => {
+    expect(providerMatchesQuery(ALICE, "")).toBe(true);
+    expect(providerMatchesQuery(BOB, "  ")).toBe(true);
+  });
+
+  it("partial first / last name match", () => {
+    expect(providerMatchesQuery(ALICE, "ali")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "DERSO")).toBe(true);
+  });
+
+  it("matches across first + last", () => {
+    expect(providerMatchesQuery(ALICE, "ce ande")).toBe(true);
+  });
+
+  it("matches title (case-insensitive, partial)", () => {
+    expect(providerMatchesQuery(ALICE, "integrative")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "MD")).toBe(true);
+  });
+
+  it("matches specialty entries", () => {
+    expect(providerMatchesQuery(ALICE, "oncolog")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "palliative")).toBe(true);
+  });
+
+  it("matches practice address partial", () => {
+    expect(providerMatchesQuery(ALICE, "asheville")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "28801")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "healing way")).toBe(true);
+  });
+
+  it("matches hospital affiliation entries", () => {
+    expect(providerMatchesQuery(ALICE, "mission")).toBe(true);
+    expect(providerMatchesQuery(ALICE, "unc")).toBe(true);
+  });
+
+  it("null fields don't crash", () => {
+    expect(providerMatchesQuery(BOB, "anything")).toBe(false);
+    expect(providerMatchesQuery(BOB, "bob")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(providerMatchesQuery(ALICE, "zzzzz")).toBe(false);
+  });
+});

--- a/src/lib/search/provider-search.ts
+++ b/src/lib/search/provider-search.ts
@@ -1,0 +1,53 @@
+// Partial-match for the clinician provider directory (/clinic/providers).
+// Matches the patient-search behaviour on consistency grounds (see
+// EMR-570) so the two search boxes feel identical to the user.
+//
+// Fields:
+//   - firstName / lastName  (partial, case-insensitive)
+//   - title                 (partial — "MD, Integrative Oncology" etc.)
+//   - specialties[]         (partial against each entry)
+//   - practiceAddress       (partial — full freeform address)
+//   - hospitalAffiliations[] (partial against each entry)
+
+export interface SearchableProvider {
+  firstName: string;
+  lastName: string;
+  title: string | null;
+  specialties: string[];
+  practiceAddress: string | null;
+  hospitalAffiliations: string[];
+}
+
+export function providerMatchesQuery(
+  p: SearchableProvider,
+  rawQuery: string,
+): boolean {
+  const q = rawQuery.trim().toLowerCase();
+  if (!q) return true;
+
+  const first = p.firstName.toLowerCase();
+  const last = p.lastName.toLowerCase();
+  if (
+    first.includes(q) ||
+    last.includes(q) ||
+    `${first} ${last}`.includes(q)
+  ) {
+    return true;
+  }
+
+  if (p.title && p.title.toLowerCase().includes(q)) return true;
+
+  for (const s of p.specialties) {
+    if (s.toLowerCase().includes(q)) return true;
+  }
+
+  if (p.practiceAddress && p.practiceAddress.toLowerCase().includes(q)) {
+    return true;
+  }
+
+  for (const h of p.hospitalAffiliations) {
+    if (h.toLowerCase().includes(q)) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Unblocks the deferred EMR-613 ticket. Adds the two columns the spec needs and a fully working partial-match search box.

### Schema (purely additive)

| Field | Type | Default | Notes |
|---|---|---|---|
| `practiceAddress` | `String?` | `NULL` | Freeform, multi-line (rendered with `whitespace-pre-line`). |
| `hospitalAffiliations` | `String[]` | `[]` | Tag array — matches the existing `specialties` style. |

Existing rows backfill cleanly (NULL / empty array). No data migration needed.

### UI

- Server `page.tsx` becomes a thin shell that fetches up to **5,000 active providers** (the ticket's stated performance target — same cap-and-log pattern the patient roster uses) and hands them to a new client component.
- `providers-directory-client.tsx` owns the search box. Filtering is in-memory using the new `@/lib/search/provider-search` helper, unit-tested side-by-side with `patient-search`.
- The card layout is preserved (Avatar + title + specialty Badges + Secure-message CTA). New surfaces: hospital-affiliation Badges and the practice-address block when present.

### Why no full-text DB search

5,000 in-memory string `.includes()` checks per keystroke is sub-millisecond — well under what the ticket asks for. If a single org outgrows the cap, the `clinic.providers_directory.cap_hit` warning log fires (the same trip-wire the patient roster has at 500 rows), and a follow-up adds server-side pagination + Postgres `pg_trgm` indexes on the searchable columns.

## Test plan
- [x] `npx vitest run src/lib/search/provider-search.test.ts` — 9 / 9 pass
- [x] `npx tsc --noEmit` — clean
- [x] `next lint` on changed files — clean
- [x] `scripts/check-no-orphan-components.mjs` — `provider-search.ts` has an importer in the diff
- [ ] Deploy: pipeline runs `prisma migrate deploy` and the columns appear on `Provider`. Seed an existing provider with a `practiceAddress` + a `hospitalAffiliations` entry and verify search hits each field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)