### PR TITLE
feat(marketplace): build PDP at /marketplace/products/[slug] (EMR-712)

### DIFF
--- a/src/app/api/agents/lab-interpreter/route.ts
+++ b/src/app/api/agents/lab-interpreter/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-141: Lab Results Auto-Interpreter (Patient Portal)
+// Agent that intercepts incoming HL7 ORU lab results. It uses an LLM to translate 
+// complex clinical jargon (e.g., CBC, CMP, Lipid Panels) into an 8th-grade reading 
+// level summary before publishing to the patient portal. This drastically reduces 
+// confused "What does this mean?" inbox messages to providers.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.LAB_WEBHOOK_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const payload = await req.json();
+
+    if (!payload.patientId || !payload.labId || !payload.results) {
+      return NextResponse.json({ error: "Missing required lab fields" }, { status: 400 });
+    }
+
+    const { patientId, labId, results } = payload;
+
+    logger.info({ 
+      event: "agents.lab_interpreter.processing", 
+      patientId, 
+      labId 
+    });
+
+    // 1. Mock LLM Translation Logic
+    // In production, we'd pass `results` (e.g., "LDL-C 145 mg/dL") to an LLM
+    let translatedSummary = "";
+
+    if (JSON.stringify(results).toLowerCase().includes("ldl")) {
+      translatedSummary = "Your recent blood test checked your cholesterol. Your 'LDL' (the bad cholesterol) is slightly high. Your doctor may recommend diet changes or medication to help lower it.";
+    } else {
+      translatedSummary = "Your lab results are back and have been reviewed by your doctor. The results look stable.";
+    }
+
+    // 2. Publish to Patient Portal via Audit Log / Message Queue
+    await prisma.auditLog.create({
+      data: {
+        organizationId: payload.organizationId || "DEFAULT",
+        action: "PATIENT_PORTAL_LAB_SUMMARY_PUBLISHED",
+        entity: "LabResult",
+        entityId: labId,
+        details: { patientId, summary: translatedSummary }
+      }
+    });
+
+    logger.info({ 
+      event: "agents.lab_interpreter.published", 
+      patientId, 
+      labId 
+    });
+
+    return NextResponse.json({ 
+      success: true, 
+      status: "summary_published",
+      translation: translatedSummary
+    });
+
+  } catch (error) {
+    logger.error({ event: "agents.lab_interpreter.failed", error });
+    return NextResponse.json({ error: "Failed to interpret lab results" }, { status: 500 });
+  }
+}

--- a/src/app/api/agents/pa-bundler/route.ts
+++ b/src/app/api/agents/pa-bundler/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-144: Automated Prior Auth Document Bundler
+// Webhook that listens to the Prior Authorization engine. When a Payer (like UHC) 
+// requests "Additional Clinical Information", this agent automatically pulls the 
+// last 3 progress notes, relevant imaging reports, and conservative therapy logs 
+// into a single cohesive PDF packet for instantaneous transmission.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.WEBHOOK_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const payload = await req.json();
+
+    if (!payload.paRequestId || !payload.patientId) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const { paRequestId, patientId } = payload;
+
+    logger.info({ 
+      event: "agents.pa_bundler.request_received", 
+      paRequestId, 
+      patientId 
+    });
+
+    // 1. Fetch relevant clinical documentation
+    const recentClinicalDocs = await prisma.document.findMany({
+      where: { 
+        patientId,
+        type: "clinical" // Grabs progress notes and imaging
+      },
+      orderBy: { createdAt: "desc" },
+      take: 3
+    });
+
+    if (recentClinicalDocs.length === 0) {
+      return NextResponse.json({ error: "No clinical documents found to bundle" }, { status: 404 });
+    }
+
+    const documentIds = recentClinicalDocs.map(doc => doc.id);
+
+    // 2. Mock PDF Bundling Process
+    const bundleReferenceId = `BNDL-PA-${paRequestId}-${Date.now()}`;
+    const bundledPdfUrl = `https://s3.aws.verdant.com/pa-bundles/${bundleReferenceId}.pdf`;
+
+    // 3. Attach bundle to the Prior Authorization request
+    logger.info({ 
+      event: "agents.pa_bundler.bundle_created", 
+      paRequestId, 
+      documentsIncluded: documentIds.length 
+    });
+
+    // Log the automated transmission preparation
+    await prisma.auditLog.create({
+      data: {
+        organizationId: payload.organizationId || "DEFAULT",
+        action: "PRIOR_AUTH_BUNDLE_GENERATED",
+        entity: "PriorAuthorization",
+        entityId: paRequestId,
+        details: { bundleId: bundleReferenceId, documentsIncluded: documentIds.length }
+      }
+    });
+
+    return NextResponse.json({ 
+      success: true, 
+      status: "bundle_generated",
+      bundleUrl: bundledPdfUrl,
+      documentsIncluded: documentIds.length
+    });
+
+  } catch (error) {
+    logger.error({ event: "agents.pa_bundler.failed", error });
+    return NextResponse.json({ error: "Failed to generate PA document bundle" }, { status: 500 });
+  }
+}

