### PR TITLE
feat(super-admin): practice health score model + scoring cron (EMR-732)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -392,6 +392,12 @@ routes:
     owner: scheduling
     notes: "Closed via PR #243 — prod hard-refuses without CRON_SECRET, non-prod logs and falls through (200 in dev). Find-and-fix pass 4 confirmed dev fall-through; prod path is gated by NODE_ENV check."
 
+  cron/practice-health:
+    methods: [POST]
+    auth: cron
+    owner: super-admin
+    notes: "EMR-732. Bearer CRON_SECRET, prod-only fail-closed, dev fall-through (matches cron/credential-check). Per-org cooldown via PRACTICE_HEALTH_MIN_AGE_SECONDS (default 300s); batch capped at 200 organizations per invocation."
+
   # ── Token-URL access ──────────────────────────────────────
   emergency/[token]:
     methods: [GET]

--- a/prisma/migrations/20260517000000_add_practice_health/migration.sql
+++ b/prisma/migrations/20260517000000_add_practice_health/migration.sql
@@ -1,0 +1,22 @@
+-- EMR-732 — PracticeHealth: per-practice composite health score.
+--
+-- Additive: a new denormalized table populated by the
+-- `cron/practice-health` route. No FK constraint on organizationId in
+-- v1 — the cron pre-filters to live practices and the row is
+-- idempotently upserted; we'd rather not couple cron writes to
+-- Organization existence checks at this layer.
+
+CREATE TABLE "PracticeHealth" (
+  "id"             TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "score"          INTEGER NOT NULL,
+  "breakdown"      JSONB NOT NULL,
+  "computedAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PracticeHealth_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PracticeHealth_organizationId_key" ON "PracticeHealth"("organizationId");
+CREATE INDEX "PracticeHealth_score_idx" ON "PracticeHealth"("score");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4207,6 +4207,31 @@ model MigrationProfile {
   @@index([status])
 }
 
+// EMR-732 — Per-practice composite health score (0–100).
+//
+// Denormalized snapshot recomputed at most every 5 minutes by the
+// cron at `src/app/api/cron/practice-health/route.ts`. The HQ
+// dashboard (E1) reads `score` and `breakdown` directly off this
+// table rather than running aggregate queries at request time.
+//
+// `breakdown` is a stable JSON shape:
+//   { publish: number, agentErrors: number, billing: number, loginFailures: number }
+// Any change to the keys is a contract break for the HQ dashboard.
+//
+// PHI posture: rates and integer subscores only — never names, IDs
+// beyond `organizationId`, claim numbers, or any patient field.
+model PracticeHealth {
+  id             String   @id @default(cuid())
+  organizationId String   @unique
+  score          Int
+  breakdown      Json
+  computedAt     DateTime @default(now())
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@index([score])
+}
+
 // --------------------------------------------------------------
 // Leafly Integrations & Strain Parsers
 // --------------------------------------------------------------

--- a/src/app/api/cron/practice-health/route.ts
+++ b/src/app/api/cron/practice-health/route.ts
@@ -1,0 +1,158 @@
+// EMR-732 — Per-practice health scoring cron.
+//
+// Recomputes the `PracticeHealth` row for every live practice at
+// most every 5 minutes. The HQ dashboard (E1) reads `score` and
+// `breakdown` off the denormalized layer so request-time aggregates
+// stay cheap.
+//
+// Auth posture mirrors `cron/coa-tracker` and `cron/credential-check`:
+// Bearer `CRON_SECRET`, prod-only fail-closed, dev fall-through.
+//
+// Throughput: capped at 200 organizations per invocation to stay
+// inside the platform request timeout. Render schedules this every
+// minute; the per-practice cooldown (`PRACTICE_HEALTH_MIN_AGE_SECONDS`,
+// default 300) prevents recompute thrash.
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import { computePracticeHealth } from "@/lib/practice-health/scorer";
+
+export const runtime = "nodejs";
+
+const DEFAULT_MIN_AGE_SECONDS = 300; // 5 minutes
+const BATCH_LIMIT = 200;
+
+// System actor used for the audit row. The controller audit table
+// requires an actor; the cron isn't a person, so we synthesize a
+// stable system identity tagged with the `system` role.
+const SYSTEM_ACTOR = {
+  id: "system:cron:practice-health",
+  email: "system@cron.practice-health",
+  roles: ["system" as const],
+  organizationId: null,
+};
+
+function isAuthorized(req: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  const authHeader = req.headers.get("authorization") ?? "";
+
+  // Prod-only fail-closed: outside production we fall through so
+  // local cron exercising doesn't need the secret. Matches the
+  // pattern in cron/credential-check.
+  if (process.env.NODE_ENV !== "production") return true;
+
+  if (!secret) return false;
+  return authHeader === `Bearer ${secret}`;
+}
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const minAgeSeconds = Number(
+    process.env.PRACTICE_HEALTH_MIN_AGE_SECONDS ?? DEFAULT_MIN_AGE_SECONDS,
+  );
+  const cooldownMs = (Number.isFinite(minAgeSeconds) ? minAgeSeconds : DEFAULT_MIN_AGE_SECONDS) * 1000;
+  const cooldownCutoff = new Date(Date.now() - cooldownMs);
+
+  try {
+    // 1) Find live practices (published configs). One row per org —
+    // dedupe at the cron-input layer so we don't double-score multi-config
+    // orgs in a single sweep.
+    const liveConfigs = await prisma.practiceConfiguration.findMany({
+      where: { status: "published" },
+      select: { organizationId: true },
+      distinct: ["organizationId"],
+      take: BATCH_LIMIT,
+      orderBy: { updatedAt: "asc" }, // oldest first → most-stale practices score first
+    });
+
+    // 2) Pull existing PracticeHealth rows so we can skip ones that
+    // were scored within the cooldown window.
+    const orgIds = liveConfigs.map((c) => c.organizationId);
+    const existing = await prisma.practiceHealth.findMany({
+      where: { organizationId: { in: orgIds } },
+      select: { organizationId: true, computedAt: true },
+    });
+    const lastComputedById = new Map<string, Date>();
+    for (const row of existing) {
+      lastComputedById.set(row.organizationId, row.computedAt);
+    }
+
+    let scored = 0;
+    let skipped = 0;
+    const scores: number[] = [];
+
+    for (const { organizationId } of liveConfigs) {
+      const lastComputed = lastComputedById.get(organizationId);
+      if (lastComputed && lastComputed > cooldownCutoff) {
+        skipped++;
+        continue;
+      }
+
+      try {
+        const { score, breakdown } = await computePracticeHealth(prisma, organizationId);
+        await prisma.practiceHealth.upsert({
+          where: { organizationId },
+          create: { organizationId, score, breakdown },
+          update: { score, breakdown, computedAt: new Date() },
+        });
+        scored++;
+        scores.push(score);
+      } catch (err) {
+        // Single-practice failure shouldn't poison the whole sweep.
+        logger.error({
+          event: "cron.practice_health.score_failed",
+          organizationId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const scanned = liveConfigs.length;
+    const mean = scores.length ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : null;
+    const min = scores.length ? Math.min(...scores) : null;
+    const max = scores.length ? Math.max(...scores) : null;
+
+    logger.info({
+      event: "cron.practice_health.swept",
+      scanned,
+      scored,
+      skipped,
+      mean,
+      min,
+      max,
+      durationMs: Date.now() - startedAt,
+    });
+
+    await logControllerAction({
+      actor: SYSTEM_ACTOR,
+      action: "controller.practice_health.swept",
+      targetId: "cron:practice-health",
+      after: { scanned, scored, skipped, mean, min, max },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      scanned,
+      scored,
+      skipped,
+      mean,
+      min,
+      max,
+    });
+  } catch (err) {
+    logger.error({
+      event: "cron.practice_health.failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "practice-health sweep failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/practice-health/scorer.test.ts
+++ b/src/lib/practice-health/scorer.test.ts
@@ -1,0 +1,288 @@
+// EMR-732 — Unit tests for the per-practice health scorer.
+//
+// We mock Prisma rather than spin up a DB; the contract under test is
+// purely the math + thresholds. Each sub-metric gets its own block
+// covering boundary inputs; the composite block covers weighting and
+// the clamp.
+
+import { describe, it, expect } from "vitest";
+import {
+  WEIGHTS,
+  computePracticeHealth,
+  scoreAgentErrorRate,
+  scoreBillingTrend,
+  scoreLoginFailureRate,
+  scorePublishHealth,
+} from "./scorer";
+
+const ORG = "org_1";
+const NOW = new Date("2026-05-17T12:00:00Z");
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// ── Helpers ────────────────────────────────────────────────────
+
+type ConfigRow = { status: string; updatedAt: Date };
+
+function prismaWithConfig(row: ConfigRow | null) {
+  return {
+    practiceConfiguration: {
+      findFirst: async () => row,
+    },
+    controllerAuditLog: { count: async () => 0 },
+    claim: {
+      aggregate: async () => ({ _sum: { billedAmountCents: 0 } }),
+    },
+  } as unknown as Parameters<typeof scorePublishHealth>[0];
+}
+
+function prismaWithErrors(count: number) {
+  return {
+    practiceConfiguration: { findFirst: async () => null },
+    controllerAuditLog: { count: async () => count },
+    claim: {
+      aggregate: async () => ({ _sum: { billedAmountCents: 0 } }),
+    },
+  } as unknown as Parameters<typeof scoreAgentErrorRate>[0];
+}
+
+function prismaWithBilling(recentCents: number, priorCents: number) {
+  let call = 0;
+  return {
+    practiceConfiguration: { findFirst: async () => null },
+    controllerAuditLog: { count: async () => 0 },
+    claim: {
+      aggregate: async () => {
+        const idx = call++;
+        const total = idx === 0 ? recentCents : priorCents;
+        return { _sum: { billedAmountCents: total } };
+      },
+    },
+  } as unknown as Parameters<typeof scoreBillingTrend>[0];
+}
+
+// ── WEIGHTS invariant ──────────────────────────────────────────
+
+describe("WEIGHTS", () => {
+  it("sums to 100", () => {
+    const total =
+      WEIGHTS.publish +
+      WEIGHTS.agentErrors +
+      WEIGHTS.billing +
+      WEIGHTS.loginFailures;
+    expect(total).toBe(100);
+  });
+});
+
+// ── Publish ────────────────────────────────────────────────────
+
+describe("scorePublishHealth", () => {
+  it("returns 0 when no configuration exists", async () => {
+    expect(await scorePublishHealth(prismaWithConfig(null), ORG, NOW)).toBe(0);
+  });
+
+  it("returns 0 when archived", async () => {
+    const row = { status: "archived", updatedAt: new Date(NOW.getTime() - HOUR_MS) };
+    expect(await scorePublishHealth(prismaWithConfig(row), ORG, NOW)).toBe(0);
+  });
+
+  it("returns 100 for fresh published config", async () => {
+    const row = { status: "published", updatedAt: new Date(NOW.getTime() - HOUR_MS) };
+    expect(await scorePublishHealth(prismaWithConfig(row), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 100 for steady-state published config (old updatedAt)", async () => {
+    const row = { status: "published", updatedAt: new Date(NOW.getTime() - 7 * DAY_MS) };
+    expect(await scorePublishHealth(prismaWithConfig(row), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 30 for fresh draft", async () => {
+    const row = { status: "draft", updatedAt: new Date(NOW.getTime() - HOUR_MS) };
+    expect(await scorePublishHealth(prismaWithConfig(row), ORG, NOW)).toBe(30);
+  });
+
+  it("returns 50 for stale draft (stuck mid-publish)", async () => {
+    const row = { status: "draft", updatedAt: new Date(NOW.getTime() - 2 * DAY_MS) };
+    expect(await scorePublishHealth(prismaWithConfig(row), ORG, NOW)).toBe(50);
+  });
+});
+
+// ── Agent errors ───────────────────────────────────────────────
+
+describe("scoreAgentErrorRate", () => {
+  it("returns 100 at 0 errors", async () => {
+    expect(await scoreAgentErrorRate(prismaWithErrors(0), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 100 at the upper edge of the green bucket (2)", async () => {
+    expect(await scoreAgentErrorRate(prismaWithErrors(2), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 70 in the next bucket (3..10)", async () => {
+    expect(await scoreAgentErrorRate(prismaWithErrors(3), ORG, NOW)).toBe(70);
+    expect(await scoreAgentErrorRate(prismaWithErrors(10), ORG, NOW)).toBe(70);
+  });
+
+  it("returns 40 for 11..30", async () => {
+    expect(await scoreAgentErrorRate(prismaWithErrors(11), ORG, NOW)).toBe(40);
+    expect(await scoreAgentErrorRate(prismaWithErrors(30), ORG, NOW)).toBe(40);
+  });
+
+  it("returns 10 above 30", async () => {
+    expect(await scoreAgentErrorRate(prismaWithErrors(31), ORG, NOW)).toBe(10);
+    expect(await scoreAgentErrorRate(prismaWithErrors(500), ORG, NOW)).toBe(10);
+  });
+});
+
+// ── Billing trend ──────────────────────────────────────────────
+
+describe("scoreBillingTrend", () => {
+  it("returns 100 when prior window is zero (new practice)", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(0, 0), ORG, NOW)).toBe(100);
+    expect(await scoreBillingTrend(prismaWithBilling(10_000, 0), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 100 for flat or growing claim volume", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(10_000, 10_000), ORG, NOW)).toBe(100);
+    expect(await scoreBillingTrend(prismaWithBilling(15_000, 10_000), ORG, NOW)).toBe(100);
+  });
+
+  it("returns 80 for a drop ≤ 10%", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(9_500, 10_000), ORG, NOW)).toBe(80);
+    expect(await scoreBillingTrend(prismaWithBilling(9_000, 10_000), ORG, NOW)).toBe(80);
+  });
+
+  it("returns 50 for a drop ≤ 30%", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(8_000, 10_000), ORG, NOW)).toBe(50);
+    expect(await scoreBillingTrend(prismaWithBilling(7_000, 10_000), ORG, NOW)).toBe(50);
+  });
+
+  it("returns 25 for a drop ≤ 60%", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(6_000, 10_000), ORG, NOW)).toBe(25);
+    expect(await scoreBillingTrend(prismaWithBilling(4_000, 10_000), ORG, NOW)).toBe(25);
+  });
+
+  it("returns 0 for a drop > 60%", async () => {
+    expect(await scoreBillingTrend(prismaWithBilling(3_000, 10_000), ORG, NOW)).toBe(0);
+    expect(await scoreBillingTrend(prismaWithBilling(0, 10_000), ORG, NOW)).toBe(0);
+  });
+});
+
+// ── Login failures (placeholder) ───────────────────────────────
+
+describe("scoreLoginFailureRate", () => {
+  it("returns the constant baseline (100) until a real source lands", async () => {
+    const prisma = prismaWithConfig(null);
+    expect(await scoreLoginFailureRate(prisma, ORG, NOW)).toBe(100);
+  });
+});
+
+// ── Composite ──────────────────────────────────────────────────
+
+describe("computePracticeHealth", () => {
+  it("returns the weighted average of sub-metric scores", async () => {
+    const prisma = {
+      practiceConfiguration: {
+        findFirst: async () => ({
+          status: "published",
+          updatedAt: new Date(NOW.getTime() - HOUR_MS),
+        }),
+      },
+      controllerAuditLog: { count: async () => 0 }, // → 100
+      claim: {
+        aggregate: async () => ({ _sum: { billedAmountCents: 100 } }), // flat → 100
+      },
+    } as unknown as Parameters<typeof computePracticeHealth>[0];
+
+    const result = await computePracticeHealth(prisma, ORG, NOW);
+    // All four sub-metrics are 100 → composite is 100.
+    expect(result.score).toBe(100);
+    expect(result.breakdown).toEqual({
+      publish: 100,
+      agentErrors: 100,
+      billing: 100,
+      loginFailures: 100,
+    });
+  });
+
+  it("weights each sub-metric by its declared weight", async () => {
+    // publish=0 (no config), agentErrors=70 (3..10), billing=0
+    // (>60% drop), loginFailures=100 (constant).
+    let claimCalls = 0;
+    const prisma = {
+      practiceConfiguration: { findFirst: async () => null },
+      controllerAuditLog: { count: async () => 5 },
+      claim: {
+        aggregate: async () => {
+          const idx = claimCalls++;
+          const total = idx === 0 ? 1_000 : 10_000;
+          return { _sum: { billedAmountCents: total } };
+        },
+      },
+    } as unknown as Parameters<typeof computePracticeHealth>[0];
+
+    const result = await computePracticeHealth(prisma, ORG, NOW);
+
+    // Hand-rolled expected:
+    //   publish=0 → 0 * 30
+    //   agentErrors=70 → 70 * 25 = 1750
+    //   billing=0 → 0 * 30
+    //   loginFailures=100 → 100 * 15 = 1500
+    //   total = 3250 / 100 = 32.5 → round → 33
+    expect(result.score).toBe(33);
+    expect(result.breakdown).toEqual({
+      publish: 0,
+      agentErrors: 70,
+      billing: 0,
+      loginFailures: 100,
+    });
+  });
+
+  it("clamps a hypothetical underflow to 0", async () => {
+    // Cannot drive any real sub-metric below 0, so we exercise the
+    // clamp by stubbing the underlying aggregate paths and feeding
+    // hostile values. We do this by spying on the round path: the
+    // smallest legal composite is when every sub-metric is 0.
+    const prisma = {
+      practiceConfiguration: {
+        findFirst: async () => ({
+          status: "archived",
+          updatedAt: NOW,
+        }),
+      },
+      controllerAuditLog: { count: async () => 999 }, // → 10
+      claim: {
+        // Forced large drop → billing=0
+        aggregate: async () => ({ _sum: { billedAmountCents: 0 } }),
+      },
+    } as unknown as Parameters<typeof computePracticeHealth>[0];
+
+    const result = await computePracticeHealth(prisma, ORG, NOW);
+    // publish=0, agentErrors=10, billing=100 (prior=0 path),
+    // loginFailures=100
+    //   = 0*30 + 10*25 + 100*30 + 100*15
+    //   = 250 + 3000 + 1500 = 4750 / 100 = 47.5 → 48
+    expect(result.score).toBe(48);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  it("never exceeds 100", async () => {
+    const prisma = {
+      practiceConfiguration: {
+        findFirst: async () => ({
+          status: "published",
+          updatedAt: new Date(NOW.getTime() - HOUR_MS),
+        }),
+      },
+      controllerAuditLog: { count: async () => 0 },
+      claim: {
+        aggregate: async () => ({ _sum: { billedAmountCents: 1_000_000 } }),
+      },
+    } as unknown as Parameters<typeof computePracticeHealth>[0];
+
+    const result = await computePracticeHealth(prisma, ORG, NOW);
+    expect(result.score).toBeLessThanOrEqual(100);
+    expect(result.score).toBe(100);
+  });
+});

--- a/src/lib/practice-health/scorer.ts
+++ b/src/lib/practice-health/scorer.ts
@@ -1,0 +1,248 @@
+// EMR-732 — Per-practice composite health scorer.
+//
+// Computes a 0–100 composite score per organization from four
+// independent signals. Each sub-metric is its own pure exported
+// function so it can be unit-tested in isolation. The composite is a
+// weighted average rounded to an integer and clamped to [0, 100].
+//
+// Weighting:
+//   publish        30%  — is the practice live and not stuck mid-publish?
+//   agentErrors    25%  — are agents quietly erroring out over the last day?
+//   billing        30%  — is the practice's claim volume trending healthy?
+//   loginFailures  15%  — are users locked out / under attack?
+//
+// HQ score-to-color thresholds (consumed by E1 dashboard):
+//   green   ≥ 80
+//   yellow  60 – 79
+//   orange  40 – 59
+//   red     < 40
+//
+// PHI posture: returns counts, rates, and integer subscores only.
+// No names, no patient IDs, no claim numbers. The cron is responsible
+// for persisting the breakdown verbatim — keep this contract stable;
+// the HQ dashboard (E1) reads `breakdown.*` keys directly.
+
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Weights for each sub-metric. MUST sum to 100. Asserted in the unit
+ * test for this module — do not edit one without re-balancing the
+ * others.
+ */
+export const WEIGHTS = {
+  publish: 30,
+  agentErrors: 25,
+  billing: 30,
+  loginFailures: 15,
+} as const;
+
+export type Breakdown = {
+  publish: number;
+  agentErrors: number;
+  billing: number;
+  loginFailures: number;
+};
+
+export type PracticeHealthResult = {
+  score: number;
+  breakdown: Breakdown;
+};
+
+/**
+ * Anything that quacks like a Prisma client for the three models this
+ * scorer touches. Narrowed (vs `PrismaClient`) so tests can stub it
+ * without recreating the full client surface.
+ */
+export type PrismaLike = Pick<
+  PrismaClient,
+  "practiceConfiguration" | "controllerAuditLog" | "claim"
+>;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Clamp `value` to the closed interval [min, max].
+ */
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Publish-health subscore.
+ *
+ *   published & updated within the last 24h    → 100
+ *   published but `updatedAt` > 24h ago        → 100 (steady-state live)
+ *   draft / non-terminal & updated > 24h ago   → 50  (stuck mid-publish)
+ *   draft (recent)                             → 30
+ *   no configuration at all                    → 0
+ *
+ * "Stuck mid-publish" means the configuration is in a non-terminal
+ * state (draft) and hasn't moved in over 24 hours. Practices that have
+ * been deliberately archived score 0 — they shouldn't be live.
+ */
+export async function scorePublishHealth(
+  prisma: PrismaLike,
+  organizationId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const config = await prisma.practiceConfiguration.findFirst({
+    where: { organizationId },
+    orderBy: { updatedAt: "desc" },
+    select: { status: true, updatedAt: true },
+  });
+
+  if (!config) return 0;
+  if (config.status === "archived") return 0;
+
+  const ageMs = now.getTime() - new Date(config.updatedAt).getTime();
+  const stale = ageMs > DAY_MS;
+
+  if (config.status === "published") {
+    // Steady-state live is fine; only published-but-stuck is suspect,
+    // and we don't have a "publishing" intermediate state in v1.
+    return 100;
+  }
+
+  // status === "draft"
+  if (stale) return 50;
+  return 30;
+}
+
+/**
+ * Agent error-rate subscore.
+ *
+ * Counts `ControllerAuditLog` rows in the last 24h scoped to this org
+ * whose `action` ends with `.error`. Buckets:
+ *
+ *   ≤ 2   → 100
+ *   ≤ 10  → 70
+ *   ≤ 30  → 40
+ *   > 30  → 10
+ */
+export async function scoreAgentErrorRate(
+  prisma: PrismaLike,
+  organizationId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const since = new Date(now.getTime() - DAY_MS);
+
+  const count = await prisma.controllerAuditLog.count({
+    where: {
+      organizationId,
+      at: { gte: since },
+      action: { endsWith: ".error" },
+    },
+  });
+
+  if (count <= 2) return 100;
+  if (count <= 10) return 70;
+  if (count <= 30) return 40;
+  return 10;
+}
+
+/**
+ * Billing-trend subscore.
+ *
+ * Compares `Claim.billedAmountCents` summed over the last 7 days
+ * against the prior 7-day window (days 8–14).
+ *
+ *   growth   ≥   0%  → 100
+ *   drop     ≤  10%  → 80
+ *   drop     ≤  30%  → 50
+ *   drop     ≤  60%  → 25
+ *   drop     >  60%  → 0
+ *
+ * Edge case: if the prior window is zero (new practice, no claims
+ * yet), we return 100 — we don't have enough signal to call it
+ * unhealthy.
+ */
+export async function scoreBillingTrend(
+  prisma: PrismaLike,
+  organizationId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const recentSince = new Date(now.getTime() - 7 * DAY_MS);
+  const priorSince = new Date(now.getTime() - 14 * DAY_MS);
+  const priorUntil = recentSince;
+
+  const [recent, prior] = await Promise.all([
+    prisma.claim.aggregate({
+      where: {
+        organizationId,
+        serviceDate: { gte: recentSince, lte: now },
+      },
+      _sum: { billedAmountCents: true },
+    }),
+    prisma.claim.aggregate({
+      where: {
+        organizationId,
+        serviceDate: { gte: priorSince, lt: priorUntil },
+      },
+      _sum: { billedAmountCents: true },
+    }),
+  ]);
+
+  const recentTotal = recent._sum.billedAmountCents ?? 0;
+  const priorTotal = prior._sum.billedAmountCents ?? 0;
+
+  if (priorTotal === 0) return 100;
+
+  const delta = (recentTotal - priorTotal) / priorTotal;
+  if (delta >= 0) return 100;
+
+  const dropPct = -delta;
+  if (dropPct <= 0.1) return 80;
+  if (dropPct <= 0.3) return 50;
+  if (dropPct <= 0.6) return 25;
+  return 0;
+}
+
+/**
+ * Login-failure-rate subscore.
+ *
+ * NOTE(EMR-732 follow-up): there is no first-class auth-failure log
+ * in the schema yet. Until one lands we return a constant baseline
+ * of 100 — assuming healthy until proven otherwise. The PR body
+ * tracks this as a follow-up so the gap is visible.
+ */
+export async function scoreLoginFailureRate(
+  _prisma: PrismaLike,
+  _organizationId: string,
+  _now: Date = new Date(),
+): Promise<number> {
+  return 100;
+}
+
+/**
+ * Compose the four sub-metrics into a single 0–100 score, rounded
+ * and clamped. Pure: makes no DB writes; just reads via the four
+ * sub-metric helpers above. The cron is responsible for persisting.
+ */
+export async function computePracticeHealth(
+  prisma: PrismaLike,
+  organizationId: string,
+  now: Date = new Date(),
+): Promise<PracticeHealthResult> {
+  const [publish, agentErrors, billing, loginFailures] = await Promise.all([
+    scorePublishHealth(prisma, organizationId, now),
+    scoreAgentErrorRate(prisma, organizationId, now),
+    scoreBillingTrend(prisma, organizationId, now),
+    scoreLoginFailureRate(prisma, organizationId, now),
+  ]);
+
+  const weighted =
+    (publish * WEIGHTS.publish +
+      agentErrors * WEIGHTS.agentErrors +
+      billing * WEIGHTS.billing +
+      loginFailures * WEIGHTS.loginFailures) /
+    100;
+
+  const score = clamp(Math.round(weighted), 0, 100);
+
+  return {
+    score,
+    breakdown: { publish, agentErrors, billing, loginFailures },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds the `PracticeHealth` Prisma model (organizationId-unique, integer 0-100 `score`, stable JSON `breakdown`, `computedAt`) and the migration `20260517000000_add_practice_health`. Denormalized layer the HQ dashboard (E1) reads directly so it doesn't run aggregate queries at request time.
- New scorer at `src/lib/practice-health/scorer.ts` with `WEIGHTS` declared at the top (sum to 100; asserted in tests) and four pure exported sub-metrics: `scorePublishHealth`, `scoreAgentErrorRate`, `scoreBillingTrend`, `scoreLoginFailureRate`. Composite `computePracticeHealth` does a weighted average, rounds, and clamps to [0, 100]. No DB writes from the scorer.
- New cron route `src/app/api/cron/practice-health/route.ts` mirroring `cron/coa-tracker` / `cron/credential-check`: Bearer `CRON_SECRET`, prod-only fail-closed + dev fall-through, batch capped at 200 orgs per invocation, per-org cooldown via `PRACTICE_HEALTH_MIN_AGE_SECONDS` (default 300s). Upserts one row per org and emits one `controller.practice_health.swept` audit entry with `{ scanned, scored, skipped, mean, min, max }`.
- Manifest entry added to `docs/security/route-auth.yaml`; `check-route-auth-manifest.mjs` passes.
- 23 unit tests in `scorer.test.ts` — per-sub-metric thresholds, the `WEIGHTS` invariant, composite weighting, and clamp bounds.

Linear: https://linear.app/emr-project/issue/EMR-732

## Sub-metric source decisions

| Sub-metric | Source | Notes |
| --- | --- | --- |
| `publish` | latest `PracticeConfiguration` for the org | `published` -> 100; `draft` & stale (>24h) -> 50 (stuck mid-publish); fresh `draft` -> 30; `archived` or no config -> 0. |
| `agentErrors` | `ControllerAuditLog` rows in last 24h with `action` endsWith `.error`, scoped to `organizationId` | Buckets per spec: <=2 -> 100, <=10 -> 70, <=30 -> 40, else 10. |
| `billing` | `Claim.billedAmountCents` summed over `serviceDate` last 7d vs prior 7d | Growth >=0 -> 100; drop <=10% -> 80; <=30% -> 50; <=60% -> 25; more -> 0. **Prior window of zero -> 100** (new practices shouldn't be flagged unhealthy from a lack of history). |
| `loginFailures` | **Constant baseline 100** | No first-class auth-failure log in the schema yet. The function signature + call site are wired so we can swap the body in a follow-up without touching the composite or the cron. **Follow-up needed before this signal carries real weight in HQ alerting.** |

## Guardrails honoured

- [x] Additive Prisma migration only
- [x] `breakdown` JSON carries only integer subscores -- no PHI, no patient/claim IDs
- [x] Batch capped at 200 to stay inside the request timeout
- [x] No HQ surfacing in this PR (owned by E2 detector tickets)
- [x] No charting library introduced
- [x] Constant-baseline fallback for `loginFailures` documented above

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings in unrelated files)
- [x] `node scripts/check-route-auth-manifest.mjs` -> "manifest in sync (108 routes, 16 pending review)"
- [x] `npx prisma generate` succeeds
- [x] `npx vitest run src/lib/practice-health/scorer.test.ts` -> 23/23 passing
- [ ] On merge: `prisma migrate deploy` on Render applies `20260517000000_add_practice_health` cleanly
- [ ] On deploy: cron tick at `POST /api/cron/practice-health` returns 200 with the `{ scanned, scored, skipped, mean, min, max }` payload and emits the `controller.practice_health.swept` audit row

Generated with [Claude Code](https://claude.com/claude-code)