### PR TITLE
feat(super-admin): anomaly detector framework + sweep cron (EMR-734)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -374,6 +374,13 @@ routes:
     notes: "HMAC-SHA256 timing-safe verification, fail-closed on missing secret."
 
   # ── Cron (inbound triggers) ───────────────────────────────
+  cron/anomaly-sweep:
+    methods: [POST]
+    auth: cron
+    owner: platform-security
+    rate_limit_bucket: cron.anomaly-sweep
+    notes: "EMR-734. Bearer CRON_SECRET check, prod-only (non-prod falls through — same pattern as cron/audit-export). Runs registered anomaly detectors and upserts results into the Anomaly table; auto-resolves rows the detector stops emitting and TTL-expires stale rows. Registry is intentionally empty until EMR-737/740/741 land — sweep returns 200 with detectorsRun=0 in the interim."
+
   cron/audit-export:
     methods: [POST]
     auth: cron

--- a/prisma/migrations/20260517130000_add_anomaly_framework/migration.sql
+++ b/prisma/migrations/20260517130000_add_anomaly_framework/migration.sql
@@ -1,0 +1,50 @@
+-- EMR-734 — Anomaly detector framework.
+--
+-- Adds the `Anomaly` table + `AnomalySeverity` enum. The framework lives in
+-- src/lib/anomaly/framework.ts; the sweep cron lives in
+-- src/app/api/cron/anomaly-sweep/route.ts. Concrete detectors land in
+-- EMR-737 / EMR-740 / EMR-741.
+--
+-- Design notes:
+--   - (kind, idempotencyKey) is unique so upserts are idempotent within a
+--     detector. Two detectors that happen to generate the same idempotency
+--     string don't collide.
+--   - resolvedAt = null means "still live"; the cron flips it to now() when
+--     the detector stops emitting (auto-resolve), or when `expiresAt < now`
+--     (ttl-expiry). Rows are NEVER deleted — the table is the audit trail.
+
+CREATE TYPE "AnomalySeverity" AS ENUM ('INFO', 'WARNING', 'CRITICAL');
+
+CREATE TABLE "Anomaly" (
+  "id"             TEXT PRIMARY KEY,
+  "slug"           TEXT NOT NULL,
+  "kind"           TEXT NOT NULL,
+  "severity"       "AnomalySeverity" NOT NULL,
+  "practiceId"     TEXT,
+  "message"        TEXT NOT NULL,
+  "deeplinkUrl"    TEXT NOT NULL,
+  "context"        JSONB NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "ttlSeconds"     INTEGER NOT NULL,
+  "firstSeenAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "lastSeenAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt"      TIMESTAMP(3) NOT NULL,
+  "resolvedAt"     TIMESTAMP(3)
+);
+
+CREATE UNIQUE INDEX "Anomaly_slug_key" ON "Anomaly" ("slug");
+
+CREATE UNIQUE INDEX "Anomaly_kind_idempotencyKey_key"
+  ON "Anomaly" ("kind", "idempotencyKey");
+
+-- HQ feed: active rows by severity, newest first.
+CREATE INDEX "Anomaly_resolvedAt_severity_lastSeenAt_idx"
+  ON "Anomaly" ("resolvedAt", "severity", "lastSeenAt" DESC);
+
+-- Per-practice drill-in.
+CREATE INDEX "Anomaly_practiceId_resolvedAt_idx"
+  ON "Anomaly" ("practiceId", "resolvedAt");
+
+-- Per-detector triage and auto-resolve sweep.
+CREATE INDEX "Anomaly_kind_resolvedAt_idx"
+  ON "Anomaly" ("kind", "resolvedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4882,3 +4882,65 @@ model ControllerAuditExport {
   @@index([runAt])
 }
 
