### PR TITLE
feat(security): enforce MFA enrollment for super_admin role (EMR-725)

### DIFF
--- a/prisma/migrations/20260517140000_add_super_admin_mfa_grace/migration.sql
+++ b/prisma/migrations/20260517140000_add_super_admin_mfa_grace/migration.sql
@@ -1,0 +1,4 @@
+-- EMR-725 — Super-admin MFA enforcement: 14-day grace window for existing
+-- super-admins who lack an enrolled second factor. Additive column on
+-- Membership; null = no grace started (either MFA enrolled or non-super_admin).
+ALTER TABLE "Membership" ADD COLUMN "mfaGraceUntil" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -215,11 +215,16 @@ model User {
 }
 
 model Membership {
-  id             String   @id @default(cuid())
+  id             String    @id @default(cuid())
   userId         String
   organizationId String
   role           Role
-  createdAt      DateTime @default(now())
+  createdAt      DateTime  @default(now())
+  // EMR-725 — Super-admin MFA enforcement grace window. Set on first
+  // post-deploy sign-in for an existing super_admin who lacks MFA;
+  // null otherwise (including fresh bootstrap grants, which require
+  // MFA at grant time and therefore never need a grace).
+  mfaGraceUntil  DateTime?
 
   user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)

--- a/src/lib/auth/api-gate.ts
+++ b/src/lib/auth/api-gate.ts
@@ -36,6 +36,10 @@ import type { Role } from "@prisma/client";
 import { logger } from "@/lib/observability/log";
 import { type AuthedUser, requireUser } from "./session";
 import { bootstrapSuperAdminIfAllowlisted } from "./super-admin-bootstrap";
