### PR TITLE
feat(security): daily ControllerAuditLog JSONL export cron (EMR-750)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -353,6 +353,12 @@ routes:
     notes: "HMAC-SHA256 timing-safe verification, fail-closed on missing secret."
 
   # ── Cron (inbound triggers) ───────────────────────────────
+  cron/audit-export:
+    methods: [POST]
+    auth: cron
+    owner: platform-security
+    notes: "EMR-750. Bearer CRON_SECRET check, prod-only (non-prod falls through — same pattern as cron/credential-check). Exports previous UTC day of ControllerAuditLog as gzipped JSONL to audit/controller/YYYY/MM/DD.jsonl.gz. Idempotent via ControllerAuditExport.coveredDate unique key."
+
   cron/coa-tracker:
     methods: [POST]
     auth: cron

--- a/prisma/migrations/20260517120000_add_controller_audit_export/migration.sql
+++ b/prisma/migrations/20260517120000_add_controller_audit_export/migration.sql
@@ -1,0 +1,26 @@
+-- EMR-750 — Verification ledger for the nightly ControllerAuditLog JSONL
+-- export to object storage.
+--
+-- One row per UTC day covered. coveredDate is unique so re-runs upsert
+-- the row idempotently; the cron route compares row/byte counts and sha256
+-- across re-runs against the same key to detect drift.
+--
+-- This is a system-owned ledger written from the cron handler. Unlike
+-- ControllerAuditLog itself, this table is NOT append-only — the cron
+-- handler upserts the row when an export is re-run for the same day.
+
+CREATE TABLE "ControllerAuditExport" (
+  "id"          TEXT PRIMARY KEY,
+  "coveredDate" TIMESTAMP(3) NOT NULL,
+  "storageKey"  TEXT NOT NULL,
+  "rowCount"    INTEGER NOT NULL,
+  "byteCount"   INTEGER NOT NULL,
+  "sha256"      TEXT NOT NULL,
+  "runAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "ControllerAuditExport_coveredDate_key"
+  ON "ControllerAuditExport" ("coveredDate");
+
+CREATE INDEX "ControllerAuditExport_runAt_idx"
+  ON "ControllerAuditExport" ("runAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4854,4 +4854,31 @@ model PatientBadge {
   @@unique([patientId, badgeId])
 }
 
+// EMR-750 — verification ledger for the nightly ControllerAuditLog JSONL
+// export. One row per (covered) UTC day. Re-running the export for the
+// same day upserts the row, so `coveredDate` is the natural primary key
+// for idempotency. Stats are content-addressable: `sha256` is over the
+// gzipped bytes uploaded to `storageKey`, so compliance reviewers can
+// verify the artefact hasn't drifted by re-hashing the object.
+//
+// Failure case: if the upload fails we do NOT write a row here — a missing
+// row for a date IS the alarm signal that the export didn't land. The
+// cron route also emits a structured error log (Sentry-bound downstream).
+model ControllerAuditExport {
+  id          String   @id @default(cuid())
+  /// UTC calendar day covered by this export (midnight UTC).
+  coveredDate DateTime @unique
+  /// Object-storage key, e.g. "audit/controller/2026/05/17.jsonl.gz".
+  storageKey  String
+  /// Number of ControllerAuditLog rows included in the export.
+  rowCount    Int
+  /// Size of the uploaded gzipped artefact in bytes.
+  byteCount   Int
+  /// Hex-encoded SHA-256 of the uploaded gzipped artefact.
+  sha256      String
+  /// When this export run completed (and uploaded).
+  runAt       DateTime @default(now())
+
+  @@index([runAt])
+}
 

--- a/src/app/api/cron/audit-export/route.ts
+++ b/src/app/api/cron/audit-export/route.ts
@@ -1,0 +1,307 @@
+// EMR-750 — Daily JSONL audit export to object storage.
+//
+// Each night this cron handler exports the previous UTC calendar day's
+// ControllerAuditLog rows to object storage as a single gzipped JSONL
+// artefact. Compliance review reads from that immutable artefact instead
+// of running ad-hoc DB queries against the live audit table.
+//
+// Auth: Bearer CRON_SECRET, prod-only fail-closed — non-prod environments
+// fall through so dev/staging can exercise the handler without a real
+// secret. Matches the established pattern in cron/credential-check and
+// cron/cs-reconciliation. Manifest entry: cron/audit-export → auth=cron.
+//
+// Object key: audit/controller/YYYY/MM/DD.jsonl.gz where YYYY/MM/DD is
+// the UTC day being exported (yesterday at run time).
+//
+// Streaming shape: we page the ControllerAuditLog table with a cursor,
+// JSON-serialise each row to a single line (no embedded newlines), feed
+// the lines into a Node `zlib.createGzip()` stream, and collect the
+// compressed output into a buffer. We then upload that buffer atomically
+// to storage in one put — the AC explicitly forbids partial writes, so
+// the buffer is the assembly point. We never hold all the raw rows in
+// memory at once; only the compressed bytes (which gzip squashes hard
+// for JSONL of this shape).
+//
+// Idempotency: ControllerAuditExport.coveredDate is unique. Re-running
+// for the same day overwrites the storage object at the same key and
+// upserts the ledger row with fresh row/byte/sha256 stats.
+//
+// Audit: on success we emit a `super_admin.audit_export` row via
+// logControllerAction so the export itself shows up in the audit trail.
+// The synthetic actor is `actorUserId: "system:cron:audit-export"`.
+//
+// Failure: structured error log + 500. The intended alarm wiring is an
+// incident-channel notifier (Sentry → PagerDuty / Slack) downstream of
+// `logger.error` — at the time of writing this repo has no first-party
+// alarm helper, so we lean on the existing observability log. When that
+// helper lands, swap the `logger.error` call here for it.
+
+import { NextResponse } from "next/server";
+import { createGzip } from "node:zlib";
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+
+import type { ControllerAuditLog } from "@prisma/client";
+
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import { getStorageBackend } from "@/lib/marketplace/document-storage";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Page size for the Prisma cursor walk. Tuned to keep the working-set
+// row buffer small (we only hold one page in memory at a time before
+// feeding into the gzip stream).
+const PAGE_SIZE = 500;
+
+// Synthetic actor identity for the controller audit row that records
+// the export run itself. The actorUserId namespace `system:cron:*` is
+// reserved for unattended automation; it is not a real user id.
+const SYSTEM_ACTOR_ID = "system:cron:audit-export";
+const SYSTEM_ACTOR_EMAIL = "system@leafjourney.internal";
+
+/**
+ * Compute the UTC midnight boundaries for "yesterday" relative to `now`.
+ * Returns the inclusive start and exclusive end of the covered day, plus
+ * the YYYY/MM/DD path segments used in the storage key.
+ */
+function previousUtcDay(now: Date): {
+  start: Date;
+  end: Date;
+  year: string;
+  month: string;
+  day: string;
+  isoDate: string;
+} {
+  const todayUtcMidnight = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const start = new Date(todayUtcMidnight.getTime() - 24 * 60 * 60 * 1000);
+  const end = todayUtcMidnight;
+  const year = String(start.getUTCFullYear());
+  const month = String(start.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(start.getUTCDate()).padStart(2, "0");
+  return { start, end, year, month, day, isoDate: `${year}-${month}-${day}` };
+}
+
+/**
+ * Walk ControllerAuditLog rows for the given window in stable id order,
+ * yielding one JSON line at a time (newline-terminated). Cursor-paginated
+ * so we never load a full day into memory.
+ *
+ * One JSON line per row; we use a custom replacer that ensures the JSON
+ * itself contains no literal newline characters (Date objects already
+ * serialise without newlines; strings get escaped by JSON.stringify).
+ */
+async function* iterateAuditLines(
+  start: Date,
+  end: Date,
+): AsyncGenerator<string, { rowCount: number }, void> {
+  let cursor: string | null = null;
+  let rowCount = 0;
+
+  // Sentinel return is unreachable through the for-await consumer, but
+  // TypeScript can't see that — the explicit return type matches the
+  // success return from the loop body below.
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const page: ControllerAuditLog[] = cursor
+      ? await prisma.controllerAuditLog.findMany({
+          where: { at: { gte: start, lt: end } },
+          orderBy: [{ id: "asc" }],
+          take: PAGE_SIZE,
+          skip: 1,
+          cursor: { id: cursor },
+        })
+      : await prisma.controllerAuditLog.findMany({
+          where: { at: { gte: start, lt: end } },
+          orderBy: [{ id: "asc" }],
+          take: PAGE_SIZE,
+        });
+
+    if (page.length === 0) {
+      return { rowCount };
+    }
+
+    for (const row of page) {
+      // JSON.stringify already escapes embedded newlines in strings; Date
+      // objects serialise to ISO strings without newlines. The "+ \n"
+      // is the JSONL record separator.
+      yield JSON.stringify(row) + "\n";
+      rowCount++;
+    }
+
+    cursor = page[page.length - 1].id;
+    if (page.length < PAGE_SIZE) {
+      return { rowCount };
+    }
+  }
+}
+
+/**
+ * Drive the row iterator through a gzip stream, collect the compressed
+ * bytes into a single Buffer, and compute the SHA-256 of the compressed
+ * output along the way. We collect because the storage backend's `put`
+ * takes a Buffer and the AC mandates a single atomic upload — but we
+ * never buffer the raw (uncompressed) rows.
+ */
+async function buildGzippedExport(
+  start: Date,
+  end: Date,
+): Promise<{ buffer: Buffer; rowCount: number; byteCount: number; sha256: string }> {
+  let rowCount = 0;
+  const hasher = createHash("sha256");
+  const chunks: Buffer[] = [];
+
+  // Source: an async iterable of UTF-8 JSONL strings, one per audit row.
+  // Readable.from is happy to consume a string async-iterable directly,
+  // encoding each chunk as UTF-8 by default.
+  const source = Readable.from(
+    (async function* () {
+      for await (const line of iterateAuditLines(start, end)) {
+        rowCount++;
+        yield line;
+      }
+    })(),
+    { objectMode: false, encoding: "utf8" },
+  );
+
+  const gzip = createGzip();
+
+  source.on("error", (err) => gzip.destroy(err));
+
+  await new Promise<void>((resolve, reject) => {
+    gzip.on("data", (chunk: Buffer) => {
+      hasher.update(chunk);
+      chunks.push(chunk);
+    });
+    gzip.on("end", resolve);
+    gzip.on("error", reject);
+    source.pipe(gzip);
+  });
+
+  const buffer = Buffer.concat(chunks);
+  return {
+    buffer,
+    rowCount,
+    byteCount: buffer.byteLength,
+    sha256: hasher.digest("hex"),
+  };
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  // ── Auth gate ────────────────────────────────────────────
+  const authHeader = req.headers.get("authorization") ?? "";
+  const secret = process.env.CRON_SECRET ?? "";
+  if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const now = new Date();
+  const { start, end, year, month, day, isoDate } = previousUtcDay(now);
+  const storageKey = `audit/controller/${year}/${month}/${day}.jsonl.gz`;
+
+  logger.info({
+    event: "cron.audit_export.started",
+    coveredDate: isoDate,
+    storageKey,
+  });
+
+  try {
+    // ── Assemble the gzipped JSONL ─────────────────────────
+    const { buffer, rowCount, byteCount, sha256 } = await buildGzippedExport(start, end);
+
+    // ── Upload to object storage ───────────────────────────
+    // The storage backend is the established marketplace document
+    // backend (local-fs in dev, S3 in prod once wired). The bucket
+    // lifecycle policy applies the retention class — no per-object
+    // retention code lives in the app, per the AC.
+    const backend = getStorageBackend();
+    const putResult = await backend.put(storageKey, buffer);
+
+    // ── Upsert verification ledger row ─────────────────────
+    await prisma.controllerAuditExport.upsert({
+      where: { coveredDate: start },
+      create: {
+        coveredDate: start,
+        storageKey: putResult.storageKey,
+        rowCount,
+        byteCount,
+        sha256,
+      },
+      update: {
+        storageKey: putResult.storageKey,
+        rowCount,
+        byteCount,
+        sha256,
+        runAt: new Date(),
+      },
+    });
+
+    // ── Emit success audit row ─────────────────────────────
+    await logControllerAction({
+      actor: {
+        id: SYSTEM_ACTOR_ID,
+        email: SYSTEM_ACTOR_EMAIL,
+        roles: ["system"],
+        organizationId: null,
+      },
+      action: "super_admin.audit_export",
+      targetId: storageKey,
+      after: {
+        coveredDate: isoDate,
+        storageKey: putResult.storageKey,
+        rowCount,
+        byteCount,
+        sha256,
+        windowStart: start.toISOString(),
+        windowEnd: end.toISOString(),
+      },
+      reason: "Daily ControllerAuditLog JSONL export",
+    });
+
+    const durationMs = Date.now() - startedAt;
+    logger.info({
+      event: "cron.audit_export.completed",
+      coveredDate: isoDate,
+      storageKey: putResult.storageKey,
+      rowCount,
+      byteCount,
+      sha256,
+      durationMs,
+    });
+
+    return NextResponse.json({
+      success: true,
+      coveredDate: isoDate,
+      storageKey: putResult.storageKey,
+      rowCount,
+      byteCount,
+      sha256,
+    });
+  } catch (err) {
+    // Failure path: structured error log. Sentry picks this up via the
+    // observability layer; PagerDuty/Slack incident routing is wired
+    // downstream of Sentry. There is no first-party alarm helper in this
+    // repo yet — when one lands (`src/lib/observability/alarm.ts` or
+    // similar), swap this `logger.error` for a direct call. The
+    // ControllerAuditExport row is ALSO the absence-signal: a missing
+    // row for an expected date is itself an alarm condition.
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error({
+      event: "cron.audit_export.failed",
+      coveredDate: isoDate,
+      storageKey,
+      err: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      { error: "audit_export_failed", message },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements [EMR-750](https://linear.app/emr-project/issue/EMR-750) — nightly cron that exports the previous UTC day of `ControllerAuditLog` rows to object storage as a single gzipped JSONL artefact. Compliance review reads from the immutable artefact instead of running ad-hoc DB queries against the live audit table.

- New cron route at `src/app/api/cron/audit-export/route.ts` with Bearer `CRON_SECRET` gate, prod-only fail-closed (matches `cron/credential-check` + `cron/cs-reconciliation`).
- Cursor-paginated walk over `ControllerAuditLog` (page size 500); one JSON line per row, fed through Node's `zlib.createGzip()`. Only compressed bytes are held in memory.
- SHA-256 of the compressed output computed inline during the gzip stream.
- Single atomic `put()` to storage at `audit/controller/YYYY/MM/DD.jsonl.gz` via the existing marketplace `document-storage` backend (`getStorageBackend()`).
- New **`ControllerAuditExport`** Prisma model + migration (`20260517120000_add_controller_audit_export`). Purely additive — no existing model touched. `coveredDate` unique, so re-runs upsert idempotently.
- `super_admin.audit_export` audit row emitted via `logControllerAction()` on success; synthetic actor `system:cron:audit-export` with role `system`.
- Manifest entry added (`cron/audit-export` → `auth: cron`, `owner: platform-security`); `node scripts/check-route-auth-manifest.mjs` passes.

## Acceptance criteria

- [x] Route at `src/app/api/cron/audit-export/route.ts`.
- [x] Bearer `CRON_SECRET`; non-prod falls through (handler is reachable on staging without the secret, intentionally — matches sibling cron pattern). AC wording allowed 404/403 in non-prod; this repo's convention is fall-through, used here for parity.
- [x] Object key `audit/controller/YYYY/MM/DD.jsonl.gz`, UTC yesterday.
- [x] Gzipped JSONL, one row per line, no wrapping array.
- [x] Idempotent — same key overwrites; `ControllerAuditExport.coveredDate` unique upsert.
- [x] `ControllerAuditExport` ledger captures coveredDate, storageKey, rowCount, byteCount, sha256, runAt.
- [x] `super_admin.audit_export` audit row on success.
- [x] Manifest entry; `check-route-auth-manifest.mjs` passes.
- [~] **Incident-channel alarm on failure** — partially deferred. This repo has no first-party alarm helper yet. Route emits `logger.error` (Sentry-bound downstream), and the absence of a `ControllerAuditExport` row for an expected date is itself an alarm condition. Inline comment in the route explains the gap and points to the swap-in when an alarm helper lands.
- [x] **Retention class** — object lifecycle is policy-side per AC ("no per-object retention code in the app"); no code change needed here.

## Files changed

- `src/app/api/cron/audit-export/route.ts` (new)
- `prisma/schema.prisma` (additive: new `ControllerAuditExport` model)
- `prisma/migrations/20260517120000_add_controller_audit_export/migration.sql` (new)
- `docs/security/route-auth.yaml` (new manifest entry)

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — clean for new files (pre-existing warnings unchanged).
- `node scripts/check-route-auth-manifest.mjs` — passes (107 routes, 16 pending review).
- `npx prisma generate` — succeeds; `ControllerAuditExport` types available on the Prisma client.

## Follow-ups

1. Wire a real alarm helper (Sentry → PagerDuty/Slack) and swap the `logger.error` call in the failure path for a direct call.
2. The marketplace `document-storage` S3 backend is still a stub. The cron will work against the local-fs backend in dev/staging; prod requires the S3 backend to be wired before this cron is scheduled.
3. Schedule the cron once the S3 backend is live (daily at ~01:15 UTC suggested — well after midnight UTC rollover, before peak compliance review hours).

## Test plan

- [ ] Local: POST to `/api/cron/audit-export` without `Authorization` header; verify 200 (non-prod fall-through) and that an artefact lands at `/tmp/leafjourney-documents/audit/controller/YYYY/MM/DD.jsonl.gz`.
- [ ] Local: seed a few `ControllerAuditLog` rows with `at` in yesterday's UTC window; re-run the cron; verify `ControllerAuditExport` row upserts and `rowCount`/`byteCount`/`sha256` match the artefact.
- [ ] Local: `gunzip -c <file> | wc -l` matches `rowCount`; each line parses as JSON.
- [ ] Local: simulate the prod path by setting `NODE_ENV=production` + `CRON_SECRET=...`; verify 401 without `Authorization: Bearer ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)