### PR TITLE
feat(super-admin): emergency revoke UI — confirmation dialog + console action

### DIFF
--- a/src/components/admin/__tests__/emergency-revoke-dialog.test.ts
+++ b/src/components/admin/__tests__/emergency-revoke-dialog.test.ts
@@ -1,0 +1,154 @@
+/**
+ * EMR-727 — EmergencyRevokeDialog: submit-gate unit test.
+ *
+ * Vitest in this repo runs in a node environment (no DOM, no
+ * @testing-library/react). We export the dialog's pure validation predicate
+ * `canSubmitEmergencyRevoke` so the same function the disabled-state of the
+ * destructive button consults can be tested without rendering JSX.
+ *
+ * If this test ever passes while the dialog's button is enabled in a state
+ * it should not be, the dialog has diverged from its predicate — fix the
+ * dialog, not the test.
+ *
+ * Acceptance gate (from the EMR-727 UI ticket):
+ *   - Dialog blocks submit until the operator types the target's email
+ *     correctly AND supplies a reason ≥10 characters.
+ */
+
+import { describe, expect, it } from "vitest";
+import { canSubmitEmergencyRevoke } from "../emergency-revoke-dialog";
+
+const TARGET_EMAIL = "alice@leafjourney.com";
+const GOOD_REASON = "compromised at 14:02 PT, see #incident-413"; // 41 chars
+
+describe("canSubmitEmergencyRevoke", () => {
+  it("blocks submit when nothing has been typed", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: "",
+        reason: "",
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit when only the reason is provided (email empty)", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: "",
+        reason: GOOD_REASON,
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit when only the email is provided (reason empty)", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: "",
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit when the email is wrong (typo)", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: "alice@leafjourny.com", // missing 'e'
+        reason: GOOD_REASON,
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit when the reason is < 10 characters after trim", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: "too short",
+        submitting: false,
+      }),
+    ).toBe(false);
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: "         exactly9", // trimmed to "exactly9" = 8 chars
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit when the reason is > 500 characters", () => {
+    const tooLong = "x".repeat(501);
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: tooLong,
+        submitting: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submit while a previous request is in flight", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: GOOD_REASON,
+        submitting: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows submit when email matches and reason is ≥10 chars", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: GOOD_REASON,
+        submitting: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a case-insensitive email match with surrounding whitespace (matches server check)", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: "  ALICE@LeafJourney.com  ",
+        reason: GOOD_REASON,
+        submitting: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a reason at exactly 10 characters", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: "1234567890", // 10 chars
+        submitting: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a reason at exactly 500 characters", () => {
+    expect(
+      canSubmitEmergencyRevoke({
+        targetEmail: TARGET_EMAIL,
+        confirmEmail: TARGET_EMAIL,
+        reason: "x".repeat(500),
+        submitting: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/components/admin/emergency-revoke-dialog.tsx
+++ b/src/components/admin/emergency-revoke-dialog.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+// EMR-727 — Emergency revoke confirmation dialog
+// -----------------------------------------------------------------------------
+//
+// Client-only modal that fronts POST
+// /api/admin/super-admins/[userId]/emergency-revoke. The server-side route
+// (src/app/api/admin/super-admins/[userId]/emergency-revoke/route.ts) is the
+// single source of truth — this dialog is purely a friction barrier so the
+// operator cannot mis-fire "burn it down" by accident:
+//
+//   1. A red warning banner spells out the blast radius (kills every active
+//      session for the target within ~1s, fleet-wide, no undo).
+//   2. The destructive button stays disabled until the operator types the
+//      target's email verbatim (case-insensitive trim, matching the server
+//      re-check at route.ts L102-L112).
+//   3. The destructive button also requires a reason ≥10 characters (server
+//      requires ≥1, but we ask the UI for a meaningful note since this row
+//      goes into the audit log + Slack alert).
+//
+// On a 200 response we call `router.refresh()` so the parent server
+// component re-fetches the super-admin list and the row drops out without
+// needing a separate `onRevoked` callback. The caller can still pass
+// `onSuccess` for extra cleanup (e.g. closing the parent picker).
+//
+// Why a separate file (not inlined in super-admin-console.tsx):
+//   - keeps the destructive-action UI testable in isolation;
+//   - lets the pure validation predicate `canSubmitEmergencyRevoke` be
+//     unit-tested without standing up a DOM.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * Pure validation predicate — exported so the unit test can exercise the
+ * "blocks submit until …" matrix without a DOM. The component below uses
+ * the exact same function so the test cannot diverge from the UI.
+ *
+ * Rules:
+ *   - reason must be ≥10 characters after trim (and ≤500, matching the
+ *     server zod schema at route.ts L45).
+ *   - confirmEmail must equal targetEmail after trim + toLowerCase (the
+ *     server does the same comparison at route.ts L102-L104).
+ *   - submitting === true short-circuits to false so the user can't
+ *     double-fire while a request is in flight.
+ */
+export function canSubmitEmergencyRevoke(args: {
+  targetEmail: string;
+  confirmEmail: string;
+  reason: string;
+  submitting: boolean;
+}): boolean {
+  if (args.submitting) return false;
+  const trimmedReason = args.reason.trim();
+  if (trimmedReason.length < 10) return false;
+  if (trimmedReason.length > 500) return false;
+  const a = args.confirmEmail.trim().toLowerCase();
+  const b = args.targetEmail.trim().toLowerCase();
+  if (a.length === 0) return false;
+  return a === b;
+}
+
+export interface EmergencyRevokeDialogProps {
+  /** The user whose super-admin role + sessions will be terminated. */
+  targetUserId: string;
+  /** Target's email — operator must re-type this to enable submit. */
+  targetEmail: string;
+  /** Called when the operator dismisses the dialog (Cancel / Esc / backdrop). */
+  onCancel: () => void;
+  /**
+   * Optional success hook fired AFTER router.refresh() kicks off. The
+   * dialog already invalidates server state on its own — use this if the
+   * caller needs to clear local UI (e.g. unset its "selected target").
+   */
+  onSuccess?: () => void;
+}
+
+export function EmergencyRevokeDialog({
+  targetUserId,
+  targetEmail,
+  onCancel,
+  onSuccess,
+}: EmergencyRevokeDialogProps) {
+  const router = useRouter();
+  const [confirmEmail, setConfirmEmail] = React.useState("");
+  const [reason, setReason] = React.useState("");
+  const [submitState, setSubmitState] = React.useState<
+    "idle" | "submitting" | "error"
+  >("idle");
+  const [error, setError] = React.useState<string | null>(null);
+  const [responseStatus, setResponseStatus] = React.useState<number | null>(
+    null,
+  );
+
+  const canSubmit = canSubmitEmergencyRevoke({
+    targetEmail,
+    confirmEmail,
+    reason,
+    submitting: submitState === "submitting",
+  });
+
+  // Esc closes the dialog. Backdrop click closes too (below). We don't trap
+  // focus here — the legacy Dialog primitive in src/components/ui/dialog.tsx
+  // doesn't either, and this dialog is small enough that focus rings on
+  // every interactive element are enough for keyboard ops.
+  React.useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && submitState !== "submitting") onCancel();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel, submitState]);
+
+  async function submit() {
+    if (!canSubmit) return;
+    setSubmitState("submitting");
+    setError(null);
+    setResponseStatus(null);
+    try {
+      const res = await fetch(
+        `/api/admin/super-admins/${encodeURIComponent(targetUserId)}/emergency-revoke`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason: reason.trim(),
+            confirmEmail: confirmEmail.trim(),
+          }),
+        },
+      );
+      setResponseStatus(res.status);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          data?.message || data?.error || `HTTP ${res.status}`,
+        );
+      }
+      // Invalidate server-rendered state (the super-admin list lives in
+      // SuperAdminConsole's AdminsTab, which re-fetches on mount via
+      // useEffect — router.refresh() forces any parent server tree to
+      // re-render so cached lists drop the revoked row).
+      router.refresh();
+      onSuccess?.();
+      onCancel();
+    } catch (e: unknown) {
+      setSubmitState("error");
+      setError(e instanceof Error ? e.message : "Failed to emergency-revoke");
+    }
+  }
+
+  const reasonTrimmed = reason.trim().length;
+  const reasonTooShort = reasonTrimmed > 0 && reasonTrimmed < 10;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Emergency revoke super-admin"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      <button
+        type="button"
+        aria-label="Close emergency revoke dialog"
+        onClick={() => {
+          if (submitState !== "submitting") onCancel();
+        }}
+        className="absolute inset-0 bg-black/50"
+      />
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-danger/40 bg-surface p-6 shadow-2xl">
+        <h3 className="text-lg font-semibold text-danger">Emergency revoke</h3>
+
+        {/* Red warning banner — the load-bearing piece of friction. */}
+        <div
+          role="alert"
+          className="mt-3 rounded-lg border border-danger/40 bg-red-50 p-3 text-sm text-danger"
+        >
+          This kills every active session for this admin within 1 second across
+          every replica. You cannot undo it.
+        </div>
+
+        <p className="mt-3 text-sm text-text">
+          Target: <span className="font-medium">{targetEmail}</span>
+        </p>
+        <p className="mt-1 text-xs text-text-muted">
+          Use this only if the account is compromised. Routine departures should
+          use the regular &ldquo;Revoke&rdquo; button.
+        </p>
+
+        <div className="mt-4 space-y-3">
+          <div>
+            <label
+              htmlFor="emergency-revoke-reason"
+              className="block text-xs font-medium uppercase tracking-wide text-text-muted"
+            >
+              Reason (required, ≥10 chars — logged to audit trail)
+            </label>
+            <textarea
+              id="emergency-revoke-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="e.g. Compromised at 14:02 PT, see #incident-413"
+              aria-label="Revocation reason"
+              aria-invalid={reasonTooShort || undefined}
+              maxLength={500}
+              rows={3}
+              className="mt-1 w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:border-danger focus:ring-2 focus:ring-danger/20"
+            />
+            <p className="mt-1 text-xs text-text-muted">
+              {reasonTrimmed}/500{" "}
+              {reasonTooShort && (
+                <span className="text-danger">
+                  &middot; need {10 - reasonTrimmed} more characters
+                </span>
+              )}
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor="emergency-revoke-confirm-email"
+              className="block text-xs font-medium uppercase tracking-wide text-text-muted"
+            >
+              Type{" "}
+              <code className="rounded bg-surface-muted px-1 py-0.5">
+                {targetEmail}
+              </code>{" "}
+              to confirm
+            </label>
+            <Input
+              id="emergency-revoke-confirm-email"
+              value={confirmEmail}
+              onChange={(e) => setConfirmEmail(e.target.value)}
+              placeholder={targetEmail}
+              aria-label="Confirm target email"
+              autoComplete="off"
+              spellCheck={false}
+              className="mt-1"
+            />
+          </div>
+        </div>
+
+        {submitState === "error" && error && (
+          <p
+            role="alert"
+            className="mt-3 rounded-md border border-danger/30 bg-red-50 p-2 text-sm text-danger"
+          >
+            {responseStatus ? `[${responseStatus}] ` : ""}
+            {error}
+          </p>
+        )}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            disabled={submitState === "submitting"}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            disabled={!canSubmit}
+            onClick={submit}
+            aria-disabled={!canSubmit}
+          >
+            {submitState === "submitting" ? "Revoking…" : "Emergency revoke"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/super-admin-console.tsx
+++ b/src/components/admin/super-admin-console.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/cn";
+import { EmergencyRevokeDialog } from "@/components/admin/emergency-revoke-dialog";
 
 type SpecialtyManifest = {
   slug: string;
@@ -511,14 +512,11 @@ function AdminsTab() {
                     <Button variant="ghost" size="sm" onClick={() => revoke(a.userId, a.email)}>
                       Revoke
                     </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
+                    <EmergencyRevokeTrigger
+                      label="Emergency revoke"
+                      ariaLabel={`Emergency revoke ${a.email}`}
                       onClick={() => setEmergencyTarget(a)}
-                      aria-label={`Emergency revoke ${a.email}`}
-                    >
-                      Emergency revoke
-                    </Button>
+                    />
                   </div>
                 </li>
               ))}
