### PR TITLE
EMR-588: Confidential clinician-only notes section

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -15,6 +15,11 @@ const TABS = [
   { key: "demographics", label: "Demographics", dot: "bg-[color:var(--info)]", group: "Overview" },
   { key: "memory", label: "Memory", dot: "bg-accent", group: "Overview" },
   { key: "notes", label: "Notes", dot: "bg-[color:var(--highlight)]", group: "Clinical" },
+  // EMR-588 — Confidential clinician-only notes (private provider
+  // notes). NOT part of the legal chart, never released to the patient
+  // or to export packets. Rendered with a danger-toned dot so the rail
+  // already telegraphs "this is a sensitive surface" before click.
+  { key: "private_notes", label: "Private notes", dot: "bg-danger", group: "Clinical" },
   { key: "labs", label: "Labs", dot: "bg-[color:var(--success)]", group: "Clinical" },
   { key: "images", label: "Images", dot: "bg-[color:var(--info)]", group: "Clinical" },
   { key: "rx", label: "Cannabis Rx", dot: "bg-[color:var(--highlight)]", group: "Clinical" },

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   assertChartAccess,
   canViewSection,
+  canEditSection,
 } from "@/lib/rbac/permissions";
 import { AccessDenied } from "@/components/rbac/access-denied";
 import { PageShell } from "@/components/shell/PageHeader";
@@ -25,6 +26,11 @@ import { TrackPatientView } from "@/components/shell/recent-patients";
 import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
 import { MemoryTab } from "./memory-tab";
+// EMR-588 — Confidential clinician-only notes (private provider notes).
+// Tab + server-action surface; storage is interim-backed by AuditLog
+// rows until Legal sign-off on retention. See private-notes-actions.ts.
+import { PrivateNotesTab } from "./private-notes-tab";
+import { listPrivateNotes } from "./private-notes-actions";
 import { ChartingTimer } from "./charting-timer";
 import { startVisit } from "./actions";
 import { checkInteractions, getSeverityLabel, type DrugInteraction } from "@/lib/domain/drug-interactions";
@@ -111,6 +117,9 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     "labs",
     "imaging",
     "problems",
+    // EMR-588 — private clinician-only notes are clinical-tier and must
+    // bounce front-office users back to demographics like the rest.
+    "private_notes",
   ]);
   if (CLINICAL_TABS.has(tab) && !canViewSection(user, "notes")) {
     redirect(`/clinic/patients/${params.id}?tab=demographics`);
@@ -314,6 +323,22 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     (o: any) => !o.acknowledgedAt,
   ).length;
 
