### PR TITLE
EMR-787 v1 foundation (788/789/790/794): schema + supplyReorderAgent + orchestrator + state machine

### DIFF
--- a/prisma/migrations/20260522000000_practice_manager_agent_v1/migration.sql
+++ b/prisma/migrations/20260522000000_practice_manager_agent_v1/migration.sql
@@ -1,0 +1,197 @@
+-- EMR-787 — Practice Manager Agent v1 (EMR-788 schema)
+-- Clinical / office supplies. Distinct from the cannabis dispensary domain
+-- (CannabisProduct / SupplyProduct). Domain helpers in
+-- src/lib/domain/supplies.ts.
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+
+CREATE TYPE "SupplyOrderStatus" AS ENUM (
+  'agent_drafted',
+  'awaiting_approval',
+  'approved',
+  'submitted',
+  'shipped',
+  'delivered',
+  'rejected',
+  'cancelled'
+);
+
+CREATE TYPE "SupplyOrderProposedByKind" AS ENUM (
+  'agent',
+  'user'
+);
+
+CREATE TYPE "SupplyOrderActorKind" AS ENUM (
+  'agent',
+  'user',
+  'system'
+);
+
+CREATE TYPE "SupplyOrderAuditAction" AS ENUM (
+  'drafted',
+  'approved',
+  'rejected',
+  'submitted',
+  'shipped',
+  'delivered',
+  'edited',
+  'cancelled',
+  'auto_submitted',
+  'reverted'
+);
+
+-- ---------------------------------------------------------------------------
+-- Supplier
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE "Supplier" (
+  "id"                      TEXT NOT NULL,
+  "organizationId"          TEXT NOT NULL,
+  "name"                    TEXT NOT NULL,
+  "contactName"             TEXT,
+  "email"                   TEXT,
+  "phone"                   TEXT,
+  "defaultPaymentTermsDays" INTEGER NOT NULL DEFAULT 30,
+  "notes"                   TEXT,
+  "createdAt"               TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"               TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Supplier_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Supplier_organizationId_idx" ON "Supplier"("organizationId");
+
+ALTER TABLE "Supplier"
+  ADD CONSTRAINT "Supplier_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- Supply
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE "Supply" (
+  "id"                TEXT NOT NULL,
+  "organizationId"    TEXT NOT NULL,
+  "name"              TEXT NOT NULL,
+  "sku"               TEXT,
+  "category"          TEXT,
+  "supplierId"        TEXT,
+  "reorderThreshold"  INTEGER NOT NULL DEFAULT 0,
+  "reorderQty"        INTEGER NOT NULL DEFAULT 0,
+  "lastUnitCostCents" INTEGER,
+  "onHand"            INTEGER NOT NULL DEFAULT 0,
+  "unit"              TEXT NOT NULL DEFAULT 'ea',
+  "notes"             TEXT,
+  "deletedAt"         TIMESTAMP(3),
+  "createdAt"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"         TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Supply_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Supply_organizationId_idx" ON "Supply"("organizationId");
+CREATE INDEX "Supply_organizationId_deletedAt_idx"
+  ON "Supply"("organizationId", "deletedAt");
+
+ALTER TABLE "Supply"
+  ADD CONSTRAINT "Supply_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Supply"
+  ADD CONSTRAINT "Supply_supplierId_fkey"
+  FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- SupplyOrder
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE "SupplyOrder" (
+  "id"                  TEXT NOT NULL,
+  "organizationId"      TEXT NOT NULL,
+  "supplyId"            TEXT NOT NULL,
+  "supplierId"          TEXT NOT NULL,
+  "status"              "SupplyOrderStatus" NOT NULL DEFAULT 'agent_drafted',
+  "qty"                 INTEGER NOT NULL,
+  "unitCostCents"       INTEGER NOT NULL,
+  "totalCents"          INTEGER NOT NULL,
+  "proposedByKind"      "SupplyOrderProposedByKind" NOT NULL,
+  "proposedByAgentId"   TEXT,
+  "proposedByUserId"    TEXT,
+  "approvedByUserId"    TEXT,
+  "autoSubmitted"       BOOLEAN NOT NULL DEFAULT false,
+  "rejectionReason"     TEXT,
+  "submittedAt"         TIMESTAMP(3),
+  "shippedAt"           TIMESTAMP(3),
+  "deliveredAt"         TIMESTAMP(3),
+  "deliveredQty"        INTEGER,
+  "expectedDeliveryAt"  TIMESTAMP(3),
+  "supplierPoRef"       TEXT,
+  "createdAt"           TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"           TIMESTAMP(3) NOT NULL,
+  "deletedAt"           TIMESTAMP(3),
+  CONSTRAINT "SupplyOrder_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "SupplyOrder_organizationId_status_idx"
+  ON "SupplyOrder"("organizationId", "status");
+CREATE INDEX "SupplyOrder_supplyId_createdAt_idx"
+  ON "SupplyOrder"("supplyId", "createdAt" DESC);
+CREATE INDEX "SupplyOrder_organizationId_createdAt_idx"
+  ON "SupplyOrder"("organizationId", "createdAt");
+
+ALTER TABLE "SupplyOrder"
+  ADD CONSTRAINT "SupplyOrder_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SupplyOrder"
+  ADD CONSTRAINT "SupplyOrder_supplyId_fkey"
+  FOREIGN KEY ("supplyId") REFERENCES "Supply"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "SupplyOrder"
+  ADD CONSTRAINT "SupplyOrder_supplierId_fkey"
+  FOREIGN KEY ("supplierId") REFERENCES "Supplier"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "SupplyOrder"
+  ADD CONSTRAINT "SupplyOrder_approvedByUserId_fkey"
+  FOREIGN KEY ("approvedByUserId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "SupplyOrder"
+  ADD CONSTRAINT "SupplyOrder_proposedByUserId_fkey"
+  FOREIGN KEY ("proposedByUserId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- SupplyOrderAuditEntry — append-only per-order activity feed.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE "SupplyOrderAuditEntry" (
+  "id"            TEXT NOT NULL,
+  "orderId"       TEXT NOT NULL,
+  "actorKind"     "SupplyOrderActorKind" NOT NULL,
+  "actorAgentId"  TEXT,
+  "actorUserId"   TEXT,
+  "action"        "SupplyOrderAuditAction" NOT NULL,
+  "payload"       JSONB,
+  "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SupplyOrderAuditEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "SupplyOrderAuditEntry_orderId_createdAt_idx"
+  ON "SupplyOrderAuditEntry"("orderId", "createdAt");
+
+ALTER TABLE "SupplyOrderAuditEntry"
+  ADD CONSTRAINT "SupplyOrderAuditEntry_orderId_fkey"
+  FOREIGN KEY ("orderId") REFERENCES "SupplyOrder"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SupplyOrderAuditEntry"
+  ADD CONSTRAINT "SupplyOrderAuditEntry_actorUserId_fkey"
+  FOREIGN KEY ("actorUserId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,6 +154,13 @@ model Organization {
   // One-to-one with Organization. Created on first paid event or via the
   // admin tooling; absent for orgs that haven't onboarded billing yet.
   practiceSubscription PracticeSubscription?
+
+  // EMR-787 — Practice Manager Agent v1 (clinical / office supplies).
+  // PARALLEL to `cannabisProducts` / `supplyProducts` (those are dispensary
+  // domain). These are the gloves-and-gowns side of the practice.
+  supplies     Supply[]
+  suppliers    Supplier[]
+  supplyOrders SupplyOrder[]
 }
 
 // EMR-420 — A Practice is a single clinical location/group under an
@@ -229,6 +236,10 @@ model User {
   cannabisRxsWritten        CannabisRx[]                @relation("CannabisRxProvider")
   pdmpChecksRequested       CuresPdmpCheck[]            @relation("PdmpRequester")
   pdmpChecksAcknowledged    CuresPdmpCheck[]            @relation("PdmpAcknowledger")
+  // EMR-787 — Practice Manager Agent v1 reverse relations.
+  approvedSupplyOrders      SupplyOrder[]               @relation("SupplyOrderApprover")
+  supplyOrdersProposed      SupplyOrder[]               @relation("SupplyOrderProposer")
+  supplyOrderAuditEntries   SupplyOrderAuditEntry[]     @relation("SupplyOrderAuditActor")
 }
 
 model Membership {
@@ -372,7 +383,7 @@ model Patient {
   freezeTokens FreezeToken[]
 
   // EMR-107 — ChatCB AI Coach
-  aiCoachThreads AICoachThread[]
+  aiCoachThreads        AICoachThread[]
   pastMedicalConditions PastMedicalCondition[]
   pastSurgeries         PastSurgery[]
 
@@ -5124,15 +5135,15 @@ model PracticeSubscription {
 }
 
 model PastMedicalCondition {
-  id           String    @id @default(cuid())
-  patientId    String
-  condition    String    // e.g., "Diabetes Mellitus Type 2"
-  notes        String?   // Clinician notes or description
-  onsetYear    Int?      // Estimated or actual year of onset
-  source       String?   // e.g., "intake", "clinician", "imported", "ai"
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  deletedAt    DateTime? // Soft delete timestamp
+  id        String    @id @default(cuid())
+  patientId String
+  condition String // e.g., "Diabetes Mellitus Type 2"
+  notes     String? // Clinician notes or description
+  onsetYear Int? // Estimated or actual year of onset
+  source    String? // e.g., "intake", "clinician", "imported", "ai"
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? // Soft delete timestamp
 
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
@@ -5142,10 +5153,10 @@ model PastMedicalCondition {
 model PastSurgery {
   id                String    @id @default(cuid())
   patientId         String
-  procedure         String    // e.g., "Left Total Knee Arthroplasty"
-  notes             String?   // Surgical notes or details
-  performedDateText String?   // Flexible display text (e.g., "August 2022")
-  source            String?   // e.g., "intake", "clinician", "imported", "ai"
+  procedure         String // e.g., "Left Total Knee Arthroplasty"
+  notes             String? // Surgical notes or details
+  performedDateText String? // Flexible display text (e.g., "August 2022")
+  source            String? // e.g., "intake", "clinician", "imported", "ai"
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
   deletedAt         DateTime? // Soft delete timestamp
@@ -5153,4 +5164,149 @@ model PastSurgery {
   patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
+}
+
+// --------------------------------------------------------------
+// EMR-787 — Practice Manager Agent v1
+// --------------------------------------------------------------
+// Clinical / office supplies (gloves, gowns, BP cuffs, exam-table paper).
+// PARALLEL to — and intentionally separate from — `CannabisProduct` /
+// `SupplyProduct`, which model the dispensary side of inventory.
+// Domain types + helpers live in `src/lib/domain/supplies.ts`.
+// --------------------------------------------------------------
+
+enum SupplyOrderStatus {
+  agent_drafted
+  awaiting_approval
+  approved
+  submitted
+  shipped
+  delivered
+  rejected
+  cancelled
+}
+
+enum SupplyOrderProposedByKind {
+  agent
+  user
+}
+
+enum SupplyOrderActorKind {
+  agent
+  user
+  system
+}
+
+enum SupplyOrderAuditAction {
+  drafted
+  approved
+  rejected
+  submitted
+  shipped
+  delivered
+  edited
+  cancelled
+  auto_submitted
+  reverted
+}
+
+model Supplier {
+  id                      String   @id @default(cuid())
+  organizationId          String
+  name                    String
+  contactName             String?
+  email                   String?
+  phone                   String?
+  defaultPaymentTermsDays Int      @default(30)
+  notes                   String?
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  organization Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  supplies     Supply[]
+  orders       SupplyOrder[]
+
+  @@index([organizationId])
+}
+
+model Supply {
+  id                String    @id @default(cuid())
+  organizationId    String
+  name              String
+  sku               String?
+  category          String? // free-form for v1: "PPE", "wound-care", "instruments", ...
+  supplierId        String?
+  reorderThreshold  Int       @default(0)
+  reorderQty        Int       @default(0)
+  lastUnitCostCents Int?
+  onHand            Int       @default(0)
+  unit              String    @default("ea")
+  notes             String?
+  deletedAt         DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  preferredSupplier Supplier?     @relation(fields: [supplierId], references: [id])
+  orders            SupplyOrder[]
+
+  @@index([organizationId])
+  @@index([organizationId, deletedAt])
+}
+
+model SupplyOrder {
+  id                 String                    @id @default(cuid())
+  organizationId     String
+  supplyId           String
+  supplierId         String
+  status             SupplyOrderStatus         @default(agent_drafted)
+  qty                Int
+  unitCostCents      Int
+  totalCents         Int
+  // Discriminated authorship — `kind` selects which id column is populated.
+  proposedByKind     SupplyOrderProposedByKind
+  proposedByAgentId  String?
+  proposedByUserId   String?
+  approvedByUserId   String?
+  autoSubmitted      Boolean                   @default(false)
+  rejectionReason    String?
+  submittedAt        DateTime?
+  shippedAt          DateTime?
+  deliveredAt        DateTime?
+  deliveredQty       Int?
+  expectedDeliveryAt DateTime?
+  supplierPoRef      String?
+  createdAt          DateTime                  @default(now())
+  updatedAt          DateTime                  @updatedAt
+  deletedAt          DateTime?
+
+  organization Organization            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  supply       Supply                  @relation(fields: [supplyId], references: [id])
+  supplier     Supplier                @relation(fields: [supplierId], references: [id])
+  approvedBy   User?                   @relation("SupplyOrderApprover", fields: [approvedByUserId], references: [id])
+  proposer     User?                   @relation("SupplyOrderProposer", fields: [proposedByUserId], references: [id])
+  auditEntries SupplyOrderAuditEntry[]
+
+  @@index([organizationId, status])
+  @@index([supplyId, createdAt(sort: Desc)])
+  @@index([organizationId, createdAt])
+}
+
+// Append-only audit log for SupplyOrder state changes. Separate from the
+// global `AuditLog` table so the approval queue can render a per-order
+// activity feed without filtering the platform-wide stream.
+model SupplyOrderAuditEntry {
+  id           String                 @id @default(cuid())
+  orderId      String
+  actorKind    SupplyOrderActorKind
+  actorAgentId String?
+  actorUserId  String?
+  action       SupplyOrderAuditAction
+  payload      Json?
+  createdAt    DateTime               @default(now())
+
+  order     SupplyOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  actorUser User?       @relation("SupplyOrderAuditActor", fields: [actorUserId], references: [id])
+
+  @@index([orderId, createdAt])
 }

--- a/src/app/(operator)/ops/supplies/actions.ts
+++ b/src/app/(operator)/ops/supplies/actions.ts
@@ -1,0 +1,560 @@
+"use server";
+
+// ===========================================================================
+// EMR-794 — Supply order server actions + state machine
+// ===========================================================================
+// One server action per legal state transition on `SupplyOrder`. Each:
+//   1. Resolves the org-scoped session via `requireUser`.
+//   2. Validates the transition through `nextValidTransitions` — illegal
+//      transitions throw with a clear error rather than silently no-op.
+//   3. Writes EXACTLY one audit entry per state change.
+//   4. Increments stock IDEMPOTENTLY on delivery (the `deliveredAt IS NULL`
+//      guard prevents double-increments).
+//   5. Revalidates `/ops/supplies` so the UI re-renders.
+//
+// The UI surface that calls these lives in EMR-791. The PDF + email pipeline
+// (EMR-792) hooks into `approveAndSubmitOrder`. The trust-threshold layer
+// (EMR-793) uses `submitDraftedOrderAsAgent` for auto-submit.
+//
+// LOAD-BEARING INVARIANTS honored:
+//   * 24h cooldown: rejection stamps `rejectionReason` + a `rejected` audit
+//     row; the agent's observe step (EMR-789) reads it.
+//   * Idempotent delivery: stock increments only when `deliveredAt IS NULL`.
+//   * Every transition lands an audit row, including auto-submits.
+//   * `proposedBy` columns are written on creation only — they never mutate.
+// ===========================================================================
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  actorToColumns,
+  isValidTransition,
+  nextValidTransitions,
+  type SupplyOrderActor,
+  type SupplyOrderAuditAction,
+  type SupplyOrderStatus,
+} from "@/lib/domain/supplies";
+
+export type ActionResult<T = undefined> =
+  | { ok: true; data?: T }
+  | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function loadOrder(orderId: string, organizationId: string) {
+  return prisma.supplyOrder.findFirst({
+    where: { id: orderId, organizationId, deletedAt: null },
+  });
+}
+
+function assertTransition(
+  from: SupplyOrderStatus,
+  to: SupplyOrderStatus,
+): void {
+  if (!isValidTransition(from, to)) {
+    throw new Error(
+      `Illegal SupplyOrder transition: ${from} → ${to}. ` +
+        `Valid next states: ${nextValidTransitions(from).join(", ") || "(none — terminal)"}`,
+    );
+  }
+}
+
+/**
+ * Write a single audit entry for a state change. Centralized here so every
+ * server action lands the same row shape — no drift.
+ */
+async function writeAuditEntry(args: {
+  orderId: string;
+  actor: SupplyOrderActor;
+  action: SupplyOrderAuditAction;
+  payload?: Record<string, unknown> | null;
+  tx?: typeof prisma;
+}) {
+  const cols = actorToColumns(args.actor);
+  const client = args.tx ?? prisma;
+  await client.supplyOrderAuditEntry.create({
+    data: {
+      orderId: args.orderId,
+      action: args.action,
+      payload: (args.payload ?? null) as any,
+      ...cols,
+    },
+  });
+}
+
+function done(): ActionResult {
+  revalidatePath("/ops/supplies");
+  return { ok: true };
+}
+
+function err(message: string): ActionResult {
+  return { ok: false, error: message };
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const OrderId = z.object({ orderId: z.string().min(1) });
+
+const ApproveSchema = OrderId.extend({
+  notes: z.string().optional(),
+  editedQty: z.number().int().positive().optional(),
+  editedSupplierId: z.string().optional(),
+});
+
+const RejectSchema = OrderId.extend({
+  reason: z.string().min(1, "Rejection reason required"),
+});
+
+const EditDraftSchema = OrderId.extend({
+  qty: z.number().int().positive().optional(),
+  supplierId: z.string().optional(),
+  notes: z.string().optional(),
+  unitCostCents: z.number().int().nonnegative().optional(),
+});
+
+const MarkShippedSchema = OrderId.extend({
+  shippedAt: z.string().datetime().optional(),
+  trackingNumber: z.string().optional(),
+});
+
+const MarkDeliveredSchema = OrderId.extend({
+  deliveredAt: z.string().datetime().optional(),
+  qtyReceived: z.number().int().nonnegative().optional(),
+});
+
+const CancelSchema = OrderId.extend({
+  reason: z.string().min(1, "Cancellation reason required"),
+});
+
+const SubmitDraftSchema = OrderId; // operator-driven submit for an agent draft.
+
+// ---------------------------------------------------------------------------
+// approveAndSubmitOrder — awaiting_approval → submitted (with optional edit)
+// ---------------------------------------------------------------------------
+
+export async function approveAndSubmitOrder(
+  input: z.infer<typeof ApproveSchema>,
+): Promise<ActionResult<{ orderId: string }>> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = ApproveSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+
+  try {
+    assertTransition(order.status, "submitted");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  const editedQty = parsed.data.editedQty ?? order.qty;
+  const editedSupplierId = parsed.data.editedSupplierId ?? order.supplierId;
+  const totalCents = editedQty * order.unitCostCents;
+  const now = new Date();
+
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "submitted",
+        qty: editedQty,
+        supplierId: editedSupplierId,
+        totalCents,
+        approvedByUserId: user.id,
+        submittedAt: now,
+      },
+    });
+    if (editedQty !== order.qty || editedSupplierId !== order.supplierId) {
+      await writeAuditEntry({
+        orderId: order.id,
+        actor: { kind: "user", userId: user.id },
+        action: "edited",
+        payload: {
+          qty: { from: order.qty, to: editedQty },
+          supplierId: { from: order.supplierId, to: editedSupplierId },
+        },
+        tx: tx as any,
+      });
+    }
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "approved",
+      payload: { notes: parsed.data.notes ?? null },
+      tx: tx as any,
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "submitted",
+      payload: null,
+      tx: tx as any,
+    });
+  });
+
+  revalidatePath("/ops/supplies");
+  return { ok: true, data: { orderId: order.id } };
+}
+
+// ---------------------------------------------------------------------------
+// rejectOrder — awaiting_approval → rejected (24h cooldown stamp)
+// ---------------------------------------------------------------------------
+
+export async function rejectOrder(
+  input: z.infer<typeof RejectSchema>,
+): Promise<ActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = RejectSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+
+  try {
+    assertTransition(order.status, "rejected");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "rejected",
+        rejectionReason: parsed.data.reason,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "rejected",
+      payload: { reason: parsed.data.reason },
+      tx: tx as any,
+    });
+  });
+
+  return done();
+}
+
+// ---------------------------------------------------------------------------
+// editDraftedOrder — modify a draft / awaiting_approval row in place
+// ---------------------------------------------------------------------------
+
+export async function editDraftedOrder(
+  input: z.infer<typeof EditDraftSchema>,
+): Promise<ActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = EditDraftSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+  if (order.status !== "agent_drafted" && order.status !== "awaiting_approval") {
+    return err(
+      `Cannot edit an order in status ${order.status}. Edits are only allowed before submit.`,
+    );
+  }
+
+  const newQty = parsed.data.qty ?? order.qty;
+  const newSupplierId = parsed.data.supplierId ?? order.supplierId;
+  const newUnitCostCents = parsed.data.unitCostCents ?? order.unitCostCents;
+  const newTotalCents = newQty * newUnitCostCents;
+
+  const diff: Record<string, unknown> = {};
+  if (newQty !== order.qty) diff.qty = { from: order.qty, to: newQty };
+  if (newSupplierId !== order.supplierId)
+    diff.supplierId = { from: order.supplierId, to: newSupplierId };
+  if (newUnitCostCents !== order.unitCostCents)
+    diff.unitCostCents = {
+      from: order.unitCostCents,
+      to: newUnitCostCents,
+    };
+  if (parsed.data.notes !== undefined) diff.notes = parsed.data.notes;
+
+  if (Object.keys(diff).length === 0) {
+    return err("No changes to apply.");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        qty: newQty,
+        supplierId: newSupplierId,
+        unitCostCents: newUnitCostCents,
+        totalCents: newTotalCents,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "edited",
+      payload: diff,
+      tx: tx as any,
+    });
+  });
+
+  return done();
+}
+
+// ---------------------------------------------------------------------------
+// submitDraftedOrder — manual submit path for `agent_drafted` orders
+// ---------------------------------------------------------------------------
+
+export async function submitDraftedOrder(
+  input: z.infer<typeof SubmitDraftSchema>,
+): Promise<ActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = SubmitDraftSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+  try {
+    assertTransition(order.status, "submitted");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  const now = new Date();
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "submitted",
+        approvedByUserId: user.id,
+        submittedAt: now,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "submitted",
+      payload: { fromStatus: order.status },
+      tx: tx as any,
+    });
+  });
+
+  return done();
+}
+
+// ---------------------------------------------------------------------------
+// markShipped — submitted → shipped
+// ---------------------------------------------------------------------------
+
+export async function markShipped(
+  input: z.infer<typeof MarkShippedSchema>,
+): Promise<ActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = MarkShippedSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+  try {
+    assertTransition(order.status, "shipped");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  const shippedAt = parsed.data.shippedAt
+    ? new Date(parsed.data.shippedAt)
+    : new Date();
+
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "shipped",
+        shippedAt,
+        supplierPoRef: parsed.data.trackingNumber ?? order.supplierPoRef,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "shipped",
+      payload: {
+        trackingNumber: parsed.data.trackingNumber ?? null,
+        shippedAt: shippedAt.toISOString(),
+      },
+      tx: tx as any,
+    });
+  });
+
+  return done();
+}
+
+// ---------------------------------------------------------------------------
+// markDelivered — submitted|shipped → delivered (idempotent stock increment)
+// ---------------------------------------------------------------------------
+
+export async function markDelivered(
+  input: z.infer<typeof MarkDeliveredSchema>,
+): Promise<ActionResult<{ idempotent: boolean }>> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = MarkDeliveredSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+
+  // Idempotency: if already delivered, return ok without doing anything.
+  if (order.status === "delivered" || order.deliveredAt !== null) {
+    return { ok: true, data: { idempotent: true } };
+  }
+
+  try {
+    assertTransition(order.status, "delivered");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  const deliveredAt = parsed.data.deliveredAt
+    ? new Date(parsed.data.deliveredAt)
+    : new Date();
+  const qtyReceived = parsed.data.qtyReceived ?? order.qty;
+  const partial = qtyReceived < order.qty;
+
+  // The guard `deliveredAt IS NULL` in the WHERE clause makes the stock
+  // increment idempotent even under concurrent execution — only the first
+  // transition wins; subsequent calls fall through to the early-return
+  // above on re-read.
+  await prisma.$transaction(async (tx) => {
+    const updated = await tx.supplyOrder.updateMany({
+      where: { id: order.id, deliveredAt: null },
+      data: {
+        status: "delivered",
+        deliveredAt,
+        deliveredQty: qtyReceived,
+      },
+    });
+    if (updated.count === 0) return; // someone beat us; do not re-increment.
+
+    await tx.supply.update({
+      where: { id: order.supplyId },
+      data: {
+        onHand: { increment: qtyReceived },
+        lastUnitCostCents: order.unitCostCents,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "delivered",
+      payload: {
+        deliveredAt: deliveredAt.toISOString(),
+        qtyReceived,
+        partial,
+        orderedQty: order.qty,
+      },
+      tx: tx as any,
+    });
+  });
+
+  return { ok: true, data: { idempotent: false } };
+}
+
+// ---------------------------------------------------------------------------
+// cancelOrder — any non-terminal → cancelled
+// ---------------------------------------------------------------------------
+
+export async function cancelOrder(
+  input: z.infer<typeof CancelSchema>,
+): Promise<ActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return err("Organization required.");
+  const parsed = CancelSchema.safeParse(input);
+  if (!parsed.success)
+    return err(parsed.error.issues[0]?.message ?? "Invalid input.");
+
+  const order = await loadOrder(parsed.data.orderId, user.organizationId);
+  if (!order) return err("Order not found.");
+  try {
+    assertTransition(order.status, "cancelled");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: { status: "cancelled" },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "user", userId: user.id },
+      action: "cancelled",
+      payload: { reason: parsed.data.reason },
+      tx: tx as any,
+    });
+  });
+
+  return done();
+}
+
+// ---------------------------------------------------------------------------
+// submitDraftedOrderAsAgent — entry point for EMR-793 trust-threshold
+// auto-submit. Internal use only; not exported via formData. Skips the
+// `approved` step but still files an `auto_submitted` audit row so the
+// approval queue can render the auto-path.
+// ---------------------------------------------------------------------------
+
+export async function submitDraftedOrderAsAgent(
+  orderId: string,
+  agentId: string,
+): Promise<ActionResult> {
+  // Caller is server-internal (the trust-threshold layer / orchestrator)
+  // so we do NOT call requireUser(). We DO scope by organizationId via the
+  // order row itself.
+  const order = await prisma.supplyOrder.findFirst({
+    where: { id: orderId, deletedAt: null },
+  });
+  if (!order) return err("Order not found.");
+  if (order.status !== "agent_drafted") {
+    return err(
+      `submitDraftedOrderAsAgent requires status agent_drafted, got ${order.status}.`,
+    );
+  }
+
+  const now = new Date();
+  await prisma.$transaction(async (tx) => {
+    await tx.supplyOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "submitted",
+        autoSubmitted: true,
+        submittedAt: now,
+      },
+    });
+    await writeAuditEntry({
+      orderId: order.id,
+      actor: { kind: "agent", agentId },
+      action: "auto_submitted",
+      payload: { totalCents: order.totalCents },
+      tx: tx as any,
+    });
+  });
+
+  revalidatePath("/ops/supplies");
+  return { ok: true };
+}

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -56,6 +56,9 @@ import { retentionRiskAgent } from "./retention-risk-agent";
 import { contentCreationAgent } from "./content-creation-agent";
 import { satisfactionAnalysisAgent } from "./satisfaction-analysis-agent";
 import { inventoryAlertAgent } from "./inventory-alert-agent";
