### PR TITLE
feat(super-admin): audit log viewer /admin/audit (EMR-747)

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -98,6 +98,18 @@ routes:
     owner: platform-security
     notes: "super_admin role. EMR-738 cross-tenant search. Query `q` is redacted before audit persistence: emails (contain '@') and phone-shaped strings (>=7 digits) are truncated to first 3 chars + '***'. Indexed columns only; no full-text. Emits controller.super_admin.cross_tenant_search audit row per request."
 
+  admin/audit:
+    methods: [GET]
+    auth: required
+    owner: platform-security
+    notes: "super_admin role. EMR-747 ControllerAuditLog viewer. Cursor-paginated (no offset). Reads only — does NOT emit an audit row per request (would create a feedback loop with the table it lists). Filters: actor, action (case-insensitive contains), target, from/to. Metadata preview masks email/phone shapes; full JSON on expand renders verbatim (super-admin surface only)."
+
+  admin/audit/export:
+    methods: [GET]
+    auth: required
+    owner: platform-security
+    notes: "super_admin role. EMR-747 streaming CSV export of ControllerAuditLog. Uses streamCsvResponse from src/lib/admin/csv-export.ts (EMR-749) — one super_admin.csv_export audit row emitted BEFORE the stream begins; rows pulled lazily via async iterator so a 100k-row export never materialises in memory. Includes a practice_id column to satisfy the utility's requirePracticeIdColumn enforcement."
+
   admin/practices/[id]/switch-specialty:
     methods: [POST]
     auth: required