+// --------------------------------------------------------------
+// EMR-734 — Anomaly Detector Framework
+// --------------------------------------------------------------
+// Detectors are pure functions that scan recent state and emit zero or more
+// `Anomaly` rows. Each row carries a severity, TTL, target `practiceId` (or
+// null for fleet-wide), a stable `kind` (the detector identifier), a human
+// `message`, a `deeplinkUrl` for the HQ surface, raw `context` JSON, and an
+// `idempotencyKey` that is unique within a kind — re-detection on the next
+// sweep is upserted, NOT duplicated.
+//
+// Lifecycle states (see src/lib/anomaly/framework.ts for the full state
+// machine):
+//   - live              → resolvedAt = null, expiresAt > now
+//   - resolved-by-ttl   → resolvedAt = null, expiresAt < now  (filtered from feed)
+//   - resolved-by-detector → resolvedAt != null               (kept for audit)
+//
+// Concrete detectors land in EMR-737 / EMR-740 / EMR-741. This model + the
+// framework + the sweep cron are the v1 substrate; the registry starts empty.
+
+enum AnomalySeverity {
+  INFO
+  WARNING
+  CRITICAL
+}
+
+model Anomaly {
+  id             String          @id @default(cuid())
+  /// Stable URL slug for the HQ feed. Unique across the table.
+  slug           String          @unique
+  /// Detector identifier — e.g. "stuck_publish", "webhook_health". Pairs
+  /// with `idempotencyKey` for upsert.
+  kind           String
+  severity       AnomalySeverity
+  /// Null = fleet-wide anomaly (e.g. webhook-provider outage). Otherwise
+  /// the practice the anomaly targets. Untyped String to match the
+  /// PracticeConfiguration precedent — no FK, since practice ids may
+  /// reference rows the anomaly detector doesn't own.
+  practiceId     String?
+  message        String
+  deeplinkUrl    String
+  context        Json
+  /// Stable key the detector generates for this anomaly instance. Same key
+  /// across sweeps = same anomaly; bumps `lastSeenAt` + `expiresAt` instead
+  /// of creating a new row. Unique within (kind, idempotencyKey).
+  idempotencyKey String
+  /// TTL in seconds, captured at emission. Used by the sweep to compute
+  /// `expiresAt = lastSeenAt + ttlSeconds` on every upsert.
+  ttlSeconds     Int
+  firstSeenAt    DateTime        @default(now())
+  lastSeenAt     DateTime        @default(now())
+  expiresAt      DateTime
+  /// Set when the detector stops emitting the anomaly on a subsequent
+  /// sweep (auto-resolve). Once set, the row is retained for the audit
+  /// trail but filtered from the active HQ feed.
+  resolvedAt     DateTime?
+
+  @@unique([kind, idempotencyKey])
+  @@index([resolvedAt, severity, lastSeenAt(sort: Desc)])
+  @@index([practiceId, resolvedAt])
+  @@index([kind, resolvedAt])
+}
+

--- a/src/app/api/cron/anomaly-sweep/route.ts
+++ b/src/app/api/cron/anomaly-sweep/route.ts
@@ -1,0 +1,162 @@
+// EMR-734 — Anomaly detector sweep cron.
+//
+// Runs the registered anomaly detectors and applies their emissions to
+// the `Anomaly` table. See src/lib/anomaly/framework.ts for the full
+// lifecycle contract (idempotent re-emission, auto-resolve, TTL expiry).
+//
+// Auth: Bearer CRON_SECRET, prod-only fail-closed — non-prod environments
+// fall through so dev/staging can exercise the handler without a real
+// secret. Matches the established pattern in cron/audit-export and
+// cron/credential-check. Manifest entry: cron/anomaly-sweep → auth=cron.
+//
+// Registry: starts empty in this PR. Concrete detectors register
+// themselves at module import time from src/lib/anomaly/registry.ts.
+// EMR-737 / EMR-740 / EMR-741 fill the registry.
+//
+// Audit: emits exactly one `controller.anomaly_sweep.completed` row per
+// sweep via logControllerAction. Metadata captures detectors run, total
+// emissions, new rows opened, auto-resolved rows, and ttl-expired rows.
+// The synthetic actor is `system:cron:anomaly-sweep`.
+
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import { logControllerAction } from "@/lib/auth/audit-stub";
+import {
+  applyEmissions,
+  getRegisteredDetectors,
+} from "@/lib/anomaly/framework";
+// Importing the registry module triggers side-effecting detector
+// registrations (none yet — see comment in registry.ts). Keep this
+// import even when the registry is empty so the wiring is in place for
+// EMR-737/740/741 to drop their detectors in.
+import "@/lib/anomaly/registry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Synthetic actor identity for the controller audit row that records the
+// sweep run itself. The `system:cron:*` namespace is reserved for
+// unattended automation — not a real user id.
+const SYSTEM_ACTOR_ID = "system:cron:anomaly-sweep";
+const SYSTEM_ACTOR_EMAIL = "system@leafjourney.internal";
+
+export async function POST(req: Request): Promise<NextResponse> {
+  // ── Auth gate ────────────────────────────────────────────
+  const authHeader = req.headers.get("authorization") ?? "";
+  const secret = process.env.CRON_SECRET ?? "";
+  if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const now = new Date();
+  const detectors = getRegisteredDetectors();
+
+  logger.info({
+    event: "cron.anomaly_sweep.started",
+    detectorsRegistered: detectors.length,
+  });
+
+  let emissionsTotal = 0;
+  let newOpened = 0;
+  let autoResolved = 0;
+  let ttlExpired = 0;
+  const perDetector: Array<{
+    slug: string;
+    emissions: number;
+    newOpened: number;
+    reaffirmed: number;
+    autoResolved: number;
+    ttlExpired: number;
+    error?: string;
+  }> = [];
+
+  for (const detector of detectors) {
+    try {
+      const emissions = await detector.run(prisma);
+      const result = await applyEmissions(prisma, detector.slug, emissions, now);
+      emissionsTotal += emissions.length;
+      newOpened += result.newOpened;
+      autoResolved += result.autoResolved;
+      ttlExpired += result.ttlExpired;
+      perDetector.push({
+        slug: detector.slug,
+        emissions: emissions.length,
+        newOpened: result.newOpened,
+        reaffirmed: result.reaffirmed,
+        autoResolved: result.autoResolved,
+        ttlExpired: result.ttlExpired,
+      });
+    } catch (err) {
+      // One bad detector must not bring down the whole sweep — the rest
+      // of the detectors keep running. We capture the failure in the
+      // per-detector breakdown so the audit row + structured log show
+      // exactly which one fell over.
+      const message = err instanceof Error ? err.message : String(err);
+      perDetector.push({
+        slug: detector.slug,
+        emissions: 0,
+        newOpened: 0,
+        reaffirmed: 0,
+        autoResolved: 0,
+        ttlExpired: 0,
+        error: message,
+      });
+      logger.error({
+        event: "cron.anomaly_sweep.detector_failed",
+        detectorSlug: detector.slug,
+        err:
+          err instanceof Error
+            ? { name: err.name, message: err.message, stack: err.stack }
+            : String(err),
+      });
+    }
+  }
+
+  // ── Emit one audit row per sweep ────────────────────────
+  // targetId is "all" when no detectors ran — gives the audit trail a
+  // stable subjectId even on empty registries (current state in this
+  // PR; registry fills in EMR-737/740/741).
+  await logControllerAction({
+    actor: {
+      id: SYSTEM_ACTOR_ID,
+      email: SYSTEM_ACTOR_EMAIL,
+      roles: ["system"],
+      organizationId: null,
+    },
+    action: "controller.anomaly_sweep.completed",
+    targetId: "anomaly-sweep",
+    after: {
+      detectorsRun: detectors.length,
+      emissionsTotal,
+      newOpened,
+      autoResolved,
+      ttlExpired,
+      perDetector,
+    },
+    reason: "Anomaly detector sweep",
+  });
+
+  const durationMs = Date.now() - startedAt;
+  logger.info({
+    event: "cron.anomaly_sweep.completed",
+    detectorsRun: detectors.length,
+    emissionsTotal,
+    newOpened,
+    autoResolved,
+    ttlExpired,
+    durationMs,
+  });
+
+  return NextResponse.json({
+    success: true,
+    detectorsRun: detectors.length,
+    emissionsTotal,
+    newOpened,
+    autoResolved,
+    ttlExpired,
+    perDetector,
+  });
+}

