### PR TITLE
EMR-675: Surface unresolved follow-ups in chart, convert to tasks

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.ts
@@ -12,6 +12,7 @@ import {
   hasPermission,
   requirePermission,
 } from "@/lib/rbac/permissions";
+import { encodeSourceRef } from "@/lib/domain/unresolved-followups";
 
 /**
  * Start a visit: find or create an in-progress encounter for today,
@@ -318,6 +319,91 @@ export async function deletePastSurgeryAction(patientId: string, id: string) {
   });
   revalidatePath(`/clinic/patients/${patientId}`);
   return { ok: true };
+}
+
+/* ── EMR-675 — Convert an unresolved follow-up into a Task ─────── */
+
+export type ConvertFollowUpResult =
+  | { ok: true; taskId: string }
+  | { ok: false; error: string };
+
+/**
+ * Convert an unresolved follow-up (from a finalized note or triaged
+ * thread) into a chart Task. The `sourceRef` is embedded in the
+ * description so the panel auto-hides converted items.
+ */
+export async function convertFollowUpToTask(input: {
+  patientId: string;
+  title: string;
+  detail?: string;
+  sourceRef: string; // e.g. "noteId:abc" or "threadId:xyz"
+  dueInDays?: number; // optional clinician-set due date hint
+}): Promise<ConvertFollowUpResult> {
+  const user = await requireUser();
+
+  // Same gate as note edits — clinicians + mid-levels only.
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: read-only access to chart" };
+  }
+
+  const patient = await prisma.patient.findFirst({
+    where: {
+      id: input.patientId,
+      organizationId: user.organizationId!,
+      deletedAt: null,
+    },
+    select: { id: true, organizationId: true },
+  });
+  if (!patient) return { ok: false, error: "Patient not found" };
+
+  try {
+    await assertChartAccess(user, input.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Forbidden: chart is restricted" };
+    }
+    throw err;
+  }
+
+  const title = input.title.trim().slice(0, 200);
+  if (title.length < 3) return { ok: false, error: "Title is required" };
+  const detail = (input.detail ?? "").trim().slice(0, 500);
+  const ref = encodeSourceRef(input.sourceRef.slice(0, 120));
+
+  const dueAt =
+    input.dueInDays && input.dueInDays > 0 && input.dueInDays <= 365
+      ? new Date(Date.now() + input.dueInDays * 86_400_000)
+      : null;
+
+  const task = await prisma.task.create({
+    data: {
+      organizationId: patient.organizationId,
+      patientId: patient.id,
+      title,
+      description: detail ? `${detail}\n\n${ref}` : ref,
+      status: "open",
+      assigneeUserId: user.id,
+      dueAt,
+    },
+    select: { id: true },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: patient.organizationId,
+      actorUserId: user.id,
+      action: "patient.followup.converted_to_task",
+      subjectType: "Task",
+      subjectId: task.id,
+      metadata: {
+        patientId: patient.id,
+        sourceRef: input.sourceRef,
+      } as any,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${input.patientId}`);
+  return { ok: true, taskId: task.id };
 }
 
 /* ── EMR-786 — Chart privacy management ────────────────────────── */

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -26,7 +26,7 @@ import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
 import { MemoryTab } from "./memory-tab";
 import { ChartingTimer } from "./charting-timer";
-import { startVisit } from "./actions";
+import { startVisit, convertFollowUpToTask } from "./actions";
 import { checkInteractions, getSeverityLabel, type DrugInteraction } from "@/lib/domain/drug-interactions";
 import { InteractionBadge } from "@/components/ui/interaction-badge";
 import { generateCDSAlerts } from "@/lib/domain/clinical-decision-support";
@@ -47,6 +47,8 @@ import {
 } from "@/lib/utils/patient-age";
 import { CarePlanSection } from "@/components/patient/CarePlanSection";
 import { ChartTaskList } from "@/components/patient/ChartTaskList";
+import { UnresolvedFollowUpsPanel } from "@/components/patient/UnresolvedFollowUpsPanel";
+import { buildUnresolvedFollowUps } from "@/lib/domain/unresolved-followups";
 import { logger } from "@/lib/observability/log";
 import { BirthdayBanner } from "./birthday-banner";
 import { MessagePatientDock } from "@/app/(clinician)/clinic/messages/dock-compose";
@@ -659,6 +661,31 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
           </div>
         </CardContent>
       </Card>
+
+      {/* ── Unresolved follow-up items (EMR-675) ───────────── */}
+      {/* Derived from finalized notes (Plan/Follow-up blocks) +
+          triaged message threads. One-click converts each loose end
+          into a Task via convertFollowUpToTask; converted items drop
+          off this panel automatically because the Task description
+          embeds the sourceRef. Sits above ChartTaskList so the
+          clinician's eye lands here first when reviewing a chart. */}
+      {(() => {
+        const followUps = buildUnresolvedFollowUps({
+          patientId: params.id,
+          notes: allNotes.slice(0, 20) as any,
+          threads: threads as any,
+          existingTasks: openTasks as any,
+        });
+        return followUps.length > 0 ? (
+          <div className="mb-6">
+            <UnresolvedFollowUpsPanel
+              patientId={params.id}
+              items={followUps}
+              onConvert={convertFollowUpToTask}
+            />
+          </div>
+        ) : null;
+      })()}
 
       {/* ── Chart task list / to-do on open (EMR-180) ─────── */}
       {/* Built from data we already fetched: open tasks + unsigned notes.

--- a/src/components/patient/UnresolvedFollowUpsPanel.tsx
+++ b/src/components/patient/UnresolvedFollowUpsPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatRelative } from "@/lib/utils/format";
+import type { UnresolvedFollowUp } from "@/lib/domain/unresolved-followups";
+
+// EMR-675 — Thin client shell over the derived items from
+// lib/domain/unresolved-followups.ts. Sits above ChartTaskList; one
+// click promotes a loose end into a tracked Task and the converted
+// item drops off automatically (Task carries the sourceRef).
+
+export interface UnresolvedFollowUpsPanelProps {
+  patientId: string;
+  items: UnresolvedFollowUp[];
+  /** Server action; enforces RBAC + chart-access server-side. */
+  onConvert: (input: {
+    patientId: string;
+    title: string;
+    detail?: string;
+    sourceRef: string;
+    dueInDays?: number;
+  }) => Promise<{ ok: true; taskId: string } | { ok: false; error: string }>;
+  className?: string;
+}
+
+const TONE: Record<UnresolvedFollowUp["severity"], string> = {
+  danger: "border-l-danger",
+  warning: "border-l-warning",
+  info: "border-l-highlight/70",
+};
+
+export function UnresolvedFollowUpsPanel({
+  patientId,
+  items,
+  onConvert,
+  className,
+}: UnresolvedFollowUpsPanelProps) {
+  const [pendingId, setPendingId] = React.useState<string | null>(null);
+  const [convertedIds, setConvertedIds] = React.useState<Set<string>>(new Set());
+  const [errorById, setErrorById] = React.useState<Record<string, string>>({});
+
+  const visible = items.filter((i) => !convertedIds.has(i.id));
+  if (visible.length === 0) return null;
+
+  const handleConvert = async (item: UnresolvedFollowUp) => {
+    setPendingId(item.id);
+    setErrorById(({ [item.id]: _gone, ...rest }) => rest);
+    try {
+      const res = await onConvert({
+        patientId,
+        title: item.title,
+        detail: item.detail,
+        sourceRef: item.sourceRef,
+      });
+      if (res.ok) {
+        setConvertedIds((prev) => new Set(prev).add(item.id));
+      } else {
+        setErrorById((prev) => ({ ...prev, [item.id]: res.error }));
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to create task";
+      setErrorById((prev) => ({ ...prev, [item.id]: msg }));
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const dangerCount = visible.filter((i) => i.severity === "danger").length;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-surface shadow-sm border-l-4",
+        dangerCount > 0 ? "border-l-danger" : "border-l-highlight/70",
+        className,
+      )}
+      data-testid="unresolved-followups-panel"
+    >
+      <div className="flex items-center justify-between px-5 py-3 border-b border-border/60">
+        <div className="flex items-center gap-2">
+          <p className="text-[11px] uppercase tracking-[0.14em] text-text-subtle font-medium">
+            Unresolved follow-ups · {visible.length}
+          </p>
+          {dangerCount > 0 && <Badge tone="danger">{dangerCount} overdue</Badge>}
+        </div>
+        <span className="text-[11px] text-text-subtle">
+          From prior notes &amp; triaged messages
+        </span>
+      </div>
+
+      <ul className="divide-y divide-border/40">
+        {visible.map((item) => {
+          const isConverting = pendingId === item.id;
+          const err = errorById[item.id];
+          return (
+            <li
+              key={item.id}
+              className={cn(
+                "px-5 py-3 flex items-start gap-3 border-l-4 -ml-px",
+                TONE[item.severity],
+              )}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[10px] uppercase tracking-wider text-text-subtle font-medium">
+                    {item.source === "note" ? "Note" : "Message"}
+                  </span>
+                  {item.severity === "danger" && <Badge tone="danger">Overdue</Badge>}
+                  {item.severity === "warning" && <Badge tone="warning">Aging</Badge>}
+                  <span className="text-[11px] text-text-subtle tabular-nums">
+                    {formatRelative(item.surfacedAt)}
+                  </span>
+                </div>
+                <Link
+                  href={item.href}
+                  className="block mt-0.5 text-sm text-text font-medium leading-snug hover:underline"
+                >
+                  {item.title}
+                </Link>
+                {item.detail && <p className="text-xs text-text-muted mt-0.5">{item.detail}</p>}
+                {err && (
+                  <p className="text-xs text-danger mt-1" role="alert">
+                    {err}
+                  </p>
+                )}
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={isConverting}
+                onClick={() => handleConvert(item)}
+                data-testid={`convert-followup-${item.id}`}
+                className="shrink-0"
+              >
+                {isConverting ? "Adding…" : "Convert to task"}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {convertedIds.size > 0 && (
+        <div className="px-5 py-2 border-t border-border/60 text-[11px] text-text-subtle">
+          {convertedIds.size} item{convertedIds.size === 1 ? "" : "s"} added to the task list.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/domain/unresolved-followups.test.ts
+++ b/src/lib/domain/unresolved-followups.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUnresolvedFollowUps,
+  encodeSourceRef,
+  extractFollowUpFromThread,
+  extractFollowUpsFromNote,
+  extractSourceRef,
+  type NoteLike,
+  type ThreadLike,
+} from "./unresolved-followups";
+
+const baseNote = (overrides: Partial<NoteLike> = {}): NoteLike => ({
+  id: "n1",
+  encounterId: "e1",
+  status: "finalized",
+  finalizedAt: "2026-05-01T12:00:00Z",
+  createdAt: "2026-05-01T11:00:00Z",
+  blocks: [
+    { heading: "Assessment", body: "Hypothyroid, well-controlled." },
+    {
+      heading: "Plan",
+      body: "Recheck TSH in 6 weeks. Continue current dose. Patient to follow up if symptoms worsen.",
+    },
+  ],
+  narrative: null,
+  ...overrides,
+});
+
+describe("extractFollowUpsFromNote", () => {
+  it("pulls follow-up sentences out of Plan blocks", () => {
+    const items = extractFollowUpsFromNote(baseNote(), "p1");
+    expect(items.length).toBeGreaterThanOrEqual(1);
+    expect(items[0].source).toBe("note");
+    expect(items[0].title.toLowerCase()).toContain("recheck tsh");
+    expect(items[0].href).toBe("/clinic/patients/p1/notes/n1");
+    expect(items[0].sourceRef).toBe("noteId:n1");
+  });
+
+  it("ignores draft notes — they are still being written", () => {
+    expect(extractFollowUpsFromNote(baseNote({ status: "draft" }), "p1")).toEqual([]);
+  });
+
+  it("returns empty when the plan block has no follow-up phrasing", () => {
+    const note = baseNote({
+      blocks: [{ heading: "Plan", body: "Patient stable. No changes." }],
+    });
+    expect(extractFollowUpsFromNote(note, "p1")).toEqual([]);
+  });
+
+  it("caps at 3 items even when the plan is verbose", () => {
+    const note = baseNote({
+      blocks: [
+        {
+          heading: "Plan",
+          body: [
+            "Recheck TSH in 6 weeks.",
+            "Repeat lipid panel in 3 months.",
+            "Titrate sertraline next visit.",
+            "Reassess BP weekly.",
+            "Reorder mammogram referral.",
+          ].join(" "),
+        },
+      ],
+    });
+    expect(extractFollowUpsFromNote(note, "p1").length).toBe(3);
+  });
+});
+
+describe("extractFollowUpFromThread", () => {
+  it("surfaces triaged symptom-report threads", () => {
+    const thread: ThreadLike = {
+      id: "t1",
+      subject: "Headaches since starting new dose",
+      lastMessageAt: "2026-05-15T10:00:00Z",
+      triageCategory: "symptom_report",
+      triageUrgency: "routine",
+      triageSummary: "Patient reports daily headaches, asks about dose adjustment.",
+    };
+    const item = extractFollowUpFromThread(thread, "p1");
+    expect(item).not.toBeNull();
+    expect(item!.source).toBe("message");
+    expect(item!.sourceRef).toBe("threadId:t1");
+    expect(item!.href).toBe("/clinic/patients/p1?tab=correspondence");
+  });
+
+  it("marks emergency/high triage as danger regardless of age", () => {
+    const thread: ThreadLike = {
+      id: "t2",
+      subject: "Bad rash",
+      lastMessageAt: new Date().toISOString(),
+      triageCategory: "symptom_report",
+      triageUrgency: "high",
+    };
+    const item = extractFollowUpFromThread(thread, "p1");
+    expect(item?.severity).toBe("danger");
+  });
+
+  it("skips untriaged / informational threads", () => {
+    const thread: ThreadLike = {
+      id: "t3",
+      subject: "Insurance card update",
+      lastMessageAt: "2026-05-15T10:00:00Z",
+      triageCategory: null,
+      triageUrgency: null,
+    };
+    expect(extractFollowUpFromThread(thread, "p1")).toBeNull();
+  });
+});
+
+describe("buildUnresolvedFollowUps", () => {
+  it("hides items already converted to a task", () => {
+    const note = baseNote();
+    const items = buildUnresolvedFollowUps({
+      patientId: "p1",
+      notes: [note],
+      threads: [],
+      existingTasks: [
+        {
+          status: "open",
+          description: `Recheck TSH in 6 weeks. ${encodeSourceRef("noteId:n1")}`,
+        },
+      ],
+    });
+    // Both follow-ups inside note n1 were "resolved" because the task
+    // references noteId:n1 — the panel should be empty.
+    expect(items).toEqual([]);
+  });
+
+  it("orders danger before info and applies the limit", () => {
+    const old = baseNote({
+      id: "n_old",
+      finalizedAt: "2026-01-01T00:00:00Z",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const fresh = baseNote({
+      id: "n_fresh",
+      finalizedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+    });
+    const items = buildUnresolvedFollowUps({
+      patientId: "p1",
+      notes: [fresh, old],
+      threads: [],
+      existingTasks: [],
+      limit: 2,
+    });
+    expect(items.length).toBe(2);
+    // Old finalized note (>30 days) → danger; it should sort first.
+    expect(items[0].severity).toBe("danger");
+  });
+});
+
+describe("source ref encode/extract round-trip", () => {
+  it("encodes and recovers a ref", () => {
+    const encoded = encodeSourceRef("noteId:n1");
+    expect(extractSourceRef(`Recheck thyroid. ${encoded}`)).toBe("noteId:n1");
+  });
+  it("returns null when no ref is embedded", () => {
+    expect(extractSourceRef("Just a regular task")).toBeNull();
+    expect(extractSourceRef(null)).toBeNull();
+  });
+});

--- a/src/lib/domain/unresolved-followups.ts
+++ b/src/lib/domain/unresolved-followups.ts
@@ -1,0 +1,186 @@
+// EMR-675 — Unresolved follow-up items in chart, convert to tasks.
+//
+// Derives "loose ends" server-side from finalized note Plan/Follow-up
+// blocks + triaged message threads. Tasks created from a follow-up
+// embed `[sourceRef:noteId|threadId:...]` in their description so
+// converted items drop off automatically — no parallel followup model.
+
+import type { TaskStatus } from "@prisma/client";
+
+// Structural duck-types — easier to unit-test without Prisma.
+export interface NoteLike {
+  id: string;
+  encounterId: string;
+  status: string;
+  finalizedAt?: Date | string | null;
+  createdAt: Date | string;
+  blocks: unknown;
+  narrative?: string | null;
+}
+export interface ThreadLike {
+  id: string;
+  subject: string;
+  lastMessageAt: Date | string;
+  triageCategory?: string | null;
+  triageUrgency?: string | null;
+  triageSummary?: string | null;
+}
+export interface TaskLike {
+  description?: string | null;
+  status: TaskStatus | string;
+}
+
+export type UnresolvedFollowUpSource = "note" | "message";
+export interface UnresolvedFollowUp {
+  id: string;
+  source: UnresolvedFollowUpSource;
+  title: string;
+  detail?: string;
+  surfacedAt: string;
+  href: string;
+  sourceRef: string;
+  severity: "info" | "warning" | "danger";
+}
+
+const FOLLOWUP_PHRASE_RE =
+  /(?:^|[.\n•–—\-])\s*([^\n.]*?\b(?:follow[- ]?up|recheck|repeat|titrate|reassess|re[- ]?evaluate|reorder|refill review|labs?\s+in\b|return\s+in\b|f\/u)\b[^\n.]{0,140})/gi;
+
+function blocksToText(blocks: unknown): { heading: string; body: string }[] {
+  if (!Array.isArray(blocks)) return [];
+  return blocks.flatMap((b: unknown) =>
+    b &&
+    typeof b === "object" &&
+    typeof (b as { heading?: unknown }).heading === "string" &&
+    typeof (b as { body?: unknown }).body === "string"
+      ? [{ heading: (b as { heading: string }).heading, body: (b as { body: string }).body }]
+      : [],
+  );
+}
+
+function ageSeverity(iso: string): UnresolvedFollowUp["severity"] {
+  const ageDays = (Date.now() - new Date(iso).getTime()) / 86_400_000;
+  if (ageDays > 30) return "danger";
+  if (ageDays > 14) return "warning";
+  return "info";
+}
+
+/**
+ * Extract follow-up snippets from Plan/Follow-up blocks of a finalized
+ * note (or narrative fallback). Capped at 3/note.
+ */
+export function extractFollowUpsFromNote(
+  note: NoteLike,
+  patientId: string,
+): UnresolvedFollowUp[] {
+  if (note.status !== "finalized" && note.status !== "amended") return [];
+
+  const blocks = blocksToText(note.blocks).filter((b) => {
+    const h = b.heading.toLowerCase();
+    return h.includes("plan") || h.includes("follow");
+  });
+  const haystack = blocks.map((b) => b.body).join("\n").trim() || (note.narrative ?? "").trim();
+  if (!haystack) return [];
+
+  const out: UnresolvedFollowUp[] = [];
+  const seen = new Set<string>();
+  FOLLOWUP_PHRASE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = FOLLOWUP_PHRASE_RE.exec(haystack)) !== null) {
+    const raw = (match[1] || "").trim().replace(/\s+/g, " ");
+    const key = raw.toLowerCase();
+    if (raw.length < 6 || seen.has(key)) continue;
+    seen.add(key);
+    const surfaced =
+      (note.finalizedAt && new Date(note.finalizedAt).toISOString()) ||
+      new Date(note.createdAt).toISOString();
+    out.push({
+      id: `note:${note.id}:${out.length}`,
+      source: "note",
+      title: raw.length > 140 ? raw.slice(0, 137) + "…" : raw,
+      detail: `From visit note · ${new Date(surfaced).toLocaleDateString()}`,
+      surfacedAt: surfaced,
+      href: `/clinic/patients/${patientId}/notes/${note.id}`,
+      sourceRef: `noteId:${note.id}`,
+      severity: ageSeverity(surfaced),
+    });
+    if (out.length >= 3) break;
+  }
+  return out;
+}
+
+const THREAD_FOLLOWUP_CATEGORIES = new Set([
+  "follow_up",
+  "symptom_report",
+  "refill_request",
+  "lab_result",
+  "side_effect",
+]);
+
+/** Surface threads triaged as needing clinician action. */
+export function extractFollowUpFromThread(
+  thread: ThreadLike,
+  patientId: string,
+): UnresolvedFollowUp | null {
+  const category = (thread.triageCategory || "").toLowerCase();
+  const urgency = (thread.triageUrgency || "").toLowerCase();
+  const urgent = urgency === "high" || urgency === "emergency";
+  if (!category && !urgent) return null;
+  if (category && !THREAD_FOLLOWUP_CATEGORIES.has(category) && !urgent) return null;
+
+  const surfaced = new Date(thread.lastMessageAt).toISOString();
+  return {
+    id: `thread:${thread.id}`,
+    source: "message",
+    title:
+      thread.triageSummary?.trim() ||
+      thread.subject ||
+      "Patient message awaiting follow-up",
+    detail:
+      `Patient message · ${new Date(surfaced).toLocaleDateString()}` +
+      (urgency ? ` · ${urgency}` : ""),
+    surfacedAt: surfaced,
+    href: `/clinic/patients/${patientId}?tab=correspondence`,
+    sourceRef: `threadId:${thread.id}`,
+    severity: urgent ? "danger" : ageSeverity(surfaced),
+  };
+}
+
+/** Compose panel input; filter out anything an existing Task references. */
+export function buildUnresolvedFollowUps(input: {
+  patientId: string;
+  notes: NoteLike[];
+  threads: ThreadLike[];
+  existingTasks: TaskLike[];
+  limit?: number;
+}): UnresolvedFollowUp[] {
+  const { patientId, notes, threads, existingTasks, limit = 6 } = input;
+
+  const resolvedRefs = new Set(
+    existingTasks.map((t) => extractSourceRef(t.description)).filter((s): s is string => !!s),
+  );
+
+  const fromNotes = notes.flatMap((n) => extractFollowUpsFromNote(n, patientId));
+  const fromThreads = threads
+    .map((t) => extractFollowUpFromThread(t, patientId))
+    .filter((x): x is UnresolvedFollowUp => x !== null);
+
+  const rank = { danger: 0, warning: 1, info: 2 } as const;
+  return [...fromNotes, ...fromThreads]
+    .filter((f) => !resolvedRefs.has(f.sourceRef))
+    .sort(
+      (a, b) =>
+        rank[a.severity] - rank[b.severity] ||
+        new Date(b.surfacedAt).getTime() - new Date(a.surfacedAt).getTime(),
+    )
+    .slice(0, limit);
+}
+
+export function extractSourceRef(description?: string | null): string | null {
+  if (!description) return null;
+  const m = description.match(/\[sourceRef:([^\]]+)\]/);
+  return m ? m[1].trim() : null;
+}
+
+export function encodeSourceRef(ref: string): string {
+  return `[sourceRef:${ref}]`;
+}


### PR DESCRIPTION
## What changed

Surface unresolved follow-up items on the patient chart and let the
clinician one-click convert each into a tracked `Task` without leaving
the chart. Implements [EMR-675](https://linear.app/emr-project/issue/EMR-675).

- New domain lib `src/lib/domain/unresolved-followups.ts` derives "loose
  ends" server-side from:
  - Finalized note **Plan / Follow-up** blocks (matched via a phrase
    regex covering `recheck`, `titrate`, `repeat`, `reassess`, `labs
    in`, `return in`, `f/u`, etc.) — capped at 3 per note.
  - Triaged `MessageThread` rows where the Correspondence Nurse Agent
    flagged a follow-up category (`symptom_report`, `refill_request`,
    `lab_result`, `side_effect`, `follow_up`) or `urgency: high|emergency`.
- New `UnresolvedFollowUpsPanel` client component renders above the
  existing `ChartTaskList`, preserving severity ordering (danger →
  warning → info), with deep-links back to the source artifact.
- New server action `convertFollowUpToTask` in the patient-chart
  `actions.ts` enforces `notes.edit` RBAC + chart-privacy gate, then
  creates a row in the existing `Task` model assigned to the current
  clinician. The Task description embeds a `[sourceRef:noteId:abc]` /
  `[sourceRef:threadId:xyz]` marker.
- The extractor checks existing open Tasks for that marker — so once a
  follow-up is converted, it disappears from the panel automatically
  on the next chart render. No parallel followup model, no schema
  change, no migration.
- Audit log written on every conversion (`patient.followup.converted_to_task`).
- 11 unit tests cover extraction, dedupe-by-source-ref, severity rank
  ordering, and the encode/extract round-trip.

## How to verify

1. Open a patient chart that has a finalized note with a Plan block
   containing phrases like "Recheck TSH in 6 weeks" or "Titrate
   sertraline at next visit", or a triaged message thread.
2. Confirm the **Unresolved follow-ups** panel renders above
   **Open tasks**, items grouped by severity (overdue = >30d danger,
   aging = >14d warning, else info), source labeled Note/Message,
   deep-links to the originating note or correspondence tab.
3. Click **Convert to task** on an item. Verify:
   - Button shows "Adding…" while pending.
   - Item disappears from the panel on success.
   - A new row appears in **Open tasks** (ChartTaskList) on refresh.
   - The new `Task.description` contains `[sourceRef:noteId:…]`.
4. Refresh the chart — the converted item stays gone (sourceRef match).
5. As a front-office or back-office user, confirm the action is
   rejected (`Forbidden: read-only access to chart`).
6. Tests: `npx vitest run src/lib/domain/unresolved-followups.test.ts`
   (11/11 pass).
7. Lint + typecheck pass; no new warnings introduced.

## Notes

- We intentionally reuse the existing `Task` model rather than
  inventing a parallel followup persistence layer — keeps a single
  source of truth and lets the `ChartTaskList` UI continue to be the
  canonical place where converted follow-ups end up.
- The extraction is heuristic/regex-based; future work could swap in
  an LLM extractor behind the same `buildUnresolvedFollowUps` API
  without UI changes.
- No schema migration. No dependency bumps. No edits to restricted
  files (`prisma/schema.prisma`, `middleware.ts`, `.github/workflows/`,
  specialty manifests, `lib/auth/`, `CLAUDE.md`).

Co-Authored-By: Claude Opus 4.7 (1M context)