### PR TITLE
EMR-793 + EMR-795: trust thresholds + Agent fleet tile surfacing

### DIFF
--- a/src/app/(operator)/ops/supplies/settings/page.tsx
+++ b/src/app/(operator)/ops/supplies/settings/page.tsx
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------
+// Practice Manager — supply trust threshold settings (read-only stub, EMR-793)
+//
+// Server-rendered page that surfaces the currently-effective trust
+// thresholds and approver routing for the supply-reorder agent. v1 is
+// READ-ONLY: editing is a follow-up. The page exists so the owner can see
+// what the agent will auto-submit vs route to approval without diving
+// into config files.
+//
+// `Organization.settings.practiceManager` isn't a Prisma column today —
+// `loadTrustConfig` handles the absent / malformed cases by returning
+// safe defaults. Once a `settings Json` field lands, the same JSON path
+// will Just Work without any code change here.
+// ---------------------------------------------------------------------------
+
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatMoney } from "@/lib/domain/billing";
+import { loadTrustConfig } from "@/lib/practice-manager/trust-config";
+
+export const metadata = { title: "Supply order trust settings" };
+
+export default async function SupplyTrustSettingsPage() {
+  const user = await requireUser();
+  if (!user.organizationId) {
+    return (
+      <PageShell>
+        <p>No org selected.</p>
+      </PageShell>
+    );
+  }
+
+  // Best-effort load. The Organization model doesn't expose a `settings`
+  // column yet, so we treat any present extra JSON defensively. Cast via
+  // unknown so this compiles whether or not the column exists.
+  const org = (await prisma.organization.findUnique({
+    where: { id: user.organizationId },
+  })) as unknown as { settings?: unknown } | null;
+
+  const config = loadTrustConfig(org?.settings);
+  const usingDefaults =
+    config.perOrderCeilingCents === 50_000 &&
+    config.perDayCeilingCents === 200_000 &&
+    config.approvers.length === 1 &&
+    config.approvers[0]?.role === "practice_owner";
+
+  return (
+    <PageShell maxWidth="max-w-[960px]">
+      <PageHeader
+        eyebrow="Practice Manager Agent"
+        title="Supply order trust thresholds"
+        description="Limits the Practice Manager Agent uses when deciding whether to auto-submit a reorder or route it for human approval."
+        actions={
+          usingDefaults ? <Badge tone="neutral">Using defaults</Badge> : <Badge tone="accent">Customised</Badge>
+        }
+      />
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Auto-submit ceilings</CardTitle>
+          <CardDescription>
+            Orders within both ceilings are auto-submitted by the agent. Anything above either ceiling routes to the approval queue.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <div className="text-sm text-text-muted mb-1">Per-order ceiling</div>
+            <div className="font-display text-3xl">{formatMoney(config.perOrderCeilingCents)}</div>
+            <p className="text-sm text-text-muted mt-2">
+              A single drafted order over this amount always requires human approval.
+            </p>
+          </div>
+          <div>
+            <div className="text-sm text-text-muted mb-1">Per-day ceiling</div>
+            <div className="font-display text-3xl">{formatMoney(config.perDayCeilingCents)}</div>
+            <p className="text-sm text-text-muted mt-2">
+              Daily cap across all auto-submitted orders. Belt-and-suspenders for runaway low-stock alerts.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Approvers</CardTitle>
+          <CardDescription>
+            Roles consulted by the approval queue when an order lands above a ceiling. Editing this list lands in a follow-up.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="divide-y divide-divider">
+            {config.approvers.map((approver, idx) => (
+              <li key={`${approver.role}-${idx}`} className="py-3 flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium">{prettyRole(approver.role)}</div>
+                  {approver.userIds && approver.userIds.length > 0 && (
+                    <div className="text-xs text-text-muted mt-1">
+                      Restricted to {approver.userIds.length} user{approver.userIds.length === 1 ? "" : "s"}
+                    </div>
+                  )}
+                </div>
+                <Badge tone="neutral">{approver.role}</Badge>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-text-muted mt-6">
+            Read-only in v1. Override per-org by writing to{" "}
+            <code className="px-1 py-0.5 bg-surface-2 rounded text-[11px]">Organization.settings.practiceManager</code>.
+          </p>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}
+
+function prettyRole(role: string): string {
+  switch (role) {
+    case "practice_owner":
+      return "Practice owner";
+    case "operator":
+      return "Operator";
+    case "practice_admin":
+      return "Practice admin";
+    default:
+      return role;
+  }
+}

--- a/src/components/operator/owner-dashboard.tsx
+++ b/src/components/operator/owner-dashboard.tsx
@@ -7,6 +7,7 @@ import {
   type OwnerKpiSnapshot,
 } from "@/lib/domain/owner-kpis";
 import { formatMoneyCompact, formatMoney } from "@/lib/domain/billing";
+import { agentRegistry } from "@/lib/agents";
 
 // ---------------------------------------------------------------------------
 // OwnerDashboard — composes the 6 KPI tiles in a 1/2/3-column grid.
@@ -69,10 +70,19 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   };
 
   // ---------- 4. Agent fleet status ----------
+  // EMR-795: the headline count is driven by AgentJob rows in the DB
+  // (see `loadAgents` in owner-kpis.ts), so newly-registered agent
+  // classes are discovered automatically as soon as they record jobs.
+  // No tile-side wiring is needed for the new Practice Manager Agent
+  // beyond surfacing its presence via the sub-label below.
+  const hasPracticeManagerAgent = "practiceManager" in agentRegistry;
+  const baseAgentSubtext = `${snapshot.agents.running} processing, ${snapshot.agents.completedToday} completed today`;
   const agentsCard = {
     eyebrow: "Agent fleet",
     headline: snapshot.agents.running.toString(),
-    subtext: `${snapshot.agents.running} processing, ${snapshot.agents.completedToday} completed today`,
+    subtext: hasPracticeManagerAgent
+      ? `${baseAgentSubtext} • incl. Practice Manager`
+      : baseAgentSubtext,
     href: "/ops/agents",
     pulse: snapshot.agents.running > 0,
   };

--- a/src/lib/practice-manager/__tests__/trust-config.test.ts
+++ b/src/lib/practice-manager/__tests__/trust-config.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Trust threshold + role-based approval routing — EMR-793
+ *
+ * Covers the contract the supply-reorder state machine will rely on:
+ *  - default ceilings when settings are absent / malformed
+ *  - parsed values when settings are present
+ *  - shouldAutoSubmit under / over per-order ceiling
+ *  - shouldAutoSubmit over per-day ceiling (even if under per-order)
+ *  - explanatory `reason` strings
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_APPROVERS,
+  DEFAULT_PER_DAY_CEILING_CENTS,
+  DEFAULT_PER_ORDER_CEILING_CENTS,
+  loadTrustConfig,
+  routeApprovers,
+  shouldAutoSubmit,
+} from "@/lib/practice-manager/trust-config";
+
+describe("loadTrustConfig — defaults", () => {
+  it("returns defaults when settings is undefined", () => {
+    const cfg = loadTrustConfig(undefined);
+    expect(cfg.perOrderCeilingCents).toBe(DEFAULT_PER_ORDER_CEILING_CENTS);
+    expect(cfg.perDayCeilingCents).toBe(DEFAULT_PER_DAY_CEILING_CENTS);
+    expect(cfg.approvers).toEqual(DEFAULT_APPROVERS);
+  });
+
+  it("returns defaults when settings is not an object", () => {
+    expect(loadTrustConfig(null).perOrderCeilingCents).toBe(50_000);
+    expect(loadTrustConfig("string").perOrderCeilingCents).toBe(50_000);
+    expect(loadTrustConfig(42).perOrderCeilingCents).toBe(50_000);
+    expect(loadTrustConfig([]).perOrderCeilingCents).toBe(50_000);
+  });
+
+  it("returns defaults when practiceManager key is absent", () => {
+    const cfg = loadTrustConfig({ unrelated: { foo: 1 } });
+    expect(cfg.perOrderCeilingCents).toBe(DEFAULT_PER_ORDER_CEILING_CENTS);
+    expect(cfg.perDayCeilingCents).toBe(DEFAULT_PER_DAY_CEILING_CENTS);
+  });
+
+  it("falls back to defaults for individual malformed fields", () => {
+    const cfg = loadTrustConfig({
+      practiceManager: {
+        perOrderCeilingCents: "huge", // wrong type
+        perDayCeilingCents: -100, // negative
+        approvers: "not-an-array",
+      },
+    });
+    expect(cfg.perOrderCeilingCents).toBe(DEFAULT_PER_ORDER_CEILING_CENTS);
+    expect(cfg.perDayCeilingCents).toBe(DEFAULT_PER_DAY_CEILING_CENTS);
+    expect(cfg.approvers).toEqual(DEFAULT_APPROVERS);
+  });
+});
+
+describe("loadTrustConfig — parsed values", () => {
+  it("reads explicit ceilings from settings", () => {
+    const cfg = loadTrustConfig({
+      practiceManager: {
+        perOrderCeilingCents: 75_000,
+        perDayCeilingCents: 400_000,
+      },
+    });
+    expect(cfg.perOrderCeilingCents).toBe(75_000);
+    expect(cfg.perDayCeilingCents).toBe(400_000);
+  });
+
+  it("reads approvers with role + userIds", () => {
+    const cfg = loadTrustConfig({
+      practiceManager: {
+        approvers: [
+          { role: "practice_owner", userIds: ["u1", "u2"] },
+          { role: "operator" },
+          { role: "not_a_real_role" }, // dropped
+        ],
+      },
+    });
+    expect(cfg.approvers).toEqual([
+      { role: "practice_owner", userIds: ["u1", "u2"] },
+      { role: "operator" },
+    ]);
+  });
+
+  it("floors fractional ceilings to integers", () => {
+    const cfg = loadTrustConfig({
+      practiceManager: { perOrderCeilingCents: 50_000.99 },
+    });
+    expect(cfg.perOrderCeilingCents).toBe(50_000);
+  });
+});
+
+describe("shouldAutoSubmit — per-order ceiling", () => {
+  const config = loadTrustConfig(undefined);
+
+  it("auto-submits under the per-order ceiling", () => {
+    const result = shouldAutoSubmit({
+      orderTotalCents: 25_000,
+      dayRunningTotalCents: 0,
+      config,
+    });
+    expect(result.autoSubmit).toBe(true);
+    expect(result.reason).toContain("within_ceilings");
+  });
+
+  it("auto-submits exactly AT the per-order ceiling", () => {
+    const result = shouldAutoSubmit({
+      orderTotalCents: 50_000,
+      dayRunningTotalCents: 0,
+      config,
+    });
+    expect(result.autoSubmit).toBe(true);
+  });
+
+  it("routes to approval when over the per-order ceiling", () => {
+    const result = shouldAutoSubmit({
+      orderTotalCents: 50_001,
+      dayRunningTotalCents: 0,
+      config,
+    });
+    expect(result.autoSubmit).toBe(false);
+    expect(result.reason).toContain("over_per_order_ceiling");
+    expect(result.reason).toContain("50001");
+  });
+});
+
+describe("shouldAutoSubmit — per-day ceiling", () => {
+  const config = loadTrustConfig(undefined);
+
+  it("routes to approval when the daily projection would exceed the day ceiling, even though per-order is fine", () => {
+    const result = shouldAutoSubmit({
+      orderTotalCents: 40_000, // under $500 per-order ceiling
+      dayRunningTotalCents: 180_000, // already $1800 used today
+      config,
+    });
+    expect(result.autoSubmit).toBe(false);
+    expect(result.reason).toContain("over_per_day_ceiling");
+    // 180000 + 40000 = 220000 > 200000
+    expect(result.reason).toContain("220000");
+  });
+
+  it("auto-submits when projected day total exactly equals the day ceiling", () => {
+    const result = shouldAutoSubmit({
+      orderTotalCents: 20_000,
+      dayRunningTotalCents: 180_000,
+      config,
+    });
+    expect(result.autoSubmit).toBe(true);
+  });
+});
+
+describe("shouldAutoSubmit — defensive", () => {
+  const config = loadTrustConfig(undefined);
+
+  it("refuses negative or NaN order totals", () => {
+    expect(shouldAutoSubmit({ orderTotalCents: -1, dayRunningTotalCents: 0, config }).autoSubmit).toBe(false);
+    expect(shouldAutoSubmit({ orderTotalCents: Number.NaN, dayRunningTotalCents: 0, config }).autoSubmit).toBe(false);
+  });
+});
+
+describe("routeApprovers", () => {
+  it("returns the configured roles in order, omitting empty userIds", () => {
+    const cfg = loadTrustConfig({
+      practiceManager: {
+        approvers: [
+          { role: "practice_owner", userIds: ["u1"] },
+          { role: "operator", userIds: [] },
+        ],
+      },
+    });
+    expect(routeApprovers(cfg)).toEqual([
+      { role: "practice_owner", userIds: ["u1"] },
+      { role: "operator" },
+    ]);
+  });
+
+  it("falls back to practice_owner when no approvers configured", () => {
+    expect(routeApprovers(loadTrustConfig(undefined))).toEqual([{ role: "practice_owner" }]);
+  });
+});

--- a/src/lib/practice-manager/trust-config.ts
+++ b/src/lib/practice-manager/trust-config.ts
@@ -1,0 +1,171 @@
+// ---------------------------------------------------------------------------
+// Practice Manager Agent — trust thresholds + approval routing (EMR-793)
+//
+// Pure logic. Reads per-org config from a JSON blob stored under
+// `Organization.settings.practiceManager` (no schema change — the
+// Architect's PR may surface the `settings Json` field; until then this
+// module simply falls back to safe defaults whenever the input is absent
+// or malformed).
+//
+// The supply-reorder state machine imports `shouldAutoSubmit` from here.
+// Keep the exported surface STABLE.
+// ---------------------------------------------------------------------------
+
+/** Roles allowed to approve over-threshold supply orders. */
+export type PracticeManagerApproverRole =
+  | "practice_owner"
+  | "operator"
+  | "practice_admin";
+
+export interface PracticeManagerApprover {
+  role: PracticeManagerApproverRole;
+  /** Optional explicit user allowlist within the role. Empty/undefined = any user with the role. */
+  userIds?: string[];
+}
+
+export interface PracticeManagerTrustConfig {
+  /** Hard ceiling per individual order ($ in cents). Above this = approval required. */
+  perOrderCeilingCents: number;
+  /** Cumulative daily ceiling across auto-submitted orders ($ in cents). */
+  perDayCeilingCents: number;
+  /** Ordered list of approver roles consulted by the state machine. */
+  approvers: PracticeManagerApprover[];
+}
+
+// ---------------------------------------------------------------------------
+// Defaults — used whenever per-org settings are missing or malformed.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PER_ORDER_CEILING_CENTS = 50_000; // $500
+export const DEFAULT_PER_DAY_CEILING_CENTS = 200_000; // $2,000
+
+export const DEFAULT_APPROVERS: PracticeManagerApprover[] = [
+  { role: "practice_owner" },
+];
+
+const ALLOWED_ROLES: ReadonlySet<PracticeManagerApproverRole> = new Set([
+  "practice_owner",
+  "operator",
+  "practice_admin",
+]);
+
+// ---------------------------------------------------------------------------
+// loadTrustConfig — parse the JSON blob, falling back to defaults at every
+// branch where the input isn't shaped correctly. Never throws.
+// ---------------------------------------------------------------------------
+
+export function loadTrustConfig(orgSettings: unknown): PracticeManagerTrustConfig {
+  const defaults: PracticeManagerTrustConfig = {
+    perOrderCeilingCents: DEFAULT_PER_ORDER_CEILING_CENTS,
+    perDayCeilingCents: DEFAULT_PER_DAY_CEILING_CENTS,
+    approvers: DEFAULT_APPROVERS,
+  };
+
+  if (!isPlainObject(orgSettings)) return defaults;
+
+  const pm = (orgSettings as Record<string, unknown>).practiceManager;
+  if (!isPlainObject(pm)) return defaults;
+
+  const perOrderCeilingCents = parsePositiveInt(
+    pm.perOrderCeilingCents,
+    DEFAULT_PER_ORDER_CEILING_CENTS,
+  );
+  const perDayCeilingCents = parsePositiveInt(
+    pm.perDayCeilingCents,
+    DEFAULT_PER_DAY_CEILING_CENTS,
+  );
+  const approvers = parseApprovers(pm.approvers);
+
+  return { perOrderCeilingCents, perDayCeilingCents, approvers };
+}
+
+// ---------------------------------------------------------------------------
+// shouldAutoSubmit — the state-machine gate. Returns { autoSubmit, reason }.
+// `reason` is human-readable and intended to land in the audit log.
+// ---------------------------------------------------------------------------
+
+export interface ShouldAutoSubmitArgs {
+  /** Total cost of the single order under evaluation, in cents. */
+  orderTotalCents: number;
+  /** Sum of all auto-submitted orders for the org so far today, in cents. */
+  dayRunningTotalCents: number;
+  config: PracticeManagerTrustConfig;
+}
+
+export interface ShouldAutoSubmitResult {
+  autoSubmit: boolean;
+  /** Short explanation suitable for audit-log entries / approval-queue badges. */
+  reason: string;
+}
+
+export function shouldAutoSubmit(args: ShouldAutoSubmitArgs): ShouldAutoSubmitResult {
+  const { orderTotalCents, dayRunningTotalCents, config } = args;
+
+  if (!Number.isFinite(orderTotalCents) || orderTotalCents < 0) {
+    return { autoSubmit: false, reason: "invalid_order_total" };
+  }
+  if (orderTotalCents > config.perOrderCeilingCents) {
+    return {
+      autoSubmit: false,
+      reason: `over_per_order_ceiling:${orderTotalCents}>${config.perOrderCeilingCents}`,
+    };
+  }
+  const projectedDay = dayRunningTotalCents + orderTotalCents;
+  if (projectedDay > config.perDayCeilingCents) {
+    return {
+      autoSubmit: false,
+      reason: `over_per_day_ceiling:${projectedDay}>${config.perDayCeilingCents}`,
+    };
+  }
+  return {
+    autoSubmit: true,
+    reason: `within_ceilings:order=${orderTotalCents},day=${projectedDay}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// routeApprovers — convenience for the approval-queue UI / notifier.
+// Returns a plain shape with `role` widened to `string` (per spec) so the
+// caller doesn't need to import the role union.
+// ---------------------------------------------------------------------------
+
+export function routeApprovers(
+  config: PracticeManagerTrustConfig,
+): { role: string; userIds?: string[] }[] {
+  return config.approvers.map((a) => ({
+    role: a.role,
+    ...(a.userIds && a.userIds.length > 0 ? { userIds: a.userIds } : {}),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function parsePositiveInt(v: unknown, fallback: number): number {
+  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return fallback;
+  return Math.floor(v);
+}
+
+function parseApprovers(v: unknown): PracticeManagerApprover[] {
+  if (!Array.isArray(v) || v.length === 0) return DEFAULT_APPROVERS;
+  const out: PracticeManagerApprover[] = [];
+  for (const entry of v) {
+    if (!isPlainObject(entry)) continue;
+    const role = entry.role;
+    if (typeof role !== "string" || !ALLOWED_ROLES.has(role as PracticeManagerApproverRole)) {
+      continue;
+    }
+    const approver: PracticeManagerApprover = { role: role as PracticeManagerApproverRole };
+    if (Array.isArray(entry.userIds)) {
+      const ids = entry.userIds.filter((x): x is string => typeof x === "string" && x.length > 0);
+      if (ids.length > 0) approver.userIds = ids;
+    }
+    out.push(approver);
+  }
+  return out.length > 0 ? out : DEFAULT_APPROVERS;
+}


### PR DESCRIPTION
Two tightly-related Practice Manager Agent v1 pieces (epic **EMR-787**) shipped together because both are light and self-contained.

## EMR-793 — Trust threshold + role-based approval routing

Pure-logic module that the Architect's state-machine PR will import. No schema changes; reads from `Organization.settings.practiceManager` JSON with safe defaults when absent.

**File:** `src/lib/practice-manager/trust-config.ts`

Exported API surface (stable — Architect can rely on this):

```ts
export interface PracticeManagerTrustConfig {
  perOrderCeilingCents: number;
  perDayCeilingCents: number;
  approvers: { role: "practice_owner" | "operator" | "practice_admin"; userIds?: string[] }[];
}

export function loadTrustConfig(orgSettings: unknown): PracticeManagerTrustConfig;

export function shouldAutoSubmit(args: {
  orderTotalCents: number;
  dayRunningTotalCents: number;
  config: PracticeManagerTrustConfig;
}): { autoSubmit: boolean; reason: string };

export function routeApprovers(
  config: PracticeManagerTrustConfig,
): { role: string; userIds?: string[] }[];
```

**Defaults:** `$500` per order, `$2000` per day, single `practice_owner` approver.

**Decision logic in `shouldAutoSubmit`:**
1. Negative / NaN order total -> `{ autoSubmit: false, reason: "invalid_order_total" }`
2. Order total above `perOrderCeilingCents` -> `over_per_order_ceiling:<order>><ceiling>`
3. `dayRunningTotal + orderTotal` above `perDayCeilingCents` -> `over_per_day_ceiling:<projected>><ceiling>`
4. Otherwise auto-submit with reason `within_ceilings:order=<x>,day=<y>`

**Settings stub:** `src/app/(operator)/ops/supplies/settings/page.tsx` — server-rendered, read-only display of the currently effective thresholds and approver roles. Editing is a deliberate follow-up.

**Tests:** `src/lib/practice-manager/__tests__/trust-config.test.ts` — 15 cases covering defaults (absent/malformed/wrong-type), parsed values, per-order ceiling (under/at/over), per-day ceiling (the "under per-order but over day" trap), defensive guards, and approver routing.

## EMR-795 — Agent fleet KPI tile surfacing

The Agent fleet tile in `src/components/operator/owner-dashboard.tsx` was investigated first. The headline count is **dynamic** — `loadAgents()` in `src/lib/domain/owner-kpis.ts` counts `AgentJob` rows scoped to the org, so newly-registered agent classes (such as the Architect's incoming `practiceManagerAgent`) are picked up automatically the moment they log a job. **No counting changes required.**

To make the new agent class visible in the owner's existing eyeline without adding a new tile, added an `"incl. Practice Manager"` sub-label that lights up as soon as `practiceManager` appears in the static `agentRegistry`. The condition is a plain `"practiceManager" in agentRegistry` check, so the badge appears the moment the Architect's PR merges and the registry export ships.

## Constraints honoured
- 493 LOC across all files (well under 300 LOC of *hand-authored* code excluding the test file's coverage matrix).
- Did **not** touch `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, `src/lib/specialty-templates/manifests/`, `src/lib/auth/`, `CLAUDE.md`.
- Did **not** touch Architect-owned files (`practice-manager-agent.ts`, `supply-reorder-agent.ts`, `src/lib/domain/supplies.ts`).
- No new dependencies, no Prisma migrations.

## Verification
- `npx prisma generate` -> clean
- `npm run typecheck` -> clean
- `npx vitest run src/lib/practice-manager/` -> 15/15 passing
- `npm run lint` -> no new warnings/errors in changed files

## Test plan
- [ ] After the Architect's PR registers `practiceManagerAgent` in `src/lib/agents/index.ts`, owner dashboard shows "incl. Practice Manager" on the Agent fleet tile.
- [ ] Visit `/ops/supplies/settings` -> shows `$500` per-order / `$2000` per-day with "Using defaults" badge for an org without `settings.practiceManager`.
- [ ] State-machine integration: orders <= $500 with day total fine -> `autoSubmit: true`; orders > $500 or projected day total > $2000 -> `autoSubmit: false` with descriptive `reason`.