### PR TITLE
EMR-614: /clinic/providers Ancillary Services section

### DIFF
--- a/src/app/(clinician)/clinic/providers/page.tsx
+++ b/src/app/(clinician)/clinic/providers/page.tsx
@@ -1,6 +1,16 @@
+import Link from "next/link";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { logger } from "@/lib/observability/log";
 import {
@@ -15,6 +25,40 @@ export const metadata = { title: "Providers" };
 // past it and log loudly when an org grows past the ceiling (mirrors the
 // pattern in `src/app/(clinician)/clinic/patients/page.tsx`).
 const PROVIDER_DIRECTORY_CAP = 5_000;
+
+type AncillaryDiscipline = "ot" | "pt" | "speech" | "case_mgmt" | "home_health";
+
+const ANCILLARY_DISCIPLINES: Array<{
+  key: AncillaryDiscipline;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    key: "ot",
+    label: "Occupational therapy",
+    blurb: "ADLs, fine motor, sensory regulation, return-to-work assessments.",
+  },
+  {
+    key: "pt",
+    label: "Physical therapy",
+    blurb: "Mobility, balance, post-op rehab, pain-driven movement therapy.",
+  },
+  {
+    key: "speech",
+    label: "Speech & language",
+    blurb: "Swallow studies, aphasia recovery, cognitive-communication therapy.",
+  },
+  {
+    key: "case_mgmt",
+    label: "Case management",
+    blurb: "Care coordination, transitional care, social work hand-offs.",
+  },
+  {
+    key: "home_health",
+    label: "Home health",
+    blurb: "Skilled nursing, wound care, IV therapy, in-home rehab.",
+  },
+];
 
 export default async function ProvidersPage() {
   const user = await requireUser();
@@ -61,6 +105,7 @@ export default async function ProvidersPage() {
         title="Provider directory"
         description="View and contact providers in your organization."
       />
+
       {rows.length === 0 ? (
         <EmptyState
           title="No providers found"
@@ -69,6 +114,44 @@ export default async function ProvidersPage() {
       ) : (
         <ProvidersDirectoryClient providers={rows} />
       )}
+
+      {/* EMR-614 — Ancillary services summary */}
+      <section className="mt-12 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="font-display text-xl font-semibold text-text tracking-tight">
+              Ancillary services
+            </h2>
+            <p className="text-sm text-text-muted mt-0.5">
+              Non-physician care team disciplines. View the full queue for open
+              referrals and pending intake.
+            </p>
+          </div>
+          <Link href="/clinic/ancillary">
+            <Button variant="secondary" size="sm">
+              View full queue
+            </Button>
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {ANCILLARY_DISCIPLINES.map((d) => (
+            <Card key={d.key} tone="raised">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">{d.label}</CardTitle>
+                <CardDescription className="text-xs">{d.blurb}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Link href={`/clinic/ancillary?discipline=${d.key}`}>
+                  <Badge tone="neutral" className="cursor-pointer hover:opacity-80 transition-opacity">
+                    Open queue →
+                  </Badge>
+                </Link>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
     </PageShell>
   );
 }


### PR DESCRIPTION
Implements EMR-614.

## What changed
- Added an **Ancillary Services** summary section at the bottom of `/clinic/providers`
- Renders the five care-team disciplines (OT, PT, Speech & Language, Case Management, Home Health) as raised cards with a one-sentence blurb each
- Each card links to `/clinic/ancillary?discipline=<key>` for a discipline-filtered queue view
- A "View full queue" button in the section header links to `/clinic/ancillary`
- Discipline list is a static constant in the file (no DB query added); data matches what `/clinic/ancillary` already uses

## How to verify
1. Navigate to `/clinic/providers` — the provider directory should render as before
2. Scroll to the bottom — "Ancillary services" section should appear with five discipline cards
3. Click "Open queue →" on any card — should route to `/clinic/ancillary?discipline=<key>`
4. Click "View full queue" button — should route to `/clinic/ancillary`
5. Confirm no visual regressions on the provider directory above the new section

## Notes
- Only `src/app/(clinician)/clinic/providers/page.tsx` touched (+83 lines, single file)
- Pre-existing repo-wide typecheck env issues (missing node types, no node_modules) were present before this change; no new error categories introduced
- Follow-up: once the ancillary queue supports actual discipline filtering server-side, the `?discipline=` param links here will resolve correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyXuBX7dByJ4ncGPGn8G4M)_