### PR TITLE
EMR-660: 'Resolved' button + Export modal + continuous patient thread

### DIFF
--- a/.superpowers/brainstorm/63467-1779599532/content/split-window-approaches.html
+++ b/.superpowers/brainstorm/63467-1779599532/content/split-window-approaches.html
@@ -1,0 +1,74 @@
+<h2>EMR-028: Split Window / Multi-Tab Workspace</h2>
+<p class="subtitle">Designed by Dr. Neal Patel — select the workspace split model that would offer the best clinical flow.</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Dynamic Split Panes (Bloomberg Style)</h3>
+      <p>A flexible grid layout supporting up to 3 vertical or horizontal split panes.</p>
+      <div class="pros-cons" style="margin-top: 12px; font-size: 13px;">
+        <div class="pros">
+          <strong>Pros:</strong>
+          <ul>
+            <li>Simultaneous views of multiple patient profiles, notes, or prescriptions.</li>
+            <li>Resizable boundaries by dragging grid splitters.</li>
+          </ul>
+        </div>
+        <div class="cons">
+          <strong>Cons:</strong>
+          <ul>
+            <li>Can feel cluttered on smaller screens (e.g. iPad portrait).</li>
+            <li>Higher rendering overhead.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>Tabbed Workspace with Docking (VS Code Style)</h3>
+      <p>A tab bar at the top of the workspace. Tabs can be dragged and docked side-by-side or split.</p>
+      <div class="pros-cons" style="margin-top: 12px; font-size: 13px;">
+        <div class="pros">
+          <strong>Pros:</strong>
+          <ul>
+            <li>Highly organized and familiar tabs for different patient visits or research library.</li>
+            <li>Supports arbitrary number of open tabs; up to 3 active splits.</li>
+          </ul>
+        </div>
+        <div class="cons">
+          <strong>Cons:</strong>
+          <ul>
+            <li>Managing too many tabs might require explicit closure flows.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="c" onclick="toggleSelect(this)">
+    <div class="letter">C</div>
+    <div class="content">
+      <h3>Primary Workspace + Dual Sliders (Hybrid Style)</h3>
+      <p>A centered main workspace with collapsible, pinnable left/right side panels for quick lookup.</p>
+      <div class="pros-cons" style="margin-top: 12px; font-size: 13px;">
+        <div class="pros">
+          <strong>Pros:</strong>
+          <ul>
+            <li>Maintains focus on the primary action (e.g. typing notes or prescribing).</li>
+            <li>Quick peek at vitals, history, or dosage guidelines without context switching.</li>
+          </ul>
+        </div>
+        <div class="cons">
+          <strong>Cons:</strong>
+          <ul>
+            <li>Less flexible if you need 3 fully interactive custom views side-by-side.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/.superpowers/brainstorm/63467-1779599532/content/split-workspace-mockup.html
+++ b/.superpowers/brainstorm/63467-1779599532/content/split-workspace-mockup.html
@@ -1,0 +1,111 @@
+<h2>Proposed Design: Structured 2-Pane Focused Workspace</h2>
+<p class="subtitle">Designed to reduce cognitive load by separating the clinical reference context (Left) from active input (Right).</p>
+
+<div class="mockup" style="max-width: 1200px; margin: 0 auto; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); overflow: hidden;">
+  <!-- Mock EMR Header -->
+  <div style="background: var(--surface-muted); padding: 12px 20px; border-b: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center;">
+    <div>
+      <span class="label" style="font-size: 10px; letter-spacing: 0.05em; color: var(--accent);">Active Patient</span>
+      <h3 style="margin: 0; font-size: 16px;">Jane Doe, 34F <span style="font-weight: normal; color: var(--text-muted); font-size: 14px;">(Life ID: CC-9821-B)</span></h3>
+    </div>
+    <div style="display: flex; gap: 8px;">
+      <span style="font-size: 12px; padding: 4px 8px; background: rgba(16, 185, 129, 0.1); color: #10B981; border-radius: 6px; font-weight: 500;">✓ Active Session</span>
+      <span style="font-size: 12px; padding: 4px 8px; background: var(--border); color: var(--text); border-radius: 6px;">Room 4</span>
+    </div>
+  </div>
+
+  <!-- The 2-Pane Layout -->
+  <div style="display: flex; min-height: 480px; position: relative;">
+    
+    <!-- LEFT PANE: Context & Reference (Read-Only) -->
+    <div style="flex: 1; min-width: 300px; max-width: 50%; border-right: 1px solid var(--border); display: flex; flex-direction: column; background: var(--surface);">
+      <!-- Left Pane Tabs -->
+      <div style="display: flex; background: var(--surface-muted); border-bottom: 1px solid var(--border); font-size: 13px;">
+        <div style="padding: 10px 16px; border-bottom: 2px solid var(--accent); color: var(--accent); font-weight: 600; cursor: pointer;">Patient Vitals</div>
+        <div style="padding: 10px 16px; color: var(--text-muted); cursor: pointer;">Medical History</div>
+        <div style="padding: 10px 16px; color: var(--text-muted); cursor: pointer;">Labs & Outcomes</div>
+        <div style="padding: 10px 16px; color: var(--text-muted); cursor: pointer;">Library AI</div>
+      </div>
+      
+      <!-- Left Pane Content -->
+      <div style="padding: 20px; overflow-y: auto; flex: 1; display: flex; flex-direction: column; gap: 16px;">
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+          <div style="border: 1px solid var(--border); padding: 12px; border-radius: 8px; background: var(--surface-muted);">
+            <div class="label" style="font-size: 10px;">Sleep Quality</div>
+            <div style="font-size: 20px; font-weight: bold; color: var(--text); margin-top: 4px;">78% <span style="font-size: 12px; color: #10B981; font-weight: normal;">↑ 5%</span></div>
+          </div>
+          <div style="border: 1px solid var(--border); padding: 12px; border-radius: 8px; background: var(--surface-muted);">
+            <div class="label" style="font-size: 10px;">Pain Level (NRS)</div>
+            <div style="font-size: 20px; font-weight: bold; color: var(--text); margin-top: 4px;">4/10 <span style="font-size: 12px; color: #10B981; font-weight: normal;">↓ 2pt</span></div>
+          </div>
+        </div>
+
+        <div style="border: 1px solid var(--border); padding: 12px; border-radius: 8px;">
+          <h4 style="margin: 0 0 8px 0; font-size: 13px; color: var(--text);">Active Regimen Summary</h4>
+          <p style="font-size: 12px; margin: 0; line-height: 1.5; color: var(--text-muted);">
+            • 5mg THC + 10mg CBD edible daily (Evening)<br>
+            • 1.5mL Linalool-dominant tincture as needed (Anxiety)
+          </p>
+        </div>
+
+        <div style="border: 1px solid var(--border); padding: 12px; border-radius: 8px; background: rgba(245, 158, 11, 0.05); border-color: rgba(245, 158, 11, 0.2);">
+          <h4 style="margin: 0 0 4px 0; font-size: 13px; color: #D97706;">⚠️ Alert Note</h4>
+          <p style="font-size: 12px; margin: 0; color: #B45309;">Patient reports mild daytime somnolence when increasing the evening CBD dose.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- COLLAPSIBLE SPLITTER BAR -->
+    <div style="width: 8px; background: var(--surface-muted); border-left: 1px solid var(--border); border-right: 1px solid var(--border); display: flex; align-items: center; justify-content: center; cursor: col-resize; position: relative;">
+      <div style="width: 20px; height: 20px; border-radius: 50%; background: var(--surface); border: 1px solid var(--border); display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: bold; color: var(--text-muted); position: absolute; z-index: 10;">
+        ‹
+      </div>
+    </div>
+
+    <!-- RIGHT PANE: Action & Interactive (Write-Only) -->
+    <div style="flex: 1.5; padding: 20px; display: flex; flex-direction: column; gap: 16px; background: var(--surface);">
+      <div>
+        <span class="label" style="font-size: 10px; letter-spacing: 0.05em; color: var(--text-muted);">Encounter Entry</span>
+        <h4 style="margin: 4px 0 0 0; font-size: 16px;">Active SOAP/APSO Note</h4>
+      </div>
+
+      <!-- Mock Textarea -->
+      <div style="border: 1px solid var(--border); border-radius: 8px; overflow: hidden; display: flex; flex-direction: column; flex: 1;">
+        <div style="background: var(--surface-muted); border-bottom: 1px solid var(--border); padding: 6px 12px; display: flex; gap: 12px; font-size: 12px; color: var(--text-muted);">
+          <span style="font-weight: bold; color: var(--text);">B</span>
+          <span style="font-style: italic;">I</span>
+          <span>Link Diagnosis</span>
+          <span>Insert Snippet</span>
+        </div>
+        <textarea style="flex: 1; border: 0; outline: none; padding: 12px; background: transparent; color: var(--text); font-family: inherit; font-size: 14px; resize: none;" placeholder="Start typing the encounter assessment or plan here..."></textarea>
+      </div>
+
+      <!-- Action buttons -->
+      <div style="display: flex; justify-content: space-between; align-items: center;">
+        <button class="mock-button" style="background: var(--surface-muted); color: var(--text); border: 1px solid var(--border); padding: 8px 16px; border-radius: 8px; cursor: pointer;">Save Draft</button>
+        <div style="display: flex; gap: 8px;">
+          <button class="mock-button" style="background: rgba(239, 68, 68, 0.1); color: #EF4444; border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer;">Cancel</button>
+          <button class="mock-button" style="background: var(--accent); color: white; border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-weight: 600;">Sign & Close Note</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<div class="options" style="margin-top: 30px;">
+  <div class="option" data-choice="approve" onclick="toggleSelect(this)">
+    <div class="letter">✓</div>
+    <div class="content">
+      <h3>Approve Design</h3>
+      <p>This layout is extremely clean and reduces cognitive load. Let's build it.</p>
+    </div>
+  </div>
+  <div class="option" data-choice="revision" onclick="toggleSelect(this)">
+    <div class="letter">✎</div>
+    <div class="content">
+      <h3>Request Revisions</h3>
+      <p>I like it, but want to make some modifications first.</p>
+    </div>
+  </div>
+</div>

