### PR TITLE
fix(nav): MobilePortraitNav duplicate-key + dead external link (EMR-715)

### DIFF
--- a/src/components/layout/MobilePortraitNav.tsx
+++ b/src/components/layout/MobilePortraitNav.tsx
@@ -55,8 +55,16 @@ export const DEFAULT_GROUPS: MobileNavGroup[] = [
     id: "shop",
     label: "Shop",
     tabs: [
-      { label: "LeafMart", href: "https://www.theleafmart.com/", icon: "✿" },
-      { label: "Marketplace", href: "https://www.theleafmart.com/", icon: "☖" },
+      // LeafMart and Marketplace previously both pointed at the legacy
+      // external storefront, which (a) defeated the in-app nav intent
+      // and (b) gave the <li key={t.href}> map two children with the
+      // same key — duplicate-key React warnings on every page that
+      // mounts MobilePortraitNav (caught by find-and-fix pass 8). Both
+      // surfaces exist as real internal routes now: /leafmart consumer
+      // storefront, /marketplace editorial catalog (PDPs landed in PR
+      // #348 / EMR-712).
+      { label: "LeafMart", href: "/leafmart", icon: "✿" },
+      { label: "Marketplace", href: "/marketplace", icon: "☖" },
       { label: "Store", href: "/store", icon: "☲" },
       { label: "Vendors", href: "/leafmart/vendors", icon: "⚘" },
     ],


### PR DESCRIPTION
## Summary

`src/components/layout/MobilePortraitNav.tsx:58-59` had two nav tabs in the Shop group pointing at the same legacy external URL:

\`\`\`tsx
{ label: \"LeafMart\",    href: \"https://www.theleafmart.com/\", icon: \"✿\" },
{ label: \"Marketplace\", href: \"https://www.theleafmart.com/\", icon: \"☖\" },
\`\`\`

The map below uses \`<li key={t.href}>\` — two siblings with the same key — so React fired

\`\`\`
Warning: Encountered two children with the same key, \`https://www.theleafmart.com/\`
\`\`\`

on every page that mounts the mobile nav. Caught by find-and-fix pass 8 (click-handlers crawler), reproducible in the debug spec that captured the actual warning value.

The duplicate external link also defeated the in-app nav. \`/leafmart\` (consumer storefront) and \`/marketplace\` (editorial catalog, PDPs landed in PR #348) are real internal routes now. Re-pointed:

- LeafMart → \`/leafmart\`
- Marketplace → \`/marketplace\`

Fixes the React warning AND the navigation intent.

## Verification

- Two distinct \`href\` values → no duplicate \`<li key>\` → no React warning
- Both targets return 200 on dev server

## Test plan

- [ ] Load any public page in mobile-portrait viewport — confirm no \"two children with the same key\" warning in console
- [ ] Tap \"LeafMart\" — lands on \`/leafmart\`
- [ ] Tap \"Marketplace\" — lands on \`/marketplace\` (PDPs from PR #348 reachable)

Closes part of EMR-715 (the remaining footer-button click-throughs are false positives covered by EMR-718).

🤖 Generated with [Claude Code](https://claude.com/claude-code)