### PR TITLE
EMR-792: PO PDF generation + supplier email

### DIFF
--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -37,6 +37,17 @@ export interface SendEmailInput {
   cc?: string[];
   /** Optional tag set (Resend supports custom tags for searching). */
   tags?: Array<{ name: string; value: string }>;
+  /** Optional file attachments (EMR-792). Resend accepts a Base64
+   * `content` string + `filename`; an optional `contentType` lets us
+   * send HTML POs in v1 and swap to PDF without API changes. */
+  attachments?: Array<{
+    filename: string;
+    content: Buffer;
+    contentType?: string;
+  }>;
+  /** Optional headers — Resend forwards select headers (e.g.
+   * `Message-ID`) so callers can drive idempotency. */
+  headers?: Record<string, string>;
 }
 
 export type SendEmailResult =
@@ -53,7 +64,7 @@ export async function sendEmail(
     return { ok: false, reason: "no-api-key" };
   }
 
-  const body = {
+  const body: Record<string, unknown> = {
     from: input.from ?? process.env.EMAIL_FROM ?? DEFAULT_FROM,
     to: input.to,
     cc: input.cc,
@@ -62,7 +73,15 @@ export async function sendEmail(
     html: input.html,
     reply_to: input.replyTo,
     tags: input.tags,
+    headers: input.headers,
   };
+  if (input.attachments && input.attachments.length > 0) {
+    body.attachments = input.attachments.map((a) => ({
+      filename: a.filename,
+      content: a.content.toString("base64"),
+      content_type: a.contentType,
+    }));
+  }
 
   let res: Response;
   try {

--- a/src/lib/po/__tests__/email.test.ts
+++ b/src/lib/po/__tests__/email.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SupplyOrderForEmail } from "../types";
+
+const base: SupplyOrderForEmail = {
+  poRef: "PO-acme-0042",
+  practice: {
+    name: "Acme Pain Clinic",
+    addressLines: ["123 Mission St", "San Francisco, CA 94103"],
+    email: "billing@acmepain.example",
+  },
+  supplier: { name: "Henry Schein Medical", email: "orders@hs.example" },
+  line: { supplyName: "Nitrile Exam Gloves, M", qty: 4, unitCostCents: 1875 },
+  expectedDeliveryAt: new Date("2026-06-01T00:00:00Z"),
+  paymentTermsDays: 30,
+  createdAt: new Date("2026-05-22T17:00:00Z"),
+};
+const fixture = (o: Partial<SupplyOrderForEmail> = {}): SupplyOrderForEmail =>
+  ({ ...base, ...o });
+
+vi.mock("@/lib/email/resend", () => ({ sendEmail: vi.fn() }));
+
+describe("sendSupplyOrderEmail", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls sendEmail with the right subject, recipient, and attachment", async () => {
+    const { sendEmail } = await import("@/lib/email/resend");
+    vi.mocked(sendEmail).mockResolvedValue({ ok: true, id: "re_zzz999" });
+
+    const { sendSupplyOrderEmail } = await import("../email");
+    const pdf = Buffer.from("pretend-pdf-bytes", "utf8");
+    const result = await sendSupplyOrderEmail(fixture(), pdf);
+
+    expect(vi.mocked(sendEmail)).toHaveBeenCalledOnce();
+    const arg = vi.mocked(sendEmail).mock.calls[0]![0];
+    expect(arg.to).toEqual(["orders@hs.example"]);
+    expect(arg.replyTo).toBe("billing@acmepain.example");
+    expect(arg.subject).toBe(
+      "[Acme Pain Clinic] Purchase Order PO-acme-0042",
+    );
+    expect(arg.text).toContain("4 × Nitrile Exam Gloves, M");
+    expect(arg.text).toContain("net 30");
+    expect(arg.html).toContain("PO-acme-0042");
+    expect(arg.attachments).toHaveLength(1);
+    expect(arg.attachments![0].filename).toBe("PO-acme-0042.html");
+    expect(arg.attachments![0].content).toBe(pdf);
+    expect(arg.tags).toEqual([
+      { name: "kind", value: "supply-order" },
+      { name: "po_ref", value: "PO-acme-0042" },
+    ]);
+    expect(result.messageId).toBe("re_zzz999");
+    expect(result.sentAt).toBeInstanceOf(Date);
+  });
+
+  it("throws SupplyOrderEmailError when the supplier has no email", async () => {
+    const { sendSupplyOrderEmail, SupplyOrderEmailError } =
+      await import("../email");
+    await expect(
+      sendSupplyOrderEmail(
+        fixture({ supplier: { name: "No Email Co" } }),
+        Buffer.from("x"),
+      ),
+    ).rejects.toBeInstanceOf(SupplyOrderEmailError);
+  });
+
+  it("throws when the provider reports failure", async () => {
+    const { sendEmail } = await import("@/lib/email/resend");
+    vi.mocked(sendEmail).mockResolvedValue({
+      ok: false,
+      reason: "http-error",
+      status: 500,
+      message: "boom",
+    });
+    const { sendSupplyOrderEmail, SupplyOrderEmailError } =
+      await import("../email");
+    await expect(
+      sendSupplyOrderEmail(fixture(), Buffer.from("x")),
+    ).rejects.toBeInstanceOf(SupplyOrderEmailError);
+  });
+
+  it("surfaces no-api-key with a typed reason", async () => {
+    const { sendEmail } = await import("@/lib/email/resend");
+    vi.mocked(sendEmail).mockResolvedValue({ ok: false, reason: "no-api-key" });
+    const { sendSupplyOrderEmail } = await import("../email");
+    await expect(
+      sendSupplyOrderEmail(fixture(), Buffer.from("x")),
+    ).rejects.toMatchObject({
+      name: "SupplyOrderEmailError",
+      reason: "no-api-key",
+    });
+  });
+});

