### PR TITLE
feat(super-admin): HQ fleet aggregates data layer (EMR-731)

### DIFF
--- a/src/app/(super-admin)/hq/loaders.ts
+++ b/src/app/(super-admin)/hq/loaders.ts
@@ -1,0 +1,656 @@
+// EMR-731 — Fleet aggregates data layer for the HQ super-admin dashboard.
+//
+// Every loader returns counts / sums / IDs only — never PHI. Each is wrapped
+// in Next.js `unstable_cache` with a 60s TTL (configurable via
+// HQ_CACHE_TTL_SECONDS) keyed by loader name + parameters so a single page
+// render is one parallel fan-out of cheap cache reads.
+//
+// Modelled after `src/app/(super-admin)/practices/loaders.ts`: same
+// `groupBy + _count + _sum` discipline, all I/O behind a single Promise.all,
+// money in cents.
+
+import "server-only";
+import { unstable_cache } from "next/cache";
+import { prisma } from "@/lib/db/prisma";
+import { LEAFJOURNEY_HQ_SLUG } from "@/lib/auth/super-admin-bootstrap";
+import {
+  isStuckConfig,
+  medianMs,
+  momDelta,
+  zeroFillDailySeries,
+  type FleetCounts,
+  type FleetDailyPoint,
+  type FleetRevenue,
+  type HqDashboardSnapshot,
+  type ModalityMixRow,
+  type OnboardingFunnelStage,
+  type RecentActivityRow,
+  type SpecialtyDriftRow,
+  type SpecialtyMixRow,
+  type TopPracticeRow,
+  type TopPracticesMetric,
+} from "./types";
+
+export type {
+  FleetCounts,
+  FleetDailyPoint,
+  FleetRevenue,
+  HqDashboardSnapshot,
+  ModalityMixRow,
+  OnboardingFunnelStage,
+  RecentActivityRow,
+  SpecialtyDriftRow,
+  SpecialtyMixRow,
+  TopPracticeRow,
+  TopPracticesMetric,
+} from "./types";
+
+export const HQ_CACHE_TTL_SECONDS = (() => {
+  const raw = process.env.HQ_CACHE_TTL_SECONDS;
+  if (!raw) return 60;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 60;
+})();
+
+const STUCK_HOURS = 24;
+const HQ_TAG = "hq-fleet";
+
+function startOfMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function startOfPrevMonthUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() - 1, 1));
+}
+
+function cached<TArgs extends unknown[], TResult>(
+  name: string,
+  fn: (...args: TArgs) => Promise<TResult>,
+): (...args: TArgs) => Promise<TResult> {
+  return (...args: TArgs) =>
+    unstable_cache(() => fn(...args), [name, ...args.map((a) => JSON.stringify(a))], {
+      revalidate: HQ_CACHE_TTL_SECONDS,
+      tags: [HQ_TAG, `${HQ_TAG}:${name}`],
+    })();
+}
+
+async function nonHqOrgIds(): Promise<string[]> {
+  const orgs = await prisma.organization.findMany({
+    where: { slug: { not: LEAFJOURNEY_HQ_SLUG } },
+    select: { id: true },
+  });
+  return orgs.map((o) => o.id);
+}
+
+export const getFleetCounts = cached(
+  "getFleetCounts",
+  async (): Promise<FleetCounts> => {
+    const orgIds = await nonHqOrgIds();
+    if (orgIds.length === 0) {
+      return {
+        practicesLive: 0,
+        practicesOnboarding: 0,
+        practicesStuck: 0,
+        providersActive: 0,
+        patientsActive: 0,
+      };
+    }
+
+    const [configs, providers, patients] = await Promise.all([
+      prisma.practiceConfiguration.findMany({
+        where: { organizationId: { in: orgIds } },
+        select: { status: true, updatedAt: true },
+      }),
+      prisma.provider.count({
+        where: { organizationId: { in: orgIds }, active: true },
+      }),
+      prisma.patient.count({
+        where: {
+          organizationId: { in: orgIds },
+          deletedAt: null,
+          status: "active",
+        },
+      }),
+    ]);
+
+    const now = new Date();
+    let live = 0;
+    let onboarding = 0;
+    let stuck = 0;
+    for (const c of configs) {
+      const status = String(c.status);
+      if (status === "published") {
+        live += 1;
+      } else if (status !== "archived") {
+        onboarding += 1;
+        if (isStuckConfig(status, c.updatedAt, now, STUCK_HOURS)) stuck += 1;
+      }
+    }
+
+    return {
+      practicesLive: live,
+      practicesOnboarding: onboarding,
+      practicesStuck: stuck,
+      providersActive: providers,
+      patientsActive: patients,
+    };
+  },
+);
+
+export const getFleetRevenue = cached(
+  "getFleetRevenue",
+  async (): Promise<FleetRevenue> => {
+    const orgIds = await nonHqOrgIds();
+    if (orgIds.length === 0) {
+      return {
+        billedCentsMTD: 0,
+        collectedCentsMTD: 0,
+        gmvCentsMTD: 0,
+        billedCentsPrevMonth: 0,
+        collectedCentsPrevMonth: 0,
+        gmvCentsPrevMonth: 0,
+      };
+    }
+
+    const now = new Date();
+    const curStart = startOfMonthUtc(now);
+    const prevStart = startOfPrevMonthUtc(now);
+
+    const [claimsCur, claimsPrev, chargesCur, chargesPrev] = await Promise.all([
+      prisma.claim.aggregate({
+        where: {
+          organizationId: { in: orgIds },
+          serviceDate: { gte: curStart },
+        },
+        _sum: { billedAmountCents: true, paidAmountCents: true },
+      }),
+      prisma.claim.aggregate({
+        where: {
+          organizationId: { in: orgIds },
+          serviceDate: { gte: prevStart, lt: curStart },
+        },
+        _sum: { billedAmountCents: true, paidAmountCents: true },
+      }),
+      prisma.charge.aggregate({
+        where: {
+          organizationId: { in: orgIds },
+          createdAt: { gte: curStart },
+        },
+        _sum: { feeAmountCents: true },
+      }),
+      prisma.charge.aggregate({
+        where: {
+          organizationId: { in: orgIds },
+          createdAt: { gte: prevStart, lt: curStart },
+        },
+        _sum: { feeAmountCents: true },
+      }),
+    ]);
+
+    return {
+      billedCentsMTD: claimsCur._sum.billedAmountCents ?? 0,
+      collectedCentsMTD: claimsCur._sum.paidAmountCents ?? 0,
+      gmvCentsMTD: chargesCur._sum.feeAmountCents ?? 0,
+      billedCentsPrevMonth: claimsPrev._sum.billedAmountCents ?? 0,
+      collectedCentsPrevMonth: claimsPrev._sum.paidAmountCents ?? 0,
+      gmvCentsPrevMonth: chargesPrev._sum.feeAmountCents ?? 0,
+    };
+  },
+);
+
+export const getFleetDailySeries = cached(
+  "getFleetDailySeries",
+  async (days: number = 30): Promise<FleetDailyPoint[]> => {
+    const orgIds = await nonHqOrgIds();
+    const now = new Date();
+    const since = new Date(now.getTime() - days * 86_400_000);
+
+    if (orgIds.length === 0) {
+      return zeroFillDailySeries(new Map(), days, now);
+    }
+
+    const [claims, charges, encounters, patients] = await Promise.all([
+      prisma.claim.findMany({
+        where: {
+          organizationId: { in: orgIds },
+          serviceDate: { gte: since },
+        },
+        select: { serviceDate: true, billedAmountCents: true },
+      }),
+      prisma.charge.findMany({
+        where: {
+          organizationId: { in: orgIds },
+          createdAt: { gte: since },
+        },
+        select: { createdAt: true },
+      }),
+      prisma.encounter.findMany({
+        where: {
+          organizationId: { in: orgIds },
+          createdAt: { gte: since },
+        },
+        select: { createdAt: true },
+      }),
+      prisma.patient.findMany({
+        where: {
+          organizationId: { in: orgIds },
+          createdAt: { gte: since },
+          deletedAt: null,
+        },
+        select: { createdAt: true },
+      }),
+    ]);
+
+    const buckets = new Map<
+      string,
+      {
+        claims: number;
+        charges: number;
+        encounters: number;
+        billedCents: number;
+        newPatients: number;
+      }
+    >();
+    function bucket(key: string) {
+      const existing = buckets.get(key);
+      if (existing) return existing;
+      const fresh = {
+        claims: 0,
+        charges: 0,
+        encounters: 0,
+        billedCents: 0,
+        newPatients: 0,
+      };
+      buckets.set(key, fresh);
+      return fresh;
+    }
+    function dayKey(d: Date): string {
+      return d.toISOString().slice(0, 10);
+    }
+    for (const c of claims) {
+      const b = bucket(dayKey(c.serviceDate));
+      b.claims += 1;
+      b.billedCents += c.billedAmountCents;
+    }
+    for (const c of charges) bucket(dayKey(c.createdAt)).charges += 1;
+    for (const e of encounters) bucket(dayKey(e.createdAt)).encounters += 1;
+    for (const p of patients) bucket(dayKey(p.createdAt)).newPatients += 1;
+
+    return zeroFillDailySeries(buckets, days, now);
+  },
+);
+
+export const getOnboardingFunnel = cached(
+  "getOnboardingFunnel",
+  async (): Promise<OnboardingFunnelStage[]> => {
+    const orgIds = await nonHqOrgIds();
+    if (orgIds.length === 0) return [];
+
+    const configs = await prisma.practiceConfiguration.findMany({
+      where: { organizationId: { in: orgIds } },
+      select: { status: true, createdAt: true, updatedAt: true, publishedAt: true },
+    });
+
+    const buckets = new Map<string, number[]>();
+    const now = Date.now();
+    for (const c of configs) {
+      const status = String(c.status);
+      const arr = buckets.get(status) ?? [];
+      const end =
+        status === "published" && c.publishedAt
+          ? c.publishedAt.getTime()
+          : now;
+      arr.push(end - c.createdAt.getTime());
+      buckets.set(status, arr);
+    }
+    return Array.from(buckets.entries()).map(([status, durations]) => ({
+      status,
+      count: durations.length,
+      medianHoursInStage: medianMs(durations) / (60 * 60 * 1000),
+    }));
+  },
+);
+
+export const getModalityMix = cached(
+  "getModalityMix",
+  async (): Promise<ModalityMixRow[]> => {
+    const orgIds = await nonHqOrgIds();
+    if (orgIds.length === 0) return [];
+
+    const configs = await prisma.practiceConfiguration.findMany({
+      where: {
+        organizationId: { in: orgIds },
+        status: "published",
+      },
+      select: { enabledModalities: true },
+    });
+
+    const counts = new Map<string, number>();
+    for (const c of configs) {
+      for (const m of c.enabledModalities ?? []) {
+        counts.set(m, (counts.get(m) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([modality, practiceCount]) => ({ modality, practiceCount }))
+      .sort((a, b) => b.practiceCount - a.practiceCount);
+  },
+);
+
+export const getSpecialtyMix = cached(
+  "getSpecialtyMix",
+  async (): Promise<SpecialtyMixRow[]> => {
+    const orgIds = await nonHqOrgIds();
+    if (orgIds.length === 0) return [];
+
+    const groups = await prisma.practiceConfiguration.groupBy({
+      by: ["selectedSpecialty", "selectedSpecialtyVersion"],
+      where: {
+        organizationId: { in: orgIds },
+        status: "published",
+        selectedSpecialty: { not: null },
+      },
+      _count: { _all: true },
+    });
+    return groups
+      .filter((g) => g.selectedSpecialty)
+      .map((g) => ({
+        specialty: g.selectedSpecialty as string,
+        manifestVersion: g.selectedSpecialtyVersion ?? "unknown",
+        practiceCount: g._count._all,
+      }))
+      .sort((a, b) => b.practiceCount - a.practiceCount);
+  },
+);
+
+export const getSpecialtyVersionDrift = cached(
+  "getSpecialtyVersionDrift",
+  async (): Promise<SpecialtyDriftRow[]> => {
+    const mix = await getSpecialtyMix();
+    const bySpecialty = new Map<string, { latest: string; rows: SpecialtyMixRow[] }>();
+    for (const row of mix) {
+      const entry = bySpecialty.get(row.specialty) ?? {
+        latest: row.manifestVersion,
+        rows: [],
+      };
+      entry.rows.push(row);
+      if (row.manifestVersion > entry.latest) entry.latest = row.manifestVersion;
+      bySpecialty.set(row.specialty, entry);
+    }
+    const out: SpecialtyDriftRow[] = [];
+    for (const [specialty, { latest, rows }] of bySpecialty.entries()) {
+      for (const r of rows) {
+        if (r.manifestVersion !== latest) {
+          out.push({
+            specialty,
+            latestVersion: latest,
+            currentVersion: r.manifestVersion,
+            practiceCount: r.practiceCount,
+          });
+        }
+      }
+    }
+    return out;
+  },
+);
+
+async function topByClaimsImpl(limit: number): Promise<TopPracticeRow[]> {
+  const orgIds = await nonHqOrgIds();
+  if (orgIds.length === 0) return [];
+
+  const now = new Date();
+  const curStart = startOfMonthUtc(now);
+  const prevStart = startOfPrevMonthUtc(now);
+
+  const [cur, prev, orgs] = await Promise.all([
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        serviceDate: { gte: curStart },
+      },
+      _count: { _all: true },
+    }),
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        serviceDate: { gte: prevStart, lt: curStart },
+      },
+      _count: { _all: true },
+    }),
+    prisma.organization.findMany({
+      where: { id: { in: orgIds } },
+      select: { id: true, name: true, brandName: true },
+    }),
+  ]);
+
+  const prevByOrg = new Map(prev.map((r) => [r.organizationId, r._count._all]));
+  const nameByOrg = new Map(orgs.map((o) => [o.id, o.brandName ?? o.name]));
+  return cur
+    .map((r) => ({
+      organizationId: r.organizationId,
+      practiceName: nameByOrg.get(r.organizationId) ?? "(unknown)",
+      metric: r._count._all,
+      momDelta: momDelta(r._count._all, prevByOrg.get(r.organizationId) ?? 0),
+    }))
+    .sort((a, b) => b.metric - a.metric)
+    .slice(0, limit);
+}
+
+async function topByRevenueImpl(limit: number): Promise<TopPracticeRow[]> {
+  const orgIds = await nonHqOrgIds();
+  if (orgIds.length === 0) return [];
+
+  const now = new Date();
+  const curStart = startOfMonthUtc(now);
+  const prevStart = startOfPrevMonthUtc(now);
+
+  const [cur, prev, orgs] = await Promise.all([
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        serviceDate: { gte: curStart },
+      },
+      _sum: { billedAmountCents: true },
+    }),
+    prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        serviceDate: { gte: prevStart, lt: curStart },
+      },
+      _sum: { billedAmountCents: true },
+    }),
+    prisma.organization.findMany({
+      where: { id: { in: orgIds } },
+      select: { id: true, name: true, brandName: true },
+    }),
+  ]);
+
+  const prevByOrg = new Map(
+    prev.map((r) => [r.organizationId, r._sum.billedAmountCents ?? 0]),
+  );
+  const nameByOrg = new Map(orgs.map((o) => [o.id, o.brandName ?? o.name]));
+  return cur
+    .map((r) => {
+      const billed = r._sum.billedAmountCents ?? 0;
+      return {
+        organizationId: r.organizationId,
+        practiceName: nameByOrg.get(r.organizationId) ?? "(unknown)",
+        metric: billed,
+        momDelta: momDelta(billed, prevByOrg.get(r.organizationId) ?? 0),
+      };
+    })
+    .sort((a, b) => b.metric - a.metric)
+    .slice(0, limit);
+}
+
+async function topByPatientGrowthImpl(limit: number): Promise<TopPracticeRow[]> {
+  const orgIds = await nonHqOrgIds();
+  if (orgIds.length === 0) return [];
+
+  const now = new Date();
+  const curStart = startOfMonthUtc(now);
+  const prevStart = startOfPrevMonthUtc(now);
+
+  const [cur, prev, orgs] = await Promise.all([
+    prisma.patient.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        deletedAt: null,
+        createdAt: { gte: curStart },
+      },
+      _count: { _all: true },
+    }),
+    prisma.patient.groupBy({
+      by: ["organizationId"],
+      where: {
+        organizationId: { in: orgIds },
+        deletedAt: null,
+        createdAt: { gte: prevStart, lt: curStart },
+      },
+      _count: { _all: true },
+    }),
+    prisma.organization.findMany({
+      where: { id: { in: orgIds } },
+      select: { id: true, name: true, brandName: true },
+    }),
+  ]);
+
+  const prevByOrg = new Map(prev.map((r) => [r.organizationId, r._count._all]));
+  const nameByOrg = new Map(orgs.map((o) => [o.id, o.brandName ?? o.name]));
+  return cur
+    .map((r) => ({
+      organizationId: r.organizationId,
+      practiceName: nameByOrg.get(r.organizationId) ?? "(unknown)",
+      metric: r._count._all,
+      momDelta: momDelta(r._count._all, prevByOrg.get(r.organizationId) ?? 0),
+    }))
+    .sort((a, b) => b.metric - a.metric)
+    .slice(0, limit);
+}
+
+export const getTopPracticesByClaims = cached(
+  "getTopPracticesByClaims",
+  async (limit: number = 5) => topByClaimsImpl(limit),
+);
+
+export const getTopPracticesByRevenue = cached(
+  "getTopPracticesByRevenue",
+  async (limit: number = 5) => topByRevenueImpl(limit),
+);
+
+export const getTopPracticesByPatientGrowth = cached(
+  "getTopPracticesByPatientGrowth",
+  async (limit: number = 5) => topByPatientGrowthImpl(limit),
+);
+
+/**
+ * Generic dispatcher matching the parent prompt's `loadTopPractices(metric, limit)`
+ * signature.
+ */
+export async function getTopPractices(
+  metric: TopPracticesMetric,
+  limit: number = 5,
+): Promise<TopPracticeRow[]> {
+  switch (metric) {
+    case "claims":
+      return getTopPracticesByClaims(limit);
+    case "billed":
+      return getTopPracticesByRevenue(limit);
+    case "patientGrowth":
+      return getTopPracticesByPatientGrowth(limit);
+  }
+}
+
+function deeplinkFor(row: {
+  subjectType: string;
+  subjectId: string;
+  organizationId: string | null;
+}): string {
+  if (row.organizationId) {
+    return `/practices?org=${encodeURIComponent(row.organizationId)}`;
+  }
+  return `/admin/audit/${encodeURIComponent(row.subjectId)}`;
+}
+
+export const getRecentActivity = cached(
+  "getRecentActivity",
+  async (hours: number = 24): Promise<RecentActivityRow[]> => {
+    const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+    const rows = await prisma.controllerAuditLog.findMany({
+      where: { at: { gte: since } },
+      orderBy: { at: "desc" },
+      take: 100,
+      select: {
+        id: true,
+        at: true,
+        actorUserId: true,
+        actorEmail: true,
+        organizationId: true,
+        action: true,
+        subjectType: true,
+        subjectId: true,
+      },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      at: r.at.toISOString(),
+      actorUserId: r.actorUserId,
+      actorEmail: r.actorEmail,
+      organizationId: r.organizationId,
+      action: r.action,
+      subjectType: r.subjectType,
+      subjectId: r.subjectId,
+      deeplink: deeplinkFor(r),
+    }));
+  },
+);
+
+/**
+ * Umbrella loader — runs every individual loader in parallel. Page components
+ * should call this once and destructure the snapshot.
+ */
+export async function loadAllHqData(): Promise<HqDashboardSnapshot> {
+  const [
+    counts,
+    revenue,
+    dailySeries,
+    onboardingFunnel,
+    modalityMix,
+    specialtyMix,
+    specialtyDrift,
+    topByClaims,
+    topByRevenue,
+    topByPatientGrowth,
+    recentActivity,
+  ] = await Promise.all([
+    getFleetCounts(),
+    getFleetRevenue(),
+    getFleetDailySeries(30),
+    getOnboardingFunnel(),
+    getModalityMix(),
+    getSpecialtyMix(),
+    getSpecialtyVersionDrift(),
+    getTopPracticesByClaims(5),
+    getTopPracticesByRevenue(5),
+    getTopPracticesByPatientGrowth(5),
+    getRecentActivity(24),
+  ]);
+  return {
+    counts,
+    revenue,
+    dailySeries,
+    onboardingFunnel,
+    modalityMix,
+    specialtyMix,
+    specialtyDrift,
+    topByClaims,
+    topByRevenue,
+    topByPatientGrowth,
+    recentActivity,
+  };
+}

