### PR TITLE
feat(super-admin): audit log row detail + diff view at /admin/audit/[id]

### DIFF
--- a/src/app/(super-admin)/admin/audit/[id]/page.tsx
+++ b/src/app/(super-admin)/admin/audit/[id]/page.tsx
@@ -1,0 +1,390 @@
+// EMR-747 — Audit log row detail (drill-in).
+//
+// Server component. Given an audit row id, render:
+//
+//   - A header with the humanised action, exact timestamp, actor
+//     (email + roles), and the operator-supplied `reason` if any.
+//   - A side-by-side before/after JSON diff with per-key colouring
+//     (rose = removed, emerald = added, amber = changed). The diff
+//     itself is built by `buildAuditDiff` in src/lib/admin/audit-diff.ts
+//     so it's unit-tested independently of the page.
+//   - A "Subject" panel that resolves subjectType/subjectId to the
+//     real entity name when possible (User by id/email, Organization
+//     by id), with a link back to that entity's super-admin surface.
+//   - "Related actions": the last 5 ControllerAuditLog rows that share
+//     this row's `subjectId`, each linking to its own detail page.
+//
+// Auth: the super-admin layout above us already runs requireSuperAdmin();
+// we re-check here as defence-in-depth because the audit surface is the
+// sensitive one. Following the same belt-and-braces pattern as the list
+// page in ../page.tsx.
+//
+// We do NOT write a fresh audit row for *reading* this page — same
+// reasoning as the list page (would create a feedback loop in the
+// activity feed every time anyone clicked through).
+
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { ArrowLeft } from "lucide-react";
+
+import { PageShell } from "@/components/shell/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Eyebrow } from "@/components/ui/ornament";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { ROLE_LABELS } from "@/lib/rbac/roles";
+import {
+  buildAuditDiff,
+  diffLineClass,
+  summariseDiff,
+} from "@/lib/admin/audit-diff";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Audit row — Leafjourney",
+};
+
+/**
+ * Humanise a dot-namespaced action key for the header. The audit log
+ * stores keys like "controller.config.publish" — split on dots and
+ * title-case the last two segments so the operator sees
+ * "Config publish" without losing the namespace context.
+ */
+function humanizeAction(action: string): string {
+  const parts = action.split(".");
+  const tail = parts.slice(-2).join(" ");
+  if (!tail) return action;
+  return tail.charAt(0).toUpperCase() + tail.slice(1).replace(/_/g, " ");
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+/** Resolve the subject entity to a display name + drill-in href. */
+async function resolveSubject(
+  subjectType: string,
+  subjectId: string,
+): Promise<{ label: string; href: string | null; kind: string } | null> {
+  // Cheapest checks first; bail early when we don't know how to resolve
+  // the type. The audit log uses "controller" as the default subjectType,
+  // which we currently treat as a free-form id (no resolver yet).
+  if (subjectType === "user") {
+    const u = await prisma.user.findUnique({
+      where: { id: subjectId },
+      select: { id: true, email: true, firstName: true, lastName: true },
+    });
+    if (!u) return null;
+    const name = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
+    return {
+      label: name ? `${name} <${u.email}>` : u.email,
+      href: null, // no /admin/console/users/[id] page exists yet
+      kind: "User",
+    };
+  }
+  if (subjectType === "organization" || subjectType === "practice") {
+    const o = await prisma.organization.findUnique({
+      where: { id: subjectId },
+      select: { id: true, name: true, slug: true },
+    });
+    if (!o) return null;
+    return {
+      label: o.name,
+      href: `/practices/${encodeURIComponent(o.id)}`,
+      kind: "Organization",
+    };
+  }
+  return null;
+}
+
+export default async function AuditRowDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const actor = await requireUser();
+  if (!actor.roles.includes("super_admin")) redirect("/");
+
+  const { id } = await params;
+
+  const row = await prisma.controllerAuditLog.findUnique({
+    where: { id },
+  });
+
+  if (!row) {
+    notFound();
+  }
+
+  // Related rows: same subject, most recent 6 (we drop the current one
+  // and show 5). subjectId is indexed on this table so the lookup is
+  // cheap even on large audit tables.
+  const relatedRaw = await prisma.controllerAuditLog.findMany({
+    where: { subjectId: row.subjectId, id: { not: row.id } },
+    orderBy: [{ at: "desc" }, { id: "desc" }],
+    take: 5,
+    select: {
+      id: true,
+      at: true,
+      action: true,
+      actorEmail: true,
+      actorUserId: true,
+    },
+  });
+
+  const subjectResolved = await resolveSubject(row.subjectType, row.subjectId);
+
+  const diffLines = buildAuditDiff(row.before, row.after);
+  const summary = summariseDiff(diffLines);
+  const totalChanged = summary.added + summary.removed + summary.changed;
+
+  const actorRoleLabels = (row.actorRoles as string[]).map(
+    (r) => ROLE_LABELS[r as keyof typeof ROLE_LABELS] ?? r,
+  );
+
+  return (
+    <PageShell maxWidth="max-w-[1280px]">
+      <div className="mb-6">
+        <Link
+          href="/admin/audit"
+          className="inline-flex items-center gap-1.5 text-[12px] text-text-muted hover:text-text transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Audit log
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-5 mb-8">
+        <Eyebrow>Audit row</Eyebrow>
+        <div className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="min-w-0">
+            <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.1]">
+              {humanizeAction(row.action)}
+            </h1>
+            <div className="text-[13px] font-mono text-text-muted mt-1.5">
+              {row.action}
+            </div>
+            <div className="flex items-center gap-2 flex-wrap mt-3">
+              <Badge tone="neutral">{formatTimestamp(row.at.toISOString())}</Badge>
+              {actorRoleLabels.map((label) => (
+                <Badge key={label} tone="accent">
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] uppercase tracking-wider text-text-muted">
+              Row id
+            </div>
+            <div className="font-mono text-xs text-text mt-1 break-all">
+              {row.id}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Actor + reason */}
+      <section className="rounded-xl border border-border bg-background/50 p-5 mb-6">
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <div className="text-[11px] uppercase tracking-wider text-text-muted mb-1">
+              Actor
+            </div>
+            <div className="text-sm text-text">
+              {row.actorEmail ?? <span className="text-text-muted">—</span>}
+            </div>
+            <div className="font-mono text-[11px] text-text-muted mt-0.5 break-all">
+              {row.actorUserId}
+            </div>
+          </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-wider text-text-muted mb-1">
+              Organization
+            </div>
+            <div className="text-sm text-text">
+              {row.organizationId ? (
+                <Link
+                  href={`/practices/${encodeURIComponent(row.organizationId)}`}
+                  className="text-accent underline"
+                >
+                  {row.organizationId}
+                </Link>
+              ) : (
+                <span className="text-text-muted">—</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-wider text-text-muted mb-1">
+              Reason
+            </div>
+            <div className="text-sm text-text whitespace-pre-wrap">
+              {row.reason ?? <span className="text-text-muted">—</span>}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Subject panel */}
+      <section className="rounded-xl border border-border bg-background/50 p-5 mb-6">
+        <div className="flex items-center justify-between gap-4 mb-3">
+          <div>
+            <div className="text-[11px] uppercase tracking-wider text-text-muted">
+              Subject
+            </div>
+            <div className="text-sm text-text mt-1">
+              <span className="font-mono text-xs mr-2">{row.subjectType}</span>
+              <span className="font-mono text-xs text-text-muted">{row.subjectId}</span>
+            </div>
+          </div>
+          {subjectResolved ? (
+            <div className="text-right">
+              <Badge tone="info">{subjectResolved.kind}</Badge>
+              <div className="text-sm text-text mt-1">
+                {subjectResolved.href ? (
+                  <Link
+                    href={subjectResolved.href}
+                    className="text-accent underline"
+                  >
+                    {subjectResolved.label}
+                  </Link>
+                ) : (
+                  subjectResolved.label
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-text-muted">
+              No resolver for this subject type yet.
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Before / After diff */}
+      <section className="mb-6">
+        <div className="flex items-baseline justify-between mb-3">
+          <h2 className="font-display text-xl text-text">Diff</h2>
+          <div className="text-xs text-text-muted">
+            {totalChanged === 0 ? (
+              <span>No top-level changes detected.</span>
+            ) : (
+              <span>
+                <span className="text-emerald-700 dark:text-emerald-300">
+                  +{summary.added}
+                </span>{" "}
+                <span className="text-rose-700 dark:text-rose-300">
+                  −{summary.removed}
+                </span>{" "}
+                <span className="text-amber-700 dark:text-amber-300">
+                  ~{summary.changed}
+                </span>{" "}
+                <span>({summary.unchanged} unchanged)</span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="rounded-xl border border-border overflow-hidden">
+            <div className="px-3 py-2 text-[11px] uppercase tracking-wider text-text-muted border-b border-border bg-muted/40">
+              Before
+            </div>
+            <div className="font-mono text-xs">
+              {diffLines.length === 0 ? (
+                <div className="px-3 py-3 text-text-muted">(empty)</div>
+              ) : (
+                diffLines.map((line, idx) => (
+                  <pre
+                    key={`b-${idx}`}
+                    className={`px-3 py-1 whitespace-pre-wrap break-all ${diffLineClass(line.kind, "before")}`}
+                  >
+                    {line.before || " "}
+                  </pre>
+                ))
+              )}
+            </div>
+          </div>
+          <div className="rounded-xl border border-border overflow-hidden">
+            <div className="px-3 py-2 text-[11px] uppercase tracking-wider text-text-muted border-b border-border bg-muted/40">
+              After
+            </div>
+            <div className="font-mono text-xs">
+              {diffLines.length === 0 ? (
+                <div className="px-3 py-3 text-text-muted">(empty)</div>
+              ) : (
+                diffLines.map((line, idx) => (
+                  <pre
+                    key={`a-${idx}`}
+                    className={`px-3 py-1 whitespace-pre-wrap break-all ${diffLineClass(line.kind, "after")}`}
+                  >
+                    {line.after || " "}
+                  </pre>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <details className="mt-4 rounded-xl border border-border bg-muted/20">
+          <summary className="cursor-pointer px-3 py-2 text-[12px] text-text-muted hover:text-text">
+            Show raw before / after JSON
+          </summary>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-0 border-t border-border">
+            <pre className="px-3 py-3 text-xs font-mono whitespace-pre-wrap break-all border-r border-border">
+              {JSON.stringify(row.before, null, 2) ?? "null"}
+            </pre>
+            <pre className="px-3 py-3 text-xs font-mono whitespace-pre-wrap break-all">
+              {JSON.stringify(row.after, null, 2) ?? "null"}
+            </pre>
+          </div>
+        </details>
+      </section>
+
+      {/* Related rows */}
+      <section className="mb-6">
+        <h2 className="font-display text-xl text-text mb-3">Related actions</h2>
+        {relatedRaw.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border px-6 py-8 text-center text-sm text-text-muted">
+            No other audit rows touch this subject.
+          </div>
+        ) : (
+          <ul className="grid gap-2">
+            {relatedRaw.map((r) => (
+              <li
+                key={r.id}
+                className="flex items-center justify-between gap-3 rounded-xl border border-border bg-background/50 px-4 py-3 text-sm hover:bg-muted/30 transition-colors"
+              >
+                <div className="min-w-0">
+                  <Link
+                    href={`/admin/audit/${encodeURIComponent(r.id)}`}
+                    className="font-mono text-xs text-accent underline"
+                  >
+                    {r.action}
+                  </Link>
+                  <div className="text-[11px] text-text-muted mt-0.5 truncate">
+                    {r.actorEmail ?? r.actorUserId}
+                  </div>
+                </div>
+                <div className="text-[11px] text-text-muted shrink-0">
+                  {formatTimestamp(r.at.toISOString())}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </PageShell>
+  );
+}

--- a/src/app/(super-admin)/admin/audit/keyboard-island.tsx
+++ b/src/app/(super-admin)/admin/audit/keyboard-island.tsx
@@ -21,6 +21,8 @@ export interface AuditRowView {
   id: string;
   at: string;
   atRelative: string;
+  /** Drill-in path for this row (/admin/audit/[id]). */
+  detailHref: string;
   actorLabel: string;
   actorHref: string | null;
   action: string;
@@ -135,7 +137,13 @@ export function AuditTableIsland({
                   onClick={() => toggleExpanded(row.id)}
                 >
                   <td className="px-3 py-2 align-top" title={row.at}>
-                    {row.atRelative}
+                    <a
+                      href={row.detailHref}
+                      className="text-accent underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {row.atRelative}
+                    </a>
                   </td>
                   <td className="px-3 py-2 align-top">
                     {row.actorHref ? (
@@ -212,6 +220,7 @@ export function AuditTableIsland({
       </table>
       <div className="px-3 py-2 text-xs text-text-muted border-t border-border">
         Navigate with j/k (or arrow keys); Enter expands the focused row;
+        click the timestamp to open the row&apos;s detail page;
         &quot;/&quot; jumps to the action filter.
       </div>
     </div>

--- a/src/app/(super-admin)/admin/audit/page.tsx
+++ b/src/app/(super-admin)/admin/audit/page.tsx
@@ -114,6 +114,7 @@ export default async function AuditLogPage({
       id: r.id,
       at: r.at,
       atRelative: relativeTime(r.at),
+      detailHref: `/admin/audit/${encodeURIComponent(r.id)}`,
       actorLabel: r.actorEmail ?? r.actorUserId,
       actorHref: `/admin/console/users/${encodeURIComponent(r.actorUserId)}`,
       action: r.action,

--- a/src/lib/admin/audit-diff.test.ts
+++ b/src/lib/admin/audit-diff.test.ts
@@ -1,0 +1,147 @@
+// EMR-747 — Unit tests for the audit-log JSON diff highlighter.
+//
+// Pure-function module, so we exercise it directly without mocks. The
+// goal is to lock in the per-key classification (added / removed /
+// changed / unchanged) and the side-by-side renderer's symmetry —
+// `before` rows are empty for added keys and vice versa.
+
+import { describe, it, expect } from "vitest";
+import {
+  buildAuditDiff,
+  diffLineClass,
+  summariseDiff,
+  type AuditDiffLine,
+} from "./audit-diff";
+
+function findLine(lines: AuditDiffLine[], key: string): AuditDiffLine {
+  const found = lines.find((l) => l.key === key);
+  if (!found) throw new Error(`expected diff line for key "${key}"`);
+  return found;
+}
+
+describe("buildAuditDiff", () => {
+  it("classifies an added key", () => {
+    const lines = buildAuditDiff({}, { newKey: "hello" });
+    const line = findLine(lines, "newKey");
+    expect(line.kind).toBe("added");
+    expect(line.before).toBe("");
+    expect(line.after).toContain('"newKey"');
+    expect(line.after).toContain('"hello"');
+  });
+
+  it("classifies a removed key", () => {
+    const lines = buildAuditDiff({ goneKey: 42 }, {});
+    const line = findLine(lines, "goneKey");
+    expect(line.kind).toBe("removed");
+    expect(line.before).toContain('"goneKey"');
+    expect(line.before).toContain("42");
+    expect(line.after).toBe("");
+  });
+
+  it("classifies a changed value", () => {
+    const lines = buildAuditDiff(
+      { status: "draft" },
+      { status: "published" },
+    );
+    const line = findLine(lines, "status");
+    expect(line.kind).toBe("changed");
+    expect(line.before).toContain("draft");
+    expect(line.after).toContain("published");
+  });
+
+  it("classifies an unchanged scalar", () => {
+    const lines = buildAuditDiff({ keep: 1 }, { keep: 1 });
+    const line = findLine(lines, "keep");
+    expect(line.kind).toBe("unchanged");
+    expect(line.before).toContain("1");
+    expect(line.after).toContain("1");
+  });
+
+  it("treats deeply-equal objects as unchanged", () => {
+    const lines = buildAuditDiff(
+      { nested: { a: 1, b: [2, 3] } },
+      { nested: { b: [2, 3], a: 1 } }, // same data, different key order
+    );
+    expect(findLine(lines, "nested").kind).toBe("unchanged");
+  });
+
+  it("treats deeply-unequal nested objects as changed", () => {
+    const lines = buildAuditDiff(
+      { nested: { items: [1, 2, 3] } },
+      { nested: { items: [1, 2, 4] } },
+    );
+    expect(findLine(lines, "nested").kind).toBe("changed");
+  });
+
+  it("returns keys in sorted order so the layout is stable", () => {
+    const lines = buildAuditDiff(
+      { b: 2, a: 1, c: 3 },
+      { c: 3, a: 1, b: 2 },
+    );
+    expect(lines.map((l) => l.key)).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles null / undefined inputs as empty objects", () => {
+    expect(buildAuditDiff(null, null)).toEqual([]);
+    expect(buildAuditDiff(undefined, undefined)).toEqual([]);
+    const onlyAfter = buildAuditDiff(null, { x: 1 });
+    expect(findLine(onlyAfter, "x").kind).toBe("added");
+  });
+
+  it("wraps non-object payloads under a synthetic _value key", () => {
+    const lines = buildAuditDiff("old", "new");
+    const line = findLine(lines, "_value");
+    expect(line.kind).toBe("changed");
+    expect(line.before).toContain("old");
+    expect(line.after).toContain("new");
+  });
+
+  it("indents multi-line values to keep nesting visually aligned", () => {
+    const lines = buildAuditDiff({}, { obj: { a: 1, b: 2 } });
+    const line = findLine(lines, "obj");
+    // The rendered string should contain a newline-indented inner line so
+    // the rendered side-by-side pre/code block doesn't collapse onto one
+    // line.
+    expect(line.after.split("\n").length).toBeGreaterThan(1);
+  });
+});
+
+describe("summariseDiff", () => {
+  it("counts each kind", () => {
+    const lines = buildAuditDiff(
+      { same: 1, gone: 2, was: "a" },
+      { same: 1, was: "b", added: 9 },
+    );
+    expect(summariseDiff(lines)).toEqual({
+      added: 1,
+      removed: 1,
+      changed: 1,
+      unchanged: 1,
+    });
+  });
+});
+
+describe("diffLineClass", () => {
+  it("returns a non-empty class for every kind/side combination", () => {
+    for (const kind of ["added", "removed", "changed", "unchanged"] as const) {
+      for (const side of ["before", "after"] as const) {
+        expect(diffLineClass(kind, side).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("highlights only the after side for added keys", () => {
+    expect(diffLineClass("added", "after")).toMatch(/emerald/);
+    expect(diffLineClass("added", "before")).not.toMatch(/emerald/);
+  });
+
+  it("highlights only the before side for removed keys", () => {
+    expect(diffLineClass("removed", "before")).toMatch(/rose/);
+    expect(diffLineClass("removed", "after")).not.toMatch(/rose/);
+  });
+
+  it("highlights both sides for changed keys", () => {
+    expect(diffLineClass("changed", "before")).toMatch(/amber/);
+    expect(diffLineClass("changed", "after")).toMatch(/amber/);
+  });
+});

--- a/src/lib/admin/audit-diff.ts
+++ b/src/lib/admin/audit-diff.ts
@@ -1,0 +1,186 @@
+// EMR-747 — JSON diff renderer for the audit-log detail page.
+//
+// The detail page renders a `before` / `after` Json pair from a
+// ControllerAuditLog row. We want a side-by-side, line-by-line diff with
+// per-key colouring:
+//
+//   - red   — key present in `before`, absent in `after`   (removed)
+//   - green — key absent in `before`, present in `after`   (added)
+//   - amber — key present in both but value differs        (changed)
+//   - none  — key present in both with equal values        (unchanged)
+//
+// The renderer is deliberately simple: we walk the top-level keys of an
+// object (deep-equality on nested values), then pretty-print each
+// (key, value) pair with `JSON.stringify(_, null, 2)`. The two sides
+// always render the same set of keys so rows line up visually — missing
+// keys render as an empty placeholder line on their side.
+//
+// Why "top-level keys only": audit payloads are flat-ish (the controller
+// surface emits one change per row). Nested diffs would be nicer but the
+// branching gets hairy fast and "the whole sub-object changed" is the
+// right call for a forensic surface. Operators can fall back to the raw
+// JSON beneath the diff when they need the gory details.
+//
+// No `server-only` import — this module is shared with the test runner
+// and is logically pure. The Next page that consumes it is what enforces
+// the server boundary.
+
+/** Per-key classification for the diff. */
+export type AuditDiffKind = "added" | "removed" | "changed" | "unchanged";
+
+/** One row of the side-by-side renderer. */
+export interface AuditDiffLine {
+  key: string;
+  kind: AuditDiffKind;
+  /** Pretty-printed `key: value` from the BEFORE side. Empty when added. */
+  before: string;
+  /** Pretty-printed `key: value` from the AFTER  side. Empty when removed. */
+  after: string;
+}
+
+/** Stable structural equality — used to classify "changed" vs "unchanged". */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const aKeys = Object.keys(a as Record<string, unknown>).sort();
+  const bKeys = Object.keys(b as Record<string, unknown>).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false;
+  }
+  for (const k of aKeys) {
+    if (
+      !deepEqual(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Stringify a value as `"key": <json>` with 2-space indent (matching the
+ * surrounding JSON.stringify aesthetic). Returns empty string when the
+ * key isn't present on that side.
+ */
+function renderField(key: string, value: unknown, present: boolean): string {
+  if (!present) return "";
+  const body = safeStringify(value);
+  // Indent every line of the value by two spaces so multi-line arrays /
+  // objects align with the key line.
+  const indented = body
+    .split("\n")
+    .map((line, idx) => (idx === 0 ? line : `  ${line}`))
+    .join("\n");
+  return `"${key}": ${indented}`;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    // Circular or non-serialisable — fall back to a tag instead of
+    // crashing the page. Audit rows shouldn't carry these, but the
+    // detail page is forensics-grade: degrade gracefully.
+    return '"[unserialisable]"';
+  }
+}
+
+/** Normalise a JSON-or-nullish input into an object for key walking. */
+function toObject(input: unknown): Record<string, unknown> {
+  if (input == null) return {};
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return input as Record<string, unknown>;
+  }
+  // Non-object payload — render under a synthetic "_value" key so the
+  // renderer still has something to align on.
+  return { _value: input };
+}
+
+/**
+ * Build the side-by-side diff rows for a (before, after) JSON pair.
+ *
+ * Key order: union of both sides, sorted lexicographically. We sort so
+ * the same row pair always lines up the same way regardless of how the
+ * upstream JSON laid the keys out — incidents are easier to read when
+ * the layout is stable across re-renders.
+ */
+export function buildAuditDiff(
+  before: unknown,
+  after: unknown,
+): AuditDiffLine[] {
+  const b = toObject(before);
+  const a = toObject(after);
+  const keys = new Set<string>([...Object.keys(b), ...Object.keys(a)]);
+  const sorted = [...keys].sort();
+
+  const lines: AuditDiffLine[] = [];
+  for (const key of sorted) {
+    const inB = Object.prototype.hasOwnProperty.call(b, key);
+    const inA = Object.prototype.hasOwnProperty.call(a, key);
+    let kind: AuditDiffKind;
+    if (inB && !inA) kind = "removed";
+    else if (!inB && inA) kind = "added";
+    else if (inB && inA && !deepEqual(b[key], a[key])) kind = "changed";
+    else kind = "unchanged";
+
+    lines.push({
+      key,
+      kind,
+      before: renderField(key, b[key], inB),
+      after: renderField(key, a[key], inA),
+    });
+  }
+  return lines;
+}
+
+/**
+ * Tailwind-class lookup keyed by diff kind. Centralised so the page
+ * component and any future surface (e.g. a CSV-style export later) agree
+ * on the colour vocabulary.
+ *
+ *   removed  → red    (rose-50 / rose-700)
+ *   added    → green  (emerald-50 / emerald-700)
+ *   changed  → amber  (amber-50 / amber-800)
+ *   unchanged → muted background, default text
+ */
+export function diffLineClass(kind: AuditDiffKind, side: "before" | "after"): string {
+  if (kind === "unchanged") return "bg-transparent text-text-muted";
+  if (kind === "removed") {
+    return side === "before"
+      ? "bg-rose-50 text-rose-800 dark:bg-rose-950/40 dark:text-rose-200"
+      : "bg-transparent text-text-muted/60";
+  }
+  if (kind === "added") {
+    return side === "after"
+      ? "bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200"
+      : "bg-transparent text-text-muted/60";
+  }
+  // changed — both sides highlighted
+  return "bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200";
+}
+
+/** Convenience aggregate used by the detail page summary line. */
+export function summariseDiff(lines: AuditDiffLine[]): {
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+} {
+  const acc = { added: 0, removed: 0, changed: 0, unchanged: 0 };
+  for (const l of lines) acc[l.kind]++;
+  return acc;
+}


### PR DESCRIPTION
## Summary

- New drill-in page at `/admin/audit/[id]` for any `ControllerAuditLog` row: humanised action header, actor + roles + reason, side-by-side before/after diff with per-key colouring (rose removed, emerald added, amber changed), resolved Subject panel (User / Organization with link), and the 5 most-recent related rows for the same `subjectId`.
- New pure helper `src/lib/admin/audit-diff.ts` (top-level key classification + symmetric side rendering + class lookup + summary counts) with a 15-case vitest covering added/removed/changed/unchanged, deep-equality, sort stability, nullish inputs, non-object payloads, and multi-line indent.
- The audit list rows are now clickable: the timestamp cell links to the detail page. Existing row-click-to-expand and j/k/Enter keyboard nav are preserved.

## Test plan

- [x] `npx prisma generate` (clean)
- [x] `npx tsc --noEmit` (clean)
- [x] `node scripts/check-admin-mutation-coverage.mjs` (16 routes, all wrapped)
- [x] `node scripts/check-route-auth-manifest.mjs` (116 routes, 0 pending review)
- [x] `npx vitest run src/lib/admin/audit-diff.test.ts` (15 / 15)
- [x] `npx vitest run src/lib/admin/audit-log.test.ts` (28 / 28; no regression)
- [ ] Manual: click a row from `/admin/audit` -> lands on `/admin/audit/[id]` with diff + related rows
- [ ] Manual: load `/admin/audit/does-not-exist` -> 404
- [ ] Manual: row with an Organization subject renders its name + `/practices/[id]` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)