--- a/src/lib/po/__tests__/pdf.test.ts
+++ b/src/lib/po/__tests__/pdf.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { generateSupplyOrderPdf, poAttachmentFilename } from "../pdf";
+import type { SupplyOrderForPdf } from "../types";
+
+const base: SupplyOrderForPdf = {
+  poRef: "PO-acme-0042",
+  practice: {
+    name: "Acme Pain Clinic",
+    addressLines: ["123 Mission St", "San Francisco, CA 94103"],
+    email: "billing@acmepain.example",
+  },
+  supplier: { name: "Henry Schein Medical", email: "orders@hs.example" },
+  line: {
+    supplyName: "Nitrile Exam Gloves, M",
+    sku: "HS-NEG-M-1000",
+    qty: 4,
+    unitCostCents: 1875,
+  },
+  expectedDeliveryAt: new Date("2026-06-01T00:00:00Z"),
+  paymentTermsDays: 30,
+  notes: "Loading dock open 9–4.",
+  createdAt: new Date("2026-05-22T17:00:00Z"),
+};
+
+const fixture = (o: Partial<SupplyOrderForPdf> = {}): SupplyOrderForPdf => ({
+  ...base,
+  ...o,
+});
+
+describe("generateSupplyOrderPdf", () => {
+  it("returns a non-empty Buffer", async () => {
+    const buf = await generateSupplyOrderPdf(fixture());
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.byteLength).toBeGreaterThan(500);
+  });
+
+  it("embeds PO ref, supply name, supplier, and practice", async () => {
+    const text = (await generateSupplyOrderPdf(fixture())).toString("utf8");
+    expect(text).toContain("PO-acme-0042");
+    expect(text).toContain("Nitrile Exam Gloves, M");
+    expect(text).toContain("Henry Schein Medical");
+    expect(text).toContain("Acme Pain Clinic");
+  });
+
+  it("renders line total = qty × unit cost", async () => {
+    const text = (await generateSupplyOrderPdf(fixture())).toString("utf8");
+    // 4 × $18.75 = $75.00 — appears twice (line + footer).
+    expect(text.match(/\$75\.00/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders payment terms from the supplier default", async () => {
+    const text = (
+      await generateSupplyOrderPdf(fixture({ paymentTermsDays: 45 }))
+    ).toString("utf8");
+    expect(text).toContain("Net 45");
+  });
+
+  it("escapes user-supplied text to defeat HTML injection", async () => {
+    const text = (
+      await generateSupplyOrderPdf(
+        fixture({ notes: "<script>alert(1)</script>" }),
+      )
+    ).toString("utf8");
+    expect(text).not.toContain("<script>alert(1)</script>");
+    expect(text).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("omits the notes section when no notes are supplied", async () => {
+    const text = (
+      await generateSupplyOrderPdf(fixture({ notes: undefined }))
+    ).toString("utf8");
+    expect(text).not.toContain(">Notes<");
+  });
+
+  it("filename uses the PO ref", () => {
+    expect(poAttachmentFilename("PO-acme-0042")).toBe("PO-acme-0042.html");
+  });
+});

--- a/src/lib/po/email.ts
+++ b/src/lib/po/email.ts
@@ -1,0 +1,94 @@
+// Supplier-facing PO email for the PMA v1 supply ordering pipeline
+// (EMR-792). Reuses the project's Resend wrapper rather than
+// introducing a second transactional-email provider.
+//
+// Throws SupplyOrderEmailError on any failure so the Architect's state
+// machine can catch and park the order in `submit_failed` for retry.
+
+import { sendEmail } from "@/lib/email/resend";
+import { poAttachmentFilename, PO_PDF_MIME } from "./pdf";
+import type { SupplyOrderForEmail } from "./types";
+
+export class SupplyOrderEmailError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: string,
+  ) {
+    super(message);
+    this.name = "SupplyOrderEmailError";
+  }
+}
+
+export interface SupplyOrderEmailResult {
+  messageId: string;
+  sentAt: Date;
+}
+
+const subject = (o: SupplyOrderForEmail): string =>
+  `[${o.practice.name}] Purchase Order ${o.poRef}`;
+
+const eta = (o: SupplyOrderForEmail): string =>
+  o.expectedDeliveryAt
+    ? o.expectedDeliveryAt.toISOString().slice(0, 10)
+    : "to be confirmed";
+
+const text = (o: SupplyOrderForEmail): string =>
+  [
+    `Please find attached PO ${o.poRef} for ${o.line.qty} × ${o.line.supplyName}.`,
+    `Expected delivery: ${eta(o)}.`,
+    `Payment terms: net ${o.paymentTermsDays}.`,
+    `Reply to confirm receipt.`,
+    ``,
+    `— ${o.practice.name}`,
+  ].join("\n");
+
+const html = (o: SupplyOrderForEmail): string =>
+  `<!doctype html><html><body style="font:14px/1.5 -apple-system,BlinkMacSystemFont,system-ui,sans-serif;color:#111;margin:0;padding:24px;background:#fff">
+<p>Please find attached PO <strong>${o.poRef}</strong> for <strong>${o.line.qty} × ${o.line.supplyName}</strong>.</p>
+<p style="color:#3a3a3c">Expected delivery: ${eta(o)}.<br/>Payment terms: net ${o.paymentTermsDays}.</p>
+<p>Reply to confirm receipt.</p>
+<p style="color:#6e6e73;margin-top:24px">— ${o.practice.name}</p>
+</body></html>`;
+
+/**
+ * Send the supplier a Purchase Order email with the PO document attached.
+ *
+ * Throws `SupplyOrderEmailError` on any failure; the orchestrator
+ * (EMR-788) catches and parks the order in `submit_failed`.
+ */
+export async function sendSupplyOrderEmail(
+  order: SupplyOrderForEmail,
+  pdfAttachment: Buffer,
+): Promise<SupplyOrderEmailResult> {
+  if (!order.supplier.email) {
+    throw new SupplyOrderEmailError(
+      `supplier "${order.supplier.name}" has no email on file`,
+      "missing-supplier-email",
+    );
+  }
+  const result = await sendEmail({
+    to: [order.supplier.email],
+    replyTo: order.practice.email,
+    subject: subject(order),
+    text: text(order),
+    html: html(order),
+    attachments: [
+      {
+        filename: poAttachmentFilename(order.poRef),
+        content: pdfAttachment,
+        contentType: PO_PDF_MIME,
+      },
+    ],
+    tags: [
+      { name: "kind", value: "supply-order" },
+      { name: "po_ref", value: order.poRef },
+    ],
+  });
+  if (!result.ok) {
+    throw new SupplyOrderEmailError(
+      `failed to send supplier email: ${result.reason}`,
+      result.reason,
+    );
+  }
+  return { messageId: result.id, sentAt: new Date() };
+}

--- a/src/lib/po/pdf.ts
+++ b/src/lib/po/pdf.ts
@@ -1,0 +1,76 @@
+// Purchase-order "PDF" renderer for the Practice Manager Agent v1
+// supply-ordering pipeline (EMR-792).
+//
+// No PDF library is installed (checked package.json: no
+// @react-pdf/renderer, pdfkit, pdf-lib, puppeteer). Per the spec we
+// ship HTML-only for v1 and document the missing dep as a follow-up.
+// The function still returns a Buffer so the public surface won't
+// change when a real PDF renderer lands.
+//
+// TODO(EMR-792-followup): swap the HTML emitter for @react-pdf/renderer.
+
+import type { SupplyOrderForPdf } from "./types";
+
+export const PO_PDF_MIME = "text/html; charset=utf-8";
+
+const esc = (v: string): string =>
+  v
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const money = (cents: number): string => `$${(cents / 100).toFixed(2)}`;
+const ymd = (d: Date): string => d.toISOString().slice(0, 10);
+
+function renderHtml(order: SupplyOrderForPdf): string {
+  const { practice, supplier, line, expectedDeliveryAt, paymentTermsDays } =
+    order;
+  const lineTotal = line.qty * line.unitCostCents;
+  const address = practice.addressLines.map(esc).join("<br/>");
+  const supplierBlock = [
+    `<strong>${esc(supplier.name)}</strong>`,
+    supplier.contactName && esc(supplier.contactName),
+    supplier.email && esc(supplier.email),
+    supplier.phone && esc(supplier.phone),
+  ]
+    .filter(Boolean)
+    .join("<br/>");
+  const eta = expectedDeliveryAt
+    ? `<div><span class="label">Expected delivery</span> ${ymd(expectedDeliveryAt)}</div>`
+    : "";
+  const notes = order.notes
+    ? `<section class="notes"><h3>Notes</h3><p>${esc(order.notes)}</p></section>`
+    : "";
+
+  // Apple-iOS aesthetic per CLAUDE.md: system font, soft greys, no chrome.
+  const css = `*{box-sizing:border-box}body{font:14px/1.5 -apple-system,BlinkMacSystemFont,"SF Pro Text",system-ui,sans-serif;color:#111;margin:0;padding:48px;background:#fff}header{display:flex;justify-content:space-between;align-items:flex-start;border-bottom:1px solid #e5e5ea;padding-bottom:24px;margin-bottom:32px}header h1{font-size:24px;font-weight:600;margin:0 0 4px;letter-spacing:-.01em}.ref{text-align:right;font-size:13px;color:#6e6e73}.ref strong{display:block;color:#111;font-size:18px;margin-top:2px}.logo{width:40px;height:40px;border-radius:10px;background:#f2f2f7;margin-bottom:12px}.blocks{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-bottom:32px}.block h3,.notes h3{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:#6e6e73;margin:0 0 8px;font-weight:600}.block p{margin:0}table{width:100%;border-collapse:collapse;margin-bottom:24px}thead th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:#6e6e73;padding:8px 12px;border-bottom:1px solid #e5e5ea;font-weight:600}tbody td{padding:14px 12px;border-bottom:1px solid #f2f2f7;vertical-align:top}td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}tfoot td{padding:14px 12px;font-weight:600}.meta{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:24px 0;font-size:13px}.meta .label{display:inline-block;min-width:140px;color:#6e6e73}.notes{background:#f8f8fa;border-radius:12px;padding:16px 20px;margin-top:24px}.notes p{margin:0;white-space:pre-wrap}footer{margin-top:32px;padding-top:16px;border-top:1px solid #e5e5ea;font-size:12px;color:#6e6e73}`;
+
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"/><title>Purchase Order ${esc(order.poRef)}</title><style>${css}</style></head><body>
+<header><div><div class="logo" aria-hidden="true"></div><h1>${esc(practice.name)}</h1><p style="margin:0;color:#6e6e73;font-size:13px">${address}</p></div><div class="ref">Purchase Order<strong>${esc(order.poRef)}</strong>${ymd(order.createdAt)}</div></header>
+<div class="blocks"><div class="block"><h3>Bill to / Ship to</h3><p><strong>${esc(practice.name)}</strong><br/>${address}</p></div><div class="block"><h3>Supplier</h3><p>${supplierBlock}</p></div></div>
+<table><thead><tr><th>Item</th><th>SKU</th><th class="num">Qty</th><th class="num">Unit cost</th><th class="num">Line total</th></tr></thead>
+<tbody><tr><td>${esc(line.supplyName)}</td><td>${line.sku ? esc(line.sku) : "—"}</td><td class="num">${line.qty}</td><td class="num">${money(line.unitCostCents)}</td><td class="num">${money(lineTotal)}</td></tr></tbody>
+<tfoot><tr><td colspan="4" class="num">Total</td><td class="num">${money(lineTotal)}</td></tr></tfoot></table>
+<section class="meta"><div><span class="label">Payment terms</span> Net ${paymentTermsDays}</div>${eta}</section>
+${notes}
+<footer>Generated ${ymd(order.createdAt)} by Leafjourney Practice Manager. Reply to <a href="mailto:${esc(practice.email ?? "")}">${esc(practice.email ?? "the practice")}</a> with questions.</footer>
+</body></html>`;
+}
+
+/**
+ * Render a Purchase Order as a printable document.
+ *
+ * v1 returns an HTML document encoded as a UTF-8 Buffer. Swappable for
+ * a real PDF later without changing this signature.
+ */
+export async function generateSupplyOrderPdf(
+  order: SupplyOrderForPdf,
+): Promise<Buffer> {
+  return Buffer.from(renderHtml(order), "utf8");
+}
+
+/** Filename for the email attachment. `.html` in v1; flip to `.pdf` later. */
+export function poAttachmentFilename(poRef: string): string {
+  return `${poRef}.html`;
+}

--- a/src/lib/po/types.ts
+++ b/src/lib/po/types.ts
@@ -1,0 +1,40 @@
+// Input shapes for the PMA v1 PO generation + supplier email pipeline
+// (EMR-792). Kept narrow: the Architect PR (EMR-788/789/790/794) owns
+// the SupplyOrder / Supplier / Practice Prisma models and adapts them
+// into these shapes when transitioning `approved` → `submitted`.
+// Decoupling storage from the PDF/email surface lets v1 ship without
+// taking a hard dep on the parallel Architect work.
+
+export interface SupplyOrderForPdf {
+  /** Human-facing PO ref, e.g. `PO-acme-0042`. Architect generates it. */
+  poRef: string;
+  practice: {
+    name: string;
+    addressLines: string[];
+    phone?: string;
+    email?: string;
+  };
+  supplier: {
+    name: string;
+    contactName?: string;
+    email?: string;
+    phone?: string;
+  };
+  /** v1 ships a single line item; PDF still renders as a table so
+   * future multi-line POs slot in without re-layout. */
+  line: {
+    supplyName: string;
+    sku?: string;
+    qty: number;
+    unitCostCents: number;
+  };
+  expectedDeliveryAt?: Date;
+  /** Net-N payment terms (from `supplier.defaultPaymentTermsDays`). */
+  paymentTermsDays: number;
+  notes?: string;
+  createdAt: Date;
+}
+
+// Identical surface in v1 — extends so callers can pass one object to
+// both `generateSupplyOrderPdf` and `sendSupplyOrderEmail`.
+export type SupplyOrderForEmail = SupplyOrderForPdf;


### PR DESCRIPTION
Closes EMR-792 (part of EMR-787 — Practice Manager Agent v1).

Self-contained library that the Architect's state machine (EMR-788/789/790/794) will call once a `SupplyOrder` transitions `approved` -> `submitted`.

## What changed

- `src/lib/po/types.ts` — `SupplyOrderForPdf` / `SupplyOrderForEmail` input shapes. Decoupled from Prisma models so the Architect PR can land in parallel.
- `src/lib/po/pdf.ts` — `generateSupplyOrderPdf(order) -> Promise<Buffer>`. Renders a printable PO with header (practice + logo placeholder + ref + date), bill-to/ship-to, supplier block, line-items table (single row in v1, table-shaped so multi-line slots in later), Net-N payment terms footer, and notes section. Apple-iOS aesthetic per project CLAUDE.md.
- `src/lib/po/email.ts` — `sendSupplyOrderEmail(order, pdfAttachment) -> Promise<{ messageId, sentAt }>`. Reuses the existing Resend wrapper. Subject `[Practice Name] Purchase Order ${poRef}`. Throws typed `SupplyOrderEmailError` on failure (missing supplier email, provider error, no-api-key) so the orchestrator can park the order in `submit_failed`.
- `src/lib/email/resend.ts` — additive extension: optional `attachments[]` (Base64-encoded automatically) and `headers` fields. Existing 4 unit tests still pass — purely additive change.
- Tests: 11 new vitest cases covering Buffer non-empty, key field rendering, line-total math, payment terms, HTML-injection escaping, notes omission, email subject/recipient/attachment/tags wiring, and all three failure paths.

## Library chosen

**HTML-only, real PDF lib is a follow-up.** `package.json` has none of `@react-pdf/renderer`, `pdfkit`, `pdf-lib`, or `puppeteer`. Per the EMR-792 spec, instead of adding a dep without approval I ship HTML rendered to a UTF-8 `Buffer` and document the swap. The public API (`generateSupplyOrderPdf -> Buffer`) is stable — only the body changes when a real renderer lands. Resend accepts HTML attachments fine for v1.

Follow-up ticket: install `@react-pdf/renderer` and swap the HTML emitter. No call-site changes required.

## Public API surface (for the Architect's state machine)

```ts
import { generateSupplyOrderPdf } from "@/lib/po/pdf";
import { sendSupplyOrderEmail, SupplyOrderEmailError } from "@/lib/po/email";
import type { SupplyOrderForPdf, SupplyOrderForEmail } from "@/lib/po/types";

// In the `approved` -> `submitted` transition:
const pdf = await generateSupplyOrderPdf(order);   // Buffer
const { messageId, sentAt } = await sendSupplyOrderEmail(order, pdf);
// store messageId on SupplyOrder.submittedMessageId, sentAt on submittedAt
// catch SupplyOrderEmailError -> park in `submit_failed`
```

## How to verify

```bash
npx prisma generate
npm run typecheck
npm run lint
npx vitest run src/lib/po/ src/lib/email/
```

All pass locally (15/15 tests, typecheck clean, lint shows only pre-existing warnings unrelated to this PR).

## Notes

- 382 LOC total (under the 400 cap).
- No new npm dependencies.
- Did NOT touch: `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, `src/lib/specialty-templates/manifests/`, `src/lib/auth/`, `CLAUDE.md`, `src/lib/agents/`, `src/lib/domain/supplies.ts`, `src/app/(operator)/ops/supplies/` (per parallel-agent constraints).
- Bounce handling is explicitly out of scope per the ticket (phase-2 problem).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>