+// EMR-787 — Practice Manager Agent v1
+import { supplyReorderAgent } from "./supply-reorder-agent";
+import { practiceManagerAgent } from "./practice-manager-agent";
 import { billingReconEnhancementAgent } from "./billing-recon-enhancement-agent";
 import { qualityImprovementAgent } from "./quality-improvement-agent";
 // Mission Control — Phase 1 (MALLIK-006 + MALLIK-007)
@@ -176,6 +179,9 @@ export const agentRegistry = {
   contentCreation: contentCreationAgent,
   satisfactionAnalysis: satisfactionAnalysisAgent,
   inventoryAlert: inventoryAlertAgent,
+  // EMR-787 — Practice Manager Agent v1
+  supplyReorder: supplyReorderAgent,
+  practiceManager: practiceManagerAgent,
   billingReconEnhancement: billingReconEnhancementAgent,
   qualityImprovement: qualityImprovementAgent,
   // Mission Control — Phase 1 (MALLIK-006 + MALLIK-007)

--- a/src/lib/agents/practice-manager-agent.ts
+++ b/src/lib/agents/practice-manager-agent.ts
@@ -1,0 +1,173 @@
+// ===========================================================================
+// EMR-790 — practiceManagerAgent (meta-orchestrator)
+// ===========================================================================
+// Umbrella under which every Practice Manager sub-agent runs. v1 fans out
+// to a single sub-agent (`supplyReorderAgent`); the value here is the
+// SHAPE — adding credentialExpiry / vendorContract / equipmentMaintenance
+// later should be a one-line change to `SUB_AGENT_REGISTRY`.
+//
+// Discipline: NO business logic in this file. Decision-making belongs in the
+// sub-agents. This layer is pure plumbing: fan-out, fan-in, error isolation,
+// run summary, fleet log.
+// ===========================================================================
+
+import { z } from "zod";
+import type { Agent, AgentContext } from "@/lib/orchestration/types";
+import { writeAgentAudit } from "@/lib/orchestration/context";
+import { supplyReorderAgent } from "./supply-reorder-agent";
+
+const AGENT_ID = "practiceManagerAgent";
+const VERSION = "1.0.0";
+
+// ---------------------------------------------------------------------------
+// Sub-agent registry
+// ---------------------------------------------------------------------------
+// Each sub-agent is keyed by its public name and exposes an `invoke` that
+// takes the orchestrator's context + practice scope. Returning unknown is
+// intentional — the orchestrator does not interpret payloads, it just
+// forwards them on the run summary.
+
+type SubAgentInvoker = (args: {
+  organizationId: string;
+  ctx: AgentContext;
+}) => Promise<unknown>;
+
+interface SubAgentEntry {
+  name: string;
+  invoke: SubAgentInvoker;
+}
+
+const SUB_AGENT_REGISTRY: Record<string, SubAgentEntry> = {
+  supplyReorderAgent: {
+    name: "supplyReorderAgent",
+    invoke: ({ organizationId, ctx }) =>
+      supplyReorderAgent.run({ organizationId }, ctx),
+  },
+  // Stubs for the fan-out contract — wired in follow-up issues
+  // (EMR-787 lists credentialExpiry / vendorContract / equipmentMaintenance
+  // as planned siblings). Until those exist we keep the registry small.
+};
+
+/** Default enabled set. Per-practice config overrides this in a later issue. */
+const DEFAULT_ENABLED: readonly string[] = ["supplyReorderAgent"];
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const input = z.object({
+  organizationId: z.string(),
+  subAgents: z.array(z.string()).optional(),
+});
+
+const subAgentRunSchema = z.object({
+  name: z.string(),
+  output: z.unknown(),
+  durationMs: z.number(),
+  error: z.string().optional(),
+});
+
+const output = z.object({
+  organizationId: z.string(),
+  subAgentRuns: z.array(subAgentRunSchema),
+  startedAt: z.string(),
+  completedAt: z.string(),
+});
+
+export type PracticeManagerAgentOutput = z.infer<typeof output>;
+export type SubAgentRun = z.infer<typeof subAgentRunSchema>;
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+export const practiceManagerAgent: Agent<
+  z.infer<typeof input>,
+  PracticeManagerAgentOutput
+> = {
+  name: AGENT_ID,
+  version: VERSION,
+  description:
+    "Meta-orchestrator for practice-management chores. Fans out to enabled " +
+    "sub-agents (v1: supplyReorderAgent), isolates errors, aggregates a run " +
+    "summary, and writes a single fleet-log entry.",
+  inputSchema: input,
+  outputSchema: output,
+  // We don't write anything ourselves; sub-agents declare their own caps.
+  // `write.task` is here so error-isolation logs can drop a follow-up task
+  // if a sub-agent throws.
+  allowedActions: ["write.task"],
+  requiresApproval: false,
+
+  async run({ organizationId, subAgents }, ctx) {
+    const requested = subAgents?.length ? subAgents : DEFAULT_ENABLED;
+    const startedAt = new Date();
+
+    const runs: SubAgentRun[] = [];
+    for (const name of requested) {
+      const entry = SUB_AGENT_REGISTRY[name];
+      if (!entry) {
+        runs.push({
+          name,
+          output: null,
+          durationMs: 0,
+          error: `Unknown sub-agent: ${name}`,
+        });
+        continue;
+      }
+      const t0 = Date.now();
+      try {
+        const out = await entry.invoke({ organizationId, ctx });
+        runs.push({
+          name,
+          output: out,
+          durationMs: Date.now() - t0,
+        });
+      } catch (e) {
+        // Error isolation: one failure does not halt the rest of the fleet.
+        const message = e instanceof Error ? e.message : String(e);
+        ctx.log("error", "Sub-agent failed", { name, error: message });
+        runs.push({
+          name,
+          output: null,
+          durationMs: Date.now() - t0,
+          error: message,
+        });
+      }
+    }
+
+    const completedAt = new Date();
+
+    await writeAgentAudit(
+      AGENT_ID,
+      VERSION,
+      organizationId,
+      "practice-manager.run.completed",
+      { type: "Organization", id: organizationId },
+      {
+        subAgents: requested,
+        runs: runs.map((r) => ({
+          name: r.name,
+          durationMs: r.durationMs,
+          ok: !r.error,
+        })),
+      },
+    );
+
+    ctx.log("info", "practiceManagerAgent fan-out complete", {
+      organizationId,
+      subAgentCount: runs.length,
+      errorCount: runs.filter((r) => r.error).length,
+    });
+
+    return {
+      organizationId,
+      subAgentRuns: runs,
+      startedAt: startedAt.toISOString(),
+      completedAt: completedAt.toISOString(),
+    };
+  },
+};
+
+/** Exported for tests / dev tooling — do NOT mutate at runtime. */
+export const PRACTICE_MANAGER_SUB_AGENTS = Object.keys(SUB_AGENT_REGISTRY);

--- a/src/lib/agents/supply-reorder-agent.ts
+++ b/src/lib/agents/supply-reorder-agent.ts
@@ -1,0 +1,225 @@
+// ===========================================================================
+// EMR-789 — supplyReorderAgent
+// ===========================================================================
+// First sub-agent under `practiceManagerAgent`. Shape mirrors
+// `inventoryAlertAgent` but writes to the real `Supply` / `SupplyOrder`
+// tables introduced in EMR-788.
+//
+// Lifecycle: OBSERVE → PROPOSE → (never auto-submit; that lives in the
+// trust-threshold layer, EMR-793).
+//
+// Invariants honored here:
+//   * Always drafts in `agent_drafted`. Never sets a later status.
+//   * Respects the 24h rejection cooldown for `(supplyId, rejectedAt)`.
+//   * Idempotent: re-running with no stock changes drafts zero new orders
+//     (open-coverage check + cooldown check).
+//   * Files an audit entry on every draft.
+//   * Files a Task per draft (batched if >3) so the practice owner sees the
+//     queue without opening the page.
+// ===========================================================================
+
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { writeAgentAudit } from "@/lib/orchestration/context";
+import type { Agent } from "@/lib/orchestration/types";
+import {
+  OPEN_COVERAGE_STATUSES,
+  REJECTION_COOLDOWN_MS,
+  computeTotalCents,
+  proposedByToColumns,
+  recommendedOrderQty,
+} from "@/lib/domain/supplies";
+
+const AGENT_ID = "supplyReorderAgent";
+const VERSION = "1.0.0";
+
+const input = z.object({
+  organizationId: z.string(),
+});
+
+const output = z.object({
+  draftedCount: z.number(),
+  lowStockCount: z.number(),
+  alreadyOpenCount: z.number(),
+  cooldownSkippedCount: z.number(),
+  draftedOrderIds: z.array(z.string()),
+});
+
+export type SupplyReorderAgentOutput = z.infer<typeof output>;
+
+export const supplyReorderAgent: Agent<
+  z.infer<typeof input>,
+  SupplyReorderAgentOutput
+> = {
+  name: AGENT_ID,
+  version: VERSION,
+  description:
+    "Practice Manager sub-agent. Observes low-stock clinical / office " +
+    "supplies and drafts SupplyOrder rows for the practice owner to approve. " +
+    "Never auto-submits — the trust-threshold layer makes that decision.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: ["write.task"],
+  requiresApproval: false,
+
+  async run({ organizationId }, ctx) {
+    ctx.assertCan("write.task");
+
+    // ── OBSERVE ─────────────────────────────────────────────────────────
+    // Pull every non-deleted supply at or below threshold for this org.
+    const lowStock = await prisma.supply.findMany({
+      where: {
+        organizationId,
+        deletedAt: null,
+      },
+      include: { preferredSupplier: true },
+    });
+    const candidates = lowStock.filter((s) => s.onHand <= s.reorderThreshold);
+
+    // Which supplies already have an open order? (Don't double-draft.)
+    const openOrders = await prisma.supplyOrder.findMany({
+      where: {
+        organizationId,
+        deletedAt: null,
+        status: { in: OPEN_COVERAGE_STATUSES as unknown as any[] },
+        supplyId: { in: candidates.map((s) => s.id) },
+      },
+      select: { supplyId: true },
+    });
+    const alreadyOpen = new Set(openOrders.map((o) => o.supplyId));
+
+    // Anti-thrash: any supply rejected in the last 24h is on cooldown.
+    const cooldownCutoff = new Date(Date.now() - REJECTION_COOLDOWN_MS);
+    const recentRejections = await prisma.supplyOrder.findMany({
+      where: {
+        organizationId,
+        status: "rejected",
+        updatedAt: { gte: cooldownCutoff },
+        supplyId: { in: candidates.map((s) => s.id) },
+      },
+      select: { supplyId: true },
+    });
+    const onCooldown = new Set(recentRejections.map((r) => r.supplyId));
+
+    // ── PROPOSE ─────────────────────────────────────────────────────────
+    const draftedOrderIds: string[] = [];
+    const draftedDescriptors: Array<{ orderId: string; supplyName: string }> = [];
+    let cooldownSkipped = 0;
+
+    for (const supply of candidates) {
+      if (alreadyOpen.has(supply.id)) continue;
+      if (onCooldown.has(supply.id)) {
+        cooldownSkipped += 1;
+        continue;
+      }
+      if (!supply.supplierId) {
+        ctx.log("warn", "Skipping supply with no preferred supplier", {
+          supplyId: supply.id,
+          name: supply.name,
+        });
+        continue;
+      }
+
+      const qty = recommendedOrderQty(supply);
+      const unitCostCents = supply.lastUnitCostCents ?? 0;
+      const totalCents = computeTotalCents(qty, unitCostCents);
+
+      const proposed = proposedByToColumns({ kind: "agent", agentId: AGENT_ID });
+
+      const order = await prisma.supplyOrder.create({
+        data: {
+          organizationId,
+          supplyId: supply.id,
+          supplierId: supply.supplierId,
+          status: "agent_drafted",
+          qty,
+          unitCostCents,
+          totalCents,
+          ...proposed,
+          auditEntries: {
+            create: {
+              actorKind: "agent",
+              actorAgentId: AGENT_ID,
+              action: "drafted",
+              payload: {
+                supplyName: supply.name,
+                onHand: supply.onHand,
+                reorderThreshold: supply.reorderThreshold,
+                qty,
+                unitCostCents,
+                totalCents,
+              },
+            },
+          },
+        },
+        select: { id: true },
+      });
+      draftedOrderIds.push(order.id);
+      draftedDescriptors.push({ orderId: order.id, supplyName: supply.name });
+    }
+
+    // ── TASKS ───────────────────────────────────────────────────────────
+    // One task per draft if small; otherwise a single batched task. Either
+    // way the owner sees something in their inbox without checking the page.
+    if (draftedOrderIds.length > 0) {
+      const taskBase = {
+        organizationId,
+        status: "open" as const,
+        assigneeRole: "practice_owner" as const,
+        dueAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+      };
+      if (draftedDescriptors.length <= 3) {
+        for (const d of draftedDescriptors) {
+          await prisma.task.create({
+            data: {
+              ...taskBase,
+              title: `Supply reorder draft awaiting review`,
+              description:
+                `supplyReorderAgent drafted a reorder for ${d.supplyName}. ` +
+                `Order id: ${d.orderId}.\n\nReview at /ops/supplies.`,
+            },
+          });
+        }
+      } else {
+        await prisma.task.create({
+          data: {
+            ...taskBase,
+            title: `${draftedOrderIds.length} supply reorder drafts awaiting review`,
+            description:
+              `supplyReorderAgent drafted ${draftedOrderIds.length} reorders. ` +
+              `Review at /ops/supplies.`,
+          },
+        });
+      }
+    }
+
+    await writeAgentAudit(
+      AGENT_ID,
+      VERSION,
+      organizationId,
+      "supply.reorder.drafted",
+      { type: "Organization", id: organizationId },
+      {
+        draftedCount: draftedOrderIds.length,
+        lowStockCount: candidates.length,
+        alreadyOpenCount: alreadyOpen.size,
+        cooldownSkippedCount: cooldownSkipped,
+      },
+    );
+
+    ctx.log("info", "supplyReorderAgent run complete", {
+      draftedCount: draftedOrderIds.length,
+      lowStockCount: candidates.length,
+      alreadyOpenCount: alreadyOpen.size,
+      cooldownSkippedCount: cooldownSkipped,
+    });
+
+    return {
+      draftedCount: draftedOrderIds.length,
+      lowStockCount: candidates.length,
+      alreadyOpenCount: alreadyOpen.size,
+      cooldownSkippedCount: cooldownSkipped,
+      draftedOrderIds,
+    };
+  },
+};

--- a/src/lib/domain/supplies.test.ts
+++ b/src/lib/domain/supplies.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyStatus,
+  computeLowStock,
+  computeTotalCents,
+  isAgentProposed,
+  isTerminalStatus,
+  isValidTransition,
+  isWithinRejectionCooldown,
+  nextValidTransitions,
+  recommendedOrderQty,
+  actorToColumns,
+  proposedByToColumns,
+  REJECTION_COOLDOWN_MS,
+} from "./supplies";
+
+describe("supplies — pure helpers (EMR-788)", () => {
+  describe("classifyStatus", () => {
+    it("flags deleted supplies as discontinued", () => {
+      expect(
+        classifyStatus({ onHand: 100, reorderThreshold: 5, deletedAt: new Date() }),
+      ).toBe("discontinued");
+    });
+    it("flags zero on-hand as out_of_stock", () => {
+      expect(classifyStatus({ onHand: 0, reorderThreshold: 5, deletedAt: null })).toBe(
+        "out_of_stock",
+      );
+    });
+    it("flags at-threshold as low_stock", () => {
+      expect(classifyStatus({ onHand: 5, reorderThreshold: 5, deletedAt: null })).toBe(
+        "low_stock",
+      );
+    });
+    it("flags above-threshold as in_stock", () => {
+      expect(classifyStatus({ onHand: 10, reorderThreshold: 5, deletedAt: null })).toBe(
+        "in_stock",
+      );
+    });
+  });
+
+  describe("computeLowStock", () => {
+    it("returns false for discontinued supplies", () => {
+      expect(
+        computeLowStock({ onHand: 0, reorderThreshold: 5, deletedAt: new Date() }),
+      ).toBe(false);
+    });
+    it("returns true at or below threshold", () => {
+      expect(computeLowStock({ onHand: 5, reorderThreshold: 5, deletedAt: null })).toBe(true);
+      expect(computeLowStock({ onHand: 1, reorderThreshold: 5, deletedAt: null })).toBe(true);
+    });
+    it("returns false above threshold", () => {
+      expect(computeLowStock({ onHand: 6, reorderThreshold: 5, deletedAt: null })).toBe(false);
+    });
+  });
+
+  describe("recommendedOrderQty", () => {
+    it("uses reorderQty when set", () => {
+      expect(recommendedOrderQty({ reorderQty: 12, reorderThreshold: 4 })).toBe(12);
+    });
+    it("falls back to 2 * threshold when reorderQty is 0", () => {
+      expect(recommendedOrderQty({ reorderQty: 0, reorderThreshold: 4 })).toBe(8);
+    });
+    it("returns at least 1 even when both are zero", () => {
+      expect(recommendedOrderQty({ reorderQty: 0, reorderThreshold: 0 })).toBe(1);
+    });
+  });
+
+  describe("computeTotalCents", () => {
+    it("multiplies qty by unit", () => {
+      expect(computeTotalCents(10, 250)).toBe(2500);
+    });
+    it("guards against negatives", () => {
+      expect(computeTotalCents(-1, 100)).toBe(0);
+      expect(computeTotalCents(10, -1)).toBe(0);
+    });
+  });
+
+  describe("state machine — nextValidTransitions / isValidTransition", () => {
+    it("agent_drafted → awaiting_approval | submitted | cancelled", () => {
+      expect(nextValidTransitions("agent_drafted")).toEqual([
+        "awaiting_approval",
+        "submitted",
+        "cancelled",
+      ]);
+    });
+    it("delivered is terminal", () => {
+      expect(nextValidTransitions("delivered")).toEqual([]);
+      expect(isTerminalStatus("delivered")).toBe(true);
+      expect(isTerminalStatus("rejected")).toBe(true);
+      expect(isTerminalStatus("cancelled")).toBe(true);
+      expect(isTerminalStatus("submitted")).toBe(false);
+    });
+    it("rejects illegal transitions", () => {
+      expect(isValidTransition("agent_drafted", "shipped")).toBe(false);
+      expect(isValidTransition("delivered", "shipped")).toBe(false);
+      expect(isValidTransition("submitted", "agent_drafted")).toBe(false);
+    });
+    it("allows the skip-shipping path", () => {
+      expect(isValidTransition("submitted", "delivered")).toBe(true);
+    });
+  });
+
+  describe("isWithinRejectionCooldown — 24h anti-thrash", () => {
+    const now = new Date("2026-05-22T12:00:00Z");
+    it("treats fresh rejections as within cooldown", () => {
+      expect(isWithinRejectionCooldown(new Date(now.getTime() - 60_000), now)).toBe(true);
+    });
+    it("treats rejections older than 24h as expired", () => {
+      expect(
+        isWithinRejectionCooldown(new Date(now.getTime() - REJECTION_COOLDOWN_MS - 1), now),
+      ).toBe(false);
+    });
+    it("null rejectedAt → not on cooldown", () => {
+      expect(isWithinRejectionCooldown(null, now)).toBe(false);
+    });
+  });
+
+  describe("proposedBy / actor discriminated unions", () => {
+    it("isAgentProposed distinguishes agent vs user", () => {
+      expect(isAgentProposed({ proposedBy: { kind: "agent", agentId: "a" } })).toBe(true);
+      expect(isAgentProposed({ proposedBy: { kind: "user", userId: "u" } })).toBe(false);
+    });
+    it("flattens actor → columns (agent)", () => {
+      expect(actorToColumns({ kind: "agent", agentId: "supplyReorderAgent" })).toEqual({
+        actorKind: "agent",
+        actorAgentId: "supplyReorderAgent",
+        actorUserId: null,
+      });
+    });
+    it("flattens actor → columns (user)", () => {
+      expect(actorToColumns({ kind: "user", userId: "u_1" })).toEqual({
+        actorKind: "user",
+        actorAgentId: null,
+        actorUserId: "u_1",
+      });
+    });
+    it("flattens actor → columns (system)", () => {
+      expect(actorToColumns({ kind: "system" })).toEqual({
+        actorKind: "system",
+        actorAgentId: null,
+        actorUserId: null,
+      });
+    });
+    it("flattens proposedBy → columns", () => {
+      expect(proposedByToColumns({ kind: "agent", agentId: "x" })).toEqual({
+        proposedByKind: "agent",
+        proposedByAgentId: "x",
+        proposedByUserId: null,
+      });
+      expect(proposedByToColumns({ kind: "user", userId: "u" })).toEqual({
+        proposedByKind: "user",
+        proposedByAgentId: null,
+        proposedByUserId: "u",
+      });
+    });
+  });
+});