--- a/src/app/(super-admin)/admin/audit/keyboard-island.tsx
+++ b/src/app/(super-admin)/admin/audit/keyboard-island.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+// EMR-747 — Client island for the audit log table.
+//
+// Mirrors search-results-island.tsx in spirit but does more, because the
+// audit table has expandable rows. Responsibilities:
+//
+//   - j/k (or ArrowDown/ArrowUp) move row focus
+//   - Enter toggles the focused row's expanded metadata
+//   - "/" focuses the action filter input (id="audit-filter-action")
+//   - per-row expanded JSON renders verbatim (super-admin only surface)
+//
+// We deliberately keep the table markup itself on the server — this
+// island just adorns the existing rows with focus/expand state and
+// keyboard wiring. The server renders one tbody-per-row (an "expand"
+// row below each data row) so toggling never round-trips.
+
+import * as React from "react";
+
+export interface AuditRowView {
+  id: string;
+  at: string;
+  atRelative: string;
+  actorLabel: string;
+  actorHref: string | null;
+  action: string;
+  subjectLabel: string;
+  subjectHref: string | null;
+  targetLabel: string;
+  targetHref: string | null;
+  metadataPreview: string;
+  metadataFullJson: string;
+}
+
+const ACTION_FILTER_INPUT_ID = "audit-filter-action";
+
+export function AuditTableIsland({
+  rows,
+  emptyState,
+}: {
+  rows: AuditRowView[];
+  emptyState: React.ReactNode;
+}) {
+  const [selected, setSelected] = React.useState(0);
+  const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
+
+  // Reset focus when the row set identity changes (new filter applied).
+  // Avoids stale "selected" index pointing past the end of a narrower
+  // result set.
+  React.useEffect(() => {
+    setSelected(0);
+    setExpanded({});
+  }, [rows]);
+
+  const toggleExpanded = React.useCallback((id: string) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  React.useEffect(() => {
+    if (rows.length === 0) return;
+
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const inField =
+        !!target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable);
+
+      // "/" focuses the action filter from anywhere. Honour the convention
+      // most editors and Gmail/Linear use: focus the filter, prevent
+      // default so the literal slash never lands in the field.
+      if (e.key === "/" && !inField) {
+        const el = document.getElementById(ACTION_FILTER_INPUT_ID) as
+          | HTMLInputElement
+          | null;
+        if (el) {
+          e.preventDefault();
+          el.focus();
+          el.select();
+        }
+        return;
+      }
+
+      if (inField) return;
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelected((s) => Math.min(rows.length - 1, s + 1));
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelected((s) => Math.max(0, s - 1));
+      } else if (e.key === "Enter") {
+        const row = rows[selected];
+        if (row) {
+          e.preventDefault();
+          toggleExpanded(row.id);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [rows, selected, toggleExpanded]);
+
+  if (rows.length === 0) return <>{emptyState}</>;
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Time</th>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Actor</th>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Action</th>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Subject</th>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Target</th>
+            <th className="px-3 py-2 text-left font-medium text-text-muted">Metadata</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => {
+            const isSelected = idx === selected;
+            const isExpanded = !!expanded[row.id];
+            return (
+              <React.Fragment key={row.id}>
+                <tr
+                  className={
+                    isSelected
+                      ? "bg-accent/30 outline outline-1 outline-accent"
+                      : "hover:bg-muted/30"
+                  }
+                  onMouseEnter={() => setSelected(idx)}
+                  onClick={() => toggleExpanded(row.id)}
+                >
+                  <td className="px-3 py-2 align-top" title={row.at}>
+                    {row.atRelative}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {row.actorHref ? (
+                      <a
+                        href={row.actorHref}
+                        className="text-accent underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {row.actorLabel}
+                      </a>
+                    ) : (
+                      row.actorLabel
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top font-mono text-xs">
+                    {row.action}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {row.subjectHref ? (
+                      <a
+                        href={row.subjectHref}
+                        className="text-accent underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {row.subjectLabel}
+                      </a>
+                    ) : (
+                      row.subjectLabel
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {row.targetHref ? (
+                      <a
+                        href={row.targetHref}
+                        className="text-accent underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {row.targetLabel}
+                      </a>
+                    ) : (
+                      row.targetLabel
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <button
+                      type="button"
+                      className="text-left text-xs text-text-muted"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleExpanded(row.id);
+                      }}
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? "▾ Collapse" : "▸ "}{" "}
+                      {!isExpanded && (
+                        <span className="font-mono">{row.metadataPreview || "—"}</span>
+                      )}
+                    </button>
+                  </td>
+                </tr>
+                {isExpanded && (
+                  <tr className="bg-muted/20">
+                    <td colSpan={6} className="px-3 py-3">
+                      <pre className="whitespace-pre-wrap break-all text-xs font-mono text-text-muted">
+                        {row.metadataFullJson}
+                      </pre>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="px-3 py-2 text-xs text-text-muted border-t border-border">
+        Navigate with j/k (or arrow keys); Enter expands the focused row;
+        &quot;/&quot; jumps to the action filter.
+      </div>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/admin/audit/page.tsx
+++ b/src/app/(super-admin)/admin/audit/page.tsx
@@ -1,0 +1,296 @@
+// EMR-747 — ControllerAuditLog viewer.
+//
+// Server component. Filters live entirely in URL params so the page is
+// deep-linkable and shareable. Filter chips above the table let the
+// operator drop individual filters with a click; the form below lets
+// them set new ones. Cursor pagination via "Load more" — no offset.
+//
+// The data fetch happens server-side via `runAuditQuery`, not by calling
+// our own API route. Same query path, one fewer hop, simpler error
+// handling on the page. The API route still exists for programmatic
+// consumers (operators paging through with curl during an incident).
+//
+// Keyboard nav (j/k/Enter, "/" → action filter) lives in
+// keyboard-island.tsx — a small client island over the server-rendered
+// table. We do NOT audit the read of /admin/audit on render (would
+// create a feedback loop, see route.ts header).
+
+import { redirect } from "next/navigation";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  encodeCursor,
+  metadataPreview,
+  parseAuditQuery,
+  runAuditQuery,
+  type AuditQuery,
+} from "@/lib/admin/audit-log";
+import { AuditTableIsland, type AuditRowView } from "./keyboard-island";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Audit log" };
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function relativeTime(iso: string): string {
+  // Inline relative-time formatter — pulling in date-fns or
+  // Intl.RelativeTimeFormat for one place is overkill, and we want stable
+  // strings during SSR so the operator's first paint matches the URL.
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return iso;
+  const diff = Date.now() - then;
+  const sec = Math.round(diff / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(then).toISOString().slice(0, 10);
+}
+
+/** Build a relative URL with the same filters minus the supplied key. */
+function urlWithout(q: AuditQuery, key: keyof AuditQuery): string {
+  const params = new URLSearchParams();
+  const set = (k: string, v: string | null | undefined) => {
+    if (v != null && v !== "") params.set(k, v);
+  };
+  set("actor", key === "actor" ? null : q.actor);
+  set("action", key === "action" ? null : q.action);
+  set("target", key === "target" ? null : q.target);
+  set("from", key === "from" ? null : q.from?.toISOString().slice(0, 10) ?? null);
+  set("to", key === "to" ? null : q.to?.toISOString().slice(0, 10) ?? null);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "?";
+}
+
+function urlWithCursor(q: AuditQuery, cursor: string): string {
+  const params = new URLSearchParams();
+  if (q.actor) params.set("actor", q.actor);
+  if (q.action) params.set("action", q.action);
+  if (q.target) params.set("target", q.target);
+  if (q.from) params.set("from", q.from.toISOString().slice(0, 10));
+  if (q.to) params.set("to", q.to.toISOString().slice(0, 10));
+  params.set("cursor", cursor);
+  return `?${params.toString()}`;
+}
+
+function exportUrl(q: AuditQuery): string {
+  const params = new URLSearchParams();
+  if (q.actor) params.set("actor", q.actor);
+  if (q.action) params.set("action", q.action);
+  if (q.target) params.set("target", q.target);
+  if (q.from) params.set("from", q.from.toISOString().slice(0, 10));
+  if (q.to) params.set("to", q.to.toISOString().slice(0, 10));
+  const qs = params.toString();
+  return `/api/admin/audit/export${qs ? `?${qs}` : ""}`;
+}
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams;
+}) {
+  // Re-check auth on every render. The layout already gates, but the
+  // audit surface is sensitive enough that a layer of defence here is
+  // cheap.
+  const actor = await requireUser();
+  if (!actor.roles.includes("super_admin")) redirect("/");
+
+  const q = parseAuditQuery(searchParams ?? {});
+  const result = await runAuditQuery(prisma, q);
+
+  // Map raw rows to the view shape the island expects. Deep-links go to
+  // /admin/console/users/<id> for users and /practices/<id> for
+  // practices (the routes the rest of the super-admin shell already
+  // uses). The audit table doesn't try to be cleverer than that — a
+  // dead deep-link is better than a wrong one.
+  const viewRows: AuditRowView[] = result.rows.map((r) => {
+    const subjectLooksLikeUser = r.subjectType === "user";
+    return {
+      id: r.id,
+      at: r.at,
+      atRelative: relativeTime(r.at),
+      actorLabel: r.actorEmail ?? r.actorUserId,
+      actorHref: `/admin/console/users/${encodeURIComponent(r.actorUserId)}`,
+      action: r.action,
+      subjectLabel: r.subjectId,
+      subjectHref: subjectLooksLikeUser
+        ? `/admin/console/users/${encodeURIComponent(r.subjectId)}`
+        : null,
+      targetLabel: r.organizationId ?? "—",
+      targetHref: r.organizationId
+        ? `/practices/${encodeURIComponent(r.organizationId)}`
+        : null,
+      metadataPreview: metadataPreview(r.after ?? r.before),
+      metadataFullJson: JSON.stringify(
+        { before: r.before, after: r.after, reason: r.reason },
+        null,
+        2,
+      ),
+    };
+  });
+
+  // Build the filter-chip set. Each chip is a link that removes its
+  // filter from the URL. Clear-all sits next to the chips when any
+  // filter is active.
+  const activeChips: Array<{ label: string; href: string }> = [];
+  if (q.actor) {
+    activeChips.push({ label: `actor: ${q.actor}`, href: urlWithout(q, "actor") });
+  }
+  if (q.action) {
+    activeChips.push({ label: `action: ${q.action}`, href: urlWithout(q, "action") });
+  }
+  if (q.target) {
+    activeChips.push({ label: `target: ${q.target}`, href: urlWithout(q, "target") });
+  }
+  if (q.from) {
+    activeChips.push({
+      label: `from: ${q.from.toISOString().slice(0, 10)}`,
+      href: urlWithout(q, "from"),
+    });
+  }
+  if (q.to) {
+    activeChips.push({
+      label: `to: ${q.to.toISOString().slice(0, 10)}`,
+      href: urlWithout(q, "to"),
+    });
+  }
+
+  return (
+    <PageShell>
+      <PageHeader
+        eyebrow="Internal"
+        title="Audit log"
+        description="Every controller mutation across every practice. Filter, expand, export."
+        actions={
+          <a
+            href={exportUrl(q)}
+            className="rounded-md border border-border px-3 py-2 text-sm font-medium hover:bg-muted/40"
+          >
+            Export CSV
+          </a>
+        }
+      />
+
+      <form method="GET" className="mb-4 flex flex-wrap items-end gap-3">
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor="audit-filter-actor">
+            Actor
+          </label>
+          <input
+            id="audit-filter-actor"
+            name="actor"
+            type="text"
+            defaultValue={q.actor ?? ""}
+            placeholder="userId or email"
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor="audit-filter-action">
+            Action
+          </label>
+          <input
+            id="audit-filter-action"
+            name="action"
+            type="text"
+            defaultValue={q.action ?? ""}
+            placeholder="contains…"
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor="audit-filter-target">
+            Target
+          </label>
+          <input
+            id="audit-filter-target"
+            name="target"
+            type="text"
+            defaultValue={q.target ?? ""}
+            placeholder="practiceId or subjectId"
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor="audit-filter-from">
+            From
+          </label>
+          <input
+            id="audit-filter-from"
+            name="from"
+            type="date"
+            defaultValue={q.from ? q.from.toISOString().slice(0, 10) : ""}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-text-muted mb-1" htmlFor="audit-filter-to">
+            To
+          </label>
+          <input
+            id="audit-filter-to"
+            name="to"
+            type="date"
+            defaultValue={q.to ? q.to.toISOString().slice(0, 10) : ""}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <button
+          type="submit"
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-foreground"
+        >
+          Apply
+        </button>
+      </form>
+
+      {activeChips.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-2 text-xs">
+          {activeChips.map((chip) => (
+            <a
+              key={chip.label}
+              href={chip.href}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2 py-1 hover:bg-muted/60"
+            >
+              {chip.label}
+              <span aria-hidden="true">×</span>
+            </a>
+          ))}
+          <a href="?" className="text-text-muted underline">
+            Clear all
+          </a>
+        </div>
+      )}
+
+      <AuditTableIsland
+        rows={viewRows}
+        emptyState={
+          <div className="rounded-md border border-dashed border-border px-6 py-12 text-center">
+            <p className="text-sm text-text-muted">
+              No audit rows match the current filters.
+            </p>
+          </div>
+        }
+      />
+
+      {result.nextCursor && (
+        <div className="mt-4">
+          <a
+            href={urlWithCursor(q, result.nextCursor)}
+            className="text-sm text-accent underline"
+          >
+            Load more →
+          </a>
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+// Tiny helper used in tests to mirror page-side cursor URL construction
+// without re-implementing it. Not part of the page render path.
+export const _internals = { encodeCursor };

--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -23,6 +23,15 @@ const SUPER_ADMIN_SECTIONS: NavSection[] = [
     label: "Search",
     items: [{ label: "Search", href: "/admin/search" }],
   },
+  // EMR-747 — ControllerAuditLog viewer. Placed between Search and
+  // Onboarding so the cross-tenant ops triad (search → audit →
+  // onboarding) reads top-to-bottom in the nav.
+  {
+    pillar: "admin",
+    icon: "layout-grid",
+    label: "Audit Log",
+    items: [{ label: "Audit Log", href: "/admin/audit" }],
+  },
   {
     pillar: "onboarding",
     icon: "clipboard-check",

--- a/src/app/api/admin/audit/export/route.ts
+++ b/src/app/api/admin/audit/export/route.ts
@@ -1,0 +1,82 @@
+// EMR-747 — ControllerAuditLog CSV export.
+//
+// GET /api/admin/audit/export?<same filters as /api/admin/audit>
+//
+// Super-admin only. Streams the entire filtered result set as CSV via
+// the shared `streamCsvResponse` utility (EMR-749), which writes exactly
+// one `super_admin.csv_export` audit row before the stream begins. The
+// audit row carries the active filter set so we can correlate an
+// exported file to the operator/intent that produced it.
+//
+// Columns: at, actorEmail, actorRole (first), action, subjectType,
+// subjectId, organizationId, practice_id (alias of organizationId — used
+// by the csv-export utility's requirePracticeIdColumn enforcement).
+
+import type { NextRequest } from "next/server";
+import { requireApiAuth } from "@/lib/auth/api-gate";
+import { prisma } from "@/lib/db/prisma";
+import {
+  type AuditRow,
+  iterateAuditRows,
+  parseAuditQuery,
+} from "@/lib/admin/audit-log";
+import {
+  type CsvColumn,
+  practiceIdColumn,
+  streamCsvResponse,
+} from "@/lib/admin/csv-export";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const COLUMNS: ReadonlyArray<CsvColumn<AuditRow>> = [
+  { header: "At", get: (r) => r.at },
+  { header: "Actor User ID", get: (r) => r.actorUserId },
+  { header: "Actor Email", get: (r) => r.actorEmail ?? "" },
+  { header: "Actor Role", get: (r) => (r.actorRoles[0] ?? "") },
+  { header: "Action", get: (r) => r.action },
+  { header: "Subject Type", get: (r) => r.subjectType },
+  { header: "Subject ID", get: (r) => r.subjectId },
+  { header: "Organization ID", get: (r) => r.organizationId ?? "" },
+  // The csv-export utility enforces a `practice_id` column on every export.
+  // We alias the same value here so the contract is satisfied without
+  // duplicating data in a confusing way — see practiceIdColumn() for the
+  // sentinel tag.
+  practiceIdColumn<AuditRow>("Practice ID", (r) => r.organizationId ?? ""),
+  { header: "Reason", get: (r) => r.reason ?? "" },
+];
+
+export async function GET(req: NextRequest) {
+  const gate = await requireApiAuth({ role: "super_admin" });
+  if (gate.error) return gate.error;
+  const actor = gate.actor;
+
+  const url = new URL(req.url);
+  // The cursor URL param means something specific in the list API; for the
+  // export we always walk from the start of the filtered set so the file
+  // is reproducible from the filter chips alone. Strip it before parsing.
+  url.searchParams.delete("cursor");
+  const q = parseAuditQuery(url.searchParams);
+
+  return streamCsvResponse<AuditRow>({
+    rows: iterateAuditRows(prisma, q),
+    columns: COLUMNS,
+    filename: "controller-audit-log",
+    audit: {
+      entity: "ControllerAuditLog",
+      filters: {
+        actor: q.actor,
+        action: q.action,
+        target: q.target,
+        from: q.from?.toISOString() ?? null,
+        to: q.to?.toISOString() ?? null,
+      },
+      actor: {
+        id: actor.id,
+        email: actor.email,
+        roles: actor.roles,
+        organizationId: actor.organizationId,
+      },
+    },
+  });
+}

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,0 +1,35 @@
+// EMR-747 — ControllerAuditLog list API.
+//
+// GET /api/admin/audit?actor=...&action=...&target=...&from=...&to=...&cursor=...&limit=...
+//
+// Super-admin only. Returns the page of rows + the next cursor. The core
+// query module is in src/lib/admin/audit-log.ts; this route is just the
+// auth gate, URL parsing, and JSON serialisation.
+//
+// Auth: requireApiAuth({ role: "super_admin" }). Non-super-admin callers
+// get a 403 so we can alarm on attempted access.
+//
+// We deliberately do NOT audit READ access to the audit log here. That
+// would create a runaway feedback loop (every read writes another row,
+// which the next read enumerates, which writes another row, …). If we
+// ever need a read trail it should land in a separate table.
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/auth/api-gate";
+import { prisma } from "@/lib/db/prisma";
+import { parseAuditQuery, runAuditQuery } from "@/lib/admin/audit-log";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const gate = await requireApiAuth({ role: "super_admin" });
+  if (gate.error) return gate.error;
+
+  const url = new URL(req.url);
+  const q = parseAuditQuery(url.searchParams);
+
+  const result = await runAuditQuery(prisma, q);
+  return NextResponse.json(result);
+}

--- a/src/lib/admin/audit-log.test.ts
+++ b/src/lib/admin/audit-log.test.ts
@@ -1,0 +1,320 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect } from "vitest";
+import {
+  AUDIT_DEFAULT_LIMIT,
+  AUDIT_MAX_LIMIT,
+  buildAuditWhere,
+  decodeCursor,
+  encodeCursor,
+  maskMetadataPreview,
+  metadataPreview,
+  parseAuditQuery,
+  parseLimit,
+  parseDate,
+  runAuditQuery,
+} from "./audit-log";
+
+describe("encodeCursor / decodeCursor", () => {
+  it("round-trips a cursor through URL-safe base64", () => {
+    const c = { at: "2026-05-17T12:34:56.789Z", id: "row_abc123" };
+    const round = decodeCursor(encodeCursor(c));
+    expect(round).toEqual(c);
+  });
+
+  it("returns null for empty input", () => {
+    expect(decodeCursor(null)).toBeNull();
+    expect(decodeCursor(undefined)).toBeNull();
+    expect(decodeCursor("")).toBeNull();
+  });
+
+  it("returns null for garbage", () => {
+    expect(decodeCursor("not-a-cursor")).toBeNull();
+    expect(decodeCursor("Zm9v")).toBeNull(); // valid base64 but not a cursor shape
+  });
+
+  it("rejects a cursor with an invalid date", () => {
+    const bad = Buffer.from(JSON.stringify({ at: "nope", id: "x" })).toString("base64url");
+    expect(decodeCursor(bad)).toBeNull();
+  });
+});
+
+describe("parseLimit", () => {
+  it("returns default for missing", () => {
+    expect(parseLimit(null)).toBe(AUDIT_DEFAULT_LIMIT);
+    expect(parseLimit("")).toBe(AUDIT_DEFAULT_LIMIT);
+  });
+
+  it("clamps to max", () => {
+    expect(parseLimit("99999")).toBe(AUDIT_MAX_LIMIT);
+  });
+
+  it("rejects non-positive", () => {
+    expect(parseLimit("0")).toBe(AUDIT_DEFAULT_LIMIT);
+    expect(parseLimit("-5")).toBe(AUDIT_DEFAULT_LIMIT);
+  });
+
+  it("passes a sensible value", () => {
+    expect(parseLimit("75")).toBe(75);
+  });
+});
+
+describe("parseDate", () => {
+  it("parses ISO", () => {
+    const d = parseDate("2026-05-17T00:00:00Z");
+    expect(d?.toISOString()).toBe("2026-05-17T00:00:00.000Z");
+  });
+
+  it("returns null on garbage", () => {
+    expect(parseDate("nope")).toBeNull();
+    expect(parseDate(null)).toBeNull();
+  });
+});
+
+describe("parseAuditQuery — URL round-trip", () => {
+  it("parses every filter", () => {
+    const params = new URLSearchParams({
+      actor: "user_42",
+      action: "publish",
+      target: "org_99",
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-17T00:00:00Z",
+      limit: "10",
+    });
+    const q = parseAuditQuery(params);
+    expect(q.actor).toBe("user_42");
+    expect(q.action).toBe("publish");
+    expect(q.target).toBe("org_99");
+    expect(q.from?.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(q.to?.toISOString()).toBe("2026-05-17T00:00:00.000Z");
+    expect(q.limit).toBe(10);
+  });
+
+  it("treats empty/whitespace strings as null filters", () => {
+    const params = new URLSearchParams({ actor: " ", action: "  " });
+    const q = parseAuditQuery(params);
+    expect(q.actor).toBeNull();
+    expect(q.action).toBeNull();
+  });
+
+  it("accepts a plain Record (server-component shape)", () => {
+    const q = parseAuditQuery({ action: "grant" });
+    expect(q.action).toBe("grant");
+  });
+});
+
+describe("buildAuditWhere", () => {
+  it("returns empty AND when no filters", () => {
+    const where = buildAuditWhere({
+      actor: null,
+      action: null,
+      target: null,
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 50,
+    });
+    expect(where).toEqual({});
+  });
+
+  it("substring-matches action case-insensitively", () => {
+    const where = buildAuditWhere({
+      actor: null,
+      action: "Publish",
+      target: null,
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 50,
+    });
+    expect(where.AND).toContainEqual({
+      action: { contains: "Publish", mode: "insensitive" },
+    });
+  });
+
+  it("matches actor on userId OR email substring", () => {
+    const where = buildAuditWhere({
+      actor: "alice@example.com",
+      action: null,
+      target: null,
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 50,
+    });
+    const and = where.AND as Array<Record<string, unknown>>;
+    expect(and[0]).toEqual({
+      OR: [
+        { actorUserId: "alice@example.com" },
+        { actorEmail: { contains: "alice@example.com", mode: "insensitive" } },
+      ],
+    });
+  });
+
+  it("matches target on organizationId OR subjectId", () => {
+    const where = buildAuditWhere({
+      actor: null,
+      action: null,
+      target: "abc",
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 50,
+    });
+    const and = where.AND as Array<Record<string, unknown>>;
+    expect(and[0]).toEqual({
+      OR: [{ organizationId: "abc" }, { subjectId: "abc" }],
+    });
+  });
+
+  it("uses half-open at range (gte from, lt to)", () => {
+    const where = buildAuditWhere({
+      actor: null,
+      action: null,
+      target: null,
+      from: new Date("2026-05-01Z"),
+      to: new Date("2026-05-17Z"),
+      cursor: null,
+      limit: 50,
+    });
+    const and = where.AND as Array<{ at?: Record<string, unknown> }>;
+    const range = and.find((c) => c.at)?.at;
+    expect(range).toEqual({
+      gte: new Date("2026-05-01Z"),
+      lt: new Date("2026-05-17Z"),
+    });
+  });
+
+  it("emits a tie-break-on-id cursor predicate", () => {
+    const where = buildAuditWhere({
+      actor: null,
+      action: null,
+      target: null,
+      from: null,
+      to: null,
+      cursor: { at: "2026-05-17T00:00:00Z", id: "row_x" },
+      limit: 50,
+    });
+    const and = where.AND as Array<Record<string, unknown>>;
+    const cursorPred = and.find((c) => c.OR) as { OR: Array<Record<string, unknown>> };
+    expect(cursorPred.OR[0]).toEqual({ at: { lt: new Date("2026-05-17T00:00:00Z") } });
+    expect(cursorPred.OR[1]).toMatchObject({
+      AND: [{ at: new Date("2026-05-17T00:00:00Z") }, { id: { lt: "row_x" } }],
+    });
+  });
+});
+
+describe("runAuditQuery — pagination peek", () => {
+  it("returns nextCursor when there is at least one more row", async () => {
+    const rows = Array.from({ length: 6 }, (_, i) => ({
+      id: `row_${i}`,
+      at: new Date(2026, 4, 17, 12, 0, 0, 5 - i),
+      actorUserId: "u",
+      actorEmail: null,
+      actorRoles: ["super_admin"],
+      organizationId: null,
+      action: "controller.test",
+      subjectType: "Test",
+      subjectId: "s",
+      before: null,
+      after: null,
+      reason: null,
+    }));
+    const fakePrisma = {
+      controllerAuditLog: {
+        findMany: vi.fn().mockResolvedValue(rows),
+      },
+    };
+
+    const result = await runAuditQuery(fakePrisma, {
+      actor: null,
+      action: null,
+      target: null,
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 5,
+    });
+
+    expect(result.rows).toHaveLength(5);
+    expect(result.nextCursor).not.toBeNull();
+    const decoded = decodeCursor(result.nextCursor);
+    expect(decoded?.id).toBe("row_4");
+  });
+
+  it("returns null nextCursor when fewer than limit rows remain", async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      id: `row_${i}`,
+      at: new Date(2026, 4, 17, 12, 0, 0, 5 - i),
+      actorUserId: "u",
+      actorEmail: null,
+      actorRoles: ["super_admin"],
+      organizationId: null,
+      action: "controller.test",
+      subjectType: "Test",
+      subjectId: "s",
+      before: null,
+      after: null,
+      reason: null,
+    }));
+    const fakePrisma = {
+      controllerAuditLog: {
+        findMany: vi.fn().mockResolvedValue(rows),
+      },
+    };
+
+    const result = await runAuditQuery(fakePrisma, {
+      actor: null,
+      action: null,
+      target: null,
+      from: null,
+      to: null,
+      cursor: null,
+      limit: 5,
+    });
+
+    expect(result.rows).toHaveLength(3);
+    expect(result.nextCursor).toBeNull();
+  });
+});
+
+describe("maskMetadataPreview", () => {
+  it("masks emails", () => {
+    const masked = maskMetadataPreview('"email":"alice@example.com"');
+    expect(masked).toContain("a***@***");
+    expect(masked).not.toContain("alice@example.com");
+  });
+
+  it("masks phone numbers", () => {
+    const masked = maskMetadataPreview('"phone":"+1 555 867 5309"');
+    expect(masked).toContain("***-***-****");
+    expect(masked).not.toContain("555 867 5309");
+  });
+
+  it("leaves non-PHI strings alone", () => {
+    expect(maskMetadataPreview('{"action":"publish"}')).toBe('{"action":"publish"}');
+  });
+});
+
+describe("metadataPreview", () => {
+  it("returns empty for null", () => {
+    expect(metadataPreview(null)).toBe("");
+    expect(metadataPreview(undefined)).toBe("");
+  });
+
+  it("compacts JSON", () => {
+    expect(metadataPreview({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it("masks PHI before clipping", () => {
+    const p = metadataPreview({ email: "alice@example.com" });
+    expect(p).toContain("a***@***");
+  });
+
+  it("clips with an ellipsis when too long", () => {
+    const big = metadataPreview({ x: "a".repeat(200) }, 50);
+    expect(big.length).toBe(50);
+    expect(big.endsWith("…")).toBe(true);
+  });
+});

--- a/src/lib/admin/audit-log.ts
+++ b/src/lib/admin/audit-log.ts
@@ -1,0 +1,332 @@
+// EMR-747 — Cross-actor ControllerAuditLog query core.
+//
+// Pure functions that take a prisma-shaped client and return filtered audit
+// rows. Exported separately from the API route so it can be unit-tested
+// with a fake prisma without booting Next.js.
+//
+// Filter surface mirrors the URL/API contract:
+//   - actor   — exact match on actorUserId, OR "system:<name>" prefix when
+//               the controller surface emitted the row as a system actor
+//               (kept as substring on actorEmail for now — see
+//               TODO(EMR-747-system-actor)).
+//   - action  — case-insensitive `contains` on the action string. Operators
+//               type "publish" to find every "*.publish.*" row regardless
+//               of namespace.
+//   - target  — exact match on subjectId OR organizationId. Operators paste
+//               either a practice id or a user id; we don't make them pick.
+//   - from/to — half-open `at` range. `to` is exclusive so a date-only "to"
+//               of 2026-05-17 doesn't accidentally drop rows that happened
+//               at 23:59:59.5 UTC.
+//
+// Cursor pagination is keyed on the (at, id) pair. Audit volume is
+// dominated by ingest bursts — two rows in the same ms is normal — so
+// `at`-only cursors would skip rows. We persist both fields in the cursor
+// and use a tie-break on `id` to keep page boundaries deterministic.
+//
+// Default sort is `at DESC, id DESC`. v1 has no other sort options (per AC).
+
+import "server-only";
+
+import type { Prisma } from "@prisma/client";
+
+export const AUDIT_DEFAULT_LIMIT = 50;
+export const AUDIT_MAX_LIMIT = 200;
+
+/** Shape of a ControllerAuditLog row as it crosses the API. */
+export interface AuditRow {
+  id: string;
+  at: string; // ISO
+  actorUserId: string;
+  actorEmail: string | null;
+  actorRoles: string[];
+  organizationId: string | null;
+  action: string;
+  subjectType: string;
+  subjectId: string;
+  before: unknown;
+  after: unknown;
+  reason: string | null;
+}
+
+/** Parsed filter set — used by both the list and export routes. */
+export interface AuditQuery {
+  actor: string | null;
+  action: string | null;
+  target: string | null;
+  from: Date | null;
+  to: Date | null;
+  cursor: AuditCursor | null;
+  limit: number;
+}
+
+export interface AuditCursor {
+  at: string; // ISO timestamp of the last row on the previous page
+  id: string; // tie-break id of the last row on the previous page
+}
+
+/** Minimal Prisma subset we depend on — keeps unit tests fake-friendly. */
+export interface AuditPrisma {
+  controllerAuditLog: {
+    findMany: (args: Prisma.ControllerAuditLogFindManyArgs) => Promise<
+      Array<{
+        id: string;
+        at: Date;
+        actorUserId: string;
+        actorEmail: string | null;
+        actorRoles: string[];
+        organizationId: string | null;
+        action: string;
+        subjectType: string;
+        subjectId: string;
+        before: unknown;
+        after: unknown;
+        reason: string | null;
+      }>
+    >;
+  };
+}
+
+/** Encode a cursor for safe URL transport. base64url-of-JSON. */
+export function encodeCursor(cursor: AuditCursor): string {
+  const json = JSON.stringify(cursor);
+  // Buffer is available in the Node runtime that hosts both the page and
+  // the API route. We base64url-encode so the cursor survives a copy/paste
+  // into a URL without re-quoting.
+  return Buffer.from(json, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Decode a cursor produced by `encodeCursor`. Returns null on any error. */
+export function decodeCursor(raw: string | null | undefined): AuditCursor | null {
+  if (!raw) return null;
+  try {
+    const padded = raw.replace(/-/g, "+").replace(/_/g, "/");
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    const parsed = JSON.parse(json) as Partial<AuditCursor>;
+    if (
+      parsed &&
+      typeof parsed.at === "string" &&
+      typeof parsed.id === "string"
+    ) {
+      // Verify `at` parses as a real date; reject otherwise.
+      const t = Date.parse(parsed.at);
+      if (Number.isFinite(t)) {
+        return { at: parsed.at, id: parsed.id };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Coerce a `limit` URL param into the allowed range. */
+export function parseLimit(raw: string | null | undefined): number {
+  if (!raw) return AUDIT_DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return AUDIT_DEFAULT_LIMIT;
+  return Math.min(n, AUDIT_MAX_LIMIT);
+}
+
+/** Parse an ISO date or date-time string. Returns null on any failure. */
+export function parseDate(raw: string | null | undefined): Date | null {
+  if (!raw) return null;
+  const t = Date.parse(raw);
+  if (!Number.isFinite(t)) return null;
+  return new Date(t);
+}
+
+/**
+ * Parse a Web URLSearchParams (or a Record<string,string>) into an
+ * `AuditQuery`. Used by both the API route (URL) and the page (server
+ * component searchParams). One function so the round-trip is identical.
+ */
+export function parseAuditQuery(
+  params:
+    | URLSearchParams
+    | Record<string, string | string[] | undefined>
+    | null
+    | undefined,
+): AuditQuery {
+  const get = (key: string): string | null => {
+    if (!params) return null;
+    if (params instanceof URLSearchParams) return params.get(key);
+    const v = params[key];
+    if (Array.isArray(v)) return v[0] ?? null;
+    return v ?? null;
+  };
+
+  const actor = (get("actor") ?? "").trim() || null;
+  const action = (get("action") ?? "").trim() || null;
+  const target = (get("target") ?? "").trim() || null;
+  const from = parseDate(get("from"));
+  const to = parseDate(get("to"));
+  const cursor = decodeCursor(get("cursor"));
+  const limit = parseLimit(get("limit"));
+
+  return { actor, action, target, from, to, cursor, limit };
+}
+
+/**
+ * Build the Prisma `where` clause for an `AuditQuery`. Exported for tests
+ * — the route and the page both go through `runAuditQuery` below in
+ * production, but the where-builder is the load-bearing piece worth
+ * verifying directly.
+ */
+export function buildAuditWhere(
+  q: AuditQuery,
+): Prisma.ControllerAuditLogWhereInput {
+  const where: Prisma.ControllerAuditLogWhereInput = {};
+  const and: Prisma.ControllerAuditLogWhereInput[] = [];
+
+  if (q.actor) {
+    // Operator pasted either a userId (exact) or an email (substring on
+    // actorEmail — convenient during incident sweeps where you only have
+    // a person, not an id).
+    and.push({
+      OR: [
+        { actorUserId: q.actor },
+        { actorEmail: { contains: q.actor, mode: "insensitive" } },
+      ],
+    });
+  }
+  if (q.action) {
+    and.push({ action: { contains: q.action, mode: "insensitive" } });
+  }
+  if (q.target) {
+    // Target can be a practice id (organizationId) or a user/subject id.
+    // We don't ask the operator to disambiguate.
+    and.push({
+      OR: [{ organizationId: q.target }, { subjectId: q.target }],
+    });
+  }
+  if (q.from || q.to) {
+    const at: Prisma.DateTimeFilter = {};
+    if (q.from) at.gte = q.from;
+    if (q.to) at.lt = q.to; // half-open — see module header
+    and.push({ at });
+  }
+  if (q.cursor) {
+    // Cursor is the last row of the previous page. Page-2 starts at
+    // (at < cursor.at) OR (at = cursor.at AND id < cursor.id). The
+    // tie-break on `id` is required because audit ingest can land
+    // multiple rows in the same millisecond.
+    const at = new Date(q.cursor.at);
+    and.push({
+      OR: [
+        { at: { lt: at } },
+        { AND: [{ at }, { id: { lt: q.cursor.id } }] },
+      ],
+    });
+  }
+  if (and.length) where.AND = and;
+  return where;
+}
+
+/** Standard Prisma `orderBy` for v1 — `at` desc, with `id` as tie-break. */
+export const AUDIT_ORDER_BY: Prisma.ControllerAuditLogOrderByWithRelationInput[] = [
+  { at: "desc" },
+  { id: "desc" },
+];
+
+/**
+ * Run a paginated query. Returns the rows for the page plus the cursor
+ * for the next page (or `null` when fewer than `limit` rows remain).
+ */
+export async function runAuditQuery(
+  prisma: AuditPrisma,
+  q: AuditQuery,
+): Promise<{ rows: AuditRow[]; nextCursor: string | null }> {
+  const rows = await prisma.controllerAuditLog.findMany({
+    where: buildAuditWhere(q),
+    orderBy: AUDIT_ORDER_BY,
+    take: q.limit + 1, // peek one extra to detect "has more"
+  });
+
+  const hasMore = rows.length > q.limit;
+  const page = hasMore ? rows.slice(0, q.limit) : rows;
+  const last = page[page.length - 1];
+
+  const mapped: AuditRow[] = page.map((r) => ({
+    id: r.id,
+    at: r.at.toISOString(),
+    actorUserId: r.actorUserId,
+    actorEmail: r.actorEmail,
+    actorRoles: r.actorRoles as string[],
+    organizationId: r.organizationId,
+    action: r.action,
+    subjectType: r.subjectType,
+    subjectId: r.subjectId,
+    before: r.before,
+    after: r.after,
+    reason: r.reason,
+  }));
+
+  return {
+    rows: mapped,
+    nextCursor:
+      hasMore && last ? encodeCursor({ at: last.at.toISOString(), id: last.id }) : null,
+  };
+}
+
+/**
+ * Async generator that walks every row matching the query, page by page.
+ * Used by the CSV export route so the entire result set can stream out
+ * without materialising in memory.
+ */
+export async function* iterateAuditRows(
+  prisma: AuditPrisma,
+  q: AuditQuery,
+): AsyncGenerator<AuditRow, void, unknown> {
+  // Page size for the export walk. Larger than the UI page because we're
+  // doing serial fetches and want to amortise the round-trip — but small
+  // enough that a single page never costs us more than ~1MB of JSON.
+  const PAGE = 500;
+  let cursor: AuditCursor | null = q.cursor;
+  while (true) {
+    const page = await runAuditQuery(prisma, { ...q, cursor, limit: PAGE });
+    for (const row of page.rows) yield row;
+    if (!page.nextCursor) return;
+    const next = decodeCursor(page.nextCursor);
+    if (!next) return;
+    cursor = next;
+  }
+}
+
+/**
+ * Mask anything that *looks* like PHI (email or phone-shaped) in a free-
+ * form string. Used for the one-line metadata preview in the table.
+ * ControllerAuditLog rows shouldn't carry PHI by design, but the audit
+ * surface is the last line of defence — preview-masking is cheap insurance.
+ *
+ * Full JSON-on-expand is rendered verbatim: the surface is super-admin
+ * only and the full payload is sometimes load-bearing during incident
+ * triage. The mask is for the at-a-glance row.
+ */
+export function maskMetadataPreview(input: string): string {
+  return input
+    .replace(/[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/g, (m) => {
+      const at = m.indexOf("@");
+      const local = m.slice(0, at);
+      return `${local.slice(0, 1)}***@***`;
+    })
+    .replace(/(?<!\d)(\+?\d[\d\s().-]{7,}\d)(?!\d)/g, "***-***-****");
+}
+
+/** Compact, single-line JSON preview with a hard char cap. */
+export function metadataPreview(value: unknown, max = 140): string {
+  if (value == null) return "";
+  let s: string;
+  try {
+    s = JSON.stringify(value);
+  } catch {
+    s = String(value);
+  }
+  if (!s) return "";
+  const masked = maskMetadataPreview(s);
+  if (masked.length <= max) return masked;
+  return masked.slice(0, max - 1) + "…";
+}


### PR DESCRIPTION
## Summary

- `/api/admin/audit` — super_admin-gated cursor-paginated list of `ControllerAuditLog`. Filters: actor (id or email substring), action (substring), target (orgId or subjectId), from/to (half-open).
- `/api/admin/audit/export` — streams the filtered set as CSV via `streamCsvResponse` (EMR-749). Always includes a `practice_id` column.
- `/admin/audit` — server-rendered table with filter chips, expandable metadata rows, and a tiny client island for j/k/Enter keyboard nav.
- PHI-shaped values are masked in the one-line metadata preview; full JSON-on-expand renders verbatim.

Linear: https://linear.app/emr-project/issue/EMR-747

## Test plan

- [x] 28 unit tests pass (parseAuditQuery round-trip, cursor encode/decode, buildAuditWhere shapes, pagination peek, PHI mask)
- [x] typecheck clean
- [x] lint clean (no new warnings)
- [x] route-auth manifest in sync (113 routes)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>