### PR TITLE
EMR-683: /telehealth Launch Video Visit popup + patient quick-search

### DIFF
--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -285,6 +285,12 @@ routes:
     auth: required
     owner: scribe
 
+  patients/search:
+    methods: [GET]
+    auth: required
+    owner: scheduling
+    notes: "EMR-683. Org-scoped patient search for launching video visits. Gated via requireApiAuth."
+
   patients/[id]/export/lfj:
     methods: [GET]
     auth: required

--- a/src/app/(clinician)/telehealth/launch-video-popup.tsx
+++ b/src/app/(clinician)/telehealth/launch-video-popup.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+// EMR-683 — "Launch Video Visit" popup.
+//
+// Rendered as the right-hand action on /telehealth. The trigger is the
+// large video/plus icon called out in the doc-2 product feedback; the
+// popup is a single free-text search field that hits
+// /api/patients/search and lets the clinician jump straight to the
+// patient's telehealth room (which then handles room creation + the
+// in-call ambient AI scribe toggle, already shipped in EMR-652).
+//
+// We deliberately do NOT touch scribe note-mapping here. The "Objective"
+// SOAP/APSO section is human-only — the scribe never pre-fills it. This
+// component just routes to the call surface; the in-call scribe button
+// is owned by src/app/(clinician)/clinic/patients/[id]/telehealth/video-room.tsx.
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Video, Plus, Search } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface PatientHit {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phone: string | null;
+  dateOfBirth: string | null;
+}
+
+export function LaunchVideoPopup() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [hits, setHits] = useState<PatientHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset state every time the popup opens — stale results from a
+  // previous launch would be confusing.
+  useEffect(() => {
+    if (open) {
+      setQ("");
+      setHits([]);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const term = q.trim();
+    if (term.length < 2) {
+      setHits([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/patients/search?q=${encodeURIComponent(term)}`,
+          { cache: "no-store" },
+        );
+        if (!res.ok) {
+          setHits([]);
+          return;
+        }
+        const data = (await res.json()) as { patients: PatientHit[] };
+        setHits(data.patients ?? []);
+      } catch {
+        setHits([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [q, open]);
+
+  function launch(p: PatientHit) {
+    setOpen(false);
+    // The patient telehealth surface owns room creation + token issuance
+    // and (per EMR-652) the in-call ambient-scribe toggle that displays a
+    // "scribe is recording" indicator. The doc-2 spec also calls for
+    // emailing the patient a HIPAA-compliant clickable telemed link;
+    // that send fires server-side when the room is provisioned.
+    router.push(`/clinic/patients/${p.id}/telehealth`);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Launch new video visit"
+        title="Launch a new video visit — opens a patient search popup"
+        className="relative inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-accent text-white shadow-md hover:brightness-110 hover:scale-[1.03] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-accent/40 focus:ring-offset-2"
+      >
+        <Video size={26} strokeWidth={1.8} />
+        <span className="absolute -right-1 -bottom-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-surface text-accent border border-accent shadow-sm">
+          <Plus size={12} strokeWidth={2.5} />
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Launch video visit</DialogTitle>
+            <p className="text-sm text-text-muted mt-1">
+              Search by name, phone, date of birth, or email. The patient
+              will receive a HIPAA-compliant clickable telemed link.
+            </p>
+          </DialogHeader>
+
+          <div className="relative">
+            <Search
+              size={15}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-text-subtle pointer-events-none"
+            />
+            <Input
+              autoFocus
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="e.g. Maya Reyes, 555-0142, 1985-03-21, maya@…"
+              className="pl-9"
+            />
+          </div>
+
+          <div className="mt-4 min-h-[140px] max-h-[320px] overflow-y-auto">
+            {q.trim().length < 2 ? (
+              <p className="text-xs text-text-subtle text-center py-6">
+                Type at least 2 characters to search.
+              </p>
+            ) : loading ? (
+              <p className="text-xs text-text-subtle text-center py-6">
+                Searching…
+              </p>
+            ) : hits.length === 0 ? (
+              <p className="text-xs text-text-subtle text-center py-6">
+                No patients match. Try a different fragment.
+              </p>
+            ) : (
+              <ul className="space-y-1.5">
+                {hits.map((p) => (
+                  <li key={p.id}>
+                    <div className="flex items-center gap-3 p-3 rounded-xl border border-border bg-surface hover:bg-surface-muted transition-colors">
+                      <div className="h-9 w-9 rounded-full bg-accent/10 text-accent flex items-center justify-center font-display text-xs shrink-0">
+                        {p.firstName[0]}
+                        {p.lastName[0]}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-text truncate">
+                          {p.firstName} {p.lastName}
+                        </p>
+                        <p className="text-[11px] text-text-muted truncate">
+                          {[
+                            p.dateOfBirth ? `DOB ${p.dateOfBirth}` : null,
+                            p.phone,
+                            p.email,
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="primary"
+                        onClick={() => launch(p)}
+                        className="shrink-0"
+                      >
+                        <Video size={13} className="mr-1" />
+                        Launch
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/(clinician)/telehealth/page.tsx
+++ b/src/app/(clinician)/telehealth/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Video, Plus } from "lucide-react";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
@@ -16,6 +15,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { PreVisitChecklistClient } from "./pre-visit-checklist-client";
 import { AmbientMicToggle } from "./ambient-mic-toggle";
+import { LaunchVideoPopup } from "./launch-video-popup";
 
 export const metadata = { title: "Telehealth" };
 
@@ -107,16 +107,10 @@ export default async function TelehealthDashboardPage() {
         description="Live and scheduled telehealth encounters across your clinic."
         actions={
           <div className="flex items-center gap-3">
-            <Link href="/clinic/patients">
-              <Button size="sm" variant="secondary" title="Select a patient to start a new video call">
-                <Video size={14} className="mr-1.5" />
-                New call
-                <Plus size={11} className="ml-1 opacity-60" />
-              </Button>
-            </Link>
             <Badge tone={dailyKeyConfigured ? "success" : "warning"}>
               {dailyKeyConfigured ? "Daily.co connected" : "Demo mode"}
             </Badge>
+            <LaunchVideoPopup />
           </div>
         }
       />

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -1,0 +1,98 @@
+// EMR-683 — Patient quick-search for the /telehealth "Launch Video Visit" popup.
+//
+// GET /api/patients/search?q=<free-text>
+//
+// Free-text matches against name, phone, DOB (ISO substring), partial name,
+// and email — scoped to the caller's organization. Returns a small list
+// suitable for a single-popup picker (max 8 rows). Soft-deleted patients
+// are excluded. Auth: any signed-in clinician in the org.
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { requireApiAuth } from "@/lib/auth/api-gate";
+import { prisma } from "@/lib/db/prisma";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const LIMIT = 8;
+const MIN_Q = 2;
+
+export async function GET(req: NextRequest) {
+  const gate = await requireApiAuth();
+  if (gate.error) return gate.error;
+  const orgId = gate.actor.organizationId;
+  if (!orgId) {
+    return NextResponse.json({ patients: [] });
+  }
+
+  const q = (new URL(req.url).searchParams.get("q") ?? "").trim();
+  if (q.length < MIN_Q) {
+    return NextResponse.json({ patients: [] });
+  }
+
+  // Build a tolerant set of OR predicates. Phone and DOB are stored
+  // verbatim (DOB is a DateTime), so we compare by stringified ISO
+  // substring; that's good enough for "type the year" or "type MM-DD"
+  // free-text matching without bringing in a date parser.
+  const patients = await prisma.patient.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      OR: [
+        { firstName: { contains: q, mode: "insensitive" } },
+        { lastName: { contains: q, mode: "insensitive" } },
+        { email: { contains: q, mode: "insensitive" } },
+        { phone: { contains: q } },
+      ],
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phone: true,
+      dateOfBirth: true,
+    },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    take: LIMIT,
+  });
+
+  // Layered DOB match — separate query so we can union without forcing
+  // Postgres to cast every row. Skipped if q has no digits.
+  let dobMatches: typeof patients = [];
+  if (/\d/.test(q) && patients.length < LIMIT) {
+    const all = await prisma.patient.findMany({
+      where: { organizationId: orgId, deletedAt: null, dateOfBirth: { not: null } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        phone: true,
+        dateOfBirth: true,
+      },
+      take: 200,
+    });
+    const known = new Set(patients.map((p) => p.id));
+    dobMatches = all
+      .filter(
+        (p) =>
+          !known.has(p.id) &&
+          p.dateOfBirth &&
+          p.dateOfBirth.toISOString().slice(0, 10).includes(q),
+      )
+      .slice(0, LIMIT - patients.length);
+  }
+
+  return NextResponse.json({
+    patients: [...patients, ...dobMatches].map((p) => ({
+      id: p.id,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      email: p.email,
+      phone: p.phone,
+      dateOfBirth: p.dateOfBirth?.toISOString().slice(0, 10) ?? null,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a prominent **video + plus** launcher icon to the right of the "Video visits" header on `/telehealth` that opens a popup.
- Popup is a free-text patient search (name, phone, DOB, partial name, email) backed by a new `GET /api/patients/search` endpoint scoped to the caller's organization.
- Selecting a patient routes to `/clinic/patients/[id]/telehealth`, which already owns room creation, the HIPAA-compliant patient join link, and the in-call ambient AI scribe toggle + "AI Scribe Active" indicator shipped in EMR-652.

## What changed
- `src/app/(clinician)/telehealth/page.tsx` — replaces the small "New call" link with the new `LaunchVideoPopup` trigger.
- `src/app/(clinician)/telehealth/launch-video-popup.tsx` — new client component (dialog + debounced search + result rows).
- `src/app/api/patients/search/route.ts` — new search endpoint (org-scoped, soft-deleted excluded, max 8 hits, DOB substring fallback).

## How to verify
- [ ] Visit `/telehealth` — confirm the large video+plus button renders on the top right.
- [ ] Click it — popup opens; type 2+ chars; results appear with name + DOB/phone/email line.
- [ ] Click **Launch** on a result — navigates to that patient's telehealth pre-visit checklist.
- [ ] Start the visit — the AI Scribe mic button still toggles the "AI Scribe Active" pill (EMR-652 behaviour, unchanged).
- [ ] `npm run typecheck` clean for the new files (pre-existing roles.ts/idle-timeouts.ts errors are on `main` and outside this PR's blast radius).

## Notes
- Total diff: 293 LOC, under the 300 cap.
- Does **not** touch scribe note mapping; the SOAP/APSO **Objective** section remains human-only per the load-bearing rule.
- Pre-visit checklist with green/dried leaf indicators is already shipped (EMR-598); not duplicated here.
- The "email the patient a telemed link" send fires server-side when the room is provisioned in the patient telehealth flow — no new outbound email path introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)