### PR TITLE
feat(super-admin): practice history tab — audit timeline with cursor paging (EMR-743)

### DIFF
--- a/src/app/(super-admin)/practices/[id]/history-humanize.test.ts
+++ b/src/app/(super-admin)/practices/[id]/history-humanize.test.ts
@@ -1,0 +1,118 @@
+// EMR-743 — Unit tests for the History tab humanizer.
+//
+// No DOM, no Prisma — exercises the pure mapper that turns audit log rows
+// into a one-line human summary. Lives next to the module per the
+// repo-wide colocation convention.
+
+import { describe, expect, it } from "vitest";
+import {
+  hasKnownAction,
+  humanizeAction,
+  summarizeChange,
+} from "./history-humanize";
+
+describe("humanizeAction", () => {
+  it("maps known controller actions to human labels", () => {
+    expect(humanizeAction("controller.config.published")).toBe(
+      "Published configuration",
+    );
+    expect(humanizeAction("controller.config.draft_created")).toBe(
+      "Created draft configuration",
+    );
+    expect(humanizeAction("controller.config.rollback")).toBe(
+      "Rolled back configuration",
+    );
+    expect(humanizeAction("controller.super_admin.grant")).toBe(
+      "Granted super-admin",
+    );
+  });
+
+  it("title-cases the tail when the action is unknown", () => {
+    expect(humanizeAction("controller.future_feature.frobbed")).toBe("Frobbed");
+    expect(humanizeAction("controller.foo.bar_baz")).toBe("Bar baz");
+  });
+
+  it("handles actions without the controller. prefix", () => {
+    expect(humanizeAction("custom.something.happened")).toBe("Happened");
+  });
+
+  it("returns the raw action if it can't extract a tail", () => {
+    expect(humanizeAction("")).toBe("");
+  });
+
+  it("reports known-action status", () => {
+    expect(hasKnownAction("controller.config.published")).toBe(true);
+    expect(hasKnownAction("controller.future_feature.frobbed")).toBe(false);
+  });
+});
+
+describe("summarizeChange", () => {
+  it("returns null for empty before/after", () => {
+    expect(summarizeChange(null, null)).toBeNull();
+    expect(summarizeChange({}, {})).toBeNull();
+    expect(summarizeChange(undefined, undefined)).toBeNull();
+  });
+
+  it("renders the `after.keys` envelope from the configs route emitter", () => {
+    expect(summarizeChange(null, { keys: ["careModel"] })).toBe(
+      "Updated careModel",
+    );
+    expect(
+      summarizeChange(null, { keys: ["careModel", "enabledModalities"] }),
+    ).toBe("Updated careModel, enabledModalities");
+    expect(summarizeChange(null, { keys: ["a", "b", "c", "d", "e"] })).toBe(
+      "Updated 5 fields",
+    );
+  });
+
+  it("renders single-field scalar diffs as before → after", () => {
+    expect(
+      summarizeChange({ careModel: "solo" }, { careModel: "group" }),
+    ).toBe('careModel: "solo" → "group"');
+    expect(summarizeChange({ count: 1 }, { count: 2 })).toBe("count: 1 → 2");
+    expect(
+      summarizeChange({ active: false }, { active: true }),
+    ).toBe("active: false → true");
+  });
+
+  it("renders single key add/remove tersely", () => {
+    expect(summarizeChange({}, { newKey: "v" })).toBe("Set newKey");
+    expect(summarizeChange({ oldKey: "v" }, {})).toBe("Cleared oldKey");
+  });
+
+  it("summarises multi-field changes by category counts", () => {
+    expect(
+      summarizeChange(
+        { a: 1, b: 2, c: 3 },
+        { a: 99, b: 2, d: 4 }, // a changed, c removed, d added
+      ),
+    ).toBe("+1 added, 1 changed, -1 removed");
+  });
+
+  it("falls back to 'Updated <k>' when a single-field change isn't a scalar", () => {
+    expect(
+      summarizeChange(
+        { modalities: ["a"] },
+        { modalities: ["a", "b"] },
+      ),
+    ).toBe("Updated modalities");
+  });
+
+  it("treats deep-equal objects as unchanged", () => {
+    expect(
+      summarizeChange(
+        { nested: { x: 1, y: 2 } },
+        { nested: { x: 1, y: 2 } },
+      ),
+    ).toBeNull();
+  });
+
+  it("truncates long string scalars in inline diffs", () => {
+    const longBefore = "a".repeat(50);
+    const longAfter = "b".repeat(50);
+    const out = summarizeChange({ note: longBefore }, { note: longAfter });
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThan(80);
+    expect(out).toContain("…");
+  });
+});

