### PR TITLE
feat(super-admin): streaming CSV export utility (EMR-749)

### DIFF
--- a/src/lib/admin/csv-export.test.ts
+++ b/src/lib/admin/csv-export.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  logControllerAction: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/auth/audit-stub", () => ({
+  logControllerAction: hoisted.logControllerAction,
+}));
+
+import {
+  escapeCsvCell,
+  practiceIdColumn,
+  streamCsvResponse,
+  type CsvColumn,
+} from "./csv-export";
+
+const ACTOR = {
+  id: "user_1",
+  email: "admin@leafjourney.com",
+  roles: [] as never[],
+  organizationId: null,
+};
+
+beforeEach(() => {
+  hoisted.logControllerAction.mockClear();
+});
+
+describe("escapeCsvCell", () => {
+  it("returns empty string for null and undefined", () => {
+    expect(escapeCsvCell(null)).toBe("");
+    expect(escapeCsvCell(undefined)).toBe("");
+  });
+
+  it("stringifies numbers without quoting", () => {
+    expect(escapeCsvCell(42)).toBe("42");
+    expect(escapeCsvCell(0)).toBe("0");
+    expect(escapeCsvCell(3.14)).toBe("3.14");
+  });
+
+  it("passes plain strings through unquoted", () => {
+    expect(escapeCsvCell("hello")).toBe("hello");
+    expect(escapeCsvCell("")).toBe("");
+  });
+
+  it("quotes strings containing commas", () => {
+    expect(escapeCsvCell("a,b")).toBe('"a,b"');
+  });
+
+  it("quotes strings containing double quotes and doubles the quote", () => {
+    expect(escapeCsvCell('she said "hi"')).toBe('"she said ""hi"""');
+  });
+
+  it("preserves embedded newlines inside a quoted cell", () => {
+    expect(escapeCsvCell("line1\nline2")).toBe('"line1\nline2"');
+    expect(escapeCsvCell("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  it("handles strings with all the dangerous characters", () => {
+    expect(escapeCsvCell('a,b"c\nd')).toBe('"a,b""c\nd"');
+  });
+});
+
+describe("streamCsvResponse — basic shape", () => {
+  it("emits header row + RFC-4180 rows from a sync iterable", async () => {
+    const columns: CsvColumn<{ id: string; name: string }>[] = [
+      { header: "Practice ID", get: (r) => r.id },
+      { header: "Name", get: (r) => r.name },
+    ];
+    const response = await streamCsvResponse({
+      rows: [
+        { id: "p1", name: "Acme, Inc." },
+        { id: "p2", name: 'Quote "Co"' },
+      ],
+      columns,
+      filename: "practices",
+      audit: { entity: "Practice", filters: {}, actor: ACTOR },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/csv; charset=utf-8",
+    );
+    const disp = response.headers.get("content-disposition");
+    expect(disp).toMatch(
+      /^attachment; filename="practices-\d{4}-\d{2}-\d{2}\.csv"$/,
+    );
+
+    const text = await response.text();
+    expect(text).toBe(
+      'Practice ID,Name\r\n' +
+        'p1,"Acme, Inc."\r\n' +
+        'p2,"Quote ""Co"""\r\n',
+    );
+  });
+
+  it("uses human-readable headers, never accessor names", async () => {
+    const response = await streamCsvResponse({
+      rows: [{ organizationId: "p1", billedAmountCents: 12345 }],
+      columns: [
+        { header: "Practice ID", get: (r) => r.organizationId },
+        { header: "Billed", get: (r) => (r.billedAmountCents / 100).toFixed(2) },
+      ],
+      filename: "claims",
+      audit: { entity: "Claim", filters: {}, actor: ACTOR },
+    });
+    const text = await response.text();
+    expect(text.split("\r\n")[0]).toBe("Practice ID,Billed");
+    expect(text).not.toContain("organizationId");
+    expect(text).not.toContain("billedAmountCents");
+  });
+});
+
+describe("streamCsvResponse — practice_id enforcement", () => {
+  it("throws when no practice_id column is present and the requirement is on", async () => {
+    await expect(
+      streamCsvResponse({
+        rows: [{ x: 1 }],
+        columns: [{ header: "X", get: (r) => r.x }],
+        filename: "x",
+        audit: { entity: "X", filters: {}, actor: ACTOR },
+      }),
+    ).rejects.toThrow(/practice_id column/);
+  });
+
+  it("accepts a column whose header normalises to 'practice id'", async () => {
+    const cols: CsvColumn<{ id: string }>[] = [
+      { header: "PRACTICE_ID", get: (r) => r.id },
+    ];
+    await expect(
+      streamCsvResponse({
+        rows: [{ id: "p1" }],
+        columns: cols,
+        filename: "x",
+        audit: { entity: "X", filters: {}, actor: ACTOR },
+      }),
+    ).resolves.toBeInstanceOf(Response);
+  });
+
+  it("accepts a column tagged via practiceIdColumn() even with a different header", async () => {
+    type Row = { orgId: string };
+    const cols: CsvColumn<Row>[] = [
+      practiceIdColumn<Row>("Organization ID", (r) => r.orgId),
+    ];
+    await expect(
+      streamCsvResponse({
+        rows: [{ orgId: "p1" }] as Row[],
+        columns: cols,
+        filename: "x",
+        audit: { entity: "X", filters: {}, actor: ACTOR },
+      }),
+    ).resolves.toBeInstanceOf(Response);
+  });
+
+  it("skips the requirement when explicitly opted out", async () => {
+    await expect(
+      streamCsvResponse({
+        rows: [{ x: 1 }],
+        columns: [{ header: "X", get: (r) => r.x }],
+        filename: "x",
+        audit: { entity: "X", filters: {}, actor: ACTOR },
+        requirePracticeIdColumn: false,
+      }),
+    ).resolves.toBeInstanceOf(Response);
+  });
+});
+
+describe("streamCsvResponse — audit emission", () => {
+  it("emits exactly one super_admin.csv_export audit row before the stream starts", async () => {
+    const columns: CsvColumn<{ id: string }>[] = [
+      { header: "Practice ID", get: (r) => r.id },
+    ];
+    let yielded = 0;
+    async function* source() {
+      for (let i = 0; i < 3; i++) {
+        yielded++;
+        yield { id: `p${i}` };
+      }
+    }
+
+    // Audit log emission happens inside streamCsvResponse BEFORE the
+    // ReadableStream is constructed, so the mock must already be called
+    // by the time we get the Response back.
+    const response = await streamCsvResponse({
+      rows: source(),
+      columns,
+      filename: "practices",
+      audit: {
+        entity: "Practice",
+        filters: { active: true, since: "2026-01-01" },
+        actor: ACTOR,
+      },
+    });
+
+    expect(hoisted.logControllerAction).toHaveBeenCalledTimes(1);
+    expect(yielded).toBe(0);
+
+    const calls = hoisted.logControllerAction.mock.calls as unknown as Array<
+      [
+        {
+          action: string;
+          actor: { id: string };
+          targetId: string;
+          after: Record<string, unknown>;
+        },
+      ]
+    >;
+    const call = calls[0][0];
+    expect(call.action).toBe("super_admin.csv_export");
+    expect(call.actor.id).toBe(ACTOR.id);
+    expect(call.targetId).toBe("Practice");
+    expect(call.after).toMatchObject({
+      entity: "Practice",
+      filters: { active: true, since: "2026-01-01" },
+      filename: "practices",
+      columns: ["Practice ID"],
+    });
+
+    await response.text();
+    expect(yielded).toBe(3);
+  });
+
+  it("refuses to run without an audit payload", async () => {
+    await expect(
+      streamCsvResponse({
+        rows: [],
+        columns: [{ header: "Practice ID", get: () => "" }],
+        filename: "x",
+        // @ts-expect-error — exercising runtime guard.
+        audit: undefined,
+      }),
+    ).rejects.toThrow(/audit/);
+  });
+});
+
+describe("streamCsvResponse — streaming behaviour", () => {
+  it("returns the Response within 200ms even for 50k rows (does not buffer)", async () => {
+    const N = 50_000;
+    async function* source() {
+      for (let i = 0; i < N; i++) {
+        yield { id: `p${i}`, name: `Practice ${i}` };
+      }
+    }
+
+    const t0 = performance.now();
+    const response = await streamCsvResponse({
+      rows: source(),
+      columns: [
+        { header: "Practice ID", get: (r) => r.id },
+        { header: "Name", get: (r) => r.name },
+      ],
+      filename: "practices",
+      audit: { entity: "Practice", filters: {}, actor: ACTOR },
+    });
+    const elapsed = performance.now() - t0;
+    expect(elapsed).toBeLessThan(200);
+    expect(response).toBeInstanceOf(Response);
+
+    // Drain and count bytes — confirms streamed total matches expectation.
+    const reader = response.body!.getReader();
+    let totalBytes = 0;
+    let rowCount = 0;
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\r\n");
+      buffer = lines.pop() ?? "";
+      rowCount += lines.length;
+    }
+    buffer += decoder.decode();
+    if (buffer.length) rowCount++;
+
+    // 1 header + N data rows, all terminated with CRLF.
+    expect(rowCount).toBe(N + 1);
+
+    // Byte total: header "Practice ID,Name\r\n" = 18 bytes.
+    // Each row: `p${i},Practice ${i}\r\n` — varying length, so compute.
+    let expected = "Practice ID,Name\r\n".length;
+    for (let i = 0; i < N; i++) {
+      expected += `p${i},Practice ${i}\r\n`.length;
+    }
+    expect(totalBytes).toBe(expected);
+  }, 30_000);
+});

--- a/src/lib/admin/csv-export.ts
+++ b/src/lib/admin/csv-export.ts
@@ -1,0 +1,237 @@
+// EMR-749 — Streaming CSV export utility for fleet-ops list views.
+//
+// Used by every super-admin list surface that needs to dump its currently
+// filtered rows to CSV (Practices list, Audit log, Providers, Claims
+// rollup, etc.). Centralising it here means:
+//
+//   - one place to fix the next time someone exports 100k rows and OOMs
+//     the server (streaming is load-bearing — we hand the response a
+//     ReadableStream and pull from the source iterable lazily),
+//   - one column convention (human-readable headers, never internal
+//     field names),
+//   - one audit emission path (`super_admin.csv_export` to
+//     `ControllerAuditLog`), so support engineers can grep across
+//     exports for tenant-shaped questions.
+//
+// The audit row is written BEFORE the stream starts so a connection drop
+// mid-stream still leaves a trail of who exported what.
+
+import "server-only";
+
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import type { AuthedUser } from "@/lib/auth/session";
+
+/** Column accessor — pulls a single cell value out of a row. */
+export type CsvAccessor<T> = (row: T) => string | number | null | undefined;
+
+/** Tag a column's `get` function as the canonical `practice_id` accessor. */
+const PRACTICE_ID_TAG = Symbol.for("emr.csv.practiceIdColumn");
+
+/**
+ * Column spec entry. `header` is the human-readable label that lands in
+ * row 1 of the CSV. Internal field names never leak.
+ */
+export interface CsvColumn<T> {
+  header: string;
+  get: CsvAccessor<T>;
+}
+
+/**
+ * Mark an accessor as the `practice_id` column. Use when the column's
+ * header isn't a literal "Practice ID" but it still semantically carries
+ * the tenant id (e.g. "Organization ID" on a Claims rollup).
+ */
+export function practiceIdColumn<T>(
+  header: string,
+  get: CsvAccessor<T>,
+): CsvColumn<T> {
+  const tagged = ((row: T) => get(row)) as CsvAccessor<T> & {
+    [PRACTICE_ID_TAG]?: true;
+  };
+  tagged[PRACTICE_ID_TAG] = true;
+  return { header, get: tagged };
+}
+
+function isPracticeIdColumn<T>(col: CsvColumn<T>): boolean {
+  const headerNorm = col.header.trim().toLowerCase().replace(/[\s_-]+/g, " ");
+  if (headerNorm === "practice id") return true;
+  const tagged = col.get as CsvAccessor<T> & { [PRACTICE_ID_TAG]?: true };
+  return tagged[PRACTICE_ID_TAG] === true;
+}
+
+export interface CsvAuditPayload {
+  /** Entity kind being exported — e.g. "Practice", "Claim", "AuditLog". */
+  entity: string;
+  /** The filter parameters that were active on the source query. */
+  filters: Record<string, unknown>;
+  /**
+   * Who is exporting. Required because every audit row must name an
+   * actor. Callers normally pass `await requireSuperAdmin()` (or its
+   * equivalent) straight through.
+   */
+  actor: Pick<AuthedUser, "id" | "email" | "roles" | "organizationId">;
+}
+
+export interface StreamCsvOptions<T> {
+  /** Async iterable of typed rows. Prisma cursors satisfy this. */
+  rows: AsyncIterable<T> | Iterable<T>;
+  /** Column spec — header + accessor per column. Order is preserved. */
+  columns: ReadonlyArray<CsvColumn<T>>;
+  /** Filename stem. UTC date is appended automatically. */
+  filename: string;
+  /** Audit-on-export payload. Refused if absent. */
+  audit: CsvAuditPayload;
+  /**
+   * Require at least one column to be the `practice_id` column. Default
+   * true. A column qualifies if its header normalises to "practice id"
+   * OR its accessor was tagged via `practiceIdColumn()`.
+   */
+  requirePracticeIdColumn?: boolean;
+}
+
+/**
+ * RFC-4180 cell escape. Wraps a value in double quotes when it contains
+ * a comma, quote, CR, or LF, and doubles any embedded quotes. `null` /
+ * `undefined` collapse to the empty string. Numbers stringify normally.
+ */
+export function escapeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const s = typeof value === "string" ? value : String(value);
+  if (s.length === 0) return "";
+  // Quoting trigger: comma, quote, CR, or LF.
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function utcDateStamp(now: Date = new Date()): string {
+  const y = now.getUTCFullYear().toString().padStart(4, "0");
+  const m = (now.getUTCMonth() + 1).toString().padStart(2, "0");
+  const d = now.getUTCDate().toString().padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function renderHeader<T>(columns: ReadonlyArray<CsvColumn<T>>): string {
+  return columns.map((c) => escapeCsvCell(c.header)).join(",") + "\r\n";
+}
+
+function getAsyncIterator<T>(
+  source: AsyncIterable<T> | Iterable<T>,
+): AsyncIterator<T> {
+  const asAsync = source as AsyncIterable<T>;
+  if (typeof asAsync[Symbol.asyncIterator] === "function") {
+    return asAsync[Symbol.asyncIterator]();
+  }
+  const sync = (source as Iterable<T>)[Symbol.iterator]();
+  return {
+    next: () => Promise.resolve(sync.next()),
+    return: sync.return
+      ? (value) => Promise.resolve(sync.return!(value))
+      : undefined,
+    throw: sync.throw
+      ? (err) => Promise.resolve(sync.throw!(err))
+      : undefined,
+  };
+}
+
+function renderRow<T>(row: T, columns: ReadonlyArray<CsvColumn<T>>): string {
+  const cells: string[] = new Array(columns.length);
+  for (let i = 0; i < columns.length; i++) {
+    cells[i] = escapeCsvCell(columns[i].get(row));
+  }
+  return cells.join(",") + "\r\n";
+}
+
+/**
+ * Build a streaming `text/csv` `Response`. Audit is emitted (and awaited)
+ * BEFORE the stream begins — if the audit row can't be written we still
+ * proceed (logControllerAction swallows its own failures with retries and
+ * Sentry), but the call site has had its one chance to be on record.
+ *
+ * The stream pulls rows lazily from the source iterable, so a 100k-row
+ * Prisma cursor never materialises in memory.
+ */
+export async function streamCsvResponse<T>(
+  opts: StreamCsvOptions<T>,
+): Promise<Response> {
+  const {
+    rows,
+    columns,
+    filename,
+    audit,
+    requirePracticeIdColumn = true,
+  } = opts;
+
+  if (!columns.length) {
+    throw new Error("streamCsvResponse: columns spec must not be empty");
+  }
+  if (!audit || !audit.entity || !audit.actor) {
+    throw new Error(
+      "streamCsvResponse: audit { entity, actor, filters } is required",
+    );
+  }
+
+  if (requirePracticeIdColumn) {
+    const hasPracticeId = columns.some((c) => isPracticeIdColumn(c));
+    if (!hasPracticeId) {
+      throw new Error(
+        'streamCsvResponse: columns spec must include a practice_id column ' +
+          '(header "Practice ID" or wrap accessor with practiceIdColumn()). ' +
+          "Pass requirePracticeIdColumn: false to opt out.",
+      );
+    }
+  }
+
+  await logControllerAction({
+    actor: audit.actor,
+    action: "super_admin.csv_export",
+    targetId: audit.entity,
+    after: {
+      entity: audit.entity,
+      filters: audit.filters,
+      filename,
+      columns: columns.map((c) => c.header),
+    },
+  });
+
+  const encoder = new TextEncoder();
+  const iterator = getAsyncIterator(rows);
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(renderHeader(columns)));
+    },
+    async pull(controller) {
+      // One row per pull. ReadableStream invokes `pull` whenever the
+      // consumer has backpressure room; per-row enqueueing keeps memory
+      // bounded regardless of source size.
+      try {
+        const next = await iterator.next();
+        if (next.done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(renderRow(next.value, columns)));
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await iterator.return?.(reason);
+      } catch {
+        // Iterator cleanup is best-effort; the consumer already gave up.
+      }
+    },
+  });
+
+  const safeStem = filename.replace(/[^A-Za-z0-9._-]+/g, "-");
+  const headers = new Headers({
+    "Content-Type": "text/csv; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${safeStem}-${utcDateStamp()}.csv"`,
+    "Cache-Control": "no-store",
+  });
+
+  return new Response(stream, { status: 200, headers });
+}

--- a/src/lib/admin/csv-export.ts
+++ b/src/lib/admin/csv-export.ts
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Foundation utility; consumers land in follow-up EMR-749 PRs (Practices/Audit/Providers export buttons)."
 // EMR-749 — Streaming CSV export utility for fleet-ops list views.
 //
 // Used by every super-admin list surface that needs to dump its currently


### PR DESCRIPTION
## Summary

Implements [EMR-749](https://linear.app/emr-project/issue/EMR-749) — a shared streaming CSV export helper at `src/lib/admin/csv-export.ts` that every super-admin / fleet-ops list view can call to dump its currently-filtered rows.

- `streamCsvResponse<T>({ rows, columns, filename, audit, requirePracticeIdColumn? })` returns a `Response` whose body is a `ReadableStream` pulling rows lazily from any `AsyncIterable<T>` (e.g. a Prisma cursor) or sync `Iterable<T>`. No row buffering — 100k-row exports won't OOM.
- Audit-on-export: `super_admin.csv_export` is written to `ControllerAuditLog` via `logControllerAction()` *before* the stream starts, so a mid-stream connection drop still leaves a trail of who-exported-what with which filters.
- Human-readable column headers come from the typed `columns` spec; internal field names never leak.
- `escapeCsvCell()` is RFC-4180-compliant: comma/quote/CR/LF trigger quoting, embedded quotes are doubled, `null`/`undefined` collapse to empty.
- `practice_id` column required by default — satisfied by any header that normalises to "practice id" OR an accessor wrapped with the exported `practiceIdColumn()` helper. Opt out with `requirePracticeIdColumn: false`.
- Filename: `<stem>-YYYY-MM-DD.csv` (UTC).

No new dependency — own escape logic, no `csv-stringify` / `papaparse`. No API route in this PR.

## Acceptance criteria

- [x] Utility lives at `src/lib/admin/csv-export.ts`.
- [x] Accepts async iterable + typed column spec (label + accessor per column).
- [x] Streams the response via `ReadableStream` — does not buffer.
- [x] Headers use human-readable labels from the spec.
- [x] Always requires a `practice_id` column (with documented opt-out).
- [x] Emits `super_admin.csv_export` to `ControllerAuditLog` with entity + filters.
- [x] RFC-4180 escaping (commas, quotes, newlines; doubled quotes).
- [x] `Content-Type: text/csv; charset=utf-8` + `Content-Disposition` with entity stem + UTC date.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (no new warnings)
- [x] `npx vitest run src/lib/admin/csv-export.test.ts` — 16/16 passing
- [x] Escape edge cases: comma, quote, newline, CRLF, null, undefined, number
- [x] 50k-row generator returns `Response` in <200ms and byte total matches expectation
- [x] Audit emission asserted: called once, before any rows are pulled, with correct entity/filters/columns payload
- [x] `practice_id` enforcement: throws without a qualifying column, accepts normalised header OR `practiceIdColumn()` tag, opt-out works

[Generated with Claude Code](https://claude.com/claude-code)