### PR TITLE
EMR-586: Required-field validation — 'please complete each field' + red border

### DIFF
--- a/src/app/(clinician)/apply/ApplicationForm.tsx
+++ b/src/app/(clinician)/apply/ApplicationForm.tsx
@@ -26,13 +26,28 @@ const STATES = [
   "SD","TN","TX","UT","VT","VA","WA","WV","WI","WY","DC",
 ];
 
+const REQUIRED_FIELD_NAMES = ["firstName", "lastName", "email", "phone", "npi", "bio", "cashRateCents"] as const;
+type RequiredFieldName = (typeof REQUIRED_FIELD_NAMES)[number];
+
 export function ApplicationForm() {
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<ApplicationSubmitResult | null>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [invalidFields, setInvalidFields] = useState<Set<RequiredFieldName>>(new Set());
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
+    const emptyFields = new Set(
+      REQUIRED_FIELD_NAMES.filter((name) => !String(formData.get(name) ?? "").trim())
+    );
+    if (emptyFields.size > 0) {
+      setInvalidFields(emptyFields);
+      setClientError("Please complete each field.");
+      return;
+    }
+    setInvalidFields(new Set());
+    setClientError(null);
     startTransition(async () => {
       const res = await submitClinicianApplication(formData);
       setResult(res);
@@ -41,9 +56,14 @@ export function ApplicationForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-8">
-      <Field label="First name" name="firstName" required errors={result?.fieldErrors?.firstName} />
-      <Field label="Last name" name="lastName" required errors={result?.fieldErrors?.lastName} />
+    <form onSubmit={onSubmit} noValidate className="space-y-8">
+      {clientError && (
+        <p role="alert" className="rounded-lg border border-danger/40 bg-danger/5 px-4 py-3 text-sm font-medium text-danger">
+          {clientError}
+        </p>
+      )}
+      <Field label="First name" name="firstName" required errors={result?.fieldErrors?.firstName} invalid={invalidFields.has("firstName")} />
+      <Field label="Last name" name="lastName" required errors={result?.fieldErrors?.lastName} invalid={invalidFields.has("lastName")} />
 
       <div>
         <label className="block text-sm font-semibold text-text mb-2">
@@ -62,22 +82,30 @@ export function ApplicationForm() {
         </select>
       </div>
 
-      <Field label="Email" name="email" type="email" required errors={result?.fieldErrors?.email} />
-      <Field label="Phone" name="phone" required errors={result?.fieldErrors?.phone} />
-      <Field label="NPI (10 digits)" name="npi" required errors={result?.fieldErrors?.npi} />
+      <Field label="Email" name="email" type="email" required errors={result?.fieldErrors?.email} invalid={invalidFields.has("email")} />
+      <Field label="Phone" name="phone" required errors={result?.fieldErrors?.phone} invalid={invalidFields.has("phone")} />
+      <Field label="NPI (10 digits)" name="npi" required errors={result?.fieldErrors?.npi} invalid={invalidFields.has("npi")} />
 
       <div>
         <label className="block text-sm font-semibold text-text mb-2">
-          Short bio
+          Short bio <span aria-hidden="true" className="text-danger">*</span>
         </label>
         <textarea
           name="bio"
           required
           rows={4}
-          className="w-full px-3 py-2 rounded-xl border border-slate-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+          aria-invalid={invalidFields.has("bio") || undefined}
+          className={`w-full px-3 py-2 rounded-xl border bg-white text-sm focus:outline-none focus:ring-2 transition-colors ${
+            invalidFields.has("bio")
+              ? "border-danger focus:ring-danger/20"
+              : "border-slate-200 focus:ring-accent"
+          }`}
         />
+        {invalidFields.has("bio") && !result?.fieldErrors?.bio && (
+          <p className="text-xs text-danger mt-1">This field is required.</p>
+        )}
         {result?.fieldErrors?.bio && (
-          <p className="text-xs text-red-600 mt-1">
+          <p className="text-xs text-danger mt-1">
             {result.fieldErrors.bio.join(" ")}
           </p>
         )}
@@ -114,6 +142,7 @@ export function ApplicationForm() {
         name="cashRateCents"
         type="number"
         required
+        invalid={invalidFields.has("cashRateCents")}
       />
 
       <button
@@ -125,7 +154,7 @@ export function ApplicationForm() {
       </button>
 
       {result && !result.ok && result.message && (
-        <p className="text-sm text-red-600">{result.message}</p>
+        <p className="text-sm text-danger">{result.message}</p>
       )}
       {result && result.ok && (
         <p className="text-sm text-accent font-semibold">{result.message}</p>
@@ -140,24 +169,37 @@ function Field({
   type = "text",
   required,
   errors,
+  invalid,
 }: {
   label: string;
   name: string;
   type?: string;
   required?: boolean;
   errors?: string[];
+  invalid?: boolean;
 }) {
   return (
     <div>
-      <label className="block text-sm font-semibold text-text mb-2">{label}</label>
+      <label className="block text-sm font-semibold text-text mb-2">
+        {label}
+        {required && <span aria-hidden="true" className="text-danger ml-0.5">*</span>}
+      </label>
       <input
         name={name}
         type={type}
         required={required}
-        className="w-full h-11 px-3 rounded-xl border border-slate-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+        aria-invalid={invalid || undefined}
+        className={`w-full h-11 px-3 rounded-xl border bg-white text-sm focus:outline-none focus:ring-2 transition-colors ${
+          invalid
+            ? "border-danger focus:ring-danger/20"
+            : "border-slate-200 focus:ring-accent"
+        }`}
       />
+      {invalid && !errors && (
+        <p className="text-xs text-danger mt-1">This field is required.</p>
+      )}
       {errors && (
-        <p className="text-xs text-red-600 mt-1">{errors.join(" ")}</p>
+        <p className="text-xs text-danger mt-1">{errors.join(" ")}</p>
       )}
     </div>
   );

--- a/src/app/contact/contact-form.tsx
+++ b/src/app/contact/contact-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { CheckCircle2, Mail } from "lucide-react";
+import { useFormValidation } from "@/hooks/use-form-validation";
 
 const RECIPIENTS = ["neal@leafjourney.com", "scott@leafjourney.com"];
 
@@ -17,6 +18,7 @@ export function ContactForm() {
   const [message, setMessage] = useState("");
   const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const { validate, fieldInvalid } = useFormValidation();
 
   const mailtoHref = `mailto:${RECIPIENTS.join(",")}?subject=${encodeURIComponent(
     subject || "Leafjourney inquiry"
@@ -25,8 +27,8 @@ export function ContactForm() {
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
-    if (!name.trim() || !email.trim() || !message.trim()) {
-      setError("Please fill in your name, email, and message.");
+    if (!validate({ name, email, message })) {
+      setError("Please complete each field.");
       return;
     }
     setStatus("submitting");
@@ -79,7 +81,7 @@ export function ContactForm() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
         <div>
           <label htmlFor="contact-name" className="block text-sm font-medium text-text mb-1.5">
-            Your name
+            Your name <span aria-hidden="true" className="text-danger">*</span>
           </label>
           <input
             id="contact-name"
@@ -88,12 +90,17 @@ export function ContactForm() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
-            className="w-full rounded-lg border border-border bg-surface px-4 py-2.5 text-sm focus:border-accent focus:outline-none"
+            aria-invalid={fieldInvalid(name)}
+            className={`w-full rounded-lg border bg-surface px-4 py-2.5 text-sm focus:outline-none transition-colors ${
+              fieldInvalid(name)
+                ? "border-danger focus:border-danger focus:ring-2 focus:ring-danger/20"
+                : "border-border focus:border-accent"
+            }`}
           />
         </div>
         <div>
           <label htmlFor="contact-email" className="block text-sm font-medium text-text mb-1.5">
-            Email
+            Email <span aria-hidden="true" className="text-danger">*</span>
           </label>
           <input
             id="contact-email"
@@ -103,7 +110,12 @@ export function ContactForm() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            className="w-full rounded-lg border border-border bg-surface px-4 py-2.5 text-sm focus:border-accent focus:outline-none"
+            aria-invalid={fieldInvalid(email)}
+            className={`w-full rounded-lg border bg-surface px-4 py-2.5 text-sm focus:outline-none transition-colors ${
+              fieldInvalid(email)
+                ? "border-danger focus:border-danger focus:ring-2 focus:ring-danger/20"
+                : "border-border focus:border-accent"
+            }`}
           />
         </div>
       </div>
@@ -122,7 +134,7 @@ export function ContactForm() {
       </div>
       <div className="mt-5">
         <label htmlFor="contact-message" className="block text-sm font-medium text-text mb-1.5">
-          Message
+          Message <span aria-hidden="true" className="text-danger">*</span>
         </label>
         <textarea
           id="contact-message"
@@ -131,7 +143,12 @@ export function ContactForm() {
           onChange={(e) => setMessage(e.target.value)}
           required
           rows={7}
-          className="w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm focus:border-accent focus:outline-none resize-none"
+          aria-invalid={fieldInvalid(message)}
+          className={`w-full rounded-lg border bg-surface px-4 py-3 text-sm focus:outline-none resize-none transition-colors ${
+            fieldInvalid(message)
+              ? "border-danger focus:border-danger focus:ring-2 focus:ring-danger/20"
+              : "border-border focus:border-accent"
+          }`}
           placeholder="Tell us about yourself, the role, and how you'd contribute…"
         />
       </div>

--- a/src/hooks/use-form-validation.ts
+++ b/src/hooks/use-form-validation.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Lightweight required-field validation hook.
+ *
+ * Call `validate(fields)` on form submit — it marks the form as
+ * submitted and returns true only if every value is non-empty.
+ * Call `fieldInvalid(value)` per-field to decide whether to show
+ * the red-border / aria-invalid state.
+ */
+export function useFormValidation() {
+  const [submitted, setSubmitted] = useState(false);
+
+  function validate(fields: Record<string, string>): boolean {
+    setSubmitted(true);
+    return Object.values(fields).every((v) => v.trim() !== "");
+  }
+
+  function fieldInvalid(value: string): boolean {
+    return submitted && !value.trim();
+  }
+
+  return { validate, fieldInvalid, submitted };
+}


### PR DESCRIPTION
Implements EMR-586.

## What changed
- **`src/hooks/use-form-validation.ts`** (new): Shared `useFormValidation` hook — `validate(fields)` marks the form as submitted and returns `true` only if all values are non-empty; `fieldInvalid(value)` returns `true` when submitted and the field is blank.
- **`src/app/contact/contact-form.tsx`**: Wired the hook; required fields (name, email, message) now get a `border-danger` ring when left empty on submit. Error copy changed from "Please fill in your name, email, and message." → "Please complete each field." Each required label gains a `*` indicator.
- **`src/app/(clinician)/apply/ApplicationForm.tsx`**: Added client-side pre-flight in `onSubmit` that reads required fields from `FormData`, shows a "Please complete each field." alert banner, and passes an `invalid` prop down to each `Field` instance for per-field red-border + hint text. Short-bio textarea gets the same treatment inline. All `text-red-600` hardcodes replaced with `text-danger` for design-system consistency.

## How to verify
- Navigate to `/contact` and click Send without filling anything in — name, email, and message fields should turn red with a danger ring; banner reads "Please complete each field."
- Fill in name only, submit again — email and message stay red, name clears its error state as you type.
- Navigate to `/apply` and click Submit without filling fields — red borders appear on each blank required field with "This field is required." under each, plus the top banner.
- Fill all required fields and submit — validation passes, server action fires normally.

## Notes
- The hook is intentionally minimal: no field-touched tracking, no cross-field rules. That complexity lives in `OnboardingWizard` which already has its own validation pattern.
- Follow-up: intake screeners (PHQ-9, GAD-7, PCL-5, pain quality) and the SOAP note fragments could adopt the hook in a subsequent pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHYxcrPEtAoEQ8pLYbPw9B)_