### PR TITLE
fix(e2e): bump click-handlers timeout 180s → 300s (#371)

### DIFF
--- a/e2e/click-handlers.spec.ts
+++ b/e2e/click-handlers.spec.ts
@@ -410,7 +410,10 @@ async function clickAndObserve(
 // hook callback). `test.describe.configure({ timeout })` is the
 // supported API for raising the budget for every test in a describe
 // group, and it actually works.
-test.describe.configure({ timeout: 180_000 });
+// Heavy marketing routes (/leafmart, /leafmart/shop) consistently brushed
+// up against 180s on staging and timed out — see issue #371. Lifting to
+// 300s gives those pages enough headroom while still bounding the suite.
+test.describe.configure({ timeout: 300_000 });
 
 test.describe("Click handlers — find-and-fix pass 8", () => {
   for (const route of ROUTES) {


### PR DESCRIPTION
## Summary
- One-line change: `test.describe.configure({ timeout: 300_000 })` for the click-handlers suite (was 180s).
- Unblocks issue #371 — `/leafmart` and `/leafmart/shop` have been chronically timing out since 2026-05-18, blocking every prod deploy.

## Why
After PR #396 landed the auth.setup fix, the staging pipeline goes 101/103 — the only remaining failures are these two Leafmart crawl tests timing out. With `MAX_CLICKS_PER_ROUTE=25` and `CLICK_OBSERVE_MS=2000ms` the test inherently needs ~100s of observe time per route plus navigation + probe overhead; on staging's Leafmart routes that consistently breaches 180s. 300s gives headroom for slow staging loads without papering over a real hang — if a future run still times out at 300s, we know it's an app issue, not a budget issue.

## Test plan
- [ ] Pipeline run on main passes `Automated Tests (Staging)` end-to-end
- [ ] `Deploy to Production` reaches the env-approval gate (which means we're actually shipping the auth fix from #396 too)
- [ ] Close #371 once the next pipeline run lands green

🤖 Generated with [Claude Code](https://claude.com/claude-code)