### PR TITLE
fix(status): defer timestamp init to useEffect for clean hydration (EMR-715)

### DIFF
--- a/src/app/status/status-view.tsx
+++ b/src/app/status/status-view.tsx
@@ -92,14 +92,20 @@ const HEALTH_TONE: Record<Health, { dot: string; label: string; tone: "success" 
 };
 
 export function StatusView() {
-  const [lastUpdated, setLastUpdated] = useState<string>(() =>
-    new Date().toLocaleTimeString()
-  );
+  // Deterministic placeholder — a `useState` lazy initializer would
+  // run with server time on the server and client time on the client,
+  // producing a hydration mismatch that cascades into the entire
+  // StatusView subtree being re-rendered client-side (caught by
+  // find-and-fix pass 8, EMR-715). Setting the timestamp inside
+  // `useEffect` keeps server-rendered HTML deterministic; the em-dash
+  // shows for the few ms before hydration completes.
+  const [lastUpdated, setLastUpdated] = useState<string>("—");
   const [email, setEmail] = useState("");
   const [subscribed, setSubscribed] = useState(false);
   const [subscribeError, setSubscribeError] = useState<string | null>(null);
 
   useEffect(() => {
+    setLastUpdated(new Date().toLocaleTimeString());
     const t = setInterval(() => {
       setLastUpdated(new Date().toLocaleTimeString());
     }, 60000);


### PR DESCRIPTION
## Summary

**Primary change (EMR-715):** Stop `/status` from triggering a hydration mismatch on every load.

The `lastUpdated` state was initialized with a lazy initializer that called `new Date().toLocaleTimeString()` — that runs on both the server (during SSR) and the client (during hydration). Server time and client time are necessarily different, so React saw a text mismatch and bailed out of streaming hydration, re-rendering the whole `StatusView` subtree client-side. The cascade showed up in the dev console as:

```
Warning: Text content did not match.
  Server: "11:22:34 AM"
  Client: "11:22:37 AM"
Warning: An error occurred during hydration. The server HTML was replaced with client content.
```

Fix: initialize with an em-dash placeholder, set the real timestamp inside `useEffect` so it only runs client-side. The em-dash shows for the few ms between SSR and hydration — cleaner than a flicker between two slightly-different times.

## Verification

Re-ran `e2e/click-handlers.spec.ts -g 'crawl /status'`:

**Before:** 3 console_error categories visible — hydration text mismatch, hydration cascade error, and a flood of secondary "duplicate React keys" warnings that follow once React falls out of streaming.

**After:** No hydration mismatch warning, no hydration error. Spec still flags `Subscribe` / `Join` / `Product+` / `Company+` buttons in the footer for **other** reasons (duplicate keys + button timeouts) — those are distinct bugs tracked in the same EMR-715 ticket and will be split into follow-up PRs.

## Note on scope

The branch also carries one auto-agent commit `d7660c4` (EMR-105..108 API routes) pushed by the night-shift orchestrator. The substantive change in this PR is only `src/app/status/status-view.tsx` (9 lines). Happy to split if preferred.

## Test plan

- [x] `BASE_URL=http://localhost:3000 npx playwright test e2e/click-handlers.spec.ts -g 'crawl /status'` — no hydration warnings in the output (verified)
- [ ] Visual smoke: load `/status` in a browser, confirm the page reads "Last updated —" for ~50ms, then snaps to "Last updated 11:23:00 AM"
- [ ] Confirm the 60-second refresh interval still ticks the displayed time

Closes part of EMR-715. The dup-key + footer-button findings remain open in that ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)