### PR TITLE
feat(super-admin): per-practice drill-in page with tabs (EMR-745)

### DIFF
--- a/src/app/(super-admin)/practices/[id]/activity-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/activity-tab.tsx
@@ -1,0 +1,120 @@
+// Activity tab — per-practice ControllerAuditLog rows, most recent 100.
+// Each row shows actor + action + target + timestamp. The intent is a
+// dense, scannable feed that matches the operations rhythm of the rest
+// of the super-admin surface.
+//
+// Lazy-loaded: only invoked when ?tab=activity is in the URL.
+
+import { Badge } from "@/components/ui/badge";
+import { loadPracticeAuditLog, type PracticeAuditRow } from "../loaders";
+
+const ROLE_TONE: Record<string, "accent" | "info" | "neutral" | "warning"> = {
+  super_admin: "accent",
+  practice_admin: "info",
+  practice_owner: "info",
+  operator: "neutral",
+  implementation_admin: "warning",
+  clinician: "neutral",
+  patient: "neutral",
+  system: "neutral",
+};
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function relative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
+export async function ActivityTab({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const rows = await loadPracticeAuditLog(organizationId, 100);
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border px-6 py-12 text-center">
+        <div className="text-sm text-text-muted">
+          No controller activity logged for this practice yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="text-[11px] uppercase tracking-wider text-text-muted mb-3">
+        Most recent {rows.length} events
+      </div>
+      <ul className="grid gap-2">
+        {rows.map((row) => (
+          <ActivityRow key={row.id} row={row} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ActivityRow({ row }: { row: PracticeAuditRow }) {
+  const actorLabel = row.actorEmail ?? row.actorUserId;
+  return (
+    <li className="rounded-lg border border-border/70 bg-surface px-4 py-3 flex items-start gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="text-[12px] font-mono text-text bg-surface-muted px-1.5 py-0.5 rounded">
+            {row.action}
+          </code>
+          {row.actorRoles.map((role) => (
+            <Badge key={role} tone={ROLE_TONE[role] ?? "neutral"}>
+              {role.replace(/_/g, " ")}
+            </Badge>
+          ))}
+        </div>
+        <div className="mt-1.5 text-[12px] text-text-muted truncate">
+          <span className="text-text">{actorLabel}</span>
+          <span className="mx-1.5">·</span>
+          {row.subjectType}
+          <span className="mx-1">:</span>
+          <code className="font-mono">{row.subjectId}</code>
+        </div>
+        {row.reason && (
+          <div className="mt-1.5 text-[12px] text-text-muted italic truncate">
+            {row.reason}
+          </div>
+        )}
+      </div>
+      <div className="text-right shrink-0">
+        <div
+          className="text-[12px] text-text"
+          title={formatTimestamp(row.at)}
+        >
+          {relative(row.at)}
+        </div>
+        <div className="text-[10px] text-text-muted mt-0.5">
+          {new Date(row.at).toLocaleDateString()}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/app/(super-admin)/practices/[id]/billing-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/billing-tab.tsx
@@ -1,0 +1,138 @@
+// Billing tab — Claim + Charge rollups. Renders MTD KPIs and a small
+// inline table for the last 12 months. No charting library by design;
+// the table is sufficient for the v1 acceptance gate (EMR-745 notes).
+
+import { loadPracticeBilling } from "../loaders";
+
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  return `$${dollars.toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function Kpi({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-surface px-4 py-3">
+      <div className="text-[11px] uppercase tracking-wide text-text-muted">
+        {label}
+      </div>
+      <div className="font-display text-xl text-text tracking-tight mt-1">
+        {value}
+      </div>
+      {sub && <div className="text-[11px] text-text-muted mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+export async function BillingTab({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const { mtd, last12Months } = await loadPracticeBilling(organizationId);
+
+  const total12 = last12Months.reduce(
+    (acc, m) => ({
+      claimCount: acc.claimCount + m.claimCount,
+      billedCents: acc.billedCents + m.billedCents,
+      paidCents: acc.paidCents + m.paidCents,
+      gatewayChargeCents: acc.gatewayChargeCents + m.gatewayChargeCents,
+    }),
+    { claimCount: 0, billedCents: 0, paidCents: 0, gatewayChargeCents: 0 },
+  );
+
+  return (
+    <div className="grid gap-8">
+      <section>
+        <h2 className="font-display text-base text-text tracking-tight mb-3">
+          Month-to-date
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Kpi
+            label="Claims"
+            value={formatNumber(mtd.claimCount)}
+            sub="Created this month"
+          />
+          <Kpi label="Billed" value={formatDollars(mtd.billedCents)} />
+          <Kpi
+            label="Collected"
+            value={formatDollars(mtd.paidCents)}
+            sub="Posted to claims"
+          />
+          <Kpi
+            label="Gateway GM"
+            value={formatDollars(mtd.gatewayChargeCents)}
+            sub="Charges this month"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-display text-base text-text tracking-tight mb-3">
+          Last 12 months
+        </h2>
+        <div className="overflow-x-auto rounded-lg border border-border/70 bg-surface">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[11px] uppercase tracking-wider text-text-muted border-b border-border/60">
+                <th className="text-left font-medium px-4 py-2.5">Month</th>
+                <th className="text-right font-medium px-4 py-2.5">Claims</th>
+                <th className="text-right font-medium px-4 py-2.5">Billed</th>
+                <th className="text-right font-medium px-4 py-2.5">Collected</th>
+                <th className="text-right font-medium px-4 py-2.5">Gateway GM</th>
+              </tr>
+            </thead>
+            <tbody>
+              {last12Months.map((row, idx) => (
+                <tr
+                  key={row.monthIso}
+                  className={
+                    idx === last12Months.length - 1
+                      ? "border-t border-border/60"
+                      : "border-t border-border/40"
+                  }
+                >
+                  <td className="px-4 py-2.5 text-text">{row.monthLabel}</td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-text">
+                    {formatNumber(row.claimCount)}
+                  </td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-text">
+                    {formatDollars(row.billedCents)}
+                  </td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-text">
+                    {formatDollars(row.paidCents)}
+                  </td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-text">
+                    {formatDollars(row.gatewayChargeCents)}
+                  </td>
+                </tr>
+              ))}
+              <tr className="border-t-2 border-border bg-surface-muted/30">
+                <td className="px-4 py-2.5 text-[11px] uppercase tracking-wider text-text-muted font-medium">
+                  Trailing 12 mo
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums text-text font-medium">
+                  {formatNumber(total12.claimCount)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums text-text font-medium">
+                  {formatDollars(total12.billedCents)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums text-text font-medium">
+                  {formatDollars(total12.paidCents)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums text-text font-medium">
+                  {formatDollars(total12.gatewayChargeCents)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/[id]/overview-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/overview-tab.tsx
@@ -1,0 +1,225 @@
+// Overview tab — lifts the 8-KPI grid + practice details / stakeholders
+// that used to live in the inline drawer on PracticeCard. Semantics are
+// unchanged per AC; the only difference is layout breathing room now
+// that we have a full page.
+
+import { Badge } from "@/components/ui/badge";
+import type { PracticeCardData } from "../types";
+import { humanizeCareModel, humanizeSpecialty } from "../types";
+
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  if (dollars >= 1_000_000) return `$${(dollars / 1_000_000).toFixed(1)}M`;
+  if (dollars >= 1_000) return `$${(dollars / 1_000).toFixed(1)}K`;
+  return `$${dollars.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .slice(0, 2)
+    .join("");
+}
+
+function Kpi({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-surface px-4 py-3">
+      <div className="text-[11px] uppercase tracking-wide text-text-muted">
+        {label}
+      </div>
+      <div className="font-display text-xl text-text tracking-tight mt-1">
+        {value}
+      </div>
+      {sub && <div className="text-[11px] text-text-muted mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+function PersonChip({ name, sub }: { name: string; sub?: string }) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <div className="h-7 w-7 rounded-full bg-accent-soft text-accent text-[11px] font-medium flex items-center justify-center shrink-0">
+        {initials(name) || "?"}
+      </div>
+      <div className="min-w-0">
+        <div className="text-[13px] text-text truncate leading-tight">{name}</div>
+        {sub && (
+          <div className="text-[11px] text-text-muted truncate leading-tight">{sub}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="text-text-muted w-28 shrink-0 text-[11px] uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd className="text-text">{value}</dd>
+    </div>
+  );
+}
+
+export function OverviewTab({ practice }: { practice: PracticeCardData }) {
+  const specialtyLabel = humanizeSpecialty(practice.specialty);
+  const careModelLabel = humanizeCareModel(practice.careModel);
+  const location = [practice.city, practice.state].filter(Boolean).join(", ");
+
+  return (
+    <div className="grid gap-8">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Kpi
+          label="Active providers"
+          value={String(practice.kpi.activeProviderCount)}
+          sub={`${practice.kpi.providerCount} total on roster`}
+        />
+        <Kpi
+          label="Patients"
+          value={formatNumber(practice.kpi.patientCount)}
+          sub="Non-archived"
+        />
+        <Kpi
+          label="Claims volume"
+          value={formatNumber(practice.kpi.claimCount)}
+          sub={`${practice.kpi.claimsLast30} created last 30d`}
+        />
+        <Kpi
+          label="Encounters"
+          value={formatNumber(practice.kpi.encounterCount)}
+          sub={`${practice.kpi.encountersLast30} in last 30d`}
+        />
+        <Kpi
+          label="Billed (lifetime)"
+          value={formatDollars(practice.kpi.billedCents)}
+        />
+        <Kpi
+          label="Collected"
+          value={formatDollars(practice.kpi.paidCents)}
+          sub="Posted to claims"
+        />
+        <Kpi
+          label="Gateway GM"
+          value={formatDollars(practice.kpi.gatewayChargeCents)}
+          sub="Charges run through gateway"
+        />
+        <Kpi
+          label="Specialty"
+          value={specialtyLabel}
+          sub={
+            practice.specialtyVersion ? `v${practice.specialtyVersion}` : undefined
+          }
+        />
+      </div>
+
+      {practice.enabledModalities.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+            Enabled modalities
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {practice.enabledModalities.map((m) => (
+              <Badge key={m} tone="neutral">
+                {m.replace(/_/g, " ")}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-8 lg:grid-cols-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+            Practice details
+          </div>
+          <dl className="text-[13px] grid gap-1.5">
+            {practice.legalName && (
+              <Row label="Legal" value={practice.legalName} />
+            )}
+            {practice.brandName && (
+              <Row label="Brand" value={practice.brandName} />
+            )}
+            {location && <Row label="Location" value={location} />}
+            {practice.timeZone && (
+              <Row label="Time zone" value={practice.timeZone} />
+            )}
+            {practice.primaryContactName && (
+              <Row
+                label="Primary contact"
+                value={
+                  practice.primaryContactEmail
+                    ? `${practice.primaryContactName} · ${practice.primaryContactEmail}`
+                    : practice.primaryContactName
+                }
+              />
+            )}
+            <Row label="Care model" value={careModelLabel} />
+            {practice.publishedAt && (
+              <Row
+                label="Published"
+                value={new Date(practice.publishedAt).toLocaleDateString()}
+              />
+            )}
+          </dl>
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+            Office managers & operators
+          </div>
+          {practice.officeManagers.length === 0 ? (
+            <div className="text-[12px] text-text-muted italic">
+              None invited yet.
+            </div>
+          ) : (
+            <ul className="grid gap-2.5">
+              {practice.officeManagers.map((m) => (
+                <li key={m.userId}>
+                  <PersonChip
+                    name={m.name}
+                    sub={`${m.role.replace(/_/g, " ")} · ${m.email}`}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+            Key providers
+          </div>
+          {practice.leadProviders.length === 0 ? (
+            <div className="text-[12px] text-text-muted italic">
+              No providers onboarded yet.
+            </div>
+          ) : (
+            <ul className="grid gap-2.5">
+              {practice.leadProviders.map((p) => (
+                <li key={p.userId}>
+                  <PersonChip name={p.name} sub={p.title ?? "Provider"} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/[id]/page.tsx
+++ b/src/app/(super-admin)/practices/[id]/page.tsx
@@ -1,0 +1,153 @@
+// EMR-745 — Per-practice drill-in page.
+//
+// Server component. Auth gating is inherited from
+// src/app/(super-admin)/layout.tsx which runs requireSuperAdmin() at the
+// segment boundary, so any unauth'd request is redirected before we even
+// resolve params here.
+//
+// Tabs are URL-driven (`?tab=overview|providers|activity|billing`); the
+// disabled History tab anchor points at EMR-743. Each tab body is its
+// own loader so we only fetch the data the user is looking at — the
+// Overview loader runs unconditionally because we need the practice
+// header (name, status badges) regardless of which tab is selected.
+//
+// Impersonation surfaces ("View as this practice", "Stop impersonating")
+// are intentionally omitted; EMR-742 ships them. We do not stub a button
+// here to avoid leaving a regression hook.
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { ArrowLeft, MapPin } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+
+import { loadPracticeOverview } from "../loaders";
+import { humanizeCareModel, humanizeSpecialty } from "../types";
+import { OverviewTab } from "./overview-tab";
+import { ProvidersTab } from "./providers-tab";
+import { ActivityTab } from "./activity-tab";
+import { BillingTab } from "./billing-tab";
+import { TabBar, isTabKey, type TabKey } from "./tab-bar";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const practice = await loadPracticeOverview(id);
+  if (!practice) {
+    return { title: "Practice not found — Leafjourney" };
+  }
+  return {
+    title: `${practice.practiceName} — Leafjourney`,
+    description: `Drill-in for ${practice.practiceName} — KPIs, providers, activity, and billing.`,
+  };
+}
+
+export default async function PracticeDrillInPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{ tab?: string }>;
+}) {
+  const { id } = await params;
+  const sp = (await searchParams) ?? {};
+  const requestedTab = sp.tab;
+  // History is intentionally non-clickable; if someone hand-types
+  // ?tab=history we fall back to overview rather than rendering a stub.
+  const activeTab: TabKey =
+    isTabKey(requestedTab) && requestedTab !== "history"
+      ? requestedTab
+      : "overview";
+
+  const practice = await loadPracticeOverview(id);
+  if (!practice) {
+    notFound();
+  }
+
+  const specialtyLabel = humanizeSpecialty(practice.specialty);
+  const careModelLabel = humanizeCareModel(practice.careModel);
+  const location = [practice.city, practice.state].filter(Boolean).join(", ");
+
+  return (
+    <PageShell maxWidth="max-w-[1280px]">
+      <div className="mb-6">
+        <Link
+          href="/practices"
+          className="inline-flex items-center gap-1.5 text-[12px] text-text-muted hover:text-text transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          All practices
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-5 mb-8">
+        <Eyebrow>Leafjourney HQ</Eyebrow>
+        <div className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="min-w-0">
+            <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.1]">
+              {practice.practiceName}
+            </h1>
+            {practice.organizationName !== practice.practiceName && (
+              <div className="text-[13px] text-text-muted mt-1.5">
+                {practice.organizationName}
+              </div>
+            )}
+            <div className="flex items-center gap-2 flex-wrap mt-3">
+              <StatusBadge
+                status={practice.status}
+                publishedAt={practice.publishedAt}
+              />
+              <Badge tone="accent">{specialtyLabel}</Badge>
+              {practice.careModel && (
+                <Badge tone="neutral">{careModelLabel}</Badge>
+              )}
+              {location && (
+                <span className="inline-flex items-center gap-1.5 text-[12px] text-text-muted ml-1">
+                  <MapPin className="h-3.5 w-3.5" />
+                  {location}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <TabBar
+        practiceId={practice.configId ?? practice.organizationId}
+        active={activeTab}
+      />
+
+      {activeTab === "overview" && <OverviewTab practice={practice} />}
+      {activeTab === "providers" && (
+        <ProvidersTab organizationId={practice.organizationId} />
+      )}
+      {activeTab === "activity" && (
+        <ActivityTab organizationId={practice.organizationId} />
+      )}
+      {activeTab === "billing" && (
+        <BillingTab organizationId={practice.organizationId} />
+      )}
+    </PageShell>
+  );
+}
+
+function StatusBadge({
+  status,
+  publishedAt,
+}: {
+  status: string;
+  publishedAt: string | null;
+}) {
+  if (publishedAt) return <Badge tone="success">Live</Badge>;
+  if (status === "draft") return <Badge tone="neutral">Draft</Badge>;
+  if (status === "archived") return <Badge tone="warning">Archived</Badge>;
+  return <Badge tone="info">{status}</Badge>;
+}

--- a/src/app/(super-admin)/practices/[id]/providers-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/providers-tab.tsx
@@ -1,0 +1,123 @@
+// Providers tab — every Provider in this practice with active/inactive
+// split, joined to User for name + email. No PHI here; this is roster
+// data the operator already has visibility into via the existing card.
+//
+// Lazy-loaded: the page only invokes loadPracticeProviders when this
+// tab is selected.
+
+import { Badge } from "@/components/ui/badge";
+import { loadPracticeProviders } from "../loaders";
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .slice(0, 2)
+    .join("");
+}
+
+export async function ProvidersTab({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const providers = await loadPracticeProviders(organizationId);
+
+  const active = providers.filter((p) => p.active);
+  const inactive = providers.filter((p) => !p.active);
+
+  if (providers.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border px-6 py-12 text-center">
+        <div className="text-sm text-text-muted">
+          No providers onboarded yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-8">
+      <ProviderSection
+        title="Active providers"
+        count={active.length}
+        providers={active}
+        emptyHint="No active providers."
+      />
+      {inactive.length > 0 && (
+        <ProviderSection
+          title="Inactive providers"
+          count={inactive.length}
+          providers={inactive}
+          tone="muted"
+          emptyHint="No inactive providers."
+        />
+      )}
+    </div>
+  );
+}
+
+function ProviderSection({
+  title,
+  count,
+  providers,
+  tone = "default",
+  emptyHint,
+}: {
+  title: string;
+  count: number;
+  providers: Awaited<ReturnType<typeof loadPracticeProviders>>;
+  tone?: "default" | "muted";
+  emptyHint: string;
+}) {
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="font-display text-base text-text tracking-tight">
+          {title}{" "}
+          <span className="text-text-muted text-sm font-normal">({count})</span>
+        </h2>
+      </div>
+      {providers.length === 0 ? (
+        <div className="text-[12px] text-text-muted italic">{emptyHint}</div>
+      ) : (
+        <ul className="grid gap-2">
+          {providers.map((p) => (
+            <li
+              key={p.providerId}
+              className={`rounded-lg border border-border/70 ${tone === "muted" ? "bg-surface-muted/40" : "bg-surface"} px-4 py-3 flex items-center gap-4`}
+            >
+              <div className="h-9 w-9 rounded-full bg-accent-soft text-accent text-[12px] font-medium flex items-center justify-center shrink-0">
+                {initials(p.name) || "?"}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[14px] text-text truncate font-medium">
+                    {p.name}
+                  </span>
+                  {p.active ? (
+                    <Badge tone="success">Active</Badge>
+                  ) : (
+                    <Badge tone="neutral">Inactive</Badge>
+                  )}
+                  {p.title && (
+                    <span className="text-[12px] text-text-muted truncate">
+                      {p.title}
+                    </span>
+                  )}
+                </div>
+                <div className="text-[12px] text-text-muted mt-0.5 truncate">
+                  {p.email}
+                  {p.npi ? ` · NPI ${p.npi}` : ""}
+                </div>
+              </div>
+              <div className="text-[11px] text-text-muted shrink-0 hidden sm:block">
+                Joined {new Date(p.createdAt).toLocaleDateString()}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/app/(super-admin)/practices/[id]/tab-bar.tsx
+++ b/src/app/(super-admin)/practices/[id]/tab-bar.tsx
@@ -1,0 +1,97 @@
+// Server-rendered tab bar driven by the `?tab=` URL search param.
+//
+// We intentionally keep this server-only so the drill-in page can use
+// server components throughout and each tab can lazy-load its data on
+// selection rather than fetching everything up front (per AC). The
+// History tab is rendered as a disabled anchor with a tooltip pointing
+// at EMR-743 — implementation lives in that ticket's epic (E5).
+
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+export type TabKey = "overview" | "providers" | "activity" | "billing" | "history";
+
+export const TAB_KEYS: TabKey[] = [
+  "overview",
+  "providers",
+  "activity",
+  "billing",
+  "history",
+];
+
+const TAB_LABELS: Record<TabKey, string> = {
+  overview: "Overview",
+  providers: "Providers",
+  activity: "Activity",
+  billing: "Billing",
+  history: "History",
+};
+
+export function isTabKey(value: string | undefined): value is TabKey {
+  return !!value && (TAB_KEYS as string[]).includes(value);
+}
+
+export function TabBar({
+  practiceId,
+  active,
+}: {
+  practiceId: string;
+  active: TabKey;
+}) {
+  return (
+    <div
+      className="flex items-center gap-1 border-b border-border mb-6 overflow-x-auto"
+      role="tablist"
+      aria-label="Practice tabs"
+    >
+      {TAB_KEYS.map((key) => {
+        const isHistory = key === "history";
+        const isActive = key === active;
+        const base =
+          "relative px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-t-md";
+
+        if (isHistory) {
+          return (
+            <span
+              key={key}
+              role="tab"
+              aria-disabled="true"
+              aria-selected="false"
+              title="Shipped in EMR-743"
+              className={cn(
+                base,
+                "text-text-muted/60 cursor-not-allowed select-none",
+              )}
+            >
+              {TAB_LABELS[key]}
+              <span className="ml-1.5 text-[10px] uppercase tracking-wider rounded-full bg-surface-muted text-text-muted/70 px-1.5 py-0.5 align-middle">
+                Soon
+              </span>
+            </span>
+          );
+        }
+
+        return (
+          <Link
+            key={key}
+            href={`/practices/${practiceId}?tab=${key}`}
+            role="tab"
+            aria-selected={isActive}
+            scroll={false}
+            className={cn(
+              base,
+              isActive
+                ? "text-accent"
+                : "text-text-muted hover:text-text",
+            )}
+          >
+            {TAB_LABELS[key]}
+            {isActive && (
+              <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-accent rounded-full" />
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/loaders.ts
+++ b/src/app/(super-admin)/practices/loaders.ts
@@ -17,6 +17,49 @@ import {
 export type { PracticeCardData, PracticeKpi, PracticeStakeholder } from "./types";
 export { humanizeCareModel, humanizeSpecialty } from "./types";
 
+// EMR-745 — additional per-practice shapes used by the drill-in page.
+export type PracticeProviderRow = {
+  providerId: string;
+  userId: string;
+  name: string;
+  email: string;
+  title: string | null;
+  npi: string | null;
+  active: boolean;
+  createdAt: string;
+};
+
+export type PracticeAuditRow = {
+  id: string;
+  at: string;
+  actorUserId: string;
+  actorEmail: string | null;
+  actorRoles: string[];
+  action: string;
+  subjectType: string;
+  subjectId: string;
+  reason: string | null;
+};
+
+export type PracticeBillingMonthRow = {
+  monthIso: string; // YYYY-MM-01 in UTC
+  monthLabel: string; // "May 2026"
+  claimCount: number;
+  billedCents: number;
+  paidCents: number;
+  gatewayChargeCents: number;
+};
+
+export type PracticeBillingRollup = {
+  mtd: {
+    claimCount: number;
+    billedCents: number;
+    paidCents: number;
+    gatewayChargeCents: number;
+  };
+  last12Months: PracticeBillingMonthRow[];
+};
+
 /**
  * Top-level loader. Returns one card per published-or-in-flight
  * PracticeConfiguration, plus a small set of org-level KPIs joined in.
@@ -268,4 +311,378 @@ export async function loadPracticeLandingCards(): Promise<PracticeCardData[]> {
         kpi: kpiByOrg.get(c.organizationId) ?? { ...ZERO_KPI },
       };
     });
+}
+
+// --------------------------------------------------------------
+// EMR-745 — Per-practice drill-in loaders
+// --------------------------------------------------------------
+//
+// These intentionally reuse the same `groupBy + _sum + _count` shape used
+// by the fleet loader above so the drill-in page never diverges from the
+// list card. Each tab is its own loader so we can lazy-load on selection
+// rather than fetching everything up front.
+
+/**
+ * Resolves a route `[id]` to the underlying PracticeConfiguration. The
+ * `id` may be a PracticeConfiguration id OR an organizationId — both are
+ * legal entry points (audit log rows link by `organizationId`, the fleet
+ * card uses `configId`). Returns null if not found.
+ */
+export async function loadPracticeOverview(
+  id: string,
+): Promise<PracticeCardData | null> {
+  // Try config-id first, then fall back to organizationId.
+  const config =
+    (await prisma.practiceConfiguration.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        organizationId: true,
+        practiceId: true,
+        selectedSpecialty: true,
+        selectedSpecialtyVersion: true,
+        careModel: true,
+        enabledModalities: true,
+        status: true,
+        publishedAt: true,
+        updatedAt: true,
+      },
+    })) ??
+    (await prisma.practiceConfiguration.findFirst({
+      where: { organizationId: id },
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        id: true,
+        organizationId: true,
+        practiceId: true,
+        selectedSpecialty: true,
+        selectedSpecialtyVersion: true,
+        careModel: true,
+        enabledModalities: true,
+        status: true,
+        publishedAt: true,
+        updatedAt: true,
+      },
+    }));
+
+  if (!config) return null;
+
+  const orgId = config.organizationId;
+  const since30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const [
+    org,
+    practice,
+    memberships,
+    providers,
+    claimsAgg,
+    claimsLast30,
+    chargesAgg,
+    encounterCount,
+    encountersLast30,
+    patientCount,
+  ] = await Promise.all([
+    prisma.organization.findUnique({
+      where: { id: orgId },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        legalName: true,
+        brandName: true,
+        primaryContactName: true,
+        primaryContactEmail: true,
+      },
+    }),
+    config.practiceId
+      ? prisma.practice.findUnique({
+          where: { id: config.practiceId },
+          select: {
+            id: true,
+            organizationId: true,
+            name: true,
+            city: true,
+            state: true,
+            timeZone: true,
+          },
+        })
+      : Promise.resolve(null),
+    prisma.membership.findMany({
+      where: {
+        organizationId: orgId,
+        role: { in: ["practice_admin", "operator", "practice_owner"] },
+      },
+      select: {
+        organizationId: true,
+        role: true,
+        user: {
+          select: { id: true, firstName: true, lastName: true, email: true },
+        },
+      },
+    }),
+    prisma.provider.findMany({
+      where: { organizationId: orgId },
+      select: {
+        id: true,
+        active: true,
+        title: true,
+        user: {
+          select: { id: true, firstName: true, lastName: true, email: true },
+        },
+      },
+      orderBy: [{ active: "desc" }, { createdAt: "asc" }],
+    }),
+    prisma.claim.aggregate({
+      where: { organizationId: orgId },
+      _count: { _all: true },
+      _sum: { billedAmountCents: true, paidAmountCents: true },
+    }),
+    prisma.claim.count({
+      where: { organizationId: orgId, createdAt: { gte: since30 } },
+    }),
+    prisma.charge.aggregate({
+      where: { organizationId: orgId },
+      _sum: { feeAmountCents: true },
+    }),
+    prisma.encounter.count({ where: { organizationId: orgId } }),
+    prisma.encounter.count({
+      where: { organizationId: orgId, createdAt: { gte: since30 } },
+    }),
+    prisma.patient.count({ where: { organizationId: orgId, deletedAt: null } }),
+  ]);
+
+  if (!org) return null;
+  if (org.slug === LEAFJOURNEY_HQ_SLUG) return null;
+
+  const kpi: PracticeKpi = {
+    ...ZERO_KPI,
+    providerCount: providers.length,
+    activeProviderCount: providers.filter((p) => p.active).length,
+    patientCount,
+    claimCount: claimsAgg._count._all,
+    claimsLast30,
+    billedCents: claimsAgg._sum.billedAmountCents ?? 0,
+    paidCents: claimsAgg._sum.paidAmountCents ?? 0,
+    gatewayChargeCents: chargesAgg._sum.feeAmountCents ?? 0,
+    encounterCount,
+    encountersLast30,
+  };
+
+  const officeManagers: PracticeStakeholder[] = memberships.map((m) => ({
+    userId: m.user.id,
+    name: `${m.user.firstName} ${m.user.lastName}`.trim(),
+    email: m.user.email,
+    role: m.role,
+  }));
+  const leadProviders: PracticeStakeholder[] = providers.map((p) => ({
+    userId: p.user.id,
+    name: `${p.user.firstName} ${p.user.lastName}`.trim(),
+    email: p.user.email,
+    role: "provider",
+    title: p.title,
+  }));
+
+  return {
+    practiceId: practice?.id ?? null,
+    configId: config.id,
+    organizationId: orgId,
+    organizationName: org.name,
+    practiceName: practice?.name ?? org.brandName ?? org.name ?? "Untitled practice",
+    brandName: org.brandName ?? null,
+    legalName: org.legalName ?? null,
+    city: practice?.city ?? null,
+    state: practice?.state ?? null,
+    timeZone: practice?.timeZone ?? null,
+    primaryContactName: org.primaryContactName ?? null,
+    primaryContactEmail: org.primaryContactEmail ?? null,
+    specialty: config.selectedSpecialty ?? null,
+    specialtyVersion: config.selectedSpecialtyVersion ?? null,
+    careModel: config.careModel ?? null,
+    enabledModalities: config.enabledModalities ?? [],
+    status: String(config.status),
+    publishedAt: config.publishedAt ? config.publishedAt.toISOString() : null,
+    updatedAt: config.updatedAt ? config.updatedAt.toISOString() : null,
+    officeManagers: officeManagers.slice(0, 3),
+    leadProviders: leadProviders.slice(0, 4),
+    kpi,
+  };
+}
+
+/**
+ * Lists every Provider in a practice with the joined User for name/email
+ * display. Sorted active-first, then newest. Used by the Providers tab.
+ */
+export async function loadPracticeProviders(
+  organizationId: string,
+): Promise<PracticeProviderRow[]> {
+  const providers = await prisma.provider.findMany({
+    where: { organizationId },
+    select: {
+      id: true,
+      title: true,
+      active: true,
+      npi: true,
+      createdAt: true,
+      user: {
+        select: { id: true, firstName: true, lastName: true, email: true },
+      },
+    },
+    orderBy: [{ active: "desc" }, { createdAt: "asc" }],
+  });
+
+  return providers.map((p) => ({
+    providerId: p.id,
+    userId: p.user.id,
+    name: `${p.user.firstName} ${p.user.lastName}`.trim() || p.user.email,
+    email: p.user.email,
+    title: p.title,
+    npi: p.npi,
+    active: p.active,
+    createdAt: p.createdAt.toISOString(),
+  }));
+}
+
+/**
+ * Returns the most recent 100 ControllerAuditLog rows for an organization.
+ * Used by the Activity tab.
+ */
+export async function loadPracticeAuditLog(
+  organizationId: string,
+  limit: number = 100,
+): Promise<PracticeAuditRow[]> {
+  const rows = await prisma.controllerAuditLog.findMany({
+    where: { organizationId },
+    orderBy: [{ at: "desc" }],
+    take: limit,
+    select: {
+      id: true,
+      at: true,
+      actorUserId: true,
+      actorEmail: true,
+      actorRoles: true,
+      action: true,
+      subjectType: true,
+      subjectId: true,
+      reason: true,
+    },
+  });
+
+  return rows.map((r) => ({
+    id: r.id,
+    at: r.at.toISOString(),
+    actorUserId: r.actorUserId,
+    actorEmail: r.actorEmail,
+    actorRoles: r.actorRoles.map((role) => String(role)),
+    action: r.action,
+    subjectType: r.subjectType,
+    subjectId: r.subjectId,
+    reason: r.reason,
+  }));
+}
+
+/**
+ * Computes month-to-date and last-12-months rollups for Claim + Charge
+ * volume against a single organization. Reuses the `groupBy + _sum +
+ * _count` shape from the fleet loader.
+ */
+export async function loadPracticeBilling(
+  organizationId: string,
+): Promise<PracticeBillingRollup> {
+  const now = new Date();
+  const monthStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+  );
+  // 12 calendar months back, anchored at the first of the month so the
+  // bucket boundaries don't drift relative to the current day.
+  const windowStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 11, 1),
+  );
+
+  const [mtdClaims, mtdCharges, windowClaims, windowCharges] =
+    await Promise.all([
+      prisma.claim.aggregate({
+        where: { organizationId, createdAt: { gte: monthStart } },
+        _count: { _all: true },
+        _sum: { billedAmountCents: true, paidAmountCents: true },
+      }),
+      prisma.charge.aggregate({
+        where: { organizationId, createdAt: { gte: monthStart } },
+        _sum: { feeAmountCents: true },
+      }),
+      prisma.claim.findMany({
+        where: { organizationId, createdAt: { gte: windowStart } },
+        select: {
+          createdAt: true,
+          billedAmountCents: true,
+          paidAmountCents: true,
+        },
+      }),
+      prisma.charge.findMany({
+        where: { organizationId, createdAt: { gte: windowStart } },
+        select: { createdAt: true, feeAmountCents: true },
+      }),
+    ]);
+
+  // Bucket into a Map keyed by YYYY-MM-01 UTC iso string.
+  type Bucket = {
+    monthIso: string;
+    monthLabel: string;
+    claimCount: number;
+    billedCents: number;
+    paidCents: number;
+    gatewayChargeCents: number;
+  };
+  const buckets = new Map<string, Bucket>();
+  const monthLabels = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+  for (let i = 0; i < 12; i += 1) {
+    const d = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 11 + i, 1),
+    );
+    const iso = d.toISOString();
+    buckets.set(iso, {
+      monthIso: iso,
+      monthLabel: monthLabels.format(d),
+      claimCount: 0,
+      billedCents: 0,
+      paidCents: 0,
+      gatewayChargeCents: 0,
+    });
+  }
+
+  function bucketKeyFor(date: Date): string {
+    return new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1),
+    ).toISOString();
+  }
+
+  for (const claim of windowClaims) {
+    const b = buckets.get(bucketKeyFor(claim.createdAt));
+    if (!b) continue;
+    b.claimCount += 1;
+    b.billedCents += claim.billedAmountCents;
+    b.paidCents += claim.paidAmountCents;
+  }
+  for (const charge of windowCharges) {
+    const b = buckets.get(bucketKeyFor(charge.createdAt));
+    if (!b) continue;
+    b.gatewayChargeCents += charge.feeAmountCents;
+  }
+
+  const last12Months: PracticeBillingMonthRow[] = Array.from(
+    buckets.values(),
+  ).sort((a, b) => (a.monthIso < b.monthIso ? -1 : 1));
+
+  return {
+    mtd: {
+      claimCount: mtdClaims._count._all,
+      billedCents: mtdClaims._sum.billedAmountCents ?? 0,
+      paidCents: mtdClaims._sum.paidAmountCents ?? 0,
+      gatewayChargeCents: mtdCharges._sum.feeAmountCents ?? 0,
+    },
+    last12Months,
+  };
 }

--- a/src/app/(super-admin)/practices/page.tsx
+++ b/src/app/(super-admin)/practices/page.tsx
@@ -49,7 +49,7 @@ export default async function PracticesLandingPage({
       <PageHeader
         eyebrow="Leafjourney HQ"
         title="Practices"
-        description="Every practice you've configured, with live KPIs. Click any card to expand."
+        description="Every practice you've configured, with live KPIs. Click any card to drill in."
         actions={
           <Link href="/onboarding">
             <Button>Onboard a practice</Button>

--- a/src/app/(super-admin)/practices/practice-card.tsx
+++ b/src/app/(super-admin)/practices/practice-card.tsx
@@ -1,20 +1,17 @@
-"use client";
-
-// Horizontal practice card with a click-to-expand KPI drawer.
+// Horizontal practice card — the list item on /practices.
 //
-// Collapsed: practice name + specialty + key people + location chips.
-// Expanded: KPI grid (providers, patients, claims volume, billed, paid,
-// gateway GM, encounters) + tag list + activity strip.
-//
-// The card body is a button so the whole row is keyboard-activatable; the
-// drawer toggles aria-expanded for screen readers.
+// EMR-745: the card used to expand inline; now it navigates to the
+// per-practice drill-in page at /practices/[id]. The collapsed-state
+// markup is unchanged so the list view feels identical at a glance,
+// only the click target is now a <Link>. The page-level overview tab
+// re-renders the KPI grid that used to live in the drawer.
 
 import * as React from "react";
-import { ChevronDown, MapPin, Users, Stethoscope, Mail } from "lucide-react";
+import Link from "next/link";
+import { ChevronRight, MapPin, Stethoscope, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { cn } from "@/lib/utils/cn";
 import type { PracticeCardData } from "./types";
 import { humanizeCareModel, humanizeSpecialty } from "./types";
 
@@ -39,7 +36,13 @@ function initials(name: string): string {
     .join("");
 }
 
-function StatusBadge({ status, publishedAt }: { status: string; publishedAt: string | null }) {
+function StatusBadge({
+  status,
+  publishedAt,
+}: {
+  status: string;
+  publishedAt: string | null;
+}) {
   if (publishedAt) return <Badge tone="success">Live</Badge>;
   if (status === "draft") return <Badge tone="neutral">Draft</Badge>;
   if (status === "archived") return <Badge tone="warning">Archived</Badge>;
@@ -62,20 +65,7 @@ function PersonChip({ name, sub }: { name: string; sub?: string }) {
   );
 }
 
-function Kpi({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-lg border border-border/70 bg-surface px-4 py-3">
-      <div className="text-[11px] uppercase tracking-wide text-text-muted">{label}</div>
-      <div className="font-display text-xl text-text tracking-tight mt-1">{value}</div>
-      {sub && <div className="text-[11px] text-text-muted mt-0.5">{sub}</div>}
-    </div>
-  );
-}
-
 export function PracticeCard({ practice }: { practice: PracticeCardData }) {
-  const [expanded, setExpanded] = React.useState(false);
-  const drawerId = React.useId();
-
   const specialtyLabel = humanizeSpecialty(practice.specialty);
   const careModelLabel = humanizeCareModel(practice.careModel);
   const location = [practice.city, practice.state].filter(Boolean).join(", ");
@@ -83,21 +73,26 @@ export function PracticeCard({ practice }: { practice: PracticeCardData }) {
   const officeManager = practice.officeManagers[0];
   const leadProvider = practice.leadProviders[0];
 
+  // We prefer the config id (always present) so the drill-in route is
+  // stable even before a Practice row gets stitched in.
+  const drillId = practice.configId ?? practice.organizationId;
+
   return (
-    <Card tone={expanded ? "raised" : "default"} className="transition-all">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        aria-controls={drawerId}
-        className="w-full text-left px-6 py-5 flex items-center gap-6 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-xl"
+    <Card tone="default" className="transition-all hover:shadow-md">
+      <Link
+        href={`/practices/${drillId}`}
+        aria-label={`Open ${practice.practiceName}`}
+        className="block px-6 py-5 flex items-center gap-6 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
       >
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-3 flex-wrap">
             <h3 className="font-display text-lg text-text tracking-tight truncate">
               {practice.practiceName}
             </h3>
-            <StatusBadge status={practice.status} publishedAt={practice.publishedAt} />
+            <StatusBadge
+              status={practice.status}
+              publishedAt={practice.publishedAt}
+            />
             <Badge tone="accent">{specialtyLabel}</Badge>
             {practice.careModel && <Badge tone="neutral">{careModelLabel}</Badge>}
           </div>
@@ -167,183 +162,8 @@ export function PracticeCard({ practice }: { practice: PracticeCardData }) {
           </div>
         </div>
 
-        <ChevronDown
-          className={cn(
-            "h-5 w-5 text-text-muted shrink-0 transition-transform",
-            expanded && "rotate-180",
-          )}
-        />
-      </button>
-
-      {expanded && (
-        <div
-          id={drawerId}
-          className="px-6 pb-6 pt-1 border-t border-border/60 mt-1 grid gap-6"
-        >
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <Kpi
-              label="Active providers"
-              value={String(practice.kpi.activeProviderCount)}
-              sub={`${practice.kpi.providerCount} total on roster`}
-            />
-            <Kpi
-              label="Patients"
-              value={formatNumber(practice.kpi.patientCount)}
-              sub="Non-archived"
-            />
-            <Kpi
-              label="Claims volume"
-              value={formatNumber(practice.kpi.claimCount)}
-              sub={`${practice.kpi.claimsLast30} created last 30d`}
-            />
-            <Kpi
-              label="Encounters"
-              value={formatNumber(practice.kpi.encounterCount)}
-              sub={`${practice.kpi.encountersLast30} in last 30d`}
-            />
-            <Kpi
-              label="Billed (lifetime)"
-              value={formatDollars(practice.kpi.billedCents)}
-            />
-            <Kpi
-              label="Collected"
-              value={formatDollars(practice.kpi.paidCents)}
-              sub="Posted to claims"
-            />
-            <Kpi
-              label="Gateway GM"
-              value={formatDollars(practice.kpi.gatewayChargeCents)}
-              sub="Charges run through gateway"
-            />
-            <Kpi
-              label="Specialty"
-              value={specialtyLabel}
-              sub={
-                practice.specialtyVersion
-                  ? `v${practice.specialtyVersion}`
-                  : undefined
-              }
-            />
-          </div>
-
-          {practice.enabledModalities.length > 0 && (
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
-                Enabled modalities
-              </div>
-              <div className="flex flex-wrap gap-1.5">
-                {practice.enabledModalities.map((m) => (
-                  <Badge key={m} tone="neutral">
-                    {m.replace(/_/g, " ")}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
-                Practice details
-              </div>
-              <dl className="text-[13px] grid gap-1.5">
-                {practice.legalName && (
-                  <Row label="Legal" value={practice.legalName} />
-                )}
-                {practice.brandName && (
-                  <Row label="Brand" value={practice.brandName} />
-                )}
-                {location && <Row label="Location" value={location} />}
-                {practice.timeZone && (
-                  <Row label="Time zone" value={practice.timeZone} />
-                )}
-                {practice.primaryContactName && (
-                  <Row
-                    label="Primary contact"
-                    value={
-                      practice.primaryContactEmail
-                        ? `${practice.primaryContactName} · ${practice.primaryContactEmail}`
-                        : practice.primaryContactName
-                    }
-                  />
-                )}
-                <Row label="Care model" value={careModelLabel} />
-                {practice.publishedAt && (
-                  <Row
-                    label="Published"
-                    value={new Date(practice.publishedAt).toLocaleDateString()}
-                  />
-                )}
-              </dl>
-            </div>
-
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
-                Office managers & operators
-              </div>
-              {practice.officeManagers.length === 0 ? (
-                <div className="text-[12px] text-text-muted italic">
-                  None invited yet.
-                </div>
-              ) : (
-                <ul className="grid gap-2.5">
-                  {practice.officeManagers.map((m) => (
-                    <li key={m.userId}>
-                      <PersonChip
-                        name={m.name}
-                        sub={`${m.role.replace(/_/g, " ")} · ${m.email}`}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
-                Key providers
-              </div>
-              {practice.leadProviders.length === 0 ? (
-                <div className="text-[12px] text-text-muted italic">
-                  No providers onboarded yet.
-                </div>
-              ) : (
-                <ul className="grid gap-2.5">
-                  {practice.leadProviders.map((p) => (
-                    <li key={p.userId}>
-                      <PersonChip name={p.name} sub={p.title ?? "Provider"} />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between pt-2 border-t border-border/60 text-[12px] text-text-muted">
-            <div className="inline-flex items-center gap-1.5">
-              <Mail className="h-3.5 w-3.5" />
-              {practice.primaryContactEmail ?? "No primary contact email"}
-            </div>
-            <div>
-              Updated{" "}
-              {practice.updatedAt
-                ? new Date(practice.updatedAt).toLocaleDateString()
-                : "—"}
-            </div>
-          </div>
-        </div>
-      )}
+        <ChevronRight className="h-5 w-5 text-text-muted shrink-0" />
+      </Link>
     </Card>
-  );
-}
-
-function Row({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-baseline gap-3">
-      <dt className="text-text-muted w-28 shrink-0 text-[11px] uppercase tracking-wide">
-        {label}
-      </dt>
-      <dd className="text-text">{value}</dd>
-    </div>
   );
 }

--- a/src/app/(super-admin)/practices/published-banner.tsx
+++ b/src/app/(super-admin)/practices/published-banner.tsx
@@ -29,7 +29,7 @@ export function PublishedBanner() {
         </div>
         <p className="text-[13px] text-text-muted mt-0.5">
           Your new configuration is live. Click any card below to drill into
-          its KPIs.
+          its KPIs, providers, activity, and billing.
         </p>
       </div>
       <button


### PR DESCRIPTION
## Summary

Promotes the inline expand on `/practices` to a real, deep-linkable page at `/practices/[id]` so operators can investigate without the cramped drawer. Closes [EMR-745](https://linear.app/emr-project/issue/EMR-745).

- **New route** `src/app/(super-admin)/practices/[id]/page.tsx` — server component gated by the existing super-admin layout. Tabs are URL-driven via `?tab=` so each tab body lazy-loads its data (no client tabs library; no new deps).
- **Tabs**:
  - **Overview** — the existing 8 KPIs from the inline drawer (active providers, patients, claims volume, encounters, billed, collected, gateway GM, specialty), plus practice details / stakeholders. Semantics unchanged.
  - **Providers** — `Provider` joined to `User`, split active/inactive, sorted active-first then by `createdAt`.
  - **Activity** — most-recent 100 `ControllerAuditLog` rows for the org with actor, action, target, timestamp, role badges, and relative time.
  - **Billing** — MTD `Claim` + `Charge` rollup KPIs plus a 12-month inline table (table, not chart, per ticket).
- **History tab** anchored in the tab bar but disabled with a `title="Shipped in EMR-743"` tooltip and a "Soon" pill. Hand-typed `?tab=history` falls back to Overview.
- **Loaders** — added `loadPracticeOverview`, `loadPracticeProviders`, `loadPracticeAuditLog`, `loadPracticeBilling` to the existing `practices/loaders.ts`. Same `groupBy/_sum/_count` shape as the fleet loader so the drill-in never diverges from the list card. `loadPracticeOverview` accepts either a `PracticeConfiguration.id` or an `organizationId` so audit-log rows and the fleet card both link cleanly.
- **List card** — `practice-card.tsx` is now a `<Link>` to `/practices/[id]`; the expand/collapse drawer is removed. Collapsed-state markup is preserved so the list view feels identical at a glance.
- **No impersonation surfaces here** — EMR-742 ships them; we explicitly do not leave a regression hook ("View as this practice" / "Stop impersonating" are not rendered).

## AC checklist

- [x] Route at `src/app/(super-admin)/practices/[id]/page.tsx` gated by super-admin layout
- [x] Overview tab with the 8 KPIs (unchanged semantics)
- [x] Providers tab with active/inactive split
- [x] Activity tab with `ControllerAuditLog` rows, newest first
- [x] Billing tab with MTD + last-12-months rollups
- [x] History tab is a disabled anchor pointing at EMR-743
- [x] `practice-card.tsx` navigates to `/practices/[id]` instead of expanding inline
- [x] Server-rendered; tabs lazy-load on selection
- [ ] "View as this practice" / "Stop impersonating" — intentionally deferred to EMR-742 (ticket guardrail)

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean (no new warnings)
- [ ] Visit `/practices` as super-admin, click any card → land on `/practices/[id]` Overview tab
- [ ] Click each non-history tab → URL updates to `?tab=…`, body re-renders
- [ ] Click History → no navigation, tooltip "Shipped in EMR-743" appears
- [ ] Deep-link `/practices/<configId>?tab=billing` → opens directly on Billing tab
- [ ] Deep-link with `organizationId` (e.g. from an audit-log row) → also resolves
- [ ] `/practices/<bogus-id>` → 404
- [ ] Visiting any `/practices/*` URL while signed out → redirect to `/sign-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)