### PR TITLE
feat(super-admin): polished empty states + CTAs on HQ tiles

### DIFF
--- a/src/app/(super-admin)/admin/hq/tiles/activity-stream.tsx
+++ b/src/app/(super-admin)/admin/hq/tiles/activity-stream.tsx
@@ -31,7 +31,18 @@ export function ActivityStream({ rows }: { rows: RecentActivityRow[] }) {
 
   if (rows.length === 0) {
     return (
-      <p className="text-sm text-text-subtle">No super-admin activity in the last 24 hours.</p>
+      <div className="py-2">
+        <p className="text-sm text-text">All quiet.</p>
+        <p className="mt-1.5 text-[12px] text-text-muted leading-snug max-w-md">
+          No super-admin actions in the last 24 hours. Every privileged action across the fleet shows up here in near-real-time.
+        </p>
+        <Link
+          href="/admin/audit"
+          className="mt-3 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-[0.14em] text-accent hover:underline focus:outline-none focus-visible:underline rounded"
+        >
+          Browse full audit log <span aria-hidden="true">→</span>
+        </Link>
+      </div>
     );
   }
 

--- a/src/app/(super-admin)/admin/hq/tiles/hero-strip.tsx
+++ b/src/app/(super-admin)/admin/hq/tiles/hero-strip.tsx
@@ -61,6 +61,34 @@ function Tile({
   );
 }
 
+function EmptyTile({
+  label,
+  hint,
+  ctaHref,
+  ctaLabel,
+}: {
+  label: string;
+  hint: string;
+  ctaHref: string;
+  ctaLabel: string;
+}) {
+  return (
+    <div className="block rounded-2xl border border-dashed border-border-strong/60 bg-surface-muted/30 px-7 py-6">
+      <div className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">{label}</div>
+      <div className="font-display text-5xl text-text-muted tracking-tight tabular-nums mt-4 leading-none">
+        —
+      </div>
+      <p className="mt-4 text-[12px] text-text-muted leading-snug">{hint}</p>
+      <Link
+        href={ctaHref}
+        className="mt-3 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-[0.14em] text-accent hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded"
+      >
+        {ctaLabel} <span aria-hidden="true">→</span>
+      </Link>
+    </div>
+  );
+}
+
 export function HeroStrip({
   counts,
   dailySeries,
@@ -81,27 +109,54 @@ export function HeroStrip({
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
-      <Tile
-        label="Practices live"
-        value={formatCount(counts.practicesLive)}
-        href="/practices"
-        series={claims}
-        momPct={practicesMom}
-      />
-      <Tile
-        label="Providers active"
-        value={formatCount(counts.providersActive)}
-        href="/admin/console"
-        series={encounters}
-        momPct={providersMom}
-      />
-      <Tile
-        label="Patients active"
-        value={formatCount(counts.patientsActive)}
-        href="/practices?focus=patients"
-        series={newPatients}
-        momPct={patientsMom}
-      />
+      {counts.practicesLive === 0 ? (
+        <EmptyTile
+          label="Practices live"
+          hint="Live practice count appears here once your first practice publishes its configuration."
+          ctaHref="/onboarding"
+          ctaLabel="Start a practice"
+        />
+      ) : (
+        <Tile
+          label="Practices live"
+          value={formatCount(counts.practicesLive)}
+          href="/practices"
+          series={claims}
+          momPct={practicesMom}
+        />
+      )}
+      {counts.providersActive === 0 ? (
+        <EmptyTile
+          label="Providers active"
+          hint="Active providers will appear here once clinicians are invited into a practice."
+          ctaHref="/admin/console"
+          ctaLabel="Manage admins"
+        />
+      ) : (
+        <Tile
+          label="Providers active"
+          value={formatCount(counts.providersActive)}
+          href="/admin/console"
+          series={encounters}
+          momPct={providersMom}
+        />
+      )}
+      {counts.patientsActive === 0 ? (
+        <EmptyTile
+          label="Patients active"
+          hint="Active patients across the fleet appear here once charts are created."
+          ctaHref="/admin/search"
+          ctaLabel="Search existing data"
+        />
+      ) : (
+        <Tile
+          label="Patients active"
+          value={formatCount(counts.patientsActive)}
+          href="/practices?focus=patients"
+          series={newPatients}
+          momPct={patientsMom}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(super-admin)/admin/hq/tiles/leaderboards.tsx
+++ b/src/app/(super-admin)/admin/hq/tiles/leaderboards.tsx
@@ -17,6 +17,12 @@ const VALUE_LABELS: Record<Metric, string> = {
   patientGrowth: "New patients",
 };
 
+const EMPTY_HINTS: Record<Metric, string> = {
+  claims: "Practices ranked by claims filed this month appear here once claims flow.",
+  billed: "Practices ranked by dollars billed this month appear here once charges post.",
+  patientGrowth: "Practices ranked by new-patient intake this month appear here once charts are created.",
+};
+
 function formatMetric(metric: Metric, raw: number): string {
   if (metric === "billed") return formatUSDCents(raw);
   return formatCount(raw);
@@ -38,7 +44,18 @@ function Leaderboard({ metric, rows }: { metric: Metric; rows: TopPracticeRow[] 
         <span className="text-[11px] text-text-subtle">MTD</span>
       </header>
       {rows.length === 0 ? (
-        <p className="text-sm text-text-subtle">No data yet.</p>
+        <div className="py-2">
+          <p className="text-sm text-text">No data yet.</p>
+          <p className="mt-1.5 text-[12px] text-text-muted leading-snug">
+            {EMPTY_HINTS[metric]}
+          </p>
+          <Link
+            href="/onboarding"
+            className="mt-3 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-[0.14em] text-accent hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded"
+          >
+            Start a practice <span aria-hidden="true">→</span>
+          </Link>
+        </div>
       ) : (
         <ol className="space-y-2">
           {rows.map((row, idx) => (

--- a/src/app/(super-admin)/admin/hq/tiles/onboarding-funnel.tsx
+++ b/src/app/(super-admin)/admin/hq/tiles/onboarding-funnel.tsx
@@ -34,7 +34,19 @@ export function OnboardingFunnel({ stages }: { stages: OnboardingFunnelStage[] }
 
   if (total === 0) {
     return (
-      <p className="text-sm text-text-muted py-6">No practices in onboarding.</p>
+      <div className="py-6">
+        <p className="text-sm text-text">No practices in onboarding yet.</p>
+        <p className="mt-1.5 text-[12px] text-text-muted leading-snug max-w-md">
+          Each practice configuration progresses through draft, in-progress, and published stages.
+          The funnel chart appears here once the first one is created.
+        </p>
+        <Link
+          href="/onboarding"
+          className="mt-3 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-[0.14em] text-accent hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded"
+        >
+          Start onboarding a practice <span aria-hidden="true">→</span>
+        </Link>
+      </div>
     );
   }
 

--- a/src/app/(super-admin)/admin/hq/tiles/revenue-strip.tsx
+++ b/src/app/(super-admin)/admin/hq/tiles/revenue-strip.tsx
@@ -38,6 +38,27 @@ function Tile({
   );
 }
 
+function EmptyRevenueTile({
+  label,
+  hint,
+}: {
+  label: string;
+  hint: string;
+}) {
+  return (
+    <div
+      tabIndex={0}
+      className="relative block rounded-2xl border border-dashed border-border-strong/60 bg-surface-muted/30 px-7 py-6 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+    >
+      <div className="text-[11px] uppercase tracking-[0.16em] text-text-subtle">{label}</div>
+      <div className="font-display text-3xl md:text-4xl text-text-muted tracking-tight tabular-nums mt-4 leading-none">
+        $0
+      </div>
+      <p className="mt-3 text-[11px] text-text-muted leading-snug">{hint}</p>
+    </div>
+  );
+}
+
 function PlaceholderTile() {
   return (
     <div
@@ -66,27 +87,48 @@ export function RevenueStrip({ revenue }: { revenue: FleetRevenue }) {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
-      <Tile
-        label="Billed MTD"
-        subtitle="Total claim charges submitted this month."
-        value={formatUSDCents(revenue.billedCentsMTD)}
-        prevValue={formatUSDCents(revenue.billedCentsPrevMonth)}
-        pct={billedPct}
-      />
-      <Tile
-        label="Collected MTD"
-        subtitle="Insurance + patient cash actually received."
-        value={formatUSDCents(revenue.collectedCentsMTD)}
-        prevValue={formatUSDCents(revenue.collectedCentsPrevMonth)}
-        pct={collectedPct}
-      />
-      <Tile
-        label="GMV MTD"
-        subtitle="All dollars routed through the payment gateway."
-        value={formatUSDCents(revenue.gmvCentsMTD)}
-        prevValue={formatUSDCents(revenue.gmvCentsPrevMonth)}
-        pct={gmvPct}
-      />
+      {revenue.billedCentsMTD === 0 && revenue.billedCentsPrevMonth === 0 ? (
+        <EmptyRevenueTile
+          label="Billed MTD"
+          hint="Total claim charges submitted this month will appear once practices file claims."
+        />
+      ) : (
+        <Tile
+          label="Billed MTD"
+          subtitle="Total claim charges submitted this month."
+          value={formatUSDCents(revenue.billedCentsMTD)}
+          prevValue={formatUSDCents(revenue.billedCentsPrevMonth)}
+          pct={billedPct}
+        />
+      )}
+      {revenue.collectedCentsMTD === 0 && revenue.collectedCentsPrevMonth === 0 ? (
+        <EmptyRevenueTile
+          label="Collected MTD"
+          hint="Insurance and patient cash received will appear once payments land."
+        />
+      ) : (
+        <Tile
+          label="Collected MTD"
+          subtitle="Insurance + patient cash actually received."
+          value={formatUSDCents(revenue.collectedCentsMTD)}
+          prevValue={formatUSDCents(revenue.collectedCentsPrevMonth)}
+          pct={collectedPct}
+        />
+      )}
+      {revenue.gmvCentsMTD === 0 && revenue.gmvCentsPrevMonth === 0 ? (
+        <EmptyRevenueTile
+          label="GMV MTD"
+          hint="Dollars routed through the payment gateway will appear once charges flow."
+        />
+      ) : (
+        <Tile
+          label="GMV MTD"
+          subtitle="All dollars routed through the payment gateway."
+          value={formatUSDCents(revenue.gmvCentsMTD)}
+          prevValue={formatUSDCents(revenue.gmvCentsPrevMonth)}
+          pct={gmvPct}
+        />
+      )}
       <PlaceholderTile />
     </div>
   );


### PR DESCRIPTION
## Summary

A fresh DB rendered "0" everywhere on `/admin/hq` with no guidance. Each tile now shows a friendly empty state inside the existing tile chrome when its underlying data is zero, with a relevant call-to-action where one is possible and a purely informational hint where it is not.

- **hero-strip** — per-metric empty tile for *Practices live* / *Providers active* / *Patients active*, with CTAs to `/onboarding`, `/admin/console`, and `/admin/search` respectively.
- **revenue-strip** — per-metric empty tile for *Billed MTD* / *Collected MTD* / *GMV MTD*. Informational only (nothing to do until claims and payments actually flow). The existing ARR placeholder is untouched.
- **onboarding-funnel** — replaces the bare "No practices in onboarding." line with a description plus a CTA to `/onboarding`.
- **leaderboards** — per-metric hint copy on the existing "No data yet." card, plus a CTA to `/onboarding`.
- **activity-stream** — polished "All quiet." copy plus a CTA to `/admin/audit`.
- **modality-mix** — left alone per instruction (already had an empty state).

Live-data paths are unchanged — the empty branches only run when the underlying `count === 0` / `rows.length === 0`. No new shared `EmptyState` abstraction; three near-duplicate inline blocks across tiles is intentional.

## Test plan

- [ ] On a fresh DB, visit `/admin/hq` as a super-admin and confirm every tile renders a dashed-border empty state with a clear hint (and a CTA where applicable) instead of `0`.
- [ ] Each empty-state CTA navigates to the correct destination (`/onboarding`, `/admin/console`, `/admin/search`, `/admin/audit`).
- [ ] With at least one published practice, confirm the live tiles render (no regression) and the empty states no longer appear for non-zero metrics.
- [ ] Keyboard-tab through the tiles — focus rings still land on every interactive element, including the new CTA links.
- [ ] `npx tsc --noEmit` clean (verified locally).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>