--- a/src/app/api/agents/rtw-note-generator/route.ts
+++ b/src/app/api/agents/rtw-note-generator/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-139: Automated Return-to-Work/School Note Generator
+// Webhook that triggers when an acute illness encounter is signed (e.g., Flu, COVID, Strep).
+// It automatically calculates the CDC-recommended isolation period, drafts a legally 
+// compliant Return-to-Work/School note, and securely emails/texts it to the patient.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.WEBHOOK_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const payload = await req.json();
+
+    if (!payload.encounterId || !payload.icd10Code) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const { encounterId, icd10Code, patientId } = payload;
+
+    // 1. Determine Excused Absence Duration based on ICD-10
+    let daysOff = 0;
+    let diagnosisName = "";
+
+    if (icd10Code.startsWith("J09") || icd10Code.startsWith("J10")) {
+      daysOff = 5; // Influenza
+      diagnosisName = "a viral respiratory illness";
+    } else if (icd10Code.startsWith("J02.0")) {
+      daysOff = 2; // Strep Pharyngitis
+      diagnosisName = "a bacterial infection";
+    } else if (icd10Code.startsWith("A09")) {
+      daysOff = 3; // Gastroenteritis
+      diagnosisName = "a gastrointestinal illness";
+    }
+
+    if (daysOff > 0) {
+      // 2. Draft the Note
+      const returnDate = new Date();
+      returnDate.setDate(returnDate.getDate() + daysOff);
+      
+      const noteText = `To Whom It May Concern:\n\nThe patient was evaluated in our clinic today and diagnosed with ${diagnosisName}. They are excused from work/school for ${daysOff} days to recover and prevent transmission. They may safely return on ${returnDate.toISOString().split("T")[0]}.\n\nElectronically Signed by Verdant EMR.`;
+
+      logger.info({ 
+        event: "agents.rtw_generator.note_created", 
+        patientId, 
+        daysOff 
+      });
+
+      // 3. Save as an official Document on the patient's chart
+      const document = await prisma.document.create({
+        data: {
+          organizationId: payload.organizationId || "DEFAULT",
+          patientId: patientId,
+          title: `Return to Work/School Note (${returnDate.toISOString().split("T")[0]})`,
+          type: "administrative",
+          url: "generated_pdf_placeholder",
+          // In reality, we would store the note text or generate a PDF buffer
+        }
+      });
+
+      // Mock: Send secure email to patient
+      // await emailClient.send(patientEmail, "Your Excuse Note", noteText)
+
+      return NextResponse.json({ 
+        success: true, 
+        status: "note_generated",
+        documentId: document.id
+      });
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      status: "no_note_required"
+    });
+
+  } catch (error) {
+    logger.error({ event: "agents.rtw_generator.failed", error });
+    return NextResponse.json({ error: "Failed to generate return to work note" }, { status: 500 });
+  }
+}

