### PR TITLE
feat(auth): HIPAA-aligned session auto-logoff (idle + 12-hour absolute cap)

### DIFF
--- a/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -20,7 +20,23 @@ const ClerkSignInBox = nextDynamic(() => import("./clerk-signin-box"), {
   ssr: false,
 });
 
-export default function SignInPage() {
+// Map the `?reason=...` query string our IdleTimeoutGuard appends on
+// forced sign-out to a friendly banner. Keeps the auto-logoff flow
+// from feeling abrupt — the user lands on /sign-in with context.
+const REASON_COPY: Record<string, string> = {
+  idle: "You were signed out after a period of inactivity. Sign in to pick back up.",
+  session_max:
+    "Your session hit the 12-hour limit. Sign in again to continue.",
+};
+
+export default function SignInPage({
+  searchParams,
+}: {
+  searchParams?: { reason?: string };
+}) {
+  const reason = searchParams?.reason;
+  const banner = reason ? REASON_COPY[reason] : null;
+
   return (
     <div className="flex flex-col items-center">
       <h1 className="font-display text-2xl text-text tracking-tight mb-2">
@@ -29,6 +45,14 @@ export default function SignInPage() {
       <p className="text-sm text-text-muted mb-8 text-center">
         Sign in to your Leafjourney account
       </p>
+      {banner && (
+        <div
+          role="status"
+          className="w-full mb-6 rounded-md border border-border bg-surface-muted/60 px-4 py-3 text-sm text-text-muted text-center"
+        >
+          {banner}
+        </div>
+      )}
       <ClerkSignInBox />
       <p className="mt-6 text-xs text-text-muted text-center max-w-sm leading-relaxed">
         Your password must contain 8 or more characters including one capital

--- a/src/components/auth/IdleTimeoutGuard.tsx
+++ b/src/components/auth/IdleTimeoutGuard.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import * as React from "react";
+import { useClerk } from "@clerk/nextjs";
+import type { Role } from "@prisma/client";
+import { Button } from "@/components/ui/button";
+import {
+  ABSOLUTE_SESSION_MS,
+  IDLE_WARNING_MS,
+  idleLimitForRoles,
+} from "@/lib/auth/idle-timeouts";
+
+// EMR session-timeout guard. Mounts inside the authenticated AppShell so
+// every signed-in surface (clinic, ops, portal, admin) inherits a HIPAA-
+// aligned automatic-logoff policy.
+//
+// Two clocks run in parallel:
+//   - Idle clock — reset by user interaction (mouse, keyboard, touch,
+//     scroll, focus). Per-role budget from idleLimitForRoles().
+//   - Absolute clock — set once when the component first mounts in this
+//     browser session. NEVER reset by activity. 12-hour ceiling.
+//
+// 60s before either clock expires we surface a soft warning modal so the
+// user can press "Stay signed in" without losing context. If they don't,
+// we call Clerk's signOut() and push them to /sign-in?reason=...
+//
+// Cross-tab: activity in any tab writes to localStorage; other tabs
+// listen on the `storage` event so all tabs reset together.
+//
+// Storage keys are namespaced under `lj.session.*` so they don't collide
+// with anything else in the app.
+
+const STORAGE_KEY_LAST_ACTIVE = "lj.session.lastActiveAt";
+const STORAGE_KEY_SESSION_START = "lj.session.startedAt";
+
+// Don't write to localStorage more than once every 2s, even if the user
+// is hammering the mouse. Cheap throttle that keeps the storage event
+// from firing on every pixel of mouse movement.
+const ACTIVITY_THROTTLE_MS = 2_000;
+
+// How often the watchdog interval re-evaluates the clocks. 5s strikes a
+// balance between responsiveness (the warning shows within 5s of the
+// real threshold) and CPU/wakeup cost.
+const TICK_MS = 5_000;
+
+const ACTIVITY_EVENTS: Array<keyof DocumentEventMap> = [
+  "mousedown",
+  "keydown",
+  "touchstart",
+  "scroll",
+  "wheel",
+  "click",
+];
+
+type Reason = "idle" | "session_max";
+
+export interface IdleTimeoutGuardProps {
+  roles: Role[];
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function readNumber(key: string): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeNumber(key: string, value: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // localStorage can throw in private modes / disabled storage. The
+    // guard still works within a single tab — we just lose cross-tab
+    // sync — so swallow.
+  }
+}
+
+function clearKeys(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY_LAST_ACTIVE);
+    window.localStorage.removeItem(STORAGE_KEY_SESSION_START);
+  } catch {
+    // no-op
+  }
+}
+
+export function IdleTimeoutGuard({ roles }: IdleTimeoutGuardProps) {
+  const { signOut } = useClerk();
+  const idleLimitMs = React.useMemo(() => idleLimitForRoles(roles), [roles]);
+
+  // lastActivityAt drives the idle clock; sessionStartedAt drives the
+  // absolute clock. Both live in refs so the activity listeners can read
+  // them synchronously without re-binding on every state update.
+  const lastActivityRef = React.useRef<number>(nowMs());
+  const sessionStartRef = React.useRef<number>(nowMs());
+  const lastWriteRef = React.useRef<number>(0);
+
+  // Warning state — when non-null, the dialog is shown and the number is
+  // the seconds remaining until forced sign-out. The countdown ticks
+  // independently of the watchdog interval so the displayed number is
+  // smooth.
+  const [warning, setWarning] = React.useState<{
+    reason: Reason;
+    secondsLeft: number;
+  } | null>(null);
+  const signingOutRef = React.useRef(false);
+
+  // ── Bootstrapping: pull existing timestamps from storage so reloads
+  // and cross-tab activity carry over. If sessionStartedAt isn't stored
+  // yet we stamp it now — the first authenticated page-load defines the
+  // absolute clock's origin.
+  React.useEffect(() => {
+    const storedActivity = readNumber(STORAGE_KEY_LAST_ACTIVE);
+    if (storedActivity !== null) lastActivityRef.current = storedActivity;
+
+    const storedStart = readNumber(STORAGE_KEY_SESSION_START);
+    if (storedStart !== null) {
+      sessionStartRef.current = storedStart;
+    } else {
+      writeNumber(STORAGE_KEY_SESSION_START, sessionStartRef.current);
+    }
+  }, []);
+
+  const recordActivity = React.useCallback(() => {
+    const now = nowMs();
+    lastActivityRef.current = now;
+    if (now - lastWriteRef.current >= ACTIVITY_THROTTLE_MS) {
+      lastWriteRef.current = now;
+      writeNumber(STORAGE_KEY_LAST_ACTIVE, now);
+    }
+  }, []);
+
+  // ── Activity listeners + cross-tab sync.
+  React.useEffect(() => {
+    for (const evt of ACTIVITY_EVENTS) {
+      document.addEventListener(evt, recordActivity, { passive: true });
+    }
+    const onVisible = () => {
+      if (document.visibilityState === "visible") recordActivity();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY_LAST_ACTIVE && e.newValue) {
+        const n = Number(e.newValue);
+        if (Number.isFinite(n)) lastActivityRef.current = n;
+      }
+    };
+    window.addEventListener("storage", onStorage);
+
+    return () => {
+      for (const evt of ACTIVITY_EVENTS) {
+        document.removeEventListener(evt, recordActivity);
+      }
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [recordActivity]);
+
+  const forceSignOut = React.useCallback(
+    async (reason: Reason) => {
+      if (signingOutRef.current) return;
+      signingOutRef.current = true;
+      clearKeys();
+      try {
+        await signOut({ redirectUrl: `/sign-in?reason=${reason}` });
+      } catch {
+        // If Clerk signOut throws for any reason, fall back to a hard
+        // navigation so the session at least appears terminated client-
+        // side.
+        window.location.href = `/sign-in?reason=${reason}`;
+      }
+    },
+    [signOut],
+  );
+
+  // ── Watchdog tick. Evaluates both clocks every TICK_MS and either
+  // opens the warning dialog, updates the countdown, or forces sign-out.
+  React.useEffect(() => {
+    const tick = () => {
+      if (signingOutRef.current) return;
+
+      const now = nowMs();
+      const idleFor = now - lastActivityRef.current;
+      const idleRemaining = idleLimitMs - idleFor;
+      const sessionAge = now - sessionStartRef.current;
+      const sessionRemaining = ABSOLUTE_SESSION_MS - sessionAge;
+
+      if (sessionRemaining <= 0) {
+        void forceSignOut("session_max");
+        return;
+      }
+      if (idleRemaining <= 0) {
+        void forceSignOut("idle");
+        return;
+      }
+
+      const reason: Reason =
+        sessionRemaining < idleRemaining ? "session_max" : "idle";
+      const remaining = Math.min(idleRemaining, sessionRemaining);
+
+      if (remaining <= IDLE_WARNING_MS) {
+        const secondsLeft = Math.max(1, Math.ceil(remaining / 1000));
+        setWarning((prev) =>
+          prev && prev.reason === reason && prev.secondsLeft === secondsLeft
+            ? prev
+            : { reason, secondsLeft },
+        );
+      } else if (warning) {
+        setWarning(null);
+      }
+    };
+    tick();
+    const id = window.setInterval(tick, TICK_MS);
+    return () => window.clearInterval(id);
+  }, [idleLimitMs, forceSignOut, warning]);
+
+  // ── Smooth countdown while the warning is up.
+  React.useEffect(() => {
+    if (!warning) return;
+    const id = window.setInterval(() => {
+      const now = nowMs();
+      const idleRemaining = idleLimitMs - (now - lastActivityRef.current);
+      const sessionRemaining =
+        ABSOLUTE_SESSION_MS - (now - sessionStartRef.current);
+      const remaining = Math.min(idleRemaining, sessionRemaining);
+
+      if (remaining <= 0) {
+        void forceSignOut(warning.reason);
+        return;
+      }
+      const reason: Reason =
+        sessionRemaining < idleRemaining ? "session_max" : "idle";
+      const secondsLeft = Math.max(1, Math.ceil(remaining / 1000));
+      setWarning((prev) =>
+        prev && prev.reason === reason && prev.secondsLeft === secondsLeft
+          ? prev
+          : { reason, secondsLeft },
+      );
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [warning, idleLimitMs, forceSignOut]);
+
+  const handleStay = React.useCallback(() => {
+    // "Stay signed in" only extends the IDLE clock — the absolute clock
+    // is by design unreset-able, so when the warning is for session_max
+    // the only choice is to sign out and re-authenticate.
+    if (warning?.reason === "session_max") {
+      void forceSignOut("session_max");
+      return;
+    }
+    const now = nowMs();
+    lastActivityRef.current = now;
+    lastWriteRef.current = now;
+    writeNumber(STORAGE_KEY_LAST_ACTIVE, now);
+    setWarning(null);
+  }, [warning, forceSignOut]);
+
+  const handleSignOutNow = React.useCallback(() => {
+    void forceSignOut(warning?.reason ?? "idle");
+  }, [warning, forceSignOut]);
+
+  if (!warning) return null;
+
+  const title =
+    warning.reason === "session_max"
+      ? "Session is ending"
+      : "Still there?";
+  const description =
+    warning.reason === "session_max"
+      ? `Your session has reached the 12-hour limit. You'll need to sign in again in ${warning.secondsLeft}s.`
+      : `For your protection, we'll sign you out in ${warning.secondsLeft}s due to inactivity.`;
+  const primaryLabel =
+    warning.reason === "session_max" ? "Sign in again" : "Stay signed in";
+
+  // Self-contained modal so we don't depend on the Dialog provider being
+  // mounted somewhere up-tree. Inline styles keep this readable even if
+  // CSS hasn't loaded yet (a sign-out path can run very early).
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="idle-timeout-title"
+      aria-describedby="idle-timeout-desc"
+      className="fixed inset-0 z-[1000] flex items-center justify-center p-4"
+    >
+      <div className="absolute inset-0 bg-black/50" aria-hidden />
+      <div className="relative w-full max-w-sm rounded-2xl bg-surface-raised border border-border shadow-xl p-6">
+        <h2
+          id="idle-timeout-title"
+          className="font-display text-lg text-text tracking-tight mb-2"
+        >
+          {title}
+        </h2>
+        <p
+          id="idle-timeout-desc"
+          className="text-sm text-text-muted leading-relaxed mb-6"
+        >
+          {description}
+        </p>
+        <div className="flex gap-3 justify-end">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleSignOutNow}
+          >
+            Sign out now
+          </Button>
+          <Button type="button" onClick={handleStay} autoFocus>
+            {primaryLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/IdleTimeoutGuard.tsx
+++ b/src/components/auth/IdleTimeoutGuard.tsx
@@ -5,9 +5,9 @@ import { useClerk } from "@clerk/nextjs";
 import type { Role } from "@prisma/client";
 import { Button } from "@/components/ui/button";
 import {
-  ABSOLUTE_SESSION_MS,
-  IDLE_WARNING_MS,
+  evaluateSession,
   idleLimitForRoles,
+  type SessionTimeoutReason,
 } from "@/lib/auth/idle-timeouts";
 
 // EMR session-timeout guard. Mounts inside the authenticated AppShell so
@@ -52,7 +52,7 @@ const ACTIVITY_EVENTS: Array<keyof DocumentEventMap> = [
   "click",
 ];
 
-type Reason = "idle" | "session_max";
+type Reason = SessionTimeoutReason;
 
 export interface IdleTimeoutGuardProps {
   roles: Role[];
@@ -185,72 +185,48 @@ export function IdleTimeoutGuard({ roles }: IdleTimeoutGuardProps) {
     [signOut],
   );
 
-  // ── Watchdog tick. Evaluates both clocks every TICK_MS and either
-  // opens the warning dialog, updates the countdown, or forces sign-out.
+  // Single decision routine — used by both the watchdog (every TICK_MS)
+  // and the smooth countdown (every 1s while the modal is up). Both
+  // intervals route through the same pure evaluator so they can never
+  // disagree about state.
+  const evaluate = React.useCallback(() => {
+    if (signingOutRef.current) return;
+    const decision = evaluateSession({
+      now: nowMs(),
+      lastActivityAt: lastActivityRef.current,
+      sessionStartedAt: sessionStartRef.current,
+      idleLimitMs,
+    });
+    if (decision.kind === "force_signout") {
+      void forceSignOut(decision.reason);
+      return;
+    }
+    if (decision.kind === "ok") {
+      setWarning((prev) => (prev ? null : prev));
+      return;
+    }
+    setWarning((prev) =>
+      prev &&
+      prev.reason === decision.reason &&
+      prev.secondsLeft === decision.secondsLeft
+        ? prev
+        : { reason: decision.reason, secondsLeft: decision.secondsLeft },
+    );
+  }, [idleLimitMs, forceSignOut]);
+
+  // ── Watchdog tick.
   React.useEffect(() => {
-    const tick = () => {
-      if (signingOutRef.current) return;
-
-      const now = nowMs();
-      const idleFor = now - lastActivityRef.current;
-      const idleRemaining = idleLimitMs - idleFor;
-      const sessionAge = now - sessionStartRef.current;
-      const sessionRemaining = ABSOLUTE_SESSION_MS - sessionAge;
-
-      if (sessionRemaining <= 0) {
-        void forceSignOut("session_max");
-        return;
-      }
-      if (idleRemaining <= 0) {
-        void forceSignOut("idle");
-        return;
-      }
-
-      const reason: Reason =
-        sessionRemaining < idleRemaining ? "session_max" : "idle";
-      const remaining = Math.min(idleRemaining, sessionRemaining);
-
-      if (remaining <= IDLE_WARNING_MS) {
-        const secondsLeft = Math.max(1, Math.ceil(remaining / 1000));
-        setWarning((prev) =>
-          prev && prev.reason === reason && prev.secondsLeft === secondsLeft
-            ? prev
-            : { reason, secondsLeft },
-        );
-      } else if (warning) {
-        setWarning(null);
-      }
-    };
-    tick();
-    const id = window.setInterval(tick, TICK_MS);
+    evaluate();
+    const id = window.setInterval(evaluate, TICK_MS);
     return () => window.clearInterval(id);
-  }, [idleLimitMs, forceSignOut, warning]);
+  }, [evaluate]);
 
   // ── Smooth countdown while the warning is up.
   React.useEffect(() => {
     if (!warning) return;
-    const id = window.setInterval(() => {
-      const now = nowMs();
-      const idleRemaining = idleLimitMs - (now - lastActivityRef.current);
-      const sessionRemaining =
-        ABSOLUTE_SESSION_MS - (now - sessionStartRef.current);
-      const remaining = Math.min(idleRemaining, sessionRemaining);
-
-      if (remaining <= 0) {
-        void forceSignOut(warning.reason);
-        return;
-      }
-      const reason: Reason =
-        sessionRemaining < idleRemaining ? "session_max" : "idle";
-      const secondsLeft = Math.max(1, Math.ceil(remaining / 1000));
-      setWarning((prev) =>
-        prev && prev.reason === reason && prev.secondsLeft === secondsLeft
-          ? prev
-          : { reason, secondsLeft },
-      );
-    }, 1000);
+    const id = window.setInterval(evaluate, 1000);
     return () => window.clearInterval(id);
-  }, [warning, idleLimitMs, forceSignOut]);
+  }, [warning, evaluate]);
 
   const handleStay = React.useCallback(() => {
     // "Stay signed in" only extends the IDLE clock — the absolute clock

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -14,6 +14,7 @@ import { RailIdentityMenu } from "./RailIdentityMenu";
 import { NavPrefsProvider } from "./NavPrefsContext";
 import { NavPrefsSections } from "./NavPrefsSections";
 import { NavVisitTracker } from "./NavVisitTracker";
+import { IdleTimeoutGuard } from "@/components/auth/IdleTimeoutGuard";
 import { hasPillarIcons, type NavItem, type NavSection } from "./nav-sections";
 
 export type { NavItem, NavSection } from "./nav-sections";
@@ -55,6 +56,7 @@ export function AppShell({
   return (
     <NavPrefsProvider>
       <NavVisitTracker sections={resolved} />
+      <IdleTimeoutGuard roles={user.roles} />
       <div
         className={cn(
           "min-h-screen bg-bg flex",

--- a/src/lib/auth/idle-timeouts.test.ts
+++ b/src/lib/auth/idle-timeouts.test.ts
@@ -3,10 +3,12 @@ import {
   ABSOLUTE_SESSION_MS,
   IDLE_LIMITS_MS,
   IDLE_WARNING_MS,
+  evaluateSession,
   idleLimitForRoles,
 } from "./idle-timeouts";
 
 const MIN = 60_000;
+const SEC = 1_000;
 
 describe("idle-timeouts", () => {
   it("clinician/operator/practice_owner get 15 minutes", () => {
@@ -52,6 +54,261 @@ describe("idle-timeouts", () => {
 
     it("falls back to patient when roles are empty", () => {
       expect(idleLimitForRoles([])).toBe(30 * MIN);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // evaluateSession — exhaustive coverage of the timer-state decision tree
+  // that drives the IdleTimeoutGuard modal. These cases replace what would
+  // otherwise need a jsdom + fake-timers integration test for the React
+  // component. The component is now a thin wrapper that calls evaluate()
+  // each tick, so anything that's true here is true at runtime.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe("evaluateSession", () => {
+    // A clinician session at t=10:00:00 with no activity at all.
+    const baseInput = {
+      now: 10 * 60 * MIN,
+      lastActivityAt: 10 * 60 * MIN,
+      sessionStartedAt: 10 * 60 * MIN,
+      idleLimitMs: 15 * MIN,
+    };
+
+    it('returns { kind: "ok" } when both clocks have lots of time', () => {
+      expect(evaluateSession(baseInput)).toEqual({ kind: "ok" });
+    });
+
+    it('returns "ok" right up until the warning window opens', () => {
+      // 61s before idle expires — still ok.
+      const result = evaluateSession({
+        ...baseInput,
+        now: baseInput.lastActivityAt + 15 * MIN - 61 * SEC,
+      });
+      expect(result).toEqual({ kind: "ok" });
+    });
+
+    it('opens the idle warning at exactly the 60s mark', () => {
+      // 60s before idle expires — warning should be up.
+      const result = evaluateSession({
+        ...baseInput,
+        now: baseInput.lastActivityAt + 15 * MIN - 60 * SEC,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "idle",
+        secondsLeft: 60,
+      });
+    });
+
+    it("counts down smoothly inside the warning window", () => {
+      // 17 seconds from sign-out → warning shows "17s".
+      const result = evaluateSession({
+        ...baseInput,
+        now: baseInput.lastActivityAt + 15 * MIN - 17 * SEC,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "idle",
+        secondsLeft: 17,
+      });
+    });
+
+    it("never shows 0s — clamps to 1s at the bottom", () => {
+      // 200ms left → display "1s" instead of "0s" so the UI doesn't lie.
+      const result = evaluateSession({
+        ...baseInput,
+        now: baseInput.lastActivityAt + 15 * MIN - 200,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "idle",
+        secondsLeft: 1,
+      });
+    });
+
+    it("forces sign-out the moment idle hits zero", () => {
+      // exactly at the limit — sign out immediately.
+      expect(
+        evaluateSession({
+          ...baseInput,
+          now: baseInput.lastActivityAt + 15 * MIN,
+        }),
+      ).toEqual({ kind: "force_signout", reason: "idle" });
+
+      // and well past the limit.
+      expect(
+        evaluateSession({
+          ...baseInput,
+          now: baseInput.lastActivityAt + 20 * MIN,
+        }),
+      ).toEqual({ kind: "force_signout", reason: "idle" });
+    });
+
+    it("forces sign-out when the 12-hour absolute cap hits, even with constant activity", () => {
+      const sessionStart = 0;
+      const result = evaluateSession({
+        now: sessionStart + 12 * 60 * MIN,
+        lastActivityAt: sessionStart + 12 * 60 * MIN, // just clicked!
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 15 * MIN,
+      });
+      expect(result).toEqual({ kind: "force_signout", reason: "session_max" });
+    });
+
+    it('shows the "session_max" warning when the absolute cap is the closer clock', () => {
+      // 30s before the 12h cap, and the user is actively clicking — so
+      // idle clock has lots of time left. Session_max should win the
+      // reason field.
+      const sessionStart = 0;
+      const now = sessionStart + 12 * 60 * MIN - 30 * SEC;
+      const result = evaluateSession({
+        now,
+        lastActivityAt: now, // active
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 15 * MIN,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "session_max",
+        secondsLeft: 30,
+      });
+    });
+
+    it("tie-breaks to session_max when both clocks have identical remaining time", () => {
+      // Constructed so idleRemaining === sessionRemaining === 45s.
+      // Tie should resolve to "session_max" — the more accurate reason
+      // since the absolute cap is fundamental and the idle clock just
+      // happened to land at the same number.
+      const idleLimitMs = 15 * MIN;
+      const absoluteCapMs = 12 * 60 * MIN;
+      const idleRemaining = 45 * SEC;
+      const sessionRemaining = 45 * SEC;
+      const sessionStart = 0;
+      const now = absoluteCapMs - sessionRemaining;
+      const lastActivityAt = now - (idleLimitMs - idleRemaining);
+      const result = evaluateSession({
+        now,
+        lastActivityAt,
+        sessionStartedAt: sessionStart,
+        idleLimitMs,
+        absoluteCapMs,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "session_max",
+        secondsLeft: 45,
+      });
+    });
+
+    it("uses the shorter clock's reason when they aren't tied", () => {
+      // 5s left on idle, 5 minutes left on absolute cap → idle wins.
+      const sessionStart = 0;
+      const now = 30 * MIN; // 11.5h to go on absolute cap
+      const lastActivityAt = now - (15 * MIN - 5 * SEC);
+      expect(
+        evaluateSession({
+          now,
+          lastActivityAt,
+          sessionStartedAt: sessionStart,
+          idleLimitMs: 15 * MIN,
+        }),
+      ).toEqual({ kind: "warn", reason: "idle", secondsLeft: 5 });
+    });
+
+    it("respects per-call overrides for absoluteCapMs and warningMs", () => {
+      // Tighten the policy: 5-minute cap, 10-second warning window. Used
+      // mostly for tests but also allows future per-deployment tuning
+      // without touching the module-level constants.
+      const sessionStart = 0;
+      const now = 4 * MIN + 55 * SEC; // 5s until 5-min cap
+      const result = evaluateSession({
+        now,
+        lastActivityAt: now,
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 60 * MIN,
+        absoluteCapMs: 5 * MIN,
+        warningMs: 10 * SEC,
+      });
+      expect(result).toEqual({
+        kind: "warn",
+        reason: "session_max",
+        secondsLeft: 5,
+      });
+    });
+
+    it("defaults absoluteCapMs and warningMs to the module constants", () => {
+      // Sanity check: omitting the overrides matches the documented
+      // policy. 30s into a fresh session, no warning yet — proves we're
+      // using the 12h cap, not some smaller test value.
+      const sessionStart = 0;
+      const result = evaluateSession({
+        now: sessionStart + 30 * SEC,
+        lastActivityAt: sessionStart + 30 * SEC,
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 15 * MIN,
+      });
+      expect(result.kind).toBe("ok");
+    });
+
+    it("matches the module ABSOLUTE_SESSION_MS exactly at the cap boundary", () => {
+      const sessionStart = 0;
+      // One ms before the cap: still warning, not yet signed out.
+      const justBefore = evaluateSession({
+        now: sessionStart + ABSOLUTE_SESSION_MS - 1,
+        lastActivityAt: sessionStart + ABSOLUTE_SESSION_MS - 1,
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 15 * MIN,
+      });
+      expect(justBefore.kind).toBe("warn");
+      expect(justBefore).toMatchObject({ reason: "session_max" });
+
+      // At the cap: forced sign-out.
+      const atCap = evaluateSession({
+        now: sessionStart + ABSOLUTE_SESSION_MS,
+        lastActivityAt: sessionStart + ABSOLUTE_SESSION_MS,
+        sessionStartedAt: sessionStart,
+        idleLimitMs: 15 * MIN,
+      });
+      expect(atCap).toEqual({ kind: "force_signout", reason: "session_max" });
+    });
+
+    it("matches the module IDLE_WARNING_MS exactly at the warning boundary", () => {
+      // Activity exactly IDLE_WARNING_MS before idle expiry — must be
+      // a warn, not an ok. The component relies on this so the modal
+      // can't be hidden for the final minute.
+      const result = evaluateSession({
+        ...baseInput,
+        now: baseInput.lastActivityAt + 15 * MIN - IDLE_WARNING_MS,
+      });
+      expect(result.kind).toBe("warn");
+    });
+
+    it("matrix: every per-role idle budget enters its warning window correctly", () => {
+      // Loop the documented policy so a future tweak to IDLE_LIMITS_MS
+      // can't silently break the warning behavior for one role.
+      const cases: Array<[keyof typeof IDLE_LIMITS_MS, number]> = [
+        ["patient", 30 * MIN],
+        ["clinician", 15 * MIN],
+        ["operator", 15 * MIN],
+        ["practice_owner", 15 * MIN],
+        ["super_admin", 10 * MIN],
+        ["implementation_admin", 10 * MIN],
+      ];
+      for (const [role, limit] of cases) {
+        const idleLimitMs = IDLE_LIMITS_MS[role];
+        expect(idleLimitMs).toBe(limit);
+        // 30s before timeout → warning shows "30s".
+        const result = evaluateSession({
+          now: idleLimitMs,
+          lastActivityAt: 30 * SEC,
+          sessionStartedAt: 0,
+          idleLimitMs,
+        });
+        expect(result).toEqual({
+          kind: "warn",
+          reason: "idle",
+          secondsLeft: 30,
+        });
+      }
     });
   });
 });

--- a/src/lib/auth/idle-timeouts.test.ts
+++ b/src/lib/auth/idle-timeouts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  ABSOLUTE_SESSION_MS,
+  IDLE_LIMITS_MS,
+  IDLE_WARNING_MS,
+  idleLimitForRoles,
+} from "./idle-timeouts";
+
+const MIN = 60_000;
+
+describe("idle-timeouts", () => {
+  it("clinician/operator/practice_owner get 15 minutes", () => {
+    expect(IDLE_LIMITS_MS.clinician).toBe(15 * MIN);
+    expect(IDLE_LIMITS_MS.operator).toBe(15 * MIN);
+    expect(IDLE_LIMITS_MS.practice_owner).toBe(15 * MIN);
+    expect(IDLE_LIMITS_MS.practice_admin).toBe(15 * MIN);
+  });
+
+  it("patient gets 30 minutes", () => {
+    expect(IDLE_LIMITS_MS.patient).toBe(30 * MIN);
+  });
+
+  it("super_admin and implementation_admin get 10 minutes", () => {
+    expect(IDLE_LIMITS_MS.super_admin).toBe(10 * MIN);
+    expect(IDLE_LIMITS_MS.implementation_admin).toBe(10 * MIN);
+  });
+
+  it("absolute cap is 12 hours", () => {
+    expect(ABSOLUTE_SESSION_MS).toBe(12 * 60 * MIN);
+  });
+
+  it("warning window is 60 seconds", () => {
+    expect(IDLE_WARNING_MS).toBe(60_000);
+  });
+
+  describe("idleLimitForRoles", () => {
+    it("returns the role's limit for a single-role user", () => {
+      expect(idleLimitForRoles(["patient"])).toBe(30 * MIN);
+      expect(idleLimitForRoles(["clinician"])).toBe(15 * MIN);
+      expect(idleLimitForRoles(["super_admin"])).toBe(10 * MIN);
+    });
+
+    it("picks the SHORTEST budget when a user has multiple roles", () => {
+      // A super_admin who is also a patient should get the 10-min cap,
+      // not the 30-min patient one.
+      expect(idleLimitForRoles(["patient", "super_admin"])).toBe(10 * MIN);
+      expect(idleLimitForRoles(["clinician", "practice_owner"])).toBe(15 * MIN);
+      expect(
+        idleLimitForRoles(["patient", "clinician", "implementation_admin"]),
+      ).toBe(10 * MIN);
+    });
+
+    it("falls back to patient when roles are empty", () => {
+      expect(idleLimitForRoles([])).toBe(30 * MIN);
+    });
+  });
+});

--- a/src/lib/auth/idle-timeouts.ts
+++ b/src/lib/auth/idle-timeouts.ts
@@ -1,0 +1,55 @@
+import type { Role } from "@prisma/client";
+
+// Per-role idle-timeout budgets.
+//
+// HIPAA's Security Rule does not name a number, but the recommended
+// safeguard is automatic logoff after a period of inactivity. The values
+// below align to community norms for EMR vendors:
+//
+//   - PHI-touching staff (clinician, operator, practice_owner,
+//     practice_admin, system) → 15 min idle
+//   - Patients on their own portal → 30 min idle (personal device,
+//     friction-light)
+//   - LeafJourney internal admins (super_admin, implementation_admin)
+//     → 10 min idle (cross-tenant access, tightest budget)
+//
+// The absolute session cap (`ABSOLUTE_SESSION_MS`) is layered on top:
+// even with continuous activity, a session ends after 12 hours so the
+// classic "left a clinic workstation logged in overnight" case is
+// bounded.
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+export const IDLE_LIMITS_MS: Record<Role, number> = {
+  patient: 30 * MINUTE,
+  clinician: 15 * MINUTE,
+  operator: 15 * MINUTE,
+  practice_owner: 15 * MINUTE,
+  practice_admin: 15 * MINUTE,
+  system: 15 * MINUTE,
+  implementation_admin: 10 * MINUTE,
+  super_admin: 10 * MINUTE,
+};
+
+/** Absolute cap on session age — applies regardless of activity. */
+export const ABSOLUTE_SESSION_MS = 12 * HOUR;
+
+/** How long the soft warning sits on screen before we force sign-out. */
+export const IDLE_WARNING_MS = 60_000;
+
+/**
+ * Pick the timeout for a user. When a user holds multiple roles, we use
+ * the SHORTEST budget so the most privileged role's policy wins — e.g.
+ * a super_admin who is also a patient still gets the 10-min internal-admin
+ * timeout, not the 30-min patient one.
+ */
+export function idleLimitForRoles(roles: Role[]): number {
+  if (roles.length === 0) return IDLE_LIMITS_MS.patient;
+  let min = Number.POSITIVE_INFINITY;
+  for (const r of roles) {
+    const limit = IDLE_LIMITS_MS[r];
+    if (limit !== undefined && limit < min) min = limit;
+  }
+  return Number.isFinite(min) ? min : IDLE_LIMITS_MS.patient;
+}

--- a/src/lib/auth/idle-timeouts.ts
+++ b/src/lib/auth/idle-timeouts.ts
@@ -53,3 +53,78 @@ export function idleLimitForRoles(roles: Role[]): number {
   }
   return Number.isFinite(min) ? min : IDLE_LIMITS_MS.patient;
 }
+
+// ---------------------------------------------------------------------------
+// Session-state evaluator
+//
+// The IdleTimeoutGuard runs two clocks (idle + absolute) and on each
+// tick has to decide one of three outcomes: keep watching, show the
+// warning modal, or force sign-out. The decision is a pure function of
+// the timestamps + the configured limits, so we extract it here for
+// exhaustive unit testing. The React component is then just an event
+// pump that feeds `now`, `lastActivityAt`, and `sessionStartedAt` into
+// this function and renders the result.
+// ---------------------------------------------------------------------------
+
+export type SessionTimeoutReason = "idle" | "session_max";
+
+export type SessionDecision =
+  | { kind: "ok" }
+  | { kind: "warn"; reason: SessionTimeoutReason; secondsLeft: number }
+  | { kind: "force_signout"; reason: SessionTimeoutReason };
+
+export interface SessionEvaluationInput {
+  /** Wall-clock now, in ms. Caller passes Date.now() in prod; tests pass a fixed value. */
+  now: number;
+  /** Last user-activity timestamp from the idle tracker, in ms. */
+  lastActivityAt: number;
+  /** Absolute session-start timestamp (first authenticated page-load), in ms. */
+  sessionStartedAt: number;
+  /** Per-role idle budget, in ms. Result of idleLimitForRoles(). */
+  idleLimitMs: number;
+  /**
+   * Overrides for testing or per-deployment tuning. Production uses the
+   * module defaults: 12h absolute cap, 60s warning window.
+   */
+  absoluteCapMs?: number;
+  warningMs?: number;
+}
+
+/**
+ * Evaluate the two session clocks and decide what the guard should do.
+ *
+ * Semantics:
+ *   - Either clock at/past zero → force_signout with that clock's reason.
+ *     The absolute clock wins ties so the user gets the more accurate
+ *     "you hit the 12-hour cap" message instead of "you went idle".
+ *   - Whichever clock is CLOSER to zero drives the reason + countdown.
+ *     This matters for the last minute of a 12-hour session: the warning
+ *     should say "session ending" even if the user is still actively
+ *     clicking.
+ *   - If the closer clock has more than `warningMs` left → "ok",
+ *     hide the modal.
+ *   - secondsLeft is `ceil(remaining / 1000)`, floor of 1 — so the
+ *     UI never shows "0s" before the actual sign-out fires.
+ */
+export function evaluateSession(input: SessionEvaluationInput): SessionDecision {
+  const cap = input.absoluteCapMs ?? ABSOLUTE_SESSION_MS;
+  const warn = input.warningMs ?? IDLE_WARNING_MS;
+
+  const idleRemaining = input.idleLimitMs - (input.now - input.lastActivityAt);
+  const sessionRemaining = cap - (input.now - input.sessionStartedAt);
+
+  if (sessionRemaining <= 0) return { kind: "force_signout", reason: "session_max" };
+  if (idleRemaining <= 0) return { kind: "force_signout", reason: "idle" };
+
+  // Tie-break on session_max: when both have the same remaining time, the
+  // user is hitting the absolute cap regardless of activity, so surface
+  // that as the reason.
+  const reason: SessionTimeoutReason =
+    sessionRemaining <= idleRemaining ? "session_max" : "idle";
+  const remaining = Math.min(idleRemaining, sessionRemaining);
+
+  if (remaining > warn) return { kind: "ok" };
+
+  const secondsLeft = Math.max(1, Math.ceil(remaining / 1000));
+  return { kind: "warn", reason, secondsLeft };
+}


### PR DESCRIPTION
Follow-up to #365. Adds HIPAA-aligned automatic-logoff to every authenticated EMR surface.

## What was broken

Clerk sessions on the EMR persisted for days. A clinician (or anyone with PHI access) who walked away from a workstation stayed authenticated overnight. There was no idle timeout and no absolute session cap — exactly the safeguard HIPAA's auto-logoff guidance is intended to cover.

## Policy (`src/lib/auth/idle-timeouts.ts`)

| Role | Idle limit | Absolute cap |
|------|-----------|--------------|
| `patient` | 30 min | 12 h |
| `clinician`, `operator`, `practice_owner`, `practice_admin`, `system` | 15 min | 12 h |
| `super_admin`, `implementation_admin` | 10 min | 12 h |

Multi-role users get the **shortest** budget of their roles. A `super_admin` who is also a `patient` gets the 10-min plan, not the 30-min one.

## Architecture

Timing/decision logic lives in a pure function — `evaluateSession()` — that returns one of `{ kind: "ok" }`, `{ kind: "warn", reason, secondsLeft }`, or `{ kind: "force_signout", reason }`. The React component (`IdleTimeoutGuard`) is a thin wrapper that:
- Listens to activity events (`mousedown`, `keydown`, `touchstart`, `scroll`, `wheel`, `click`, `visibilitychange`).
- Syncs `lastActivityAt` across tabs via `localStorage` + `storage` event.
- On each tick (5 s watchdog + 1 s smooth countdown), feeds the current state into `evaluateSession()` and applies the decision.

This separation respects the repo's "no DOM in vitest" convention — the bug-prone surface is unit-testable without `jsdom` or `@testing-library/react`.

## Behavior

- 60 s before either clock expires, a soft modal offers **Stay signed in** / **Sign out now** with a live 1 Hz countdown.
- On expiry → `clerk.signOut()` with a redirect to `/sign-in?reason=idle` or `?reason=session_max`.
- The absolute clock is **never** reset by activity. "Stay signed in" only extends the idle clock; when the warning is for `session_max`, the primary button reads "Sign in again" instead.
- Mounted inside `AppShell`, so every authenticated surface (clinic, ops, portal, admin) inherits it.

## UX polish

`/sign-in` reads the `?reason=` query and renders a friendly banner — "You were signed out after a period of inactivity. Sign in to pick back up." — so the auto-logoff doesn't feel abrupt.

## Tests

`src/lib/auth/idle-timeouts.test.ts` — **23 cases**, all green:

**8 policy cases** — per-role budgets, the 12 h absolute cap, the 60 s warning window, and the multi-role "shortest budget wins" rule.

**15 `evaluateSession` cases:**
- `ok` at session start
- `ok` right up to the 60 s warning boundary; `warn` at exactly that boundary
- Smooth `secondsLeft` countdown (17 s → `"17s"`)
- `secondsLeft` floored at 1 so the modal never displays `"0s"`
- `force_signout` the moment idle hits zero
- `force_signout` when the 12 h cap fires even with constant activity
- Warning reason switches to `"session_max"` when the cap is the closer clock
- Tie-break to `"session_max"` when both clocks have identical time left
- `"idle"` wins when its clock is strictly closer than the cap
- Override knobs (`absoluteCapMs` / `warningMs`) for per-deployment tuning
- Defaults match the documented module constants
- Exact `ABSOLUTE_SESSION_MS` boundary: 1 ms before = warn, at = sign out
- Exact `IDLE_WARNING_MS` boundary behavior
- Matrix: every per-role budget enters its warning window correctly

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | exit 0 |
| New unit tests | 23/23 pass |

## Manual test plan

- [ ] As a clinician, sit idle 14 min — no warning. At 14 min, warning modal appears with 60 s countdown.
- [ ] Click **Stay signed in** — modal dismisses, idle timer resets, no sign-out.
- [ ] Let the warning run out — redirected to `/sign-in?reason=idle` with the inactivity banner.
- [ ] As a patient on `/portal`, confirm 30-min budget (no warning at 20 min, warning at 29 min).
- [ ] As a super_admin, confirm 10-min budget.
- [ ] Open two tabs in `/clinic`. Interact in tab A — verify tab B's timer also resets (cross-tab sync via `storage` event).
- [ ] Force the absolute cap: `localStorage.setItem("lj.session.startedAt", String(Date.now() - 12*60*60*1000 + 30_000))` and wait 30 s — see "Session is ending" warning, not the idle one. Buttons read **Sign in again** / **Sign out now**.

https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL)_