### PR TITLE
EMR-662: /clinic/sign-off split-pane layout + Sign-Off tree restructure

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/layout.tsx
+++ b/src/app/(clinician)/clinic/sign-off/layout.tsx
@@ -1,5 +1,6 @@
-import Link from "next/link";
+import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { SignOffNav, type NavSection } from "./sign-off-nav";
 
 export default async function SignOffLayout({
   children,
@@ -7,32 +8,86 @@ export default async function SignOffLayout({
   children: React.ReactNode;
 }) {
   const user = await requireUser();
+  const orgId = user.organizationId!;
+
+  const [
+    labTotal,
+    labUrgent,
+    refillTotal,
+    refillUrgent,
+    noteTotal,
+    noteUrgent,
+    msgTotal,
+  ] = await Promise.all([
+    prisma.labResult.count({ where: { organizationId: orgId, signedAt: null } }),
+    prisma.labResult.count({ where: { organizationId: orgId, signedAt: null, abnormalFlag: true } }),
+    prisma.refillRequest.count({
+      where: { organizationId: orgId, signedAt: null, status: { in: ["new", "flagged"] } },
+    }),
+    prisma.refillRequest.count({
+      where: { organizationId: orgId, signedAt: null, status: "flagged" },
+    }),
+    prisma.note.count({
+      where: { status: "needs_review", encounter: { patient: { organizationId: orgId } } },
+    }),
+    prisma.note.count({
+      where: {
+        status: "needs_review",
+        aiConfidence: { lt: 0.6 },
+        encounter: { patient: { organizationId: orgId } },
+      },
+    }),
+    prisma.message.count({
+      where: { status: "draft", aiDrafted: true, thread: { patient: { organizationId: orgId } } },
+    }),
+  ]);
+
+  const total = labTotal + refillTotal + noteTotal + msgTotal;
+
+  const sections: NavSection[] = [
+    {
+      label: "All items",
+      href: "/clinic/sign-off",
+      count: total,
+      hasUrgent: labUrgent > 0 || refillUrgent > 0 || noteUrgent > 0,
+    },
+    {
+      label: "Labs",
+      href: "/clinic/sign-off/labs",
+      count: labTotal,
+      hasUrgent: labUrgent > 0,
+    },
+    {
+      label: "Refills",
+      href: "/clinic/sign-off/refills",
+      count: refillTotal,
+      hasUrgent: refillUrgent > 0,
+    },
+    {
+      label: "Clinical notes",
+      href: "/clinic/sign-off/notes",
+      count: noteTotal,
+      hasUrgent: noteUrgent > 0,
+    },
+    {
+      label: "Messages",
+      href: "/clinic/sign-off/messages",
+      count: msgTotal,
+      hasUrgent: false,
+    },
+  ];
 
   return (
     <div className="flex h-full min-h-[calc(100vh-4rem)]">
-      {/* Left split-pane (sidebar navigation) */}
-      <div className="w-64 shrink-0 border-r border-border bg-surface flex flex-col p-4">
-        <h2 className="text-sm font-semibold text-text uppercase tracking-wider mb-4 px-2">Sign-Off Queues</h2>
-        <nav className="flex flex-col gap-1">
-          <Link href="/clinic/sign-off" className="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-surface-muted transition-colors">
-            Unified Queue (All)
-          </Link>
-          <Link href="/clinic/sign-off/labs" className="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-surface-muted transition-colors">
-            Labs
-          </Link>
-          <Link href="/clinic/sign-off/refills" className="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-surface-muted transition-colors">
-            Refills
-          </Link>
-          <Link href="/clinic/sign-off/notes" className="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-surface-muted transition-colors">
-            Clinical Notes
-          </Link>
-          <Link href="/clinic/sign-off/messages" className="px-3 py-2 rounded-md text-sm font-medium text-text hover:bg-surface-muted transition-colors">
-            Messages (Approvals)
-          </Link>
-        </nav>
+      {/* Left sidebar — Sign-Off tree navigation */}
+      <div className="w-56 shrink-0 border-r border-border bg-surface flex flex-col p-3">
+        <p className="text-[11px] font-semibold text-text-subtle uppercase tracking-[0.12em] mb-3 px-2">
+          Sign-off
+        </p>
+        <SignOffNav sections={sections} />
       </div>
-      
-      {/* Right split-pane (content) */}
+
+      {/* Right content */}
       <div className="flex-1 min-w-0 bg-surface-raised overflow-y-auto">
         {children}
       </div>

--- a/src/app/(clinician)/clinic/sign-off/page.tsx
+++ b/src/app/(clinician)/clinic/sign-off/page.tsx
@@ -1,35 +1,8 @@
-import Link from "next/link";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
-import { PageHeader, PageShell } from "@/components/shell/PageHeader";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { EmptyState } from "@/components/ui/empty-state";
+import { SignOffTreeView, type SignOffRow } from "./sign-off-tree-view";
 
 export const metadata = { title: "Sign-Off Queue" };
-
-// EMR-165: Doctor Sign-Off Workflow for Patient Results
-//
-// One queue, four sources. Clinicians have to sign labs, refills,
-// AI-drafted clinic notes, and outbound messages. Today each lives on
-// its own page; this is the unified inbox so a doctor can clear the
-// day's pending review in a single sweep, sorted by urgency. Each row
-// deep-links to the existing review surface that owns the actual sign
-// action — this page only aggregates and routes.
-
-type Row = {
-  id: string;
-  kind: "lab" | "refill" | "note" | "message";
-  title: string;
-  patientName: string;
-  patientId: string;
-  receivedAt: Date;
-  urgency: "high" | "normal" | "low";
-  /** Description shown beneath the title — context for triage. */
-  hint: string;
-  /** Where clicking the row deep-links to. */
-  href: string;
-};
 
 export default async function SignOffPage() {
   const user = await requireUser();
@@ -88,170 +61,67 @@ export default async function SignOffPage() {
     }),
   ]);
 
-  const rows: Row[] = [
-    ...labs.map<Row>((l) => ({
+  const urgRank = { high: 0, normal: 1, low: 2 } as const;
+
+  const rows: SignOffRow[] = [
+    ...labs.map<SignOffRow>((l) => ({
       id: `lab-${l.id}`,
-      kind: "lab" as const,
+      kind: "lab",
       title: l.panelName,
       patientName: `${l.patient.firstName} ${l.patient.lastName}`,
       patientId: l.patient.id,
-      receivedAt: l.receivedAt,
-      urgency: l.abnormalFlag ? ("high" as const) : ("normal" as const),
-      hint: l.abnormalFlag
-        ? "Abnormal — review and route"
-        : "Within reference range",
+      receivedAt: l.receivedAt.toISOString(),
+      urgency: l.abnormalFlag ? "high" : "normal",
+      hint: l.abnormalFlag ? "Abnormal — review and route" : "Within reference range",
       href: `/clinic/sign-off/labs`,
     })),
-    ...refills.map<Row>((r) => ({
+    ...refills.map<SignOffRow>((r) => ({
       id: `refill-${r.id}`,
-      kind: "refill" as const,
+      kind: "refill",
       title: `${r.medication.name}${r.medication.dosage ? ` · ${r.medication.dosage}` : ""}`,
       patientName: `${r.patient.firstName} ${r.patient.lastName}`,
       patientId: r.patient.id,
-      receivedAt: r.receivedAt,
+      receivedAt: r.receivedAt.toISOString(),
       urgency:
-        r.status === "flagged"
-          ? "high"
-          : r.copilotSuggestion === "review"
-            ? "normal"
-            : "low",
+        r.status === "flagged" ? "high" : r.copilotSuggestion === "review" ? "normal" : "low",
       hint: r.rationale ?? `Qty ${r.requestedQty} · ${r.pharmacyName}`,
       href: `/clinic/sign-off/refills`,
     })),
-    ...notes.map<Row>((n) => ({
+    ...notes.map<SignOffRow>((n) => ({
       id: `note-${n.id}`,
-      kind: "note" as const,
+      kind: "note",
       title: "AI-drafted clinic note",
       patientName: `${n.encounter.patient.firstName} ${n.encounter.patient.lastName}`,
       patientId: n.encounter.patient.id,
-      receivedAt: n.updatedAt,
-      urgency:
-        (n.aiConfidence ?? 1) < 0.6 ? ("high" as const) : ("normal" as const),
+      receivedAt: n.updatedAt.toISOString(),
+      urgency: (n.aiConfidence ?? 1) < 0.6 ? "high" : "normal",
       hint:
         (n.aiConfidence ?? 1) < 0.6
           ? `Low confidence (${Math.round((n.aiConfidence ?? 0) * 100)}%) — verify before signing`
           : `Confidence ${Math.round((n.aiConfidence ?? 1) * 100)}%`,
       href: `/clinic/patients/${n.encounter.patient.id}/notes/${n.id}`,
     })),
-    ...messages.map<Row>((m) => ({
+    ...messages.map<SignOffRow>((m) => ({
       id: `msg-${m.id}`,
-      kind: "message" as const,
+      kind: "message",
       title: m.thread.subject,
       patientName: `${m.thread.patient.firstName} ${m.thread.patient.lastName}`,
       patientId: m.thread.patient.id,
-      receivedAt: m.createdAt,
+      receivedAt: m.createdAt.toISOString(),
       urgency:
-        m.thread.triageUrgency === "emergency"
+        m.thread.triageUrgency === "emergency" || m.thread.triageUrgency === "high"
           ? "high"
-          : m.thread.triageUrgency === "high"
-            ? "high"
-            : "normal",
+          : "normal",
       hint: m.thread.triageSummary ?? "AI-drafted reply awaiting review",
       href: `/clinic/sign-off/messages`,
     })),
   ];
 
-  // Sort: high urgency first, then by oldest within each band so things
-  // don't sit forever.
-  const urgRank = { high: 0, normal: 1, low: 2 };
   rows.sort((a, b) => {
     const u = urgRank[a.urgency] - urgRank[b.urgency];
     if (u !== 0) return u;
-    return a.receivedAt.getTime() - b.receivedAt.getTime();
+    return new Date(a.receivedAt).getTime() - new Date(b.receivedAt).getTime();
   });
 
-  const total = rows.length;
-  const highCount = rows.filter((r) => r.urgency === "high").length;
-
-  return (
-    <PageShell>
-      <PageHeader
-        eyebrow="Provider"
-        title="Sign-off queue"
-        description="One unified queue for everything that needs a physician signature today — labs, refills, AI notes, and outbound messages, ranked by urgency."
-        actions={
-          total > 0 ? (
-            <div className="flex items-center gap-3 text-sm">
-              <span className="text-text-subtle">
-                {total} item{total === 1 ? "" : "s"} pending
-              </span>
-              {highCount > 0 && (
-                <Badge tone="danger">{highCount} urgent</Badge>
-              )}
-            </div>
-          ) : null
-        }
-      />
-
-      {rows.length === 0 ? (
-        <EmptyState
-          title="Queue clear"
-          description="Nothing waiting on a signature right now. Take a moment, then come back — the queue refreshes as items arrive."
-        />
-      ) : (
-        <div className="space-y-2">
-          {rows.map((r) => (
-            <SignOffRow key={r.id} row={r} />
-          ))}
-        </div>
-      )}
-    </PageShell>
-  );
-}
-
-function SignOffRow({ row }: { row: Row }) {
-  const kindLabel: Record<Row["kind"], string> = {
-    lab: "Lab",
-    refill: "Refill",
-    note: "Note",
-    message: "Message",
-  };
-  const kindTone: Record<Row["kind"], string> = {
-    lab: "bg-[color:var(--info-soft)] text-[color:var(--info)]",
-    refill: "bg-success/10 text-success",
-    note: "bg-highlight-soft text-[color:var(--highlight-hover)]",
-    message: "bg-accent-soft text-accent",
-  };
-
-  return (
-    <Link href={row.href} className="block">
-      <Card className="hover:border-accent/50 transition-colors">
-        <CardContent className="flex items-center gap-4 px-5 py-3.5">
-          <span
-            className={`inline-flex items-center justify-center text-[10px] font-medium uppercase tracking-wider rounded-md px-2 py-1 shrink-0 ${kindTone[row.kind]}`}
-          >
-            {kindLabel[row.kind]}
-          </span>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-text truncate">
-              {row.title}{" "}
-              <span className="text-text-subtle font-normal">·</span>{" "}
-              <span className="text-text-muted font-normal">{row.patientName}</span>
-            </p>
-            <p className="text-[12px] text-text-subtle mt-0.5 truncate">
-              {row.hint}
-            </p>
-          </div>
-          {row.urgency === "high" && (
-            <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
-          )}
-          <span className="text-[11px] text-text-subtle tabular-nums shrink-0">
-            {formatRelative(row.receivedAt)}
-          </span>
-        </CardContent>
-      </Card>
-    </Link>
-  );
-}
-
-function formatRelative(d: Date): string {
-  const now = Date.now();
-  const ms = now - d.getTime();
-  const min = Math.floor(ms / 60_000);
-  if (min < 1) return "just now";
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const day = Math.floor(hr / 24);
-  return `${day}d ago`;
+  return <SignOffTreeView rows={rows} />;
 }

--- a/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils/cn";
+
+export type NavSection = {
+  label: string;
+  href: string;
+  count: number;
+  hasUrgent: boolean;
+};
+
+export function SignOffNav({ sections }: { sections: NavSection[] }) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-col gap-0.5">
+      {sections.map((s) => {
+        const isAll = s.href === "/clinic/sign-off";
+        const active = isAll
+          ? pathname === "/clinic/sign-off"
+          : pathname === s.href || pathname.startsWith(s.href + "/");
+        return (
+          <Link
+            key={s.href}
+            href={s.href}
+            className={cn(
+              "flex items-center justify-between gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+              active
+                ? "bg-accent/10 text-accent"
+                : "text-text hover:bg-surface-muted"
+            )}
+          >
+            <span className="flex items-center gap-1.5 truncate">
+              {s.hasUrgent && (
+                <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" aria-label="urgent items" />
+              )}
+              {s.label}
+            </span>
+            {s.count > 0 && (
+              <span
+                className={cn(
+                  "shrink-0 text-[10px] font-semibold tabular-nums rounded-full px-1.5 py-0.5 min-w-[18px] text-center",
+                  active
+                    ? "bg-accent/20 text-accent"
+                    : "bg-surface-muted text-text-subtle"
+                )}
+              >
+                {s.count}
+              </span>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils/cn";
+
+export type SignOffRow = {
+  id: string;
+  kind: "lab" | "refill" | "note" | "message";
+  title: string;
+  patientName: string;
+  patientId: string;
+  receivedAt: string; // ISO string — Date is not serialisable across the server→client boundary
+  urgency: "high" | "normal" | "low";
+  hint: string;
+  href: string;
+};
+
+const KIND_LABEL: Record<SignOffRow["kind"], string> = {
+  lab: "Labs",
+  refill: "Refills",
+  note: "Clinical Notes",
+  message: "Messages",
+};
+
+const KIND_TONE: Record<SignOffRow["kind"], string> = {
+  lab: "bg-[color:var(--info-soft)] text-[color:var(--info)]",
+  refill: "bg-success/10 text-success",
+  note: "bg-highlight-soft text-[color:var(--highlight-hover)]",
+  message: "bg-accent-soft text-accent",
+};
+
+const KIND_ORDER: SignOffRow["kind"][] = ["lab", "refill", "note", "message"];
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
+export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState<Set<SignOffRow["kind"]>>(new Set());
+
+  const selected = rows.find((r) => r.id === selectedId) ?? null;
+
+  const groups = KIND_ORDER.map((kind) => ({
+    kind,
+    label: KIND_LABEL[kind],
+    items: rows.filter((r) => r.kind === kind),
+    urgentCount: rows.filter((r) => r.kind === kind && r.urgency === "high").length,
+  })).filter((g) => g.items.length > 0);
+
+  const toggleCollapse = (kind: SignOffRow["kind"]) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      next.has(kind) ? next.delete(kind) : next.add(kind);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {/* Tree (left) */}
+      <div className="w-72 shrink-0 border-r border-border overflow-y-auto bg-surface">
+        {groups.map((group) => {
+          const isCollapsed = collapsed.has(group.kind);
+          return (
+            <div key={group.kind}>
+              <button
+                type="button"
+                onClick={() => toggleCollapse(group.kind)}
+                className="w-full flex items-center justify-between px-4 py-2.5 bg-surface-muted/40 border-b border-border/60 hover:bg-surface-muted transition-colors sticky top-0 z-10"
+                aria-expanded={!isCollapsed}
+              >
+                <span className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
+                  {group.urgentCount > 0 && (
+                    <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
+                  )}
+                  {group.label}
+                </span>
+                <span className="flex items-center gap-2">
+                  {group.urgentCount > 0 && (
+                    <Badge tone="danger" className="text-[9px] px-1 py-0">
+                      {group.urgentCount}
+                    </Badge>
+                  )}
+                  <span className="text-[10px] text-text-subtle select-none">
+                    {isCollapsed ? "▶" : "▼"}
+                  </span>
+                </span>
+              </button>
+
+              {!isCollapsed && (
+                <ul>
+                  {group.items.map((item) => (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedId(item.id === selectedId ? null : item.id)}
+                        className={cn(
+                          "w-full text-left px-4 py-2.5 border-b border-border/40 transition-colors",
+                          selectedId === item.id
+                            ? "bg-accent/10"
+                            : "hover:bg-surface-muted/60"
+                        )}
+                      >
+                        <div className="flex items-start gap-2">
+                          {item.urgency === "high" && (
+                            <span className="mt-[5px] h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
+                          )}
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-text truncate leading-snug">
+                              {item.title}
+                            </p>
+                            <p className="text-[11px] text-text-subtle mt-0.5">
+                              {item.patientName} · {formatRelative(item.receivedAt)}
+                            </p>
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+
+        {groups.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+            <p className="text-sm font-medium text-text">Queue clear</p>
+            <p className="text-[12px] text-text-subtle mt-1">Nothing waiting on a signature</p>
+          </div>
+        )}
+      </div>
+
+      {/* Detail panel (right) */}
+      <div className="flex-1 min-w-0 overflow-y-auto">
+        {selected ? (
+          <SignOffDetail row={selected} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-text-subtle">
+            <p className="text-sm">Select an item from the tree to preview</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SignOffDetail({ row }: { row: SignOffRow }) {
+  return (
+    <div className="p-6 max-w-lg">
+      <div className="mb-4 flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center text-[10px] font-medium uppercase tracking-wider rounded-md px-2 py-1",
+            KIND_TONE[row.kind]
+          )}
+        >
+          {KIND_LABEL[row.kind].replace(/s$/, "")}
+        </span>
+        {row.urgency === "high" && (
+          <Badge tone="danger" className="text-[10px]">Urgent</Badge>
+        )}
+      </div>
+
+      <h2 className="font-display text-xl text-text tracking-tight leading-snug mb-1">
+        {row.title}
+      </h2>
+      <p className="text-sm text-text-muted mb-1">{row.patientName}</p>
+      <p className="text-[12px] text-text-subtle mb-4">{formatRelative(row.receivedAt)}</p>
+
+      <div className="rounded-xl bg-surface-muted/60 border border-border/60 px-4 py-3 text-sm text-text mb-6">
+        {row.hint}
+      </div>
+
+      <Link
+        href={row.href}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"
+      >
+        Open full review →
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements EMR-662.

## What changed

- **`layout.tsx`** — Upgraded the static nav sidebar to query live counts per section (labs, refills, notes, messages) and pass them to a new client component. Each section now shows its pending count badge and a red urgency dot when any high-urgency items exist.

- **`sign-off-nav.tsx`** (new) — Client component for the sidebar nav that uses `usePathname` to highlight the active route with accent styling. Renders count badges and urgency dots per section.

- **`sign-off-tree-view.tsx`** (new) — Client component that replaces the old flat list on the main `/clinic/sign-off` page. Left pane shows items grouped by kind (Labs / Refills / Clinical Notes / Messages) with collapsible sections, per-section urgent counts, and per-item urgency dots. Right pane shows a detail card for the selected item (kind badge, title, patient, hint context, received-at) plus a deep-link CTA to the full review surface.

- **`page.tsx`** — Simplified to just fetch + serialize rows (dates → ISO strings) and render `<SignOffTreeView>`. Removed the old flat `<SignOffRow>` card rendering; the tree view owns all UI now.

## How to verify

1. Navigate to `/clinic/sign-off` — should see the two-column tree layout (left tree + right detail placeholder).
2. Click any item in the tree — right panel shows the item's detail with an "Open full review →" link.
3. Click a section header — it collapses/expands.
4. Sections with urgent items show a red dot in both the sidebar nav and tree.
5. Navigate to a sub-route (e.g. `/clinic/sign-off/labs`) — sidebar nav item becomes accent-highlighted.
6. Count badges in the sidebar reflect actual pending items from the DB.

## Notes

- All typecheck errors in the diff are pre-existing (same `TS2307`/`TS7026`/`TS7006` pattern present throughout the codebase due to missing `node_modules` in the CI env); confirmed by stash-baseline comparison.
- No schema changes, no new dependencies, no middleware touch.
- The sub-route pages (`/labs`, `/refills`, `/notes`, `/messages`) are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011YAkYRHN9gyL3yoxJmsX3G)_