### PR TITLE
EMR-616: /clinic/library clickable interaction bubbles

### DIFF
--- a/src/app/(clinician)/clinic/library/interaction-bubbles.tsx
+++ b/src/app/(clinician)/clinic/library/interaction-bubbles.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils/cn";
+import { InteractionBadge } from "@/components/ui/interaction-badge";
+import type { DrugInteraction, Severity } from "@/lib/domain/drug-interactions";
+
+const GROUPS: { severity: Severity; heading: string }[] = [
+  { severity: "red", heading: "Contraindicated" },
+  { severity: "yellow", heading: "Use with caution" },
+  { severity: "green", heading: "No known interaction" },
+];
+
+const BUBBLE: Record<Severity, string> = {
+  red: "bg-red-50 border-red-200 text-danger hover:bg-red-100",
+  yellow: "bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100",
+  green: "bg-emerald-50 border-emerald-200 text-emerald-700 hover:bg-emerald-100",
+};
+
+const RING: Record<Severity, string> = {
+  red: "ring-2 ring-danger/40 ring-offset-1",
+  yellow: "ring-2 ring-amber-400/50 ring-offset-1",
+  green: "ring-2 ring-emerald-400/50 ring-offset-1",
+};
+
+const DOT: Record<Severity, string> = {
+  red: "bg-danger",
+  yellow: "bg-amber-400",
+  green: "bg-emerald-500",
+};
+
+export function InteractionBubbles({
+  interactions,
+}: {
+  interactions: DrugInteraction[];
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const toggle = (key: string) =>
+    setSelected((prev) => (prev === key ? null : key));
+
+  return (
+    <div className="space-y-5">
+      {GROUPS.map(({ severity, heading }) => {
+        const group = interactions.filter((i) => i.severity === severity);
+        if (group.length === 0) return null;
+        const detail = group.find(
+          (i) => `${i.drug}|${i.cannabinoid}` === selected,
+        );
+
+        return (
+          <div key={severity}>
+            <p className="text-xs text-text-subtle uppercase tracking-wider mb-2">
+              {heading} &middot; {group.length}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {group.map((interaction) => {
+                const key = `${interaction.drug}|${interaction.cannabinoid}`;
+                const isOpen = selected === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => toggle(key)}
+                    aria-expanded={isOpen}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full border transition-colors capitalize",
+                      BUBBLE[severity],
+                      isOpen && RING[severity],
+                    )}
+                  >
+                    <span
+                      className={cn("h-1.5 w-1.5 rounded-full shrink-0", DOT[severity])}
+                      aria-hidden="true"
+                    />
+                    {interaction.drug}
+                    <span className="opacity-50 font-normal text-[10px]">
+                      {interaction.cannabinoid}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {detail && (
+              <div className="mt-3 rounded-lg border border-border bg-surface-muted p-4 text-sm">
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <p className="font-medium text-text capitalize">{detail.drug}</p>
+                    <p className="text-xs text-text-muted">
+                      Cannabinoid: {detail.cannabinoid}
+                    </p>
+                  </div>
+                  <InteractionBadge severity={detail.severity} />
+                </div>
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-[10px] text-text-subtle uppercase tracking-wider mb-1">
+                      Mechanism
+                    </p>
+                    <p className="text-text-muted leading-relaxed">{detail.mechanism}</p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-text-subtle uppercase tracking-wider mb-1">
+                      Recommendation
+                    </p>
+                    <p className="text-text-muted leading-relaxed">
+                      {detail.recommendation}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSelected(null)}
+                  className="mt-3 text-[11px] text-text-subtle hover:text-text transition-colors"
+                >
+                  Close ✕
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/library/page.tsx
+++ b/src/app/(clinician)/clinic/library/page.tsx
@@ -1,13 +1,16 @@
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import Link from "next/link";
+import { getAllInteractions } from "@/lib/domain/drug-interactions";
 import { PdfExportButton } from "./pdf-export-button";
+import { InteractionBubbles } from "./interaction-bubbles";
 
 export const metadata = { title: "Clinical Library" };
 
 export default function LibraryPage() {
+  const interactions = getAllInteractions();
   return (
     <PageShell maxWidth="max-w-[960px]">
       <PageHeader
@@ -190,26 +193,13 @@ export default function LibraryPage() {
       <Card tone="raised" className="mb-6">
         <CardHeader>
           <CardTitle>Drug interaction reference</CardTitle>
-          <CardDescription>Cannabis-drug interactions are checked automatically in the Cannabis Rx tab.</CardDescription>
+          <CardDescription>
+            Click any bubble to see mechanism and recommendation.{" "}
+            {interactions.length} interactions in the database — checked automatically when prescribing.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="space-y-3">
-            <div className="flex items-start gap-3">
-              <Badge tone="danger">Red</Badge>
-              <p className="text-sm text-text-muted">Contraindicated: Warfarin (CYP2C9), Clobazam (dramatic CBD interaction, FDA warning)</p>
-            </div>
-            <div className="flex items-start gap-3">
-              <Badge tone="warning">Yellow</Badge>
-              <p className="text-sm text-text-muted">Caution: Opioids (additive CNS depression), Benzodiazepines, SSRIs (CYP2D6), Statins (CYP3A4), Immunosuppressants, Antiepileptics</p>
-            </div>
-            <div className="flex items-start gap-3">
-              <Badge tone="success">Green</Badge>
-              <p className="text-sm text-text-muted">Generally safe: Acetaminophen, Ibuprofen, Vitamin D, Melatonin, Magnesium, Probiotics</p>
-            </div>
-          </div>
-          <p className="text-xs text-text-subtle mt-4">
-            43 interactions in the database. Full interaction check runs automatically when prescribing.
-          </p>
+          <InteractionBubbles interactions={interactions} />
         </CardContent>
       </Card>
 

--- a/src/lib/domain/drug-interactions.ts
+++ b/src/lib/domain/drug-interactions.ts
@@ -84,6 +84,19 @@ export function checkInteractions(
   );
 }
 
+/** Return the full interaction database sorted by severity (red → yellow → green). */
+export function getAllInteractions(): DrugInteraction[] {
+  return (interactionData.interactions as InteractionEntry[])
+    .map((e) => ({
+      drug: e.drug,
+      cannabinoid: e.cannabinoid,
+      severity: e.severity as Severity,
+      mechanism: e.mechanism,
+      recommendation: e.recommendation,
+    }))
+    .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+}
+
 /** Human-readable label for each severity level. */
 export function getSeverityLabel(severity: Severity): string {
   switch (severity) {


### PR DESCRIPTION
Implements EMR-616.

## What changed
- **Clickable interaction bubbles** — replaced the static three-line drug-interaction summary on `/clinic/library` with interactive pill bubbles grouped by severity (red / yellow / green). Clicking any bubble expands an inline detail panel showing the mechanism and clinical recommendation, drawn from all 43 entries in `drug-interactions.json`. One panel open at a time; clicking the same bubble or "Close ✕" collapses it.
- **`getAllInteractions()` domain export** — added a thin getter to `src/lib/domain/drug-interactions.ts` so server components can load the full interaction list without reaching into the JSON path directly.
- **PDF export + terpene pharmacology** — these two EMR-616 sub-features were already present on `main` (`pdf-export-button.tsx` + terpene table in the page); this PR completes the third part of the ticket scope.

## How to verify
1. Navigate to `/clinic/library`
2. Scroll to "Drug interaction reference" — should show coloured pill bubbles grouped under Contraindicated / Use with caution / No known interaction
3. Click any bubble (e.g. "warfarin THC") — an inline panel should expand below the group showing mechanism + recommendation
4. Click a different bubble — previous panel closes, new one opens
5. Click "Close ✕" — panel dismisses
6. Click "Export to PDF" (top right of page header) — browser print dialog opens

## Notes
- All 43 drug-interaction entries are exposed; the bubbles replace the previous static category labels entirely
- No new dependencies; no schema changes
- Pre-existing typecheck errors in `vendor-auth/`, `middleware.ts`, and environment types are not introduced by this PR

## Follow-up
- EMR-617: Drug Mix standalone public module (`/education`)
- EMR-668 / EMR-669: Better multi-source search and ChatCB conversational AI on `/clinic/research`

---
_Generated by [Claude Code](https://claude.ai/code/session_013ku1WsoAWXfC9osdEYHRjf)_