--- a/src/app/api/agents/scribe-qa/route.ts
+++ b/src/app/api/agents/scribe-qa/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-137: AI Medical Scribe Quality Assurance Loop
+// Acts as a secondary AI reviewer that validates the output of the primary Voice-to-SOAP 
+// AI Scribe. It checks for clinical hallucinations, ensures the Physical Exam matches 
+// the Chief Complaint, and flags missing elements before the provider signs the chart.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.WEBHOOK_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const payload = await req.json();
+
+    if (!payload.encounterId || !payload.aiGeneratedNote) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const { encounterId, aiGeneratedNote, chiefComplaint } = payload;
+    const noteText = aiGeneratedNote.toLowerCase();
+    const ccText = (chiefComplaint || "").toLowerCase();
+
+    // 1. NLP Quality Assurance Rules (Mocked)
+    let isFlagged = false;
+    let qaFlags: string[] = [];
+
+    // Rule 1: Chief complaint mentions chest pain, but Physical Exam is missing Cardiac auscultation
+    if (ccText.includes("chest pain") && !noteText.includes("cardiovascular")) {
+      isFlagged = true;
+      qaFlags.push("Missing Cardiovascular exam for Chest Pain complaint.");
+    }
+
+    // Rule 2: AI hallucinates a non-existent medication in the plan
+    // In production, we'd cross-reference against the FDA NDC database
+    if (noteText.includes("prescribed unobtanium")) {
+      isFlagged = true;
+      qaFlags.push("Potential medication hallucination detected.");
+    }
+
+    // 2. Update Encounter with QA Flags
+    if (isFlagged) {
+      logger.warn({ 
+        event: "agents.scribe_qa.flags_detected", 
+        encounterId, 
+        flags: qaFlags.length 
+      });
+
+      // Append a warning banner to the top of the provider's draft note
+      const qaBanner = `[AI QA WARNING]: Please review this auto-generated note.\n- ${qaFlags.join("\n- ")}\n\n`;
+      
+      await prisma.encounter.update({
+        where: { id: encounterId },
+        data: {
+          reason: `${qaBanner}${aiGeneratedNote}`
+        }
+      });
+    } else {
+      logger.info({ 
+        event: "agents.scribe_qa.passed", 
+        encounterId 
+      });
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      status: isFlagged ? "qa_failed" : "qa_passed",
+      flags: qaFlags
+    });
+
+  } catch (error) {
+    logger.error({ event: "agents.scribe_qa.failed", error });
+    return NextResponse.json({ error: "Failed to run scribe QA" }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/chart-locker/route.ts
+++ b/src/app/api/cron/chart-locker/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-143: Unsigned Chart Auto-Lock (Compliance)
+// Nightly cron that enforces JCAHO and Medicare charting compliance. 
+// It scans for provider progress notes left unsigned for >72 hours. 
+// If found, it temporarily freezes the provider's ability to schedule new 
+// non-emergent patients until their charting backlog is cleared.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.CRON_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    logger.info({ event: "cron.chart_locker.started" });
+
+    // 1. Find Unsigned Encounters older than 72 hours
+    const seventyTwoHoursAgo = new Date();
+    seventyTwoHoursAgo.setHours(seventyTwoHoursAgo.getHours() - 72);
+
+    const delinquentEncounters = await prisma.encounter.findMany({
+      where: {
+        status: "in_progress", // Indicates draft/unsigned
+        createdAt: { lte: seventyTwoHoursAgo }
+      },
+      // Assume schema has a relation to provider
+      take: 100
+    });
+
+    const flaggedProviderIds = new Set<string>();
+
+    for (const encounter of delinquentEncounters) {
+      if (encounter.providerId) {
+        flaggedProviderIds.add(encounter.providerId);
+      }
+    }
+
+    // 2. Enforce Scheduling Freeze
+    for (const providerId of flaggedProviderIds) {
+      logger.warn({ 
+        event: "cron.chart_locker.provider_frozen", 
+        providerId 
+      });
+
+      // Update provider profile to block scheduling (Mock action)
+      // await prisma.provider.update({ where: { id: providerId }, data: { schedulingStatus: 'locked' } });
+
+      // Notify the Chief Medical Officer / Admin
+      await prisma.auditLog.create({
+        data: {
+          organizationId: "DEFAULT", // Requires org mapping in full schema
+          action: "PROVIDER_SCHEDULING_LOCKED",
+          entity: "Provider",
+          entityId: providerId,
+          details: { reason: ">72 hours charting delinquency. JCAHO Compliance Risk." }
+        }
+      });
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      unsignedEncountersFound: delinquentEncounters.length,
+      providersLocked: flaggedProviderIds.size
+    });
+
+  } catch (error) {
+    logger.error({ event: "cron.chart_locker.failed", error });
+    return NextResponse.json({ error: "Failed to run unsigned chart locker" }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/gap-in-care/route.ts
+++ b/src/app/api/cron/gap-in-care/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-138: Population Health Gap-in-Care Closer
+// Nightly cron job that scans the active patient panel for HEDIS measure gaps 
+// (e.g., overdue mammograms, colonoscopies, diabetic A1C/Eye Exams). 
+// Automatically drops bulk lab/imaging orders into the Provider's queue to mass-sign.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.CRON_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    logger.info({ event: "cron.gap_in_care.started" });
+
+    // 1. Fetch active patients (Mock target: Females > 40 for Mammogram)
+    const fortyYearsAgo = new Date();
+    fortyYearsAgo.setFullYear(fortyYearsAgo.getFullYear() - 40);
+
+    const eligiblePatients = await prisma.patient.findMany({
+      where: {
+        sexAtBirth: "FEMALE",
+        dateOfBirth: { lte: fortyYearsAgo }
+      },
+      take: 100
+    });
+
+    let gapsClosed = 0;
+
+    for (const patient of eligiblePatients) {
+      // 2. Evaluate Clinical Guidelines
+      // Mock logic: check if patient had a mammogram in the last 2 years
+      const needsMammogram = true; 
+
+      if (needsMammogram) {
+        // 3. Draft an Order in the Provider's Queue
+        logger.info({ 
+          event: "cron.gap_in_care.order_drafted", 
+          patientId: patient.id, 
+          measure: "Breast Cancer Screening" 
+        });
+
+        // Add to audit log (acting as order queue in this schema)
+        await prisma.auditLog.create({
+          data: {
+            organizationId: patient.organizationId,
+            action: "CLINICAL_ORDER_DRAFTED",
+            entity: "Patient",
+            entityId: patient.id,
+            details: { 
+              orderType: "Screening Mammography Bilateral", 
+              reason: "HEDIS Gap Closure",
+              requiresProviderSignature: true
+            }
+          }
+        });
+
+        gapsClosed++;
+      }
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      patientsScanned: eligiblePatients.length,
+      ordersDrafted: gapsClosed
+    });
+
+  } catch (error) {
+    logger.error({ event: "cron.gap_in_care.failed", error });
+    return NextResponse.json({ error: "Failed to run gap in care closer" }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/mips-reporter/route.ts
+++ b/src/app/api/cron/mips-reporter/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-142: MIPS/MACRA Quality Reporting Engine
+// Nightly script that calculates CMS MIPS (Merit-based Incentive Payment System) scores.
+// It scans the clinic's patient panel for quality measures (e.g., Blood Pressure Control, 
+// Depression Screening). This ensures the practice stays above the penalty threshold to 
+// avoid a massive 9% Medicare reimbursement cut.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.CRON_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    logger.info({ event: "cron.mips_reporter.started" });
+
+    // 1. Fetch eligible Medicare encounters
+    // Mocking finding completed encounters for patients > 65
+    const eligibleEncounters = await prisma.encounter.findMany({
+      where: {
+        status: "completed",
+        // patient: { dateOfBirth: { lte: sixtyFiveYearsAgo } }
+      },
+      take: 200
+    });
+
+    let measuresSatisfied = 0;
+    let measuresFailed = 0;
+
+    for (const encounter of eligibleEncounters) {
+      // 2. Evaluate MIPS Quality Measures
+      // Measure 236: Controlling High Blood Pressure
+      const hasVitals = true; // Mock checking for BP < 140/90
+      
+      // Measure 134: Preventive Care and Screening: Screening for Depression
+      const hasDepressionScreen = Math.random() > 0.2; // 80% pass rate mock
+
+      if (hasVitals && hasDepressionScreen) {
+        measuresSatisfied++;
+      } else {
+        measuresFailed++;
+        
+        // Flag for the Quality Coordinator to intervene
+        await prisma.auditLog.create({
+          data: {
+            organizationId: encounter.organizationId,
+            action: "MIPS_MEASURE_FAILED",
+            entity: "Encounter",
+            entityId: encounter.id,
+            details: { reason: "Missing PHQ-9 Depression Screen or BP > 140/90" }
+          }
+        });
+      }
+    }
+
+    // 3. Calculate Score
+    const total = measuresSatisfied + measuresFailed;
+    const scorePercentage = total > 0 ? (measuresSatisfied / total) * 100 : 100;
+
+    logger.info({ 
+      event: "cron.mips_reporter.completed", 
+      score: scorePercentage.toFixed(2) 
+    });
+
+    return NextResponse.json({ 
+      success: true, 
+      encountersEvaluated: total,
+      mipsScorePercentage: scorePercentage,
+      status: scorePercentage >= 75 ? "passing" : "failing_risk_penalty"
+    });
+
+  } catch (error) {
+    logger.error({ event: "cron.mips_reporter.failed", error });
+    return NextResponse.json({ error: "Failed to run MIPS reporting engine" }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/ift-packager/route.ts
+++ b/src/app/api/integrations/ift-packager/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+// EMR-140: Inter-Facility Transfer (IFT) Auto-Packager
+// Webhook that triggers when a patient is transferred from the Urgent Care / Clinic 
+// directly to an Emergency Department via EMS. Automatically bundles the EMS run sheet, 
+// recent EKG, and the provider's progress note, and faxes it directly to the receiving ER's trauma bay.
+
+export async function POST(req: Request) {
+  try {
+    const authHeader = req.headers.get("authorization") ?? "";
+    const secret = process.env.WEBHOOK_SECRET ?? "";
+    
+    if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const payload = await req.json();
+
+    if (!payload.encounterId || !payload.receivingFacilityFax) {
+      return NextResponse.json({ error: "Missing required transfer fields" }, { status: 400 });
+    }
+
+    const { encounterId, patientId, receivingFacilityFax, emsUnit } = payload;
+
+    logger.warn({ 
+      event: "integrations.ift_packager.transfer_initiated", 
+      encounterId, 
+      receivingFacilityFax 
+    });
+
+    // 1. Gather all required clinical documents
+    // E.g., Progress Note, EKG Document, Vitals
+    const recentDocuments = await prisma.document.findMany({
+      where: { patientId },
+      take: 3,
+      orderBy: { createdAt: "desc" }
+    });
+
+    const docIds = recentDocuments.map(d => d.id);
+
+    // 2. Generate Inter-Facility Transfer (IFT) Cover Sheet
+    const coverSheetText = `URGENT INTER-FACILITY TRANSFER\nPatient ID: ${patientId}\nTransported via: ${emsUnit || "EMS/Ambulance"}\nAttached: Progress Note, EKG, Vitals Flowsheet.`;
+
+    // 3. Mock transmission via eFax API (e.g., Sfax or etherFAX)
+    const faxSuccess = true;
+
+    if (faxSuccess) {
+      logger.info({ 
+        event: "integrations.ift_packager.fax_transmitted", 
+        patientId, 
+        faxNumber: receivingFacilityFax,
+        documentsIncluded: docIds.length
+      });
+
+      // Log the transmission for HIPAA compliance
+      await prisma.auditLog.create({
+        data: {
+          organizationId: payload.organizationId || "DEFAULT",
+          action: "IFT_PACKET_FAXED",
+          entity: "Patient",
+          entityId: patientId,
+          details: { destinationFax: receivingFacilityFax, docsTransmitted: docIds }
+        }
+      });
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      status: "transfer_packet_transmitted",
+      documentsIncluded: docIds.length
+    });
+
+  } catch (error) {
+    logger.error({ event: "integrations.ift_packager.failed", error });
+    return NextResponse.json({ error: "Failed to process IFT transfer packet" }, { status: 500 });
+  }
+}

--- a/src/app/marketplace/products/[slug]/page.tsx
+++ b/src/app/marketplace/products/[slug]/page.tsx
@@ -1,0 +1,379 @@
+// EMR-712 — Marketplace product detail page.
+//
+// The /marketplace listing renders cards that link here, but until now
+// no `[slug]/page.tsx` existed under marketplace/products/ — every card
+// → 404. find-and-fix pass 6 (link-integrity) caught 33 dead links.
+//
+// Design notes:
+// - Server component. The data layer (`src/lib/marketplace/data.ts`) is
+//   synchronous; there's no point in a client boundary for read-only
+//   detail rendering.
+// - Visual style matches the listing card pattern in
+//   `marketplace-client.tsx`: brand-letter gradient placeholder, warm
+//   tokens from --bg/--surface, accent and highlight chips for trust
+//   signals.
+// - We deliberately do NOT reuse Leafmart's `ProductDetailClient`
+//   because that component expects a `LeafmartProduct` shape (UI-mapped
+//   for the consumer storefront) and is wired into the cart store +
+//   variant selector + dosing guides. Marketplace is an editorial
+//   catalog, not a checkout funnel — the simpler PDP keeps shape
+//   ownership clear.
+// - `curatedDetailsForMarketplaceProduct` was already built (EMR-307)
+//   and is the canonical bullet generator for highlights + specs.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Eyebrow } from "@/components/ui/ornament";
+import {
+  getProductBySlug,
+  getRelatedProducts,
+  getCategoryBySlug,
+  PRODUCTS,
+} from "@/lib/marketplace/data";
+import { curatedDetailsForMarketplaceProduct } from "@/lib/marketplace/product-details";
+import type { MarketplaceProduct } from "@/lib/marketplace/types";
+
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return PRODUCTS.map((p) => ({ slug: p.slug }));
+}
+
+export function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Metadata {
+  const product = getProductBySlug(params.slug);
+  if (!product) return { title: "Product" };
+  return {
+    title: `${product.name} — ${product.brand}`,
+    description: product.shortDescription,
+    openGraph: {
+      title: `${product.name} — ${product.brand}`,
+      description: product.shortDescription,
+      type: "website",
+      siteName: "Leafjourney Marketplace",
+    },
+  };
+}
+
+function priceLabel(cents: number): string {
+  // Marketplace data stores price as whole dollars (not cents) — see
+  // `PRODUCTS[].price` in `data.ts`. Keep the helper name generic so
+  // future cents-based migration only touches this one function.
+  return `$${cents.toFixed(0)}`;
+}
+
+function StarBar({ rating, count }: { rating: number; count: number }) {
+  const filled = Math.round(rating);
+  return (
+    <div className="flex items-center gap-2 text-[12px] text-text-subtle">
+      <span className="text-amber-500 tracking-tight" aria-hidden="true">
+        {"★".repeat(filled)}
+        {"☆".repeat(Math.max(0, 5 - filled))}
+      </span>
+      <span className="tabular-nums">
+        {rating.toFixed(1)} · {count} {count === 1 ? "review" : "reviews"}
+      </span>
+    </div>
+  );
+}
+
+function ProductImagePlaceholder({ product }: { product: MarketplaceProduct }) {
+  // Same gradient-letter pattern as marketplace listing cards. Keeps
+  // visual consistency without depending on real product imagery that
+  // most catalog entries don't have yet.
+  return (
+    <div className="aspect-square rounded-2xl bg-gradient-to-br from-accent-soft via-surface to-highlight-soft flex items-center justify-center shadow-sm border border-border">
+      <span className="font-display text-7xl text-accent/60 select-none">
+        {product.brand[0]}
+      </span>
+    </div>
+  );
+}
+
+export default function MarketplaceProductPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const product = getProductBySlug(params.slug);
+  if (!product) notFound();
+
+  const details = curatedDetailsForMarketplaceProduct(product);
+  const related = getRelatedProducts(product.id, 4);
+  const primaryCategory = product.categoryIds[0]
+    ? getCategoryBySlug(product.categoryIds[0].replace(/^cat-/, ""))
+    : undefined;
+
+  return (
+    <main id="main-content" className="bg-bg min-h-screen">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-12 pt-8 pb-20">
+        {/* Breadcrumbs */}
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-6 text-[12px] text-text-subtle flex items-center gap-1.5"
+        >
+          <Link href="/marketplace" className="hover:text-text">
+            Marketplace
+          </Link>
+          <span aria-hidden="true">/</span>
+          {primaryCategory ? (
+            <>
+              <Link
+                href={`/marketplace?category=${primaryCategory.slug}`}
+                className="hover:text-text"
+              >
+                {primaryCategory.name}
+              </Link>
+              <span aria-hidden="true">/</span>
+            </>
+          ) : null}
+          <span className="text-text">{product.name}</span>
+        </nav>
+
+        {/* Hero */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1.05fr_1fr] gap-8 lg:gap-14">
+          <ProductImagePlaceholder product={product} />
+
+          <div className="flex flex-col">
+            <Eyebrow className="mb-3">{product.brand}</Eyebrow>
+            <h1 className="font-display text-3xl sm:text-4xl tracking-tight text-text leading-[1.08] mb-3">
+              {product.name}
+            </h1>
+            <p className="text-[15px] text-text-muted leading-relaxed mb-5">
+              {product.shortDescription}
+            </p>
+
+            {/* Price + ratings */}
+            <div className="flex items-baseline gap-3 mb-4">
+              <span className="font-display text-3xl text-text tabular-nums">
+                {priceLabel(product.price)}
+              </span>
+              {product.compareAtPrice &&
+              product.compareAtPrice > product.price ? (
+                <span className="text-[14px] text-text-subtle line-through tabular-nums">
+                  {priceLabel(product.compareAtPrice)}
+                </span>
+              ) : null}
+              <div className="ml-auto">
+                <StarBar
+                  rating={product.averageRating}
+                  count={product.reviewCount}
+                />
+              </div>
+            </div>
+
+            {/* Trust chips */}
+            <div className="flex flex-wrap gap-2 mb-5">
+              {product.clinicianPick ? (
+                <Badge tone="success">Clinician pick</Badge>
+              ) : null}
+              {product.labVerified ? (
+                <Badge tone="success">Lab verified · COA</Badge>
+              ) : null}
+              {product.beginnerFriendly ? (
+                <Badge tone="neutral">Beginner friendly</Badge>
+              ) : null}
+              {product.requires21Plus ? (
+                <Badge tone="warning">21+ only</Badge>
+              ) : null}
+              {!product.inStock ? (
+                <Badge tone="danger">Out of stock</Badge>
+              ) : null}
+            </div>
+
+            {/* Clinician note */}
+            {product.clinicianNote ? (
+              <div className="rounded-xl border border-accent/30 bg-accent-soft p-4 mb-5">
+                <p className="text-[11px] uppercase tracking-[0.14em] text-accent font-semibold mb-1.5">
+                  From the clinical team
+                </p>
+                <p className="text-[14px] text-text leading-relaxed italic">
+                  {product.clinicianNote}
+                </p>
+              </div>
+            ) : null}
+
+            {/* Highlights */}
+            {details.highlights.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-5">
+                {details.highlights.map((h, i) => (
+                  <div
+                    key={`${h.label}-${i}`}
+                    className="rounded-lg border border-border bg-surface px-3 py-2"
+                  >
+                    <p className="text-[10.5px] uppercase tracking-[0.12em] text-text-subtle font-medium">
+                      {h.label}
+                    </p>
+                    <p className="text-[13px] text-text font-medium mt-0.5">
+                      {h.value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Description + Specs */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-8 lg:gap-14 mt-14">
+          <section>
+            <h2 className="font-display text-2xl tracking-tight text-text mb-4">
+              About this product
+            </h2>
+            <p className="text-[15px] text-text leading-relaxed whitespace-pre-line">
+              {product.description}
+            </p>
+
+            {product.dosageGuidance ? (
+              <div className="mt-6 rounded-xl bg-surface-muted p-5">
+                <p className="text-[11px] uppercase tracking-[0.14em] text-text-subtle font-semibold mb-1.5">
+                  Dosage guidance
+                </p>
+                <p className="text-[14px] text-text leading-relaxed">
+                  {product.dosageGuidance}
+                </p>
+              </div>
+            ) : null}
+          </section>
+
+          <aside>
+            <h2 className="font-display text-2xl tracking-tight text-text mb-4">
+              Specs
+            </h2>
+            <dl className="divide-y divide-border border-y border-border">
+              {details.specs.map((s, i) => (
+                <div
+                  key={`${s.label}-${i}`}
+                  className="py-3 grid grid-cols-[120px_1fr] gap-3"
+                >
+                  <dt className="text-[12px] text-text-subtle uppercase tracking-[0.1em] font-medium">
+                    {s.label}
+                  </dt>
+                  <dd
+                    className={`text-[13.5px] ${
+                      s.emphasis === "warning"
+                        ? "text-highlight font-medium"
+                        : "text-text"
+                    }`}
+                  >
+                    {s.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+
+            {/* Variants */}
+            {product.variants.length > 0 ? (
+              <div className="mt-8">
+                <h3 className="text-[11px] uppercase tracking-[0.14em] text-text-subtle font-semibold mb-3">
+                  Available sizes
+                </h3>
+                <ul className="space-y-2">
+                  {product.variants.map((v) => (
+                    <li
+                      key={v.id}
+                      className="flex items-baseline justify-between gap-3 rounded-lg border border-border bg-surface px-3 py-2"
+                    >
+                      <span className="text-[13.5px] text-text">{v.name}</span>
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-[14px] text-text tabular-nums">
+                          {priceLabel(v.price)}
+                        </span>
+                        {v.compareAtPrice && v.compareAtPrice > v.price ? (
+                          <span className="text-[11px] text-text-subtle line-through tabular-nums">
+                            {priceLabel(v.compareAtPrice)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </aside>
+        </div>
+
+        {/* Reviews */}
+        {product.reviews.length > 0 ? (
+          <section className="mt-14">
+            <h2 className="font-display text-2xl tracking-tight text-text mb-5">
+              What people are saying
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {product.reviews.slice(0, 6).map((r) => (
+                <article
+                  key={r.id}
+                  className="rounded-xl border border-border bg-surface p-5"
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <span
+                      className="text-amber-500 text-[13px]"
+                      aria-label={`${r.rating} out of 5 stars`}
+                    >
+                      {"★".repeat(r.rating)}
+                      {"☆".repeat(Math.max(0, 5 - r.rating))}
+                    </span>
+                    {r.verified ? (
+                      <span className="text-[10px] uppercase tracking-[0.14em] text-accent font-semibold">
+                        Verified
+                      </span>
+                    ) : null}
+                  </div>
+                  {r.title ? (
+                    <p className="font-display text-[15px] text-text mb-1.5">
+                      {r.title}
+                    </p>
+                  ) : null}
+                  <p className="text-[13px] text-text-muted leading-relaxed">
+                    {r.body}
+                  </p>
+                  <p className="text-[11px] text-text-subtle mt-3">
+                    {r.authorName} · {r.createdAt}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Related */}
+        {related.length > 0 ? (
+          <section className="mt-16">
+            <h2 className="font-display text-2xl tracking-tight text-text mb-5">
+              You might also like
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {related.map((p) => (
+                <Link
+                  key={p.id}
+                  href={`/marketplace/products/${p.slug}`}
+                  className="group rounded-xl border border-border bg-surface p-4 hover:border-accent transition-colors flex flex-col"
+                >
+                  <div className="aspect-square rounded-lg bg-gradient-to-br from-accent-soft via-surface to-highlight-soft flex items-center justify-center mb-3">
+                    <span className="font-display text-3xl text-accent/60 select-none">
+                      {p.brand[0]}
+                    </span>
+                  </div>
+                  <p className="text-[10px] uppercase tracking-[0.14em] text-text-subtle font-medium">
+                    {p.brand}
+                  </p>
+                  <h3 className="font-display text-[15px] text-text leading-tight mt-1 line-clamp-2 group-hover:text-accent">
+                    {p.name}
+                  </h3>
+                  <p className="text-[13px] text-text tabular-nums mt-auto pt-3">
+                    {priceLabel(p.price)}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Closes **EMR-712** — the 33 dead `/marketplace/products/*` links surfaced by `e2e/link-integrity.spec.ts` (find-and-fix pass 6).

`marketplace-client.tsx:308` was rendering product cards linked to `/marketplace/products/{slug}` but no `[slug]/page.tsx` existed under that path — every card → 404. This PR builds the missing page.

## What's in the page

Server component (no client boundary needed — the data layer is synchronous). Renders:

- **Breadcrumbs** (Marketplace → Category → Product)
- **Hero**: brand-letter gradient placeholder + name + brand + price + compare-at + star rating + trust chips (Clinician pick, Lab verified, Beginner friendly, 21+)
- **Clinician note** when present (called out in accent-soft frame)
- **Highlights** from `curatedDetailsForMarketplaceProduct` (the bullet generator already built in EMR-307)
- **About this product** — full description + dosage guidance
- **Specs** dl: cannabinoids, terpenes, strain type, best-for, age restriction
- **Variants** list with per-variant price + compare-at
- **Reviews** grid (up to 6, verified badge)
- **Related products** carousel (top 4 by shared categoryIds)

## Design decisions

- **Did not** reuse Leafmart's `ProductDetailClient` — that component expects `LeafmartProduct` shape (UI-mapped for the consumer storefront) and is wired into the cart store + variant selector + dosing guides. Marketplace is editorial, not checkout — keeping shape ownership clean.
- **Did** reuse `curatedDetailsForMarketplaceProduct` from `src/lib/marketplace/product-details.ts` — exactly the bullet generator built for this purpose.
- Visual style matches the listing-card pattern in `marketplace-client.tsx` (brand-letter gradient placeholder, warm tokens, accent/highlight chips). Catalog has no real product imagery yet.

## Verification

Bulk-curled all 33 product slugs from `src/lib/marketplace/data.ts`:

```
RESULT: 33 passed, 0 failed (of 33)
```

Nonexistent slug correctly returns 404. `e2e/link-integrity.spec.ts` should now show 0 × 404 in the marketplace cluster.

## Note on scope

This branch also carries several auto-agent commits (EMR-101..144 scaffolded API routes) the night-shift orchestrator pushed onto it while it was checked out. The substantive change in this PR is the single new file `src/app/marketplace/products/[slug]/page.tsx` (340 lines).

## Test plan

- [x] All 33 product slugs return 200 (verified)
- [x] Nonexistent slug returns 404 (verified)
- [ ] `npx playwright test e2e/link-integrity.spec.ts` — 0 × 404 in marketplace cluster
- [ ] Visual smoke: load `/marketplace/products/solace-nightfall-tincture` and confirm hero, specs, reviews, related products all render

Closes EMR-712. Related parent: EMR-709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)