### PR TITLE
EMR-617: /education Drug Mix standalone module

### DIFF
--- a/src/app/education/drug-mix/page.tsx
+++ b/src/app/education/drug-mix/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronLeft, Pill } from "lucide-react";
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { Eyebrow } from "@/components/ui/ornament";
+import { DrugMixChecker } from "@/components/education/DrugMixChecker";
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * EMR-617 — Drug Mix standalone module.
+ *
+ * Public, patient-facing drug-interaction checker. No login required and no
+ * PHI is captured (everything lives in component state). The same
+ * `DrugMixChecker` is also embedded as a tab on /education for users who
+ * arrive at the hub first.
+ */
+export const metadata: Metadata = {
+  title: "Drug Mix — Cannabis interaction checker — Leafjourney",
+  description:
+    "Add all of your medications and supplements to see if they interact with cannabis. Green/yellow/red verdicts from the same evidence base our clinicians use.",
+  alternates: { canonical: `${SITE_URL}/education/drug-mix` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Drug Mix — Cannabis interaction checker",
+    description:
+      "Patient-friendly cannabis interaction checker. No login required.",
+    url: `${SITE_URL}/education/drug-mix`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function DrugMixPage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <SiteHeader />
+
+      <main id="main-content">
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-12 pb-8 lg:pt-16 lg:pb-10">
+          <Link
+            href="/education"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-text-muted hover:text-accent transition-colors mb-6"
+          >
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+            Back to Education
+          </Link>
+
+          <div className="text-center">
+            <Eyebrow className="justify-center mb-5 text-accent">
+              <Pill className="w-3.5 h-3.5" aria-hidden="true" />
+              Drug Mix
+            </Eyebrow>
+            <h1 className="font-display text-4xl md:text-5xl lg:text-6xl tracking-tight text-text leading-[1.05] mb-5">
+              Cannabis Interaction Checker
+            </h1>
+            <p className="text-lg md:text-xl text-text-muted max-w-2xl mx-auto leading-relaxed">
+              Add all of your medications and supplements to see if they
+              interact with cannabis.
+            </p>
+          </div>
+        </section>
+
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pb-20">
+          <DrugMixChecker heading={null} />
+        </section>
+
+        <section className="max-w-3xl mx-auto px-6 lg:px-12 pb-20 text-xs text-text-muted leading-relaxed">
+          <p className="mb-2">
+            <strong className="text-text">For education only.</strong> This
+            checker draws on the same interaction database used by clinicians
+            on Leafjourney, but it is not a substitute for advice from your
+            doctor or pharmacist. Always discuss new medications, supplements,
+            or cannabis use with your care team.
+          </p>
+          <p>
+            We do not store the list you enter. Nothing is sent to a Leafjourney
+            account, and no record is kept in your browser after you leave.
+          </p>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Search, ArrowRight, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { Search, ArrowRight, Sparkles, Pill } from "lucide-react";
 import { Eyebrow } from "@/components/ui/ornament";
 import { SiteHeader } from "@/components/marketing/SiteHeader";
 import { SiteFooter } from "@/components/marketing/SiteFooter";
@@ -71,6 +72,20 @@ export default function EducationPage() {
           explore cannabinoid science, and join the community — all free,
           no login required.
         </p>
+
+        {/* EMR-617 — direct CTA for the Drug Mix standalone module so
+            patients arriving on /education can jump straight to the
+            interaction checker without first discovering the tab strip. */}
+        <div className="mt-8 flex flex-wrap justify-center gap-3">
+          <Link
+            href="/education/drug-mix"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-accent text-white text-sm font-semibold shadow-md hover:bg-accent/90 transition-all hover:-translate-y-0.5"
+          >
+            <Pill className="w-4 h-4" aria-hidden="true" />
+            Open Drug Mix
+            <ArrowRight className="w-4 h-4" aria-hidden="true" />
+          </Link>
+        </div>
       </section>
 
       <EducationTabs activeTab={activeTab} onTabChange={setActiveTab} />

--- a/src/components/education/DrugMixChecker.tsx
+++ b/src/components/education/DrugMixChecker.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import React, { useState } from "react";
+import { cn } from "@/lib/utils/cn";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, CheckCircle, ShieldAlert } from "lucide-react";
+import {
+  checkInteractions,
+  type DrugInteraction,
+} from "@/lib/domain/drug-interactions";
+
+/**
+ * Parse a free-text list of meds/supplements separated by commas, newlines,
+ * or semicolons. Trims whitespace and drops empty entries.
+ *
+ * EMR-617 — patients enter meds & supplements in a single textarea and the
+ * acceptance criteria explicitly call out both comma- and newline-separated
+ * input. Centralized here so the standalone page and the embedded tab both
+ * parse identically.
+ */
+export function parseMedicationInput(input: string): string[] {
+  return input
+    .split(/[,\n;]+/)
+    .map((m) => m.trim())
+    .filter(Boolean);
+}
+
+const DEFAULT_CANNABINOIDS = ["THC", "CBD", "CBN"];
+
+export interface DrugMixCheckerProps {
+  /**
+   * Heading shown above the form. The standalone /education/drug-mix page
+   * supplies its own page header so it passes `heading={null}` to suppress
+   * the embedded title. The tab variant gets the default heading.
+   */
+  heading?: React.ReactNode;
+  /** Description shown under the heading. */
+  description?: React.ReactNode;
+  /** Optional className applied to the outer wrapper. */
+  className?: string;
+}
+
+/**
+ * Patient-facing drug interaction checker (EMR-617).
+ *
+ * Renders a textarea + "Check Interactions" button and a list of
+ * green/yellow/red interaction cards backed by the same data source as
+ * /clinic/library. No PHI is captured — input lives only in component state.
+ */
+export function DrugMixChecker({
+  heading,
+  description,
+  className,
+}: DrugMixCheckerProps) {
+  const [input, setInput] = useState("");
+  const [results, setResults] = useState<DrugInteraction[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = parseMedicationInput(input);
+  const itemCount = parsed.length;
+
+  function checkMix() {
+    setLoading(true);
+    // Small delay preserves the "analyzing" affordance the existing tab UI
+    // exposed; users perceive the work as substantive even though the lookup
+    // is synchronous against the bundled JSON.
+    setTimeout(() => {
+      setResults(checkInteractions(parsed, DEFAULT_CANNABINOIDS));
+      setLoading(false);
+    }, 600);
+  }
+
+  const showDefaultHeading = heading === undefined;
+
+  return (
+    <div className={cn("max-w-3xl mx-auto space-y-8 sm:space-y-10 px-4 sm:px-0", className)}>
+      {showDefaultHeading ? (
+        <div className="text-center mb-6 sm:mb-8">
+          <h2 className="font-display text-3xl sm:text-4xl text-text tracking-tight mb-3">
+            Drug Interaction Checker
+          </h2>
+          <p className="text-sm sm:text-base text-text-muted max-w-xl mx-auto leading-relaxed">
+            {description ??
+              "Add all of your medications and supplements to see if they interact with cannabis."}
+          </p>
+        </div>
+      ) : (
+        heading
+      )}
+
+      <Card tone="raised" className="rounded-3xl shadow-xl overflow-hidden border border-border bg-white">
+        <CardContent className="p-5 sm:p-8">
+          <div className="flex items-center justify-between mb-3">
+            <label
+              htmlFor="drugmix-meds"
+              className="block text-base font-semibold text-text"
+            >
+              Your medications &amp; supplements
+            </label>
+            <span className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
+              {itemCount} {itemCount === 1 ? "item" : "items"}
+            </span>
+          </div>
+          <p className="text-sm text-text-muted mb-3 leading-relaxed">
+            Add all of your medications and supplements to see if they interact with cannabis.
+          </p>
+          <textarea
+            id="drugmix-meds"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={
+              "Separate with commas or new lines, e.g.:\nWarfarin, Metformin, Lisinopril\nSt. John's Wort\nVitamin D"
+            }
+            rows={6}
+            aria-describedby="drugmix-help"
+            className="w-full rounded-2xl border-2 border-slate-200 bg-slate-50 px-5 py-4 text-base text-text placeholder:text-slate-400 focus:outline-none focus:border-accent focus:bg-white focus:ring-4 focus:ring-accent/20 transition-all resize-none shadow-inner"
+          />
+          <p id="drugmix-help" className="text-xs text-slate-500 mt-2">
+            No login required. Your list stays on your device — nothing is saved.
+          </p>
+          <Button
+            onClick={checkMix}
+            disabled={itemCount === 0 || loading}
+            className="mt-6 rounded-xl w-full h-14 text-base sm:text-lg font-semibold shadow-md"
+          >
+            {loading ? "Analyzing Database..." : "Check Interactions"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {results !== null && (
+        <div className="space-y-4 animate-in fade-in slide-in-from-bottom-4">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-display text-2xl">Results</h3>
+            {results.length > 0 && (
+              <Badge tone="neutral" className="text-[10px] uppercase tracking-widest font-bold">
+                {results.length} {results.length === 1 ? "interaction" : "interactions"}
+              </Badge>
+            )}
+          </div>
+
+          {results.length === 0 ? (
+            <Card className="rounded-2xl border-2 border-emerald-400 bg-emerald-50/50 shadow-sm">
+              <CardContent className="p-6 flex items-start gap-4">
+                <div className="bg-emerald-100 p-3 rounded-full text-emerald-600 shrink-0">
+                  <CheckCircle className="w-6 h-6" />
+                </div>
+                <div>
+                  <h4 className="text-lg font-bold text-emerald-900 mb-1">
+                    No known interactions found
+                  </h4>
+                  <p className="text-emerald-700 font-medium">
+                    Based on our database, the items you listed do not have known severe interactions with cannabis. Always consult your provider.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            results.map((ix, i) => {
+              const isRed = ix.severity === "red";
+              const isYellow = ix.severity === "yellow";
+
+              return (
+                <Card
+                  key={`${ix.drug}-${ix.cannabinoid}-${i}`}
+                  className={cn(
+                    "rounded-2xl border-2 shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5",
+                    isRed
+                      ? "border-red-400 bg-red-50/30"
+                      : isYellow
+                        ? "border-amber-400 bg-amber-50/30"
+                        : "border-emerald-400 bg-emerald-50/30"
+                  )}
+                >
+                  <CardContent className="p-5 sm:p-6">
+                    <div className="flex items-start gap-3 sm:gap-4">
+                      <div
+                        className={cn(
+                          "p-3 rounded-full shrink-0",
+                          isRed
+                            ? "bg-red-100 text-red-600"
+                            : isYellow
+                              ? "bg-amber-100 text-amber-600"
+                              : "bg-emerald-100 text-emerald-600"
+                        )}
+                      >
+                        {isRed ? (
+                          <ShieldAlert className="w-6 h-6" />
+                        ) : isYellow ? (
+                          <AlertTriangle className="w-6 h-6" />
+                        ) : (
+                          <CheckCircle className="w-6 h-6" />
+                        )}
+                      </div>
+
+                      <div className="flex-1">
+                        <div className="flex flex-wrap items-center gap-3 mb-2">
+                          <h4 className="text-lg font-bold text-slate-800">
+                            {ix.drug}
+                            <span className="text-slate-400 font-normal mx-1">+</span>
+                            {ix.cannabinoid}
+                          </h4>
+                          <Badge
+                            tone={isRed ? "danger" : isYellow ? "warning" : "success"}
+                            className="uppercase tracking-widest text-[10px] font-bold"
+                          >
+                            {ix.severity} Severity
+                          </Badge>
+                        </div>
+
+                        <div className="bg-white/60 p-4 rounded-xl border border-black/5 mb-3">
+                          <p className="text-sm text-slate-700 font-medium leading-relaxed">
+                            <strong className="text-slate-900 block mb-1">Mechanism:</strong>
+                            {ix.mechanism}
+                          </p>
+                        </div>
+
+                        <p
+                          className={cn(
+                            "text-sm font-bold flex items-center gap-2",
+                            isRed
+                              ? "text-red-700"
+                              : isYellow
+                                ? "text-amber-700"
+                                : "text-emerald-700"
+                          )}
+                        >
+                          <span>Action:</span> {ix.recommendation}
+                        </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/education/DrugMixTab.tsx
+++ b/src/components/education/DrugMixTab.tsx
@@ -1,162 +1,28 @@
 "use client";
 
-import React, { useState } from "react";
-import { cn } from "@/lib/utils/cn";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { AlertTriangle, CheckCircle, ShieldAlert } from "lucide-react";
+import React from "react";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { DrugMixChecker } from "./DrugMixChecker";
 
+/**
+ * Embedded /education tab variant of the Drug Mix module. The same
+ * `DrugMixChecker` powers the standalone /education/drug-mix page (EMR-617),
+ * so the form/results/parsing logic stays in lockstep.
+ */
 export function DrugMixTab() {
-  const [meds, setMeds] = useState("");
-  const [results, setResults] = useState<any[] | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  async function checkMix() {
-    setLoading(true);
-    // Dynamic import to mimic existing behavior
-    const { checkInteractions } = await import("@/lib/domain/drug-interactions");
-    const medList = meds.split("\n").map((m) => m.trim()).filter(Boolean);
-    const cannabinoids = ["THC", "CBD", "CBN"];
-    
-    setTimeout(() => {
-      const interactions = checkInteractions(medList, cannabinoids);
-      setResults(interactions);
-      setLoading(false);
-    }, 800); // Add a small delay for realistic UX
-  }
-
-  const medCount = meds.split("\n").map((m) => m.trim()).filter(Boolean).length;
-
   return (
-    <div className="max-w-3xl mx-auto space-y-8 sm:space-y-10 px-4 sm:px-0">
-      <div className="text-center mb-6 sm:mb-8">
-        <h2 className="font-display text-3xl sm:text-4xl text-text tracking-tight mb-3">
-          Drug Interaction Checker
-        </h2>
-        <p className="text-sm sm:text-base text-text-muted max-w-xl mx-auto leading-relaxed">
-          Check how your current medications interact with cannabinoids like THC, CBD, and CBN.
-        </p>
+    <>
+      <DrugMixChecker />
+      <div className="max-w-3xl mx-auto mt-8 px-4 sm:px-0 text-center">
+        <Link
+          href="/education/drug-mix"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-accent hover:underline"
+        >
+          Open Drug Mix in its own page
+          <ArrowUpRight className="w-4 h-4" aria-hidden="true" />
+        </Link>
       </div>
-
-      <Card tone="raised" className="rounded-3xl shadow-xl overflow-hidden border border-border bg-white">
-        <CardContent className="p-5 sm:p-8">
-          <div className="flex items-center justify-between mb-3">
-            <label
-              htmlFor="drugmix-meds"
-              className="block text-base font-semibold text-text"
-            >
-              Your current medications
-            </label>
-            <span className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
-              {medCount} {medCount === 1 ? "med" : "meds"}
-            </span>
-          </div>
-          <div className="relative">
-            <textarea
-              id="drugmix-meds"
-              value={meds}
-              onChange={(e) => setMeds(e.target.value)}
-              placeholder={"Enter one medication per line, e.g.:\nWarfarin\nMetformin\nLisinopril\nSertraline"}
-              rows={6}
-              className="w-full rounded-2xl border-2 border-slate-200 bg-slate-50 px-5 py-4 text-base text-text placeholder:text-slate-400 focus:outline-none focus:border-accent focus:bg-white focus:ring-4 focus:ring-accent/20 transition-all resize-none shadow-inner"
-            />
-          </div>
-          <Button
-            onClick={checkMix}
-            disabled={!meds.trim() || loading}
-            className="mt-6 rounded-xl w-full h-14 text-base sm:text-lg font-semibold shadow-md"
-          >
-            {loading ? "Analyzing Database..." : "Check Interactions"}
-          </Button>
-        </CardContent>
-      </Card>
-
-      {results !== null && (
-        <div className="space-y-4 animate-in fade-in slide-in-from-bottom-4">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="font-display text-2xl">Results</h3>
-            {results.length > 0 && (
-              <Badge tone="neutral" className="text-[10px] uppercase tracking-widest font-bold">
-                {results.length} {results.length === 1 ? "interaction" : "interactions"}
-              </Badge>
-            )}
-          </div>
-          
-          {results.length === 0 ? (
-            <Card className="rounded-2xl border-2 border-emerald-400 bg-emerald-50/50 shadow-sm">
-              <CardContent className="p-6 flex items-start gap-4">
-                <div className="bg-emerald-100 p-3 rounded-full text-emerald-600 shrink-0">
-                  <CheckCircle className="w-6 h-6" />
-                </div>
-                <div>
-                  <h4 className="text-lg font-bold text-emerald-900 mb-1">No known interactions found</h4>
-                  <p className="text-emerald-700 font-medium">Based on our database, the medications listed do not have known severe interactions with cannabis. Always consult your provider.</p>
-                </div>
-              </CardContent>
-            </Card>
-          ) : (
-            results.map((ix, i) => {
-              const isRed = ix.severity === "red";
-              const isYellow = ix.severity === "yellow";
-              
-              return (
-                <Card key={i} className={cn(
-                  "rounded-2xl border-2 shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5",
-                  isRed ? "border-red-400 bg-red-50/30" :
-                  isYellow ? "border-amber-400 bg-amber-50/30" :
-                  "border-emerald-400 bg-emerald-50/30"
-                )}>
-                  <CardContent className="p-5 sm:p-6">
-                    <div className="flex items-start gap-3 sm:gap-4">
-                      <div className={cn(
-                        "p-3 rounded-full shrink-0",
-                        isRed ? "bg-red-100 text-red-600" :
-                        isYellow ? "bg-amber-100 text-amber-600" :
-                        "bg-emerald-100 text-emerald-600"
-                      )}>
-                        {isRed ? <ShieldAlert className="w-6 h-6" /> :
-                         isYellow ? <AlertTriangle className="w-6 h-6" /> :
-                         <CheckCircle className="w-6 h-6" />}
-                      </div>
-                      
-                      <div className="flex-1">
-                        <div className="flex flex-wrap items-center gap-3 mb-2">
-                          <h4 className="text-lg font-bold text-slate-800">
-                            {ix.drug} <span className="text-slate-400 font-normal mx-1">+</span> {ix.cannabinoid}
-                          </h4>
-                          <Badge 
-                            tone={isRed ? "danger" : isYellow ? "warning" : "success"}
-                            className="uppercase tracking-widest text-[10px] font-bold"
-                          >
-                            {ix.severity} Severity
-                          </Badge>
-                        </div>
-                        
-                        <div className="bg-white/60 p-4 rounded-xl border border-black/5 mb-3">
-                          <p className="text-sm text-slate-700 font-medium leading-relaxed">
-                            <strong className="text-slate-900 block mb-1">Mechanism:</strong> 
-                            {ix.mechanism}
-                          </p>
-                        </div>
-                        
-                        <p className={cn(
-                          "text-sm font-bold flex items-center gap-2",
-                          isRed ? "text-red-700" :
-                          isYellow ? "text-amber-700" :
-                          "text-emerald-700"
-                        )}>
-                          <span>Action:</span> {ix.recommendation}
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })
-          )}
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/src/components/layout/MobilePortraitNav.tsx
+++ b/src/components/layout/MobilePortraitNav.tsx
@@ -48,7 +48,7 @@ export const DEFAULT_GROUPS: MobileNavGroup[] = [
       { label: "ChatCB", href: "/education", icon: "❦" },
       { label: "Research", href: "/education#research", icon: "⚘" },
       { label: "Wheel", href: "/education#wheel", icon: "", wheelGradient: true },
-      { label: "Drug Mix", href: "/education#drugmix", icon: "⚗" },
+      { label: "Drug Mix", href: "/education/drug-mix", icon: "⚗" },
     ],
   },
   {


### PR DESCRIPTION
## What changed
- New public route `/education/drug-mix` (no auth, no PHI) renders a patient-friendly cannabis interaction checker with SiteHeader/Footer, eyebrow + hero copy ("Add all of your medications and supplements to see if they interact with cannabis."), a "Back to Education" link, and a privacy disclosure.
- Extracted the form + results into a shared `DrugMixChecker` component used by both the standalone page and the existing `/education` Drug Mix tab so parsing and the green/yellow/red verdict stay in lockstep.
- Input now accepts comma-, newline-, or semicolon-separated meds **and supplements** (acceptance criterion). Re-used the existing `checkInteractions()` helper in `src/lib/domain/drug-interactions.ts` — same data source as `/clinic/library`.
- `/education` hero now exposes a direct "Open Drug Mix" CTA so patients can jump to the module without first discovering the tab strip.
- `MobilePortraitNav` "Drug Mix" link now points at `/education/drug-mix` instead of the fragment hash.

## How to verify
- `npm run dev`, open `/education` — confirm the new "Open Drug Mix" pill CTA in the hero, click through to `/education/drug-mix`.
- On the standalone page enter e.g. `Warfarin, Sertraline\nSt. John's Wort` and press **Check Interactions** — confirm a mixed red/yellow/green result list rendered with the existing severity styling.
- Confirm the `/education#drugmix` tab still works and now shows an "Open Drug Mix in its own page" link beneath the form.
- `npm run typecheck` and `npm run lint` — pass (no new warnings).

## Notes
- No prisma schema or migration changes. No dep bumps. No new env vars.
- Practice-level cannabis opt-out gating (one of the acceptance items) requires server-side practice context that does not flow through `/education` today; left as a follow-up so this PR stays focused on the standalone surface. Cannabis-specific copy is kept generic enough that a future `<ClientModalityGate modality="cannabis-medicine" />` wrap will be a one-line change.
- The route is intentionally a server component for metadata + SEO; the checker itself remains a client island.