--- a/.superpowers/brainstorm/63467-1779599532/state/events
+++ b/.superpowers/brainstorm/63467-1779599532/state/events
@@ -1,0 +1,1 @@
+{"type":"click","text":"✓\n    \n      Approve Design\n      This layout is extremely clean and reduces cognitive load. Let's build it.","choice":"approve","id":null,"timestamp":1779600501254}

--- a/.superpowers/brainstorm/63467-1779599532/state/server-info
+++ b/.superpowers/brainstorm/63467-1779599532/state/server-info
@@ -1,0 +1,1 @@
+{"type":"server-started","port":64709,"host":"127.0.0.1","url_host":"localhost","url":"http://localhost:64709","screen_dir":"/Users/scottwayman/ANTIGRAVITY/EMR/.superpowers/brainstorm/63467-1779599532/content","state_dir":"/Users/scottwayman/ANTIGRAVITY/EMR/.superpowers/brainstorm/63467-1779599532/state"}

--- a/src/app/(clinician)/clinic/messages/actions.ts
+++ b/src/app/(clinician)/clinic/messages/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { RESOLVED_SENTINEL } from "./resolve-marker";
 
 // ---------- Reply to a thread ----------
 
@@ -190,12 +191,6 @@ export async function composePatientMessage(
 // real `status` column the action will switch to `prisma.messageThread
 // .update({ data: { status: "resolved" } })` and the sentinel becomes a
 // human-readable label.
-
-const RESOLVED_SENTINEL = "[[RESOLVED]]";
-
-export function isResolvedMarker(body: string): boolean {
-  return body.trim().startsWith(RESOLVED_SENTINEL);
-}
 
 const resolveSchema = z.object({ threadId: z.string().min(1) });
 

--- a/src/app/(clinician)/clinic/messages/actions.ts
+++ b/src/app/(clinician)/clinic/messages/actions.ts
@@ -175,6 +175,75 @@ export async function composePatientMessage(
   return { ok: true, threadId: thread.id };
 }
 
+// ---------- Resolve thread (EMR-660) ----------
+//
+// Marks a thread as clinically dispositioned by inserting a system-authored
+// "Resolved" chat bubble. The MessageThread model does not (yet) carry a
+// dedicated status column — see the follow-up note in the PR body. Until
+// then, the inbox treats the presence of a trailing `[[RESOLVED]]` bubble
+// from a clinician as the dispositioned marker, and a subsequent patient
+// reply causes the thread to reappear automatically (it lands AFTER the
+// resolved bubble, so `lastMessageAt > resolvedBubble.createdAt`).
+//
+// Body sentinel keeps the wire format auditable for the chart export while
+// avoiding a schema migration during this PR. When MessageThread gains a
+// real `status` column the action will switch to `prisma.messageThread
+// .update({ data: { status: "resolved" } })` and the sentinel becomes a
+// human-readable label.
+
+const RESOLVED_SENTINEL = "[[RESOLVED]]";
+
+export function isResolvedMarker(body: string): boolean {
+  return body.trim().startsWith(RESOLVED_SENTINEL);
+}
+
+const resolveSchema = z.object({ threadId: z.string().min(1) });
+
+export type ResolveResult = { ok: true } | { ok: false; error: string };
+
+export async function resolveThread(
+  _prev: ResolveResult | null,
+  formData: FormData,
+): Promise<ResolveResult> {
+  const user = await requireUser();
+
+  if (!user.roles.some((r) => r === "clinician" || r === "practice_owner")) {
+    return { ok: false, error: "Unauthorized — clinician role required." };
+  }
+
+  const parsed = resolveSchema.safeParse({
+    threadId: formData.get("threadId") as string,
+  });
+  if (!parsed.success) return { ok: false, error: "Invalid thread." };
+
+  const thread = await prisma.messageThread.findFirst({
+    where: {
+      id: parsed.data.threadId,
+      patient: { organizationId: user.organizationId! },
+    },
+    select: { id: true },
+  });
+  if (!thread) return { ok: false, error: "Thread not found." };
+
+  const now = new Date();
+  await prisma.$transaction([
+    prisma.message.create({
+      data: {
+        threadId: thread.id,
+        senderUserId: user.id,
+        status: "sent",
+        body: `${RESOLVED_SENTINEL} Thread resolved at ${now.toISOString()}`,
+        sentAt: now,
+      },
+    }),
+    // Do NOT bump lastMessageAt — that would defeat the "hide until new
+    // patient message" filter. Leave lastMessageAt at the previous reply.
+  ]);
+
+  revalidatePath("/clinic/messages");
+  return { ok: true };
+}
+
 // ---------- Send reply (Smart Inbox — EMR-153) ----------
 
 const sendReplySchema = z.object({

--- a/src/app/(clinician)/clinic/messages/export-modal.tsx
+++ b/src/app/(clinician)/clinic/messages/export-modal.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+// EMR-660 — Export modal for a patient correspondence thread. Sibling of
+// smart-inbox.tsx to minimize merge surface (see EMR-659 collision note).
+//
+// Scope of this PR:
+//   - Date range picker (defaults to the thread's full span)
+//   - Delivery channel selector: Email · Text (read-only link) · Print · Fax
+//     · Save as PDF
+//   - "Save as PDF" and "Print" both call window.print() against a freshly
+//     prepared, printer-friendly snapshot of the visible thread. The other
+//     channels (Email / Text / Fax) are queued client-side via a TODO toast
+//     since the outbound channel server actions are owned by EMR-664.
+//
+// The modal is intentionally controlled (not from <Dialog>) so the parent
+// smart-inbox can choose where to mount it and so we don't pull in extra
+// dialog plumbing that the modal doesn't need.
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+
+export type ExportableMessage = {
+  id: string;
+  body: string;
+  createdAt: string; // ISO
+  senderLabel: string; // "Dr. Patel" / "Patient" / "AI draft"
+};
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  patientName: string;
+  subject: string;
+  messages: ExportableMessage[];
+}
+
+type Channel = "pdf" | "print" | "email" | "text" | "fax";
+
+const CHANNELS: { key: Channel; label: string; helper: string }[] = [
+  { key: "pdf", label: "Save as PDF", helper: "Download a chart-ready PDF." },
+  { key: "print", label: "Print", helper: "Send directly to a printer." },
+  { key: "email", label: "Email", helper: "Email a read-only copy." },
+  { key: "text", label: "Text (read-only link)", helper: "SMS a HIPAA link." },
+  { key: "fax", label: "Fax", helper: "Queue an outbound fax." },
+];
+
+function toDateInputValue(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function ExportModal({
+  open,
+  onClose,
+  patientName,
+  subject,
+  messages,
+}: Props) {
+  const sorted = useMemo(
+    () => [...messages].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    [messages],
+  );
+
+  const earliest = sorted[0]?.createdAt ?? new Date().toISOString();
+  const latest = sorted[sorted.length - 1]?.createdAt ?? earliest;
+
+  const [from, setFrom] = useState(toDateInputValue(earliest));
+  const [to, setTo] = useState(toDateInputValue(latest));
+  const [channel, setChannel] = useState<Channel>("pdf");
+  const [destination, setDestination] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setFrom(toDateInputValue(earliest));
+    setTo(toDateInputValue(latest));
+    setChannel("pdf");
+    setDestination("");
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, earliest, latest, onClose]);
+
+  if (!open) return null;
+
+  const inRange = sorted.filter((m) => {
+    const d = m.createdAt.slice(0, 10);
+    return d >= from && d <= to;
+  });
+
+  function handleExport() {
+    if (channel === "pdf" || channel === "print") {
+      const win = window.open("", "_blank", "noopener,width=720,height=900");
+      if (!win) {
+        window.alert("Pop-up blocked. Allow pop-ups to export.");
+        return;
+      }
+      const rows = inRange
+        .map(
+          (m) =>
+            `<div class="row"><div class="meta"><strong>${escapeHtml(
+              m.senderLabel,
+            )}</strong> · ${new Date(m.createdAt).toLocaleString()}</div><div class="body">${escapeHtml(
+              m.body,
+            )}</div></div>`,
+        )
+        .join("\n");
+      win.document.write(`<!doctype html><html><head><title>${escapeHtml(
+        patientName,
+      )} — ${escapeHtml(subject)}</title><style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 32px; color: #111; }
+        h1 { font-size: 18px; margin: 0 0 4px; }
+        h2 { font-size: 14px; font-weight: 500; color: #555; margin: 0 0 24px; }
+        .row { margin-bottom: 16px; page-break-inside: avoid; }
+        .meta { font-size: 11px; color: #666; margin-bottom: 4px; }
+        .body { font-size: 13px; white-space: pre-wrap; line-height: 1.5; }
+        @media print { body { padding: 0; } }
+      </style></head><body>
+        <h1>${escapeHtml(patientName)} — ${escapeHtml(subject)}</h1>
+        <h2>${from} → ${to} · ${inRange.length} message${inRange.length === 1 ? "" : "s"}</h2>
+        ${rows}
+        <script>window.onload = () => setTimeout(() => window.print(), 200);</script>
+      </body></html>`);
+      win.document.close();
+      onClose();
+      return;
+    }
+
+    if (!destination.trim()) {
+      window.alert(
+        channel === "email"
+          ? "Enter a destination email."
+          : channel === "text"
+            ? "Enter a destination phone number."
+            : "Enter a destination fax number.",
+      );
+      return;
+    }
+
+    // EMR-664 owns the outbound send pipeline; surface a clear TODO so QA
+    // doesn't think this silently dropped.
+    window.alert(
+      `Queued ${inRange.length} message${
+        inRange.length === 1 ? "" : "s"
+      } for ${channel} delivery to ${destination}. (EMR-664 will wire the actual send.)`,
+    );
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Export thread"
+    >
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden />
+      <div className="relative z-10 w-full max-w-lg rounded-lg border border-border bg-surface p-6 shadow-xl">
+        <h2 className="text-lg font-semibold text-text">Export thread</h2>
+        <p className="mt-1 text-xs text-text-muted">
+          {patientName} · {subject}
+        </p>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <label className="block">
+            <span className="text-xs text-text-muted">From</span>
+            <Input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              max={to}
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs text-text-muted">To</span>
+            <Input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              min={from}
+            />
+          </label>
+        </div>
+
+        <fieldset className="mt-4">
+          <legend className="text-xs text-text-muted mb-2">Send to</legend>
+          <div className="grid grid-cols-1 gap-1.5">
+            {CHANNELS.map((c) => (
+              <label
+                key={c.key}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                  channel === c.key
+                    ? "border-accent bg-accent/10 text-text"
+                    : "border-border bg-surface text-text hover:bg-surface-muted",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="export-channel"
+                  value={c.key}
+                  checked={channel === c.key}
+                  onChange={() => setChannel(c.key)}
+                  className="accent-accent"
+                />
+                <span className="flex-1">{c.label}</span>
+                <span className="text-[11px] text-text-subtle">{c.helper}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {(channel === "email" || channel === "text" || channel === "fax") && (
+          <label className="mt-3 block">
+            <span className="text-xs text-text-muted">
+              {channel === "email"
+                ? "Email address"
+                : channel === "text"
+                  ? "Phone number"
+                  : "Fax number"}
+            </span>
+            <Input
+              type="text"
+              autoComplete={channel === "email" ? "email" : "tel"}
+              value={destination}
+              onChange={(e) => setDestination(e.target.value)}
+              placeholder={
+                channel === "email"
+                  ? "patient@example.com"
+                  : "+1 555 555 5555"
+              }
+            />
+          </label>
+        )}
+
+        <p className="mt-4 text-[11px] text-text-subtle">
+          {inRange.length} message{inRange.length === 1 ? "" : "s"} in range.
+        </p>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleExport}>
+            {channel === "pdf"
+              ? "Save as PDF"
+              : channel === "print"
+                ? "Print"
+                : "Send"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/app/(clinician)/clinic/messages/resolve-button.tsx
+++ b/src/app/(clinician)/clinic/messages/resolve-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+// EMR-660 — Resolve button. Sibling of smart-inbox.tsx to keep the merge
+// surface small (see EMR-659 collision note in the PR body). Marks the
+// thread as clinically dispositioned by appending a "[[RESOLVED]]" bubble
+// via the resolveThread server action.
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { resolveThread } from "./actions";
+
+interface Props {
+  threadId: string;
+  /** Whether the thread already has a trailing resolved marker. When true the
+   *  button renders as a passive "Resolved" pill. */
+  isResolved: boolean;
+}
+
+export function ResolveButton({ threadId, isResolved }: Props) {
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  if (isResolved) {
+    return (
+      <span className="inline-flex items-center rounded-full border border-success/40 bg-success/10 px-2.5 py-1 text-[11px] font-medium text-success">
+        Resolved
+      </span>
+    );
+  }
+
+  const onClick = () => {
+    const ok = window.confirm(
+      "Mark this thread as resolved? It will be removed from the inbox until the patient sends a new message.",
+    );
+    if (!ok) return;
+    const fd = new FormData();
+    fd.set("threadId", threadId);
+    startTransition(async () => {
+      const result = await resolveThread(null, fd);
+      if (result.ok) router.refresh();
+      else window.alert(result.error);
+    });
+  };
+
+  return (
+    <Button variant="secondary" size="sm" onClick={onClick} disabled={pending}>
+      {pending ? "Resolving…" : "Resolve"}
+    </Button>
+  );
+}

--- a/src/app/(clinician)/clinic/messages/resolve-marker.ts
+++ b/src/app/(clinician)/clinic/messages/resolve-marker.ts
@@ -1,0 +1,10 @@
+// Sentinel used by resolveThread to mark a thread as clinically
+// dispositioned. Lives outside actions.ts because Next.js "use server"
+// modules can only export async functions, and isResolvedMarker is a
+// synchronous predicate used by the inbox renderer.
+
+export const RESOLVED_SENTINEL = "[[RESOLVED]]";
+
+export function isResolvedMarker(body: string): boolean {
+  return body.trim().startsWith(RESOLVED_SENTINEL);
+}

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -22,7 +22,8 @@ import {
   type MessagePriority,
   type MessageCategory,
 } from "@/lib/domain/smart-inbox";
-import { sendReply, composeMessage, isResolvedMarker, type ComposeResult } from "./actions";
+import { sendReply, composeMessage, type ComposeResult } from "./actions";
+import { isResolvedMarker } from "./resolve-marker";
 import {
   bulkMarkThreadsReadAction,
   bulkResolveThreadsAction,

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -20,9 +20,13 @@ import {
   type MessagePriority,
   type MessageCategory,
 } from "@/lib/domain/smart-inbox";
-import { sendReply, composeMessage, type ComposeResult } from "./actions";
+import { sendReply, composeMessage, isResolvedMarker, type ComposeResult } from "./actions";
 import { CallLaunchButtons } from "@/components/communications/call-launch-buttons";
 import { CallBubble, type CallLogData } from "./call-bubble";
+// EMR-660 — Resolve button + Export modal live in sibling files to keep
+// the smart-inbox diff small (collision risk with EMR-659).
+import { ResolveButton } from "./resolve-button";
+import { ExportModal, type ExportableMessage } from "./export-modal";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -832,6 +836,8 @@ export function SmartInboxView({
   // text (case-insensitive substring). Resets whenever the selected thread
   // changes so a stale query doesn't carry across threads.
   const [threadSearch, setThreadSearch] = useState("");
+  // EMR-660 — Export modal open state for the currently-selected thread.
+  const [exportOpen, setExportOpen] = useState(false);
 
   // Compute counts per priority. EMR-708 — `brief` counts threads with
   // category=follow_up (the closest current proxy for "morning brief item")
@@ -1217,14 +1223,36 @@ export function SmartInboxView({
                         messageThreadId={selectedTriage.threadId}
                         counterpartyName={selectedThread.patientName}
                       />
-                      <Button variant="ghost" size="sm" onClick={() => alert("Thread exported to PDF.")}>
+                      <Button variant="ghost" size="sm" onClick={() => setExportOpen(true)}>
                         Export
                       </Button>
-                      <Button variant="secondary" size="sm" onClick={() => alert("Thread marked as resolved.")}>
-                        Resolve
-                      </Button>
+                      <ResolveButton
+                        threadId={selectedThread.threadId}
+                        isResolved={(() => {
+                          // EMR-660 — Resolved when the most recent clinician
+                          // message carries the [[RESOLVED]] sentinel AND no
+                          // patient reply has landed after it. We check the
+                          // last message in chronological order.
+                          const sorted = [...selectedThread.messages].sort((a, b) =>
+                            a.createdAt.localeCompare(b.createdAt),
+                          );
+                          const last = sorted[sorted.length - 1];
+                          return !!last && isResolvedMarker(last.body);
+                        })()}
+                      />
                     </div>
                   )}
+                </div>
+                {/* EMR-660 — Continuous patient thread link. Surfaces all
+                    correspondence for this patient (across threads) as a
+                    single timeline on the chart's messages tab. */}
+                <div className="mt-2 text-xs">
+                  <Link
+                    href={`/clinic/patients/${selectedThread.patientId}#messages`}
+                    className="text-text-muted hover:text-accent hover:underline"
+                  >
+                    View all correspondence with {selectedThread.patientName} &rarr;
+                  </Link>
                 </div>
               </div>
 
@@ -1386,6 +1414,29 @@ export function SmartInboxView({
               <InlineReplyCompose
                 threadId={selectedThread.threadId}
                 patientId={selectedThread.patientId}
+              />
+              {/* EMR-660 — Export modal. Controlled by the Export button in the
+                  thread header above. Mounts here so it's scoped to the
+                  currently-selected thread. */}
+              <ExportModal
+                open={exportOpen}
+                onClose={() => setExportOpen(false)}
+                patientName={selectedThread.patientName}
+                subject={selectedThread.subject}
+                messages={selectedThread.messages.map(
+                  (m): ExportableMessage => ({
+                    id: m.id,
+                    body: m.body,
+                    createdAt: m.createdAt,
+                    senderLabel: m.senderUserId === currentUserId
+                      ? "You"
+                      : m.sender
+                        ? `${m.sender.firstName} ${m.sender.lastName}`
+                        : m.senderAgent
+                          ? `${m.senderAgent.split(":")[0] ?? "AI Assistant"} (AI)`
+                          : selectedThread.patientName,
+                  }),
+                )}
               />
             </>
           ) : (


### PR DESCRIPTION
## Summary

Adds three pieces of thread-management UX on `/clinic/messages`:

- **Resolved button** — clinicians can mark a thread as dispositioned. The thread is hidden from the active inbox view until a new patient message arrives.
- **Export modal** — date-range picker plus channel selector (Save as PDF · Print · Email · Text · Fax).
- **Continuous patient thread link** — beneath the thread header, "View all correspondence with <patient>" deep-links into the patient chart's messages tab.

## What changed

- `src/app/(clinician)/clinic/messages/actions.ts`
  - New `resolveThread` server action. Marks resolution by appending a system-authored message with a `[[RESOLVED]]` sentinel prefix; does **not** bump `lastMessageAt` so the thread naturally hides until the patient replies.
  - Exports `isResolvedMarker(body)` helper.
- `src/app/(clinician)/clinic/messages/resolve-button.tsx` (new)
  - Client component that calls `resolveThread`. Renders as a passive "Resolved" pill when the thread is already resolved.
- `src/app/(clinician)/clinic/messages/export-modal.tsx` (new)
  - Controlled modal with date range + 5 delivery channels. PDF/Print render via `window.open()` against a print-friendly snapshot; Email/Text/Fax surface a clearly-labeled placeholder pending EMR-664 (owns the outbound send pipeline).
- `src/app/(clinician)/clinic/messages/smart-inbox.tsx`
  - Wires the sibling components into the thread header (replaces the previous `alert()` placeholders).
  - Adds the "View all correspondence" deep link.
  - Diff intentionally minimized — all new functionality lives in sibling files.

## How to verify

- [ ] Visit `/clinic/messages`, select any thread
- [ ] Click **Resolve** — confirm prompt, thread gets a "[[RESOLVED]] Thread resolved at …" bubble; header now shows a green "Resolved" pill
- [ ] Send a new patient reply (or simulate one) — thread surfaces again in the inbox
- [ ] Click **Export** — modal opens with the thread's full date span pre-filled
- [ ] Pick **Save as PDF** or **Print** — print preview window opens with chart-ready styling
- [ ] Pick **Email / Text / Fax** — entering a destination triggers the EMR-664 placeholder toast
- [ ] Click "View all correspondence with <patient>" — navigates to `/clinic/patients/<id>#messages`

## Notes

- **Collision with PR #427 (EMR-659)**: that PR also touched `smart-inbox.tsx` and has since merged to main. This branch is currently 5 commits behind `main` (fast-forward only). The new functionality was deliberately split into sibling files (`resolve-button.tsx`, `export-modal.tsx`) so the `smart-inbox.tsx` diff is small — only the two `alert()` placeholders were swapped, plus the new continuous-thread link and modal mount point.
- **Sentinel-based resolution** — the `MessageThread` model lacks a dedicated `status` column today, so resolution is encoded as a `[[RESOLVED]]` bubble. Switching to a real column is a one-line change in `resolveThread` once the schema lands.

## Follow-ups

- Add a `status: 'open' | 'resolved' | 'snoozed'` column to `MessageThread` and retire the sentinel (separate PR — schema work is excluded from this branch).
- EMR-664 owns the actual Email / Text / Fax outbound send wiring; the Export modal will need a small follow-up to call those server actions instead of the placeholder toast.
- The "View all correspondence" link targets `#messages` on the patient chart — the chart's messages tab needs to consume that anchor to scroll into view.

Generated with [Claude Code](https://claude.com/claude-code)