+  // EMR-588 — Pull private clinician-only notes for the chart sidebar
+  // count + the tab render. Loader is permission-gated internally and
+  // writes a read-audit row; we only call it when the caller can see
+  // notes at all, so back-office without notes.read never triggers it.
+  const userCanSeePrivateNotes = canViewSection(user, "notes");
+  const privateNotes = userCanSeePrivateNotes
+    ? await listPrivateNotes(params.id).catch((err) => {
+        logger.error({
+          event: "private_notes_load_failed",
+          patientId: params.id,
+          err: String(err),
+        });
+        return [];
+      })
+    : [];
+
   const counts = {
     demographics: 1,
     memory: patientMemories.length + openObservationCount,
@@ -321,6 +346,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     images: imageDocs.length,
     labs: labDocs.length + assessmentResponses.length,
     notes: allNotes.length,
+    private_notes: privateNotes.length,
     correspondence: threads.length,
     rx: activeRegimens.length,
     billing: openClaimCount,
@@ -755,6 +781,20 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
           patientId={params.id}
           startVisitAction={startVisitWithPatient}
           scribeProcessing={searchParams.scribe === "processing"}
+        />
+      )}
+      {tab === "private_notes" && userCanSeePrivateNotes && (
+        // EMR-588 — Confidential clinician-only notes. Section-gated on
+        // canViewSection(notes) so back-office without notes.read
+        // (already redirected by the CLINICAL_TABS guard) and patients
+        // (already on a different surface entirely) can never reach
+        // this render path. Authoring requires notes.edit, surfaced
+        // here as canAuthor for the client component.
+        <PrivateNotesTab
+          patientId={params.id}
+          notes={privateNotes}
+          canAuthor={canEditSection(user, "notes")}
+          patientFirstName={patient.firstName}
         />
       )}
       {tab === "memory" && (

--- a/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
@@ -23,6 +23,12 @@ const TAB_LABELS: Record<TabKey, string> = {
   images: "Images",
   labs: "Labs",
   notes: "Notes",
+  // EMR-588 — Private clinician-only notes never feed the peek summary
+  // pipeline (no agent ever reads or paraphrases them). We keep the
+  // label present so the Record type is total, but loadPeekSummaries
+  // only iterates `peeks` entries — and the page never seeds a peek for
+  // `private_notes`, so no summary is ever generated.
+  private_notes: "Private notes",
   correspondence: "Correspondence",
   rx: "Cannabis Rx",
   billing: "Billing",

--- a/src/app/(clinician)/clinic/patients/[id]/private-notes-actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/private-notes-actions.ts
@@ -1,0 +1,166 @@
+"use server";
+
+// EMR-588 — Confidential clinician-only notes.
+//
+// These are "private provider notes" that live *outside* the patient's
+// legal chart: never visible on the patient portal, never included in
+// chart-export / records-release packets, never auto-populated by an
+// agent (Objective-section rule from Doc 1 extends here — human-author
+// only). Use cases per ticket: violent-behavior flags, abusive toward
+// staff, safety context the provider needs to remember but should not
+// land in the discoverable record.
+//
+// Storage (v1): we use `AuditLog` rows as the underlying store. Each row
+// IS the audit entry — `subjectType = "PrivateClinicianNote"`, `subjectId
+// = patientId`, `metadata.body` is the note text. This keeps every
+// create/read traceable to a real actor and timestamp without a schema
+// migration on the path to legal review.
+//
+// TODO(EMR-588 follow-up): replace the AuditLog-backed store with a
+// dedicated `PrivateClinicianNote` model once Legal signs off on
+// retention + discoverability. The model needs: id, patientId,
+// organizationId, authorUserId, body, createdAt, deletedAt, plus a
+// separate `PrivateClinicianNoteAccessLog` for read-audit. Add to the
+// chart-export EXCLUDE list at the same time.
+
+import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  ForbiddenError,
+  assertChartAccess,
+  requirePermission,
+} from "@/lib/rbac/permissions";
+import { logger } from "@/lib/observability/log";
+
+const SUBJECT_TYPE = "PrivateClinicianNote";
+const ACTION_CREATE = "private_note.create";
+const ACTION_READ = "private_note.read";
+
+export interface PrivateNote {
+  id: string;
+  body: string;
+  authorName: string;
+  createdAt: string; // ISO — server components stringify before rendering
+}
+
+/**
+ * Load private clinician-only notes for a patient. Throws ForbiddenError
+ * when the caller lacks notes.read or fails the chart-privacy gate.
+ * Writes a read-audit row on success so we know who pulled the section.
+ */
+export async function listPrivateNotes(patientId: string): Promise<PrivateNote[]> {
+  const user = await requireUser();
+  requirePermission(user, "notes.read");
+  await assertChartAccess(user, patientId);
+
+  // The store + the audit are the same table — newest first, cap at 200
+  // so a chart that's accumulated a decade of safety notes doesn't blow
+  // the panel out. (Same cap as the legal notes feed in page.tsx.)
+  const rows = await prisma.auditLog.findMany({
+    where: {
+      organizationId: user.organizationId!,
+      subjectType: SUBJECT_TYPE,
+      subjectId: patientId,
+      action: ACTION_CREATE,
+    },
+    orderBy: { createdAt: "desc" },
+    take: 200,
+    include: {
+      actor: { select: { firstName: true, lastName: true, email: true } },
+    },
+  });
+
+  // Read-audit: log that this user pulled the private-notes panel. Fail
+  // open — never block the clinician from seeing safety context because
+  // the audit insert hiccuped.
+  try {
+    await prisma.auditLog.create({
+      data: {
+        organizationId: user.organizationId!,
+        actorUserId: user.id,
+        action: ACTION_READ,
+        subjectType: SUBJECT_TYPE,
+        subjectId: patientId,
+        metadata: { count: rows.length } as Prisma.InputJsonValue,
+      },
+    });
+  } catch (err) {
+    logger.error({ event: "private_note.read_audit_failed", patientId, err: String(err) });
+  }
+
+  return rows.map((row) => {
+    const meta = (row.metadata as { body?: unknown } | null) ?? null;
+    const body = typeof meta?.body === "string" ? meta.body : "";
+    const author = row.actor;
+    const authorName = author
+      ? [author.firstName, author.lastName].filter(Boolean).join(" ").trim() ||
+        author.email
+      : "Unknown clinician";
+    return {
+      id: row.id,
+      body,
+      authorName,
+      createdAt: row.createdAt.toISOString(),
+    };
+  });
+}
+
+/**
+ * Add a confidential clinician-only note. Requires notes.edit (so
+ * read-only back-office can't author), plus chart-privacy access.
+ *
+ * Per Doc 1 / Doc 3 rule: this entry point is server-action only and
+ * accepts a human-typed body — there is no AI fill path here and the
+ * client surface never wires up an autofill button.
+ */
+export async function addPrivateNote(
+  patientId: string,
+  body: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser();
+
+  try {
+    requirePermission(user, "notes.edit");
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "You don't have permission to add private notes." };
+    }
+    throw err;
+  }
+
+  const trimmed = body?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return { ok: false, error: "Note can't be empty." };
+  }
+  if (trimmed.length > 4000) {
+    return { ok: false, error: "Note is too long (4000 character cap)." };
+  }
+
+  // Confirm the patient is in this org before writing — defense in depth
+  // beyond the chart-access gate.
+  const patient = await prisma.patient.findFirst({
+    where: { id: patientId, organizationId: user.organizationId!, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) {
+    return { ok: false, error: "Patient not found." };
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: ACTION_CREATE,
+      subjectType: SUBJECT_TYPE,
+      subjectId: patientId,
+      metadata: { body: trimmed } as Prisma.InputJsonValue,
+    },
+  });
+
+  // Revalidate the chart so the new note shows up immediately.
+  revalidatePath(`/clinic/patients/${patientId}`);
+  return { ok: true };
+}