--- a/src/app/(super-admin)/practices/[id]/history-humanize.ts
+++ b/src/app/(super-admin)/practices/[id]/history-humanize.ts
@@ -1,0 +1,200 @@
+// EMR-743 — Humanize ControllerAuditLog rows for the practice History tab.
+//
+// Maps dot-namespaced action keys (e.g. "controller.config.published") to a
+// short, human-readable phrase suitable for a timeline header. Also derives
+// a one-line summary from before/after JSON snapshots when possible.
+//
+// The ticket calls out a "semantic label map" owned by EMR-744 (Child 2 —
+// the diff viewer). That label map is field-level (e.g. `careModel → "Care
+// Model"`); this module is action-level (e.g. `controller.config.published
+// → "Published configuration"`). They're complementary: when EMR-744 lands
+// we'll import its label map for the per-field summary in `summarize()`
+// rather than duplicating the prettifier here.
+//
+// No React, no Prisma — pure functions so they're trivially unit-tested.
+// The matching test sits next to this file at `history-humanize.test.ts`.
+
+const ACTION_LABELS: Record<string, string> = {
+  // Config lifecycle
+  "controller.config.draft_created": "Created draft configuration",
+  "controller.config.updated": "Updated configuration",
+  "controller.config.published": "Published configuration",
+  "controller.config.archived": "Archived configuration",
+  "controller.config.rollback": "Rolled back configuration",
+  "controller.config.switch_specialty": "Switched specialty",
+  "controller.config.template_upgraded": "Upgraded to newer template",
+
+  // Wizard
+  "controller.wizard.step.save": "Saved onboarding step",
+
+  // Templates
+  "controller.template.create": "Created template",
+  "controller.template.update": "Updated template",
+
+  // Super-admin housekeeping
+  "controller.super_admin.grant": "Granted super-admin",
+  "controller.super_admin.revoke": "Revoked super-admin",
+  "controller.super_admin.bootstrap_grant": "Bootstrap-granted super-admin",
+  "controller.super_admin.cross_tenant_search": "Cross-tenant search",
+  "controller.super_admin.mfa_blocked": "MFA blocked elevation",
+
+  // Migration profiles
+  "controller.migration_profile.created": "Created migration profile",
+  "controller.migration_profile.read": "Viewed migration profile",
+
+  // Cron-emitted system events (rarely scoped to a single practice but
+  // included so unknown labels don't surface as raw strings).
+  "controller.anomaly_sweep.completed": "Anomaly sweep completed",
+  "controller.practice_health.swept": "Practice health swept",
+  "controller.mutation_budget.sweep_completed": "Mutation budget sweep completed",
+};
+
+/**
+ * Convert an action key like "controller.config.published" into a short
+ * human phrase like "Published configuration". Unknown actions fall back to
+ * a best-effort title-case of the tail segment ("controller.foo.bar_baz"
+ * → "Bar baz") so we never render raw dotted strings in the UI.
+ */
+export function humanizeAction(action: string): string {
+  const known = ACTION_LABELS[action];
+  if (known) return known;
+
+  // Fallback: take everything after "controller." (or the whole string),
+  // split on the final dot, then humanize the tail.
+  const trimmed = action.startsWith("controller.")
+    ? action.slice("controller.".length)
+    : action;
+  const parts = trimmed.split(".");
+  const tail = parts[parts.length - 1] ?? trimmed;
+  const spaced = tail.replace(/[_.]+/g, " ").trim();
+  if (!spaced) return action;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/**
+ * Returns true if the module has an explicit mapping for `action`. Useful
+ * in tests to detect drift between action emitters and the label map.
+ */
+export function hasKnownAction(action: string): boolean {
+  return action in ACTION_LABELS;
+}
+
+/**
+ * Snapshot shape persisted into ControllerAuditLog.before / .after. We
+ * type it loosely because the controller writes heterogeneous payloads
+ * (configs, templates, wizard steps).
+ */
+export type AuditSnapshot = Record<string, unknown> | null | undefined;
+
+/**
+ * Best-effort one-line summary derived from before/after JSON snapshots.
+ * Returns `null` if neither snapshot is informative — the caller can fall
+ * back to the action label alone.
+ *
+ * Strategy: detect new/removed/changed top-level keys (depth-1 only — the
+ * full field-level diff lives in the EMR-744 diff viewer linked from each
+ * timeline entry). For the common controller patterns:
+ *   - `after.keys = [...]`   → "Updated <n> fields"
+ *   - newly-present key      → "Set <key>"
+ *   - newly-absent key       → "Cleared <key>"
+ *   - changed scalar         → "<key>: <before> → <after>"
+ */
+export function summarizeChange(
+  before: AuditSnapshot,
+  after: AuditSnapshot,
+): string | null {
+  // Handle the "after.keys is an array of mutated field names" pattern that
+  // src/app/api/configs/[id]/route.ts uses — that's the most common
+  // controller emission.
+  if (
+    after &&
+    typeof after === "object" &&
+    Array.isArray((after as { keys?: unknown }).keys)
+  ) {
+    const keys = (after as { keys: unknown[] }).keys.filter(
+      (k): k is string => typeof k === "string",
+    );
+    if (keys.length === 0) return null;
+    if (keys.length === 1) return `Updated ${keys[0]}`;
+    if (keys.length <= 3) return `Updated ${keys.join(", ")}`;
+    return `Updated ${keys.length} fields`;
+  }
+
+  const b = (before && typeof before === "object" ? before : {}) as Record<
+    string,
+    unknown
+  >;
+  const a = (after && typeof after === "object" ? after : {}) as Record<
+    string,
+    unknown
+  >;
+  const beforeKeys = new Set(Object.keys(b));
+  const afterKeys = new Set(Object.keys(a));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  for (const k of afterKeys) {
+    if (!beforeKeys.has(k)) {
+      added.push(k);
+      continue;
+    }
+    if (!shallowEqual(b[k], a[k])) {
+      changed.push(k);
+    }
+  }
+  for (const k of beforeKeys) {
+    if (!afterKeys.has(k)) removed.push(k);
+  }
+
+  const total = added.length + removed.length + changed.length;
+  if (total === 0) return null;
+
+  // Single-field change: render the actual before → after when both are
+  // primitives that are reasonable to inline.
+  if (total === 1 && changed.length === 1) {
+    const k = changed[0];
+    const beforeStr = formatScalar(b[k]);
+    const afterStr = formatScalar(a[k]);
+    if (beforeStr !== null && afterStr !== null) {
+      return `${k}: ${beforeStr} → ${afterStr}`;
+    }
+    return `Updated ${k}`;
+  }
+  if (total === 1 && added.length === 1) return `Set ${added[0]}`;
+  if (total === 1 && removed.length === 1) return `Cleared ${removed[0]}`;
+
+  const parts: string[] = [];
+  if (added.length) parts.push(`+${added.length} added`);
+  if (changed.length) parts.push(`${changed.length} changed`);
+  if (removed.length) parts.push(`-${removed.length} removed`);
+  return parts.join(", ");
+}
+
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  // For arrays / objects, JSON-stringify is a pragmatic depth-1+ compare.
+  // We're never deep-comparing huge blobs here (snapshots are small).
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function formatScalar(v: unknown): string | null {
+  if (v === null) return "null";
+  if (v === undefined) return "—";
+  const t = typeof v;
+  if (t === "string") {
+    const s = v as string;
+    if (s.length > 32) return `"${s.slice(0, 29)}…"`;
+    return `"${s}"`;
+  }
+  if (t === "number" || t === "boolean") return String(v);
+  return null;
+}

--- a/src/app/(super-admin)/practices/[id]/history-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/history-tab.tsx
@@ -1,0 +1,237 @@
+// EMR-743 — History tab. Vertical timeline of ControllerAuditLog rows for a
+// single practice, most-recent first, cursor-paged via the URL.
+//
+// Server component. The loader (`loadPracticeHistoryPage`) lives in
+// practices/loaders.ts so the cursor query stays out of the React tree.
+// Pagination is plain `?historyCursor=…` on the same page route — no
+// client fetch, no React state. "Load more" is a `<Link>` that the parent
+// page resolves on the next request.
+//
+// Field-level diffs live behind a native `<details>` so we don't need any
+// client JS to expand them. The "open diff viewer" + "compare arbitrary
+// versions" affordances are referenced as TODOs (EMR-744) — we stub the
+// targets so the UI converges on the same anchor when that ticket ships.
+
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils/cn";
+
+import {
+  loadPracticeHistoryPage,
+  type PracticeHistoryRow,
+} from "../loaders";
+import { humanizeAction, summarizeChange } from "./history-humanize";
+
+const ROLE_TONE: Record<string, "accent" | "info" | "neutral" | "warning"> = {
+  super_admin: "accent",
+  practice_admin: "info",
+  practice_owner: "info",
+  operator: "neutral",
+  implementation_admin: "warning",
+  clinician: "neutral",
+  patient: "neutral",
+  system: "neutral",
+};
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatRelative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
+export async function HistoryTab({
+  practiceRouteId,
+  organizationId,
+  alsoSubjectIds,
+  cursor,
+}: {
+  /** The `[id]` from the URL (config id OR org id) — used to build paging links. */
+  practiceRouteId: string;
+  organizationId: string;
+  alsoSubjectIds?: string[];
+  cursor?: string | null;
+}) {
+  const { rows, nextCursor } = await loadPracticeHistoryPage({
+    organizationId,
+    alsoSubjectIds,
+    cursor: cursor ?? null,
+  });
+
+  if (rows.length === 0 && !cursor) {
+    return (
+      <div className="rounded-xl border border-dashed border-border px-6 py-12 text-center">
+        <div className="font-display text-base text-text tracking-tight">
+          No changes yet
+        </div>
+        <div className="mt-1.5 text-[12px] text-text-muted">
+          This practice has only the initial configuration. New mutations
+          will surface here as a versioned timeline.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-4 mb-3">
+        <div className="text-[11px] uppercase tracking-wider text-text-muted">
+          Configuration history
+        </div>
+        {/* EMR-744 — the diff viewer + "Compare versions" picker land in the
+            companion ticket. We stub the entry-point here so the layout has
+            the right whitespace and so super-admins can see where the UI is
+            headed. The link is intentionally non-functional until EMR-744. */}
+        <span
+          className="text-[11px] text-text-muted/70 italic"
+          title="Arrives with EMR-744 — diff viewer"
+        >
+          Compare versions · coming soon
+        </span>
+      </div>
+
+      <ol className="relative pl-5">
+        <span
+          aria-hidden="true"
+          className="absolute left-1.5 top-1.5 bottom-1.5 w-px bg-border/70"
+        />
+        {rows.map((row) => (
+          <HistoryEntry key={row.id} row={row} />
+        ))}
+      </ol>
+
+      {nextCursor && (
+        <div className="mt-6 flex justify-center">
+          <Link
+            href={`/practices/${practiceRouteId}?tab=history&historyCursor=${encodeURIComponent(
+              nextCursor,
+            )}`}
+            scroll={false}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-4 py-2",
+              "text-[12px] text-text hover:bg-surface-muted transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+            )}
+          >
+            Load earlier history
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HistoryEntry({ row }: { row: PracticeHistoryRow }) {
+  const headline = humanizeAction(row.action);
+  const summary = summarizeChange(
+    row.before as Record<string, unknown> | null,
+    row.after as Record<string, unknown> | null,
+  );
+  const actorLabel = row.actorEmail ?? row.actorUserId;
+  const hasDetails = row.before != null || row.after != null;
+
+  return (
+    <li className="relative pb-5 last:pb-0">
+      <span
+        aria-hidden="true"
+        className="absolute -left-[14px] top-[6px] h-2 w-2 rounded-full bg-accent ring-4 ring-bg"
+      />
+      <div className="rounded-lg border border-border/70 bg-surface px-4 py-3">
+        <div className="flex items-baseline justify-between gap-4 flex-wrap">
+          <div className="min-w-0">
+            <div className="font-display text-[14px] text-text tracking-tight">
+              {headline}
+            </div>
+            {summary && (
+              <div className="mt-1 text-[12px] text-text-muted">
+                {summary}
+              </div>
+            )}
+          </div>
+          <div className="text-right shrink-0">
+            <div
+              className="text-[12px] text-text"
+              title={formatTimestamp(row.at)}
+            >
+              {formatRelative(row.at)}
+            </div>
+            <div className="text-[10px] text-text-muted mt-0.5">
+              {new Date(row.at).toLocaleDateString()}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-2 flex items-center gap-2 flex-wrap">
+          <span className="text-[12px] text-text">{actorLabel}</span>
+          {row.actorRoles.map((role) => (
+            <Badge key={role} tone={ROLE_TONE[role] ?? "neutral"}>
+              {role.replace(/_/g, " ")}
+            </Badge>
+          ))}
+          <code className="text-[11px] font-mono text-text-muted bg-surface-muted px-1.5 py-0.5 rounded">
+            {row.action}
+          </code>
+        </div>
+
+        {row.reason && (
+          <div className="mt-2 text-[12px] text-text-muted italic">
+            “{row.reason}”
+          </div>
+        )}
+
+        {hasDetails && (
+          <details className="mt-3 group">
+            <summary className="cursor-pointer text-[11px] uppercase tracking-wider text-text-muted hover:text-text select-none list-none flex items-center gap-1.5">
+              <span className="inline-block transition-transform group-open:rotate-90">
+                ›
+              </span>
+              Expand details
+            </summary>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <SnapshotBlock label="Before" value={row.before} />
+              <SnapshotBlock label="After" value={row.after} />
+            </div>
+          </details>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function SnapshotBlock({
+  label,
+  value,
+}: {
+  label: string;
+  value: unknown;
+}) {
+  return (
+    <div className="rounded-md border border-border/60 bg-surface-muted/40 p-2">
+      <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1">
+        {label}
+      </div>
+      <pre className="text-[11px] font-mono text-text whitespace-pre-wrap break-words max-h-48 overflow-auto">
+        {value == null ? "—" : JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/practices/[id]/page.tsx
+++ b/src/app/(super-admin)/practices/[id]/page.tsx
@@ -5,11 +5,12 @@
 // segment boundary, so any unauth'd request is redirected before we even
 // resolve params here.
 //
-// Tabs are URL-driven (`?tab=overview|providers|activity|billing`); the
-// disabled History tab anchor points at EMR-743. Each tab body is its
-// own loader so we only fetch the data the user is looking at — the
-// Overview loader runs unconditionally because we need the practice
-// header (name, status badges) regardless of which tab is selected.
+// Tabs are URL-driven (`?tab=overview|providers|activity|billing|history`).
+// Each tab body is its own loader so we only fetch the data the user is
+// looking at — the Overview loader runs unconditionally because we need
+// the practice header (name, status badges) regardless of which tab is
+// selected. EMR-743 wired the History tab; cursor paging on that tab is
+// driven by the `?historyCursor=` URL param so paging stays server-side.
 //
 // Impersonation surfaces ("View as this practice", "Stop impersonating")
 // are intentionally omitted; EMR-742 ships them. We do not stub a button
@@ -30,6 +31,7 @@ import { OverviewTab } from "./overview-tab";
 import { ProvidersTab } from "./providers-tab";
 import { ActivityTab } from "./activity-tab";
 import { BillingTab } from "./billing-tab";
+import { HistoryTab } from "./history-tab";
 import { TabBar, isTabKey, type TabKey } from "./tab-bar";
 
 export const dynamic = "force-dynamic";
@@ -55,17 +57,13 @@ export default async function PracticeDrillInPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ tab?: string }>;
+  searchParams?: Promise<{ tab?: string; historyCursor?: string }>;
 }) {
   const { id } = await params;
   const sp = (await searchParams) ?? {};
   const requestedTab = sp.tab;
-  // History is intentionally non-clickable; if someone hand-types
-  // ?tab=history we fall back to overview rather than rendering a stub.
-  const activeTab: TabKey =
-    isTabKey(requestedTab) && requestedTab !== "history"
-      ? requestedTab
-      : "overview";
+  const activeTab: TabKey = isTabKey(requestedTab) ? requestedTab : "overview";
+  const historyCursor = sp.historyCursor ?? null;
 
   const practice = await loadPracticeOverview(id);
   if (!practice) {
@@ -134,6 +132,18 @@ export default async function PracticeDrillInPage({
       )}
       {activeTab === "billing" && (
         <BillingTab organizationId={practice.organizationId} />
+      )}
+      {activeTab === "history" && (
+        <HistoryTab
+          practiceRouteId={id}
+          organizationId={practice.organizationId}
+          alsoSubjectIds={[
+            practice.configId,
+            practice.practiceId,
+            practice.organizationId,
+          ].filter((s): s is string => !!s)}
+          cursor={historyCursor}
+        />
       )}
     </PageShell>
   );

--- a/src/app/(super-admin)/practices/[id]/tab-bar.tsx
+++ b/src/app/(super-admin)/practices/[id]/tab-bar.tsx
@@ -2,9 +2,8 @@
 //
 // We intentionally keep this server-only so the drill-in page can use
 // server components throughout and each tab can lazy-load its data on
-// selection rather than fetching everything up front (per AC). The
-// History tab is rendered as a disabled anchor with a tooltip pointing
-// at EMR-743 — implementation lives in that ticket's epic (E5).
+// selection rather than fetching everything up front (per AC). EMR-743
+// promoted the History tab from a "Soon" placeholder to a real link.
 
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
@@ -45,31 +44,9 @@ export function TabBar({
       aria-label="Practice tabs"
     >
       {TAB_KEYS.map((key) => {
-        const isHistory = key === "history";
         const isActive = key === active;
         const base =
           "relative px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-t-md";
-
-        if (isHistory) {
-          return (
-            <span
-              key={key}
-              role="tab"
-              aria-disabled="true"
-              aria-selected="false"
-              title="Shipped in EMR-743"
-              className={cn(
-                base,
-                "text-text-muted/60 cursor-not-allowed select-none",
-              )}
-            >
-              {TAB_LABELS[key]}
-              <span className="ml-1.5 text-[10px] uppercase tracking-wider rounded-full bg-surface-muted text-text-muted/70 px-1.5 py-0.5 align-middle">
-                Soon
-              </span>
-            </span>
-          );
-        }
 
         return (
           <Link

--- a/src/app/(super-admin)/practices/loaders.ts
+++ b/src/app/(super-admin)/practices/loaders.ts
@@ -41,6 +41,29 @@ export type PracticeAuditRow = {
   reason: string | null;
 };
 
+// EMR-743 — History tab row + paged result envelope. Shape is intentionally
+// a superset of PracticeAuditRow (adds before/after JSON) so the timeline
+// can render a one-line summary without a second round trip.
+export type PracticeHistoryRow = {
+  id: string;
+  at: string;
+  actorUserId: string;
+  actorEmail: string | null;
+  actorRoles: string[];
+  action: string;
+  subjectType: string;
+  subjectId: string;
+  reason: string | null;
+  before: unknown;
+  after: unknown;
+};
+
+export type PracticeHistoryPage = {
+  rows: PracticeHistoryRow[];
+  /** Opaque cursor for the next page, or null if exhausted. */
+  nextCursor: string | null;
+};
+
 export type PracticeBillingMonthRow = {
   monthIso: string; // YYYY-MM-01 in UTC
   monthLabel: string; // "May 2026"
@@ -684,5 +707,150 @@ export async function loadPracticeBilling(
       gatewayChargeCents: mtdCharges._sum.feeAmountCents ?? 0,
     },
     last12Months,
+  };
+}
+
+// --------------------------------------------------------------
+// EMR-743 — History tab loader (cursor-paged audit timeline)
+// --------------------------------------------------------------
+//
+// Reads ControllerAuditLog rows whose `organizationId` matches the practice
+// OR whose `subjectId` matches a known config / practice id for the same
+// practice. Cursor-paged most-recent-first so "Load more" can append
+// without refetching the head of the timeline.
+//
+// The cursor is an opaque `${atIso}|${id}` string — we tiebreak on `id` so
+// two rows with identical `at` (rare but possible — the audit writer uses
+// `default(now())`) don't get skipped or duplicated.
+
+/** Default page size for the history timeline. */
+export const PRACTICE_HISTORY_PAGE_SIZE = 25;
+
+/** Hard upper bound on `take` to protect against runaway query params. */
+const PRACTICE_HISTORY_MAX_PAGE_SIZE = 100;
+
+/**
+ * Encode a (timestamp, id) tuple as an opaque cursor for the URL.
+ * Exported for tests / route handlers; the format is deliberately stable.
+ */
+export function encodeHistoryCursor(at: Date, id: string): string {
+  return `${at.toISOString()}|${id}`;
+}
+
+/**
+ * Inverse of `encodeHistoryCursor`. Returns null when the input is
+ * malformed — callers should treat that as "no cursor".
+ */
+export function decodeHistoryCursor(
+  cursor: string | null | undefined,
+): { at: Date; id: string } | null {
+  if (!cursor) return null;
+  const idx = cursor.indexOf("|");
+  if (idx <= 0) return null;
+  const atRaw = cursor.slice(0, idx);
+  const id = cursor.slice(idx + 1);
+  if (!id) return null;
+  const at = new Date(atRaw);
+  if (Number.isNaN(at.getTime())) return null;
+  return { at, id };
+}
+
+/**
+ * Page of ControllerAuditLog rows for a practice. Cursor is the
+ * `(at, id)` of the last row returned; pass it back as `cursor` for the
+ * next page. Returns at most `pageSize` rows.
+ *
+ * `organizationId` is the canonical lookup key; we also OR-in any rows
+ * whose `subjectId` matches the practice's configuration id or practice
+ * id, so audit rows emitted before `organizationId` was populated on the
+ * row (or on a different scope) still surface here.
+ */
+export async function loadPracticeHistoryPage(args: {
+  organizationId: string;
+  /** Additional subjectIds (e.g. PracticeConfiguration.id, Practice.id) to OR-in. */
+  alsoSubjectIds?: string[];
+  cursor?: string | null;
+  pageSize?: number;
+}): Promise<PracticeHistoryPage> {
+  const pageSize = Math.min(
+    Math.max(1, args.pageSize ?? PRACTICE_HISTORY_PAGE_SIZE),
+    PRACTICE_HISTORY_MAX_PAGE_SIZE,
+  );
+  const decoded = decodeHistoryCursor(args.cursor);
+
+  // OR clause: organizationId match OR subjectId in [config.id, practice.id].
+  const subjectIds = Array.from(
+    new Set((args.alsoSubjectIds ?? []).filter((s): s is string => !!s)),
+  );
+
+  const scope =
+    subjectIds.length > 0
+      ? {
+          OR: [
+            { organizationId: args.organizationId },
+            { subjectId: { in: subjectIds } },
+          ],
+        }
+      : { organizationId: args.organizationId };
+
+  // Cursor predicate: rows strictly older than (at, id).
+  //
+  // Prisma's built-in `cursor` option does a single-column tie-break and
+  // can't AND `(at < x) OR (at = x AND id < y)` directly without raw SQL,
+  // so we filter in `where` and order by (at desc, id desc).
+  const cursorPredicate = decoded
+    ? {
+        OR: [
+          { at: { lt: decoded.at } },
+          { AND: [{ at: decoded.at }, { id: { lt: decoded.id } }] },
+        ],
+      }
+    : null;
+
+  const where = cursorPredicate
+    ? { AND: [scope, cursorPredicate] }
+    : scope;
+
+  // Fetch pageSize + 1 so we know whether another page exists without a
+  // separate count round-trip.
+  const raw = await prisma.controllerAuditLog.findMany({
+    where,
+    orderBy: [{ at: "desc" }, { id: "desc" }],
+    take: pageSize + 1,
+    select: {
+      id: true,
+      at: true,
+      actorUserId: true,
+      actorEmail: true,
+      actorRoles: true,
+      action: true,
+      subjectType: true,
+      subjectId: true,
+      reason: true,
+      before: true,
+      after: true,
+    },
+  });
+
+  const hasMore = raw.length > pageSize;
+  const page = hasMore ? raw.slice(0, pageSize) : raw;
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last ? encodeHistoryCursor(last.at, last.id) : null;
+
+  return {
+    rows: page.map((r) => ({
+      id: r.id,
+      at: r.at.toISOString(),
+      actorUserId: r.actorUserId,
+      actorEmail: r.actorEmail,
+      actorRoles: r.actorRoles.map((role) => String(role)),
+      action: r.action,
+      subjectType: r.subjectType,
+      subjectId: r.subjectId,
+      reason: r.reason,
+      before: r.before,
+      after: r.after,
+    })),
+    nextCursor,
   };
 }


### PR DESCRIPTION
## Summary
- Promotes the previously-disabled History tab on `/practices/[id]` to a real, data-backed vertical timeline of `ControllerAuditLog` rows for the practice (org-scoped, plus OR-in for `subjectId` matches on the config/practice ids).
- Each entry shows actor email, humanized action (`controller.config.published` → "Published configuration"), one-line summary derived from `before`/`after` JSON, relative + absolute timestamp, role badges, optional reason, and a native `<details>` disclosure with the raw snapshots.
- Server-side cursor pagination ("Load earlier history") via `?historyCursor=` so paging never escapes the server tree. Cursor is `(at, id)` with explicit tiebreak.
- 13-case Vitest unit suite covers `humanizeAction()` (known map + unknown-action fallback) and `summarizeChange()` (`after.keys` envelope, scalar diffs, add/remove, multi-field counts, truncation, deep-equal).

Implements EMR-743. The "Compare arbitrary versions" picker + diff-viewer links are referenced as a stub headed for EMR-744 (Child 2) per the ticket notes — the field-level label map lives there.

## Test plan
- [ ] `npx vitest run src/app/(super-admin)/practices/[id]/history-humanize.test.ts` — 13 passing.
- [ ] `npx tsc --noEmit` clean.
- [ ] `node scripts/check-admin-mutation-coverage.mjs` + `node scripts/check-route-auth-manifest.mjs` clean (no new API routes).
- [ ] Visit `/practices/<id>?tab=history` on a seeded practice — timeline renders most-recent first, "Load earlier history" appends the next page.
- [ ] Visit `/practices/<id>?tab=history` on a practice with zero audit rows — renders the "No changes yet" empty state.
- [ ] Click "Expand details" on an entry with `before`/`after` snapshots — JSON pretty-prints inline.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>