### PR TITLE
EMR-666: iMessage-style split pane + directory search for /clinic/providers/messages

### DIFF
--- a/src/app/(clinician)/clinic/providers/messages/page.tsx
+++ b/src/app/(clinician)/clinic/providers/messages/page.tsx
@@ -1,18 +1,21 @@
-// EMR-033 — Provider-to-Provider Secure Portal (real DB-backed view).
+// EMR-033 / EMR-666 — Provider-to-Provider Secure Portal.
 //
-// Replaces the prior demo. Threads are scoped to the caller's
+// iMessage-style two-pane layout: left = directory-searchable list of
+// peer providers (with any existing thread surfaced inline); right =
+// open thread or compose. Threads are scoped to the caller's
 // organization; bodies are decrypted on the server and shipped to the
-// client component, which never sees ciphertext. A clinician can also
-// start a brand-new thread from this page.
+// client component, which never sees ciphertext.
 
-import Link from "next/link";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
-import { Button } from "@/components/ui/button";
 import { Eyebrow } from "@/components/ui/ornament";
 import { decryptMessageBodySafe } from "@/lib/communications/message-crypto";
-import { ProviderInboxView, type DecryptedThread } from "./view";
+import {
+  ProviderInboxView,
+  type DecryptedThread,
+  type DirectoryProvider,
+} from "./view";
 
 export const metadata = { title: "Provider Messages" };
 
@@ -91,7 +94,7 @@ export default async function ProviderMessagesPage() {
     };
   });
 
