### PR TITLE
EMR-640: route every whisper to scott@ + neal@ founders

### DIFF
--- a/src/app/api/feedback/whisper/route.ts
+++ b/src/app/api/feedback/whisper/route.ts
@@ -8,36 +8,80 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { sendEmail } from "@/lib/email/resend";
 import { logger } from "@/lib/observability/log";
 
-// EMR-128 — Whisper inbox + EMR-594 founder email fan-out.
+// EMR-128 — Whisper inbox + EMR-594 founder email fan-out + EMR-640 explicit
+// founder routing for every submission.
 //
 // In-memory ring buffer until persistence lands. The route validates the
 // FAB's submission contract end-to-end, classifies the whisper, and emails
-// both founders (Scott + Neil) when an email provider is configured. If the
-// founder fan-out fails for any reason other than a missing API key the
-// route surfaces the failure (502) so the clinician sees the error inline
-// — silent loss is the explicit anti-acceptance.
+// both founders (Scott + Neal) on EVERY submission so the AC for EMR-640
+// ("a whisper from any page lands in both inboxes") is unconditional —
+// area-specialised inboxes still get a Cc when the classifier picks up a
+// clinical or billing signal, but they no longer replace the founder
+// recipients. If the send fails for any reason other than a missing API
+// key the route logs the failure but returns 200 because the ring buffer
+// still has the suggestion for replay (silent loss is the anti-acceptance,
+// surfacing a transient HTTP wobble to the user is worse than a missed
+// email we can replay).
 const RING_CAP = 500;
 const ring: ClassifiedWhisper[] = [];
 