@@ -528,10 +526,11 @@ function AdminsTab() {
       </Card>
 
       {emergencyTarget && (
-        <EmergencyRevokeModal
-          target={emergencyTarget}
+        <EmergencyRevokeDialog
+          targetUserId={emergencyTarget.userId}
+          targetEmail={emergencyTarget.email}
           onCancel={() => setEmergencyTarget(null)}
-          onRevoked={onEmergencyRevoked}
+          onSuccess={onEmergencyRevoked}
         />
       )}
     </div>
@@ -539,123 +538,63 @@ function AdminsTab() {
 }
 
 // -----------------------------------------------------------------------------
-// EMR-727 — Emergency revoke modal
+// EMR-727 — Emergency revoke row trigger
 // -----------------------------------------------------------------------------
 //
-// Double-confirmation modal for the destructive emergency-revoke action.
-// Two friction gates before the POST goes out:
-//   1. Operator must type the target's email exactly (server re-checks).
-//   2. Operator must supply a non-empty reason (server requires 1..500).
-//
-// The server is the source of truth on both — this UI is just a friction
-// barrier. A clever attacker who could call the API directly still has to
-// satisfy the same server-side schema + last-admin guard + adminMutationLimiter.
+// Red destructive button with a small "?" tooltip next to it. The tooltip
+// is intentionally lightweight (CSS-only hover/focus reveal — no
+// JS-driven popper) because the row already has its own visual weight and
+// we don't want a heavyweight tooltip primitive added to the bundle just
+// for this one explainer. The "?" pill is keyboard-focusable so screen-
+// reader users can read the explanation via aria-describedby.
+// -----------------------------------------------------------------------------
 
-function EmergencyRevokeModal({
-  target,
-  onCancel,
-  onRevoked,
+function EmergencyRevokeTrigger({
+  label,
+  ariaLabel,
+  onClick,
 }: {
-  target: AdminRow;
-  onCancel: () => void;
-  onRevoked: () => void;
+  label: string;
+  ariaLabel: string;
+  onClick: () => void;
 }) {
-  const [confirmEmail, setConfirmEmail] = React.useState("");
-  const [reason, setReason] = React.useState("");
-  const [submitState, setSubmitState] = React.useState<"idle" | "submitting" | "error">("idle");
-  const [error, setError] = React.useState<string | null>(null);
-
-  const emailMatches = confirmEmail.trim().toLowerCase() === target.email.trim().toLowerCase();
-  const reasonOk = reason.trim().length > 0 && reason.trim().length <= 500;
-  const canSubmit = emailMatches && reasonOk && submitState !== "submitting";
-
-  async function submit() {
-    if (!canSubmit) return;
-    setSubmitState("submitting");
-    setError(null);
-    try {
-      const res = await fetch(
-        `/api/admin/super-admins/${encodeURIComponent(target.userId)}/emergency-revoke`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ reason: reason.trim(), confirmEmail: confirmEmail.trim() }),
-        },
-      );
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(data?.message || data?.error || `HTTP ${res.status}`);
-      }
-      onRevoked();
-    } catch (e: unknown) {
-      setSubmitState("error");
-      setError(e instanceof Error ? e.message : "Failed to emergency-revoke");
-    }
-  }
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Emergency revoke super-admin"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-    >
-      <div className="w-full max-w-md rounded-lg border border-danger/40 bg-surface p-6 shadow-xl">
-        <h3 className="text-lg font-semibold text-danger">Emergency revoke</h3>
-        <p className="mt-2 text-sm text-text">
-          This will immediately strip <span className="font-medium">{target.email}</span>&rsquo;s
-          super-admin role AND terminate every active session within ~1 second across the fleet.
-        </p>
-        <p className="mt-2 text-xs text-text-muted">
-          Use this if the account is compromised. Routine revocations should use the regular
-          &ldquo;Revoke&rdquo; button.
-        </p>
-
-        <div className="mt-4 space-y-3">
-          <div>
-            <label className="block text-xs font-medium uppercase tracking-wide text-text-muted">
-              Type <code className="rounded bg-surface-muted px-1 py-0.5">{target.email}</code> to confirm
-            </label>
-            <Input
-              value={confirmEmail}
-              onChange={(e) => setConfirmEmail(e.target.value)}
-              placeholder={target.email}
-              aria-label="Confirm target email"
-              className="mt-1"
-            />
-          </div>
-          <div>
-            <label className="block text-xs font-medium uppercase tracking-wide text-text-muted">
-              Reason (required, logged to audit trail)
-            </label>
-            <textarea
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              placeholder="e.g. Compromised at 14:02 PT, see #incident-413"
-              aria-label="Revocation reason"
-              maxLength={500}
-              rows={3}
-              className="mt-1 w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text focus:outline-none focus:border-danger focus:ring-2 focus:ring-danger/20"
-            />
-            <p className="mt-1 text-xs text-text-muted">{reason.trim().length}/500</p>
-          </div>
-        </div>
-
-        {submitState === "error" && error && (
-          <p role="alert" className="mt-3 text-sm text-danger">
-            {error}
-          </p>
-        )}
-
-        <div className="mt-5 flex items-center justify-end gap-2">
-          <Button variant="ghost" size="sm" onClick={onCancel} disabled={submitState === "submitting"}>
-            Cancel
-          </Button>
-          <Button variant="danger" size="sm" disabled={!canSubmit} onClick={submit}>
-            {submitState === "submitting" ? "Revoking…" : "Emergency revoke"}
-          </Button>
-        </div>
-      </div>
+    <div className="flex items-center gap-1">
+      <Button
+        variant="danger"
+        size="sm"
+        onClick={onClick}
+        aria-label={ariaLabel}
+      >
+        {label}
+      </Button>
+      <span className="group relative inline-flex">
+        <button
+          type="button"
+          aria-label="What does emergency revoke do?"
+          aria-describedby="emergency-revoke-help"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border-strong bg-surface text-[10px] font-bold text-text-muted hover:text-danger hover:border-danger focus:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
+          // No onClick — purely informational. Stops the row's revoke
+          // button from accidentally firing if the user mis-clicks the "?".
+          onClick={(e) => e.preventDefault()}
+        >
+          ?
+        </button>
+        <span
+          id="emergency-revoke-help"
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full right-0 z-40 mb-2 hidden w-64 rounded-lg border border-border bg-surface-raised p-3 text-xs text-text shadow-lg group-hover:block group-focus-within:block"
+        >
+          Strips super-admin AND terminates every active session for this user
+          within ~1 second across the fleet. Requires a typed email
+          confirmation. Used for compromised accounts.
+        </span>
+      </span>
     </div>
   );
 }
