### PR TITLE
feat(super-admin): "view as practice" UI — banner + button + cookie tests (EMR-742 Phase 2)

### DIFF
--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/auth/session";
 import { requireSuperAdmin } from "@/lib/auth/super-admin";
 import { bootstrapSuperAdminIfAllowlisted } from "@/lib/auth/super-admin-bootstrap";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
+import { ImpersonationBanner } from "@/components/super-admin/impersonation-banner";
 import { ROLE_LABELS } from "@/lib/rbac/roles";
 
 export const dynamic = "force-dynamic";
@@ -76,14 +77,21 @@ export default async function SuperAdminLayout({
   }
 
   return (
-    <AppShell
-      user={user}
-      activeRole="super_admin"
-      sections={SUPER_ADMIN_SECTIONS}
-      roleLabel={ROLE_LABELS.super_admin}
-      showNavPrefs={false}
-    >
-      {children}
-    </AppShell>
+    <>
+      {/* EMR-742 Phase 2 — Spans the entire viewport (sticky top). Renders
+          nothing when there is no active impersonation session. Mounted
+          above AppShell so it sits above the role rail / drawer rather
+          than being clipped by them. */}
+      <ImpersonationBanner />
+      <AppShell
+        user={user}
+        activeRole="super_admin"
+        sections={SUPER_ADMIN_SECTIONS}
+        roleLabel={ROLE_LABELS.super_admin}
+        showNavPrefs={false}
+      >
+        {children}
+      </AppShell>
+    </>
   );
 }

--- a/src/app/(super-admin)/practices/[id]/page.tsx
+++ b/src/app/(super-admin)/practices/[id]/page.tsx
@@ -23,6 +23,7 @@ import { ArrowLeft, MapPin } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
+import { ViewAsPracticeButton } from "@/components/super-admin/view-as-practice-button";
 
 import { loadPracticeOverview } from "../loaders";
 import { humanizeCareModel, humanizeSpecialty } from "../types";
@@ -117,6 +118,13 @@ export default async function PracticeDrillInPage({
               )}
             </div>
           </div>
+          {/* EMR-742 Phase 2 — super-admin-only; the (super-admin) layout
+              guards this segment with requireSuperAdmin() so anyone who
+              renders this page is already cleared to see the button. */}
+          <ViewAsPracticeButton
+            practiceOrgId={practice.organizationId}
+            practiceName={practice.practiceName}
+          />
         </div>
       </div>
 

--- a/src/components/super-admin/impersonation-banner.tsx
+++ b/src/components/super-admin/impersonation-banner.tsx
@@ -1,0 +1,88 @@
+// EMR-742 Phase 2 — "Viewing as <practice>" sticky banner.
+//
+// Server component. Mounted in src/app/(super-admin)/layout.tsx ABOVE
+// the AppShell so it spans the entire viewport regardless of which
+// drawer / nav state the shell is in. Renders nothing when there is no
+// active impersonation session — keeping it inert is cheap because
+// `readImpersonationFromCookies` is a single cookie read + HMAC verify.
+//
+// The banner is intentionally undismissable: closing it without
+// actually ending the impersonation session would be a security
+// foot-gun (a super-admin could forget they're impersonating). The
+// only way to make it disappear is to hit Exit (which calls
+// /api/admin/impersonate/exit and clears the cookie).
+//
+// Visuals: high-contrast amber stripe. We do not use a Tailwind
+// design-system token for this because the banner needs to scream
+// regardless of role-theme — amber-400 is the universal "you are in a
+// state that is not your normal state" colour across the codebase
+// (see PinButton, NavSections badge severities, ambient warnings).
+
+import { getCurrentUser } from "@/lib/auth/session";
+import { readImpersonationFromCookies } from "@/lib/auth/impersonation";
+import { ImpersonationExitButton } from "./impersonation-exit-button";
+
+function formatRemaining(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m <= 0) return `${s}s left`;
+  return `${m}m ${s.toString().padStart(2, "0")}s left`;
+}
+
+export async function ImpersonationBanner() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  // readImpersonationFromCookies throws outside a request scope; inside
+  // a layout it's always safe. We still guard with try/catch so a
+  // malformed cookie never blows up the whole shell.
+  let session;
+  try {
+    session = await readImpersonationFromCookies(user.id);
+  } catch {
+    return null;
+  }
+  if (!session) return null;
+
+  const remainingMs = session.expiresAt - Date.now();
+  const remainingLabel = formatRemaining(remainingMs);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-impersonation-banner
+      className={
+        "sticky top-0 z-[60] w-full " +
+        "bg-amber-400 text-amber-950 " +
+        "border-b border-amber-600/40 shadow-[0_1px_0_rgba(0,0,0,0.05)]"
+      }
+    >
+      <div className="mx-auto flex items-center justify-between gap-4 px-4 py-2 max-w-[1600px]">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            aria-hidden
+            className="inline-block h-2 w-2 rounded-full bg-amber-900 animate-pulse"
+          />
+          <p className="text-[13px] font-semibold truncate">
+            Viewing as{" "}
+            <span className="font-bold">{session.practiceName}</span>
+          </p>
+          <span
+            className={
+              "inline-flex items-center rounded-full " +
+              "bg-amber-900/15 text-amber-950 " +
+              "px-2 py-0.5 text-[11px] font-medium tabular-nums " +
+              "whitespace-nowrap"
+            }
+            title={`Auto-expires at ${new Date(session.expiresAt).toLocaleTimeString()}`}
+          >
+            {remainingLabel}
+          </span>
+        </div>
+        <ImpersonationExitButton />
+      </div>
+    </div>
+  );
+}