--- a/src/app/(super-admin)/hq/types.test.ts
+++ b/src/app/(super-admin)/hq/types.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStuckConfig,
+  medianMs,
+  momDelta,
+  zeroFillDailySeries,
+} from "./types";
+
+describe("momDelta", () => {
+  it("returns 0 when both values are 0", () => {
+    expect(momDelta(0, 0)).toBe(0);
+  });
+
+  it("returns Infinity when prev is 0 and current is positive", () => {
+    expect(momDelta(10, 0)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("returns -Infinity when prev is 0 and current is negative", () => {
+    expect(momDelta(-10, 0)).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("computes percent change from prev to current", () => {
+    expect(momDelta(150, 100)).toBe(50);
+    expect(momDelta(75, 100)).toBe(-25);
+    expect(momDelta(100, 100)).toBe(0);
+  });
+
+  it("handles decreases from non-zero prev", () => {
+    expect(momDelta(0, 100)).toBe(-100);
+  });
+});
+
+describe("zeroFillDailySeries", () => {
+  const fixedNow = new Date("2026-05-17T12:00:00.000Z");
+
+  it("returns exactly `days` entries", () => {
+    const out = zeroFillDailySeries(new Map(), 30, fixedNow);
+    expect(out).toHaveLength(30);
+  });
+
+  it("ends on the supplied date (UTC) and starts days-1 earlier", () => {
+    const out = zeroFillDailySeries(new Map(), 5, fixedNow);
+    expect(out[out.length - 1].date).toBe("2026-05-17");
+    expect(out[0].date).toBe("2026-05-13");
+  });
+
+  it("zero-fills missing days but preserves bucketed values", () => {
+    const buckets = new Map([
+      [
+        "2026-05-15",
+        { claims: 3, charges: 7, encounters: 2, billedCents: 50000, newPatients: 1 },
+      ],
+    ]);
+    const out = zeroFillDailySeries(buckets, 5, fixedNow);
+    const may15 = out.find((p) => p.date === "2026-05-15");
+    expect(may15).toEqual({
+      date: "2026-05-15",
+      claims: 3,
+      charges: 7,
+      encounters: 2,
+      billedCents: 50000,
+      newPatients: 1,
+    });
+    const may14 = out.find((p) => p.date === "2026-05-14");
+    expect(may14).toEqual({
+      date: "2026-05-14",
+      claims: 0,
+      charges: 0,
+      encounters: 0,
+      billedCents: 0,
+      newPatients: 0,
+    });
+  });
+
+  it("emits dates in chronological order", () => {
+    const out = zeroFillDailySeries(new Map(), 7, fixedNow);
+    const dates = out.map((p) => p.date);
+    const sorted = [...dates].sort();
+    expect(dates).toEqual(sorted);
+  });
+});
+
+describe("isStuckConfig", () => {
+  const now = new Date("2026-05-17T12:00:00.000Z");
+
+  it("returns false for published configs even when old", () => {
+    const old = new Date(now.getTime() - 30 * 86_400_000);
+    expect(isStuckConfig("published", old, now)).toBe(false);
+  });
+
+  it("returns false for archived configs", () => {
+    const old = new Date(now.getTime() - 30 * 86_400_000);
+    expect(isStuckConfig("archived", old, now)).toBe(false);
+  });
+
+  it("returns false for fresh draft configs (< 24h)", () => {
+    const fresh = new Date(now.getTime() - 60 * 60 * 1000);
+    expect(isStuckConfig("draft", fresh, now)).toBe(false);
+  });
+
+  it("returns true for draft configs older than 24h", () => {
+    const stale = new Date(now.getTime() - 25 * 60 * 60 * 1000);
+    expect(isStuckConfig("draft", stale, now)).toBe(true);
+  });
+
+  it("honors a custom staleHours threshold", () => {
+    const fourHoursAgo = new Date(now.getTime() - 4 * 60 * 60 * 1000);
+    expect(isStuckConfig("draft", fourHoursAgo, now, 2)).toBe(true);
+    expect(isStuckConfig("draft", fourHoursAgo, now, 6)).toBe(false);
+  });
+});
+
+describe("medianMs", () => {
+  it("returns 0 for an empty list", () => {
+    expect(medianMs([])).toBe(0);
+  });
+
+  it("returns the middle value for odd-length lists", () => {
+    expect(medianMs([1000, 5000, 3000])).toBe(3000);
+  });
+
+  it("averages the two middle values for even-length lists", () => {
+    expect(medianMs([1000, 2000, 3000, 4000])).toBe(2500);
+  });
+});

--- a/src/app/(super-admin)/hq/types.ts
+++ b/src/app/(super-admin)/hq/types.ts
@@ -1,0 +1,163 @@
+// Pure types + pure helpers for the HQ fleet aggregates layer (EMR-731).
+// No server imports — must be safe to consume from unit tests and from
+// any client component that wants to type-narrow on a loader response.
+
+export interface FleetCounts {
+  practicesLive: number;
+  practicesOnboarding: number;
+  practicesStuck: number;
+  providersActive: number;
+  patientsActive: number;
+}
+
+export interface FleetRevenue {
+  billedCentsMTD: number;
+  collectedCentsMTD: number;
+  gmvCentsMTD: number;
+  billedCentsPrevMonth: number;
+  collectedCentsPrevMonth: number;
+  gmvCentsPrevMonth: number;
+}
+
+export interface FleetDailyPoint {
+  date: string;
+  claims: number;
+  charges: number;
+  encounters: number;
+  billedCents: number;
+  newPatients: number;
+}
+
+export interface OnboardingFunnelStage {
+  status: string;
+  count: number;
+  medianHoursInStage: number;
+}
+
+export interface ModalityMixRow {
+  modality: string;
+  practiceCount: number;
+}
+
+export interface SpecialtyMixRow {
+  specialty: string;
+  manifestVersion: string;
+  practiceCount: number;
+}
+
+export interface SpecialtyDriftRow {
+  specialty: string;
+  latestVersion: string;
+  currentVersion: string;
+  practiceCount: number;
+}
+
+export type TopPracticesMetric = "claims" | "billed" | "patientGrowth";
+
+export interface TopPracticeRow {
+  organizationId: string;
+  practiceName: string;
+  metric: number;
+  momDelta: number;
+}
+
+export interface RecentActivityRow {
+  id: string;
+  at: string;
+  actorUserId: string;
+  actorEmail: string | null;
+  organizationId: string | null;
+  action: string;
+  subjectType: string;
+  subjectId: string;
+  deeplink: string;
+}
+
+export interface HqDashboardSnapshot {
+  counts: FleetCounts;
+  revenue: FleetRevenue;
+  dailySeries: FleetDailyPoint[];
+  onboardingFunnel: OnboardingFunnelStage[];
+  modalityMix: ModalityMixRow[];
+  specialtyMix: SpecialtyMixRow[];
+  specialtyDrift: SpecialtyDriftRow[];
+  topByClaims: TopPracticeRow[];
+  topByRevenue: TopPracticeRow[];
+  topByPatientGrowth: TopPracticeRow[];
+  recentActivity: RecentActivityRow[];
+}
+
+/**
+ * Month-over-month delta percent: (current - prev) / prev * 100, clamped to
+ * 0 when prev is 0 and current is 0, and to Infinity (encoded as a finite
+ * sentinel +/-100 when prev is 0 but current is not). UI renders a "—"
+ * dash for the Infinity case via the `isFinite` check.
+ */
+export function momDelta(current: number, prev: number): number {
+  if (prev === 0) {
+    if (current === 0) return 0;
+    return current > 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  }
+  return ((current - prev) / prev) * 100;
+}
+
+/**
+ * Zero-fills a daily-bucketed map into a `days`-long array ending on `endUtc`.
+ * Dates are emitted as YYYY-MM-DD in UTC.
+ */
+export function zeroFillDailySeries(
+  buckets: Map<string, Omit<FleetDailyPoint, "date">>,
+  days: number,
+  endUtc: Date = new Date(),
+): FleetDailyPoint[] {
+  const out: FleetDailyPoint[] = [];
+  const end = new Date(
+    Date.UTC(
+      endUtc.getUTCFullYear(),
+      endUtc.getUTCMonth(),
+      endUtc.getUTCDate(),
+    ),
+  );
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(end.getTime() - i * 86_400_000);
+    const key = d.toISOString().slice(0, 10);
+    const row = buckets.get(key);
+    out.push({
+      date: key,
+      claims: row?.claims ?? 0,
+      charges: row?.charges ?? 0,
+      encounters: row?.encounters ?? 0,
+      billedCents: row?.billedCents ?? 0,
+      newPatients: row?.newPatients ?? 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * A `PracticeConfiguration` is "stuck" when its status is non-terminal
+ * (draft) and `updatedAt` is older than the threshold.
+ */
+export function isStuckConfig(
+  status: string,
+  updatedAt: Date,
+  now: Date = new Date(),
+  staleHours: number = 24,
+): boolean {
+  if (status === "published" || status === "archived") return false;
+  const ageMs = now.getTime() - updatedAt.getTime();
+  return ageMs > staleHours * 60 * 60 * 1000;
+}
+
+/**
+ * Median in milliseconds for a list of durations. Returns 0 for an empty list.
+ */
+export function medianMs(durationsMs: number[]): number {
+  if (durationsMs.length === 0) return 0;
+  const sorted = [...durationsMs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}


### PR DESCRIPTION
Linear: https://linear.app/emr-project/issue/EMR-731

## Summary

- New `src/app/(super-admin)/hq/loaders.ts` exporting every aggregate the HQ super-admin dashboard reads, modelled after `src/app/(super-admin)/practices/loaders.ts` (same `groupBy + _count + _sum` shape, all money in cents).
- Each loader is wrapped in `next/cache#unstable_cache` keyed by loader name + parameters with TTL `HQ_CACHE_TTL_SECONDS` (env-configurable, default 60). Single render = one parallel fan-out of cache reads.
- Pure helpers (`momDelta`, `zeroFillDailySeries`, `isStuckConfig`, `medianMs`) live in `types.ts` so unit tests can import them without `server-only`.
- Umbrella `loadAllHqData()` runs every loader via `Promise.all`.
- No PHI in any returned shape — counts, IDs, money in cents, and org/brand names only.

## Loaders shipped

| Function | Returns |
| --- | --- |
| `getFleetCounts` | `{ practicesLive, practicesOnboarding, practicesStuck, providersActive, patientsActive }` |
| `getFleetRevenue` | MTD + prev-month `billed/collected/gmv` cents |
| `getFleetDailySeries(days = 30)` | zero-filled `{ date, claims, charges, encounters, billedCents, newPatients }[]` |
| `getOnboardingFunnel` | `{ status, count, medianHoursInStage }[]` |
| `getModalityMix` / `getSpecialtyMix` / `getSpecialtyVersionDrift` | adoption + drift rollups |
| `getTopPracticesByClaims/Revenue/PatientGrowth(limit = 5)` | top N with MoM delta % |
| `getTopPractices(metric, limit)` | dispatcher for the generic `metric` form |
| `getRecentActivity(hours = 24)` | last-day `ControllerAuditLog` rows with actor + deeplink |
| `loadAllHqData()` | umbrella snapshot |

## Schema notes

- `PracticeConfigurationStatus` is `draft | published | archived` in `prisma/schema.prisma` (no `in_progress`). "Onboarding" is treated as any non-terminal status (i.e. `draft`); "stuck" is a non-terminal status whose `updatedAt` is older than 24h.
- `getFleetRevenue` uses `Claim.serviceDate` for month bucketing (indexed) and `Charge.createdAt` for gateway GM since `Charge` has no `serviceDate`.
- No `prisma/schema.prisma` changes. No route handlers call these loaders in this PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run test -- src/app/(super-admin)/hq/types.test.ts` (17/17 passing)
- [ ] Wired into HQ dashboard page in the follow-up ticket