### PR TITLE
feat(super-admin): anomaly detectors bundle (EMR-737, EMR-740, EMR-741)

### DIFF
--- a/src/lib/anomaly/detectors/agent-failure.test.ts
+++ b/src/lib/anomaly/detectors/agent-failure.test.ts
@@ -1,0 +1,47 @@
+// EMR-737 — agent-failure detector tests.
+
+import { describe, it, expect } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+
+import { agentFailureDetector } from "./agent-failure";
+
+type Group = { organizationId: string | null; _count: { _all: number } };
+
+function fakePrisma(groups: Group[]): PrismaClient {
+  return {
+    controllerAuditLog: {
+      groupBy: async () => groups,
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("agent-failure detector", () => {
+  it("emits CRITICAL when an org has >5 errors in the last hour", async () => {
+    const prisma = fakePrisma([
+      { organizationId: "org_bad", _count: { _all: 6 } },
+      { organizationId: "org_worse", _count: { _all: 42 } },
+    ]);
+    const emissions = await agentFailureDetector.run(prisma);
+    expect(emissions).toHaveLength(2);
+    expect(emissions.every((e) => e.severity === "critical")).toBe(true);
+    const bad = emissions.find((e) => e.practiceId === "org_bad");
+    expect((bad?.context as any).errorCount).toBe(6);
+  });
+
+  it("emits nothing at or under the 5-error threshold", async () => {
+    const prisma = fakePrisma([
+      { organizationId: "org_ok", _count: { _all: 5 } },
+      { organizationId: "org_quiet", _count: { _all: 1 } },
+    ]);
+    const emissions = await agentFailureDetector.run(prisma);
+    expect(emissions).toEqual([]);
+  });
+
+  it("idempotency key is deterministic for the same input (hour bucket)", async () => {
+    const data = [{ organizationId: "org_x", _count: { _all: 10 } }];
+    const a = await agentFailureDetector.run(fakePrisma(data));
+    const b = await agentFailureDetector.run(fakePrisma(data));
+    expect(a[0].idempotencyKey).toBe(b[0].idempotencyKey);
+    expect(a[0].idempotencyKey.startsWith("agent_failure:org_x:")).toBe(true);
+  });
+});

--- a/src/lib/anomaly/detectors/agent-failure.ts
+++ b/src/lib/anomaly/detectors/agent-failure.ts
@@ -1,0 +1,73 @@
+// EMR-737 — Agent failure detector.
+//
+// Counts `ControllerAuditLog` rows over the last hour whose `action` ends
+// in `.error` (e.g. "controller.template.create.error"), grouped by
+// `organizationId`. Threshold: more than 5 errors per organization within
+// the trailing 1h window. See `src/lib/practice-health/scorer.ts` for the
+// established pattern this detector mirrors.
+//
+// Severity: CRITICAL — agent errors are operator-actionable now, not in
+// hours.
+//
+// Idempotency key: `agent_failure:${orgId}:${YYYY-MM-DDTHH}` (UTC). The
+// hour bucket coalesces re-detection on the same window.
+//
+// PHI: none. `context` carries org id, error count, and the bucket — no
+// audit payload, no actor identity.
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+
+const ERROR_THRESHOLD = 5;
+const TTL_SECONDS = 60 * 60; // 1 hour
+
+/** UTC YYYY-MM-DDTHH bucket. */
+function hourBucket(d: Date): string {
+  return `${d.toISOString().slice(0, 13)}`;
+}
+
+export const agentFailureDetector: AnomalyDetector = {
+  slug: "agent_failure",
+  async run(prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    const now = new Date();
+    const since = new Date(now.getTime() - 60 * 60 * 1000);
+
+    const groups = await prisma.controllerAuditLog.groupBy({
+      by: ["organizationId"],
+      where: {
+        at: { gte: since },
+        action: { endsWith: ".error" },
+        organizationId: { not: null },
+      },
+      _count: { _all: true },
+    });
+
+    const bucket = hourBucket(now);
+    const emissions: AnomalyEmission[] = [];
+    for (const g of groups) {
+      const orgId = g.organizationId;
+      if (!orgId) continue;
+      const count = g._count._all;
+      if (count <= ERROR_THRESHOLD) continue;
+
+      const idempotencyKey = `agent_failure:${orgId}:${bucket}`;
+      emissions.push({
+        slug: `agent-failure-${orgId}-${bucket}`,
+        idempotencyKey,
+        severity: "critical",
+        practiceId: orgId,
+        message: `Practice ${orgId} hit ${count} agent errors in the last hour`,
+        deeplinkUrl: `/admin/audit?practice=${orgId}&action=error`,
+        context: {
+          organizationId: orgId,
+          errorCount: count,
+          windowHours: 1,
+          hourBucket: bucket,
+        },
+        ttlSeconds: TTL_SECONDS,
+      });
+    }
+    return emissions;
+  },
+};

--- a/src/lib/anomaly/detectors/billing-drop.test.ts
+++ b/src/lib/anomaly/detectors/billing-drop.test.ts
@@ -1,0 +1,92 @@
+// EMR-737 — billing-drop detector tests.
+//
+// Fake `prisma.claim.groupBy` returns hand-rolled aggregates for the two
+// 7-day windows. Tests exercise the WARNING / CRITICAL thresholds and
+// the "skip when prior week is zero" guard.
+
+import { describe, it, expect } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+
+import { billingDropDetector } from "./billing-drop";
+
+type Aggregate = { organizationId: string; _sum: { billedAmountCents: number | null } };
+
+function fakePrisma(opts: {
+  recent: Aggregate[];
+  prior: Aggregate[];
+}): PrismaClient {
+  let call = 0;
+  return {
+    claim: {
+      groupBy: async () => {
+        const out = call === 0 ? opts.recent : opts.prior;
+        call++;
+        return out;
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("billing-drop detector", () => {
+  it("emits WARNING at ≥30% drop and CRITICAL at ≥60% drop", async () => {
+    const prisma = fakePrisma({
+      recent: [
+        { organizationId: "org_warn", _sum: { billedAmountCents: 6500 } }, // -35%
+        { organizationId: "org_crit", _sum: { billedAmountCents: 2500 } }, // -75%
+        { organizationId: "org_ok", _sum: { billedAmountCents: 9500 } }, //  -5%
+      ],
+      prior: [
+        { organizationId: "org_warn", _sum: { billedAmountCents: 10000 } },
+        { organizationId: "org_crit", _sum: { billedAmountCents: 10000 } },
+        { organizationId: "org_ok", _sum: { billedAmountCents: 10000 } },
+      ],
+    });
+    const emissions = await billingDropDetector.run(prisma);
+    expect(emissions).toHaveLength(2);
+    const warn = emissions.find((e) => e.practiceId === "org_warn");
+    const crit = emissions.find((e) => e.practiceId === "org_crit");
+    expect(warn?.severity).toBe("warning");
+    expect(crit?.severity).toBe("critical");
+    expect((warn?.context as any).dropPct).toBeGreaterThanOrEqual(30);
+    expect((crit?.context as any).dropPct).toBeGreaterThanOrEqual(60);
+  });
+
+  it("emits nothing when no organization has dropped enough", async () => {
+    const prisma = fakePrisma({
+      recent: [
+        { organizationId: "org_a", _sum: { billedAmountCents: 9500 } },
+        { organizationId: "org_b", _sum: { billedAmountCents: 12000 } },
+      ],
+      prior: [
+        { organizationId: "org_a", _sum: { billedAmountCents: 10000 } },
+        { organizationId: "org_b", _sum: { billedAmountCents: 10000 } },
+      ],
+    });
+    const emissions = await billingDropDetector.run(prisma);
+    expect(emissions).toEqual([]);
+  });
+
+  it("skips orgs with zero prior-week total (new practice guard)", async () => {
+    const prisma = fakePrisma({
+      recent: [
+        { organizationId: "org_new", _sum: { billedAmountCents: 0 } },
+      ],
+      prior: [
+        { organizationId: "org_new", _sum: { billedAmountCents: 0 } },
+      ],
+    });
+    const emissions = await billingDropDetector.run(prisma);
+    expect(emissions).toEqual([]);
+  });
+
+  it("idempotency key is deterministic for the same input (week bucket)", async () => {
+    const data = {
+      recent: [{ organizationId: "org_x", _sum: { billedAmountCents: 2000 } }],
+      prior: [{ organizationId: "org_x", _sum: { billedAmountCents: 10000 } }],
+    };
+    const a = await billingDropDetector.run(fakePrisma(data));
+    const b = await billingDropDetector.run(fakePrisma(data));
+    expect(a[0].idempotencyKey).toBe(b[0].idempotencyKey);
+    expect(a[0].idempotencyKey.startsWith("billing_drop:org_x:")).toBe(true);
+  });
+});

--- a/src/lib/anomaly/detectors/billing-drop.ts
+++ b/src/lib/anomaly/detectors/billing-drop.ts
@@ -1,0 +1,102 @@
+// EMR-737 — Billing drop detector.
+//
+// Per organization, compares `Claim.billedAmountCents` summed over the
+// current 7-day window against the prior 7-day window. Flags an anomaly
+// when this-week total has dropped ≥ 30% (WARNING) or ≥ 60% (CRITICAL)
+// versus prior week.
+//
+// "New practice" guard: if `prevWeekTotal === 0` we skip emission — there
+// is nothing to compare against and we don't want to flag every newly-
+// onboarded practice as a billing collapse.
+//
+// Idempotency key: `billing_drop:${orgId}:${weekStartISO}`. weekStart is
+// the UTC midnight at the beginning of the current 7-day window so the
+// same drop on the same week collapses to a single row.
+//
+// PHI: none. `context` is org-scoped totals and percent — no patient or
+// claim line-item detail flows through.
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+
+const WARNING_DROP_PCT = 30;
+const CRITICAL_DROP_PCT = 60;
+const TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** ISO date for the start of the current 7-day window (UTC midnight). */
+function weekBucket(now: Date): string {
+  const start = new Date(now.getTime() - 7 * DAY_MS);
+  return start.toISOString().slice(0, 10);
+}
+
+export const billingDropDetector: AnomalyDetector = {
+  slug: "billing_drop",
+  async run(prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    const now = new Date();
+    const recentSince = new Date(now.getTime() - 7 * DAY_MS);
+    const priorSince = new Date(now.getTime() - 14 * DAY_MS);
+
+    // Group both windows by organizationId in a single aggregate per
+    // window. Anything that didn't bill in either window is excluded
+    // because Prisma groupBy only returns rows present in the filter.
+    const recentGroups = await prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        serviceDate: { gte: recentSince, lte: now },
+      },
+      _sum: { billedAmountCents: true },
+    });
+
+    const priorGroups = await prisma.claim.groupBy({
+      by: ["organizationId"],
+      where: {
+        serviceDate: { gte: priorSince, lt: recentSince },
+      },
+      _sum: { billedAmountCents: true },
+    });
+
+    const priorByOrg = new Map<string, number>();
+    for (const g of priorGroups) {
+      priorByOrg.set(g.organizationId, g._sum.billedAmountCents ?? 0);
+    }
+    const recentByOrg = new Map<string, number>();
+    for (const g of recentGroups) {
+      recentByOrg.set(g.organizationId, g._sum.billedAmountCents ?? 0);
+    }
+
+    const bucket = weekBucket(now);
+    const emissions: AnomalyEmission[] = [];
+
+    // Iterate organizations that have *prior* data; new practices are
+    // intentionally skipped per the "prevWeekTotal === 0 → skip" guard.
+    for (const [orgId, prevTotal] of priorByOrg) {
+      if (prevTotal <= 0) continue;
+      const currentTotal = recentByOrg.get(orgId) ?? 0;
+      const dropPct = ((prevTotal - currentTotal) / prevTotal) * 100;
+      if (dropPct < WARNING_DROP_PCT) continue;
+
+      const severity = dropPct >= CRITICAL_DROP_PCT ? "critical" : "warning";
+      const idempotencyKey = `billing_drop:${orgId}:${bucket}`;
+      emissions.push({
+        slug: `billing-drop-${orgId}-${bucket}`,
+        idempotencyKey,
+        severity,
+        practiceId: orgId,
+        message: `Practice ${orgId} billing dropped ${dropPct.toFixed(1)}% week-over-week`,
+        deeplinkUrl: `/admin/practices/${orgId}`,
+        context: {
+          organizationId: orgId,
+          currentWeekTotalCents: currentTotal,
+          priorWeekTotalCents: prevTotal,
+          dropPct: Number(dropPct.toFixed(2)),
+          weekBucket: bucket,
+        },
+        ttlSeconds: TTL_SECONDS,
+      });
+    }
+    return emissions;
+  },
+};

--- a/src/lib/anomaly/detectors/login-failure.test.ts
+++ b/src/lib/anomaly/detectors/login-failure.test.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect } from "vitest";
+import { loginFailureDetector } from "./login-failure";
+
+describe("loginFailureDetector (no-op stub — EMR-737)", () => {
+  it("has stable slug login_failure", () => {
+    expect(loginFailureDetector.slug).toBe("login_failure");
+  });
+
+  it("emits nothing until a first-class auth-failure source exists", async () => {
+    const fakePrisma = {} as never;
+    const out = await loginFailureDetector.run(fakePrisma);
+    expect(out).toEqual([]);
+  });
+});

--- a/src/lib/anomaly/detectors/login-failure.ts
+++ b/src/lib/anomaly/detectors/login-failure.ts
@@ -1,0 +1,23 @@
+// EMR-737 — Login-failure spike detector.
+//
+// Per-organization detector for a sudden burst of failed sign-ins.
+//
+// TODO(login-failure-source): There is no first-class auth-failure log on
+// main today. Clerk's webhook surface includes `user.failed_sign_in` events,
+// but they are not yet routed into a persistent table this detector could
+// read. Until that lands, this detector is a no-op stub that emits nothing —
+// running it costs ~0 and the sweep cron tolerates an empty emission list.
+//
+// When the upstream source lands, the body becomes a group-by-organization
+// count over the last 24h with thresholds (>5 → WARNING, >20 → CRITICAL).
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+
+export const loginFailureDetector: AnomalyDetector = {
+  slug: "login_failure",
+  async run(_prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    return [];
+  },
+};

--- a/src/lib/anomaly/detectors/stale-config.test.ts
+++ b/src/lib/anomaly/detectors/stale-config.test.ts
@@ -1,0 +1,123 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/specialty-templates/registry", () => ({
+  getSpecialtyTemplate: vi.fn(),
+  listAllManifestVersions: vi.fn(),
+}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { staleConfigDetector } from "./stale-config";
+import {
+  getSpecialtyTemplate,
+  listAllManifestVersions,
+} from "@/lib/specialty-templates/registry";
+
+const mockedGet = vi.mocked(getSpecialtyTemplate);
+const mockedList = vi.mocked(listAllManifestVersions);
+
+function fakePrismaWith(configs: Array<Record<string, unknown>>) {
+  return {
+    practiceConfiguration: {
+      findMany: vi.fn().mockResolvedValue(configs),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-17T12:00:00Z"));
+});
+
+describe("staleConfigDetector — EMR-741", () => {
+  it("has stable slug stale_config", () => {
+    expect(staleConfigDetector.slug).toBe("stale_config");
+  });
+
+  it("emits nothing when config is on the latest version", async () => {
+    mockedGet.mockReturnValue({ slug: "pain-management", version: "1.0.0" } as never);
+    mockedList.mockReturnValue([
+      { slug: "pain-management", version: "1.0.0" },
+    ] as never);
+    const out = await staleConfigDetector.run(
+      fakePrismaWith([
+        {
+          id: "c1",
+          organizationId: "org1",
+          practiceId: "p1",
+          selectedSpecialty: "pain-management",
+          selectedSpecialtyVersion: "1.0.0",
+        },
+      ]) as never,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("emits nothing when 1 version behind (within rollout lag)", async () => {
+    mockedGet.mockReturnValue({ slug: "pain-management", version: "2.0.0" } as never);
+    mockedList.mockReturnValue([
+      { slug: "pain-management", version: "2.0.0" },
+      { slug: "pain-management", version: "1.0.0" },
+    ] as never);
+    const out = await staleConfigDetector.run(
+      fakePrismaWith([
+        {
+          id: "c1",
+          organizationId: "org1",
+          practiceId: "p1",
+          selectedSpecialty: "pain-management",
+          selectedSpecialtyVersion: "1.0.0",
+        },
+      ]) as never,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("emits INFO when 2 versions behind", async () => {
+    mockedGet.mockReturnValue({ slug: "pain-management", version: "3.0.0" } as never);
+    mockedList.mockReturnValue([
+      { slug: "pain-management", version: "3.0.0" },
+      { slug: "pain-management", version: "2.0.0" },
+      { slug: "pain-management", version: "1.0.0" },
+    ] as never);
+    const out = await staleConfigDetector.run(
+      fakePrismaWith([
+        {
+          id: "c1",
+          organizationId: "org1",
+          practiceId: "p1",
+          selectedSpecialty: "pain-management",
+          selectedSpecialtyVersion: "1.0.0",
+        },
+      ]) as never,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("info");
+    expect(out[0].context.versionsBehind).toBe(2);
+  });
+
+  it("emits WARNING when 3+ versions behind", async () => {
+    mockedGet.mockReturnValue({ slug: "pain-management", version: "4.0.0" } as never);
+    mockedList.mockReturnValue([
+      { slug: "pain-management", version: "4.0.0" },
+      { slug: "pain-management", version: "3.0.0" },
+      { slug: "pain-management", version: "2.0.0" },
+      { slug: "pain-management", version: "1.0.0" },
+    ] as never);
+    const out = await staleConfigDetector.run(
+      fakePrismaWith([
+        {
+          id: "c1",
+          organizationId: "org1",
+          practiceId: "p1",
+          selectedSpecialty: "pain-management",
+          selectedSpecialtyVersion: "1.0.0",
+        },
+      ]) as never,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("warning");
+    expect(out[0].context.versionsBehind).toBe(3);
+  });
+});

--- a/src/lib/anomaly/detectors/stale-config.ts
+++ b/src/lib/anomaly/detectors/stale-config.ts
@@ -1,0 +1,104 @@
+// EMR-741 — Stale-config detector.
+//
+// Compares each published `PracticeConfiguration` against the latest
+// non-deprecated version of its specialty manifest from the template
+// registry. Flags configs that are N versions behind.
+//
+//   - 1 version behind  → not flagged (normal lag during a rollout).
+//   - 2 versions behind → INFO.
+//   - 3+ versions behind → WARNING.
+//
+// Severity caps at WARNING. Stale config is a slow-burn problem — we don't
+// want it to ever page someone.
+//
+// Idempotency key: `stale_config:${configId}:${YYYY-MM-DD}` so the same
+// stale config on the same UTC day collapses to one row.
+//
+// PHI: none. `context` carries config/org ids, current vs latest version
+// strings, and the version-distance count.
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+import {
+  getSpecialtyTemplate,
+  listAllManifestVersions,
+} from "@/lib/specialty-templates/registry";
+
+const TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function dayBucket(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Number of registered (non-deprecated) versions between `current` and the
+ * latest. Returns 0 when `current` is the latest, 1 when one behind, etc.
+ * Returns null when we can't locate the current version in the registry.
+ */
+function versionsBehind(slug: string, current: string, latest: string): number | null {
+  if (current === latest) return 0;
+  const all = listAllManifestVersions(slug);
+  if (all.length === 0) return null;
+  const idxLatest = all.findIndex((m) => m.version === latest);
+  const idxCurrent = all.findIndex((m) => m.version === current);
+  if (idxLatest < 0 || idxCurrent < 0) return null;
+  return Math.abs(idxCurrent - idxLatest);
+}
+
+export const staleConfigDetector: AnomalyDetector = {
+  slug: "stale_config",
+  async run(prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    const configs = await prisma.practiceConfiguration.findMany({
+      where: {
+        status: "published",
+        selectedSpecialty: { not: null },
+        selectedSpecialtyVersion: { not: null },
+      },
+      select: {
+        id: true,
+        organizationId: true,
+        practiceId: true,
+        selectedSpecialty: true,
+        selectedSpecialtyVersion: true,
+      },
+    });
+
+    const now = new Date();
+    const bucket = dayBucket(now);
+    const emissions: AnomalyEmission[] = [];
+
+    for (const config of configs) {
+      const slug = config.selectedSpecialty;
+      const current = config.selectedSpecialtyVersion;
+      if (!slug || !current) continue;
+
+      const latestManifest = getSpecialtyTemplate(slug);
+      if (!latestManifest) continue;
+      const behind = versionsBehind(slug, current, latestManifest.version);
+      if (behind === null || behind < 2) continue;
+
+      const severity = behind >= 3 ? "warning" : "info";
+      const idempotencyKey = `stale_config:${config.id}:${bucket}`;
+      emissions.push({
+        slug: `stale-config-${config.id}-${bucket}`,
+        idempotencyKey,
+        severity,
+        practiceId: config.practiceId,
+        message: `${slug} config is ${behind} versions behind (${current} → ${latestManifest.version})`,
+        deeplinkUrl: `/admin/practices/${config.organizationId}`,
+        context: {
+          configId: config.id,
+          organizationId: config.organizationId,
+          specialtySlug: slug,
+          currentVersion: current,
+          latestVersion: latestManifest.version,
+          versionsBehind: behind,
+        },
+        ttlSeconds: TTL_SECONDS,
+      });
+    }
+
+    return emissions;
+  },
+};

--- a/src/lib/anomaly/detectors/stuck-publish.test.ts
+++ b/src/lib/anomaly/detectors/stuck-publish.test.ts
@@ -1,0 +1,97 @@
+// EMR-737 — stuck-publish detector tests.
+//
+// Strategy: fake `prisma.practiceConfiguration.findMany` that returns
+// fixture rows. The detector is a pure projection over Prisma state, so
+// the tests just verify the projection (threshold, idempotency key,
+// severity, deeplink).
+
+import { describe, it, expect } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+
+import { stuckPublishDetector } from "./stuck-publish";
+
+type ConfigRow = {
+  id: string;
+  organizationId: string;
+  practiceId: string;
+  status: string;
+  updatedAt: Date;
+};
+
+function fakePrisma(rows: ConfigRow[]): PrismaClient {
+  return {
+    practiceConfiguration: {
+      findMany: async ({ where }: any) => {
+        return rows.filter((r) => {
+          if (where?.status?.in && !where.status.in.includes(r.status)) {
+            return false;
+          }
+          if (where?.updatedAt?.lt && !(r.updatedAt < where.updatedAt.lt)) {
+            return false;
+          }
+          return true;
+        });
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("stuck-publish detector", () => {
+  it("emits for a draft config older than 24h", async () => {
+    const prisma = fakePrisma([
+      {
+        id: "cfg_abc",
+        organizationId: "org_1",
+        practiceId: "prac_1",
+        status: "draft",
+        updatedAt: new Date(Date.now() - 30 * 60 * 60 * 1000), // 30h ago
+      },
+    ]);
+    const emissions = await stuckPublishDetector.run(prisma);
+    expect(emissions).toHaveLength(1);
+    const e = emissions[0];
+    expect(e.severity).toBe("warning");
+    expect(e.practiceId).toBe("prac_1");
+    expect(e.deeplinkUrl).toBe("/admin/practices/org_1");
+    expect((e.context as Record<string, unknown>).configId).toBe("cfg_abc");
+    expect((e.context as Record<string, unknown>).status).toBe("draft");
+    expect((e.context as Record<string, unknown>).hoursStuck).toBeGreaterThanOrEqual(30);
+  });
+
+  it("emits nothing when no drafts are stuck", async () => {
+    const prisma = fakePrisma([
+      {
+        id: "cfg_recent",
+        organizationId: "org_1",
+        practiceId: "prac_1",
+        status: "draft",
+        updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2h ago
+      },
+      {
+        id: "cfg_published",
+        organizationId: "org_2",
+        practiceId: "prac_2",
+        status: "published",
+        updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // ancient
+      },
+    ]);
+    const emissions = await stuckPublishDetector.run(prisma);
+    expect(emissions).toEqual([]);
+  });
+
+  it("idempotency key is deterministic for the same input (day bucket)", async () => {
+    const updatedAt = new Date("2026-05-15T03:00:00Z");
+    const row: ConfigRow = {
+      id: "cfg_x",
+      organizationId: "org_x",
+      practiceId: "prac_x",
+      status: "draft",
+      updatedAt,
+    };
+    const prisma = fakePrisma([row]);
+    const a = await stuckPublishDetector.run(prisma);
+    const b = await stuckPublishDetector.run(prisma);
+    expect(a[0].idempotencyKey).toBe(b[0].idempotencyKey);
+    expect(a[0].idempotencyKey).toBe("stuck_publish:cfg_x:2026-05-15");
+  });
+});

--- a/src/lib/anomaly/detectors/stuck-publish.ts
+++ b/src/lib/anomaly/detectors/stuck-publish.ts
@@ -1,0 +1,87 @@
+// EMR-737 — Stuck publish detector.
+//
+// Flags any `PracticeConfiguration` row whose `status` is non-terminal
+// (i.e. still `draft`) and whose `updatedAt` is more than 24h old. The
+// onboarding controller is supposed to drive every draft to `published`
+// or `archived`; sitting in `draft` for >24h means a wizard step stalled,
+// an admin walked away, or the publish path threw silently — all things
+// fleet-ops should look at.
+//
+// Severity: WARNING. (Stuck != broken: super-admins triage, they don't
+// page on it.)
+//
+// Idempotency: `stuck_publish:${configId}:${YYYY-MM-DD}`. The day bucket
+// collapses repeated re-detection of the same stuck config on the same
+// day to a single row. A config that's stuck for a week generates one row
+// per day, which matches how the HQ feed wants to display it.
+//
+// PHI: none. `context` carries configId, status, hoursStuck, updatedAt
+// only — no patient data ever flows through PracticeConfiguration.
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+
+/** Statuses considered "in motion" — anything outside this set is terminal. */
+const NON_TERMINAL_STATUSES = ["draft"] as const;
+
+/** Hours a draft must sit untouched before we flag it. */
+const STUCK_THRESHOLD_HOURS = 24;
+
+/** Per-anomaly TTL — one day. */
+const TTL_SECONDS = 86400;
+
+/** YYYY-MM-DD bucket in UTC; stable across timezones. */
+function dayBucket(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export const stuckPublishDetector: AnomalyDetector = {
+  slug: "stuck_publish",
+  async run(prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    const now = new Date();
+    const cutoff = new Date(
+      now.getTime() - STUCK_THRESHOLD_HOURS * 60 * 60 * 1000,
+    );
+
+    const configs = await prisma.practiceConfiguration.findMany({
+      where: {
+        status: { in: NON_TERMINAL_STATUSES as unknown as ("draft")[] },
+        updatedAt: { lt: cutoff },
+      },
+      select: {
+        id: true,
+        organizationId: true,
+        practiceId: true,
+        status: true,
+        updatedAt: true,
+      },
+    });
+
+    const emissions: AnomalyEmission[] = [];
+    for (const config of configs) {
+      const hoursStuck = Math.floor(
+        (now.getTime() - config.updatedAt.getTime()) / (60 * 60 * 1000),
+      );
+      const bucket = dayBucket(config.updatedAt);
+      const idempotencyKey = `stuck_publish:${config.id}:${bucket}`;
+      emissions.push({
+        slug: `stuck-publish-${config.id}-${bucket}`,
+        idempotencyKey,
+        severity: "warning",
+        practiceId: config.practiceId,
+        message: `Practice ${config.practiceId} has been in ${config.status} for ${hoursStuck}h`,
+        deeplinkUrl: `/admin/practices/${config.organizationId}`,
+        context: {
+          configId: config.id,
+          organizationId: config.organizationId,
+          status: config.status,
+          hoursStuck,
+          updatedAt: config.updatedAt.toISOString(),
+        },
+        ttlSeconds: TTL_SECONDS,
+      });
+    }
+    return emissions;
+  },
+};

--- a/src/lib/anomaly/detectors/webhook-health.test.ts
+++ b/src/lib/anomaly/detectors/webhook-health.test.ts
@@ -1,0 +1,60 @@
+import { vi } from "vitest";
+vi.mock("server-only", () => ({}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { webhookHealthDetector } from "./webhook-health";
+
+function fakePrismaWith(okCount: number, errorCount: number) {
+  // The detector fires its two `count()` calls via `Promise.all` in a fixed
+  // order: OK first, then error. We exploit that ordering for the mock.
+  let call = 0;
+  return {
+    controllerAuditLog: {
+      count: vi.fn().mockImplementation(() => {
+        call += 1;
+        return Promise.resolve(call === 1 ? okCount : errorCount);
+      }),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-17T12:00:00Z"));
+});
+
+describe("webhookHealthDetector — EMR-740", () => {
+  it("has stable slug webhook_health", () => {
+    expect(webhookHealthDetector.slug).toBe("webhook_health");
+  });
+
+  it("emits nothing when zero webhook traffic", async () => {
+    const out = await webhookHealthDetector.run(fakePrismaWith(0, 0) as never);
+    expect(out).toEqual([]);
+  });
+
+  it("emits nothing when success rate is healthy (>=95%)", async () => {
+    const out = await webhookHealthDetector.run(fakePrismaWith(99, 1) as never);
+    expect(out).toEqual([]);
+  });
+
+  it("emits WARNING when success rate is 80-95%", async () => {
+    const out = await webhookHealthDetector.run(fakePrismaWith(90, 10) as never);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("warning");
+    expect(out[0].practiceId).toBeNull();
+    expect(out[0].idempotencyKey).toBe("webhook_health:2026-05-17T12");
+  });
+
+  it("emits CRITICAL when success rate dips below 80%", async () => {
+    const out = await webhookHealthDetector.run(fakePrismaWith(50, 50) as never);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("critical");
+  });
+
+  it("keys idempotency by hour bucket — same hour collapses", async () => {
+    const first = await webhookHealthDetector.run(fakePrismaWith(70, 30) as never);
+    const second = await webhookHealthDetector.run(fakePrismaWith(70, 30) as never);
+    expect(first[0].idempotencyKey).toBe(second[0].idempotencyKey);
+  });
+});

--- a/src/lib/anomaly/detectors/webhook-health.ts
+++ b/src/lib/anomaly/detectors/webhook-health.ts
@@ -1,0 +1,93 @@
+// EMR-740 — Webhook delivery health detector.
+//
+// Watches fleet-wide webhook health by counting `ControllerAuditLog` rows
+// whose `action` matches `webhook.*` over the last hour. Outcome split is
+// inferred from the `.ok` vs `.error` suffix that controller audit emitters
+// use across the codebase.
+//
+//   - success rate < 95% over 1h → WARNING
+//   - success rate < 80% over 1h → CRITICAL
+//
+// Per-organization rollups would be cleaner, but most inbound webhooks
+// (Clerk, Payabli, Payabli marketplace, ProHub, etc.) are not yet tagged
+// with an organizationId on every emission — they fire before tenant
+// resolution. So this v1 detector emits ONE fleet-wide anomaly per hour
+// when the rate dips below the threshold. The drill-deeplink filters the
+// audit-log viewer for the same window so an operator can see which
+// upstream is faulty.
+//
+// TODO(webhook-health-per-tenant): once webhook handlers tag rows with
+// organizationId at receipt time, switch to a groupBy over orgs and emit
+// per-practice anomalies. The fleet-wide row will still fire when
+// no-tenant deliveries dominate (e.g. svix sig verification failures).
+//
+// PHI: none. `context` carries counts and the hour bucket.
+
+import type { PrismaClient } from "@prisma/client";
+
+import type { AnomalyDetector, AnomalyEmission } from "../framework";
+
+const WARNING_THRESHOLD = 0.95;
+const CRITICAL_THRESHOLD = 0.8;
+const TTL_SECONDS = 60 * 60; // 1 hour
+
+function hourBucket(d: Date): string {
+  return `${d.toISOString().slice(0, 13)}`;
+}
+
+export const webhookHealthDetector: AnomalyDetector = {
+  slug: "webhook_health",
+  async run(prisma: PrismaClient): Promise<AnomalyEmission[]> {
+    const now = new Date();
+    const since = new Date(now.getTime() - 60 * 60 * 1000);
+
+    const [okRows, errorRows] = await Promise.all([
+      prisma.controllerAuditLog.count({
+        where: {
+          at: { gte: since },
+          AND: [
+            { action: { startsWith: "webhook." } },
+            { NOT: { action: { endsWith: ".error" } } },
+          ],
+        },
+      }),
+      prisma.controllerAuditLog.count({
+        where: {
+          at: { gte: since },
+          AND: [
+            { action: { startsWith: "webhook." } },
+            { action: { endsWith: ".error" } },
+          ],
+        },
+      }),
+    ]);
+
+    const total = okRows + errorRows;
+    if (total === 0) return [];
+
+    const successRate = okRows / total;
+    if (successRate >= WARNING_THRESHOLD) return [];
+
+    const severity = successRate < CRITICAL_THRESHOLD ? "critical" : "warning";
+    const bucket = hourBucket(now);
+    const idempotencyKey = `webhook_health:${bucket}`;
+    return [
+      {
+        slug: `webhook-health-${bucket}`,
+        idempotencyKey,
+        severity,
+        practiceId: null,
+        message: `Webhook success rate dropped to ${(successRate * 100).toFixed(1)}% over the last hour (${errorRows} of ${total} failed)`,
+        deeplinkUrl: `/admin/audit?action=webhook&from=${since.toISOString()}`,
+        context: {
+          windowHours: 1,
+          hourBucket: bucket,
+          okCount: okRows,
+          errorCount: errorRows,
+          successRate,
+        },
+        ttlSeconds: TTL_SECONDS,
+      },
+    ];
+  },
+};

--- a/src/lib/anomaly/registry.ts
+++ b/src/lib/anomaly/registry.ts
@@ -1,18 +1,17 @@
 // EMR-734 — Anomaly detector registry.
 //
-// Concrete detectors register themselves by importing this module's
-// `registerDetector` helper and calling it at module top-level. The sweep
-// cron imports the registry getter and iterates all registered detectors.
-//
-// THIS FILE INTENTIONALLY DOES NOT REGISTER ANY DETECTORS. The framework
-// + sweep cron + Anomaly model are landing alone in EMR-734 so that
-// EMR-737 (4 detectors), EMR-740 (webhook health), and EMR-741 (stale
-// config) can land independently against a stable surface.
-//
-// When EMR-737/740/741 land, each adds a `import "./detectors/<slug>"`
-// line to the section below — the side-effecting import registers the
-// detector with the framework. Co-locating registration here gives PR
-// reviewers a single file to scan for "what does the sweep run?".
+// Concrete detectors are imported here and registered via
+// `registerDetector`. The sweep cron imports `getRegisteredDetectors` and
+// iterates the list. Centralising registration in one file gives PR
+// reviewers a single place to scan for "what does the sweep run?".
+
+import { registerDetector } from "./framework";
+import { stuckPublishDetector } from "./detectors/stuck-publish";
+import { billingDropDetector } from "./detectors/billing-drop";
+import { agentFailureDetector } from "./detectors/agent-failure";
+import { loginFailureDetector } from "./detectors/login-failure";
+import { webhookHealthDetector } from "./detectors/webhook-health";
+import { staleConfigDetector } from "./detectors/stale-config";
 
 export {
   registerDetector,
@@ -24,18 +23,16 @@ export {
 
 // ── Detector registrations ────────────────────────────────
 //
-// Each concrete detector module is expected to call `registerDetector`
-// at import time. The registry is intentionally empty until those
-// modules land.
-//
-// EMR-737:
-//   import "./detectors/stuck-publish";
-//   import "./detectors/template-regression";
-//   import "./detectors/auth-failure-spike";
-//   import "./detectors/cron-stall";
-//
-// EMR-740:
-//   import "./detectors/webhook-health";
-//
-// EMR-741:
-//   import "./detectors/stale-config";
+// EMR-737 (four detectors): stuck-publish, billing-drop, agent-failure,
+// and a login-failure no-op stub (real source pending — see header in
+// login-failure.ts).
+registerDetector(stuckPublishDetector);
+registerDetector(billingDropDetector);
+registerDetector(agentFailureDetector);
+registerDetector(loginFailureDetector);
+
+// EMR-740 — fleet-wide webhook delivery health.
+registerDetector(webhookHealthDetector);
+
+// EMR-741 — stale specialty manifest version.
+registerDetector(staleConfigDetector);


### PR DESCRIPTION
## Summary

Six concrete detectors plug into the EMR-734 framework. Bundling avoids the registry-merge friction of three separate PRs.

Closes:
- **EMR-737** — stuck-publish + billing-drop + agent-failure + login-failure (no-op stub) — https://linear.app/emr-project/issue/EMR-737
- **EMR-740** — webhook delivery health (fleet-wide) — https://linear.app/emr-project/issue/EMR-740
- **EMR-741** — stale specialty manifest version — https://linear.app/emr-project/issue/EMR-741

## Known stubs (documented in source)

- `login-failure.ts` — no first-class auth-failure log on main; detector returns empty until that lands.
- `webhook-health.ts` — emits fleet-wide rows because most inbound webhooks aren't tagged with an organizationId at receipt time. TODO inline.

## Test plan

- [x] 33 tests pass across the anomaly framework + 6 detectors
- [x] typecheck clean
- [x] lint clean (no new warnings)
- [x] registry wires all six detectors

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>