+import {
+  buildMfaRequiredResponse,
+  loadSuperAdminMfaState,
+} from "./super-admin-mfa";
 
 export interface RequireApiAuthOptions {
   /**
@@ -126,6 +130,26 @@ export async function requireApiAuth(
     };
   }
 
+  // EMR-725 — Super-admin MFA enforcement. Existing super-admins without
+  // MFA get a one-time 14-day grace window (stamped on first read by
+  // loadSuperAdminMfaState); after that the gate hard-blocks with a
+  // structured `mfa_required` 403. See ./super-admin-mfa.ts for the
+  // grace-window design rationale.
+  if (user.roles.includes("super_admin")) {
+    const mfaState = await loadSuperAdminMfaState(user);
+    if (mfaState.status === "blocked") {
+      await logMfaBlocked(user, mfaState.graceUntil);
+      return { actor: null, error: buildMfaRequiredResponse(mfaState.graceUntil) };
+    }
+    if (mfaState.status === "grace") {
+      logger.warn({
+        event: "auth.super_admin_mfa.grace_active",
+        userId: user.id,
+        graceUntil: mfaState.graceUntil.toISOString(),
+      });
+    }
+  }
+
   if (options.rateLimit) {
     const result = options.rateLimit.limiter.check(user.id);
     if (!result.allowed) {
@@ -151,4 +175,28 @@ export async function requireApiAuth(
   }
 
   return { actor: user, error: null };
+}
+
+async function logMfaBlocked(user: AuthedUser, graceUntil: Date | null): Promise<void> {
+  try {
+    const { logControllerAction } = await import("./audit-stub");
+    await logControllerAction({
+      actor: {
+        id: user.id,
+        email: user.email,
+        roles: user.roles,
+        organizationId: user.organizationId,
+      },
+      action: "controller.super_admin.mfa_blocked",
+      targetId: user.id,
+      after: { graceUntil: graceUntil ? graceUntil.toISOString() : null },
+      reason: "super_admin without enrolled MFA — request blocked.",
+    });
+  } catch (err) {
+    logger.error({
+      event: "auth.super_admin_mfa.audit_write_failed",
+      userId: user.id,
+      err,
+    });
+  }
 }

--- a/src/lib/auth/super-admin-bootstrap.test.ts
+++ b/src/lib/auth/super-admin-bootstrap.test.ts
@@ -1,0 +1,127 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    organization: { upsert: vi.fn() },
+    membership: { upsert: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./bootstrap-audit", () => ({
+  runBootstrapAllowlistAudit: vi.fn(),
+}));
+
+vi.mock("./super-admin-mfa", () => ({
+  clerkUserHasMfa: vi.fn(),
+  getCurrentClerkUserForMfa: vi.fn(),
+}));
+
+vi.mock("./audit-stub", () => ({
+  logControllerAction: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db/prisma";
+import { bootstrapSuperAdminIfAllowlisted } from "./super-admin-bootstrap";
+import { clerkUserHasMfa, getCurrentClerkUserForMfa } from "./super-admin-mfa";
+import type { AuthedUser } from "./session";
+
+const mockedPrisma = vi.mocked(prisma, true) as unknown as {
+  organization: { upsert: ReturnType<typeof vi.fn> };
+  membership: { upsert: ReturnType<typeof vi.fn> };
+};
+const mockedClerkHasMfa = vi.mocked(clerkUserHasMfa);
+const mockedClerkUser = vi.mocked(getCurrentClerkUserForMfa);
+
+const allowlistedUser: AuthedUser = {
+  id: "user_seed",
+  email: "scott@leafjourney.com",
+  firstName: "Scott",
+  lastName: "Wayman",
+  roles: ["clinician"],
+  organizationId: "org_clinic",
+  organizationName: "Test Clinic",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubEnv("NODE_ENV", "production");
+  vi.stubEnv("SUPER_ADMIN_BOOTSTRAP_ENABLED", "1");
+  vi.stubEnv("SUPER_ADMIN_BOOTSTRAP_EMAILS", "scott@leafjourney.com,neal@leafjourney.com");
+  vi.stubEnv("SUPER_ADMIN_MFA_ENFORCE", "1");
+  mockedPrisma.organization.upsert.mockResolvedValue({ id: "org_hq" });
+  mockedPrisma.membership.upsert.mockResolvedValue({});
+  mockedClerkUser.mockResolvedValue({ id: "clerk_1" } as never);
+});
+
+describe("bootstrapSuperAdminIfAllowlisted — MFA gate (EMR-725)", () => {
+  it("refuses to promote when MFA is not enrolled", async () => {
+    mockedClerkHasMfa.mockReturnValue(false);
+    const user = { ...allowlistedUser };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(false);
+    expect(user.roles).not.toContain("super_admin");
+    expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+  });
+
+  it("promotes when MFA IS enrolled", async () => {
+    mockedClerkHasMfa.mockReturnValue(true);
+    const user = { ...allowlistedUser };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(true);
+    expect(user.roles).toContain("super_admin");
+    expect(mockedPrisma.membership.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote when email is not on the allowlist", async () => {
+    vi.stubEnv("SUPER_ADMIN_BOOTSTRAP_EMAILS", "someone-else@leafjourney.com");
+    mockedClerkHasMfa.mockReturnValue(true);
+    const user = { ...allowlistedUser };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(false);
+    expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+  });
+
+  it("does not promote when bootstrap is disabled in prod", async () => {
+    vi.stubEnv("SUPER_ADMIN_BOOTSTRAP_ENABLED", "");
+    mockedClerkHasMfa.mockReturnValue(true);
+    const user = { ...allowlistedUser };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(false);
+  });
+
+  it("skips MFA check when SUPER_ADMIN_MFA_ENFORCE=0 in non-prod", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SUPER_ADMIN_MFA_ENFORCE", "0");
+    mockedClerkHasMfa.mockReturnValue(false);
+    const user = { ...allowlistedUser };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(true);
+    expect(user.roles).toContain("super_admin");
+  });
+
+  it("returns false when user already has super_admin (idempotent)", async () => {
+    mockedClerkHasMfa.mockReturnValue(true);
+    const user = { ...allowlistedUser, roles: ["super_admin" as const] };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(false);
+    expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/super-admin-bootstrap.ts
+++ b/src/lib/auth/super-admin-bootstrap.ts
@@ -25,6 +25,10 @@ import { prisma } from "@/lib/db/prisma";
 import { logger } from "@/lib/observability/log";
 import { runBootstrapAllowlistAudit } from "./bootstrap-audit";
 import type { AuthedUser } from "./session";
+import {
+  clerkUserHasMfa,
+  getCurrentClerkUserForMfa,
+} from "./super-admin-mfa";
 
 export const LEAFJOURNEY_HQ_SLUG = "leafjourney-hq";
 const LEAFJOURNEY_HQ_NAME = "LeafJourney HQ";
@@ -99,6 +103,27 @@ export async function bootstrapSuperAdminIfAllowlisted(
   const allowlist = bootstrapAllowlist();
   if (allowlist.size === 0) return false;
   if (!allowlist.has(user.email.toLowerCase())) return false;
+
+  // EMR-725 — Refuse to promote without an enrolled second factor. Fresh
+  // bootstrap grants get no grace window (see super-admin-mfa.ts header).
+  // The check is skipped in non-prod environments that explicitly disable
+  // MFA enforcement, matching `mfaEnforcementDisabled()` semantics.
+  const mfaEnforced =
+    process.env.NODE_ENV === "production" ||
+    process.env.SUPER_ADMIN_MFA_ENFORCE !== "0";
+  if (mfaEnforced) {
+    const clerkUser = await getCurrentClerkUserForMfa();
+    if (!clerkUserHasMfa(clerkUser)) {
+      logger.warn({
+        event: "auth.bootstrap.refused_no_mfa",
+        userId: user.id,
+        email: user.email,
+        message:
+          "Allowlisted user attempted bootstrap promotion without an enrolled second factor.",
+      });
+      return false;
+    }
+  }
 
   const hqOrgId = await ensureLeafjourneyHq();
   await prisma.membership.upsert({

--- a/src/lib/auth/super-admin-mfa.test.ts
+++ b/src/lib/auth/super-admin-mfa.test.ts
@@ -1,0 +1,246 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    membership: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+  currentUser: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db/prisma";
+import {
+  clerkUserHasMfa,
+  resolveSuperAdminMfaState,
+  buildMfaRequiredResponse,
+  MfaRequiredError,
+  SUPER_ADMIN_MFA_GRACE_MS,
+} from "./super-admin-mfa";
+import type { AuthedUser } from "./session";
+
+const mockedPrisma = vi.mocked(prisma, true) as unknown as {
+  membership: {
+    findFirst: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const superAdmin: AuthedUser = {
+  id: "user_super",
+  email: "super@leafjourney.com",
+  firstName: "Super",
+  lastName: "Admin",
+  roles: ["super_admin"],
+  organizationId: "org_hq",
+  organizationName: "LeafJourney HQ",
+};
+
+const clinician: AuthedUser = {
+  ...superAdmin,
+  id: "user_clin",
+  email: "clin@example.com",
+  roles: ["clinician"],
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubEnv("NODE_ENV", "production");
+  vi.stubEnv("SUPER_ADMIN_MFA_ENFORCE", "1");
+});
+
+describe("clerkUserHasMfa", () => {
+  it("returns false for null user", () => {
+    expect(clerkUserHasMfa(null)).toBe(false);
+  });
+
+  it("returns true when twoFactorEnabled is set", () => {
+    expect(
+      clerkUserHasMfa({
+        twoFactorEnabled: true,
+        totpEnabled: false,
+        backupCodeEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when only totpEnabled is set", () => {
+    expect(
+      clerkUserHasMfa({
+        twoFactorEnabled: false,
+        totpEnabled: true,
+        backupCodeEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when only backupCodeEnabled is set", () => {
+    expect(
+      clerkUserHasMfa({
+        twoFactorEnabled: false,
+        totpEnabled: false,
+        backupCodeEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when no factor is enabled", () => {
+    expect(
+      clerkUserHasMfa({
+        twoFactorEnabled: false,
+        totpEnabled: false,
+        backupCodeEnabled: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSuperAdminMfaState", () => {
+  it("returns not_super for non-super_admin actors", async () => {
+    const state = await resolveSuperAdminMfaState(clinician, null);
+    expect(state.status).toBe("not_super");
+  });
+
+  it("returns enrolled when MFA is on", async () => {
+    const state = await resolveSuperAdminMfaState(superAdmin, {
+      twoFactorEnabled: true,
+      totpEnabled: false,
+      backupCodeEnabled: false,
+    });
+    expect(state.status).toBe("enrolled");
+    expect(mockedPrisma.membership.updateMany).toHaveBeenCalled();
+  });
+
+  it("stamps grace + returns grace on first observation of unenrolled super_admin", async () => {
+    mockedPrisma.membership.findFirst.mockResolvedValue({
+      id: "m_1",
+      mfaGraceUntil: null,
+    });
+    mockedPrisma.membership.update.mockResolvedValue({});
+
+    const state = await resolveSuperAdminMfaState(superAdmin, {
+      twoFactorEnabled: false,
+      totpEnabled: false,
+      backupCodeEnabled: false,
+    });
+
+    expect(state.status).toBe("grace");
+    if (state.status === "grace") {
+      const now = Date.now();
+      const elapsed = state.graceUntil.getTime() - now;
+      expect(elapsed).toBeGreaterThan(SUPER_ADMIN_MFA_GRACE_MS - 5000);
+      expect(elapsed).toBeLessThanOrEqual(SUPER_ADMIN_MFA_GRACE_MS + 5000);
+    }
+    expect(mockedPrisma.membership.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns grace (no stamp) when graceUntil is still in the future", async () => {
+    const future = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
+    mockedPrisma.membership.findFirst.mockResolvedValue({
+      id: "m_2",
+      mfaGraceUntil: future,
+    });
+
+    const state = await resolveSuperAdminMfaState(superAdmin, {
+      twoFactorEnabled: false,
+      totpEnabled: false,
+      backupCodeEnabled: false,
+    });
+
+    expect(state.status).toBe("grace");
+    expect(mockedPrisma.membership.update).not.toHaveBeenCalled();
+  });
+
+  it("returns blocked when grace has expired", async () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockedPrisma.membership.findFirst.mockResolvedValue({
+      id: "m_3",
+      mfaGraceUntil: past,
+    });
+
+    const state = await resolveSuperAdminMfaState(superAdmin, {
+      twoFactorEnabled: false,
+      totpEnabled: false,
+      backupCodeEnabled: false,
+    });
+
+    expect(state.status).toBe("blocked");
+  });
+
+  it("returns blocked when no Membership row matches", async () => {
+    mockedPrisma.membership.findFirst.mockResolvedValue(null);
+    const state = await resolveSuperAdminMfaState(superAdmin, null);
+    expect(state.status).toBe("blocked");
+    if (state.status === "blocked") {
+      expect(state.graceUntil).toBeNull();
+    }
+  });
+
+  it("bypasses enforcement when SUPER_ADMIN_MFA_ENFORCE=0 in non-prod", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SUPER_ADMIN_MFA_ENFORCE", "0");
+    const state = await resolveSuperAdminMfaState(superAdmin, null);
+    expect(state.status).toBe("enrolled");
+  });
+
+  it("DOES enforce in production even with SUPER_ADMIN_MFA_ENFORCE=0", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SUPER_ADMIN_MFA_ENFORCE", "0");
+    mockedPrisma.membership.findFirst.mockResolvedValue({
+      id: "m_4",
+      mfaGraceUntil: null,
+    });
+    mockedPrisma.membership.update.mockResolvedValue({});
+
+    const state = await resolveSuperAdminMfaState(superAdmin, null);
+    expect(state.status).toBe("grace");
+  });
+});
+
+describe("buildMfaRequiredResponse", () => {
+  it("returns a 403 with the structured envelope", async () => {
+    const grace = new Date("2026-06-01T00:00:00Z");
+    const res = buildMfaRequiredResponse(grace);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("mfa_required");
+    expect(body.error).toBe("MFA_REQUIRED");
+    expect(body.enrollUrl).toBe("/sign-in/factor-two");
+    expect(body.graceUntil).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("serialises null graceUntil as null", async () => {
+    const res = buildMfaRequiredResponse(null);
+    const body = await res.json();
+    expect(body.graceUntil).toBeNull();
+  });
+});
+
+describe("MfaRequiredError", () => {
+  it("carries the typed code + graceUntil", () => {
+    const err = new MfaRequiredError(new Date("2026-06-01T00:00:00Z"));
+    expect(err.code).toBe("MFA_REQUIRED");
+    expect(err.message).toBe("MFA_REQUIRED");
+    expect(err.graceUntil?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+});
+

--- a/src/lib/auth/super-admin-mfa.ts
+++ b/src/lib/auth/super-admin-mfa.ts
@@ -1,0 +1,223 @@
+// EMR-725 — Super-admin MFA enforcement.
+//
+// Why this lives separately from ./super-admin.ts:
+//   super-admin.ts is the pure role gate ("does the actor hold the role?").
+//   This module is the orthogonal security check ("does the actor with that
+//   role have an enrolled second factor, or are they still inside the
+//   one-time 14-day grace window?").
+//
+// Grace window design (the only non-obvious piece in this PR):
+//   When EMR-725 ships, existing super-admins may not have MFA enrolled —
+//   abruptly locking them out would brick the operations team. So on the
+//   first sign-in by an EXISTING super_admin without MFA we stamp a
+//   `mfaGraceUntil = now + 14 days` on their Membership row. During those
+//   14 days the gate emits a warning audit row and a banner appears in the
+//   super-admin shell, but the request is allowed through. After the
+//   deadline, the gate hard-blocks with a structured `mfa_required` 403.
+//
+//   Fresh bootstrap grants (SUPER_ADMIN_BOOTSTRAP_EMAILS path) do NOT get
+//   a grace window — the bootstrap helper refuses to promote a user whose
+//   Clerk identity has no enrolled factor in the first place.
+
+import "server-only";
+
+import { auth, currentUser as clerkCurrentUser } from "@clerk/nextjs/server";
+import type { User as ClerkUser } from "@clerk/backend";
+import { prisma } from "@/lib/db/prisma";
+import { logger } from "@/lib/observability/log";
+import type { AuthedUser } from "./session";
+
+/** 14 days, in milliseconds. */
+export const SUPER_ADMIN_MFA_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** Clerk path users are redirected to for MFA enrollment. */
+export const MFA_ENROLL_PATH = "/sign-in/factor-two";
+
+/**
+ * Resolved MFA state for the currently-authenticated super_admin.
+ *
+ *   - status="enrolled"    → MFA is on; no friction.
+ *   - status="grace"       → MFA missing but grace window active.
+ *                            Caller should let the request through and
+ *                            surface a banner / warn-audit.
+ *   - status="blocked"     → MFA missing and grace expired (or never
+ *                            existed). Caller MUST 403.
+ *   - status="not_super"   → Actor is not a super_admin — caller should
+ *                            skip this check entirely.
+ *
+ * `graceUntil` is populated for the "grace" and "blocked" states so the
+ * 403 envelope and banner can surface the deadline.
+ */
+export type SuperAdminMfaState =
+  | { status: "enrolled" }
+  | { status: "grace"; graceUntil: Date }
+  | { status: "blocked"; graceUntil: Date | null }
+  | { status: "not_super" };
+
+/**
+ * Bypass flag for non-production environments that don't want to set up
+ * Clerk MFA locally. Production always enforces.
+ */
+function mfaEnforcementDisabled(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  return process.env.SUPER_ADMIN_MFA_ENFORCE === "0";
+}
+
+/**
+ * True when the Clerk user has any second factor enrolled. We accept
+ * TOTP, backup codes, or Clerk's generic twoFactorEnabled flag — any one
+ * of them satisfies the "has a second factor" check.
+ */
+export function clerkUserHasMfa(
+  user: Pick<ClerkUser, "twoFactorEnabled" | "totpEnabled" | "backupCodeEnabled"> | null,
+): boolean {
+  if (!user) return false;
+  return Boolean(user.twoFactorEnabled || user.totpEnabled || user.backupCodeEnabled);
+}
+
+/**
+ * Load the current Clerk user (server-side). Wrapper exists so tests can
+ * mock one symbol rather than the entire `@clerk/nextjs/server` surface.
+ */
+export async function getCurrentClerkUserForMfa(): Promise<ClerkUser | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+  return await clerkCurrentUser();
+}
+
+/**
+ * Resolve the actor's super-admin MFA state. Stamps the grace deadline on
+ * first read when needed.
+ *
+ *   - If the actor is not super_admin → "not_super".
+ *   - If MFA is enrolled → "enrolled" (and any stale grace timestamp is
+ *     cleared as a side-effect — the actor no longer needs the warning
+ *     banner).
+ *   - Otherwise, look at the Membership.mfaGraceUntil column:
+ *       null  → first observation; stamp now+14d and return "grace".
+ *       future → still in grace; return "grace".
+ *       past   → grace expired; return "blocked".
+ */
+export async function resolveSuperAdminMfaState(
+  user: AuthedUser,
+  clerkUser: Pick<ClerkUser, "twoFactorEnabled" | "totpEnabled" | "backupCodeEnabled"> | null,
+): Promise<SuperAdminMfaState> {
+  if (!user.roles.includes("super_admin")) {
+    return { status: "not_super" };
+  }
+
+  if (mfaEnforcementDisabled()) {
+    return { status: "enrolled" };
+  }
+
+  if (clerkUserHasMfa(clerkUser)) {
+    // Clear any lingering grace row — once MFA is on, the banner stops.
+    try {
+      await prisma.membership.updateMany({
+        where: {
+          userId: user.id,
+          role: "super_admin",
+          mfaGraceUntil: { not: null },
+        },
+        data: { mfaGraceUntil: null },
+      });
+    } catch (err) {
+      // Don't fail the request on a grace-clear hiccup; the banner will
+      // simply persist until the next successful write.
+      logger.warn({
+        event: "auth.super_admin_mfa.clear_grace_failed",
+        userId: user.id,
+        err,
+      });
+    }
+    return { status: "enrolled" };
+  }
+
+  // MFA not enrolled — consult the grace clock.
+  const membership = await prisma.membership.findFirst({
+    where: { userId: user.id, role: "super_admin" },
+    select: { id: true, mfaGraceUntil: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (!membership) {
+    // Defensive: roles include super_admin but no Membership row matches.
+    // Treat as blocked so we don't accidentally hand out a grace.
+    return { status: "blocked", graceUntil: null };
+  }
+
+  const now = Date.now();
+
+  if (membership.mfaGraceUntil == null) {
+    const graceUntil = new Date(now + SUPER_ADMIN_MFA_GRACE_MS);
+    try {
+      await prisma.membership.update({
+        where: { id: membership.id },
+        data: { mfaGraceUntil: graceUntil },
+      });
+    } catch (err) {
+      // If the stamp fails, treat as blocked so we don't hand out an
+      // unbounded grace via repeated failed writes.
+      logger.error({
+        event: "auth.super_admin_mfa.stamp_grace_failed",
+        userId: user.id,
+        err,
+      });
+      return { status: "blocked", graceUntil: null };
+    }
+    return { status: "grace", graceUntil };
+  }
+
+  if (membership.mfaGraceUntil.getTime() > now) {
+    return { status: "grace", graceUntil: membership.mfaGraceUntil };
+  }
+
+  return { status: "blocked", graceUntil: membership.mfaGraceUntil };
+}
+
+/**
+ * Convenience wrapper used by the page-layout gate: loads the Clerk user
+ * AND resolves the state in one call.
+ */
+export async function loadSuperAdminMfaState(
+  user: AuthedUser,
+): Promise<SuperAdminMfaState> {
+  const clerkUser = await getCurrentClerkUserForMfa();
+  return await resolveSuperAdminMfaState(user, clerkUser);
+}
+
+/**
+ * The structured 403 body returned to API callers when MFA is required.
+ * Stable shape so clients can branch on `code === "mfa_required"`.
+ */
+export interface MfaRequiredBody {
+  code: "mfa_required";
+  error: "MFA_REQUIRED";
+  message: string;
+  enrollUrl: string;
+  graceUntil: string | null;
+}
+
+export function buildMfaRequiredResponse(graceUntil: Date | null): Response {
+  const body: MfaRequiredBody = {
+    code: "mfa_required",
+    error: "MFA_REQUIRED",
+    message: "Super-admin role requires an enrolled second factor.",
+    enrollUrl: MFA_ENROLL_PATH,
+    graceUntil: graceUntil ? graceUntil.toISOString() : null,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Typed error thrown from server-component gates so the layout can catch + redirect. */
+export class MfaRequiredError extends Error {
+  readonly code = "MFA_REQUIRED";
+  readonly graceUntil: Date | null;
+  constructor(graceUntil: Date | null) {
+    super("MFA_REQUIRED");
+    this.graceUntil = graceUntil;
+  }
+}

--- a/src/lib/auth/super-admin.ts
+++ b/src/lib/auth/super-admin.ts
@@ -26,6 +26,7 @@ import "server-only";
 import type { Role } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { type AuthedUser, requireUser } from "./session";
+import { loadSuperAdminMfaState, MfaRequiredError } from "./super-admin-mfa";
 
 /** Roles allowed to operate the onboarding controller (write-path). */
 const CONTROLLER_ROLES: ReadonlyArray<Role> = ["super_admin", "implementation_admin"];
@@ -45,11 +46,20 @@ function hasAnyRole(user: AuthedUser, allowed: ReadonlyArray<Role>): boolean {
  * Require the caller to be a LeafJourney super_admin.
  * Throws "FORBIDDEN" otherwise — same contract as `requireRole()` in
  * `./session.ts`. Caller is expected to surface this as a 403.
+ *
+ * EMR-725 — Also enforces MFA at this layer: a super_admin without an
+ * enrolled second factor (and past their 14-day grace window) gets a
+ * typed `MfaRequiredError` so the layout can redirect to enrollment
+ * rather than the generic /forbidden surface.
  */
 export async function requireSuperAdmin(): Promise<AuthedUser> {
   const user = await requireUser();
   if (!user.roles.includes("super_admin")) {
     throw new Error("FORBIDDEN");
+  }
+  const mfa = await loadSuperAdminMfaState(user);
+  if (mfa.status === "blocked") {
+    throw new MfaRequiredError(mfa.graceUntil);
   }
   return user;
 }


### PR DESCRIPTION
## Summary

- `requireApiAuth` gates super_admin actors on enrolled MFA. Blocked path returns a structured `403 { code: "mfa_required", enrollUrl, graceUntil }`.
- `requireSuperAdmin` throws a typed `MfaRequiredError` so the (super-admin) layout can redirect to `/sign-in/factor-two`.
- `bootstrapSuperAdminIfAllowlisted` refuses to promote when MFA isn't enrolled — fresh allowlist grants never see a grace window.
- Existing super-admins without MFA get a one-time 14-day grace stamped on `Membership.mfaGraceUntil` (additive column); banner UI is a follow-up.

Linear: https://linear.app/emr-project/issue/EMR-725

## Test plan

- [x] 22 new unit tests (super-admin-mfa.test.ts + super-admin-bootstrap.test.ts) pass
- [x] typecheck clean
- [x] lint clean (no new warnings)
- [ ] follow-up: render the grace-deadline banner in the super-admin layout

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>