-const FOUNDER_RECIPIENTS = [
-  "neal@leafjourney.com",
+// EMR-640: founders are unconditional recipients on every whisper.
+// Order intentionally stable so the To: line reads `scott, neal` across
+// providers. Email casing follows the founder bootstrap allowlist
+// (`SUPER_ADMIN_BOOTSTRAP_EMAILS`) — see leafjourney_founders memory.
+const FOUNDER_RECIPIENTS: readonly string[] = [
   "scott@leafjourney.com",
+  "neal@leafjourney.com",
 ];
 
-function getRecipients(whisper: ClassifiedWhisper): string[] {
-  if (whisper.cSuiteRoute) {
-    return FOUNDER_RECIPIENTS;
+// Area-specialised inboxes that get Cc'd when the classifier picks a
+// signal. Keeping them as a Cc (vs. swapping the To:) ensures founders
+// always see traffic flowing to ops queues — critical for the v1
+// "founders triage everything" stage.
+const AREA_CC: Partial<Record<ClassifiedWhisper["area"], string>> = {
+  billing: "billing@leafjourney.com",
+  medications: "clinical@leafjourney.com",
+};
+
+function getRecipients(whisper: ClassifiedWhisper): {
+  to: string[];
+  cc?: string[];
+} {
+  const cc = AREA_CC[whisper.area];
+  return { to: [...FOUNDER_RECIPIENTS], cc: cc ? [cc] : undefined };
+}
+
+// EMR-640: server-side rate limit + spam guard. The whisper endpoint is
+// public (signed-out leafmart and marketing surfaces both mount the FAB)
+// so we key on IP rather than user. 10/min/IP is generous for a human
+// typing into a textarea and stops a noisy script cold. In-memory only;
+// see lib/auth/rate-limit.ts for the Upstash swap point.
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 10;
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function getClientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  const xri = req.headers.get("x-real-ip");
+  if (xri) return xri.trim();
+  return "unknown";
+}
+
+function checkRateLimit(
+  ip: string,
+): { ok: true } | { ok: false; retryAfterSec: number } {
+  const now = Date.now();
+  const bucket = rateBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    rateBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { ok: true };
   }
-  
-  if (whisper.area === "billing") {
-    return ["billing@leafjourney.com"];
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return { ok: false, retryAfterSec: Math.ceil((bucket.resetAt - now) / 1000) };
   }
-  
-  if (whisper.area === "medications") {
-    return ["clinical@leafjourney.com"];
-  }
-  
-  return ["support@leafjourney.com"];
+  bucket.count += 1;
+  return { ok: true };
 }
 
 function formatRoles(roles: string[] | undefined): string {
@@ -101,6 +145,20 @@ function buildEmail(
 }
 
 export async function POST(req: Request) {
+  // EMR-640 — rate limit before parsing to keep abuse cheap. Done in-line
+  // (no requireApiAuth) because the FAB is mounted on signed-out surfaces.
+  const ip = getClientIp(req);
+  const limit = checkRateLimit(ip);
+  if (!limit.ok) {
+    return NextResponse.json(
+      { error: "Too many whispers — give us a moment to read what you sent." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(limit.retryAfterSec) },
+      },
+    );
+  }
+
   let body: unknown;
   try {
     body = await req.json();
@@ -121,9 +179,11 @@ export async function POST(req: Request) {
   // because the FAB renders on signed-out surfaces (leafmart, marketing) too.
   const currentUser = await getCurrentUser().catch(() => null);
   const { subject, text, html } = buildEmail(classified, currentUser);
+  const recipients = getRecipients(classified);
 
   const send = await sendEmail({
-    to: getRecipients(classified),
+    to: recipients.to,
+    cc: recipients.cc,
     subject,
     text,
     html,
@@ -135,16 +195,49 @@ export async function POST(req: Request) {
     ],
   });
 
-  if (!send.ok && send.reason !== "no-api-key") {
-    // Genuine failure (HTTP or network) — the whisper is already in the in-memory
-    // ring buffer so the operator inbox still has it for replay. We log the error
-    // but return 200 so the user sees a success screen instead of a confusing red error.
+  // EMR-640 — every whisper is logged with the suggestion id, page, and
+  // user identity so the founders can follow up even if the email leg
+  // fails. Email outcome ride-along is just a tag on the same record.
+  if (send.ok) {
+    logger.info({
+      event: "whisper.received",
+      whisperId: classified.id,
+      page: classified.pageUrl,
+      area: classified.area,
+      sentiment: classified.sentiment,
+      userId: currentUser?.id ?? null,
+      userEmail: currentUser?.email ?? null,
+      to: recipients.to,
+      cc: recipients.cc ?? [],
+      emailId: send.id,
+    });
+  } else if (send.reason === "no-api-key") {
+    // Dev / un-provisioned deploy. The ring buffer still holds it for the
+    // operator inbox; log loudly so the team knows email isn't wired up.
+    logger.warn({
+      event: "whisper.email_skipped_no_api_key",
+      whisperId: classified.id,
+      page: classified.pageUrl,
+      area: classified.area,
+      userId: currentUser?.id ?? null,
+      to: recipients.to,
+      cc: recipients.cc ?? [],
+    });
+  } else {
+    // Genuine failure (HTTP or network) — the whisper is already in the
+    // in-memory ring buffer so the operator inbox still has it for replay.
+    // We log the error but return 200 so the user sees a success screen
+    // instead of a confusing red error for a transient send issue.
     logger.error({
       event: "whisper.email_failed",
       whisperId: classified.id,
+      page: classified.pageUrl,
+      area: classified.area,
+      userId: currentUser?.id ?? null,
+      to: recipients.to,
+      cc: recipients.cc ?? [],
       reason: send.reason,
     });
-    // Fall through to 200 OK.
   }
 
   return NextResponse.json({

--- a/src/components/feedback/UniversalFeedbackFab.tsx
+++ b/src/components/feedback/UniversalFeedbackFab.tsx
@@ -113,7 +113,7 @@ export function UniversalFeedbackFab() {
             <p className="text-xs uppercase tracking-wider text-text-subtle">Whisper</p>
             <h3 className="font-display text-lg text-text mt-0.5">What's on your mind?</h3>
             <p className="text-xs text-text-muted mt-1">
-              Goes straight to Dr. Patel & Scott. No bots in between.
+              Goes straight to Scott & Neal. No bots in between.
             </p>
           </div>
           <button onClick={close} className="text-text-subtle hover:text-text text-lg leading-none px-2" aria-label="Close">

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -32,6 +32,9 @@ export interface SendEmailInput {
   from?: string;
   /** Optional reply-to header. */
   replyTo?: string;
+  /** Optional Cc list — e.g. area-specialised inboxes that should see
+   * the message without replacing the primary recipients (EMR-640). */
+  cc?: string[];
   /** Optional tag set (Resend supports custom tags for searching). */
   tags?: Array<{ name: string; value: string }>;
 }
@@ -53,6 +56,7 @@ export async function sendEmail(
   const body = {
     from: input.from ?? process.env.EMAIL_FROM ?? DEFAULT_FROM,
     to: input.to,
+    cc: input.cc,
     subject: input.subject,
     text: input.text,
     html: input.html,


### PR DESCRIPTION
Closes EMR-640.

## What changed
- `src/app/api/feedback/whisper/route.ts` — every whisper now lists both founders (`scott@leafjourney.com`, `neal@leafjourney.com`) as primary `To:` recipients, unconditionally. Area-specialised inboxes (`billing@`, `clinical@`) are demoted to `Cc` so they keep getting their signal without replacing the founder recipients.
- Added per-IP sliding-window rate limit (10/min, in-memory, same shape as `leafmart/vendor-apply`) — the FAB is mounted on signed-out surfaces so we can't lean on `requireApiAuth`. Returns 429 + `Retry-After`.
- Structured logging on every submission (`whisper.received` / `email_skipped_no_api_key` / `email_failed`) capturing suggestion id, page URL, classified area + sentiment, user id/email (or null), and the resolved recipient list — satisfies the AC "Logged (suggestion id, page, user) for follow-up."
- `src/lib/email/resend.ts` — `SendEmailInput` gains an optional `cc` field, threaded through to Resend's `cc` body param.
- `src/components/feedback/UniversalFeedbackFab.tsx` — modal subhead now reads "Goes straight to Scott & Neal" (was "Dr. Patel & Scott") so the visible promise matches the routing.

## How to verify
- `curl -s -X POST http://localhost:3000/api/feedback/whisper -H 'content-type: application/json' -d '{"clientId":"verify-1","pageUrl":"http://localhost:3000/clinic","comment":"Loving the new sign-off flow.","area":"feature_request","occurredAt":"2026-05-22T12:00:00Z"}'` — expect `{ ok: true, emailed: true|false }` and a `whisper.received` log line with `to: ["scott@leafjourney.com","neal@leafjourney.com"]`.
- Submit a billing-area whisper — log line should now show `cc: ["billing@leafjourney.com"]` while `to` still lists the founders.
- Hit the route 11 times in a minute from the same IP — request 11 should return 429 with `Retry-After`.
- `npm run typecheck` — clean. `npm run lint` — no new warnings on touched files.

## Notes
- Recipient list mirrors `SUPER_ADMIN_BOOTSTRAP_EMAILS` (Neal with an 'a' — `leafjourney_founders` memory).
- Rate limiter is in-memory (single-process). Same Upstash swap point flagged in `lib/auth/rate-limit.ts` applies once we scale horizontally.
- Did not touch `src/lib/auth/` (only imported from it), `prisma/schema.prisma`, `src/middleware.ts`, workflows, or specialty manifests. No dep bumps, no migrations.