### PR TITLE
EMR-638: Replace red/yellow/green status bubbles with leaf emojis

### DIFF
--- a/src/app/(clinician)/clinic/audit-trail/audit-view.tsx
+++ b/src/app/(clinician)/clinic/audit-trail/audit-view.tsx
@@ -54,17 +54,17 @@ function getActionTone(action: string): "success" | "warning" | "danger" | "neut
   return "neutral";
 }
 
-function getActionColor(action: string): string {
+function getActionLeaf(action: string): string {
   const tone = getActionTone(action);
   switch (tone) {
     case "success":
-      return "bg-emerald-500";
+      return "🌿";
     case "warning":
-      return "bg-amber-500";
+      return "🌱";
     case "danger":
-      return "bg-red-500";
+      return "🍂";
     default:
-      return "bg-gray-400";
+      return "🍃";
   }
 }
 
@@ -362,13 +362,13 @@ export function AuditTrailView({
                               </svg>
                             </button>
 
-                            {/* Color dot */}
+                            {/* Action leaf */}
                             <span
-                              className={cn(
-                                "mt-1.5 h-2 w-2 rounded-full shrink-0",
-                                getActionColor(log.action),
-                              )}
-                            />
+                              aria-hidden="true"
+                              className="mt-0.5 text-[11px] leading-none shrink-0"
+                            >
+                              {getActionLeaf(log.action)}
+                            </span>
 
                             {/* Content */}
                             <div className="flex-1 min-w-0">
@@ -497,19 +497,19 @@ export function AuditTrailView({
       {/* Legend */}
       <div className="mt-6 flex items-center gap-6 text-xs text-text-muted">
         <div className="flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-full bg-emerald-500" />
+          <span aria-hidden="true">🌿</span>
           Reads
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-full bg-amber-500" />
+          <span aria-hidden="true">🌱</span>
           Writes
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-full bg-red-500" />
+          <span aria-hidden="true">🍂</span>
           Deletes
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-full bg-gray-400" />
+          <span aria-hidden="true">🍃</span>
           Other
         </div>
       </div>

--- a/src/components/shell/NavSections.tsx
+++ b/src/components/shell/NavSections.tsx
@@ -59,10 +59,10 @@ function CountBadge({ count, tone }: { count: number; tone: CountTone }) {
 // signals severity at a glance; the label gives the punchline; `context`
 // becomes a native title-attribute tooltip.
 
-const SEVERITY_DOT_CLASS: Record<Exclude<BadgeSeverity, "ok">, string> = {
-  critical: "bg-red-600",
-  warn: "bg-amber-500",
-  info: "bg-accent",
+const SEVERITY_LEAF: Record<Exclude<BadgeSeverity, "ok">, string> = {
+  critical: "🍂",
+  warn: "🌱",
+  info: "🌿",
 };
 
 const SEVERITY_TEXT_CLASS: Record<Exclude<BadgeSeverity, "ok">, string> = {
@@ -73,20 +73,19 @@ const SEVERITY_TEXT_CLASS: Record<Exclude<BadgeSeverity, "ok">, string> = {
 
 export function SemanticBadge({ badge }: { badge: NavBadge }) {
   if (badge.severity === "ok") return null;
-  const dot = SEVERITY_DOT_CLASS[badge.severity];
+  const leaf = SEVERITY_LEAF[badge.severity];
   const text = SEVERITY_TEXT_CLASS[badge.severity];
   return (
     <span
       title={badge.context}
       className={cn(
-        "inline-flex items-center gap-1.5 text-[11px] font-medium tabular-nums",
+        "inline-flex items-center gap-1 text-[11px] font-medium tabular-nums",
         text,
       )}
     >
-      <span
-        aria-hidden="true"
-        className={cn("h-1.5 w-1.5 rounded-full", dot)}
-      />
+      <span aria-hidden="true" className="text-[9px] leading-none">
+        {leaf}
+      </span>
       {badge.label}
     </span>
   );

--- a/src/components/ui/interaction-badge.tsx
+++ b/src/components/ui/interaction-badge.tsx
@@ -5,22 +5,22 @@ type Severity = "red" | "yellow" | "green";
 
 const SEVERITY_CONFIG: Record<
   Severity,
-  { label: string; dot: string; badge: string }
+  { label: string; leaf: string; badge: string }
 > = {
   red: {
     label: "Contraindicated",
-    dot: "bg-[color:var(--danger)]",
+    leaf: "🍂",
     badge: "bg-red-50 text-danger border-red-200",
   },
   yellow: {
     label: "Caution",
-    dot: "bg-[color:var(--highlight)]",
+    leaf: "🌱",
     badge:
       "bg-highlight-soft text-[color:var(--highlight-hover)] border-highlight/30",
   },
   green: {
     label: "Safe",
-    dot: "bg-[color:var(--success)]",
+    leaf: "🌿",
     badge: "bg-accent-soft text-success border-[color:var(--success)]/20",
   },
 };
@@ -36,15 +36,14 @@ export function InteractionBadge({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 px-2.5 py-0.5 text-[11px] font-medium rounded-full border tracking-wide",
+        "inline-flex items-center gap-1 px-2.5 py-0.5 text-[11px] font-medium rounded-full border tracking-wide",
         config.badge,
         className
       )}
     >
-      <span
-        className={cn("h-2 w-2 rounded-full shrink-0", config.dot)}
-        aria-hidden="true"
-      />
+      <span aria-hidden="true" className="text-[10px] leading-none">
+        {config.leaf}
+      </span>
       {config.label}
     </span>
   );


### PR DESCRIPTION
Implements EMR-638.

## What changed
- **`InteractionBadge`** (`src/components/ui/interaction-badge.tsx`): Replaced the colored CSS dot (`h-2 w-2 rounded-full bg-*`) with a leaf emoji per severity — 🍂 Contraindicated, 🌱 Caution, 🌿 Safe
- **Audit trail row indicators** (`src/app/(clinician)/clinic/audit-trail/audit-view.tsx`): Renamed `getActionColor` → `getActionLeaf`; each action type now renders a leaf emoji instead of a colored circle in the timeline rows (🌿 Reads, 🌱 Writes, 🍂 Deletes, 🍃 Other)
- **Audit trail legend**: Same four leaf emojis replace the four colored dots in the footer legend
- **`SemanticBadge` in NavSections** (`src/components/shell/NavSections.tsx`): Renamed `SEVERITY_DOT_CLASS` → `SEVERITY_LEAF`; critical/warn/info nav badges now use 🍂/🌱/🌿 instead of red/amber/accent dots

All `aria-hidden="true"` attributes are preserved so screen readers skip the decorative emojis unchanged.

## How to verify
- Open the Drug Mix / Interaction checker — badges should show 🍂 Contraindicated, 🌱 Caution, 🌿 Safe instead of colored circles
- Open `/clinic/audit-trail` — each log row and the legend footer should show leaf emojis instead of colored dots
- Open the clinician sidebar — any `critical`/`warn`/`info` nav badges should show leaf emojis instead of colored dots

## Notes
- Voice recorder recording light (red pulse dot), telehealth call controls badge, vitals/lab colored backgrounds, and the tiny IconRail absolute-position dot badges are intentionally left as-is — those carry functional/clinical meaning distinct from the tricolor status indicator pattern this ticket targets
- Follow-up: the `IconRail` absolute dot badges (lines 71–73 in `IconRail.tsx`) use the same red/amber/accent severity pattern and could be updated in a follow-on ticket if desired

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtJ5ZLJLw96dpM8sQ3p14o)_