### PR TITLE
EMR-663: Labs review modal — marker trends, patient message preview, PDF

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/ui/avatar";
+import { Printer } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { explainLabValue } from "@/lib/domain/lab-explainer";
 import { LabTooltip } from "@/components/ui/lab-tooltip";
@@ -41,6 +42,7 @@ export interface LabRow {
     receivedAt: string;
     results: Record<string, unknown>;
   } | null;
+  history: Array<{ receivedAt: string; results: Record<string, unknown> }>;
   outreach: {
     id: string;
     patientDraft: string;
@@ -78,6 +80,56 @@ function fmtDate(iso: string) {
 
 function patientLabel(first: string, last: string) {
   return `${first} ${last.charAt(0).toUpperCase()}.`;
+}
+
+function TrendSparkline({
+  name,
+  current,
+  history,
+}: {
+  name: string;
+  current: number;
+  history: Array<{ receivedAt: string; results: Record<string, unknown> }>;
+}) {
+  const priorVals = [...history].reverse().reduce<number[]>((acc, h) => {
+    const m = (h.results as Record<string, MarkerValue>)[name];
+    if (typeof m?.value === "number") acc.push(m.value);
+    return acc;
+  }, []);
+
+  const all = [...priorVals, current];
+  if (all.length < 2) return null;
+
+  const W = 52, H = 20, PAD = 2;
+  const lo = Math.min(...all), hi = Math.max(...all);
+  const span = hi - lo || 1;
+
+  const pts = all.map((v, i) => {
+    const x = PAD + (i / (all.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - lo) / span) * (H - PAD * 2);
+    return { x: x.toFixed(1), y: y.toFixed(1) };
+  });
+  const pStr = pts.map((p) => `${p.x},${p.y}`).join(" ");
+  const last = pts[pts.length - 1];
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      className="inline-block align-middle text-text-subtle"
+      aria-hidden="true"
+    >
+      <polyline
+        points={pStr}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={last.x} cy={last.y} r="2" fill="currentColor" />
+    </svg>
+  );
 }
 
 export function LabsReviewView({ rows }: { rows: LabRow[] }) {
@@ -299,13 +351,24 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
               {row.prior && ` · compared against ${fmtDate(row.prior.receivedAt)}`}
             </p>
           </div>
-          <button
-            onClick={onClose}
-            className="text-text-subtle hover:text-text text-xl leading-none px-2"
-            aria-label="Close"
-          >
-            &times;
-          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="text-text-subtle hover:text-text p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
+              aria-label="Print / Save as PDF"
+              title="Print / Save as PDF"
+            >
+              <Printer className="h-4 w-4" aria-hidden="true" />
+            </button>
+            <button
+              onClick={onClose}
+              className="text-text-subtle hover:text-text text-xl leading-none px-2"
+              aria-label="Close"
+            >
+              &times;
+            </button>
+          </div>
         </div>
 
         {/* Body */}
@@ -320,6 +383,7 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
                     <th className="text-left px-4 py-2 font-medium">Marker</th>
                     <th className="text-right px-4 py-2 font-medium">Current</th>
                     <th className="text-right px-4 py-2 font-medium">Prior</th>
+                    <th className="text-right px-4 py-2 font-medium">Trend</th>
                     <th className="text-right px-4 py-2 font-medium">Reference</th>
                   </tr>
                 </thead>
@@ -388,6 +452,13 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
                               {delta.toFixed(Math.abs(delta) < 1 ? 1 : 0)})
                             </span>
                           )}
