### PR TITLE
EMR-658: /clinic/messages — Gmail-style docked compose on patient chart

### DIFF
--- a/src/app/(clinician)/clinic/messages/actions.ts
+++ b/src/app/(clinician)/clinic/messages/actions.ts
@@ -63,6 +63,66 @@ export async function sendClinicReplyAction(
   return { ok: true };
 }
 
+// ---------- Compose new patient thread (EMR-658) ----------
+
+const composeSchema = z.object({
+  patientId: z.string().min(1),
+  subject: z.string().min(1).max(200),
+  body: z.string().min(1).max(5000),
+});
+
+export type ComposeResult =
+  | { ok: true; threadId: string }
+  | { ok: false; error: string };
+
+export async function composePatientMessage(
+  _prev: ComposeResult | null,
+  formData: FormData,
+): Promise<ComposeResult> {
+  const user = await requireUser();
+
+  if (!user.roles.some((r) => r === "clinician" || r === "practice_owner")) {
+    return { ok: false, error: "Unauthorized — clinician role required." };
+  }
+
+  const parsed = composeSchema.safeParse({
+    patientId: formData.get("patientId") as string,
+    subject: (formData.get("subject") as string)?.trim(),
+    body: (formData.get("body") as string)?.trim(),
+  });
+
+  if (!parsed.success) return { ok: false, error: "Please complete all fields." };
+
+  const patient = await prisma.patient.findFirst({
+    where: { id: parsed.data.patientId, organizationId: user.organizationId! },
+    select: { id: true },
+  });
+  if (!patient) return { ok: false, error: "Patient not found." };
+
+  const now = new Date();
+  const thread = await prisma.messageThread.create({
+    data: {
+      patientId: parsed.data.patientId,
+      subject: parsed.data.subject,
+      lastMessageAt: now,
+    },
+    select: { id: true },
+  });
+
+  await prisma.message.create({
+    data: {
+      threadId: thread.id,
+      senderUserId: user.id,
+      status: "sent",
+      body: parsed.data.body,
+      sentAt: now,
+    },
+  });
+
+  revalidatePath("/clinic/messages");
+  return { ok: true, threadId: thread.id };
+}
+
 // ---------- Send reply (Smart Inbox — EMR-153) ----------
 
 const sendReplySchema = z.object({

--- a/src/app/(clinician)/clinic/messages/dock-compose.tsx
+++ b/src/app/(clinician)/clinic/messages/dock-compose.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input, Textarea } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import { composePatientMessage, type ComposeResult } from "./actions";
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function PencilSquareIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+    </svg>
+  );
+}
+
+function MinimizeIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+function RestoreIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="15 3 21 3 21 9" />
+      <polyline points="9 21 3 21 3 15" />
+      <line x1="21" y1="3" x2="14" y2="10" />
+      <line x1="3" y1="21" x2="10" y2="14" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Submit button — reads form pending state
+// ---------------------------------------------------------------------------
+
+function SendButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Sending…" : "Send Message"}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dock component
+// ---------------------------------------------------------------------------
+
+type DockMode = "closed" | "minimized" | "open";
+
+interface Props {
+  patientId: string;
+  patientName: string;
+}
+
+/**
+ * EMR-658 — Gmail-style docked compose panel for use on the patient chart.
+ *
+ * Renders an inline "Message Patient" ghost button (placed in the
+ * quick-actions row) plus a fixed bottom-right compose panel that supports
+ * minimize / restore / close. On successful send the dock closes and the
+ * new thread appears in /clinic/messages.
+ */
+export function MessagePatientDock({ patientId, patientName }: Props) {
+  const [mode, setMode] = useState<DockMode>("closed");
+  const [state, formAction] = useFormState<ComposeResult | null, FormData>(
+    composePatientMessage,
+    null,
+  );
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Close and reset the form after a successful send
+  useEffect(() => {
+    if (state?.ok) {
+      formRef.current?.reset();
+      setMode("closed");
+    }
+  }, [state]);
+
+  const open = () => setMode("open");
+  const close = () => setMode("closed");
+  const toggleMinimize = () =>
+    setMode(mode === "minimized" ? "open" : "minimized");
+
+  return (
+    <>
+      {/* Inline trigger — sits in the quick-actions flex row */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={open}
+        className="inline-flex items-center gap-1.5"
+      >
+        <PencilSquareIcon />
+        Message Patient
+      </Button>
+
+      {/* Docked panel — fixed bottom-right, overlays the page */}
+      {mode !== "closed" && (
+        <div
+          className={cn(
+            "fixed bottom-0 right-6 z-50 w-[380px] rounded-t-xl shadow-2xl",
+            "border border-border bg-surface overflow-hidden",
+            "transition-[height] duration-200 ease-out",
+            mode === "minimized" ? "h-[44px]" : "h-[340px]",
+          )}
+          role="dialog"
+          aria-label={`Message ${patientName}`}
+          aria-modal="false"
+        >
+          {/* Title bar */}
+          <div className="flex items-center h-[44px] bg-surface-muted border-b border-border">
+            {/* Left area: click to toggle minimize */}
+            <button
+              type="button"
+              onClick={toggleMinimize}
+              className="flex-1 min-w-0 px-4 text-left cursor-pointer select-none"
+              aria-label={mode === "minimized" ? "Restore compose" : "Minimize compose"}
+            >
+              <span className="text-xs font-semibold text-text truncate block">
+                Message: {patientName}
+              </span>
+            </button>
+
+            {/* Right: minimize / close controls */}
+            <div className="flex items-center gap-0.5 pr-2 shrink-0">
+              <button
+                type="button"
+                onClick={toggleMinimize}
+                className="p-1.5 rounded hover:bg-surface-raised transition-colors text-text-muted hover:text-text"
+                aria-label={mode === "minimized" ? "Restore" : "Minimize"}
+              >
+                {mode === "minimized" ? <RestoreIcon /> : <MinimizeIcon />}
+              </button>
+              <button
+                type="button"
+                onClick={close}
+                className="p-1.5 rounded hover:bg-surface-raised transition-colors text-text-muted hover:text-text"
+                aria-label="Close compose"
+              >
+                <XIcon />
+              </button>
+            </div>
+          </div>
+
+          {/* Compose body — only rendered when expanded */}
+          {mode === "open" && (
+            <form
+              ref={formRef}
+              action={formAction}
+              className="flex flex-col"
+              style={{ height: "calc(340px - 44px)" }}
+            >
+              <input type="hidden" name="patientId" value={patientId} />
+
+              <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+                <div>
+                  <label className="block text-[11px] font-semibold text-text-subtle uppercase tracking-wide mb-1">
+                    Subject
+                  </label>
+                  <Input
+                    name="subject"
+                    placeholder="Subject…"
+                    required
+                    className="text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-[11px] font-semibold text-text-subtle uppercase tracking-wide mb-1">
+                    Message
+                  </label>
+                  <Textarea
+                    name="body"
+                    rows={5}
+                    placeholder="Write your message to the patient…"
+                    required
+                    className="resize-none text-sm"
+                  />
+                </div>
+                {state?.ok === false && (
+                  <p className="text-xs text-danger">{state.error}</p>
+                )}
+              </div>
+
+              <div className="px-4 py-3 border-t border-border bg-surface flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="text-xs text-text-muted hover:text-text transition-colors"
+                >
+                  Discard
+                </button>
+                <SendButton />
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -37,6 +37,7 @@ import {
 import { CarePlanSection } from "@/components/patient/CarePlanSection";
 import { ChartTaskList } from "@/components/patient/ChartTaskList";
 import { logger } from "@/lib/observability/log";
+import { MessagePatientDock } from "@/app/(clinician)/clinic/messages/dock-compose";
 
 /* ── Types ────────────────────────────────────────────────────── */
 
@@ -486,6 +487,10 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
 
             {/* Quick actions */}
             <div className="flex items-center gap-2 shrink-0 pt-1">
+              <MessagePatientDock
+                patientId={patient.id}
+                patientName={`${patient.firstName} ${patient.lastName}`}
+              />
               <Link href={`/clinic/patients/${params.id}/voice-chart`}>
                 <Button variant="ghost" size="sm">
                   Voice chart


### PR DESCRIPTION
Implements EMR-658.

## What changed

- **`actions.ts`** — New `composePatientMessage` server action: validates patientId/subject/body, verifies the patient belongs to the org, creates a `MessageThread` + first `Message`, and revalidates `/clinic/messages`. Exports a `ComposeResult` type consumed by the dock component.

- **`dock-compose.tsx`** (new) — `MessagePatientDock` client component. Renders two things from a single mount point:
  1. An inline "Message Patient" ghost button (placed in the quick-actions row on the chart).
  2. A fixed bottom-right compose panel (`z-50`, `w-[380px]`) that supports three modes — `closed`, `minimized` (44px title bar only), `open` (full 340px panel). Title bar click and the minimize/restore icon both toggle between minimized and open. Close button dismisses entirely. On successful send the form resets and the dock closes.

- **`patients/[id]/page.tsx`** — Imports `MessagePatientDock` and renders it as the first item in the quick-actions flex row, pre-populated with `patient.id` and `patient.firstName + lastName`.

## How to verify

1. Open any patient chart at `/clinic/patients/[id]`
2. Click **Message Patient** in the top-right quick-actions bar — the docked compose panel slides up from the bottom-right corner
3. Fill in Subject and Message, click **Send Message** — dock closes, thread appears in `/clinic/messages`
4. Click the **−** button (or the title bar) — panel minimizes to just the title bar
5. Click again — panel restores
6. Click **×** — panel closes entirely; chart is fully interactive throughout

## Notes

- The dock is `aria-modal="false"` so screen readers know the chart remains interactive behind it.
- No portal library needed — `position: fixed` achieves the Gmail-style float regardless of DOM nesting.
- `npm run lint` requires the `next` binary which is unavailable in the remote container; lint passes on all other overnight PRs in this environment via the same constraint.
- Follow-up: persist draft body to `localStorage` (keyed by patientId) between dock open/close cycles — carries into EMR-659 polish pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ro2C3EaqJjD9Lqpyw8CLhw)_