### PR TITLE
fix(e2e): make crawl-spec timeouts actually take effect

### DIFF
--- a/e2e/click-handlers.spec.ts
+++ b/e2e/click-handlers.spec.ts
@@ -402,12 +402,17 @@ async function clickAndObserve(
   return local;
 }
 
-test.describe("Click handlers — find-and-fix pass 8", () => {
-  // Each route fires up to MAX_CLICKS_PER_ROUTE per-click pages; with
-  // CLICK_OBSERVE_MS=2s plus nav+probe time this easily breaches the
-  // 30s default test timeout. Give each route its own generous budget.
-  test.setTimeout(180_000);
+// Each route fires up to MAX_CLICKS_PER_ROUTE per-click pages; with
+// CLICK_OBSERVE_MS=2s plus nav+probe time this easily breaches the
+// 30s default test timeout. The previous attempt called
+// `test.setTimeout(180_000)` inside the describe body — that's a no-op
+// in Playwright (the static helper only takes effect inside a test or
+// hook callback). `test.describe.configure({ timeout })` is the
+// supported API for raising the budget for every test in a describe
+// group, and it actually works.
+test.describe.configure({ timeout: 180_000 });
 
+test.describe("Click handlers — find-and-fix pass 8", () => {
   for (const route of ROUTES) {
     test(`crawl ${route}`, async ({ page, context }) => {
       stats.routesScanned += 1;

--- a/e2e/link-integrity.spec.ts
+++ b/e2e/link-integrity.spec.ts
@@ -93,6 +93,19 @@ function normaliseHref(raw: string, base: string): string | null {
   }
 }
 
+// A heavy seed page (e.g. /leafmart, /leafmart/shop) can expose 40+
+// internal product links. Probing them serially at the previous 10 s
+// per-probe ceiling blew past the default 30 s test timeout on
+// staging. Two-part fix:
+//   1. raise the per-test budget to 120 s so we have headroom
+//   2. probe in parallel with a small concurrency cap so a single
+//      slow target doesn't block the next 39 probes from starting.
+// Findings collection is unchanged — every probe still gets recorded.
+test.describe.configure({ timeout: 120_000 });
+
+const PROBE_CONCURRENCY = 8;
+const PROBE_TIMEOUT_MS = 8_000;
+
 test.describe("Link integrity — find-and-fix pass 6", () => {
   for (const seed of SEED_PAGES) {
     test(`crawl ${seed}`, async ({ page, request }) => {
@@ -123,16 +136,22 @@ test.describe("Link integrity — find-and-fix pass 6", () => {
       }
       state.hrefsBySource.set(seed, targets);
 
-      // Probe each unique target ONCE across the whole run.
-      for (const target of targets) {
-        if (state.visitedTargets.has(target)) continue;
-        state.visitedTargets.add(target);
+      // Probe each unique target ONCE across the whole run, with a small
+      // concurrency cap so slow targets don't serialise the whole batch.
+      // `pending` shrinks as workers pull from it; each worker loops
+      // until empty.
+      const pending = [...targets].filter((t) => {
+        if (state.visitedTargets.has(t)) return false;
+        state.visitedTargets.add(t);
+        return true;
+      });
 
+      const probeOne = async (target: string): Promise<void> => {
         try {
           const res = await request.get(target, {
             maxRedirects: 0,
             failOnStatusCode: false,
-            timeout: 10_000,
+            timeout: PROBE_TIMEOUT_MS,
           });
           const status = res.status();
 
@@ -140,7 +159,7 @@ test.describe("Link integrity — find-and-fix pass 6", () => {
             // Redirects are recorded but treated as ok at this level —
             // the destination page is one of the seed pages or will get
             // crawled later if it's internal.
-            continue;
+            return;
           }
 
           // 404 / 5xx — capture context
@@ -155,10 +174,7 @@ test.describe("Link integrity — find-and-fix pass 6", () => {
             source: seed,
             target,
             status,
-            evidence: bodyPeek
-              .replace(/\s+/g, " ")
-              .slice(0, 200)
-              .trim(),
+            evidence: bodyPeek.replace(/\s+/g, " ").slice(0, 200).trim(),
             category,
           });
         } catch (err) {
@@ -170,7 +186,21 @@ test.describe("Link integrity — find-and-fix pass 6", () => {
             category: "other",
           });
         }
+      };
+
+      let cursor = 0;
+      const workers: Promise<void>[] = [];
+      for (let i = 0; i < PROBE_CONCURRENCY; i++) {
+        workers.push(
+          (async () => {
+            while (cursor < pending.length) {
+              const idx = cursor++;
+              await probeOne(pending[idx]);
+            }
+          })(),
+        );
       }
+      await Promise.all(workers);
     });
   }
 


### PR DESCRIPTION
## What was broken

The Staging & Production Pipeline's Playwright job was failing on three tests across two specs, all with `Test timeout of 30000ms exceeded`:

- `click-handlers.spec.ts > crawl /pricing`
- `link-integrity.spec.ts > crawl /leafmart`
- `link-integrity.spec.ts > crawl /leafmart/shop`

These have been failing on main since before #365. Not caused by recent app changes — the test infrastructure itself was buggy.

## Root causes

**click-handlers.spec.ts** had `test.setTimeout(180_000)` called inside the `describe` body. That's a Playwright no-op: the static helper only takes effect when called inside a test function or a `beforeEach`/`afterEach` hook. The intended 3-min budget never applied, so every test ran on the default 30 s budget — and a route with 25 click probes × ~2 s observe window blows that easily.

**link-integrity.spec.ts** had **no** per-test timeout config at all (default 30 s) and probed every harvested link **serially** with a 10 s ceiling each. `/leafmart/shop` alone exposes 40+ product links; one slow probe serialised the rest off the budget.

## The fix

**click-handlers.spec.ts** — Replaced the broken `test.setTimeout` call with `test.describe.configure({ timeout: 180_000 })`, which is the supported API for per-describe budgets and actually propagates to every test in the group.

**link-integrity.spec.ts** — Two changes:
1. `test.describe.configure({ timeout: 120_000 })` for headroom.
2. Replaced the serial probe loop with a small worker pool (concurrency = 8, per-probe timeout dropped to 8 s). Same findings, same once-per-target semantics; just N at a time instead of one.

## Coverage unchanged

- Every URL still gets probed exactly once (the `visitedTargets` dedupe stays in place).
- Every finding is still recorded with the same shape.
- The afterAll report still writes `docs/audit/LINK_INTEGRITY_<date>.md`.

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | exit 0 |
| `npx playwright test --list` | 36 tests discovered, no parse errors |

## Manual test plan

- [ ] Re-run the Staging & Production Pipeline against this branch — `Automated Tests (Staging)` should now complete inside its job window.
- [ ] Confirm the three previously-failing tests pass: `crawl /pricing`, `crawl /leafmart`, `crawl /leafmart/shop`.
- [ ] Spot-check `docs/audit/LINK_INTEGRITY_<date>.md` is still written and lists the same shape of findings as before.

https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL)_