### PR TITLE
feat(security): bootstrap allowlist rotation audit + UI (EMR-726)

### DIFF
--- a/prisma/migrations/20260517120000_add_bootstrap_allowlist_snapshot/migration.sql
+++ b/prisma/migrations/20260517120000_add_bootstrap_allowlist_snapshot/migration.sql
@@ -1,0 +1,19 @@
+-- EMR-726 — Bootstrap allowlist rotation audit.
+--
+-- One row per observed *change* of SUPER_ADMIN_BOOTSTRAP_EMAILS. The
+-- boot-audit helper in src/lib/auth/bootstrap-audit.ts computes a
+-- SHA-256 over the sorted/normalised allowlist and only inserts a new
+-- row when the hash differs from the most recent snapshot.
+--
+-- Additive only — no existing table is touched.
+
+CREATE TABLE "BootstrapAllowlistSnapshot" (
+  "id"        TEXT PRIMARY KEY,
+  "hash"      TEXT NOT NULL,
+  "emails"    TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "deploySha" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "BootstrapAllowlistSnapshot_createdAt_idx"
+  ON "BootstrapAllowlistSnapshot" ("createdAt" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1797,6 +1797,27 @@ model ControllerAuditLog {
   @@index([actorUserId, at])
 }
 
+// EMR-726 — Bootstrap allowlist rotation audit.
+//
+// One row per *change* of SUPER_ADMIN_BOOTSTRAP_EMAILS as observed at boot.
+// The boot-audit helper computes a SHA-256 over the sorted/normalised email
+// list and inserts a snapshot only when the hash differs from the most
+// recent row. That makes idempotent reboots silent while still catching a
+// silent expansion of the allowlist between deploys — which is the whole
+// point of EMR-726.
+model BootstrapAllowlistSnapshot {
+  id        String   @id @default(cuid())
+  /// SHA-256 hex of `sorted(lowercased(trimmed(emails))).join(",")`.
+  hash      String
+  /// The parsed allowlist at the moment of capture.
+  emails    String[]
+  /// Resolved from RENDER_GIT_COMMIT / GIT_SHA at boot. Null in dev.
+  deploySha String?
+  createdAt DateTime @default(now())
+
+  @@index([createdAt(sort: Desc)])
+}
+
 // --------------------------------------------------------------
 // Agentic Memory Harness
 // --------------------------------------------------------------

--- a/src/app/(super-admin)/admin/bootstrap/page.tsx
+++ b/src/app/(super-admin)/admin/bootstrap/page.tsx
@@ -1,0 +1,309 @@
+// EMR-726 — Bootstrap allowlist UI.
+//
+// Server component. Already gated by (super-admin)/layout.tsx, so we don't
+// re-check role here. Two sections:
+//   1. Current allowlist (parsed env), with per-email "promoted?" status
+//      cross-referenced against Membership rows where role = super_admin.
+//   2. History of BootstrapAllowlistSnapshot rows, most recent 50, with
+//      added/removed diffs computed against the prior row.
+
+import type { Metadata } from "next";
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Eyebrow } from "@/components/ui/ornament";
+import { prisma } from "@/lib/db/prisma";
+import {
+  diffAllowlists,
+  normaliseAllowlist,
+} from "@/lib/auth/bootstrap-audit";
+
+export const metadata: Metadata = {
+  title: "Bootstrap allowlist — Leafjourney HQ",
+};
+
+export const dynamic = "force-dynamic";
+
+interface SnapshotRow {
+  id: string;
+  hash: string;
+  emails: string[];
+  deploySha: string | null;
+  createdAt: Date;
+}
+
+interface SnapshotWithDiff extends SnapshotRow {
+  added: string[];
+  removed: string[];
+}
+
+async function loadSnapshots(): Promise<SnapshotWithDiff[]> {
+  // Pull 51 so we can diff the oldest visible row against the row just
+  // before it (otherwise the bottom row would always look empty).
+  const rows = await prisma.bootstrapAllowlistSnapshot.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 51,
+    select: {
+      id: true,
+      hash: true,
+      emails: true,
+      deploySha: true,
+      createdAt: true,
+    },
+  });
+
+  const out: SnapshotWithDiff[] = [];
+  for (let i = 0; i < Math.min(rows.length, 50); i++) {
+    const curr = rows[i]!;
+    const prev = rows[i + 1] ?? null;
+    const { added, removed } = prev
+      ? diffAllowlists(prev.emails, curr.emails)
+      : { added: curr.emails, removed: [] };
+    out.push({ ...curr, added, removed });
+  }
+  return out;
+}
+
+async function loadPromotedEmails(emails: string[]): Promise<Set<string>> {
+  if (emails.length === 0) return new Set();
+  const memberships = await prisma.membership.findMany({
+    where: {
+      role: "super_admin",
+      user: { email: { in: emails, mode: "insensitive" } },
+    },
+    select: { user: { select: { email: true } } },
+  });
+  return new Set(memberships.map((m) => m.user.email.toLowerCase()));
+}
+
+export default async function BootstrapAllowlistPage() {
+  const currentEmails = normaliseAllowlist(
+    process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS,
+  );
+  const isEnabled = process.env.SUPER_ADMIN_BOOTSTRAP_ENABLED === "1";
+  const isProd = process.env.NODE_ENV === "production";
+
+  const [snapshots, promoted] = await Promise.all([
+    loadSnapshots(),
+    loadPromotedEmails(currentEmails),
+  ]);
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Leafjourney HQ"
+        title="Bootstrap allowlist"
+        description="The SUPER_ADMIN_BOOTSTRAP_EMAILS allowlist controls who can lazy-promote into the super_admin role. Rotations between deploys are detected automatically and recorded here."
+      />
+
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Current allowlist</CardTitle>
+            <div className="mt-2 flex items-center gap-2 text-[12px] text-text-muted">
+              <StatusBadge
+                ok={isEnabled || !isProd}
+                label={
+                  isEnabled
+                    ? "Bootstrap enabled"
+                    : isProd
+                      ? "Bootstrap disabled in production"
+                      : "Bootstrap permitted (non-production)"
+                }
+              />
+              <span aria-hidden>·</span>
+              <span>
+                {currentEmails.length}{" "}
+                {currentEmails.length === 1 ? "address" : "addresses"}
+              </span>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {currentEmails.length === 0 ? (
+              <p className="text-sm text-text-muted">
+                The allowlist is empty. No lazy promotion will occur.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border/60">
+                {currentEmails.map((email) => {
+                  const isPromoted = promoted.has(email);
+                  return (
+                    <li
+                      key={email}
+                      className="flex items-center justify-between py-2.5"
+                    >
+                      <span className="font-mono text-[13px] text-text">
+                        {email}
+                      </span>
+                      <StatusBadge
+                        ok={isPromoted}
+                        label={isPromoted ? "Promoted" : "Pending sign-in"}
+                      />
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Change history</CardTitle>
+            <p className="text-sm text-text-muted mt-1">
+              One row per observed rotation between deploys. Reboots with the
+              same allowlist produce no row.
+            </p>
+          </CardHeader>
+          <CardContent>
+            {snapshots.length === 0 ? (
+              <p className="text-sm text-text-muted">
+                No snapshots yet — the first server boot will record a
+                baseline.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left border-b border-border/60">
+                      <Th>Recorded</Th>
+                      <Th>Deploy</Th>
+                      <Th>Added</Th>
+                      <Th>Removed</Th>
+                      <Th>Hash</Th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {snapshots.map((row) => (
+                      <tr
+                        key={row.id}
+                        className="border-b border-border/40 align-top"
+                      >
+                        <Td>{formatDate(row.createdAt)}</Td>
+                        <Td className="font-mono text-[12px]">
+                          {row.deploySha ? shortSha(row.deploySha) : "—"}
+                        </Td>
+                        <Td>
+                          <DiffList items={row.added} tone="add" />
+                        </Td>
+                        <Td>
+                          <DiffList items={row.removed} tone="remove" />
+                        </Td>
+                        <Td className="font-mono text-[11px] text-text-muted">
+                          {row.hash.slice(0, 12)}…
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card tone="outlined">
+          <CardContent className="py-5">
+            <Eyebrow className="mb-2">Rotation runbook</Eyebrow>
+            <ol className="text-sm text-text-muted space-y-1.5 list-decimal pl-5">
+              <li>
+                Update <code>SUPER_ADMIN_BOOTSTRAP_EMAILS</code> in Render
+                (comma-separated).
+              </li>
+              <li>
+                Trigger a redeploy. The boot-audit path writes a snapshot
+                row and an error-level log line if the allowlist changed.
+              </li>
+              <li>
+                Have the new admin sign in once to receive the role.
+              </li>
+              <li>
+                Unset <code>SUPER_ADMIN_BOOTSTRAP_ENABLED</code> and
+                redeploy to close the bootstrap path.
+              </li>
+            </ol>
+          </CardContent>
+        </Card>
+      </div>
+    </PageShell>
+  );
+}
+
+function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span
+      className={
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium " +
+        (ok
+          ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          : "bg-amber-500/10 text-amber-700 dark:text-amber-300")
+      }
+    >
+      <span
+        aria-hidden
+        className={
+          "h-1.5 w-1.5 rounded-full " +
+          (ok ? "bg-emerald-500" : "bg-amber-500")
+        }
+      />
+      {label}
+    </span>
+  );
+}
+
+function DiffList({
+  items,
+  tone,
+}: {
+  items: string[];
+  tone: "add" | "remove";
+}) {
+  if (items.length === 0) {
+    return <span className="text-text-muted">—</span>;
+  }
+  return (
+    <ul className="space-y-0.5">
+      {items.map((email) => (
+        <li
+          key={email}
+          className={
+            "font-mono text-[12px] " +
+            (tone === "add"
+              ? "text-emerald-700 dark:text-emerald-300"
+              : "text-rose-700 dark:text-rose-300")
+          }
+        >
+          {tone === "add" ? "+" : "−"} {email}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th className="text-[11px] uppercase tracking-wider text-text-muted font-medium pb-2 pr-4">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <td className={"py-3 pr-4 " + (className ?? "")}>{children}</td>;
+}
+
+function shortSha(sha: string): string {
+  return sha.length > 8 ? sha.slice(0, 8) : sha;
+}
+
+function formatDate(d: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(d);
+}

--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -30,7 +30,10 @@ const SUPER_ADMIN_SECTIONS: NavSection[] = [
     pillar: "admin",
     icon: "settings",
     label: "Admin",
-    items: [{ label: "Console", href: "/admin" }],
+    items: [
+      { label: "Console", href: "/admin" },
+      { label: "Bootstrap allowlist", href: "/admin/bootstrap" },
+    ],
   },
 ];
 

--- a/src/lib/auth/bootstrap-audit.test.ts
+++ b/src/lib/auth/bootstrap-audit.test.ts
@@ -1,0 +1,221 @@
+// Unit tests for the bootstrap-audit helpers + the once-per-process
+// audit runner. Mocks @prisma/client at the module level (so the import
+// of @prisma/client in `bootstrap-audit.ts` for the Role type doesn't
+// require generated client output) and stubs the audit + prisma layers.
+
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+vi.mock("@prisma/client", () => ({}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    bootstrapAllowlistSnapshot: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    with: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock("./audit-stub", () => ({
+  logControllerAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import {
+  __resetBootstrapAllowlistAuditForTests,
+  diffAllowlists,
+  hashAllowlist,
+  normaliseAllowlist,
+  runBootstrapAllowlistAudit,
+} from "./bootstrap-audit";
+import { logControllerAction } from "./audit-stub";
+
+const mockedFindFirst = vi.mocked(
+  (prisma as unknown as {
+    bootstrapAllowlistSnapshot: { findFirst: ReturnType<typeof vi.fn> };
+  }).bootstrapAllowlistSnapshot.findFirst,
+);
+const mockedCreate = vi.mocked(
+  (prisma as unknown as {
+    bootstrapAllowlistSnapshot: { create: ReturnType<typeof vi.fn> };
+  }).bootstrapAllowlistSnapshot.create,
+);
+const mockedLogControllerAction = vi.mocked(logControllerAction);
+const mockedLoggerError = vi.mocked(logger.error);
+const mockedLoggerInfo = vi.mocked(logger.info);
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  __resetBootstrapAllowlistAuditForTests();
+  // Reset env to a known baseline so individual tests can set just the
+  // var they care about.
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS;
+  delete process.env.RENDER_GIT_COMMIT;
+  delete process.env.GIT_SHA;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("normaliseAllowlist", () => {
+  it("lowercases, trims, and sorts emails", () => {
+    const result = normaliseAllowlist(
+      "  Bob@Example.com, alice@example.com,  charlie@example.com  ",
+    );
+    expect(result).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+      "charlie@example.com",
+    ]);
+  });
+
+  it("dedupes case- and whitespace-collapsed addresses", () => {
+    const result = normaliseAllowlist("a@b.com, A@B.COM ,  a@b.com");
+    expect(result).toEqual(["a@b.com"]);
+  });
+
+  it("ignores empty and whitespace-only entries", () => {
+    expect(normaliseAllowlist(",, , a@b.com ,,")).toEqual(["a@b.com"]);
+  });
+
+  it("returns an empty array for null/undefined/empty input", () => {
+    expect(normaliseAllowlist(undefined)).toEqual([]);
+    expect(normaliseAllowlist(null)).toEqual([]);
+    expect(normaliseAllowlist("")).toEqual([]);
+  });
+
+  it("produces the same hash regardless of input order or casing", () => {
+    const a = normaliseAllowlist("alice@x.com, BOB@x.com");
+    const b = normaliseAllowlist("bob@x.com, Alice@X.COM");
+    expect(hashAllowlist(a)).toEqual(hashAllowlist(b));
+  });
+
+  it("produces different hashes when the membership changes", () => {
+    const a = normaliseAllowlist("alice@x.com");
+    const b = normaliseAllowlist("alice@x.com, bob@x.com");
+    expect(hashAllowlist(a)).not.toEqual(hashAllowlist(b));
+  });
+});
+
+describe("diffAllowlists", () => {
+  it("reports added and removed sets disjointly", () => {
+    const result = diffAllowlists(
+      ["alice@x.com", "bob@x.com"],
+      ["bob@x.com", "carol@x.com"],
+    );
+    expect(result.added).toEqual(["carol@x.com"]);
+    expect(result.removed).toEqual(["alice@x.com"]);
+  });
+
+  it("returns empty arrays when the lists are identical", () => {
+    const result = diffAllowlists(["a@x.com"], ["a@x.com"]);
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
+  it("sorts diff output for stable audit payloads", () => {
+    const result = diffAllowlists([], ["zach@x.com", "alice@x.com"]);
+    expect(result.added).toEqual(["alice@x.com", "zach@x.com"]);
+  });
+});
+
+describe("runBootstrapAllowlistAudit — first boot", () => {
+  it("inserts a baseline snapshot and emits the 'initialised' event without alarming", async () => {
+    process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS = "alice@x.com";
+    mockedFindFirst.mockResolvedValue(null);
+    mockedCreate.mockResolvedValue({});
+
+    await runBootstrapAllowlistAudit();
+
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    expect(mockedLogControllerAction).toHaveBeenCalledTimes(1);
+    const entry = mockedLogControllerAction.mock.calls[0]![0];
+    expect(entry.action).toBe(
+      "super_admin.bootstrap_allowlist_initialised",
+    );
+    // Baseline should not trigger the error-level alarm.
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+    expect(mockedLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "super_admin.bootstrap_allowlist_initialised",
+      }),
+    );
+  });
+});
+
+describe("runBootstrapAllowlistAudit — change detection", () => {
+  it("emits change event with diff when the allowlist rotates", async () => {
+    process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS = "alice@x.com, carol@x.com";
+    process.env.RENDER_GIT_COMMIT = "deadbeef";
+    mockedFindFirst.mockResolvedValue({
+      hash: hashAllowlist(["alice@x.com", "bob@x.com"]),
+      emails: ["alice@x.com", "bob@x.com"],
+    });
+    mockedCreate.mockResolvedValue({});
+
+    await runBootstrapAllowlistAudit();
+
+    expect(mockedCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        emails: ["alice@x.com", "carol@x.com"],
+        deploySha: "deadbeef",
+      }),
+    });
+    const entry = mockedLogControllerAction.mock.calls[0]![0];
+    expect(entry.action).toBe("super_admin.bootstrap_allowlist_changed");
+    expect(mockedLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "super_admin.bootstrap_allowlist_changed",
+        added: ["carol@x.com"],
+        removed: ["bob@x.com"],
+        deploySha: "deadbeef",
+      }),
+    );
+  });
+
+  it("is idempotent — no insert when the hash matches the most recent snapshot", async () => {
+    process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS = "alice@x.com";
+    mockedFindFirst.mockResolvedValue({
+      hash: hashAllowlist(["alice@x.com"]),
+      emails: ["alice@x.com"],
+    });
+
+    await runBootstrapAllowlistAudit();
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedLogControllerAction).not.toHaveBeenCalled();
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("only runs once per process (memoised)", async () => {
+    process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS = "alice@x.com";
+    mockedFindFirst.mockResolvedValue({
+      hash: hashAllowlist(["alice@x.com"]),
+      emails: ["alice@x.com"],
+    });
+
+    await runBootstrapAllowlistAudit();
+    await runBootstrapAllowlistAudit();
+    await runBootstrapAllowlistAudit();
+
+    expect(mockedFindFirst).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/auth/bootstrap-audit.ts
+++ b/src/lib/auth/bootstrap-audit.ts
@@ -1,0 +1,192 @@
+// EMR-726 — Boot-time audit for SUPER_ADMIN_BOOTSTRAP_EMAILS rotation.
+//
+// Why this exists: changing the bootstrap allowlist is a security-relevant
+// event. Today the only signal is reading the env var in Render — a silent
+// expansion (e.g. an attacker adding their address) would go unnoticed
+// until someone manually diffed two deploys. This helper closes that gap:
+//
+//   - On first call per Node process, compute a SHA-256 over the
+//     sorted/lowercased/trimmed allowlist.
+//   - If it differs from the most-recent BootstrapAllowlistSnapshot row
+//     (or no prior row exists), insert a new snapshot and emit (a) a
+//     ControllerAuditLog entry via logControllerAction() and (b) a
+//     structured error-level log line so log-aggregator alerts can fire.
+//   - Idempotent: a redeploy with the same env produces no new row and
+//     no alarm.
+//
+// The "first-boot" path uses a distinct action name
+// (super_admin.bootstrap_allowlist_initialised) so SIEM rules can
+// differentiate "fresh install" from "the allowlist changed".
+
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import type { Role } from "@prisma/client";
+
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+
+import { logControllerAction } from "./audit-stub";
+
+/**
+ * Parse + normalise the allowlist exactly the same way
+ * `bootstrapAllowlist()` in super-admin-bootstrap.ts does, but without
+ * the env-flag gating — we want to observe the raw rotation even when
+ * SUPER_ADMIN_BOOTSTRAP_ENABLED is off. (The kill-switch governs *use*,
+ * not visibility.)
+ */
+export function normaliseAllowlist(raw: string | undefined | null): string[] {
+  const value = raw ?? "";
+  const seen = new Set<string>();
+  for (const part of value.split(",")) {
+    const cleaned = part.trim().toLowerCase();
+    if (cleaned.length > 0) seen.add(cleaned);
+  }
+  return [...seen].sort();
+}
+
+/**
+ * SHA-256 hex over the canonical comma-joined form.
+ */
+export function hashAllowlist(emails: string[]): string {
+  return createHash("sha256").update(emails.join(",")).digest("hex");
+}
+
+export interface AllowlistDiff {
+  added: string[];
+  removed: string[];
+}
+
+/**
+ * Set-diff of two sorted email arrays. Output arrays are sorted for
+ * deterministic logging/audit payloads.
+ */
+export function diffAllowlists(
+  prev: string[],
+  next: string[],
+): AllowlistDiff {
+  const prevSet = new Set(prev);
+  const nextSet = new Set(next);
+  const added = next.filter((e) => !prevSet.has(e)).sort();
+  const removed = prev.filter((e) => !nextSet.has(e)).sort();
+  return { added, removed };
+}
+
+function resolveDeploySha(): string | null {
+  return (
+    process.env.RENDER_GIT_COMMIT ||
+    process.env.GIT_SHA ||
+    null
+  );
+}
+
+/**
+ * System actor used for the audit row. The bootstrap-diff event is
+ * synthesised by the app at boot — there's no human actor. Using a
+ * stable synthetic id makes these rows easy to filter out (or in) when
+ * querying ControllerAuditLog.
+ */
+const SYSTEM_ACTOR: {
+  id: string;
+  email: string;
+  roles: Role[];
+  organizationId: string | null;
+} = {
+  id: "system:bootstrap-diff",
+  email: "system@leafjourney.local",
+  roles: ["system"],
+  organizationId: null,
+};
+
+/**
+ * Memoise so the audit runs once per Node process, not per request — the
+ * snapshot table only needs the boot-time observation, and re-running on
+ * every request would burn DB round-trips for zero added signal.
+ */
+let auditPromise: Promise<void> | null = null;
+
+export function runBootstrapAllowlistAudit(): Promise<void> {
+  if (auditPromise !== null) return auditPromise;
+  auditPromise = doAudit().catch((err) => {
+    // Don't poison the cache on failure — let a subsequent call retry
+    // (e.g. transient DB unavailability at cold-start).
+    auditPromise = null;
+    logger.error({
+      event: "super_admin.bootstrap_allowlist_audit_failed",
+      err: err instanceof Error ? err.message : String(err),
+    });
+  });
+  return auditPromise;
+}
+
+async function doAudit(): Promise<void> {
+  const emails = normaliseAllowlist(process.env.SUPER_ADMIN_BOOTSTRAP_EMAILS);
+  const hash = hashAllowlist(emails);
+  const deploySha = resolveDeploySha();
+
+  const previous = await prisma.bootstrapAllowlistSnapshot.findFirst({
+    orderBy: { createdAt: "desc" },
+    select: { hash: true, emails: true },
+  });
+
+  if (previous && previous.hash === hash) {
+    // Idempotent reboot — no change, no row, no alarm.
+    return;
+  }
+
+  await prisma.bootstrapAllowlistSnapshot.create({
+    data: { hash, emails, deploySha },
+  });
+
+  if (!previous) {
+    // First-boot path: record the baseline but don't alarm. There's
+    // nothing to diff against yet, and treating cold-start as a
+    // "change" would just create noise.
+    await logControllerAction({
+      actor: SYSTEM_ACTOR,
+      action: "super_admin.bootstrap_allowlist_initialised",
+      targetId: "bootstrap-allowlist",
+      after: { emails, hash, deploySha },
+      reason: "Baseline snapshot captured at first boot.",
+    });
+    logger.info({
+      event: "super_admin.bootstrap_allowlist_initialised",
+      deploySha,
+      size: emails.length,
+    });
+    return;
+  }
+
+  const { added, removed } = diffAllowlists(previous.emails, emails);
+
+  await logControllerAction({
+    actor: SYSTEM_ACTOR,
+    action: "super_admin.bootstrap_allowlist_changed",
+    targetId: "bootstrap-allowlist",
+    before: { emails: previous.emails, hash: previous.hash },
+    after: { emails, hash, deploySha },
+    reason:
+      `Allowlist rotated between deploys — ` +
+      `+${added.length} / -${removed.length}.`,
+  });
+
+  // Error-level so log-aggregator alarms fire. Emails appear only inside
+  // the structured payload, never as a raw logger.info line.
+  logger.error({
+    event: "super_admin.bootstrap_allowlist_changed",
+    added,
+    removed,
+    fromHash: previous.hash,
+    toHash: hash,
+    deploySha,
+  });
+}
+
+/**
+ * Reset the memoised audit — exported for tests only. Production code
+ * relies on the once-per-process semantics.
+ */
+export function __resetBootstrapAllowlistAuditForTests(): void {
+  auditPromise = null;
+}

--- a/src/lib/auth/super-admin-bootstrap.ts
+++ b/src/lib/auth/super-admin-bootstrap.ts
@@ -23,6 +23,7 @@ import "server-only";
 
 import { prisma } from "@/lib/db/prisma";
 import { logger } from "@/lib/observability/log";
+import { runBootstrapAllowlistAudit } from "./bootstrap-audit";
 import type { AuthedUser } from "./session";
 
 export const LEAFJOURNEY_HQ_SLUG = "leafjourney-hq";
@@ -90,6 +91,10 @@ export async function ensureLeafjourneyHq(): Promise<string> {
 export async function bootstrapSuperAdminIfAllowlisted(
   user: AuthedUser,
 ): Promise<boolean> {
+  // Fire-and-forget the rotation audit. Memoised in bootstrap-audit.ts so
+  // this is effectively zero-cost after the first request per process.
+  void runBootstrapAllowlistAudit();
+
   if (user.roles.includes("super_admin")) return false;
   const allowlist = bootstrapAllowlist();
   if (allowlist.size === 0) return false;


### PR DESCRIPTION
## Summary
- Detects SUPER_ADMIN_BOOTSTRAP_EMAILS rotations between deploys via a SHA-256 over the sorted/lowercased allowlist; idempotent reboots produce no row and no alarm, but any change writes a `BootstrapAllowlistSnapshot` row + a `ControllerAuditLog` entry (`super_admin.bootstrap_allowlist_changed`) + an error-level structured log line.
- New `/admin/bootstrap` page (server component, gated by `(super-admin)/layout.tsx`) showing the current parsed allowlist with per-email promoted/pending status and the last 50 snapshots with added/removed diffs.
- Additive Prisma model only; the audit runs once per Node process, called lazily from `bootstrapSuperAdminIfAllowlisted()` so it never blocks a request.

Linear: https://linear.app/emr-project/issue/EMR-726

## Test plan
- [x] new unit tests pass (13 tests in `bootstrap-audit.test.ts`)
- [x] full auth suite green (29 tests)
- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new warnings from this change
- [x] `node scripts/check-route-auth-manifest.mjs` passes (page route, no API surface added)
- [x] `npx prisma generate` runs cleanly
- [ ] `/admin/bootstrap` renders against a real DB after migration applies on Render

🤖 Generated with [Claude Code](https://claude.com/claude-code)