### PR TITLE
EMR-684: finalize /clinic/patients toggle removal + redirect on new patient

### DIFF
--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -97,12 +97,13 @@ export default async function PatientsPage({
     }
   }
 
-  // Compute status counts
+  // EMR-684: Dr. Patel removed the active/inactive toggles in Doc 2 — a
+  // patient is either visible or soft-deleted, no third state. We still
+  // surface "in intake" (prospects) because that drives clinician workflow,
+  // but "active" and "inactive" buckets are gone.
   const statusCounts = {
     all: patients.length,
-    active: patients.filter((p) => p.status === "active").length,
     prospect: patients.filter((p) => p.status === "prospect").length,
-    inactive: patients.filter((p) => p.status === "inactive").length,
   };
 
   // Compute avg chart readiness

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -31,9 +31,7 @@ interface PatientRow {
 
 interface StatusCounts {
   all: number;
-  active: number;
   prospect: number;
-  inactive: number;
 }
 
 interface Props {
@@ -47,7 +45,9 @@ interface Props {
 /*  Power filter chips (EMR-clinician power-tools)                     */
 /* ------------------------------------------------------------------ */
 
-type PowerFilter = "all" | "active" | "new" | "vip" | "high-risk";
+// EMR-684: "active" used to be a chip; it was dropped along with the
+// active/inactive segmented toggle. Keep the union minimal.
+type PowerFilter = "all" | "new" | "vip" | "high-risk";
 
 const POWER_FILTERS: { key: PowerFilter; label: string }[] = [
   { key: "all", label: "All" },
@@ -236,7 +236,6 @@ export function PatientListClient({
   /* Power filter predicate ----------------------------------------- */
   const matchesPowerFilter = (p: PatientRow): boolean => {
     if (powerFilter === "all") return true;
-    if (powerFilter === "active") return p.status === "active";
     if (powerFilter === "new") {
       const created = new Date(p.updatedAt).getTime();
       const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
@@ -415,7 +414,7 @@ export function PatientListClient({
             <div className="px-5 pb-6">
               <EmptyState
                 title="No patients match your search"
-                description="Try adjusting your search terms or changing the status filter."
+                description="Try adjusting your search terms or selecting a different filter chip."
               />
             </div>
           ) : (

--- a/src/components/clinic/NewPatientModal.tsx
+++ b/src/components/clinic/NewPatientModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { AvatarUpload } from "@/components/ui/avatar-upload";
@@ -27,6 +28,7 @@ interface EmergencyContactInput {
 }
 
 export function NewPatientModal({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(1);
   const [isPending, startTransition] = useTransition();
@@ -185,6 +187,9 @@ export function NewPatientModal({ children }: { children: React.ReactNode }) {
       if (res.ok) {
         setOpen(false);
         resetForm();
+        // EMR-684: After creating, jump straight to the new chart so the
+        // clinician can begin documenting without an extra click.
+        router.push(`/clinic/patients/${res.patientId}`);
       } else {
         setSubmitError(res.error || "Failed to create patient chart.");
       }


### PR DESCRIPTION
## What changed
- **Cleanup, not net-new UI.** The active/inactive segmented toggle was already removed in EMR-599 and the multi-step `NewPatientModal` (personal info + 3 emergency contacts + insurance) landed earlier with `createPatientAction` already wired through. EMR-684 was carrying dead code that referenced the old toggle.
- Drop the dead `"active"` branch from the `PowerFilter` union and predicate in `patient-list-client.tsx` — it was unreachable (not in the displayed `POWER_FILTERS` chip list) but kept lying around to confuse the next reader.
- Drop the unused `statusCounts.active` and `statusCounts.inactive` fields from both `page.tsx` (computation) and `patient-list-client.tsx` (interface). Nothing rendered them; they were ghost props.
- Update the "no patients match" empty-state copy to stop telling the user to "change the status filter" (there isn't one anymore).
- **Add the redirect step the ticket actually asks for**: on a successful `createPatientAction`, `NewPatientModal` now `router.push`es to `/clinic/patients/{patientId}` so the clinician lands on the chart they just created instead of being dropped back on the roster.

## How to verify
- [ ] `/clinic/patients` renders with no active/inactive segmented toggle (chips are All / New (30d) / VIP / High-risk).
- [ ] Click "New patient" → fill firstName, lastName, DOB, advance to step 2 (one emergency contact required) and step 3 (insurance required) → submit. You should land on `/clinic/patients/{new-id}` (the new chart's front page).
- [ ] `npx prisma generate` → ok. `npm run typecheck` → clean. `npm run lint` → no new warnings in touched files.

## Notes
- 21 LOC across 3 files. No deps, no migrations, no auth/middleware/schema touched.
- The `Badge` rendering of an individual patient's stored status ("Active", "Inactive", "In Intake") is intentionally untouched — those describe the row's actual data, not the removed segmented control.
- Parent epic EMR-678. Source: `docs/product-feedback/2026-05-16_clinic-website-revisions-doc2.md` lines 93–101.