--- a/src/components/super-admin/impersonation-exit-button.tsx
+++ b/src/components/super-admin/impersonation-exit-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+// EMR-742 Phase 2 — Exit button used inside the impersonation banner.
+// Split out from impersonation-banner.tsx because the banner itself is
+// a server component (it reads the cookie via `readImpersonationFromCookies`).
+//
+// POSTs to /api/admin/impersonate/exit (idempotent) and refreshes so
+// the layout re-renders without the banner.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { X } from "lucide-react";
+
+export function ImpersonationExitButton() {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleClick() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/admin/impersonate/exit", {
+          method: "POST",
+          credentials: "same-origin",
+          headers: { "content-type": "application/json" },
+        });
+        if (!res.ok) {
+          setError(`Exit failed (HTTP ${res.status}).`);
+          return;
+        }
+        router.refresh();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Network error exiting.",
+        );
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {error && (
+        <span
+          role="alert"
+          className="text-[11px] text-amber-900/80"
+        >
+          {error}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={pending}
+        className={
+          "inline-flex items-center gap-1.5 rounded-md " +
+          "bg-amber-900/10 hover:bg-amber-900/20 " +
+          "text-amber-950 text-[12px] font-semibold " +
+          "px-2.5 h-7 transition-colors " +
+          "disabled:opacity-60 disabled:cursor-not-allowed " +
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-900/40"
+        }
+        aria-label="Exit impersonation"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden />
+        {pending ? "Exiting…" : "Exit"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/super-admin/view-as-practice-button.tsx
+++ b/src/components/super-admin/view-as-practice-button.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// EMR-742 Phase 2 — "View as practice" entry button.
+//
+// Rendered on the super-admin practice drill-in page header. On click,
+// POSTs to /api/admin/impersonate/[practiceId]; the route handler issues
+// the signed HttpOnly cookie. We then call router.refresh() so the
+// server re-renders the (super-admin) layout — which is where the
+// impersonation banner mounts — and the banner appears without a full
+// page reload.
+//
+// Errors (MFA required, practice not found, network) surface as inline
+// red text under the button. We deliberately keep this surface
+// minimal: no toast system, no dialog. The audit-critical work happens
+// server-side; this client just relays the click.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Eye } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  /**
+   * Practice identifier to impersonate. The API accepts either
+   * Organization.id or PracticeConfiguration.id (it resolves both),
+   * so the caller can pass whichever it has on hand.
+   */
+  practiceOrgId: string;
+  /** Human-readable name, used only for the confirm prompt. */
+  practiceName: string;
+}
+
+export function ViewAsPracticeButton({ practiceOrgId, practiceName }: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleClick() {
+    // Confirm to prevent accidental clicks — impersonation writes an
+    // audit row that the user can't undo, so making the action
+    // intentional is cheap insurance.
+    const ok = window.confirm(
+      `Enter "View as practice" mode for ${practiceName}?\n\n` +
+        "Your super-admin identity remains the audit attribution. " +
+        "Session auto-expires in 30 minutes.",
+    );
+    if (!ok) return;
+
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/admin/impersonate/${encodeURIComponent(practiceOrgId)}`,
+          {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "content-type": "application/json" },
+          },
+        );
+
+        if (!res.ok) {
+          let message = `Failed to start impersonation (HTTP ${res.status}).`;
+          try {
+            const body = (await res.json()) as { message?: string; error?: string };
+            message = body.message ?? body.error ?? message;
+          } catch {
+            // body wasn't JSON; keep the generic message
+          }
+          setError(message);
+          return;
+        }
+
+        // Refresh so the (super-admin) layout re-renders and the
+        // banner picks up the newly-set cookie.
+        router.refresh();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Network error starting impersonation.",
+        );
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <Button
+        variant="secondary"
+        size="sm"
+        leadingIcon={<Eye className="h-4 w-4" aria-hidden />}
+        onClick={handleClick}
+        disabled={pending}
+        aria-label={`View as ${practiceName}`}
+      >
+        {pending ? "Starting…" : "View as practice"}
+      </Button>
+      {error && (
+        <p
+          role="alert"
+          className="text-[11px] text-danger max-w-[260px] text-right"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/auth/impersonation.test.ts
+++ b/src/lib/auth/impersonation.test.ts
@@ -1,0 +1,127 @@
+// EMR-742 Phase 2 — unit tests for the impersonation cookie helpers.
+//
+// These tests exercise the pure sign/verify pair only. We deliberately
+// do NOT touch `readImpersonationFromCookies` / `setImpersonationCookie`
+// here — those wrap Next.js `cookies()` which throws outside a request
+// scope and would require a heavy mock. The sign/verify functions are
+// where every meaningful security property lives (HMAC, version prefix,
+// bound user check, expiry check), so covering them covers the threat
+// model the module is defending against.
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  signImpersonationCookie,
+  verifyImpersonationCookie,
+  type ImpersonationSession,
+} from "./impersonation";
+
+const ORIGINAL_SECRET = process.env.SESSION_SECRET;
+
+function freshSession(
+  overrides: Partial<ImpersonationSession> = {},
+): ImpersonationSession {
+  const now = Date.now();
+  return {
+    impersonatorUserId: "user_super_admin_123",
+    practiceOrgId: "org_practice_abc",
+    practiceName: "Maple Wellness Clinic",
+    startedAt: now,
+    expiresAt: now + 30 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe("impersonation cookie sign/verify", () => {
+  beforeEach(() => {
+    // Pin a known secret so tests are deterministic and independent of
+    // whatever shell env they ran from.
+    process.env.SESSION_SECRET = "test-secret-do-not-use-in-prod";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.SESSION_SECRET;
+    } else {
+      process.env.SESSION_SECRET = ORIGINAL_SECRET;
+    }
+  });
+
+  it("roundtrips a valid signature: signed cookie verifies and returns the same session", () => {
+    const session = freshSession();
+    const cookie = signImpersonationCookie(session);
+
+    expect(cookie.startsWith("v1.")).toBe(true);
+    expect(cookie.split(".")).toHaveLength(3);
+
+    const verified = verifyImpersonationCookie(
+      cookie,
+      session.impersonatorUserId,
+    );
+    expect(verified).not.toBeNull();
+    expect(verified).toEqual(session);
+  });
+
+  it("rejects a tampered signature", () => {
+    const session = freshSession();
+    const cookie = signImpersonationCookie(session);
+
+    // Flip the last character of the hex signature. We pick a char we
+    // know is different (a -> b, otherwise -> a) so the test is stable
+    // regardless of which signature came out of the HMAC.
+    const lastChar = cookie.slice(-1);
+    const flipped = lastChar === "a" ? "b" : "a";
+    const tampered = cookie.slice(0, -1) + flipped;
+    expect(tampered).not.toBe(cookie);
+
+    const verified = verifyImpersonationCookie(
+      tampered,
+      session.impersonatorUserId,
+    );
+    expect(verified).toBeNull();
+  });
+
+  it("rejects an expired payload (expiresAt in the past)", () => {
+    const past = Date.now() - 60_000;
+    const session = freshSession({
+      startedAt: past - 30 * 60 * 1000,
+      expiresAt: past,
+    });
+    const cookie = signImpersonationCookie(session);
+
+    const verified = verifyImpersonationCookie(
+      cookie,
+      session.impersonatorUserId,
+    );
+    expect(verified).toBeNull();
+  });
+
+  it("rejects a cookie bound to a different user id (replay protection)", () => {
+    const session = freshSession({ impersonatorUserId: "user_alice" });
+    const cookie = signImpersonationCookie(session);
+
+    const verified = verifyImpersonationCookie(cookie, "user_bob");
+    expect(verified).toBeNull();
+
+    // Sanity check: same cookie still verifies for the correct user.
+    const verifiedForOwner = verifyImpersonationCookie(cookie, "user_alice");
+    expect(verifiedForOwner).not.toBeNull();
+  });
+
+  it("rejects an undefined / empty raw cookie", () => {
+    expect(verifyImpersonationCookie(undefined, "anyone")).toBeNull();
+    expect(verifyImpersonationCookie("", "anyone")).toBeNull();
+  });
+
+  it("rejects a wrong-version prefix (forward compatibility guard)", () => {
+    const session = freshSession();
+    const cookie = signImpersonationCookie(session);
+    // v1.<payload>.<sig> -> v2.<payload>.<sig>
+    const wrongVersion = "v2" + cookie.slice(2);
+
+    const verified = verifyImpersonationCookie(
+      wrongVersion,
+      session.impersonatorUserId,
+    );
+    expect(verified).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Wires the user-facing impersonation surfaces on top of the EMR-742 Phase 1 cookie / route infra that landed on main.

- **`ViewAsPracticeButton`** (client): sits in the practice drill-in header, confirms, POSTs to `/api/admin/impersonate/[practiceId]`, then `router.refresh()` so the banner picks up the new cookie. Wired into `src/app/(super-admin)/practices/[id]/page.tsx` — that segment is already gated by `requireSuperAdmin()` in the route-group layout, so visibility = super-admin only.
- **`ImpersonationBanner`** (server): reads `readImpersonationFromCookies(user.id)`; when active, renders a sticky amber stripe across the entire viewport with `Viewing as <practiceName>`, a remaining-time pill, and an `Exit` button. Mounted in `src/app/(super-admin)/layout.tsx` ABOVE `AppShell` so it spans rail + drawer + main column. Returns `null` (and is therefore inert) when no session is active.
- **`ImpersonationExitButton`** (client, split out so the banner can stay a server component): POSTs to `/api/admin/impersonate/exit` and refreshes. Banner cannot be dismissed without going through this exit path — by design.
- **Unit tests** for the cookie sign/verify pair in `src/lib/auth/impersonation.test.ts`:
  - valid signature roundtrip
  - tampered signature rejected
  - expired payload rejected (`expiresAt <= now`)
  - wrong-bound-user rejected (replay protection)
  - empty/undefined input rejected
  - wrong version prefix rejected (forward-compat guard)

## Decisions
- **Confirm dialog before entering.** Impersonation writes an audit row the user can't undo, so a `window.confirm()` makes accidental clicks deliberate. No design-system dialog — keeps the surface minimal and matches the "Apple-iOS minimal" CLAUDE.md guidance.
- **Banner is undismissable.** A super-admin who could hide the banner without exiting is the exact foot-gun the banner exists to prevent. Only `/api/admin/impersonate/exit` removes it.
- **Split `ImpersonationExitButton` into its own client file** so `ImpersonationBanner` can remain a server component (it needs `readImpersonationFromCookies` which is server-only).
- **Amber-400 / amber-950** palette: matches `NavSections.tsx`, `IconRail.tsx`, and `PinButton.tsx` — the codebase's established "you are in a non-normal state" colour.
- **Remaining-time pill is static** (server-rendered at request time). A live ticking countdown would require a heavier client component just for cosmetics; the cookie's `expiresAt` and the API's 30-min ceiling are the real enforcement, and the pill refreshes on any `router.refresh()` / navigation.
- **Tests cover the pure sign/verify pair only** — `readImpersonationFromCookies` / `setImpersonationCookie` wrap Next.js `cookies()` which throws outside a request scope. All meaningful security properties (HMAC, version prefix, bound-user check, expiry check) live in the pure functions, so coverage tracks the threat model directly without a heavy mock harness.

## Test plan
- [x] `npx prisma generate && npx tsc --noEmit` — clean
- [x] `node scripts/check-admin-mutation-coverage.mjs` — 16/16 routes wrapped
- [x] `node scripts/check-route-auth-manifest.mjs` — 116 routes in sync
- [x] `npx vitest run src/lib/auth/impersonation.test.ts` — 6/6 pass
- [ ] Manual smoke: super-admin loads `/practices/[id]`, clicks "View as practice", confirms; banner appears at the top of every super-admin page; "Exit" clears the cookie and removes the banner.
- [ ] Negative smoke: tamper the cookie value in DevTools → banner disappears on next nav (verify rejects the bad sig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)