### PR TITLE
EMR-652: /telehealth video/plus call entry + ambient mic

### DIFF
--- a/src/app/(clinician)/telehealth/ambient-mic-toggle.tsx
+++ b/src/app/(clinician)/telehealth/ambient-mic-toggle.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { Mic, MicOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function AmbientMicToggle() {
+  const [active, setActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  // Release stream on unmount
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    };
+  }, []);
+
+  const toggle = useCallback(async () => {
+    if (active) {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      setActive(false);
+      setError(null);
+      return;
+    }
+
+    setError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+      streamRef.current = stream;
+      setActive(true);
+    } catch {
+      setError("Microphone permission denied. Allow mic access in your browser settings.");
+    }
+  }, [active]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {active ? (
+            <>
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inset-0 rounded-full bg-danger animate-ping opacity-60" />
+                <span className="relative rounded-full h-2 w-2 bg-danger" />
+              </span>
+              <span className="text-sm font-medium text-danger">Listening…</span>
+            </>
+          ) : (
+            <span className="text-sm text-text-muted">Off</span>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant={active ? "primary" : "secondary"}
+          onClick={() => void toggle()}
+          className={
+            active
+              ? "bg-danger/10 text-danger hover:bg-danger/20 border-danger/30"
+              : undefined
+          }
+        >
+          {active ? (
+            <>
+              <MicOff size={13} className="mr-1.5" /> Stop
+            </>
+          ) : (
+            <>
+              <Mic size={13} className="mr-1.5" /> Enable
+            </>
+          )}
+        </Button>
+      </div>
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+
+      <p className="text-xs text-text-subtle leading-relaxed">
+        Keeps your microphone active between visits for hands-free ambient note
+        capture. Stream is released when you stop or leave the page.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(clinician)/telehealth/page.tsx
+++ b/src/app/(clinician)/telehealth/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Video, Plus } from "lucide-react";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
@@ -14,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { PreVisitChecklistClient } from "./pre-visit-checklist-client";
+import { AmbientMicToggle } from "./ambient-mic-toggle";
 
 export const metadata = { title: "Telehealth" };
 
@@ -104,9 +106,18 @@ export default async function TelehealthDashboardPage() {
         title="Video visits"
         description="Live and scheduled telehealth encounters across your clinic."
         actions={
-          <Badge tone={dailyKeyConfigured ? "success" : "warning"}>
-            {dailyKeyConfigured ? "Daily.co connected" : "Demo mode"}
-          </Badge>
+          <div className="flex items-center gap-3">
+            <Link href="/clinic/patients">
+              <Button size="sm" variant="secondary" title="Select a patient to start a new video call">
+                <Video size={14} className="mr-1.5" />
+                New call
+                <Plus size={11} className="ml-1 opacity-60" />
+              </Button>
+            </Link>
+            <Badge tone={dailyKeyConfigured ? "success" : "warning"}>
+              {dailyKeyConfigured ? "Daily.co connected" : "Demo mode"}
+            </Badge>
+          </div>
         }
       />
 
@@ -294,6 +305,18 @@ export default async function TelehealthDashboardPage() {
             </CardHeader>
             <CardContent>
               <PreVisitChecklistClient />
+            </CardContent>
+          </Card>
+
+          <Card tone="raised">
+            <CardHeader>
+              <CardTitle className="text-base">Ambient mic</CardTitle>
+              <CardDescription>
+                Passive microphone for hands-free note capture between visits.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <AmbientMicToggle />
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
Implements EMR-652.

## What changed
- Added a **"New call +"** button to the `/telehealth` page header actions (Video + Plus icons from lucide-react). Clicking it navigates to `/clinic/patients` so the provider can select a patient and immediately start a video encounter — removing the friction of having to find the patient chart first.
- Created **`AmbientMicToggle`** (`ambient-mic-toggle.tsx`) — a new `"use client"` component that:
  - Requests `getUserMedia({ audio: true })` on enable
  - Holds the mic stream open between visits as a passive ambient listener
  - Shows a pulsing red dot + "Listening…" label while active
  - Stops and releases all tracks on disable or unmount (no stream leaks)
  - Surfaces mic permission errors inline
- Added an **"Ambient mic"** card to the right-column sidebar on the telehealth dashboard, below the pre-visit checklist.

## How to verify
1. Visit `/telehealth` — header actions should show `[New call +]  [Daily.co badge]`
2. Click **New call +** → navigates to `/clinic/patients` (patient search list)
3. In the right sidebar below "Pre-visit checklist", an **"Ambient mic"** card appears
4. Click **Enable** — browser prompts for mic permission; on grant the button turns red, dot pulses, label shows "Listening…"
5. Click **Stop** — mic stream released, indicator clears
6. Navigating away from the page also stops the stream (useEffect cleanup)

## Notes
- `node_modules` absent in this environment; typecheck/lint errors are all pre-existing environment-level issues (no `react`/`next` type declarations), identical to the errors in the existing `pre-visit-checklist-client.tsx`. No new logical errors introduced.
- Follow-up: EMR-653 (pre-visit checklist leaf indicators) is next in queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_016v4gZraB28L8CDMvd9MvLS)_