### PR TITLE
EMR-644: /clinic top-ribbon RELAX mindfulness button

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -648,6 +648,12 @@ export default async function ClinicHomePage() {
           {/* Right: Quick actions */}
           <div className="flex items-center gap-3 shrink-0">
             <UniversalPatientSearch className="hidden md:block" />
+            <Link href="/clinic/mindful" title="Take a mindful break">
+              <Button variant="ghost" size="sm" className="hidden sm:inline-flex text-text-subtle hover:text-accent gap-1.5">
+                <span aria-hidden="true">🍃</span>
+                Relax
+              </Button>
+            </Link>
             <NewVisitModal>
               <Button size="sm">New visit</Button>
             </NewVisitModal>


### PR DESCRIPTION
Implements EMR-644.

## What changed
- Added a ghost-style "🍃 Relax" button to the right section of the `/clinic` command strip, between the patient search and the "New visit" button
- The button links to the existing `/clinic/mindful` hub (Breathe/Move/Inspire cards)
- Hidden on mobile (`hidden sm:inline-flex`) to keep the ribbon uncluttered on small screens
- No new components, no new routes — just wires the existing mindful page into the top ribbon

## How to verify
1. Visit `/clinic` — the command strip right section should show: `[Search]  [🍃 Relax]  [New visit]`
2. Click "🍃 Relax" → lands on `/clinic/mindful` (the breathing hub)
3. On a narrow viewport (< 640px) the Relax button should be hidden; "New visit" stays visible

## Notes
- `node_modules` is absent in this execution environment so `npm run typecheck` / `npm run lint` could not be run locally. The change is 6 lines of JSX using `Link` and `Button` — the same pattern already used dozens of times in this file, with no new imports required.
- Follow-up: EMR-645 (counts as links) is next in queue with no existing PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW4Mr7Ct1LSy5pXbjF5dJD)_