### PR TITLE
feat(security): per-actor mutation budget alarm cron (EMR-730)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -712,3 +712,10 @@ routes:
     auth: webhook
     owner: integrations
     notes: "EMR-078 scaffold. Bearer STATE_REGISTRY_SECRET check, prod-only. Outbound METRC/BioTrack/PDMP compliance reporting."
+
+  cron/mutation-budget-sweep:
+    methods: [POST]
+    auth: cron
+    rate_limit_bucket: cron.mutation-budget
+    owner: platform-security
+    notes: "EMR-730. Bearer CRON_SECRET check, prod-only. Sweeps ControllerAuditLog over a 5-minute window, fires a logger.error alarm (event: super_admin.mutation_budget_exceeded) when any actor exceeds 30 mutations/min OR 100 mutations/5min. Per-actor dedupe ledger: MutationBudgetAlarm, 10-minute window. Threshold env knobs: SUPER_ADMIN_ALARM_PER_MIN, SUPER_ADMIN_ALARM_PER_5MIN."

--- a/prisma/migrations/20260517120000_add_mutation_budget_alarm/migration.sql
+++ b/prisma/migrations/20260517120000_add_mutation_budget_alarm/migration.sql
@@ -1,0 +1,17 @@
+-- EMR-730 — Per-actor mutation budget alarm ledger.
+--
+-- One row per (actor, alarm-fire). The cron at
+-- /api/cron/mutation-budget-sweep reads the most-recent row per actor to
+-- dedupe re-fires inside a 10-minute window.
+
+CREATE TABLE "MutationBudgetAlarm" (
+  "id"             TEXT PRIMARY KEY,
+  "actorUserId"    TEXT NOT NULL,
+  "firstSeenAt"    TIMESTAMP(3) NOT NULL,
+  "lastAlertedAt"  TIMESTAMP(3) NOT NULL,
+  "perMinAtAlert"  INTEGER NOT NULL,
+  "per5MinAtAlert" INTEGER NOT NULL
+);
+
+CREATE INDEX "MutationBudgetAlarm_actorUserId_lastAlertedAt_idx"
+  ON "MutationBudgetAlarm" ("actorUserId", "lastAlertedAt" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1797,6 +1797,24 @@ model ControllerAuditLog {
   @@index([actorUserId, at])
 }
 
+// EMR-730 — Per-actor mutation budget alarm ledger.
+//
+// One row per (actor, alarm-fire). The cron at
+// /api/cron/mutation-budget-sweep reads the most-recent row per actor to
+// dedupe re-fires inside a 10-minute window. We don't UPDATE existing rows
+// — every alarm fire is its own row so on-call has a forensic history of
+// when an account tripped the budget and how badly.
+model MutationBudgetAlarm {
+  id             String   @id @default(cuid())
+  actorUserId    String
+  firstSeenAt    DateTime
+  lastAlertedAt  DateTime
+  perMinAtAlert  Int
+  per5MinAtAlert Int
+
+  @@index([actorUserId, lastAlertedAt(sort: Desc)])
+}
+
 // --------------------------------------------------------------
 // Agentic Memory Harness
 // --------------------------------------------------------------

--- a/src/app/api/cron/mutation-budget-sweep/route.ts
+++ b/src/app/api/cron/mutation-budget-sweep/route.ts
@@ -1,0 +1,189 @@
+// EMR-730 — Per-actor mutation budget alarm cron.
+//
+// Why this exists: the per-bucket rate limiter (PR S, agent.* etc.)
+// prevents abuse-via-volume on any single endpoint. But a compromised
+// super_admin that *spreads* its mutations across many endpoints can
+// stay under every individual bucket cap while still firing a
+// catastrophic number of writes. This cron is the anomaly signal that
+// says "this account is acting wrong" regardless of which buckets it
+// touches.
+//
+// How it works:
+//   1. Every ~60 seconds (cron cadence is wired in the deployment
+//      scheduler — see render.yaml / Render dashboard), this route is
+//      POSTed by the cron daemon with a Bearer CRON_SECRET header.
+//   2. We read ControllerAuditLog for the trailing 5 minutes, grouped
+//      per actor.
+//   3. For each actor we compute two counts:
+//        - perMin   = rows in the trailing 1 minute window
+//        - per5Min  = rows in the trailing 5 minute window
+//      If either exceeds its threshold (defaults: 30/min, 100/5min,
+//      configurable via SUPER_ADMIN_ALARM_PER_{MIN,5MIN}), the actor is
+//      a candidate for an alarm.
+//   4. Dedupe: we read the most-recent MutationBudgetAlarm row for the
+//      actor. If `lastAlertedAt` is within the last 10 minutes, we
+//      *suppress* the new fire — but we still log the suppression so
+//      on-call sees it on review. Otherwise we emit a structured
+//      `logger.error` (event: `super_admin.mutation_budget_exceeded`)
+//      that the log-aggregator routes to the incident channel, AND
+//      we insert a new MutationBudgetAlarm row so the next sweep within
+//      10 minutes dedupes.
+//
+// Tuning the thresholds:
+//   - Set SUPER_ADMIN_ALARM_PER_MIN and SUPER_ADMIN_ALARM_PER_5MIN env
+//     vars in Render. Values must be positive integers; anything
+//     unparseable falls back to the default and logs a warning at the
+//     next cron tick (event: `mutation_budget.threshold_unparseable`).
+//
+// Cost ceiling: query is bounded to the last 5 minutes (the largest
+// window we care about) — never iterates the full table. Index used:
+// ControllerAuditLog.at (implicit via the WHERE clause; the existing
+// composite indexes on actorUserId+at also help the group-by).
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import {
+  aggregatePerActor,
+  DEDUPE_WINDOW_MS,
+  exceedsBudget,
+  isSuppressedByDedupe,
+  loadThresholds,
+  SWEEP_WINDOW_MS,
+  type AuditRow,
+} from "@/lib/security/mutation-budget";
+
+export const runtime = "nodejs";
+
+function isAuthorized(req: Request): boolean {
+  const authHeader = req.headers.get("authorization") ?? "";
+  const secret = process.env.CRON_SECRET ?? "";
+
+  // Prod: fail-closed. If the secret is missing OR the header doesn't
+  // match, reject. Same pattern as cron/credential-check and PR S.
+  if (process.env.NODE_ENV === "production") {
+    if (!secret) return false;
+    return authHeader === `Bearer ${secret}`;
+  }
+  // Non-prod: fall through so local cron probing doesn't require an
+  // env var. Matches cron/reminders + cron/credential-check.
+  return true;
+}
+
+export async function POST(req: Request) {
+  try {
+    if (!isAuthorized(req)) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const now = new Date();
+    const windowStart = new Date(now.getTime() - SWEEP_WINDOW_MS);
+    const thresholds = loadThresholds(process.env, logger);
+
+    // Pull the 5-minute window. `controller.%` matches every action the
+    // controller surface emits via logControllerAction(). The same
+    // prefix is the convention with-admin-mutation will inherit when it
+    // lands (PR #343), so this filter is forward-compatible.
+    const rows = (await prisma.controllerAuditLog.findMany({
+      where: {
+        at: { gte: windowStart },
+        action: { startsWith: "controller." },
+      },
+      select: {
+        at: true,
+        actorUserId: true,
+        actorEmail: true,
+        action: true,
+      },
+    })) as AuditRow[];
+
+    const perActor = aggregatePerActor(rows, now);
+
+    let alarmsFired = 0;
+    let suppressedByDedupe = 0;
+
+    for (const counts of perActor.values()) {
+      if (!exceedsBudget(counts, thresholds)) continue;
+
+      // Look up the most-recent prior alarm for this actor.
+      const prior = await prisma.mutationBudgetAlarm.findFirst({
+        where: { actorUserId: counts.actorUserId },
+        orderBy: { lastAlertedAt: "desc" },
+        select: { lastAlertedAt: true, firstSeenAt: true },
+      });
+
+      if (isSuppressedByDedupe(prior?.lastAlertedAt ?? null, now)) {
+        suppressedByDedupe += 1;
+        logger.warn({
+          event: "super_admin.mutation_budget_suppressed",
+          actorUserId: counts.actorUserId,
+          actorEmail: counts.actorEmail,
+          perMin: counts.perMin,
+          per5Min: counts.per5Min,
+          lastAlertedAt: prior?.lastAlertedAt?.toISOString(),
+          dedupeWindowMs: DEDUPE_WINDOW_MS,
+        });
+        continue;
+      }
+
+      // Fire the alarm. Structured logger.error → log-aggregator → incident channel.
+      logger.error({
+        event: "super_admin.mutation_budget_exceeded",
+        actorUserId: counts.actorUserId,
+        actorEmail: counts.actorEmail,
+        perMin: counts.perMin,
+        per5Min: counts.per5Min,
+        thresholds,
+        sampleActions: counts.sampleActions,
+        revokeDeepLink: `/admin/console?actor=${counts.actorUserId}`,
+      });
+
+      // Persist the alarm row so subsequent sweeps within the dedupe
+      // window can suppress. `firstSeenAt` carries forward from the
+      // earliest prior fire on record, so the on-call view can see how
+      // long this actor has been firing.
+      await prisma.mutationBudgetAlarm.create({
+        data: {
+          actorUserId: counts.actorUserId,
+          firstSeenAt: prior?.firstSeenAt ?? now,
+          lastAlertedAt: now,
+          perMinAtAlert: counts.perMin,
+          per5MinAtAlert: counts.per5Min,
+        },
+      });
+
+      alarmsFired += 1;
+    }
+
+    // Audit the sweep itself so the controller log has a record that
+    // the alarm system actually ran (silence here would itself be a
+    // failure mode worth seeing on review).
+    await logControllerAction({
+      actor: {
+        id: "system:cron:mutation-budget",
+        email: "system@cron.mutation-budget",
+        roles: ["system"],
+        organizationId: null,
+      },
+      action: "controller.mutation_budget.sweep_completed",
+      targetId: "system:cron:mutation-budget",
+      after: {
+        actorsScanned: perActor.size,
+        alarmsFired,
+        suppressedByDedupe,
+        thresholds,
+      },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      actorsScanned: perActor.size,
+      alarmsFired,
+      suppressedByDedupe,
+    });
+  } catch (error) {
+    logger.error({ event: "cron.mutation_budget_sweep.failed", error });
+    return NextResponse.json({ error: "sweep_failed" }, { status: 500 });
+  }
+}

--- a/src/lib/security/mutation-budget.test.ts
+++ b/src/lib/security/mutation-budget.test.ts
@@ -1,0 +1,177 @@
+// EMR-730 — Unit tests for the mutation-budget pure helpers.
+//
+// Three behaviours under test:
+//   1. Threshold env parsing — defaults, well-formed overrides, bad values.
+//   2. Window counting — 1-min vs 5-min with mocked timestamps.
+//   3. Dedupe ledger — first fire, within-window suppression, after-window re-fire.
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  aggregatePerActor,
+  DEDUPE_WINDOW_MS,
+  DEFAULT_PER_5MIN,
+  DEFAULT_PER_MIN,
+  exceedsBudget,
+  isSuppressedByDedupe,
+  loadThresholds,
+  type AuditRow,
+} from "./mutation-budget";
+
+const NOW = new Date("2026-05-17T12:00:00.000Z");
+
+function row(actorUserId: string, secondsAgo: number, action = "controller.config.publish", actorEmail: string | null = `${actorUserId}@example.com`): AuditRow {
+  return {
+    at: new Date(NOW.getTime() - secondsAgo * 1_000),
+    actorUserId,
+    actorEmail,
+    action,
+  };
+}
+
+describe("loadThresholds", () => {
+  it("returns defaults when env is empty", () => {
+    const t = loadThresholds({});
+    expect(t.perMin).toBe(DEFAULT_PER_MIN);
+    expect(t.per5Min).toBe(DEFAULT_PER_5MIN);
+  });
+
+  it("parses valid positive integers", () => {
+    const t = loadThresholds({
+      SUPER_ADMIN_ALARM_PER_MIN: "12",
+      SUPER_ADMIN_ALARM_PER_5MIN: "55",
+    });
+    expect(t.perMin).toBe(12);
+    expect(t.per5Min).toBe(55);
+  });
+
+  it.each([
+    ["abc"],
+    ["0"],
+    ["-5"],
+    ["3.14"],
+    [""],
+  ])("falls back to default when value is %j", (raw) => {
+    const warn = vi.fn();
+    const t = loadThresholds({ SUPER_ADMIN_ALARM_PER_MIN: raw }, { warn });
+    expect(t.perMin).toBe(DEFAULT_PER_MIN);
+    // "" is treated as "not set" → no warning; the others warn.
+    if (raw !== "") {
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "mutation_budget.threshold_unparseable",
+          envKey: "SUPER_ADMIN_ALARM_PER_MIN",
+          raw,
+        }),
+      );
+    } else {
+      expect(warn).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe("aggregatePerActor", () => {
+  it("counts rows in the 1-min and 5-min windows separately", () => {
+    const rows: AuditRow[] = [
+      // Actor A: 3 in last 30s, 5 more between 1-4 min ago → 3/min, 8/5min.
+      row("A", 5),
+      row("A", 10),
+      row("A", 25),
+      row("A", 90),
+      row("A", 120),
+      row("A", 180),
+      row("A", 200),
+      row("A", 240),
+      // Actor B: 1 in last 30s only.
+      row("B", 15),
+      // Out of window (older than 5 min) — must be excluded.
+      row("A", 400),
+    ];
+
+    const result = aggregatePerActor(rows, NOW);
+    const a = result.get("A")!;
+    const b = result.get("B")!;
+
+    expect(a.perMin).toBe(3);
+    expect(a.per5Min).toBe(8);
+    expect(b.perMin).toBe(1);
+    expect(b.per5Min).toBe(1);
+  });
+
+  it("returns up to 5 distinct most-recent actions in sampleActions", () => {
+    const rows: AuditRow[] = [
+      row("A", 5, "controller.template.create"),
+      row("A", 10, "controller.config.publish"),
+      row("A", 20, "controller.config.publish"), // dup — should be deduped
+      row("A", 30, "controller.config.archive"),
+      row("A", 40, "controller.wizard.step.save"),
+      row("A", 50, "controller.config.rollback"),
+      row("A", 60, "controller.template.update"),
+    ];
+    const a = aggregatePerActor(rows, NOW).get("A")!;
+    expect(a.sampleActions).toHaveLength(5);
+    expect(a.sampleActions[0]).toBe("controller.template.create");
+    // No duplicate of controller.config.publish.
+    expect(a.sampleActions.filter((x) => x === "controller.config.publish")).toHaveLength(1);
+  });
+
+  it("includes the firing actor when 31 mutations land inside 50 seconds", () => {
+    // AC repro: one actor, 31 mutations over 50s — perMin > 30 must trip.
+    const rows: AuditRow[] = Array.from({ length: 31 }, (_, i) =>
+      row("compromised_admin", (50 / 31) * i),
+    );
+    const counts = aggregatePerActor(rows, NOW).get("compromised_admin")!;
+    expect(counts.perMin).toBe(31);
+    expect(exceedsBudget(counts, { perMin: DEFAULT_PER_MIN, per5Min: DEFAULT_PER_5MIN })).toBe(true);
+  });
+});
+
+describe("exceedsBudget", () => {
+  it("trips when perMin exceeds threshold", () => {
+    expect(
+      exceedsBudget(
+        { actorUserId: "A", actorEmail: null, perMin: 31, per5Min: 31, sampleActions: [] },
+        { perMin: 30, per5Min: 100 },
+      ),
+    ).toBe(true);
+  });
+
+  it("trips when per5Min exceeds threshold even if perMin is fine", () => {
+    expect(
+      exceedsBudget(
+        { actorUserId: "A", actorEmail: null, perMin: 10, per5Min: 101, sampleActions: [] },
+        { perMin: 30, per5Min: 100 },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not trip when both counts equal thresholds (strict >)", () => {
+    expect(
+      exceedsBudget(
+        { actorUserId: "A", actorEmail: null, perMin: 30, per5Min: 100, sampleActions: [] },
+        { perMin: 30, per5Min: 100 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isSuppressedByDedupe", () => {
+  it("does not suppress on first-ever fire (no prior row)", () => {
+    expect(isSuppressedByDedupe(null, NOW)).toBe(false);
+  });
+
+  it("suppresses within the 10-minute window", () => {
+    const fiveMinAgo = new Date(NOW.getTime() - 5 * 60 * 1_000);
+    expect(isSuppressedByDedupe(fiveMinAgo, NOW)).toBe(true);
+  });
+
+  it("re-fires after the 10-minute window has elapsed", () => {
+    const justOver = new Date(NOW.getTime() - DEDUPE_WINDOW_MS - 1);
+    expect(isSuppressedByDedupe(justOver, NOW)).toBe(false);
+  });
+
+  it("treats the boundary itself as expired (strict <)", () => {
+    const exactBoundary = new Date(NOW.getTime() - DEDUPE_WINDOW_MS);
+    expect(isSuppressedByDedupe(exactBoundary, NOW)).toBe(false);
+  });
+});

--- a/src/lib/security/mutation-budget.ts
+++ b/src/lib/security/mutation-budget.ts
@@ -1,0 +1,158 @@
+// EMR-730 — Per-actor mutation budget alarm: pure helpers.
+//
+// This module contains the threshold parser and the two windowing /
+// dedupe predicates that the cron route at
+// /api/cron/mutation-budget-sweep wires together. Splitting it out keeps
+// the cron handler thin and lets the unit tests exercise the logic
+// without standing up Next.js, Prisma, or a clock.
+//
+// Defaults match the AC on EMR-730:
+//   - >30 mutations/min  → fire
+//   - >100 mutations/5min → fire
+//   - 10-minute dedupe window per actor
+//
+// Env knobs (read at boot via `loadThresholds()`):
+//   - SUPER_ADMIN_ALARM_PER_MIN    (default 30)
+//   - SUPER_ADMIN_ALARM_PER_5MIN   (default 100)
+//
+// "Boot" = the first time the cron route is invoked in this process.
+// Bad env values fall back to the default and log a structured warning
+// so ops sees the misconfiguration without the cron silently turning
+// itself off.
+
+import type { Logger } from "@/lib/observability/log";
+
+export const DEFAULT_PER_MIN = 30;
+export const DEFAULT_PER_5MIN = 100;
+export const DEDUPE_WINDOW_MS = 10 * 60 * 1_000; // 10 minutes
+export const SWEEP_WINDOW_MS = 5 * 60 * 1_000; // 5 minutes
+export const ONE_MIN_MS = 60 * 1_000;
+
+export interface BudgetThresholds {
+  perMin: number;
+  per5Min: number;
+}
+
+/**
+ * Parse the two env vars into integer thresholds. Returns defaults +
+ * emits a structured warning when a value is missing, non-numeric, or
+ * <= 0. Refusing to fire (parsing to NaN and silently disabling the
+ * cron) is the failure mode we explicitly do not want.
+ */
+export function loadThresholds(
+  env: Partial<Record<string, string | undefined>> = process.env,
+  log?: Pick<Logger, "warn">,
+): BudgetThresholds {
+  const perMin = parsePositiveInt(env.SUPER_ADMIN_ALARM_PER_MIN, DEFAULT_PER_MIN, "SUPER_ADMIN_ALARM_PER_MIN", log);
+  const per5Min = parsePositiveInt(env.SUPER_ADMIN_ALARM_PER_5MIN, DEFAULT_PER_5MIN, "SUPER_ADMIN_ALARM_PER_5MIN", log);
+  return { perMin, per5Min };
+}
+
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  envKey: string,
+  log?: Pick<Logger, "warn">,
+): number {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    log?.warn({
+      event: "mutation_budget.threshold_unparseable",
+      envKey,
+      raw,
+      fallback,
+    });
+    return fallback;
+  }
+  return n;
+}
+
+/**
+ * Audit-log row shape this module needs. Narrowed so the test harness
+ * can hand-roll fixtures without depending on Prisma's generated types.
+ */
+export interface AuditRow {
+  at: Date;
+  actorUserId: string;
+  actorEmail: string | null;
+  action: string;
+}
+
+export interface ActorWindowCounts {
+  actorUserId: string;
+  actorEmail: string | null;
+  perMin: number;
+  per5Min: number;
+  sampleActions: string[];
+}
+
+/**
+ * Aggregate audit rows into per-actor counts over the 1-minute and
+ * 5-minute windows ending at `now`. The 5-min window is the upper
+ * bound; the 1-min window is a strict subset.
+ *
+ * `sampleActions` is the last 5 distinct action strings seen for the
+ * actor inside the 5-minute window (most-recent first), included in the
+ * structured alarm payload so on-call can eyeball what kind of activity
+ * tripped the budget.
+ */
+export function aggregatePerActor(
+  rows: readonly AuditRow[],
+  now: Date,
+): Map<string, ActorWindowCounts> {
+  const cutoff5 = now.getTime() - SWEEP_WINDOW_MS;
+  const cutoff1 = now.getTime() - ONE_MIN_MS;
+
+  const acc = new Map<string, ActorWindowCounts>();
+  // Iterate in reverse-chronological order so the first 5 distinct
+  // actions we observe per actor are the most-recent ones.
+  const sorted = [...rows].sort((a, b) => b.at.getTime() - a.at.getTime());
+
+  for (const row of sorted) {
+    const t = row.at.getTime();
+    if (t < cutoff5) continue;
+
+    let entry = acc.get(row.actorUserId);
+    if (!entry) {
+      entry = {
+        actorUserId: row.actorUserId,
+        actorEmail: row.actorEmail,
+        perMin: 0,
+        per5Min: 0,
+        sampleActions: [],
+      };
+      acc.set(row.actorUserId, entry);
+    }
+    // Carry the first non-null email we see — older rows may have it
+    // even if a more-recent one doesn't.
+    if (!entry.actorEmail && row.actorEmail) entry.actorEmail = row.actorEmail;
+
+    entry.per5Min += 1;
+    if (t >= cutoff1) entry.perMin += 1;
+
+    if (entry.sampleActions.length < 5 && !entry.sampleActions.includes(row.action)) {
+      entry.sampleActions.push(row.action);
+    }
+  }
+
+  return acc;
+}
+
+/**
+ * True when the actor's counts exceed either threshold.
+ */
+export function exceedsBudget(counts: ActorWindowCounts, thresholds: BudgetThresholds): boolean {
+  return counts.perMin > thresholds.perMin || counts.per5Min > thresholds.per5Min;
+}
+
+/**
+ * Dedupe predicate. `lastAlertedAt` is the most-recent fire we have on
+ * record for the actor (or `null` if there's never been one). Returns
+ * true when we should suppress the alarm because we already fired
+ * within `DEDUPE_WINDOW_MS`.
+ */
+export function isSuppressedByDedupe(lastAlertedAt: Date | null, now: Date): boolean {
+  if (!lastAlertedAt) return false;
+  return now.getTime() - lastAlertedAt.getTime() < DEDUPE_WINDOW_MS;
+}


### PR DESCRIPTION
## Summary
- New cron `/api/cron/mutation-budget-sweep` reads the trailing 5 minutes of `ControllerAuditLog`, groups by `actorUserId`, and fires a structured `logger.error` alarm (`event: super_admin.mutation_budget_exceeded`) when any actor exceeds `30 mutations/min` or `100 mutations/5min`. Thresholds configurable via `SUPER_ADMIN_ALARM_PER_MIN` / `SUPER_ADMIN_ALARM_PER_5MIN`.
- Additive `MutationBudgetAlarm` ledger backs a 10-minute per-actor dedupe window; suppressed fires are still logged (`super_admin.mutation_budget_suppressed`) so on-call sees them on review.
- Auth + manifest follow the existing cron pattern: Bearer `CRON_SECRET`, prod-only fail-closed, dev fall-through. Manifest entry adds `rate_limit_bucket: cron.mutation-budget`.

Linear: https://linear.app/emr-project/issue/EMR-730

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `node scripts/check-route-auth-manifest.mjs` clean (107 routes in sync)
- [x] `npx prisma generate` clean
- [x] 17 new unit tests pass (`src/lib/security/mutation-budget.test.ts`): threshold env parsing (good + bad values), 1-min and 5-min counting with mocked clock, sampleActions dedupe, dedupe-ledger first-fire / within-window suppress / after-window re-fire.
- [ ] Smoke once deployed: hit the route in non-prod (no secret needed) and confirm a `super_admin.mutation_budget_exceeded` line lands in the structured log when the controller surface is exercised hard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)