--- a/src/lib/domain/supplies.ts
+++ b/src/lib/domain/supplies.ts
@@ -1,0 +1,319 @@
+// ===========================================================================
+// EMR-788 — Practice Manager Agent v1: Supplies domain
+// ===========================================================================
+// Clinical / office supplies (gloves, gowns, BP cuffs, exam-table paper, etc.).
+// PARALLEL to — and DISTINCT from — `lib/domain/inventory.ts`, which models
+// cannabis product inventory for the dispensary. Do not cross the streams.
+//
+// This module is the contract that the rest of the Practice Manager Agent v1
+// epic builds against:
+//   * EMR-789 supplyReorderAgent — reads `computeLowStock` + cooldown helper
+//   * EMR-790 practiceManagerAgent — fans out to sub-agents
+//   * EMR-791 approval-queue UI    — consumes `SupplyOrder` shapes + helpers
+//   * EMR-792 PO/email             — consumes `SupplyOrder` + `Supplier`
+//   * EMR-793 trust-threshold      — reads `totalCostCents` to decide auto vs
+//                                    awaiting_approval
+//   * EMR-794 server actions       — enforces `nextValidTransitions`
+//   * EMR-795 fleet KPI tile       — counts `practiceManagerAgent` runs
+//
+// LOAD-BEARING INVARIANTS (from the EMR-787 epic memo — must hold across
+// every consumer of these types):
+//   1. Sub-agents always DRAFT. They never set status past `agent_drafted`.
+//   2. 24h cooldown on the `(supplyId, rejectedAt)` pair — see
+//      `isWithinRejectionCooldown`.
+//   3. All monetary amounts are in CENTS (matching the billing convention).
+//   4. `proposedBy` is a discriminated union — agent vs user — so audit can
+//      reconstruct authorship without joins.
+//   5. `markDelivered` is idempotent (server-action side; see EMR-794).
+//   6. Auto-submitted orders still file an audit entry — `autoSubmitted=true`
+//      is informational, not a bypass.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Status enums (mirror prisma enums of the same names)
+// ---------------------------------------------------------------------------
+
+export const SUPPLY_ORDER_STATUSES = [
+  "agent_drafted",
+  "awaiting_approval",
+  "approved",
+  "submitted",
+  "shipped",
+  "delivered",
+  "rejected",
+  "cancelled",
+] as const;
+export type SupplyOrderStatus = (typeof SUPPLY_ORDER_STATUSES)[number];
+
+export const SUPPLY_ORDER_AUDIT_ACTIONS = [
+  "drafted",
+  "approved",
+  "rejected",
+  "submitted",
+  "shipped",
+  "delivered",
+  "edited",
+  "cancelled",
+  "auto_submitted",
+  "reverted",
+] as const;
+export type SupplyOrderAuditAction = (typeof SUPPLY_ORDER_AUDIT_ACTIONS)[number];
+
+/**
+ * Derived stock state. Persisted on `Supply.status` for query speed; the
+ * source of truth is `(onHand, reorderThreshold)` — `classifyStatus` is the
+ * canonical computation.
+ */
+export type SupplyStatus =
+  | "in_stock"
+  | "low_stock"
+  | "out_of_stock"
+  | "discontinued";
+
+// ---------------------------------------------------------------------------
+// `proposedBy` / `actor` discriminated unions
+// ---------------------------------------------------------------------------
+// Stored as TWO columns on the row (kind + agentId or userId) so audit
+// reconstruction is a single SELECT.
+
+export type ProposedBy =
+  | { kind: "agent"; agentId: string }
+  | { kind: "user"; userId: string };
+
+export type SupplyOrderActor =
+  | { kind: "agent"; agentId: string }
+  | { kind: "user"; userId: string }
+  | { kind: "system" };
+
+// ---------------------------------------------------------------------------
+// Plain-object shapes (the ones consumers should read; Prisma types are
+// auto-generated but include relations we don't want leaking everywhere).
+// ---------------------------------------------------------------------------
+
+export interface Supplier {
+  id: string;
+  organizationId: string;
+  name: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  defaultPaymentTermsDays: number;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Supply {
+  id: string;
+  organizationId: string;
+  name: string;
+  sku: string | null;
+  category: string | null;
+  supplierId: string | null;
+  reorderThreshold: number;
+  reorderQty: number;
+  lastUnitCostCents: number | null;
+  onHand: number;
+  unit: string;
+  notes: string | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SupplyOrder {
+  id: string;
+  organizationId: string;
+  supplyId: string;
+  supplierId: string;
+  status: SupplyOrderStatus;
+  qty: number;
+  unitCostCents: number;
+  totalCents: number;
+  proposedBy: ProposedBy;
+  approvedByUserId: string | null;
+  autoSubmitted: boolean;
+  rejectionReason: string | null;
+  submittedAt: Date | null;
+  shippedAt: Date | null;
+  deliveredAt: Date | null;
+  deliveredQty: number | null;
+  expectedDeliveryAt: Date | null;
+  supplierPoRef: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export interface SupplyOrderAuditEntry {
+  id: string;
+  orderId: string;
+  actor: SupplyOrderActor;
+  action: SupplyOrderAuditAction;
+  payload: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// State machine
+// ---------------------------------------------------------------------------
+// The single source of truth for "can this status go to that status". The
+// server actions (EMR-794) enforce these transitions; the UI (EMR-791) reads
+// them to know which buttons to enable.
+//
+// Diagram (from EMR-794 spec):
+//
+//   agent_drafted ─┬─► auto_submit ──► submitted
+//                  ├─► awaiting_approval ──► approved ──► submitted
+//                  │                       └─► rejected
+//                  └─► cancelled
+//
+//   submitted ──► shipped ──► delivered
+//             └─────────────► delivered   (skip-ship path)
+//             └─► cancelled
+//   shipped  ──► cancelled                (rare supplier issue)
+//
+// Terminal: delivered, rejected, cancelled.
+
+const TRANSITIONS: Record<SupplyOrderStatus, readonly SupplyOrderStatus[]> = {
+  agent_drafted: ["awaiting_approval", "submitted", "cancelled"],
+  awaiting_approval: ["approved", "submitted", "rejected", "cancelled"],
+  approved: ["submitted", "cancelled"],
+  submitted: ["shipped", "delivered", "cancelled"],
+  shipped: ["delivered", "cancelled"],
+  delivered: [],
+  rejected: [],
+  cancelled: [],
+};
+
+export function nextValidTransitions(
+  status: SupplyOrderStatus,
+): readonly SupplyOrderStatus[] {
+  return TRANSITIONS[status];
+}
+
+export function isValidTransition(
+  from: SupplyOrderStatus,
+  to: SupplyOrderStatus,
+): boolean {
+  return TRANSITIONS[from].includes(to);
+}
+
+const TERMINAL: ReadonlySet<SupplyOrderStatus> = new Set([
+  "delivered",
+  "rejected",
+  "cancelled",
+]);
+
+export function isTerminalStatus(status: SupplyOrderStatus): boolean {
+  return TERMINAL.has(status);
+}
+
+const OPEN_COVERAGE: ReadonlySet<SupplyOrderStatus> = new Set([
+  "agent_drafted",
+  "awaiting_approval",
+  "approved",
+  "submitted",
+  "shipped",
+]);
+
+/** Statuses that count as "this supply already has an open order". */
+export function isOpenCoverage(status: SupplyOrderStatus): boolean {
+  return OPEN_COVERAGE.has(status);
+}
+
+export const OPEN_COVERAGE_STATUSES: readonly SupplyOrderStatus[] = Array.from(
+  OPEN_COVERAGE,
+);
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** True if this order was drafted by a sub-agent (vs proposed by a human). */
+export function isAgentProposed(order: Pick<SupplyOrder, "proposedBy">): boolean {
+  return order.proposedBy.kind === "agent";
+}
+
+/** Quantity to order; falls back to `2 * reorderThreshold` if reorderQty is 0. */
+export function recommendedOrderQty(
+  supply: Pick<Supply, "reorderQty" | "reorderThreshold">,
+): number {
+  if (supply.reorderQty && supply.reorderQty > 0) return supply.reorderQty;
+  return Math.max(1, supply.reorderThreshold * 2);
+}
+
+/** Map (onHand, reorderThreshold) → SupplyStatus. */
+export function classifyStatus(
+  supply: Pick<Supply, "onHand" | "reorderThreshold" | "deletedAt">,
+): SupplyStatus {
+  if (supply.deletedAt) return "discontinued";
+  if (supply.onHand <= 0) return "out_of_stock";
+  if (supply.onHand <= supply.reorderThreshold) return "low_stock";
+  return "in_stock";
+}
+
+/** True if a supply is at or below its reorder threshold (low or out). */
+export function computeLowStock(
+  supply: Pick<Supply, "onHand" | "reorderThreshold" | "deletedAt">,
+): boolean {
+  if (supply.deletedAt) return false;
+  return supply.onHand <= supply.reorderThreshold;
+}
+
+export const REJECTION_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Anti-thrash: a sub-agent must not redraft a supply that the owner just
+ * rejected within the last 24h. The server action (EMR-794) stamps
+ * `rejectionReason` AND a `rejected` audit entry on the prior order; the
+ * agent's observe step checks the most-recent rejected order for each supply.
+ */
+export function isWithinRejectionCooldown(
+  rejectedAt: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!rejectedAt) return false;
+  return now.getTime() - rejectedAt.getTime() < REJECTION_COOLDOWN_MS;
+}
+
+/** Compute total cents (qty * unit), guarding against negatives. */
+export function computeTotalCents(qty: number, unitCostCents: number): number {
+  return Math.max(0, Math.trunc(qty) * Math.max(0, Math.trunc(unitCostCents)));
+}
+
+// ---------------------------------------------------------------------------
+// Audit-entry construction helpers (kept here so every writer formats actors
+// the same way — see EMR-794 server actions + EMR-789 agent).
+// ---------------------------------------------------------------------------
+
+export interface AuditEntryInput {
+  orderId: string;
+  actor: SupplyOrderActor;
+  action: SupplyOrderAuditAction;
+  payload?: Record<string, unknown> | null;
+}
+
+/** Flatten the actor discriminated union into the two prisma columns. */
+export function actorToColumns(actor: SupplyOrderActor): {
+  actorKind: "agent" | "user" | "system";
+  actorAgentId: string | null;
+  actorUserId: string | null;
+} {
+  if (actor.kind === "agent")
+    return { actorKind: "agent", actorAgentId: actor.agentId, actorUserId: null };
+  if (actor.kind === "user")
+    return { actorKind: "user", actorAgentId: null, actorUserId: actor.userId };
+  return { actorKind: "system", actorAgentId: null, actorUserId: null };
+}
+
+/** Flatten the proposedBy union into the two prisma columns. */
+export function proposedByToColumns(p: ProposedBy): {
+  proposedByKind: "agent" | "user";
+  proposedByAgentId: string | null;
+  proposedByUserId: string | null;
+} {
+  return p.kind === "agent"
+    ? { proposedByKind: "agent", proposedByAgentId: p.agentId, proposedByUserId: null }
+    : { proposedByKind: "user", proposedByAgentId: null, proposedByUserId: p.userId };
+}


### PR DESCRIPTION
## Summary

Foundation PR for EMR-787 (Practice Manager Agent v1). Establishes the data model, the first sub-agent (`supplyReorderAgent`), the meta-orchestrator (`practiceManagerAgent`), and the full server-action state machine. Other parallel PRs (UI EMR-791, PDF+email EMR-792, config EMR-793, KPI EMR-795) build against the contract defined here.

Closes (in part) EMR-788, EMR-789, EMR-790, EMR-794.

## Public contract (UI / PDF / KPI agents — read this)

Everything below is exported from `src/lib/domain/supplies.ts` or `src/app/(operator)/ops/supplies/actions.ts`.

### Status enums

```ts
type SupplyOrderStatus =
  | "agent_drafted" | "awaiting_approval" | "approved"
  | "submitted" | "shipped" | "delivered" | "rejected" | "cancelled";

type SupplyOrderAuditAction =
  | "drafted" | "approved" | "rejected" | "submitted" | "shipped"
  | "delivered" | "edited" | "cancelled" | "auto_submitted" | "reverted";

type SupplyStatus = "in_stock" | "low_stock" | "out_of_stock" | "discontinued";
```

### Discriminated unions

```ts
type ProposedBy =
  | { kind: "agent"; agentId: string }
  | { kind: "user"; userId: string };

type SupplyOrderActor =
  | { kind: "agent"; agentId: string }
  | { kind: "user"; userId: string }
  | { kind: "system" };
```

The Prisma row stores these flat: `proposedByKind` + `proposedByAgentId | proposedByUserId`, and on audit rows `actorKind` + `actorAgentId | actorUserId`. Use `proposedByToColumns()` / `actorToColumns()` from `lib/domain/supplies.ts` to convert.

### Public shapes

```ts
interface Supply {
  id; organizationId; name; sku|null; category|null; supplierId|null;
  reorderThreshold; reorderQty; lastUnitCostCents|null; onHand; unit;
  notes|null; deletedAt|null; createdAt; updatedAt;
}
interface Supplier {
  id; organizationId; name; contactName|null; email|null; phone|null;
  defaultPaymentTermsDays; notes|null; createdAt; updatedAt;
}
interface SupplyOrder {
  id; organizationId; supplyId; supplierId; status; qty;
  unitCostCents; totalCents; proposedBy; approvedByUserId|null;
  autoSubmitted; rejectionReason|null; submittedAt|null; shippedAt|null;
  deliveredAt|null; deliveredQty|null; expectedDeliveryAt|null;
  supplierPoRef|null; createdAt; updatedAt; deletedAt|null;
}
interface SupplyOrderAuditEntry {
  id; orderId; actor; action; payload|null; createdAt;
}
```

### Helpers (UI / agents call these directly)

```ts
classifyStatus(supply) -> SupplyStatus
computeLowStock(supply) -> boolean
recommendedOrderQty(supply) -> number
computeTotalCents(qty, unitCostCents) -> number
isAgentProposed(order) -> boolean
isTerminalStatus(status) -> boolean
isOpenCoverage(status) -> boolean
isValidTransition(from, to) -> boolean
nextValidTransitions(from) -> readonly SupplyOrderStatus[]
isWithinRejectionCooldown(rejectedAt, now?) -> boolean
REJECTION_COOLDOWN_MS = 24h
```

### Server actions (signatures)

```ts
// (operator)/ops/supplies/actions.ts

type ActionResult<T = undefined> =
  | { ok: true; data?: T } | { ok: false; error: string };

approveAndSubmitOrder(input: { orderId; notes?; editedQty?; editedSupplierId? })
  : Promise<ActionResult<{ orderId: string }>>

rejectOrder(input: { orderId; reason })
  : Promise<ActionResult>

editDraftedOrder(input: { orderId; qty?; supplierId?; unitCostCents?; notes? })
  : Promise<ActionResult>

submitDraftedOrder(input: { orderId })
  : Promise<ActionResult>

markShipped(input: { orderId; shippedAt?; trackingNumber? })
  : Promise<ActionResult>

markDelivered(input: { orderId; deliveredAt?; qtyReceived? })
  : Promise<ActionResult<{ idempotent: boolean }>>

cancelOrder(input: { orderId; reason })
  : Promise<ActionResult>

// EMR-793 trust-threshold layer entry point (server-internal):
submitDraftedOrderAsAgent(orderId: string, agentId: string)
  : Promise<ActionResult>
```

### State machine

```
agent_drafted ─┬─► awaiting_approval ─┬─► approved ──► submitted
               │                      └─► rejected
               ├─► submitted (auto-submit via submitDraftedOrderAsAgent)
               └─► cancelled

submitted ──► shipped ──► delivered
          └─────────────► delivered    (skip-ship path)
          └─► cancelled
shipped   ──► cancelled                (rare supplier issue)

Terminal: delivered, rejected, cancelled.
```

Illegal transitions THROW with a clear message (no silent no-op).

### Agent registry additions

`src/lib/agents/index.ts` now exposes `supplyReorder` and `practiceManager` in `agentRegistry`. The meta-orchestrator currently fans out to `[supplyReorderAgent]` and is set up to add `credentialExpiryAgent` etc. with a one-line change.

## Verification — per invariant

| Invariant | How it is enforced | Where to verify |
| --- | --- | --- |
| 1. Sub-agents always draft | `supplyReorderAgent` only writes `status: "agent_drafted"`. Never sets `submittedAt`, `approvedByUserId`, etc. | `src/lib/agents/supply-reorder-agent.ts` line ~130 (`prisma.supplyOrder.create`) |
| 2. 24h rejection cooldown | Agent reads `SupplyOrder.status=rejected` rows where `updatedAt >= now-24h` and skips those `supplyId`s. Pure helper `isWithinRejectionCooldown()` is unit-tested. | `supply-reorder-agent.ts` `cooldownCutoff` block; `domain/supplies.test.ts` |
| 3. Costs in cents | All money columns end in `Cents` and are `Int`. `computeTotalCents` and `lastUnitCostCents` enforce this end-to-end. | `prisma/schema.prisma` Supply + SupplyOrder; `domain/supplies.ts` |
| 4. `proposedBy` discriminated union | Two columns (`proposedByKind` + `proposedByAgentId|proposedByUserId`) on every order; `proposedByToColumns()` is the only writer. | `domain/supplies.ts::proposedByToColumns`; `supply-reorder-agent.ts` |
| 5. `markDelivered` is idempotent | Implemented as `updateMany` with `where: { id, deliveredAt: null }` then a `count === 0` short-circuit. Repeat calls early-return `{ idempotent: true }`. | `actions.ts::markDelivered` |
| 6. Auto-submit still audited | `submitDraftedOrderAsAgent` writes an `auto_submitted` `SupplyOrderAuditEntry` inside the transaction that flips status. | `actions.ts::submitDraftedOrderAsAgent` |
| 7. `/ops/supplies` is clinical-supplies only | No edits to `src/lib/domain/inventory.ts`. New schema models do not touch CannabisProduct / SupplyProduct (dispensary). | `git diff --stat` shows zero changes in `lib/domain/inventory.ts` |

## Untouched (per architect guardrails)
- `src/middleware.ts`
- `.github/workflows/`
- `src/lib/specialty-templates/manifests/`
- `src/lib/auth/`
- `CLAUDE.md`
- `src/lib/domain/inventory.ts`
- existing `/ops/supplies/{page,supplies-view}.tsx` (UI agent EMR-791 owns these)

## Test plan
- [x] `npx prisma validate` — schema valid
- [x] `npx prisma generate` — client generated
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors / warnings
- [x] `vitest run src/lib/domain/supplies.test.ts` — 24/24 passing
- [ ] Apply migration on staging DB and confirm tables / enums land
- [ ] End-to-end: draft → approve → submit → ship → deliver via server actions; verify exactly one audit entry per transition; verify stock increments once
- [ ] Reject test: reject an order, re-run `supplyReorderAgent`, confirm 0 new drafts for that supply for ≥24h
- [ ] Idempotency test: call `markDelivered` twice in quick succession, verify `onHand` increments only once

## Stats

```
8 files changed, 1807 insertions(+), 14 deletions(-)
  prisma/schema.prisma                              (+184)
  prisma/migrations/.../migration.sql               (+197)
  src/lib/domain/supplies.ts                        (+319)
  src/lib/domain/supplies.test.ts                   (+157)
  src/lib/agents/supply-reorder-agent.ts            (+225)
  src/lib/agents/practice-manager-agent.ts          (+173)
  src/lib/agents/index.ts                           (+6)
  src/app/(operator)/ops/supplies/actions.ts        (+560)
```

DO NOT merge. DO NOT enable auto-merge. Parallel epics (EMR-791/792/793/795) depend on this contract; let them rebase on top once approved.

Generated with [Claude Code](https://claude.com/claude-code)