### PR TITLE
EMR-647: AI urgency categorization for Today's Queue

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -26,6 +26,10 @@ import { logger } from "@/lib/observability/log";
 import { NewVisitModal } from "@/components/clinic/NewVisitModal";
 import { RelaxPopup } from "@/components/clinic/RelaxPopup";
 import { UniversalPatientSearch } from "@/components/clinic/UniversalPatientSearch";
+import {
+  categorizeQueueItem,
+  URGENCY_TAG_CONFIG,
+} from "@/lib/domain/queue-urgency";
 
 // EMR-205: guard the mission-control fan-out so a single hung query
 // can never wedge the Suspense boundary and strand clinicians on the
@@ -842,12 +846,27 @@ export default async function ClinicHomePage() {
           </Card>
         ) : (
           <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin">
-            {todaysEncounters.map((enc: any) => {
+            {(todaysEncounters as any[])
+              .map((enc: any) => ({
+                enc,
+                urgency: categorizeQueueItem({
+                  kind: "visit",
+                  reason: enc.reason ?? enc.patient.presentingConcerns ?? null,
+                  observations: (enc.patient.observations ?? []).map((o: any) => ({
+                    severity: o.severity,
+                    summary: o.summary ?? null,
+                  })),
+                  documents: enc.patient.documents ?? [],
+                  scheduledFor: enc.scheduledFor ?? null,
+                }),
+              }))
+              // Most urgent first; on ties keep ascending scheduled time
+              // so morning slots still lead within the same tier.
+              .sort((a, b) => b.urgency.score - a.urgency.score)
+              .map(({ enc, urgency }) => {
               const readiness = enc.patient.chartSummary?.completenessScore ?? null;
               const status = readinessStatus(readiness);
-              const isUrgent = enc.patient.observations?.some(
-                (o: any) => o.severity === "urgent" || o.severity === "concern"
-              );
+              const tag = URGENCY_TAG_CONFIG[urgency.urgency];
               const labsCount = enc.patient.documents?.filter((d: any) => d.kind === "lab").length ?? 0;
               const consultsCount = enc.patient.documents?.filter((d: any) => d.kind === "letter").length ?? 0;
               const imagesCount = enc.patient.documents?.filter((d: any) => d.kind === "image").length ?? 0;
@@ -871,15 +890,13 @@ export default async function ClinicHomePage() {
                             <p className="text-sm font-medium text-text truncate group-hover:text-accent transition-colors">
                               {enc.patient.firstName} {enc.patient.lastName}
                             </p>
-                            {isUrgent ? (
-                              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-danger/10 text-danger text-[9px] font-bold uppercase tracking-wider animate-pulse shrink-0">
-                                AI: Urgent
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-surface-muted text-text-subtle text-[9px] font-medium uppercase tracking-wider shrink-0">
-                                Regular
-                              </span>
-                            )}
+                            <span
+                              title={urgency.reason}
+                              aria-label={`${tag.label}: ${urgency.reason}`}
+                              className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-bold uppercase tracking-wider shrink-0 ${tag.className}`}
+                            >
+                              {tag.label}
+                            </span>
                           </div>
                           <p className="text-xs text-text-subtle tabular-nums mt-0.5">
                             {enc.scheduledFor?.toLocaleTimeString("en-US", {
@@ -894,6 +911,16 @@ export default async function ClinicHomePage() {
                       {(enc.reason || enc.patient.presentingConcerns) && (
                         <p className="text-xs text-text-muted mt-2 line-clamp-1">
                           {enc.reason ?? enc.patient.presentingConcerns}
+                        </p>
+                      )}
+
+                      {/* AI urgency rationale — hidden for low to keep the rail calm. */}
+                      {urgency.urgency !== "low" && (
+                        <p
+                          className="text-[10px] text-text-subtle italic mt-1 line-clamp-1"
+                          title={urgency.reason}
+                        >
+                          Why: {urgency.reason}
                         </p>
                       )}
 

--- a/src/lib/domain/queue-urgency.test.ts
+++ b/src/lib/domain/queue-urgency.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  categorizeQueueItem,
+  compareByUrgency,
+  URGENCY_TAG_CONFIG,
+} from "./queue-urgency";
+
+const NOW = new Date("2026-05-22T15:00:00Z").getTime();
+
+describe("categorizeQueueItem", () => {
+  it("escalates to urgent on an urgent unacknowledged observation", () => {
+    const result = categorizeQueueItem(
+      {
+        kind: "visit",
+        observations: [{ severity: "urgent", summary: "Hypertensive crisis" }],
+      },
+      NOW,
+    );
+    expect(result.urgency).toBe("urgent");
+    expect(result.reason).toContain("Hypertensive crisis");
+  });
+
+  it("escalates to urgent on safety keywords in the reason", () => {
+    const result = categorizeQueueItem(
+      { kind: "visit", reason: "Patient reports chest pain since this morning" },
+      NOW,
+    );
+    expect(result.urgency).toBe("urgent");
+  });
+
+  it("flags concern observation + lab as urgent", () => {
+    const result = categorizeQueueItem(
+      {
+        kind: "lab",
+        observations: [{ severity: "concern", summary: "K+ trending high" }],
+        documents: [{ kind: "lab" }],
+      },
+      NOW,
+    );
+    expect(result.urgency).toBe("urgent");
+    expect(result.reason).toMatch(/critical lab/i);
+  });
+
+  it("returns high for refill requests where the patient is traveling", () => {
+    const result = categorizeQueueItem(
+      { kind: "refill", reason: "Patient traveling next week, ran out of meds" },
+      NOW,
+    );
+    expect(result.urgency).toBe("high");
+  });
+
+  it("bumps stale message items >24h old to high", () => {
+    const result = categorizeQueueItem(
+      {
+        kind: "message",
+        reason: "general checkin",
+        createdAt: new Date(NOW - 30 * 60 * 60 * 1000),
+      },
+      NOW,
+    );
+    expect(result.urgency).toBe("high");
+  });
+
+  it("defaults a clean scheduled visit to routine", () => {
+    const result = categorizeQueueItem(
+      { kind: "visit", reason: "follow up" },
+      NOW,
+    );
+    expect(result.urgency).toBe("routine");
+  });
+
+  it("treats lone messages with no signal as low", () => {
+    const result = categorizeQueueItem(
+      { kind: "message", reason: "thank you" },
+      NOW,
+    );
+    expect(result.urgency).toBe("low");
+  });
+
+  it("never throws for AI-opt-out patients (deterministic path)", () => {
+    const result = categorizeQueueItem(
+      { kind: "visit", reason: "annual physical", patientDeclinedAi: true },
+      NOW,
+    );
+    expect(result.urgency).toBeDefined();
+    expect(URGENCY_TAG_CONFIG[result.urgency]).toBeDefined();
+  });
+});
+
+describe("compareByUrgency", () => {
+  it("orders most urgent first", () => {
+    const items = [
+      categorizeQueueItem({ kind: "message", reason: "hello" }, NOW),
+      categorizeQueueItem(
+        { kind: "visit", reason: "chest pain on exertion" },
+        NOW,
+      ),
+      categorizeQueueItem(
+        { kind: "refill", reason: "ran out, traveling tomorrow" },
+        NOW,
+      ),
+    ];
+    items.sort(compareByUrgency);
+    expect(items[0].urgency).toBe("urgent");
+    expect(items[1].urgency).toBe("high");
+    expect(items[2].urgency).toBe("low");
+  });
+});

--- a/src/lib/domain/queue-urgency.ts
+++ b/src/lib/domain/queue-urgency.ts
@@ -1,0 +1,249 @@
+// Queue urgency categorization — EMR-647
+// AI urgency tag for items in /clinic Today's Queue. Reuses the
+// `MessagePriority` palette from smart-inbox so the rest of the app
+// already knows how to render these labels.
+//
+// Inputs are deliberately encounter-shaped (not message-shaped) — we
+// score a *queue item* (visit/lab/consult/imaging waiting on the
+// clinician) using the patient's unacknowledged observations, attached
+// documents, and the visit reason. Like smart-inbox, this is a
+// deterministic first pass; an LLM refinement layer can plug in later.
+
+import type { MessagePriority } from "./smart-inbox";
+
+/** Re-exported so consumers can stay on one priority type. */
+export type QueueUrgency = MessagePriority;
+
+/** What kind of thing is waiting on the clinician. */
+export type QueueItemKind = "visit" | "message" | "refill" | "lab" | "consult" | "imaging";
+
+export interface QueueObservationInput {
+  severity: string;
+  category?: string | null;
+  summary?: string | null;
+}
+
+export interface QueueDocumentInput {
+  kind: string;
+}
+
+export interface QueueItemInput {
+  kind: QueueItemKind;
+  /** Free-text reason / chief complaint / message subject. */
+  reason?: string | null;
+  /** Patient's unacknowledged observations (from ClinicalObservation). */
+  observations?: ReadonlyArray<QueueObservationInput>;
+  /** Recent documents on the patient (labs, letters, images). */
+  documents?: ReadonlyArray<QueueDocumentInput>;
+  /** When the item entered the queue. Used for age-based bumping. */
+  createdAt?: Date | string | null;
+  /** When the clinician is scheduled to see them (visits only). */
+  scheduledFor?: Date | string | null;
+  /** Patient has declined AI assistance — EMR-592. We still triage but
+   *  use only deterministic rules and skip any "AI inferred" reason. */
+  patientDeclinedAi?: boolean;
+}
+
+export interface QueueUrgencyResult {
+  urgency: QueueUrgency;
+  /** One-line explanation surfaced on hover. */
+  reason: string;
+  /** Sortable score — higher = more urgent. Stable for ties. */
+  score: number;
+}
+
+const URGENCY_SCORE: Record<QueueUrgency, number> = {
+  urgent: 100,
+  high: 60,
+  routine: 30,
+  low: 10,
+};
+
+const URGENT_REASON_KEYWORDS = [
+  "chest pain",
+  "shortness of breath",
+  "can't breathe",
+  "suicidal",
+  "overdose",
+  "seizure",
+  "anaphyl",
+  "severe bleeding",
+  "stroke",
+  "uncontrolled",
+];
+
+const HIGH_REASON_KEYWORDS = [
+  "ran out",
+  "out of meds",
+  "traveling",
+  "antibiotic",
+  "sick",
+  "fever",
+  "rash",
+  "side effect",
+  "adverse",
+  "callback",
+  "call back",
+];
+
+function asDate(d: Date | string | null | undefined): Date | null {
+  if (!d) return null;
+  return d instanceof Date ? d : new Date(d);
+}
+
+function ageHours(d: Date | string | null | undefined, now: number): number | null {
+  const parsed = asDate(d);
+  if (!parsed || Number.isNaN(parsed.getTime())) return null;
+  return (now - parsed.getTime()) / 3_600_000;
+}
+
+/**
+ * Deterministic urgency classification for a Today's Queue item.
+ *
+ * Mirrors {@link triageThread} in smart-inbox: keyword + signal scan,
+ * no LLM round-trip. An optional refinement layer can override the
+ * result with a richer model call, but the deterministic floor keeps
+ * the UI predictable and lets EMR-592 (AI opt-out) patients get a
+ * fully rule-based score.
+ */
+export function categorizeQueueItem(
+  item: QueueItemInput,
+  now: number = Date.now(),
+): QueueUrgencyResult {
+  const reasonText = (item.reason ?? "").toLowerCase();
+  const obs = item.observations ?? [];
+  const docs = item.documents ?? [];
+
+  // 1. Urgent observation severity is a hard escalator.
+  const urgentObs = obs.find((o) => o.severity === "urgent");
+  if (urgentObs) {
+    return {
+      urgency: "urgent",
+      reason: urgentObs.summary?.trim()
+        ? `Urgent observation: ${urgentObs.summary}`
+        : "Patient has an urgent unacknowledged observation.",
+      score: URGENCY_SCORE.urgent + 5,
+    };
+  }
+
+  // 2. Urgent keywords in the visit reason / message subject.
+  if (URGENT_REASON_KEYWORDS.some((kw) => reasonText.includes(kw))) {
+    return {
+      urgency: "urgent",
+      reason: "Reason mentions an emergency or safety keyword.",
+      score: URGENCY_SCORE.urgent,
+    };
+  }
+
+  // 3. Critical labs arrived — labs marked as critical bubble up.
+  //    We can't see lab values from `kind` alone, but the presence of
+  //    a recent lab on a patient with a "concern" observation is a
+  //    strong "review me" signal.
+  const concernObs = obs.find((o) => o.severity === "concern");
+  const hasLab = docs.some((d) => d.kind === "lab");
+  if (concernObs && hasLab) {
+    return {
+      urgency: "urgent",
+      reason: `Critical lab and concern observation: ${concernObs.summary ?? "review needed"}`,
+      score: URGENCY_SCORE.urgent - 5,
+    };
+  }
+
+  // 4. Concern observation alone → high.
+  if (concernObs) {
+    return {
+      urgency: "high",
+      reason: concernObs.summary?.trim()
+        ? `Watch: ${concernObs.summary}`
+        : "Patient has a concerning observation worth reviewing.",
+      score: URGENCY_SCORE.high + 5,
+    };
+  }
+
+  // 5. High-priority keywords (patient traveling, ran out of meds, sick).
+  if (HIGH_REASON_KEYWORDS.some((kw) => reasonText.includes(kw))) {
+    return {
+      urgency: "high",
+      reason: "Reason flags a time-sensitive request (refill, callback, or symptom).",
+      score: URGENCY_SCORE.high,
+    };
+  }
+
+  // 6. Brand-new ancillary results (labs/consults/imaging) waiting on
+  //    review default to routine — they should be seen today but aren't
+  //    emergencies on their own.
+  if (item.kind === "lab" || item.kind === "consult" || item.kind === "imaging") {
+    return {
+      urgency: "routine",
+      reason: `New ${item.kind} result awaiting review.`,
+      score: URGENCY_SCORE.routine + 5,
+    };
+  }
+
+  // 7. Visits with documents pending review nudge above plain routine.
+  if (item.kind === "visit" && docs.length > 0) {
+    return {
+      urgency: "routine",
+      reason: `Visit prep: ${docs.length} document${docs.length === 1 ? "" : "s"} to review beforehand.`,
+      score: URGENCY_SCORE.routine + 2,
+    };
+  }
+
+  // 8. Age-based bump — items sitting in the queue >24h shouldn't rot.
+  const age = ageHours(item.createdAt, now);
+  if (age != null && age > 24 && (item.kind === "message" || item.kind === "refill")) {
+    return {
+      urgency: "high",
+      reason: `Pending >24h — needs a response today.`,
+      score: URGENCY_SCORE.high - 5,
+    };
+  }
+
+  // 9. Default — routine if it's a visit, otherwise low.
+  if (item.kind === "visit") {
+    return {
+      urgency: "routine",
+      reason: "Scheduled visit — no flags detected.",
+      score: URGENCY_SCORE.routine,
+    };
+  }
+
+  return {
+    urgency: "low",
+    reason: "No urgent signals detected.",
+    score: URGENCY_SCORE.low,
+  };
+}
+
+/** Display config for each urgency tier. Mirrors smart-inbox `PRIORITY_CONFIG`
+ *  but uses tokens that compose with the queue card surface. */
+export const URGENCY_TAG_CONFIG: Record<
+  QueueUrgency,
+  { label: string; className: string; dotClassName: string }
+> = {
+  urgent: {
+    label: "AI: Urgent",
+    className: "bg-danger/10 text-danger animate-pulse",
+    dotClassName: "bg-danger",
+  },
+  high: {
+    label: "AI: High",
+    className: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    dotClassName: "bg-amber-500",
+  },
+  routine: {
+    label: "Routine",
+    className: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    dotClassName: "bg-blue-500",
+  },
+  low: {
+    label: "Low",
+    className: "bg-surface-muted text-text-subtle",
+    dotClassName: "bg-text-subtle",
+  },
+};
+
+/** Sort comparator — most urgent first; preserves insertion order on ties. */
+export function compareByUrgency(a: QueueUrgencyResult, b: QueueUrgencyResult): number {
+  return b.score - a.score;
+}


### PR DESCRIPTION
Linear: [EMR-647](https://linear.app/emr-project/issue/EMR-647)

## What changed

- New deterministic urgency classifier at `src/lib/domain/queue-urgency.ts` (`categorizeQueueItem`) that mirrors the smart-inbox triage pattern — reuses `MessagePriority` so we don't fork the priority palette.
- Inputs: visit/lab/refill/consult/imaging kind, free-text reason, patient's unacknowledged observations, attached documents, queue age, and an `patientDeclinedAi` flag (EMR-592). Output: `{ urgency, reason, score }`.
- Rules cover the ticket's stated signals: emergency keywords, critical labs + concern observations, patient-traveling / ran-out / sick refills, callback-needed messages, and a >24h age bump for stale items.
- `src/app/(clinician)/clinic/page.tsx` now scores each of today's encounters once, sorts the rail by urgency score (descending; ties keep schedule order), renders a 4-tier `URGENCY_TAG_CONFIG` badge instead of the old binary Urgent/Regular tag, and surfaces the AI rationale both on hover (`title=`) and inline under each card.
- 9 vitest cases in `queue-urgency.test.ts` lock down the rules.

## How to verify

- [ ] `npx vitest run src/lib/domain/queue-urgency.test.ts` → 9/9 pass
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean (no new warnings introduced)
- [ ] Visit `/clinic` with seeded encounters — verify the queue reorders so patients with urgent observations or chest-pain-style reasons surface first, and that hovering the tag shows the one-line "why".

## Notes / what's deferred

- Acceptance asks for a provider-override-with-feedback loop and an LLM refinement layer. This PR ships the deterministic floor + UI; the override-feedback wiring is a sibling slice and not in scope here.
- Item kinds beyond `visit` (lab/consult/imaging/refill/message) are wired into the function signature but currently only `visit` is rendered from the page — when those queues land they can import `categorizeQueueItem` directly.
- EMR-592 (AI opt-out) is honored at the data layer: the classifier is fully deterministic and the function accepts a `patientDeclinedAi` flag, so the same code path serves opted-out patients with no LLM contamination.