--- a/src/app/(clinician)/clinic/patients/[id]/private-notes-tab.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/private-notes-tab.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+// EMR-588 — Confidential clinician-only notes tab.
+//
+// Lives inside the chart, but everything in this surface screams "not
+// in the legal chart": shield-lock icon, danger-tinted header banner,
+// inline reminder above the composer, "Private — not in chart" badge
+// on every entry. The composer is a single textarea (no formatting
+// chrome, no AI autofill button) — Doc 1/Doc 3 rule: Objective and
+// private notes are human-authored only.
+//
+// Authoring requires notes.edit; the parent page also gates the entire
+// tab render on canViewSection(notes), so a front-office user never
+// reaches this client component.
+
+import * as React from "react";
+import { ShieldAlert, Lock } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { formatRelative } from "@/lib/utils/format";
+import { addPrivateNote, type PrivateNote } from "./private-notes-actions";
+
+interface PrivateNotesTabProps {
+  patientId: string;
+  notes: PrivateNote[];
+  /** True when the current user has notes.edit. Read-only callers (back-office) see view-only. */
+  canAuthor: boolean;
+  patientFirstName: string;
+}
+
+const MAX_LEN = 4000;
+
+export function PrivateNotesTab({
+  patientId,
+  notes: initialNotes,
+  canAuthor,
+  patientFirstName,
+}: PrivateNotesTabProps) {
+  const [notes, setNotes] = React.useState<PrivateNote[]>(initialNotes);
+  const [draft, setDraft] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const [isPending, startTransition] = React.useTransition();
+
+  const submit = () => {
+    const body = draft.trim();
+    if (!body) {
+      setError("Note can't be empty.");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const res = await addPrivateNote(patientId, body);
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      // Optimistically prepend so the new entry is visible before the
+      // next server render lands. The revalidate in the action will
+      // overwrite this with the canonical row on refresh.
+      setNotes((prev) => [
+        {
+          id: `temp-${Date.now()}`,
+          body,
+          authorName: "You",
+          createdAt: new Date().toISOString(),
+        },
+        ...prev,
+      ]);
+      setDraft("");
+    });
+  };
+
+  return (
+    <section className="space-y-6">
+      {/* Confidentiality banner — load-bearing UI affordance. Renders
+          first and uses the danger token so a clinician opening the tab
+          can't mistake this for a regular chart section. */}
+      <div
+        className="flex items-start gap-3 rounded-lg border border-danger/40 bg-danger/5 px-4 py-3"
+        role="note"
+        aria-label="Confidentiality notice"
+      >
+        <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-danger" aria-hidden />
+        <div className="text-sm leading-relaxed">
+          <p className="font-medium text-text">
+            Private provider notes — not in {patientFirstName || "this patient"}'s chart
+          </p>
+          <p className="mt-1 text-text-subtle">
+            Visible to providers only. Never shown on the patient portal and
+            excluded from chart exports and records-release packets. Use for
+            safety, interpersonal context, and private impressions that should
+            stay out of the legal record. All access is audit-logged.
+          </p>
+        </div>
+      </div>
+
+      {canAuthor && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Lock className="h-4 w-4 text-text-subtle" aria-hidden />
+              Add a private note
+            </CardTitle>
+            <CardDescription>
+              Human-authored only. No AI autofill. Stays out of the chart.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <textarea
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                if (error) setError(null);
+              }}
+              placeholder="e.g. Patient has shown escalating verbal aggression toward intake staff — flag for safety pairing on next visit."
+              rows={4}
+              maxLength={MAX_LEN}
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              aria-label="Private clinician note"
+              aria-invalid={error ? "true" : "false"}
+              disabled={isPending}
+            />
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs text-text-subtle">
+                {draft.length}/{MAX_LEN}
+              </span>
+              <Button onClick={submit} disabled={isPending || draft.trim().length === 0}>
+                {isPending ? "Saving…" : "Save private note"}
+              </Button>
+            </div>
+            {error && (
+              <p role="alert" className="text-sm text-danger">
+                {error}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium text-text-subtle">
+          {notes.length === 0
+            ? "No private notes"
+            : `${notes.length} private note${notes.length === 1 ? "" : "s"}`}
+        </h3>
+        {notes.length === 0 ? (
+          <EmptyState
+            title="Nothing here yet"
+            description={
+              canAuthor
+                ? "Add safety context or private impressions above. They stay outside the legal chart."
+                : "No private notes have been added for this patient."
+            }
+          />
+        ) : (
+          <ul className="space-y-2">
+            {notes.map((n) => (
+              <li
+                key={n.id}
+                className="rounded-lg border border-border bg-surface px-4 py-3"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 text-xs text-text-subtle">
+                    <Badge tone="danger">
+                      <Lock className="h-3 w-3" aria-hidden />
+                      Private — not in chart
+                    </Badge>
+                    <span>{n.authorName}</span>
+                    <span aria-hidden>·</span>
+                    <span>{formatRelative(n.createdAt)}</span>
+                  </div>
+                </div>
+                <p className="mt-2 whitespace-pre-wrap text-sm text-text">
+                  {n.body}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed

Adds a "Private notes" tab to the patient chart for confidential clinician-only notes per [EMR-588](https://linear.app/emr-project/issue/EMR-588).

- New tab `private_notes` in `chart-tabs.tsx` (Clinical group, danger-toned dot)
- New client component `private-notes-tab.tsx` with a danger banner, a shield-lock icon, an inline reminder ("not in chart"), a single textarea composer (no AI autofill — human-only per Doc 1/Doc 3), and per-entry "Private — not in chart" badges
- New server actions `private-notes-actions.ts`:
  - `listPrivateNotes` gated by `notes.read` + `assertChartAccess`, writes a read-audit row on every fetch
  - `addPrivateNote` gated by `notes.edit` + `assertChartAccess`, 4000-char cap, blocks empty bodies
- `page.tsx` wires the tab: adds `private_notes` to `CLINICAL_TABS` (front-office redirected), fetches notes only when caller has `notes.read`, surfaces `canAuthor = canEditSection(user, "notes")`
- `peek-summary.ts` adds the new key to the `TAB_LABELS` Record purely for type-completeness — private notes never seed a peek (never paraphrased by any agent)

## Safety properties

- **Never on patient portal**: nothing under `src/app/(patient)/` references this surface.
- **Never in chart export**: `chart-export.ts` uses an allow-list catalog (`SECTION_CATALOG`); `private_notes` is intentionally absent.
- **Never AI-populated**: the composer is a plain `<textarea>`; there's no `generate`/`autofill` button. Same Objective-section rule as Doc 1.
- **Audit-logged**: every create AND every read writes an `AuditLog` row.
- **Role-gated**: clinician/practice_owner/midlevel (notes.edit) can author; back-office (notes.read) sees view-only; front-office/patient roles are redirected before render.

## How to verify

- [ ] Open a patient chart as a clinician → "Private notes" tab appears in the Clinical group with a danger-toned dot.
- [ ] Type a note (e.g. "Patient verbally aggressive toward intake staff") and save → entry appears with a "Private — not in chart" badge and timestamp.
- [ ] Switch to a back-office user → tab visible, composer absent, existing notes readable.
- [ ] Switch to a front-office user → `?tab=private_notes` redirects to `?tab=demographics`.
- [ ] Inspect the patient portal (`/portal/...`) → no surface lists or links to private notes.
- [ ] Hit the chart download endpoint → exported `.lfj` / PDF contains no private-notes section.
- [ ] Query `AuditLog where subjectType = "PrivateClinicianNote"` → both `private_note.create` and `private_note.read` rows present, attributable to the actor.

## Notes — schema follow-up (explicit)

**This PR does not touch `prisma/schema.prisma`** per the daytime-engineer constraints. Storage is interim-backed by `AuditLog` rows (`subjectType: "PrivateClinicianNote"`, `metadata.body`). This is functional and audit-clean, but should be replaced before launch:

- Add a dedicated `PrivateClinicianNote` model (id, patientId, organizationId, authorUserId, body, createdAt, deletedAt).
- Add a separate `PrivateClinicianNoteAccessLog` for the read-audit (volume on the main AuditLog will balloon otherwise).
- Add a `chart-export` EXCLUDE-list assertion test so future contributors can't accidentally add the section to the allow-list catalog.
- Per ticket: Legal review on retention + discoverability before launch.

TODO comments referencing this follow-up are present in `private-notes-actions.ts` (top-of-file block + a tag on the store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)