+
+// EMR-727 — Emergency revoke modal lives in
+// `./emergency-revoke-dialog.tsx` and is rendered above. The trigger
+// `<EmergencyRevokeTrigger>` is co-located here because it is tightly
+// coupled to the per-row layout.


### PR DESCRIPTION
## Summary

Adds the missing UI for the EMR-727 emergency-revoke endpoint (`POST /api/admin/super-admins/[userId]/emergency-revoke`):

- **New** `src/components/admin/emergency-revoke-dialog.tsx` — client modal with red warning banner ("This kills every active session for this admin within 1 second across every replica. You cannot undo it."), a required reason textarea (≥10 chars, ≤500), and an email-typed-confirmation gate before the destructive POST. On 2xx it calls `router.refresh()` so the super-admin list re-renders without a manual reload; on failure it surfaces the HTTP status and server message. Exports a pure `canSubmitEmergencyRevoke` predicate so the disable-state stays testable without a DOM.
- **Wires** an `EmergencyRevokeTrigger` into every super-admin row in `super-admin-console.tsx` — red destructive button plus an adjacent "?" pill with a CSS-only tooltip explaining the blast radius. The previous inline `EmergencyRevokeModal` is removed in favor of the extracted component.
- **Tests** `src/components/admin/__tests__/emergency-revoke-dialog.test.ts` — 11 vitest cases locking the submit gate: blocks while email empty / typo / case mismatch fixed by trim+lower, reason <10 or >500, in-flight; allows at exactly 10 and 500 chars and on case-insensitive whitespace-padded email match. Mirrors the server-side checks at `route.ts` L45 and L102–112.

## Test plan

- [x] `npx vitest run src/components/admin/__tests__/emergency-revoke-dialog.test.ts` — 11/11 pass
- [x] `npx prisma generate`
- [x] `npx tsc --noEmit` — clean
- [x] `node scripts/check-admin-mutation-coverage.mjs` — 16 admin/configs routes wrapped
- [x] `node scripts/check-route-auth-manifest.mjs` — 116 routes in sync, 0 pending
- [ ] Manual: open `/admin/hq`, Super-admins tab, click "Emergency revoke" on a peer row, verify (a) button is disabled until email matches verbatim AND reason ≥10 chars, (b) "?" tooltip appears on hover/keyboard focus, (c) on success the row drops from the list within one render cycle without a page reload, (d) on a 4xx response the HTTP status code is shown alongside the server error message.
- [ ] Manual: cannot self-revoke (server returns 400 `cannot_revoke_self`; UI surfaces the message).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>