### PR TITLE
feat(super-admin): breadcrumb nav on every admin page

### DIFF
--- a/src/app/(super-admin)/admin/audit/page.tsx
+++ b/src/app/(super-admin)/admin/audit/page.tsx
@@ -17,6 +17,7 @@
 
 import { redirect } from "next/navigation";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import {
@@ -162,6 +163,13 @@ export default async function AuditLogPage({
 
   return (
     <PageShell>
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Audit" },
+          { label: "Audit log" },
+        ]}
+      />
       <PageHeader
         eyebrow="Internal"
         title="Audit log"

--- a/src/app/(super-admin)/admin/bootstrap/page.tsx
+++ b/src/app/(super-admin)/admin/bootstrap/page.tsx
@@ -10,6 +10,7 @@
 import type { Metadata } from "next";
 
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Eyebrow } from "@/components/ui/ornament";
 import { prisma } from "@/lib/db/prisma";
@@ -90,6 +91,13 @@ export default async function BootstrapAllowlistPage() {
 
   return (
     <PageShell maxWidth="max-w-[1100px]">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Security" },
+          { label: "Bootstrap allowlist" },
+        ]}
+      />
       <PageHeader
         eyebrow="Leafjourney HQ"
         title="Bootstrap allowlist"

--- a/src/app/(super-admin)/admin/console/page.tsx
+++ b/src/app/(super-admin)/admin/console/page.tsx
@@ -1,4 +1,5 @@
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { SuperAdminConsole } from "@/components/admin/super-admin-console";
 
 export const metadata = { title: "Super-admin console" };
@@ -7,6 +8,13 @@ export const dynamic = "force-dynamic";
 export default async function SuperAdminConsolePage() {
   return (
     <PageShell>
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Security" },
+          { label: "Super-admin console" },
+        ]}
+      />
       <PageHeader
         eyebrow="Internal"
         title="Super-admin console"

--- a/src/app/(super-admin)/admin/hq/page.tsx
+++ b/src/app/(super-admin)/admin/hq/page.tsx
@@ -5,6 +5,7 @@ import { requireUser } from "@/lib/auth/session";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 
 import { loadAllHqData } from "./loaders";
 import { HeroStrip } from "./tiles/hero-strip";
@@ -38,6 +39,12 @@ export default async function LeafjourneyHqPage() {
 
   return (
     <PageShell maxWidth="max-w-[1240px]">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Dashboard" },
+        ]}
+      />
       <header className="flex flex-col md:flex-row md:items-end md:justify-between gap-5 mb-10">
         <div>
           <Eyebrow className="mb-3">Internal</Eyebrow>

--- a/src/app/(super-admin)/admin/search/page.tsx
+++ b/src/app/(super-admin)/admin/search/page.tsx
@@ -22,6 +22,7 @@
 
 import { redirect } from "next/navigation";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { prisma } from "@/lib/db/prisma";
 import {
   SEARCH_ENTITY_KINDS,
@@ -136,6 +137,13 @@ export default async function CrossTenantSearchPage({
 
   return (
     <PageShell>
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Cross-tenant search" },
+        ]}
+      />
       <PageHeader
         eyebrow="Internal"
         title="Cross-tenant search"

--- a/src/app/(super-admin)/onboarding/page.tsx
+++ b/src/app/(super-admin)/onboarding/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow, EmptyIllustration } from "@/components/ui/ornament";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import {
   listDraftsForOrganization,
   requireImplementationAdminCompat,
@@ -28,6 +29,13 @@ export default async function OnboardingDashboardPage() {
 
   return (
     <PageShell maxWidth="max-w-[1100px]">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Onboarding" },
+        ]}
+      />
       <PageHeader
         eyebrow="Implementation"
         title="Practice onboarding"

--- a/src/app/(super-admin)/practices/[id]/page.tsx
+++ b/src/app/(super-admin)/practices/[id]/page.tsx
@@ -23,6 +23,7 @@ import { ArrowLeft, MapPin } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 
 import { loadPracticeOverview } from "../loaders";
 import { humanizeCareModel, humanizeSpecialty } from "../types";
@@ -78,6 +79,15 @@ export default async function PracticeDrillInPage({
 
   return (
     <PageShell maxWidth="max-w-[1280px]">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Practices", href: "/practices" },
+          { label: practice.practiceName },
+        ]}
+      />
+
       <div className="mb-6">
         <Link
           href="/practices"

--- a/src/app/(super-admin)/practices/page.tsx
+++ b/src/app/(super-admin)/practices/page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Eyebrow, EmptyIllustration } from "@/components/ui/ornament";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 
 import { loadPracticeLandingCards } from "./loaders";
 import { PracticeCard } from "./practice-card";
@@ -46,6 +47,13 @@ export default async function PracticesLandingPage({
 
   return (
     <PageShell maxWidth="max-w-[1280px]">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Practices" },
+        ]}
+      />
       <PageHeader
         eyebrow="Leafjourney HQ"
         title="Practices"

--- a/src/app/(super-admin)/templates/[slug]/page.tsx
+++ b/src/app/(super-admin)/templates/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   TemplateDetail,
   type DependentPractice,
 } from "@/components/admin/template-detail";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 // TODO(EMR-428): integrate once branch lands.
 import { requireSuperAdmin } from "@/lib/auth/super-admin";
 // TODO(EMR-408): integrate once branch lands.
@@ -63,8 +64,18 @@ export default async function SpecialtyTemplateDetailPage({
 
   const dependentPractices = await loadDependentPractices(params.slug);
 
+  const templateName = (manifest as { name: string }).name;
+
   return (
     <div className="mx-auto max-w-5xl px-6 py-10 space-y-5">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Templates", href: "/templates" },
+          { label: templateName },
+        ]}
+      />
       <div className="flex items-center gap-3 text-xs text-text-subtle">
         <Link
           href="/templates"
@@ -80,7 +91,7 @@ export default async function SpecialtyTemplateDetailPage({
             Super admin · Specialty template
           </p>
           <h1 className="font-display text-2xl font-medium text-text tracking-tight mt-1">
-            {(manifest as { name: string }).name}
+            {templateName}
           </h1>
           <p className="text-sm text-text-muted mt-2">
             Templates are edited via pull request to{" "}

--- a/src/app/(super-admin)/templates/page.tsx
+++ b/src/app/(super-admin)/templates/page.tsx
@@ -4,6 +4,7 @@ import {
   TemplateList,
   type TemplateRow,
 } from "@/components/admin/template-list";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 // TODO(EMR-428): integrate once branch lands.
 import { requireSuperAdmin } from "@/lib/auth/super-admin";
 // TODO(EMR-408): integrate once branch lands.
@@ -91,6 +92,13 @@ export default async function SpecialtyTemplatesPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <Breadcrumbs
+        items={[
+          { label: "HQ", href: "/admin/hq" },
+          { label: "Operations" },
+          { label: "Templates" },
+        ]}
+      />
       <Card>
         <CardHeader>
           <p className="text-[11px] uppercase tracking-wide text-text-subtle font-medium">

--- a/src/components/super-admin/breadcrumbs.test.tsx
+++ b/src/components/super-admin/breadcrumbs.test.tsx
@@ -1,0 +1,107 @@
+// Unit tests for the super-admin <Breadcrumbs/> component.
+//
+// Vitest in this repo runs in a node environment with no DOM, so we
+// inspect the React element tree directly via util.inspect (same pattern
+// as src/app/(clinician)/clinic/page.test.tsx). That's enough to lock
+// down the contract: ARIA wrapper, last-item current-page semantics,
+// separators between items, and the no-link rule for the final entry.
+
+import { describe, it, expect } from "vitest";
+import util from "util";
+
+import { Breadcrumbs } from "./breadcrumbs";
+
+function dump(node: React.ReactElement | null): string {
+  return util.inspect(node, { depth: null });
+}
+
+describe("<Breadcrumbs/>", () => {
+  it("renders a <nav aria-label=\"Breadcrumb\"> wrapper", () => {
+    const out = Breadcrumbs({
+      items: [
+        { label: "HQ", href: "/admin/hq" },
+        { label: "Dashboard" },
+      ],
+    });
+    const str = dump(out as React.ReactElement);
+    expect(str).toContain("'aria-label': 'Breadcrumb'");
+  });
+
+  it("marks the last item with aria-current=page and gives it NO link", () => {
+    const out = Breadcrumbs({
+      items: [
+        { label: "HQ", href: "/admin/hq" },
+        { label: "Operations" },
+        { label: "Practices", href: "/practices" },
+        { label: "Sunrise Pain Clinic" },
+      ],
+    });
+    const str = dump(out as React.ReactElement);
+
+    // aria-current marker is present
+    expect(str).toContain("'aria-current': 'page'");
+
+    // The final label should NOT appear inside a Link href
+    // (i.e. no "Sunrise Pain Clinic" string near an href= attribute).
+    // We check by ensuring the substring "Sunrise Pain Clinic" never
+    // appears alongside an href in the same element block.
+    const finalLabel = "Sunrise Pain Clinic";
+    expect(str).toContain(finalLabel);
+    // No href referencing the final label's slugged path should exist —
+    // simplest tight check: the final label should only ever appear in a
+    // span element, never inside a Link's children alongside an href.
+    const linkifiedFinal = new RegExp(
+      `href:\\s*['"][^'"]*['"][^}]*children:\\s*['"]${finalLabel}`,
+    );
+    expect(str).not.toMatch(linkifiedFinal);
+  });
+
+  it("renders the chevron separator between every pair of items", () => {
+    const out = Breadcrumbs({
+      items: [
+        { label: "HQ", href: "/admin/hq" },
+        { label: "Audit" },
+        { label: "Audit log" },
+      ],
+    });
+    const str = dump(out as React.ReactElement);
+    // Three items → two separators.
+    const matches = str.match(/›/g) ?? [];
+    expect(matches.length).toBe(2);
+    // Separators are aria-hidden so they don't pollute screen readers.
+    expect(str).toContain("'aria-hidden': 'true'");
+  });
+
+  it("renders mid-chain pillar items WITHOUT an href as plain spans", () => {
+    const out = Breadcrumbs({
+      items: [
+        { label: "HQ", href: "/admin/hq" },
+        { label: "Security" }, // pillar — no href on purpose
+        { label: "Super-admin console" },
+      ],
+    });
+    const str = dump(out as React.ReactElement);
+
+    // First item is a Link (it has href="/admin/hq").
+    expect(str).toContain("'/admin/hq'");
+
+    // Pillar item "Security" must NOT appear inside a Link element — we
+    // detect a Link by the presence of an `href` adjacent to the pillar
+    // label.
+    const linkifiedPillar = /href:\s*['"][^'"]*['"][^}]*children:\s*['"]Security/;
+    expect(str).not.toMatch(linkifiedPillar);
+  });
+
+  it("returns null when given an empty items array", () => {
+    const out = Breadcrumbs({ items: [] });
+    expect(out).toBeNull();
+  });
+
+  it("renders a single-item trail as just the current page with no separators", () => {
+    const out = Breadcrumbs({ items: [{ label: "Dashboard" }] });
+    const str = dump(out as React.ReactElement);
+    expect(str).not.toContain("›");
+    expect(str).toContain("'aria-current': 'page'");
+    expect(str).toContain("Dashboard");
+  });
+});

--- a/src/components/super-admin/breadcrumbs.tsx
+++ b/src/components/super-admin/breadcrumbs.tsx
@@ -1,0 +1,81 @@
+// Super-admin breadcrumb trail.
+//
+// Renders the canonical chain that mirrors the nav rail pillars
+// (HQ / Operations / Audit / Security) so an operator can drill into a
+// detail page and back out without hunting through the sidebar. Mid-chain
+// pillar labels are intentionally NOT links — the rail itself owns
+// navigation; rendering them as anchors would 404 because no dedicated
+// page exists for "Operations" et al.
+//
+// Server component. No state, no client JS. The last item carries
+// aria-current="page" and is bolded; everything before it is rendered as
+// either a Link (when `href` is set) or a muted span (pillar labels).
+//
+// Used directly above the H1 in every (super-admin) page header — see
+// the wiring in src/app/(super-admin)/**/page.tsx for the per-route
+// chain shape.
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+export interface BreadcrumbItem {
+  /** Visible label. */
+  label: string;
+  /** Optional href. Last item must NEVER have one (it's the current page). */
+  href?: string;
+}
+
+export function Breadcrumbs({
+  items,
+  className,
+}: {
+  items: BreadcrumbItem[];
+  className?: string;
+}) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("mb-4", className)}
+    >
+      <ol className="flex flex-wrap items-center gap-1.5 text-[12px] leading-none text-text-muted">
+        {items.map((item, idx) => {
+          const isLast = idx === items.length - 1;
+          const isFirst = idx === 0;
+
+          return (
+            <li key={`${item.label}-${idx}`} className="inline-flex items-center gap-1.5">
+              {!isFirst && (
+                <span
+                  aria-hidden="true"
+                  className="text-text-subtle/70 select-none"
+                >
+                  ›
+                </span>
+              )}
+              {isLast ? (
+                <span
+                  aria-current="page"
+                  className="font-semibold text-text"
+                >
+                  {item.label}
+                </span>
+              ) : item.href ? (
+                <Link
+                  href={item.href}
+                  className="text-text-muted hover:text-text transition-colors"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-text-muted">{item.label}</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `src/components/super-admin/breadcrumbs.tsx`, a small server component that renders a `<nav aria-label="Breadcrumb">` trail with a subtle "›" separator and `aria-current="page"` on the final (bolded, link-less) item.
- Wires the trail into every (super-admin) page header above the H1: HQ → Dashboard; HQ → Operations → {Cross-tenant search, Practices, Onboarding, Templates}; HQ → Audit → Audit log; HQ → Security → {Super-admin console, Bootstrap allowlist}. Detail pages append the live entity name (practice name, template name).
- Mid-chain pillar labels (Operations, Audit, Security) are intentionally non-link spans — the rail itself owns navigation, and rendering them as anchors would 404.

## Test plan
- [x] `npx vitest run src/components/super-admin/breadcrumbs.test.tsx` — 6/6 pass (ARIA wrapper, last-item current-page, separator count, pillar-as-span, empty-array, single-item).
- [x] `npx prisma generate && npx tsc --noEmit` — clean.
- [ ] Manual smoke: visit each /admin, /practices, /practices/:id, /onboarding, /templates, /templates/:slug; confirm the trail renders above the H1 and HQ link works.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>