### PR TITLE
fix(foundation): route dead Donor FAQ + Form 990 links to /contact (EMR-717)

### DIFF
--- a/src/app/foundation/page.tsx
+++ b/src/app/foundation/page.tsx
@@ -219,8 +219,12 @@ export default function FoundationPage() {
             >
               Donate via member portal
             </Link>
+            {/* Donor FAQ page hasn't shipped yet (EMR-717). Route the CTA
+                through the marketing contact form with a role tag so any
+                donor with a question still reaches the founders' inbox
+                instead of a 404. */}
             <Link
-              href="/legal/donor-faq"
+              href="/contact?role=foundation-donor-faq"
               className="rounded-full border border-zinc-300 bg-white px-5 py-2.5 text-sm font-semibold text-zinc-900 hover:bg-zinc-50"
             >
               Donor FAQ

--- a/src/lib/community/charitable-fund.ts
+++ b/src/lib/community/charitable-fund.ts
@@ -217,7 +217,11 @@ export const LEAFJOURNEY_COMPLIANCE: ComplianceSummary = {
   ein: "00-0000000",
   irsDeterminationDate: "2025-04-12",
   publicCharityClassification: "509(a)(2)",
-  formNineNinetyUrl: "/legal/form-990.pdf",
+  // Form 990 PDF not yet hosted (EMR-717). Route requests through
+  // the marketing contact form so anyone interested in our financials
+  // reaches the founders' inbox instead of a 404. Replace with the
+  // real PDF URL once the 501(c)(3) filing is signed and uploaded.
+  formNineNinetyUrl: "/contact?role=foundation-form-990",
   boardSize: 7,
   independentBoardMembers: 5,
   programServiceRatioPct: 88,


### PR DESCRIPTION
## Summary

`/foundation` had two dead links surfaced by find-and-fix pass 6:

- "Donor FAQ" button -> `/legal/donor-faq` (404)
- "Form 990 (latest filing)" link -> `/legal/form-990.pdf` (404)

Both target content that should ship but isn't ready for the 3-week commercial launch. Rather than remove the CTAs (which would hide planned work and weaken the 501(c)(3) transparency story), route both through `/contact?role=...` so interested donors still reach the founders' inbox.

- "Donor FAQ" -> `/contact?role=foundation-donor-faq`
- Form 990 link -> `/contact?role=foundation-form-990`

The contact form already honors the `role` query param (see `src/app/contact/contact-form.tsx:11-12`) — these submissions will surface alongside other inbound leads tagged by source.

Replace with the real Donor FAQ page + Form 990 PDF once they're authored / signed.

## Test plan

- [x] Both links return 200 (route to `/contact` which is already live)
- [ ] Visual smoke: load `/foundation`, click "Donor FAQ" -> lands on `/contact?role=foundation-donor-faq`; click "Form 990 (latest filing)" -> lands on `/contact?role=foundation-form-990`

Closes EMR-717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)