### PR TITLE
ci(self-heal): make failure triage standard pipeline behavior

### DIFF
--- a/.github/workflows/staging-test-triage.yml
+++ b/.github/workflows/staging-test-triage.yml
@@ -1,0 +1,242 @@
+name: Staging Failure Triage
+
+# Self-heal layer for the Staging & Production Pipeline.
+#
+# Fires every time the staging pipeline finishes — passes are ignored; on
+# failure we parse the run, classify risk via scripts/triage-staging-failure.ts,
+# and route to one of three outcomes:
+#
+#   • action="rerun"     — known-flake signature, retry the failed jobs (max
+#                          RERUN_BUDGET in the classifier, today = 2).
+#   • action="autofix"   — real failure on a non-sensitive surface. Opens a
+#                          de-duped issue tagged `autofix-needed` so a human
+#                          or a follow-on Claude task can pick it up.
+#   • action="escalate"  — auth, PHI, billing, or controller surface. Opens an
+#                          issue tagged `pipeline-escalate`. No autofix.
+#
+# Production never auto-deploys past a failed pipeline — that invariant lives
+# in staging-to-prod.yml (`deploy_production` needs `test_staging`). This
+# workflow only changes *what happens* when the pipeline goes red.
+
+on:
+  workflow_run:
+    workflows: ["Staging & Production Pipeline"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+  actions: write
+  pull-requests: write
+
+jobs:
+  triage:
+    # Only triage failures on main. PR-level pipelines don't ship to prod
+    # anyway, and triaging their failures would generate issue noise.
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (head commit the pipeline ran against)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps (classifier only)
+        # We don't need the full app — just enough to run tsx + the
+        # classifier. Use the precise package set to keep this step fast.
+        run: npm ci --ignore-scripts
+
+      - name: Gather failure context
+        id: gather
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # Which job(s) failed inside the run?
+          gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.conclusion=="failure") | {name, id}' \
+            > /tmp/failed_jobs.json
+          FAILED_JOB_NAME="$(jq -r 'first | .name // empty' /tmp/failed_jobs.json)"
+          echo "failed_job=${FAILED_JOB_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Failed job: ${FAILED_JOB_NAME:-<none>}"
+
+          # Files the merge commit touched. Used by the classifier to weigh
+          # blast radius — touching src/lib/auth/* always escalates.
+          if git rev-parse "${HEAD_SHA}^" >/dev/null 2>&1; then
+            git diff --name-only "${HEAD_SHA}^" "${HEAD_SHA}" > /tmp/changed_paths.txt
+          else
+            : > /tmp/changed_paths.txt
+          fi
+
+          # Failed tests. The Playwright JSON report isn't uploaded as an
+          # artifact today, so we fall back to scraping the failed step's
+          # log output. Each "✘ <num> [project] › path:line:col › title" line
+          # marks a failure; we capture the next "Error: ..." line as the
+          # error excerpt. Best-effort; the classifier escalates if the
+          # parse comes back empty.
+          mkdir -p /tmp/logs
+          gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/logs" \
+            > /tmp/logs/run.zip || echo "(no logs artifact)"
+          if [ -s /tmp/logs/run.zip ]; then
+            (cd /tmp/logs && unzip -q run.zip) || true
+          fi
+
+          node scripts/parse-playwright-failures.js \
+            /tmp/logs > /tmp/failed_tests.json || echo "[]" > /tmp/failed_tests.json
+
+          echo "Parsed failures:"
+          cat /tmp/failed_tests.json
+
+      - name: Look up existing rerun count
+        id: rerun_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          # How many times has THIS SHA's pipeline been re-run already?
+          # GitHub exposes run_attempt; the first attempt is 1, so rerun_count
+          # = run_attempt - 1. The classifier caps reruns at RERUN_BUDGET
+          # and upgrades to autofix once the budget is spent.
+          ATTEMPT="${{ github.event.workflow_run.run_attempt }}"
+          RERUN_COUNT=$(( ATTEMPT - 1 ))
+          echo "rerun_count=${RERUN_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Attempt ${ATTEMPT} → rerun_count=${RERUN_COUNT}"
+
+      - name: Classify
+        id: classify
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          FAILED_JOB: ${{ steps.gather.outputs.failed_job }}
+          RERUN_COUNT: ${{ steps.rerun_state.outputs.rerun_count }}
+        run: |
+          set -euo pipefail
+
+          FAILED_TESTS_JSON="$(cat /tmp/failed_tests.json)"
+          CHANGED_PATHS_JSON="$(jq -R -s 'split("\n") | map(select(length>0))' \
+            /tmp/changed_paths.txt)"
+
+          jq -n \
+            --argjson workflowRunId "${RUN_ID}" \
+            --arg headSha "${HEAD_SHA}" \
+            --arg failedJobName "${FAILED_JOB:-unknown}" \
+            --argjson failedTests "${FAILED_TESTS_JSON}" \
+            --argjson changedPaths "${CHANGED_PATHS_JSON}" \
+            --argjson rerunCount "${RERUN_COUNT}" \
+            '{workflowRunId: $workflowRunId, headSha: $headSha, failedJobName: $failedJobName, failedTests: $failedTests, changedPaths: $changedPaths, rerunCount: $rerunCount}' \
+            > /tmp/ctx.json
+
+          npx tsx scripts/triage-staging-failure.ts < /tmp/ctx.json \
+            > /tmp/decision.json
+          cat /tmp/decision.json
+
+          {
+            echo "action=$(jq -r .action /tmp/decision.json)"
+            echo "risk=$(jq -r .risk /tmp/decision.json)"
+            echo "signal=$(jq -r .signal /tmp/decision.json)"
+            echo "signature=$(jq -r .failureSignature /tmp/decision.json)"
+            {
+              echo "reason<<EOF"
+              jq -r .reason /tmp/decision.json
+              echo "EOF"
+            }
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Action — rerun failed jobs
+        if: steps.classify.outputs.action == 'rerun'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          echo "Classifier says flake — re-running failed jobs only."
+          gh api -X POST \
+            "repos/${{ github.repository }}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+
+      - name: Action — open autofix / escalate issue
+        if: |
+          steps.classify.outputs.action == 'autofix' ||
+          steps.classify.outputs.action == 'escalate'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          ACTION: ${{ steps.classify.outputs.action }}
+          RISK: ${{ steps.classify.outputs.risk }}
+          SIGNAL: ${{ steps.classify.outputs.signal }}
+          SIGNATURE: ${{ steps.classify.outputs.signature }}
+          REASON: ${{ steps.classify.outputs.reason }}
+        run: |
+          set -euo pipefail
+
+          LABEL="autofix-needed"
+          TITLE_PREFIX="🤖 CI autofix"
+          if [ "${ACTION}" = "escalate" ]; then
+            LABEL="pipeline-escalate"
+            TITLE_PREFIX="🚨 CI escalation"
+          fi
+
+          # Ensure the label exists. Idempotent — `gh label create` errors
+          # if it already exists, which we suppress.
+          gh label create "${LABEL}" \
+            --description "Created by the staging-test-triage workflow" \
+            --color "$([ "${LABEL}" = "pipeline-escalate" ] && echo b60205 || echo fbca04)" \
+            2>/dev/null || true
+
+          TITLE="${TITLE_PREFIX}: staging pipeline failed on ${HEAD_SHA:0:7} (sig ${SIGNATURE})"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+
+          # Dedupe: if an open issue with this signature already exists, comment
+          # on it instead of opening a duplicate. Signature is embedded in the
+          # title so search-by-title is a reliable lookup.
+          EXISTING=$(gh issue list \
+            --state open \
+            --label "${LABEL}" \
+            --search "sig ${SIGNATURE} in:title" \
+            --json number --jq '.[0].number // empty')
+
+          # Compose the issue body in /tmp. Using a file (rather than a
+          # bash heredoc that interpolates inline) keeps YAML happy — a
+          # heredoc body starting with markdown bold (`**`) at column 0
+          # confuses the YAML block-scalar scanner.
+          {
+            printf '**Pipeline run:** %s\n' "${RUN_URL}"
+            printf '**Commit:** `%s`\n' "${HEAD_SHA}"
+            printf '**Action:** `%s` · **Risk:** `%s` · **Signal:** `%s`\n' \
+              "${ACTION}" "${RISK}" "${SIGNAL}"
+            printf '**Signature:** `%s`\n\n' "${SIGNATURE}"
+            printf '### Why this was routed here\n%s\n\n' "${REASON}"
+            printf '### Failed tests\n```json\n'
+            cat /tmp/failed_tests.json
+            printf '\n```\n\n### Files touched by the merge commit\n```\n'
+            head -50 /tmp/changed_paths.txt
+            printf '```\n\n---\n\n'
+            printf '**For autofix (low/medium risk):** read the failed tests + diff above, push a fix to a `claude/autofix-%s` branch, open a PR against `main`. The PR'\''s pipeline run will re-trigger triage; a clean run closes this issue.\n\n' "${SIGNATURE}"
+            printf '**For escalation (high risk):** do **not** autofix. Auth, PHI, billing, or controller code is involved. A human reviewer must read the diff, decide whether to roll back the merge, and either land a fix or revert. Close this issue once the next pipeline run is green.\n'
+          } > /tmp/issue-body.md
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Found existing issue #${EXISTING} for signature ${SIGNATURE}; commenting."
+            gh issue comment "${EXISTING}" --body-file /tmp/issue-body.md
+          else
+            echo "Opening new issue."
+            gh issue create \
+              --title "${TITLE}" \
+              --label "${LABEL}" \
+              --body-file /tmp/issue-body.md
+          fi

--- a/docs/runbooks/ci-pipeline-self-heal.md
+++ b/docs/runbooks/ci-pipeline-self-heal.md
@@ -1,0 +1,137 @@
+# CI/CD pipeline — self-heal runbook
+
+This is the operator's guide to the staging-to-production pipeline and the
+triage layer that sits on top of it. Read this before you touch a
+red main, before you mute a failing test, or before you wonder why a
+deploy is "stuck."
+
+## Pipeline shape
+
+```
+push to main
+  └─ Staging & Production Pipeline   (.github/workflows/staging-to-prod.yml)
+       ├─ verify              typecheck + lint           ~3 min
+       ├─ deploy_staging      Render hook + /api/health   ~3 min
+       ├─ test_staging        Playwright vs staging      ~5–15 min
+       └─ deploy_production   Render hook + /api/health   ~3 min   ← only runs if all of the above passed
+```
+
+`deploy_production` has `needs: test_staging`. There is no parallel "deploy
+on push" workflow. A red anywhere in the chain stops prod from shipping.
+
+## What happens when the pipeline goes red
+
+A second workflow — `staging-test-triage.yml` — fires on every completed
+run of the main pipeline. If the conclusion is `success`, it does nothing.
+If it's `failure` and the branch is `main`, it:
+
+1. Identifies which job failed.
+2. Parses the failed Playwright tests out of the run's log archive
+   (`scripts/parse-playwright-failures.js`).
+3. Reads the merge commit's touched paths.
+4. Pipes all of that into `scripts/triage-staging-failure.ts`, which
+   classifies the failure and returns one of three actions.
+
+### Action: `rerun`
+
+The failure signature matches a known transient pattern — Playwright
+test-timeout, target-page-closed, `net::ERR_CONNECTION_RESET`,
+`ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`. Triage calls the GitHub API to
+rerun just the failed jobs.
+
+- Cap: `RERUN_BUDGET = 2` (in `scripts/triage-staging-failure.ts`).
+- After the budget is spent on the same signature, triage upgrades the
+  classification to `autofix` so we stop reflexively retrying.
+
+### Action: `autofix`
+
+The failure is real (not a flake) AND lives on a non-sensitive surface
+(public marketing, leafmart storefront, education routes — and the diff
+didn't touch auth / RBAC / Prisma / middleware / role-group pages).
+
+Triage opens (or comments on) an issue labelled `autofix-needed`. The
+issue body contains:
+- A link to the failed pipeline run.
+- The failed tests as JSON.
+- The list of files the merge commit touched.
+- A stable failure signature so a repeat of the same failure
+  consolidates onto the same issue instead of spamming.
+
+**You (or a follow-on Claude task) should:**
+1. Read the issue.
+2. Push a fix to `claude/autofix-<signature>`.
+3. Open a PR against `main`.
+4. When that PR merges, its pipeline run re-triggers triage. A green run
+   closes the issue automatically (TODO: not wired yet — close manually
+   for now).
+
+### Action: `escalate`
+
+The failure is on a sensitive surface, OR the merge touched a sensitive
+path. Sensitive means any of:
+
+**Test surface** — `/portal`, `/clinic`, `/ops`, `/admin`, `/onboarding`,
+`/sign-in`, `/sign-up`. Or the failure trace mentions an API at `/api/auth`,
+`/api/imaging`, `/api/billing`, `/api/configs`, `/api/webhooks`,
+`/api/admin`, `/api/leafmart/checkout`.
+
+**Diff** — any change under `src/lib/auth/**`, `src/lib/rbac/**`,
+`src/lib/db/**`, `src/middleware.ts`, `prisma/schema.prisma`,
+`prisma/migrations/**`, `src/app/api/(auth|admin|configs|webhooks|imaging|billing)/**`,
+or any of the `(clinician)/`, `(operator)/`, `(patient)/`, `(super-admin)/`
+route groups.
+
+Triage opens (or comments on) an issue labelled `pipeline-escalate`. **No
+autofix is attempted.** A human reviewer must:
+
+1. Read the diff in the merge commit.
+2. Decide: roll back, or land a forward-fix.
+3. Drive the next pipeline to green.
+4. Close the issue.
+
+## Why two labels matter
+
+`autofix-needed` is safe automation territory. A workflow or an agent that
+auto-pushes a fix to a branch and opens a PR is fine for these — the PR
+itself still has to pass the pipeline, so prod is never at risk.
+
+`pipeline-escalate` is the opposite: the kind of failure where an
+automated fix could cause real harm (silently weakening an auth gate,
+masking a PHI leak by adjusting an assertion). These deserve a human read
+of the diff before any code is written.
+
+## Where the heuristics live
+
+- Routing decisions: `scripts/triage-staging-failure.ts` — pure function,
+  unit-tested in `scripts/triage-staging-failure.test.ts`.
+- Workflow wiring: `.github/workflows/staging-test-triage.yml`.
+- Log parsing: `scripts/parse-playwright-failures.js`.
+
+Tweaking a heuristic is a code change with a test attached. If you find
+a class of failure that's being mis-routed, add a case to the test file
+first and watch it fail; then change the classifier.
+
+## Required GitHub secrets
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `RENDER_STAGING_DEPLOY_HOOK` | `deploy_staging` | trigger Render staging build |
+| `RENDER_PRODUCTION_DEPLOY_HOOK` | `deploy_production` | trigger Render prod build |
+| `STAGING_URL` | `deploy_staging`, `test_staging` | `/api/health` poll + Playwright base URL |
+| `PRODUCTION_URL` | `deploy_production` | `/api/health` poll |
+| `TEST_USER_EMAIL`, `TEST_USER_PASSWORD` | `test_staging` | authed E2E flows |
+| `GITHUB_TOKEN` | triage workflow | (provided automatically) |
+
+## Manual override
+
+If you need to deploy to production despite a red pipeline (genuine
+emergency, e.g. a security hotfix where a single test is the broken thing):
+
+1. Hit the Render production deploy hook directly from the Render
+   dashboard.
+2. **Open an incident note** in `docs/incidents/` describing why the
+   gate was bypassed.
+3. File a follow-up to either fix the test or revert the bypass.
+
+There is intentionally no "deploy anyway" button in the GitHub UI. We
+want the override to feel deliberate.

--- a/scripts/parse-playwright-failures.js
+++ b/scripts/parse-playwright-failures.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Parse Playwright failures out of a GitHub Actions log archive.
+//
+// Inputs:  argv[2] = directory containing the unzipped run logs.
+// Output:  JSON array of { file, title, error } on stdout — the shape
+//          scripts/triage-staging-failure.ts (FailedTest) expects.
+//
+// Why a JS file (not TS): the triage workflow runs this BEFORE
+// installing dev deps, and node can execute .js directly without tsx.
+// Kept tiny + dependency-free for the same reason.
+
+"use strict";
+const fs = require("node:fs");
+const path = require("node:path");
+
+const logDir = process.argv[2];
+if (!logDir) {
+  process.stderr.write("usage: parse-playwright-failures.js <log-dir>\n");
+  process.exit(2);
+}
+
+if (!fs.existsSync(logDir)) {
+  process.stdout.write("[]\n");
+  process.exit(0);
+}
+
+// Walk every text file inside the unzipped log bundle. Playwright logs
+// live under "<job-name>/<step-number>_Run Playwright tests.txt".
+function walk(dir) {
+  const out = [];
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...walk(full));
+    } else if (ent.isFile() && /\.txt$/i.test(ent.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Playwright's GitHub reporter prints a per-failure block that looks
+// roughly like:
+//
+//   1) [chromium] › e2e/link-integrity.spec.ts:111:9 › Link integrity — find-and-fix pass 6 › crawl /leafmart
+//
+//      Error: Test timeout of 30000ms exceeded.
+//
+//      <stack...>
+//
+// We pull (file, title, first non-empty error line) out of each block.
+// Strict-but-tolerant: anything we don't recognize is skipped.
+const HEADER_RE =
+  /^\d+\)\s+(?:\[[^\]]+\]\s*›\s*)?(.+?\.spec\.ts):\d+:\d+\s*›\s*(.+?)\s*$/;
+
+function parseFailures(text) {
+  const lines = text.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADER_RE.exec(stripTimestamp(lines[i]));
+    if (!m) continue;
+    const file = m[1].trim();
+    const title = m[2].trim();
+    // Walk forward up to 25 lines looking for the first "Error:" line.
+    let error = "";
+    for (let j = i + 1; j < Math.min(i + 25, lines.length); j++) {
+      const raw = stripTimestamp(lines[j]).trim();
+      if (!raw) continue;
+      if (/^\d+\)\s+/.test(raw)) break; // next failure block
+      if (/^Error:/i.test(raw) || /timeout|exceeded/i.test(raw)) {
+        error = raw;
+        break;
+      }
+      if (!error && raw.length > 0) error = raw; // first non-empty as fallback
+    }
+    out.push({ file, title, error });
+  }
+  return out;
+}
+
+// GitHub Actions prefixes every log line with an ISO timestamp.
+function stripTimestamp(line) {
+  return line.replace(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?/,
+    "",
+  );
+}
+
+// Aggregate across every log file and dedupe by (file + title).
+const seen = new Set();
+const failures = [];
+for (const f of walk(logDir)) {
+  let text;
+  try {
+    text = fs.readFileSync(f, "utf8");
+  } catch {
+    continue;
+  }
+  for (const fail of parseFailures(text)) {
+    const key = `${fail.file}::${fail.title}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    failures.push(fail);
+  }
+}
+
+process.stdout.write(JSON.stringify(failures, null, 2));
+process.stdout.write("\n");

--- a/scripts/triage-staging-failure.test.ts
+++ b/scripts/triage-staging-failure.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from "vitest";
+import {
+  RERUN_BUDGET,
+  classify,
+  type FailureContext,
+} from "./triage-staging-failure";
+
+// Builder so each test only spells out the fields that matter to its
+// case. Defaults represent a no-op pipeline run: one failing public-route
+// crawl with a plain assertion error, no sensitive paths touched.
+function ctx(overrides: Partial<FailureContext> = {}): FailureContext {
+  return {
+    workflowRunId: 12345,
+    headSha: "abc123",
+    failedJobName: "Automated Tests (Staging)",
+    failedTests: [
+      {
+        file: "e2e/public-surfaces.spec.ts",
+        title: "Public surfaces — pass 1 > scan /pricing",
+        error: "expect(received).toBe(expected) // some assertion",
+      },
+    ],
+    changedPaths: ["docs/README.md"],
+    rerunCount: 0,
+    ...overrides,
+  };
+}
+
+describe("classify (CI/CD self-heal triage)", () => {
+  it("escalates when no failed tests were parsed (infra failure)", () => {
+    const d = classify(ctx({ failedTests: [] }));
+    expect(d.action).toBe("escalate");
+    expect(d.risk).toBe("high");
+    expect(d.signal).toBe("unknown");
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Flake → rerun
+  // ─────────────────────────────────────────────────────────────────────
+  describe("flake detection", () => {
+    it("reroutes a Playwright test-timeout to rerun", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/link-integrity.spec.ts",
+              title: "Link integrity > crawl /leafmart",
+              error: "Test timeout of 30000ms exceeded",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("rerun");
+      expect(d.signal).toBe("flake");
+      expect(d.risk).toBe("low");
+    });
+
+    it("treats target-page-closed as a flake", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/click-handlers.spec.ts",
+              title: "Click handlers > crawl /pricing",
+              error:
+                "Error: page.waitForTimeout: Target page, context or browser has been closed",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("rerun");
+    });
+
+    it("treats net::ERR_CONNECTION_RESET as a flake", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/health.spec.ts",
+              title: "Platform smoke > homepage loads",
+              error: "net::ERR_CONNECTION_RESET at https://staging.../",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("rerun");
+    });
+
+    it("escalates a transient signature once the rerun budget is spent", () => {
+      // Same flake, third time in a row → stop calling it a flake.
+      const d = classify(
+        ctx({
+          rerunCount: RERUN_BUDGET,
+          failedTests: [
+            {
+              file: "e2e/link-integrity.spec.ts",
+              title: "Link integrity > crawl /leafmart",
+              error: "Test timeout of 30000ms exceeded",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("autofix");
+      expect(d.signal).toBe("regression");
+      expect(d.reason).toMatch(/treating as a real bug/i);
+    });
+
+    it("does NOT classify as flake if even one failed test is non-transient", () => {
+      // Two failures: one timeout (flaky), one assertion (real).
+      // Whole batch must be classified by the worst signal.
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/link-integrity.spec.ts",
+              title: "Link integrity > crawl /leafmart",
+              error: "Test timeout of 30000ms exceeded",
+            },
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /pricing",
+              error: "Expected title to match /Pricing/, got /Leafjourney/",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("autofix");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Sensitive surface → escalate (no autofix)
+  // ─────────────────────────────────────────────────────────────────────
+  describe("sensitive-surface escalation", () => {
+    it("escalates failures on /portal (patient PHI)", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/click-handlers.spec.ts",
+              title: "Click handlers > crawl /portal",
+              error: "Expected modal to be visible",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+      expect(d.risk).toBe("high");
+    });
+
+    it("escalates failures on /clinic", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/auth.spec.ts",
+              title: "Clinician > redirected to /clinic",
+              error: "Got /portal instead",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+    });
+
+    it("escalates failures on /admin", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/admin.spec.ts",
+              title: "Super admin > /admin/hq loads",
+              error: "Expected status 200, got 500",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+    });
+
+    it("escalates when a public-route test calls a sensitive API", () => {
+      // Test title is public, but the failure trace includes a fetch to
+      // /api/billing — that's a privileged surface. Still escalate.
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /pricing",
+              error: "Failed POST /api/billing/calculate → 500",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+    });
+
+    it("does NOT escalate on '/portal-marketing' (substring false positive)", () => {
+      // Token-boundary check: /portal-marketing is a marketing route that
+      // happens to start with /portal. We don't escalate on that.
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /portal-marketing",
+              error: "Title mismatch",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("autofix");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Sensitive diff → escalate (regardless of which test failed)
+  // ─────────────────────────────────────────────────────────────────────
+  describe("sensitive-diff escalation", () => {
+    it("escalates when the merge touched src/lib/auth/*", () => {
+      const d = classify(
+        ctx({
+          changedPaths: [
+            "src/lib/auth/session.ts",
+            "docs/CHANGELOG.md",
+          ],
+          failedTests: [
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /pricing",
+              error: "Title mismatch",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+      expect(d.reason).toMatch(/sensitive path/i);
+    });
+
+    it("escalates when the merge touched the Prisma schema", () => {
+      const d = classify(
+        ctx({
+          changedPaths: ["prisma/schema.prisma"],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+    });
+
+    it("escalates when the merge touched middleware.ts", () => {
+      const d = classify(ctx({ changedPaths: ["src/middleware.ts"] }));
+      expect(d.action).toBe("escalate");
+    });
+
+    it("escalates when the merge touched any (clinician)/(operator)/(patient) page", () => {
+      const d = classify(
+        ctx({
+          changedPaths: ["src/app/(clinician)/clinic/page.tsx"],
+        }),
+      );
+      expect(d.action).toBe("escalate");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Default → autofix (real regression on a non-sensitive surface)
+  // ─────────────────────────────────────────────────────────────────────
+  describe("autofix routing", () => {
+    it("routes plain assertion failures on /pricing to autofix", () => {
+      const d = classify(ctx());
+      expect(d.action).toBe("autofix");
+      expect(d.risk).toBe("medium");
+      expect(d.signal).toBe("regression");
+    });
+
+    it("routes assertion failures on /leafmart to autofix", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /leafmart",
+              error: "Expected hero copy to include 'Shop' got 'Welcome'",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("autofix");
+    });
+
+    it("routes assertion failures on /education to autofix", () => {
+      const d = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/link-integrity.spec.ts",
+              title: "Link integrity > crawl /education",
+              error: "Expected status 200, got 404",
+            },
+          ],
+        }),
+      );
+      expect(d.action).toBe("autofix");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Signatures are stable + dedupable
+  // ─────────────────────────────────────────────────────────────────────
+  describe("failure signatures", () => {
+    it("produces the same signature for identical failures", () => {
+      const a = classify(ctx());
+      const b = classify(ctx());
+      expect(a.failureSignature).toBe(b.failureSignature);
+    });
+
+    it("produces a different signature when a different test fails", () => {
+      const a = classify(ctx());
+      const b = classify(
+        ctx({
+          failedTests: [
+            {
+              file: "e2e/public-surfaces.spec.ts",
+              title: "Public surfaces > scan /features",
+              error: "expect(received).toBe(expected) // some assertion",
+            },
+          ],
+        }),
+      );
+      expect(a.failureSignature).not.toBe(b.failureSignature);
+    });
+
+    it("is order-independent across the failedTests array", () => {
+      const t1 = {
+        file: "a.spec.ts",
+        title: "alpha test",
+        error: "boom 1",
+      };
+      const t2 = {
+        file: "b.spec.ts",
+        title: "beta test",
+        error: "boom 2",
+      };
+      const ordered = classify(ctx({ failedTests: [t1, t2] }));
+      const reordered = classify(ctx({ failedTests: [t2, t1] }));
+      expect(ordered.failureSignature).toBe(reordered.failureSignature);
+    });
+  });
+});

--- a/scripts/triage-staging-failure.ts
+++ b/scripts/triage-staging-failure.ts
@@ -1,0 +1,313 @@
+// Triage classifier for failed staging-pipeline runs.
+//
+// Reads a structured failure summary (test names, error excerpts, the
+// merge commit's touched paths) from stdin and prints a routing decision
+// as JSON on stdout. The triage workflow at
+// .github/workflows/staging-test-triage.yml calls this via
+// `npx tsx scripts/triage-staging-failure.ts` and pipes the failure
+// context in.
+//
+// Why a separate script: keeping classification logic in TypeScript with
+// unit tests means we can evolve the heuristics safely. A shell-script
+// classifier would have to be exercised end-to-end every time we want
+// to change a rule, which is slow and gappy.
+//
+// Routing contract — there are exactly three outcomes:
+//
+//   action="rerun"
+//     The failure signature looks transient (timeout, network reset,
+//     target page closed mid-test). Re-run the failed jobs once. If the
+//     next run hits the same signature, the workflow upgrades the
+//     classification to "autofix" (no infinite reruns).
+//
+//   action="autofix"
+//     The failure is a real assertion on a low-risk surface (public
+//     marketing or storefront route the diff didn't touch, OR a clear
+//     code-driven failure outside auth/PHI). Triage opens an
+//     `autofix-needed` issue with the full context so a human or a
+//     follow-up Claude task can pick it up. Production stays gated.
+//
+//   action="escalate"
+//     The failure is on a sensitive surface (auth, PHI, billing,
+//     onboarding controller) OR the diff touched files in those areas.
+//     No autofix attempt — open a `pipeline-escalate` issue, ping
+//     code-owners. The pipeline never auto-deploys past this.
+//
+// The "risk" field is purely advisory for the human triager; routing
+// is decided by `action`.
+
+import { stdin } from "node:process";
+
+export type Risk = "low" | "medium" | "high";
+export type Signal = "flake" | "regression" | "unknown";
+export type Action = "rerun" | "autofix" | "escalate";
+
+export interface FailureContext {
+  /** Identifier of the run we're triaging — for the issue body. */
+  workflowRunId: number;
+  /** Merge commit SHA the pipeline ran against. */
+  headSha: string;
+  /** Whichever job failed inside the pipeline (e.g. "Automated Tests (Staging)"). */
+  failedJobName: string;
+  /** Failed Playwright tests as reported by the run. */
+  failedTests: FailedTest[];
+  /** Paths touched by the merge commit (used to weigh blast radius). */
+  changedPaths: string[];
+  /** How many times this signature has already been re-run. Defaults to 0. */
+  rerunCount?: number;
+}
+
+export interface FailedTest {
+  /** Spec file relative path, e.g. "e2e/link-integrity.spec.ts". */
+  file: string;
+  /** Full test title incl. describe chain. */
+  title: string;
+  /** First line(s) of the captured error — used for flake heuristics. */
+  error: string;
+}
+
+export interface TriageDecision {
+  risk: Risk;
+  signal: Signal;
+  action: Action;
+  reason: string;
+  /** Stable per-failure hash for issue dedupe + iteration tracking. */
+  failureSignature: string;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristics
+// ---------------------------------------------------------------------------
+
+/** Transient-failure signatures. These are network/timing artifacts, not bugs. */
+const FLAKE_PATTERNS = [
+  /Test timeout of \d+ms exceeded/i,
+  /Target page, context or browser has been closed/i,
+  /net::ERR_(?:CONNECTION_RESET|NETWORK_CHANGED|TIMED_OUT|EMPTY_RESPONSE)/i,
+  /ECONNRESET/i,
+  /EAI_AGAIN/i,
+  /socket hang up/i,
+  /ETIMEDOUT/i,
+  /Navigation timeout of \d+ms exceeded/i,
+];
+
+/** Route prefixes considered high-risk: auth, PHI, billing, controller. */
+const HIGH_RISK_TEST_PREFIXES = [
+  "/portal",
+  "/clinic",
+  "/ops",
+  "/admin",
+  "/onboarding",
+  "/sign-in",
+  "/sign-up",
+];
+
+/** API paths whose failure means PHI / money / privileged access is broken. */
+const HIGH_RISK_API_SUBSTRINGS = [
+  "/api/auth",
+  "/api/imaging",
+  "/api/billing",
+  "/api/configs",
+  "/api/webhooks",
+  "/api/admin",
+  "/api/leafmart/checkout",
+];
+
+/** Source paths whose modification widens blast radius regardless of test surface. */
+const HIGH_RISK_PATH_PATTERNS = [
+  /^src\/lib\/auth\//,
+  /^src\/lib\/rbac\//,
+  /^src\/lib\/db\//,
+  /^src\/middleware\.ts$/,
+  /^prisma\/schema\.prisma$/,
+  /^prisma\/migrations\//,
+  /^src\/app\/api\/(auth|admin|configs|webhooks|imaging|billing)\//,
+  /^src\/app\/\(clinician\)\//,
+  /^src\/app\/\(operator\)\//,
+  /^src\/app\/\(patient\)\//,
+  /^src\/app\/\(super-admin\)\//,
+];
+
+/** Max times we'll auto-rerun the same failure before escalating. */
+export const RERUN_BUDGET = 2;
+
+// ---------------------------------------------------------------------------
+// Classifier
+// ---------------------------------------------------------------------------
+
+export function classify(ctx: FailureContext): TriageDecision {
+  const sig = computeSignature(ctx);
+  const rerunCount = ctx.rerunCount ?? 0;
+
+  if (ctx.failedTests.length === 0) {
+    // Pipeline failed but we couldn't parse which tests. Be conservative.
+    return {
+      risk: "high",
+      signal: "unknown",
+      action: "escalate",
+      reason:
+        "Job failed but no failed tests were parsed from the report. " +
+        "Could be infra/setup failure; safer to escalate.",
+      failureSignature: sig,
+    };
+  }
+
+  // 1) Diff touches a high-risk path → escalate regardless of which test failed.
+  const sensitiveChange = ctx.changedPaths.find((p) =>
+    HIGH_RISK_PATH_PATTERNS.some((re) => re.test(p)),
+  );
+  if (sensitiveChange) {
+    return {
+      risk: "high",
+      signal: "regression",
+      action: "escalate",
+      reason:
+        `Diff touches sensitive path: ${sensitiveChange}. ` +
+        `No autofix attempted on auth/PHI/billing surfaces.`,
+      failureSignature: sig,
+    };
+  }
+
+  // 2) Any failing test runs against a high-risk surface → escalate.
+  const sensitiveTest = ctx.failedTests.find((t) =>
+    testTouchesSensitiveSurface(t),
+  );
+  if (sensitiveTest) {
+    return {
+      risk: "high",
+      signal: "regression",
+      action: "escalate",
+      reason:
+        `Failed test exercises a sensitive surface: "${sensitiveTest.title}". ` +
+        `No autofix attempted on auth/PHI/billing surfaces.`,
+      failureSignature: sig,
+    };
+  }
+
+  // 3) Pure flake — every failed test matches a known transient pattern.
+  const allFlaky = ctx.failedTests.every((t) => isFlakyError(t.error));
+  if (allFlaky) {
+    if (rerunCount >= RERUN_BUDGET) {
+      // We've already re-run twice. Stop calling it a flake and start
+      // investigating — but keep risk low because surface is non-sensitive.
+      return {
+        risk: "medium",
+        signal: "regression",
+        action: "autofix",
+        reason:
+          `Same transient signature failed ${rerunCount + 1} times in a row — ` +
+          `treating as a real bug. Opening autofix issue.`,
+        failureSignature: sig,
+      };
+    }
+    return {
+      risk: "low",
+      signal: "flake",
+      action: "rerun",
+      reason:
+        `All ${ctx.failedTests.length} failures match known transient patterns ` +
+        `(timeout / network / page-closed). Re-running ` +
+        `(attempt ${rerunCount + 1}/${RERUN_BUDGET}).`,
+      failureSignature: sig,
+    };
+  }
+
+  // 4) Real failure on a low-risk public surface → autofix.
+  return {
+    risk: "medium",
+    signal: "regression",
+    action: "autofix",
+    reason:
+      `${ctx.failedTests.length} test(s) failed on public/non-sensitive surfaces ` +
+      `with non-flake errors. Suitable for autofix workflow.`,
+    failureSignature: sig,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isFlakyError(error: string): boolean {
+  return FLAKE_PATTERNS.some((re) => re.test(error));
+}
+
+/**
+ * Does this test exercise a sensitive surface? Two ways to qualify:
+ *   1. The test title mentions a high-risk route prefix.
+ *   2. The error mentions a high-risk API path (e.g. a fetch to /api/auth/...).
+ */
+function testTouchesSensitiveSurface(t: FailedTest): boolean {
+  const haystack = `${t.title}\n${t.error}`;
+  for (const prefix of HIGH_RISK_TEST_PREFIXES) {
+    // Look for the prefix as a path token (next char is "/", ")", or space)
+    // so "/portal" doesn't match "/portal-marketing".
+    const re = new RegExp(
+      `${escapeRegex(prefix)}(?=[/)\\s"'\\\\]|$)`,
+      "i",
+    );
+    if (re.test(haystack)) return true;
+  }
+  for (const api of HIGH_RISK_API_SUBSTRINGS) {
+    if (haystack.includes(api)) return true;
+  }
+  return false;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Stable hash of (sorted test titles + first 80 chars of each error).
+ * Same failure across multiple runs yields the same signature, so the
+ * triage workflow can find the existing issue and comment on it instead
+ * of opening a duplicate.
+ */
+function computeSignature(ctx: FailureContext): string {
+  const parts = [...ctx.failedTests]
+    .sort((a, b) => a.title.localeCompare(b.title))
+    .map((t) => `${t.title}::${t.error.slice(0, 80)}`);
+  return fnv1a(parts.join("|")).toString(16).padStart(8, "0");
+}
+
+/** FNV-1a 32-bit. Deterministic, no crypto dep — good enough for dedupe. */
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint — only runs when invoked directly, not when imported by tests.
+// ---------------------------------------------------------------------------
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<void> {
+  const raw = await readAllStdin();
+  if (!raw.trim()) {
+    process.stderr.write(
+      "triage-staging-failure: expected FailureContext JSON on stdin\n",
+    );
+    process.exit(2);
+  }
+  const ctx = JSON.parse(raw) as FailureContext;
+  const decision = classify(ctx);
+  process.stdout.write(JSON.stringify(decision, null, 2));
+  process.stdout.write("\n");
+}
+
+// `import.meta.url` would be cleaner, but the project's tsx config makes
+// the simple "are we the entrypoint?" check via process.argv[1] more
+// reliable across module systems.
+if (process.argv[1]?.endsWith("triage-staging-failure.ts")) {
+  void main();
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -14,7 +14,13 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      // Scripts that ship classifier/agent logic also need unit coverage
+      // (e.g. the CI/CD triage classifier at scripts/triage-staging-failure.ts).
+      "scripts/**/*.test.ts",
+    ],
     // Don't load .env — the transcription module reads env vars, and
     // tests should run deterministically regardless of .env state.
     passWithNoTests: false,


### PR DESCRIPTION
## Why this PR exists

PR #368 gates production on a green pipeline. This PR makes a red pipeline *actionable*: every failure gets classified and routed to one of three outcomes instead of just sitting in the Actions tab. Production stays gated — this only changes *what happens* when the pipeline goes red.

## The three outcomes

| action | when | what happens |
|---|---|---|
| `rerun` | transient signature (timeout, `ECONNRESET`, target-page-closed) | re-run failed jobs only; capped at `RERUN_BUDGET=2` per signature so we never loop forever |
| `autofix` | real assertion failure on a non-sensitive surface; diff didn't touch auth/RBAC/Prisma/middleware/role-group pages | open (or dedupe onto) a `autofix-needed` issue with the full failure context. A human or a follow-on Claude task picks it up, pushes a fix to a `claude/autofix-<signature>` branch, opens a PR. The PR's own pipeline re-triggers triage. |
| `escalate` | any sensitive surface (`/portal`, `/clinic`, `/ops`, `/admin`, `/onboarding`, `/sign-in`, `/sign-up`, `/api/auth\|imaging\|billing\|configs\|webhooks\|admin`) OR diff touches `src/lib/auth`, `src/lib/rbac`, `src/lib/db`, `middleware.ts`, `prisma/`, or any `(clinician)/(operator)/(patient)/(super-admin)` route group | open (or dedupe onto) a `pipeline-escalate` issue. **No autofix attempted.** Human reviews the diff. |

Production never auto-deploys past a failed pipeline. That invariant lives in PR #368 — this workflow is additive.

## Three components

1. **`scripts/triage-staging-failure.ts`** — pure classifier. Takes `{ workflowRunId, headSha, failedJobName, failedTests, changedPaths, rerunCount }` and returns `{ risk, signal, action, reason, failureSignature }`. 21 unit tests in `scripts/triage-staging-failure.test.ts` lock in every routing decision, including token-boundary false-positives (`/portal-marketing` correctly routed to `autofix`, not `escalate`).

2. **`scripts/parse-playwright-failures.js`** — dependency-free JS log parser. Pulls `{ file, title, error }` tuples out of the GitHub Actions log zip. JS so the triage workflow can run it before `npm ci`.

3. **`.github/workflows/staging-test-triage.yml`** — `workflow_run`-triggered workflow. On failure of "Staging & Production Pipeline" against `main`: downloads the log archive, parses failed tests, diffs the merge commit, runs the classifier, then routes via `gh api .../rerun-failed-jobs` or `gh issue create / comment`.

## Dedup + iteration

Every failure carries a stable FNV-1a signature of `sorted(test-title + first-80-chars-of-error)`. The workflow searches for an open issue with `sig <hash>` in the title and comments on it instead of opening a duplicate. Iteration count is read from `workflow_run.run_attempt - 1` — once the rerun budget is spent on the same signature, classification upgrades from `rerun` to `autofix`.

## Operator docs

`docs/runbooks/ci-pipeline-self-heal.md` covers the pipeline shape, every routing decision, the sensitive-surface taxonomy, required secrets, and the deliberate-manual-override procedure (no "deploy anyway" button by design).

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | exit 0 |
| `npx vitest run scripts/triage-staging-failure.test.ts` | 21/21 pass |
| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/staging-test-triage.yml'))"` | parses clean |

## Manual test plan

- [ ] Land this PR. Triage workflow is now registered to fire on every staging-pipeline completion.
- [ ] Land a deliberate flake (e.g. a 1s timeout in a public test) on main; confirm the workflow re-runs the failed job and the run goes green on attempt 2.
- [ ] Land a real assertion failure on `/pricing`; confirm an `autofix-needed` issue is opened with the failed test JSON and the diff.
- [ ] Land a real failure touching `src/lib/auth/session.ts`; confirm a `pipeline-escalate` issue is opened and no autofix is attempted.
- [ ] Trigger the same failure twice; confirm the second time comments on the existing issue rather than opening a duplicate.

## Future work (intentionally out of scope here)

The `autofix` path today *opens an issue with structured context* — it does not yet *push a fix automatically*. Wiring an Anthropic-API-driven autofix loop (read the issue, propose a diff, push branch, open PR) is the natural next iteration. It needs an `ANTHROPIC_API_KEY` secret, a budget guardrail, and a stricter classifier so we never auto-modify a sensitive surface even via a PR. Happy to scope that as PR #370 once #369 has run for a week and we've seen a few real classifications.

https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3RBoisUtt4gqMuspUzQzL)_