-  // Co-providers in same org for the "new thread" form.
+  // Co-providers in same org for the directory + composer.
   const providers = await prisma.provider.findMany({
     where: {
       organizationId: orgId,
@@ -104,36 +107,33 @@ export default async function ProviderMessagesPage() {
     orderBy: { createdAt: "asc" },
   });
 
-  const recipientOptions = providers.map((p) => ({
+  const directory: DirectoryProvider[] = providers.map((p) => ({
     userId: p.user.id,
-    name: `${p.user.firstName} ${p.user.lastName}`,
-    title: p.title ?? null,
+    firstName: p.user.firstName,
+    lastName: p.user.lastName,
+    title: p.title,
+    specialties: p.specialties,
+    practiceAddress: p.practiceAddress,
+    hospitalAffiliations: p.hospitalAffiliations,
   }));
 
   return (
     <PageShell maxWidth="max-w-[1280px]">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <Eyebrow className="mb-2">Secure provider channel</Eyebrow>
-          <h1 className="font-display text-2xl text-text tracking-tight">
-            Provider-to-Provider Messaging
-          </h1>
-          <p className="text-sm text-text-muted mt-1">
-            HIPAA-compliant internal communication between providers about
-            patient care. Messages are encrypted at rest.
-          </p>
-        </div>
-        <Link href="/clinic/providers">
-          <Button variant="secondary" size="sm">
-            Provider directory
-          </Button>
-        </Link>
+      <div className="mb-6">
+        <Eyebrow className="mb-2">Secure provider channel</Eyebrow>
+        <h1 className="font-display text-2xl text-text tracking-tight">
+          Provider-to-Provider Messaging
+        </h1>
+        <p className="text-sm text-text-muted mt-1">
+          View and contact providers in your organization. Messages are
+          encrypted at rest and visible only to participants.
+        </p>
       </div>
 
       <ProviderInboxView
         threads={decrypted}
         currentUserId={user.id}
-        recipientOptions={recipientOptions}
+        directory={directory}
       />
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/providers/messages/view.tsx
+++ b/src/app/(clinician)/clinic/providers/messages/view.tsx
@@ -1,26 +1,30 @@
 "use client";
 
-// EMR-033 — client view for the provider-to-provider portal.
-// Renders the thread list / detail panes and the "new conversation"
-// composer. Plays the same role as `smart-inbox.tsx` does for the
-// patient inbox.
+// EMR-033 / EMR-666 — client view for the provider-to-provider portal.
+//
+// iMessage-style split pane: left = directory search + provider list
+// (with chat indicators), right = active thread or new-conversation
+// composer. Click a provider row in the left pane to open their thread,
+// or click the (i) badge to surface the provider info pop-up with
+// Secure Message + Secure Call actions.
 
-import { useState, useTransition, useRef, useEffect } from "react";
+import { useState, useTransition, useRef, useEffect, useMemo } from "react";
 import { useFormState } from "react-dom";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input, Textarea } from "@/components/ui/input";
 import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { EmptyState } from "@/components/ui/empty-state";
-import { LeafSprig } from "@/components/ui/ornament";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { formatRelative } from "@/lib/utils/format";
+import {
+  providerMatchesQuery,
+  type SearchableProvider,
+} from "@/lib/search/provider-search";
 import {
   createProviderThread,
   sendProviderReply,
@@ -45,143 +49,366 @@ export interface DecryptedThread {
   }[];
 }
 
-interface RecipientOption {
+export interface DirectoryProvider extends SearchableProvider {
   userId: string;
-  name: string;
-  title: string | null;
 }
 
 interface Props {
   threads: DecryptedThread[];
   currentUserId: string;
-  recipientOptions: RecipientOption[];
+  directory: DirectoryProvider[];
 }
 
-export function ProviderInboxView({
-  threads,
-  currentUserId,
-  recipientOptions,
-}: Props) {
-  const [activeId, setActiveId] = useState<string | null>(threads[0]?.id ?? null);
-  const [composing, setComposing] = useState(false);
+// One row in the left pane — either an existing thread (preferred) or
+// a directory-only provider (no chat yet, so clicking opens compose).
+type LeftPaneRow =
+  | { kind: "thread"; thread: DecryptedThread; peer: DirectoryProvider | null }
+  | { kind: "directory"; provider: DirectoryProvider };
 
-  const active = threads.find((t) => t.id === activeId) ?? null;
+type RightPane =
+  | { kind: "thread"; threadId: string }
+  | { kind: "compose"; prefillUserId: string | null }
+  | { kind: "empty" };
 
-  // Mark thread read when a thread becomes active.
+export function ProviderInboxView({ threads, currentUserId, directory }: Props) {
+  const [search, setSearch] = useState("");
+  const [right, setRight] = useState<RightPane>(
+    threads[0] ? { kind: "thread", threadId: threads[0].id } : { kind: "empty" },
+  );
+  const [popupUserId, setPopupUserId] = useState<string | null>(null);
+
+  // Build merged left-pane list: every existing thread first (in chat
+  // order), then any directory-only providers we haven't messaged yet.
+  // Filter by the same partial-match query used by /clinic/providers so
+  // search feels consistent across the surface (EMR-613).
+  const rows: LeftPaneRow[] = useMemo(() => {
+    const peerByUserId = new Map(directory.map((p) => [p.userId, p]));
+    const messagedUserIds = new Set<string>();
+    const threadRows: LeftPaneRow[] = threads.map((t) => {
+      const peerId = t.participants[0]?.userId ?? null;
+      if (peerId) messagedUserIds.add(peerId);
+      return {
+        kind: "thread",
+        thread: t,
+        peer: peerId ? (peerByUserId.get(peerId) ?? null) : null,
+      };
+    });
+    const directoryRows: LeftPaneRow[] = directory
+      .filter((p) => !messagedUserIds.has(p.userId))
+      .map((p) => ({ kind: "directory", provider: p }));
+    const all = [...threadRows, ...directoryRows];
+    if (!search.trim()) return all;
+    return all.filter((row) => {
+      if (row.kind === "thread") {
+        // Subject + patient name + peer fields are all fair game.
+        if (row.thread.subject.toLowerCase().includes(search.toLowerCase()))
+          return true;
+        if (
+          row.thread.patient?.name.toLowerCase().includes(search.toLowerCase())
+        )
+          return true;
+        return row.peer ? providerMatchesQuery(row.peer, search) : false;
+      }
+      return providerMatchesQuery(row.provider, search);
+    });
+  }, [threads, directory, search]);
+
+  const activeThread =
+    right.kind === "thread"
+      ? threads.find((t) => t.id === right.threadId) ?? null
+      : null;
+
+  // Mark thread read when it becomes active.
   useEffect(() => {
-    if (active && active.unreadCount > 0) {
-      void markProviderThreadRead(active.id);
+    if (activeThread && activeThread.unreadCount > 0) {
+      void markProviderThreadRead(activeThread.id);
     }
-  }, [active]);
+  }, [activeThread]);
 
-  if (threads.length === 0 && !composing) {
-    return (
-      <div className="space-y-4">
-        <EmptyState
-          title="No provider conversations yet"
-          description="Start a secure conversation with another provider in your organization."
-        />
-        <div className="flex justify-center">
-          <Button onClick={() => setComposing(true)}>Start a conversation</Button>
-        </div>
-      </div>
-    );
-  }
+  const popupProvider = popupUserId
+    ? directory.find((p) => p.userId === popupUserId) ?? null
+    : null;
 
   return (
-    <div className="grid grid-cols-12 gap-6 min-h-[600px]">
-      {/* Thread list */}
-      <div className="col-span-4 flex flex-col gap-4">
-        <Button onClick={() => setComposing(true)} variant="primary">
-          New conversation
-        </Button>
-        <Card tone="raised" className="flex-1 overflow-hidden">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center gap-2">
-              <LeafSprig size={14} className="text-accent" />
-              Conversations
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-1 px-2 max-h-[640px] overflow-y-auto">
-            {threads.map((t) => {
-              const last = t.messages[t.messages.length - 1];
-              const peerName = t.participants[0]?.name ?? "Provider";
-              const isActive = t.id === activeId;
-              return (
-                <button
-                  key={t.id}
-                  onClick={() => {
-                    setComposing(false);
-                    setActiveId(t.id);
-                  }}
-                  className={`w-full text-left rounded-xl px-4 py-3 transition-all ${
-                    isActive && !composing
-                      ? "bg-accent/10 border border-accent/20"
-                      : "hover:bg-surface-muted border border-transparent"
-                  }`}
-                >
-                  <div className="flex items-start gap-3">
-                    <Avatar
-                      firstName={peerName.split(" ")[0]}
-                      lastName={peerName.split(" ").slice(-1)[0]}
-                      size="sm"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center justify-between gap-2">
-                        <p className="text-sm font-medium text-text truncate">
-                          {peerName}
-                        </p>
-                        {t.unreadCount > 0 && (
-                          <span className="h-2 w-2 rounded-full bg-accent shrink-0" />
-                        )}
-                      </div>
-                      <p className="text-[11px] text-text-subtle truncate">
-                        {t.subject}
-                      </p>
-                      {last && (
-                        <p className="text-xs text-text-muted mt-1 line-clamp-2 leading-relaxed">
-                          {last.body}
-                        </p>
-                      )}
-                      <p className="text-[10px] text-text-subtle mt-1">
-                        {formatRelative(t.lastMessageAt)}
-                        {t.patient ? ` · ${t.patient.name}` : ""}
-                      </p>
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Right pane: compose or thread detail */}
-      <div className="col-span-8 flex flex-col">
-        {composing ? (
-          <NewConversationCard
-            recipientOptions={recipientOptions}
-            onCancel={() => setComposing(false)}
-            onCreated={(threadId) => {
-              setComposing(false);
-              setActiveId(threadId);
-            }}
+    <div className="grid grid-cols-12 gap-0 min-h-[640px] rounded-2xl border border-border overflow-hidden bg-surface">
+      {/* Left pane — directory search + chat list */}
+      <aside className="col-span-4 border-r border-border flex flex-col bg-surface-muted/40">
+        <div className="p-3 border-b border-border">
+          <Input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search name, specialty, address, hospital…"
+            aria-label="Search providers"
           />
-        ) : active ? (
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {rows.length === 0 ? (
+            <p className="text-xs text-text-subtle p-4">
+              No providers match your search.
+            </p>
+          ) : (
+            <ul className="divide-y divide-border/60">
+              {rows.map((row) => (
+                <DirectoryRow
+                  key={
+                    row.kind === "thread"
+                      ? `t-${row.thread.id}`
+                      : `d-${row.provider.userId}`
+                  }
+                  row={row}
+                  active={
+                    right.kind === "thread" && row.kind === "thread"
+                      ? right.threadId === row.thread.id
+                      : right.kind === "compose" && row.kind === "directory"
+                        ? right.prefillUserId === row.provider.userId
+                        : false
+                  }
+                  onSelect={() => {
+                    if (row.kind === "thread") {
+                      setRight({ kind: "thread", threadId: row.thread.id });
+                    } else {
+                      setRight({
+                        kind: "compose",
+                        prefillUserId: row.provider.userId,
+                      });
+                    }
+                  }}
+                  onInfo={(userId) => setPopupUserId(userId)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+
+      {/* Right pane — active thread or composer */}
+      <section className="col-span-8 flex flex-col bg-surface">
+        {right.kind === "compose" ? (
+          <NewConversationCard
+            directory={directory}
+            prefillUserId={right.prefillUserId}
+            onCancel={() =>
+              setRight(
+                threads[0]
+                  ? { kind: "thread", threadId: threads[0].id }
+                  : { kind: "empty" },
+              )
+            }
+            onCreated={(threadId) =>
+              setRight({ kind: "thread", threadId })
+            }
+          />
+        ) : activeThread ? (
           <ThreadDetail
-            thread={active}
+            thread={activeThread}
             currentUserId={currentUserId}
-            recipientOptions={recipientOptions}
+            directory={directory}
+            onPeerInfo={(userId) => setPopupUserId(userId)}
           />
         ) : (
-          <Card tone="raised" className="flex-1 flex items-center justify-center">
-            <p className="text-sm text-text-muted">
-              Select a conversation to view messages.
+          <div className="flex-1 flex items-center justify-center text-center px-8">
+            <div>
+              <p className="text-sm text-text-muted">
+                Select a provider on the left to start or continue a
+                conversation.
+              </p>
+              <p className="text-[11px] text-text-subtle mt-2">
+                HIPAA-secure · encrypted at rest
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Provider info pop-up */}
+      <Dialog
+        open={!!popupProvider}
+        onOpenChange={(next) => {
+          if (!next) setPopupUserId(null);
+        }}
+      >
+        {popupProvider && (
+          <ProviderInfoDialog
+            provider={popupProvider}
+            onMessage={() => {
+              setPopupUserId(null);
+              // Reuse existing thread if there is one, else compose.
+              const existing = threads.find(
+                (t) => t.participants[0]?.userId === popupProvider.userId,
+              );
+              if (existing) {
+                setRight({ kind: "thread", threadId: existing.id });
+              } else {
+                setRight({
+                  kind: "compose",
+                  prefillUserId: popupProvider.userId,
+                });
+              }
+            }}
+          />
+        )}
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left-pane row
+// ---------------------------------------------------------------------------
+
+function DirectoryRow({
+  row,
+  active,
+  onSelect,
+  onInfo,
+}: {
+  row: LeftPaneRow;
+  active: boolean;
+  onSelect: () => void;
+  onInfo: (userId: string) => void;
+}) {
+  const name =
+    row.kind === "thread"
+      ? row.peer
+        ? `${row.peer.firstName} ${row.peer.lastName}`
+        : row.thread.participants[0]?.name ?? "Provider"
+      : `${row.provider.firstName} ${row.provider.lastName}`;
+  const specialty =
+    row.kind === "thread"
+      ? row.peer?.specialties[0] ?? row.peer?.title ?? null
+      : row.provider.specialties[0] ?? row.provider.title ?? null;
+  const peerUserId =
+    row.kind === "thread"
+      ? row.thread.participants[0]?.userId ?? null
+      : row.provider.userId;
+  const last = row.kind === "thread" ? row.thread.messages.at(-1) : null;
+  const unread = row.kind === "thread" ? row.thread.unreadCount : 0;
+
+  return (
+    <li>
+      <div
+        className={`relative flex items-start gap-3 px-4 py-3 cursor-pointer transition-colors ${
+          active ? "bg-accent/10" : "hover:bg-surface-muted"
+        }`}
+        onClick={onSelect}
+      >
+        <Avatar
+          firstName={name.split(" ")[0]}
+          lastName={name.split(" ").slice(-1)[0]}
+          size="sm"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium text-text truncate">{name}</p>
+            {unread > 0 && (
+              <span className="h-2 w-2 rounded-full bg-accent shrink-0" />
+            )}
+          </div>
+          {specialty && (
+            <p className="text-[11px] text-text-subtle truncate">{specialty}</p>
+          )}
+          {last ? (
+            <p className="text-xs text-text-muted mt-1 line-clamp-1">
+              {last.body}
             </p>
-          </Card>
+          ) : (
+            <p className="text-[11px] text-text-subtle mt-1 italic">
+              No messages yet
+            </p>
+          )}
+          {row.kind === "thread" && (
+            <p className="text-[10px] text-text-subtle mt-0.5">
+              {formatRelative(row.thread.lastMessageAt)}
+            </p>
+          )}
+        </div>
+        {peerUserId && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onInfo(peerUserId);
+            }}
+            aria-label={`Show provider info for ${name}`}
+            className="shrink-0 h-6 w-6 rounded-full border border-border bg-surface text-text-subtle hover:text-text hover:border-accent/50 transition-colors text-[11px] font-semibold flex items-center justify-center"
+          >
+            i
+          </button>
         )}
       </div>
-    </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Provider info pop-up
+// ---------------------------------------------------------------------------
+
+function ProviderInfoDialog({
+  provider,
+  onMessage,
+}: {
+  provider: DirectoryProvider;
+  onMessage: () => void;
+}) {
+  const fullName = `${provider.firstName} ${provider.lastName}`;
+  return (
+    <DialogContent className="max-w-md">
+      <DialogHeader>
+        <DialogTitle>{fullName}</DialogTitle>
+        {provider.title && (
+          <p className="text-sm text-text-muted">{provider.title}</p>
+        )}
+      </DialogHeader>
+
+      <div className="flex items-start gap-4">
+        <Avatar
+          firstName={provider.firstName}
+          lastName={provider.lastName}
+          size="lg"
+        />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          {provider.specialties.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {provider.specialties.map((s) => (
+                <Badge key={s} tone="accent">
+                  {s}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {provider.hospitalAffiliations.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {provider.hospitalAffiliations.map((h) => (
+                <Badge key={h} tone="neutral">
+                  {h}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {provider.practiceAddress && (
+        <div className="mt-4 text-xs text-text-muted whitespace-pre-line leading-relaxed">
+          {provider.practiceAddress}
+        </div>
+      )}
+
+      <p className="text-[11px] text-text-subtle mt-3">
+        Phone, fax, website, and profile photo populate once the provider
+        completes their public-directory profile.
+      </p>
+
+      <div className="mt-5 flex items-center gap-2 justify-end">
+        <CallLaunchButtons
+          providerUserId={provider.userId}
+          counterpartyName={fullName}
+        />
+        <Button onClick={onMessage}>Secure message</Button>
+      </div>
+    </DialogContent>
   );
 }
 
@@ -190,16 +417,21 @@ export function ProviderInboxView({
 // ---------------------------------------------------------------------------
 
 function NewConversationCard({
-  recipientOptions,
+  directory,
+  prefillUserId,
   onCancel,
   onCreated,
 }: {
-  recipientOptions: RecipientOption[];
+  directory: DirectoryProvider[];
+  prefillUserId: string | null;
   onCancel: () => void;
   onCreated: (threadId: string) => void;
 }) {
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const prefill = prefillUserId
+    ? directory.find((p) => p.userId === prefillUserId) ?? null
+    : null;
 
   function onSubmit(formData: FormData) {
     setError(null);
@@ -214,96 +446,109 @@ function NewConversationCard({
   }
 
   return (
-    <Card tone="raised" className="flex-1 flex flex-col">
-      <CardHeader>
-        <CardTitle className="text-base">New secure conversation</CardTitle>
-        <CardDescription className="text-xs">
-          Pick at least one provider in your organization. Bodies are encrypted
-          at rest.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex-1 flex flex-col">
-        <form action={onSubmit} className="space-y-4 flex-1 flex flex-col">
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-text-muted">Subject</label>
-            <Input name="subject" required maxLength={200} placeholder="e.g. Maya Reyes — review CBD ratio" />
-          </div>
+    <form
+      action={onSubmit}
+      className="flex-1 flex flex-col"
+    >
+      <header className="px-5 py-4 border-b border-border">
+        <h2 className="text-base font-semibold text-text">
+          New secure conversation
+          {prefill && (
+            <span className="text-text-muted font-normal">
+              {" "}
+              with {prefill.firstName} {prefill.lastName}
+            </span>
+          )}
+        </h2>
+        <p className="text-xs text-text-muted mt-0.5">
+          Bodies are encrypted at rest. Visible only to participants in your
+          organization.
+        </p>
+      </header>
 
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-text-muted">
-              Recipients
-            </label>
-            <div className="border border-border rounded-md max-h-40 overflow-y-auto divide-y divide-border/60">
-              {recipientOptions.length === 0 ? (
-                <p className="text-xs text-text-subtle p-3">
-                  No other active providers in your organization.
-                </p>
-              ) : (
-                recipientOptions.map((r) => (
-                  <label
-                    key={r.userId}
-                    className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-surface-muted"
-                  >
-                    <input
-                      type="checkbox"
-                      name="recipientUserIds"
-                      value={r.userId}
-                      className="h-4 w-4"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-text truncate">{r.name}</p>
-                      {r.title && (
-                        <p className="text-[11px] text-text-subtle truncate">
-                          {r.title}
-                        </p>
-                      )}
-                    </div>
-                  </label>
-                ))
-              )}
-            </div>
-          </div>
+      <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-text-muted">Subject</label>
+          <Input
+            name="subject"
+            required
+            maxLength={200}
+            placeholder="e.g. Maya Reyes — review CBD ratio"
+          />
+        </div>
 
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-text-muted">
-              Patient context (optional)
-            </label>
-            <Input
-              name="patientId"
-              placeholder="Patient ID (optional)"
-              maxLength={64}
-            />
-            <p className="text-[10px] text-text-subtle">
-              When attached, the conversation is linked to that chart for the
-              audit log.
-            </p>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-text-muted">
+            Recipients
+          </label>
+          <div className="border border-border rounded-md max-h-48 overflow-y-auto divide-y divide-border/60">
+            {directory.length === 0 ? (
+              <p className="text-xs text-text-subtle p-3">
+                No other active providers in your organization.
+              </p>
+            ) : (
+              directory.map((r) => (
+                <label
+                  key={r.userId}
+                  className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-surface-muted"
+                >
+                  <input
+                    type="checkbox"
+                    name="recipientUserIds"
+                    value={r.userId}
+                    defaultChecked={r.userId === prefillUserId}
+                    className="h-4 w-4"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-text truncate">
+                      {r.firstName} {r.lastName}
+                    </p>
+                    {(r.specialties[0] || r.title) && (
+                      <p className="text-[11px] text-text-subtle truncate">
+                        {r.specialties[0] ?? r.title}
+                      </p>
+                    )}
+                  </div>
+                </label>
+              ))
+            )}
           </div>
+        </div>
 
-          <div className="flex-1 flex flex-col space-y-1.5">
-            <label className="text-xs font-medium text-text-muted">Message</label>
-            <Textarea
-              name="initialBody"
-              required
-              rows={6}
-              maxLength={5000}
-              placeholder="Type your secure message…"
-              className="flex-1"
-            />
-          </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-text-muted">
+            Patient context (optional)
+          </label>
+          <Input
+            name="patientId"
+            placeholder="Patient ID (optional)"
+            maxLength={64}
+          />
+        </div>
 
-          {error && <p className="text-xs text-danger">{error}</p>}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-text-muted">Message</label>
+          <Textarea
+            name="initialBody"
+            required
+            rows={6}
+            maxLength={5000}
+            placeholder="Type your secure message…"
+          />
+        </div>
 
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="secondary" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={pending}>
-              {pending ? "Sending…" : "Send message"}
-            </Button>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+        {error && <p className="text-xs text-danger">{error}</p>}
+      </div>
+
+      <footer className="border-t border-border px-5 py-3 flex justify-end gap-2 bg-surface-muted/40">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={pending}>
+          {pending ? "Sending…" : "Send"}
+        </Button>
+      </footer>
+    </form>
   );
 }
 
@@ -314,83 +559,96 @@ function NewConversationCard({
 function ThreadDetail({
   thread,
   currentUserId,
-  recipientOptions,
+  directory,
+  onPeerInfo,
 }: {
   thread: DecryptedThread;
   currentUserId: string;
-  recipientOptions: RecipientOption[];
+  directory: DirectoryProvider[];
+  onPeerInfo: (userId: string) => void;
 }) {
-  const peerName = thread.participants[0]?.name ?? "Provider";
-  // For 1:1 threads, take the call counterparty as the other participant.
   const oneOnOnePeer =
     thread.participants.length === 1 ? thread.participants[0] : null;
   const peerProvider = oneOnOnePeer
-    ? recipientOptions.find((r) => r.userId === oneOnOnePeer.userId)
+    ? directory.find((p) => p.userId === oneOnOnePeer.userId)
     : null;
+  const peerName = oneOnOnePeer?.name ?? "Provider";
+  // Auto-scroll to newest message on thread open / new reply.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [thread.id, thread.messages.length]);
 
   return (
-    <Card tone="raised" className="flex-1 flex flex-col">
-      <CardHeader className="pb-3 border-b border-border">
-        <div className="flex items-center gap-3">
-          <Avatar
-            firstName={peerName.split(" ")[0]}
-            lastName={peerName.split(" ").slice(-1)[0]}
-            size="md"
-          />
-          <div className="min-w-0 flex-1">
-            <CardTitle className="text-base truncate">{thread.subject}</CardTitle>
-            <CardDescription className="text-xs">
-              {thread.participants.map((p) => p.name).join(", ")}
-              {thread.patient && (
-                <>
-                  <span className="mx-1">·</span>
-                  <span>Re: {thread.patient.name}</span>
-                </>
-              )}
-            </CardDescription>
-          </div>
-            <div className="flex items-center gap-2">
-            {oneOnOnePeer && peerProvider && (
-              <CallLaunchButtons
-                providerUserId={oneOnOnePeer.userId}
-                providerMessageThreadId={thread.id}
-                counterpartyName={peerProvider.name}
-              />
+    <div className="flex-1 flex flex-col">
+      <header className="px-5 py-3 border-b border-border flex items-center gap-3">
+        <Avatar
+          firstName={peerName.split(" ")[0]}
+          lastName={peerName.split(" ").slice(-1)[0]}
+          size="md"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-text truncate">
+              {peerName}
+            </h2>
+            {oneOnOnePeer && (
+              <button
+                type="button"
+                onClick={() => onPeerInfo(oneOnOnePeer.userId)}
+                aria-label={`Show provider info for ${peerName}`}
+                className="h-5 w-5 rounded-full border border-border bg-surface text-text-subtle hover:text-text hover:border-accent/50 transition-colors text-[10px] font-semibold flex items-center justify-center"
+              >
+                i
+              </button>
             )}
-            <Badge tone="success">HIPAA Secure</Badge>
-            <Badge tone="neutral">Encrypted at rest</Badge>
-            <label className="flex items-center gap-1.5 ml-2 cursor-pointer border border-border px-2 py-1 rounded-full bg-surface">
-              <input type="checkbox" className="h-3 w-3 accent-emerald-600" defaultChecked />
-              <span className="text-[10px] font-medium text-text">SMS Opt-In</span>
-            </label>
           </div>
+          <p className="text-[11px] text-text-subtle truncate">
+            {thread.subject}
+            {thread.patient ? ` · Re: ${thread.patient.name}` : ""}
+          </p>
         </div>
-      </CardHeader>
+        <div className="flex items-center gap-2 shrink-0">
+          {oneOnOnePeer && peerProvider && (
+            <CallLaunchButtons
+              providerUserId={oneOnOnePeer.userId}
+              providerMessageThreadId={thread.id}
+              counterpartyName={`${peerProvider.firstName} ${peerProvider.lastName}`}
+            />
+          )}
+          <Badge tone="success">HIPAA</Badge>
+        </div>
+      </header>
 
-      <CardContent className="flex-1 overflow-y-auto py-6 space-y-4">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-6 space-y-3 bg-surface-muted/30">
         {thread.messages.map((msg) => {
           const isOwn = msg.senderUserId === currentUserId;
           return (
             <div
               key={msg.id}
-              className={`flex gap-3 ${isOwn ? "flex-row-reverse" : ""}`}
+              className={`flex gap-2 ${isOwn ? "flex-row-reverse" : ""}`}
             >
-              <Avatar
-                firstName={msg.senderName.split(" ")[0] ?? "P"}
-                lastName={msg.senderName.split(" ").slice(-1)[0] ?? ""}
-                size="sm"
-              />
               <div
                 className={`max-w-[70%] rounded-2xl px-4 py-2 shadow-sm ${
                   isOwn
-                    ? "bg-blue-500 text-white rounded-tr-sm"
-                    : "bg-surface-raised border border-border text-text rounded-tl-sm"
+                    ? "bg-blue-500 text-white rounded-br-sm"
+                    : "bg-surface border border-border text-text rounded-bl-sm"
                 }`}
               >
-                <p className={`text-sm leading-relaxed whitespace-pre-wrap ${isOwn ? "text-white" : "text-text"}`}>
+                <p
+                  className={`text-sm leading-relaxed whitespace-pre-wrap ${
+                    isOwn ? "text-white" : "text-text"
+                  }`}
+                >
                   {msg.body}
                 </p>
-                <p className={`text-[10px] mt-1.5 ${isOwn ? "text-blue-100" : "text-text-subtle"}`}>
+                <p
+                  className={`text-[10px] mt-1 ${
+                    isOwn ? "text-blue-100" : "text-text-subtle"
+                  }`}
+                >
                   {isOwn ? "Delivered" : msg.senderName} ·{" "}
                   {formatRelative(msg.createdAt)}
                 </p>
@@ -398,15 +656,15 @@ function ThreadDetail({
             </div>
           );
         })}
-      </CardContent>
+      </div>
 
       <ReplyComposer threadId={thread.id} />
-    </Card>
+    </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Reply composer (uses sendProviderReply server action)
+// Reply composer (Cancel / Send pair, per ticket)
 // ---------------------------------------------------------------------------
 
 function ReplyComposer({ threadId }: { threadId: string }) {
@@ -424,28 +682,37 @@ function ReplyComposer({ threadId }: { threadId: string }) {
     <form
       ref={formRef}
       action={formAction}
-      className="border-t border-border p-4 flex flex-col gap-2"
+      className="border-t border-border p-3 flex flex-col gap-2 bg-surface"
     >
       <input type="hidden" name="threadId" value={threadId} />
-      <div className="flex gap-3 items-end">
-        <Textarea
-          name="body"
-          rows={2}
-          placeholder="Type a secure reply…"
-          required
-          maxLength={5000}
-          className="flex-1 resize-none"
-        />
-        <Button type="submit" size="md">
-          Send
-        </Button>
-      </div>
+      <Textarea
+        name="body"
+        rows={2}
+        placeholder="Type a secure reply…"
+        required
+        maxLength={5000}
+        className="resize-none"
+      />
       {state?.ok === false && (
         <p className="text-xs text-danger">{state.error}</p>
       )}
-      <p className="text-[10px] text-text-subtle">
-        Encrypted at rest. Visible only to participants in your organization.
-      </p>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[10px] text-text-subtle">
+          Encrypted at rest · participants only
+        </p>
+        <div className="flex gap-2">
+          <Button
+            type="reset"
+            variant="secondary"
+            size="sm"
+          >
+            Cancel
+          </Button>
+          <Button type="submit" size="sm">
+            Send
+          </Button>
+        </div>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
Implements EMR-666.

## What changed
- `/clinic/providers/messages` is now an iMessage-style two-pane layout. Left pane has the directory search box at top and a unified list of (a) existing peer chats and (b) directory-only providers I have not messaged yet, sorted by recency then by directory order.
- Search filters by partial first name, last name, specialty, practice address, and hospital affiliation, sharing the same `providerMatchesQuery` helper that powers `/clinic/providers` so behavior is consistent across the surface.
- Right pane renders either the active thread (auto-scrolled to newest, with reply composer that exposes the explicit **Cancel / Send** footer the ticket calls for) or the new-conversation composer when the row has no existing thread yet.
- Provider info pop-up via the shared `Dialog` component: shows name, specialty, practice address, hospital affiliations, and an explainer for the still-unpopulated phone / fax / website / photo fields. Buttons: **Secure Message** (jumps the right pane to that provider's thread or compose) and **Secure Call** via the existing `CallLaunchButtons` (phone + video). Dialog already implements X + outside-click "Are you sure?" close.
- Page header tightened so the directory feel reads as a single contiguous chat surface.

## How to verify
- Sign in as a clinician with at least one peer provider, visit `/clinic/providers/messages`.
- Confirm the left pane shows directory search at top, then a row per provider; existing chats sort first.
- Type "endo", "cardio", a hospital name, or a partial street name into the search box — list should narrow correctly.
- Click a directory-only provider row → right pane opens the composer with that provider pre-selected; Cancel returns to most recent thread; Send creates the thread and opens it.
- Click an existing chat row → right pane shows the full scrollable thread side-by-side; the **i** badge in the header opens the provider info pop-up.
- In the pop-up, **Secure Message** closes the dialog and jumps to that thread (or compose if none); **Secure Call** uses the existing call-launch flow (phone + video). X button or outside click triggers the dirty-form confirmation when applicable.

## Notes
- **Opt-in / opt-out (call, message, per-field directory visibility)** is intentionally deferred — it requires new Provider columns and `prisma migrate`, which this branch is explicitly out of scope for. Tracked as a follow-up under EMR-666.
- Phone / fax / website / profile picture rendering in the pop-up shows an explainer paragraph until the underlying Provider model gains those fields (also follow-up).
- Diff is ~580 LOC, slightly over the 300-LOC ideal because the screen had to be restructured top-to-bottom; no new files were added.