+                        </td>
+                        <td className="text-right px-4 py-2.5">
+                          <TrendSparkline
+                            name={name}
+                            current={c.value}
+                            history={row.history}
+                          />
                         </td>
                         <td className="text-right px-4 py-2.5 text-xs text-text-subtle tabular-nums">
                           {c.refLow !== undefined && c.refHigh !== undefined
@@ -495,6 +566,7 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
                   description="Friendly, 6th-grade tone. Sent to the patient's portal or as SMS on sign."
                   value={drafts.patientDraft}
                   onBlur={(v) => saveEdit("patientDraft", v)}
+                  preview
                 />
                 <DraftBlock
                   label="MA task"
@@ -588,11 +660,13 @@ function DraftBlock({
   description,
   value,
   onBlur,
+  preview,
 }: {
   label: string;
   description: string;
   value: string;
   onBlur: (v: string) => void;
+  preview?: boolean;
 }) {
   const [local, setLocal] = useState(value);
   return (
@@ -601,6 +675,18 @@ function DraftBlock({
         {label}
       </label>
       <p className="text-[11px] text-text-subtle mb-1.5">{description}</p>
+      {preview && local && (
+        <div className="mb-3 flex">
+          <div className="rounded-2xl rounded-tl-sm bg-surface-muted px-4 py-3 max-w-[85%]">
+            <p className="text-[10px] text-accent font-medium mb-1">
+              💬 From your care team
+            </p>
+            <p className="text-sm text-text leading-relaxed whitespace-pre-wrap">
+              {local}
+            </p>
+          </div>
+        </div>
+      )}
       <textarea
         value={local}
         onChange={(e) => setLocal(e.target.value)}

--- a/src/app/(clinician)/clinic/sign-off/labs/page.tsx
+++ b/src/app/(clinician)/clinic/sign-off/labs/page.tsx
@@ -33,7 +33,7 @@ export default async function LabsReviewPage() {
   // queue ever grows to hundreds.
   const rows: LabRow[] = await Promise.all(
     pending.map(async (lab) => {
-      const prior = await prisma.labResult.findFirst({
+      const priors = await prisma.labResult.findMany({
         where: {
           patientId: lab.patientId,
           panelName: lab.panelName,
@@ -41,8 +41,10 @@ export default async function LabsReviewPage() {
           receivedAt: { lt: lab.receivedAt },
         },
         orderBy: { receivedAt: "desc" },
+        take: 4,
         select: { id: true, receivedAt: true, results: true },
       });
+      const prior = priors[0] ?? null;
       return {
         id: lab.id,
         patientId: lab.patient.id,
@@ -59,6 +61,10 @@ export default async function LabsReviewPage() {
               results: prior.results as Record<string, unknown>,
             }
           : null,
+        history: priors.map((p) => ({
+          receivedAt: p.receivedAt.toISOString(),
+          results: p.results as Record<string, unknown>,
+        })),
         outreach: lab.outreach
           ? {
               id: lab.outreach.id,


### PR DESCRIPTION
Implements EMR-663.

## What changed
- **`page.tsx`** — Changed `findFirst` → `findMany` (take: 4) for prior results. The first result still populates `prior` (backward compat); all results feed a new `history` field on `LabRow` for sparkline rendering.
- **`labs-review-view.tsx`** — Three additions to the `LabOverlay` modal:
  1. **Marker trend sparklines** — New `TrendSparkline` SVG component renders an inline polyline (oldest→newest, current-value dot) in a new "Trend" column in the results table. Uses `currentColor` / `text-text-subtle` so it respects the design system tokens.
  2. **Print / Save as PDF** — `Printer` icon button added to the overlay header; calls `window.print()`. Consistent with the `TrifoldPrintButton` pattern already in the codebase.
  3. **Friendly patient message preview** — `DraftBlock` gains an optional `preview` prop. When set (patient message only), a live iMessage-style bubble renders above the textarea showing exactly what the patient will receive. Updates in real time as the physician edits.

## How to verify
1. Navigate to `/clinic/sign-off/labs` and click any lab row to open the overlay.
2. Results table now has a **Trend** column — labs with 2+ prior results show an inline sparkline; labs with no history show nothing (gracefully hidden).
3. Click the **🖨 printer icon** in the overlay header — browser print dialog opens; the modal content is printable as a PDF.
4. Click **Looks good — draft outreach** to generate a draft. The **Patient message** section now shows a chat-bubble preview ("💬 From your care team") above the textarea. Edit the textarea — the bubble updates live.
5. MA task and Chart note blocks are unchanged (no preview bubble).

## Notes
- No schema changes, no new dependencies, no middleware touch.
- All typecheck errors in the diff are pre-existing infrastructure errors (missing `node_modules` / `@prisma/client` in the CI env) — same `TS2307`/`TS7026`/`TS7006` pattern present throughout the codebase.
- Follow-up: consider `@media print` CSS to hide the sidebar nav and batch-sign tray when printing the modal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx8giYvxDF6hWpMRUkykRZ)_