### PR TITLE
fix(e2e): stabilize auth.setup against Clerk session polling

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -27,13 +27,24 @@ setup('authenticate as test user', async ({ page }) => {
   // Click continue
   await page.click('button:has-text("Continue")');
 
-  // Wait until we land on the post-sign-in router or a secure page
-  await page.waitForURL(/.*(\/post-sign-in|\/clinic|\/portal|\/ops).*/, { timeout: 20000 }).catch(() => {
-    console.log('Did not detect typical post-auth URL. Continuing anyway to save state.');
-  });
-  
-  // Wait for the network to be idle to ensure cookies are persisted
-  await page.waitForLoadState('networkidle');
+  // Wait until we land on the post-sign-in router or a secure page.
+  // Fail loudly here rather than swallowing — if this doesn't match, the
+  // cookie wait below will time out with a misleading message.
+  await page.waitForURL(/.*(\/post-sign-in|\/clinic|\/portal|\/ops).*/, { timeout: 30000 });
+
+  // Wait until Clerk's session cookie is persisted. Don't use
+  // waitForLoadState('networkidle') — Clerk does background session polling
+  // (v1/environment, client/me, etc.) so the page never reaches networkidle
+  // and the wait times out at 60s.
+  await expect
+    .poll(
+      async () => {
+        const cookies = await page.context().cookies();
+        return cookies.some((c) => c.name === '__session' || c.name.startsWith('__session_'));
+      },
+      { timeout: 15000, message: 'Clerk __session cookie was not set after sign-in' },
+    )
+    .toBe(true);
 
   await page.context().storageState({ path: authFile });
 });


### PR DESCRIPTION
## Summary
- Replace `waitForLoadState('networkidle')` with a poll for Clerk's `__session` cookie — Clerk's background session sync (v1/environment, client/me) means the page never reaches networkidle, causing the 60s timeout that was cascading into ~all e2e failures on `main`.
- Stop swallowing the post-sign-in `waitForURL` timeout (the `.catch()`) so the real failure surfaces at its source instead of as a misleading networkidle timeout.
- Bump post-sign-in URL wait from 20s → 30s for staging headroom.

## Why
The `Staging & Production Pipeline` has been failing repeatedly with the same auth.setup timeout on `e2e/auth.setup.ts:36`, which then cascades into `click-handlers.spec.ts` failures on public routes (`/leafmart`, `/leafmart/shop`) because the setup project failure aborts dependent tests. Fixing the setup should unblock the bulk of those.

## Test plan
- [ ] CI: `Staging & Production Pipeline` → `Automated Tests (Staging)` job is green (or at least no longer fails on auth.setup or click-handler cascade)
- [ ] Locally (optional): `BASE_URL=<staging> TEST_USER_EMAIL=… TEST_USER_PASSWORD=… npx playwright test --project=setup`
- [ ] Confirm `form-submit-paths` `/book-demo` + `/status` failures remain (those are a real app bug, not in scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)