--- a/src/lib/anomaly/framework.test.ts
+++ b/src/lib/anomaly/framework.test.ts
@@ -1,0 +1,289 @@
+// EMR-734 — Framework unit tests.
+//
+// Strategy: a tiny in-memory fake of `prisma.anomaly` that implements
+// just enough of the surface `applyEmissions` uses (findUnique, create,
+// update, updateMany). This is cheaper than vi.mock-per-call and lets
+// us test the real upsert / auto-resolve / TTL semantics end-to-end.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  applyEmissions,
+  registerDetector,
+  getRegisteredDetectors,
+  __resetRegistryForTests,
+  type AnomalyEmission,
+} from "./framework";
+
+// ── In-memory fake prisma.anomaly ──────────────────────────
+
+type FakeAnomalyRow = {
+  id: string;
+  slug: string;
+  kind: string;
+  severity: "INFO" | "WARNING" | "CRITICAL";
+  practiceId: string | null;
+  message: string;
+  deeplinkUrl: string;
+  context: unknown;
+  idempotencyKey: string;
+  ttlSeconds: number;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  expiresAt: Date;
+  resolvedAt: Date | null;
+};
+
+function makeFakePrisma() {
+  const rows: FakeAnomalyRow[] = [];
+  let idSeq = 0;
+
+  const matches = (row: FakeAnomalyRow, where: any): boolean => {
+    if (where.kind !== undefined && row.kind !== where.kind) return false;
+    if (where.resolvedAt !== undefined) {
+      if (where.resolvedAt === null && row.resolvedAt !== null) return false;
+    }
+    if (where.idempotencyKey?.notIn) {
+      if (where.idempotencyKey.notIn.includes(row.idempotencyKey)) return false;
+    }
+    if (where.expiresAt?.gte && row.expiresAt < where.expiresAt.gte) return false;
+    if (where.expiresAt?.lt && row.expiresAt >= where.expiresAt.lt) return false;
+    return true;
+  };
+
+  const anomaly = {
+    findUnique: async ({ where }: any): Promise<FakeAnomalyRow | null> => {
+      if (where.kind_idempotencyKey) {
+        const { kind, idempotencyKey } = where.kind_idempotencyKey;
+        return (
+          rows.find((r) => r.kind === kind && r.idempotencyKey === idempotencyKey) ??
+          null
+        );
+      }
+      return null;
+    },
+    create: async ({ data }: any): Promise<FakeAnomalyRow> => {
+      const row: FakeAnomalyRow = {
+        id: `anom_${++idSeq}`,
+        slug: data.slug,
+        kind: data.kind,
+        severity: data.severity,
+        practiceId: data.practiceId ?? null,
+        message: data.message,
+        deeplinkUrl: data.deeplinkUrl,
+        context: data.context,
+        idempotencyKey: data.idempotencyKey,
+        ttlSeconds: data.ttlSeconds,
+        firstSeenAt: data.firstSeenAt ?? new Date(),
+        lastSeenAt: data.lastSeenAt ?? new Date(),
+        expiresAt: data.expiresAt,
+        resolvedAt: null,
+      };
+      rows.push(row);
+      return row;
+    },
+    update: async ({ where, data }: any): Promise<FakeAnomalyRow> => {
+      const row = rows.find((r) => r.id === where.id);
+      if (!row) throw new Error(`fake prisma: no row with id ${where.id}`);
+      Object.assign(row, data);
+      return row;
+    },
+    updateMany: async ({ where, data }: any): Promise<{ count: number }> => {
+      let count = 0;
+      for (const row of rows) {
+        if (matches(row, where)) {
+          Object.assign(row, data);
+          count++;
+        }
+      }
+      return { count };
+    },
+    // Test introspection helpers (not on real prisma).
+    __rows: rows,
+  };
+
+  return { anomaly, __rows: rows } as unknown as PrismaClient & {
+    __rows: FakeAnomalyRow[];
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+function emission(over: Partial<AnomalyEmission> = {}): AnomalyEmission {
+  return {
+    slug: over.slug ?? "stuck-publish-cfg-abc",
+    idempotencyKey: over.idempotencyKey ?? "configId=cfg_abc",
+    severity: over.severity ?? "warning",
+    practiceId: over.practiceId === undefined ? null : over.practiceId,
+    message: over.message ?? "Publish stuck >10m",
+    deeplinkUrl: over.deeplinkUrl ?? "/super-admin/practices/p1/configs/cfg_abc",
+    context: over.context ?? { configId: "cfg_abc" },
+    ttlSeconds: over.ttlSeconds ?? 3600,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe("anomaly framework — applyEmissions", () => {
+  let prisma: ReturnType<typeof makeFakePrisma>;
+
+  beforeEach(() => {
+    prisma = makeFakePrisma();
+  });
+
+  it("inserts a new row on first emission", async () => {
+    const now = new Date("2026-05-17T12:00:00Z");
+    const result = await applyEmissions(prisma, "stuck_publish", [emission()], now);
+    expect(result.newOpened).toBe(1);
+    expect(result.reaffirmed).toBe(0);
+    expect(result.autoResolved).toBe(0);
+    expect(result.ttlExpired).toBe(0);
+    expect(prisma.__rows).toHaveLength(1);
+    expect(prisma.__rows[0].kind).toBe("stuck_publish");
+    expect(prisma.__rows[0].expiresAt.getTime()).toBe(
+      now.getTime() + 3600 * 1000,
+    );
+  });
+
+  it("upserts on duplicate idempotencyKey — single row, bumped lastSeenAt", async () => {
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    await applyEmissions(prisma, "stuck_publish", [emission()], t1);
+
+    const t2 = new Date("2026-05-17T12:10:00Z");
+    const result = await applyEmissions(
+      prisma,
+      "stuck_publish",
+      [emission()],
+      t2,
+    );
+
+    expect(prisma.__rows).toHaveLength(1);
+    expect(result.newOpened).toBe(0);
+    expect(result.reaffirmed).toBe(1);
+    expect(prisma.__rows[0].lastSeenAt.getTime()).toBe(t2.getTime());
+    expect(prisma.__rows[0].expiresAt.getTime()).toBe(t2.getTime() + 3600_000);
+    expect(prisma.__rows[0].resolvedAt).toBeNull();
+  });
+
+  it("auto-resolves when detector stops emitting a previously-emitted key", async () => {
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    await applyEmissions(prisma, "stuck_publish", [emission()], t1);
+
+    // TTL is 1h, so on a 10-minute-later sweep the row is still live.
+    // Detector now emits nothing → row should auto-resolve.
+    const t2 = new Date("2026-05-17T12:10:00Z");
+    const result = await applyEmissions(prisma, "stuck_publish", [], t2);
+
+    expect(result.autoResolved).toBe(1);
+    expect(result.ttlExpired).toBe(0);
+    expect(prisma.__rows).toHaveLength(1);
+    expect(prisma.__rows[0].resolvedAt?.getTime()).toBe(t2.getTime());
+  });
+
+  it("TTL-expires a stale live row even if detector emits nothing", async () => {
+    // Plant a row whose expiresAt is in the past — simulates a detector
+    // that emitted once and then went silent (bug, deploy, etc.).
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    await applyEmissions(
+      prisma,
+      "stuck_publish",
+      [emission({ ttlSeconds: 60 })], // 1-minute TTL
+      t1,
+    );
+
+    // Two hours later, no emissions. The row should be TTL-expired, not
+    // double-counted as auto-resolved.
+    const t2 = new Date("2026-05-17T14:00:00Z");
+    const result = await applyEmissions(prisma, "stuck_publish", [], t2);
+
+    expect(result.autoResolved).toBe(0);
+    expect(result.ttlExpired).toBe(1);
+    expect(prisma.__rows[0].resolvedAt?.getTime()).toBe(t2.getTime());
+  });
+
+  it("cross-detector isolation — detector A does not resolve detector B's rows", async () => {
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    // Open one anomaly under each detector.
+    await applyEmissions(
+      prisma,
+      "stuck_publish",
+      [emission({ idempotencyKey: "A", slug: "a" })],
+      t1,
+    );
+    await applyEmissions(
+      prisma,
+      "webhook_health",
+      [emission({ idempotencyKey: "B", slug: "b" })],
+      t1,
+    );
+    expect(prisma.__rows).toHaveLength(2);
+
+    // Detector A emits nothing — it should resolve its own row, but
+    // leave detector B's row alone.
+    const t2 = new Date("2026-05-17T12:10:00Z");
+    const result = await applyEmissions(prisma, "stuck_publish", [], t2);
+
+    expect(result.autoResolved).toBe(1);
+
+    const aRow = prisma.__rows.find((r) => r.kind === "stuck_publish");
+    const bRow = prisma.__rows.find((r) => r.kind === "webhook_health");
+    expect(aRow?.resolvedAt).not.toBeNull();
+    expect(bRow?.resolvedAt).toBeNull();
+  });
+
+  it("supports null practiceId (fleet-wide anomalies)", async () => {
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    await applyEmissions(
+      prisma,
+      "platform_health",
+      [emission({ practiceId: null, idempotencyKey: "fleet" })],
+      t1,
+    );
+    expect(prisma.__rows[0].practiceId).toBeNull();
+  });
+
+  it("re-opens a previously-resolved key when the detector starts re-emitting", async () => {
+    const t1 = new Date("2026-05-17T12:00:00Z");
+    await applyEmissions(prisma, "stuck_publish", [emission()], t1);
+
+    // Resolve it.
+    const t2 = new Date("2026-05-17T12:10:00Z");
+    await applyEmissions(prisma, "stuck_publish", [], t2);
+    expect(prisma.__rows[0].resolvedAt).not.toBeNull();
+
+    // Detector flaps and re-emits — row should come back live.
+    const t3 = new Date("2026-05-17T12:20:00Z");
+    const result = await applyEmissions(
+      prisma,
+      "stuck_publish",
+      [emission()],
+      t3,
+    );
+    expect(result.reaffirmed).toBe(1);
+    expect(prisma.__rows[0].resolvedAt).toBeNull();
+    expect(prisma.__rows[0].lastSeenAt.getTime()).toBe(t3.getTime());
+  });
+});
+
+describe("anomaly framework — registry", () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it("starts empty", () => {
+    expect(getRegisteredDetectors()).toHaveLength(0);
+  });
+
+  it("registers detectors in order", () => {
+    registerDetector({ slug: "a", run: async () => [] });
+    registerDetector({ slug: "b", run: async () => [] });
+    expect(getRegisteredDetectors().map((d) => d.slug)).toEqual(["a", "b"]);
+  });
+
+  it("rejects duplicate slugs", () => {
+    registerDetector({ slug: "a", run: async () => [] });
+    expect(() =>
+      registerDetector({ slug: "a", run: async () => [] }),
+    ).toThrow(/already registered/);
+  });
+});

--- a/src/lib/anomaly/framework.ts
+++ b/src/lib/anomaly/framework.ts
@@ -1,0 +1,325 @@
+// EMR-734 — Anomaly detector framework.
+//
+// Why this exists
+// ---------------
+// Fleet-ops needs a single substrate for "things HQ should look at" —
+// stuck publishes, unhealthy webhooks, stale configs, etc. Each concrete
+// detector is a pure function over recent Prisma state that emits zero or
+// more `AnomalyEmission` objects. The framework here turns those emissions
+// into rows in the `Anomaly` table, with three guarantees:
+//
+//   1. Re-detection is idempotent. A detector that emits the same
+//      `idempotencyKey` on two successive sweeps does NOT create two rows
+//      — the second sweep bumps `lastSeenAt` and pushes `expiresAt` out by
+//      the freshly-supplied `ttlSeconds`.
+//
+//   2. Auto-resolve. If a detector previously emitted an idempotencyKey
+//      and then STOPS emitting it on a later sweep, the row is marked
+//      `resolvedAt = now` (not deleted). The HQ feed filters resolved
+//      rows out of the active list, but they remain in the audit trail.
+//
+//   3. TTL expiry. Rows whose `expiresAt < now` at sweep time are also
+//      marked `resolvedAt = now` regardless of detector decision. This
+//      catches the case where a detector itself goes silent (bug, deploy)
+//      and would otherwise leave stale rows live forever.
+//
+// Lifecycle states
+// ----------------
+//   live                  → resolvedAt = null, expiresAt > now
+//   resolved-by-detector  → resolvedAt set on the sweep the detector
+//                           stopped emitting the key
+//   resolved-by-ttl       → resolvedAt set on the sweep that observed
+//                           expiresAt < now without re-confirmation
+//
+// idempotencyKey contract
+// -----------------------
+// The detector author owns the key shape. The contract is:
+//
+//   * Same anomaly across sweeps ⇒ same key.
+//     e.g. "stuck_publish:configId=cfg_abc" — keyed on the entity that's
+//     stuck, not on the timestamp it was first noticed.
+//
+//   * Different anomaly instances ⇒ different keys. Two distinct
+//     publishes both stuck must produce two distinct keys.
+//
+//   * Uniqueness is scoped to (kind, idempotencyKey) so a detector
+//     doesn't have to worry about collisions with other detectors.
+//
+// PHI scrubbing
+// -------------
+// The `context` JSON is surfaced verbatim to super-admins via the HQ
+// feed. Detectors MUST scrub PHI before emitting — no patient names,
+// MRNs, DOBs, free-text clinical notes, etc. Reference ids only.
+//
+// Testability
+// -----------
+// `applyEmissions` takes the prisma instance as an argument; the registry
+// is the only module-level state. Tests inject a mock prisma client.
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+/**
+ * A single anomaly the detector wants surfaced. Severity is a 3-level
+ * triage hint for the HQ feed:
+ *
+ *   - "info"     — context only, no immediate operator action.
+ *   - "warning"  — fleet-ops should look soon (hours).
+ *   - "critical" — fleet-ops should look now (minutes).
+ *
+ * Wire severities are uppercase in Prisma; we accept lowercase here for
+ * detector ergonomics and translate before insert.
+ */
+export type AnomalySeverity = "info" | "warning" | "critical";
+
+export type AnomalyEmission = {
+  /**
+   * Stable URL slug for the row. Used as the path segment in deep links
+   * on the HQ surface (e.g. /super-admin/anomalies/<slug>). Must be
+   * unique across the table — typically the same shape as
+   * idempotencyKey but URL-friendly. Detectors are responsible for
+   * generating a slug that's both stable across sweeps and unique.
+   */
+  slug: string;
+  /**
+   * Detector-author-supplied key. Same anomaly across sweeps = same key.
+   * See module header for the contract.
+   */
+  idempotencyKey: string;
+  severity: AnomalySeverity;
+  /**
+   * Null = fleet-wide anomaly. Otherwise the practice the anomaly
+   * targets. Matches the PracticeConfiguration precedent — bare string,
+   * no FK.
+   */
+  practiceId?: string | null;
+  message: string;
+  /**
+   * Absolute or app-relative URL the HQ surface deep-links to so the
+   * super-admin can act on the anomaly directly.
+   */
+  deeplinkUrl: string;
+  /**
+   * Free-form JSON payload. MUST be PHI-free — see module header.
+   */
+  context: Record<string, unknown>;
+  /**
+   * Time-to-live in seconds. The framework computes
+   * `expiresAt = now + ttlSeconds` on each upsert.
+   */
+  ttlSeconds: number;
+};
+
+export type AnomalyDetector = {
+  /** Stable detector identifier — e.g. "stuck_publish". Stored as `kind`. */
+  slug: string;
+  run: (prisma: PrismaClient) => Promise<AnomalyEmission[]>;
+};
+
+/**
+ * Result of applying one detector's emissions. Returned to the sweep so
+ * the cron can produce a structured audit row covering the whole run.
+ */
+export type ApplyEmissionsResult = {
+  newOpened: number;
+  reaffirmed: number;
+  autoResolved: number;
+  ttlExpired: number;
+};
+
+// ── Detector registry ──────────────────────────────────────
+//
+// Module-level array. Detectors are registered at import time from the
+// concrete detector modules (none in this PR — registry starts empty).
+// The sweep cron iterates this array in registration order.
+
+const REGISTRY: AnomalyDetector[] = [];
+
+export function registerDetector(detector: AnomalyDetector): void {
+  // Reject duplicate slugs at registration time — collisions silently
+  // double-emit otherwise, which would defeat the auto-resolve sweep
+  // (each registration's emissions would resolve the other's).
+  if (REGISTRY.some((d) => d.slug === detector.slug)) {
+    throw new Error(
+      `anomaly: detector with slug "${detector.slug}" already registered`,
+    );
+  }
+  REGISTRY.push(detector);
+}
+
+export function getRegisteredDetectors(): readonly AnomalyDetector[] {
+  return REGISTRY;
+}
+
+/**
+ * Test-only registry reset. Exposed so unit tests can establish a clean
+ * registry per case without leaking state across files. Not exported via
+ * any index module — import the symbol directly from "framework.ts".
+ */
+export function __resetRegistryForTests(): void {
+  REGISTRY.length = 0;
+}
+
+// ── Severity translation ───────────────────────────────────
+
+const SEVERITY_TO_PRISMA = {
+  info: "INFO",
+  warning: "WARNING",
+  critical: "CRITICAL",
+} as const;
+
+// ── applyEmissions ─────────────────────────────────────────
+
+/**
+ * Apply one detector's emissions to the `Anomaly` table. The framework
+ * runs three passes against this detector's slug only:
+ *
+ *   1. Upsert every emission by (kind, idempotencyKey). Insert on miss;
+ *      on hit, bump `lastSeenAt` and recompute `expiresAt`.
+ *
+ *   2. Auto-resolve: any live row for THIS detector's slug whose
+ *      idempotencyKey is NOT in the current emission batch → mark
+ *      `resolvedAt = now`.
+ *
+ *   3. TTL expiry: any live row for THIS detector's slug whose
+ *      `expiresAt < now` (and that we didn't just refresh) → also mark
+ *      `resolvedAt = now`. Belt-and-suspenders for the case where the
+ *      detector itself fell silent.
+ *
+ * Cross-detector isolation: we only touch rows whose `kind` matches this
+ * detector's slug. Detector A's auto-resolve sweep cannot resolve
+ * detector B's live rows.
+ */
+export async function applyEmissions(
+  prisma: PrismaClient,
+  detectorSlug: string,
+  emissions: AnomalyEmission[],
+  now: Date = new Date(),
+): Promise<ApplyEmissionsResult> {
+  let newOpened = 0;
+  let reaffirmed = 0;
+
+  // ── Pass 1: upsert each emission ─────────────────────────
+  for (const emission of emissions) {
+    const expiresAt = new Date(now.getTime() + emission.ttlSeconds * 1000);
+    const severity = SEVERITY_TO_PRISMA[emission.severity];
+
+    // We can't use prisma.anomaly.upsert directly because the unique key
+    // is composite (kind, idempotencyKey) AND we need to distinguish
+    // create vs. update for the counters. Two-step is fine — the unique
+    // index serialises concurrent sweeps at the DB layer.
+    const existing = await prisma.anomaly.findUnique({
+      where: {
+        kind_idempotencyKey: {
+          kind: detectorSlug,
+          idempotencyKey: emission.idempotencyKey,
+        },
+      },
+      select: { id: true, resolvedAt: true },
+    });
+
+    if (existing) {
+      // Re-affirm: bump lastSeenAt + expiresAt, clear resolvedAt if a
+      // prior sweep resolved this same key and the detector is now
+      // re-emitting it (rare but possible — e.g. a flapping condition).
+      await prisma.anomaly.update({
+        where: { id: existing.id },
+        data: {
+          lastSeenAt: now,
+          expiresAt,
+          severity,
+          message: emission.message,
+          deeplinkUrl: emission.deeplinkUrl,
+          context: emission.context as Prisma.InputJsonValue,
+          ttlSeconds: emission.ttlSeconds,
+          practiceId: emission.practiceId ?? null,
+          resolvedAt: null,
+        },
+      });
+      reaffirmed++;
+    } else {
+      await prisma.anomaly.create({
+        data: {
+          slug: emission.slug,
+          kind: detectorSlug,
+          severity,
+          practiceId: emission.practiceId ?? null,
+          message: emission.message,
+          deeplinkUrl: emission.deeplinkUrl,
+          context: emission.context as Prisma.InputJsonValue,
+          idempotencyKey: emission.idempotencyKey,
+          ttlSeconds: emission.ttlSeconds,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          expiresAt,
+        },
+      });
+      newOpened++;
+    }
+  }
+
+  // ── Pass 2: auto-resolve rows the detector stopped emitting ─
+  const emittedKeys = emissions.map((e) => e.idempotencyKey);
+  const autoResolve = await prisma.anomaly.updateMany({
+    where: {
+      kind: detectorSlug,
+      resolvedAt: null,
+      idempotencyKey: { notIn: emittedKeys.length > 0 ? emittedKeys : [""] },
+      // Don't double-count TTL-expired rows in this pass — they're
+      // handled in pass 3 with a different counter.
+      expiresAt: { gte: now },
+    },
+    data: { resolvedAt: now },
+  });
+  const autoResolved = autoResolve.count;
+
+  // ── Pass 3: TTL expiry ──────────────────────────────────
+  // Catches rows whose expiresAt is in the past AND the detector didn't
+  // re-emit them. (If the detector DID re-emit, pass 1 already pushed
+  // expiresAt forward.)
+  const ttlExpire = await prisma.anomaly.updateMany({
+    where: {
+      kind: detectorSlug,
+      resolvedAt: null,
+      expiresAt: { lt: now },
+    },
+    data: { resolvedAt: now },
+  });
+  const ttlExpired = ttlExpire.count;
+
+  return { newOpened, reaffirmed, autoResolved, ttlExpired };
+}
+
+// ── listActiveAnomalies ─────────────────────────────────────
+//
+// Helper for the HQ feed (rendered by a future ticket — see EMR-721 /
+// child issues). Returns only rows that are both unresolved AND
+// unexpired. Resolved + expired rows are retained for audit but not
+// surfaced here.
+
+export type ListActiveAnomaliesFilter = {
+  practiceId?: string | null;
+  severity?: AnomalySeverity;
+};
+
+export async function listActiveAnomalies(
+  prisma: PrismaClient,
+  filter: ListActiveAnomaliesFilter = {},
+  now: Date = new Date(),
+) {
+  const where: Prisma.AnomalyWhereInput = {
+    resolvedAt: null,
+    expiresAt: { gte: now },
+  };
+  if (filter.practiceId !== undefined) {
+    // Explicit null = fleet-wide only; explicit string = that practice;
+    // omitted = both. This matches the HQ feed's filter UX.
+    where.practiceId = filter.practiceId;
+  }
+  if (filter.severity) {
+    where.severity = SEVERITY_TO_PRISMA[filter.severity];
+  }
+  return prisma.anomaly.findMany({
+    where,
+    orderBy: [{ severity: "desc" }, { lastSeenAt: "desc" }],
+  });
+}

--- a/src/lib/anomaly/registry.ts
+++ b/src/lib/anomaly/registry.ts
@@ -1,0 +1,41 @@
+// EMR-734 — Anomaly detector registry.
+//
+// Concrete detectors register themselves by importing this module's
+// `registerDetector` helper and calling it at module top-level. The sweep
+// cron imports the registry getter and iterates all registered detectors.
+//
+// THIS FILE INTENTIONALLY DOES NOT REGISTER ANY DETECTORS. The framework
+// + sweep cron + Anomaly model are landing alone in EMR-734 so that
+// EMR-737 (4 detectors), EMR-740 (webhook health), and EMR-741 (stale
+// config) can land independently against a stable surface.
+//
+// When EMR-737/740/741 land, each adds a `import "./detectors/<slug>"`
+// line to the section below — the side-effecting import registers the
+// detector with the framework. Co-locating registration here gives PR
+// reviewers a single file to scan for "what does the sweep run?".
+
+export {
+  registerDetector,
+  getRegisteredDetectors,
+  type AnomalyDetector,
+  type AnomalyEmission,
+  type AnomalySeverity,
+} from "./framework";
+
+// ── Detector registrations ────────────────────────────────
+//
+// Each concrete detector module is expected to call `registerDetector`
+// at import time. The registry is intentionally empty until those
+// modules land.
+//
+// EMR-737:
+//   import "./detectors/stuck-publish";
+//   import "./detectors/template-regression";
+//   import "./detectors/auth-failure-spike";
+//   import "./detectors/cron-stall";
+//
+// EMR-740:
+//   import "./detectors/webhook-health";
+//
+// EMR-741:
+//   import "./detectors/stale-config";


### PR DESCRIPTION
## Summary
- Adds the `Anomaly` Prisma model + `AnomalySeverity` enum, the `src/lib/anomaly/framework.ts` runtime (registry, `applyEmissions`, `listActiveAnomalies`), and the `cron/anomaly-sweep` route. Detectors emit zero or more anomalies per sweep; framework upserts by `(kind, idempotencyKey)`, auto-resolves rows the detector stopped emitting, and TTL-expires stale rows.
- Sweep cron follows the standard Bearer CRON_SECRET / prod-only fail-closed pattern (mirrors `cron/audit-export`) and emits one `controller.anomaly_sweep.completed` audit row per run with the per-detector breakdown.
- Registry is intentionally empty — concrete detectors land in EMR-737 / EMR-740 / EMR-741. Sweep returns 200 with `detectorsRun: 0` until then. No UI in this PR.

Linear: https://linear.app/emr-project/issue/EMR-734

## Test plan
- [x] framework unit tests pass (upsert dedupe, auto-resolve, TTL expiry, cross-detector isolation, fleet-wide null practiceId, re-open on flap, registry duplicate-slug guard) — 10/10 green
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean for new files (pre-existing warnings unrelated)
- [x] `node scripts/check-route-auth-manifest.mjs` clean (manifest entry added with `auth: cron`, `rate_limit_bucket: cron.anomaly-sweep`)
- [x] `npx prisma generate` clean against the additive schema
- [x] sweep cron returns 200 with empty registry (confirmed by reading the handler — `for` loop over `detectors` is a no-op, audit row still emitted, response is `{success: true, detectorsRun: 0, ...}`)