### PR TITLE
ux: operator filter/sort UX upgrade (3 surfaces)

### DIFF
--- a/src/app/(operator)/ops/feedback/feedback-view.tsx
+++ b/src/app/(operator)/ops/feedback/feedback-view.tsx
@@ -4,7 +4,15 @@ import { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Textarea } from "@/components/ui/input";
+import { Input, Textarea } from "@/components/ui/input";
+import {
+  EmptyFilterState,
+  FilterChips,
+  MultiSelectFilter,
+  SavedViewsBar,
+  SortMenu,
+  type ActiveChip,
+} from "@/components/ui/filter-bar";
 import { cn } from "@/lib/utils/cn";
 
 export type FeedbackStatus = "new" | "in_progress" | "resolved";
@@ -34,28 +42,151 @@ const TAG_LABELS: Record<FeedbackTag, string> = {
   not_actionable: "Not actionable",
 };
 
+type RatingBand = "detractor" | "passive" | "promoter";
+const RATING_BAND_LABELS: Record<RatingBand, string> = {
+  detractor: "Detractor (0-6)",
+  passive: "Passive (7-8)",
+  promoter: "Promoter (9-10)",
+};
+
+function ratingBand(r: number): RatingBand {
+  if (r < 7) return "detractor";
+  if (r < 9) return "passive";
+  return "promoter";
+}
+
 function ratingTone(r: number): "danger" | "warning" | "success" {
   if (r < 7) return "danger";
   if (r < 9) return "warning";
   return "success";
 }
 
+type SortKey = "smart" | "newest" | "oldest" | "rating-asc" | "rating-desc";
+
+const SORT_OPTIONS = [
+  { value: "smart", label: "Detractors first" },
+  { value: "newest", label: "Newest first" },
+  { value: "oldest", label: "Oldest first" },
+  { value: "rating-asc", label: "Rating (low to high)" },
+  { value: "rating-desc", label: "Rating (high to low)" },
+] as const;
+
+type ViewState = {
+  tab: "all" | FeedbackStatus;
+  query: string;
+  bands: RatingBand[];
+  tags: Array<FeedbackTag | "untagged">;
+  sort: SortKey;
+};
+
+const DEFAULT_STATE: ViewState = {
+  tab: "all",
+  query: "",
+  bands: [],
+  tags: [],
+  sort: "smart",
+};
+
 export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackItem[] }) {
   const [items, setItems] = useState<FeedbackItem[]>(initialFeedback);
-  const [tab, setTab] = useState<"all" | FeedbackStatus>("all");
+  const [state, setState] = useState<ViewState>(DEFAULT_STATE);
   const [responding, setResponding] = useState<FeedbackItem | null>(null);
   const [responseText, setResponseText] = useState("");
 
   const sorted = useMemo(() => {
-    const filtered = tab === "all" ? items : items.filter((i) => i.status === tab);
-    return [...filtered].sort((a, b) => {
-      // Promote negative NPS first
-      const aNeg = a.rating < 7 ? 0 : 1;
-      const bNeg = b.rating < 7 ? 0 : 1;
-      if (aNeg !== bNeg) return aNeg - bNeg;
-      return b.submittedAt.localeCompare(a.submittedAt);
+    const q = state.query.trim().toLowerCase();
+    const filtered = items.filter((i) => {
+      if (state.tab !== "all" && i.status !== state.tab) return false;
+      if (state.bands.length > 0 && !state.bands.includes(ratingBand(i.rating))) {
+        return false;
+      }
+      if (state.tags.length > 0) {
+        const tagKey: FeedbackTag | "untagged" = i.tag ?? "untagged";
+        if (!state.tags.includes(tagKey)) return false;
+      }
+      if (q) {
+        const hay = `${i.patientName} ${i.excerpt}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
     });
-  }, [items, tab]);
+
+    return [...filtered].sort((a, b) => {
+      switch (state.sort) {
+        case "smart": {
+          const aNeg = a.rating < 7 ? 0 : 1;
+          const bNeg = b.rating < 7 ? 0 : 1;
+          if (aNeg !== bNeg) return aNeg - bNeg;
+          return b.submittedAt.localeCompare(a.submittedAt);
+        }
+        case "newest":
+          return b.submittedAt.localeCompare(a.submittedAt);
+        case "oldest":
+          return a.submittedAt.localeCompare(b.submittedAt);
+        case "rating-asc":
+          return a.rating - b.rating;
+        case "rating-desc":
+          return b.rating - a.rating;
+      }
+    });
+  }, [items, state]);
+
+  const chips: ActiveChip[] = [];
+  if (state.tab !== "all") {
+    chips.push({
+      id: "tab",
+      label: "Status",
+      value: TABS.find((t) => t.key === state.tab)?.label ?? state.tab,
+    });
+  }
+  if (state.query.trim()) {
+    chips.push({ id: "query", label: "Search", value: state.query.trim() });
+  }
+  if (state.bands.length > 0) {
+    chips.push({
+      id: "bands",
+      label: "NPS",
+      value: state.bands.map((b) => RATING_BAND_LABELS[b]),
+    });
+  }
+  if (state.tags.length > 0) {
+    chips.push({
+      id: "tags",
+      label: "Tag",
+      value: state.tags.map((t) => (t === "untagged" ? "Untagged" : TAG_LABELS[t])),
+    });
+  }
+
+  function removeChip(id: string) {
+    setState((s) => {
+      switch (id) {
+        case "tab":
+          return { ...s, tab: "all" };
+        case "query":
+          return { ...s, query: "" };
+        case "bands":
+          return { ...s, bands: [] };
+        case "tags":
+          return { ...s, tags: [] };
+        default:
+          return s;
+      }
+    });
+  }
+
+  function clearAll() {
+    setState({ ...DEFAULT_STATE, sort: state.sort });
+  }
+
+  function isDefault(s: ViewState) {
+    return (
+      s.tab === "all" &&
+      s.query === "" &&
+      s.bands.length === 0 &&
+      s.tags.length === 0 &&
+      s.sort === DEFAULT_STATE.sort
+    );
+  }
 
   function draftReply(f: FeedbackItem) {
     const template =
@@ -95,17 +226,25 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
 
   return (
     <div className="space-y-5">
+      <SavedViewsBar
+        storageKey="ops.feedback"
+        currentState={state}
+        isDefault={isDefault}
+        onApply={(s) => setState(s)}
+        onReset={() => setState(DEFAULT_STATE)}
+      />
+
       <div className="flex items-center gap-2 flex-wrap">
         {TABS.map((t) => {
           const count = t.key === "all" ? items.length : items.filter((i) => i.status === t.key).length;
-          const active = tab === t.key;
+          const active = state.tab === t.key;
           return (
             <button
               key={t.key}
               type="button"
-              onClick={() => setTab(t.key)}
+              onClick={() => setState((s) => ({ ...s, tab: t.key }))}
               className={cn(
-                "px-3 py-1.5 rounded-full text-xs font-medium border transition-colors",
+                "h-9 px-3.5 rounded-full text-xs font-medium border transition-colors",
                 active
                   ? "bg-emerald-700 text-white border-emerald-700"
                   : "bg-surface text-text-muted border-border hover:bg-surface-muted",
@@ -120,63 +259,112 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
         })}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {sorted.map((f) => {
-          const isNegative = f.rating < 7;
-          return (
-            <Card
-              key={f.id}
-              tone="raised"
-              className={cn(isNegative && "border-red-300/70 ring-1 ring-red-200")}
-            >
-              <CardContent className="py-5 space-y-3">
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-medium text-text">{f.patientName}</p>
-                    <p className="text-[11px] text-text-subtle">
-                      {new Date(f.submittedAt).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <Badge tone={ratingTone(f.rating)}>NPS {f.rating}/10</Badge>
-                </div>
-                <p className="text-sm text-text-muted">&ldquo;{f.excerpt}&rdquo;</p>
-                <div className="flex items-center gap-2 flex-wrap">
-                  <Badge tone={f.status === "resolved" ? "success" : f.status === "in_progress" ? "warning" : "neutral"}>
-                    {f.status.replace("_", " ")}
-                  </Badge>
-                  {f.tag && <Badge tone="accent">{TAG_LABELS[f.tag]}</Badge>}
-                </div>
-                <div className="flex items-center gap-2 pt-2 border-t border-border/60 flex-wrap">
-                  <Button size="sm" variant="secondary" onClick={() => draftReply(f)}>
-                    Respond
-                  </Button>
-                  <select
-                    value={f.tag ?? ""}
-                    onChange={(e) => {
-                      const val = e.target.value as FeedbackTag | "";
-                      if (val) setTag(f.id, val);
-                    }}
-                    className="rounded-md border border-border-strong bg-surface px-2 h-8 text-xs text-text-muted"
-                  >
-                    <option value="">Tag…</option>
-                    <option value="reviewed">Reviewed</option>
-                    <option value="action_taken">Action taken</option>
-                    <option value="not_actionable">Not actionable</option>
-                  </select>
-                </div>
-                {f.responseDraft && (
-                  <details className="mt-1">
-                    <summary className="text-[11px] text-text-subtle cursor-pointer">
-                      Draft reply saved
-                    </summary>
-                    <p className="mt-2 text-xs text-text-muted whitespace-pre-line">{f.responseDraft}</p>
-                  </details>
-                )}
-              </CardContent>
-            </Card>
-          );
-        })}
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          type="search"
+          placeholder="Search by name or excerpt…"
+          value={state.query}
+          onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+          className="md:w-64 h-9"
+        />
+        <MultiSelectFilter
+          label="NPS band"
+          options={(["detractor", "passive", "promoter"] as RatingBand[]).map((b) => ({
+            value: b,
+            label: RATING_BAND_LABELS[b],
+          }))}
+          selected={state.bands}
+          onChange={(next) => setState((s) => ({ ...s, bands: next as RatingBand[] }))}
+          placeholder="All bands"
+        />
+        <MultiSelectFilter
+          label="Tag"
+          options={[
+            { value: "untagged", label: "Untagged" },
+            { value: "reviewed", label: TAG_LABELS.reviewed },
+            { value: "action_taken", label: TAG_LABELS.action_taken },
+            { value: "not_actionable", label: TAG_LABELS.not_actionable },
+          ]}
+          selected={state.tags}
+          onChange={(next) =>
+            setState((s) => ({ ...s, tags: next as Array<FeedbackTag | "untagged"> }))
+          }
+          placeholder="Any tag"
+        />
+        <SortMenu
+          options={[...SORT_OPTIONS]}
+          value={state.sort}
+          onChange={(next) => setState((s) => ({ ...s, sort: next as SortKey }))}
+        />
       </div>
+
+      <FilterChips chips={chips} onRemove={removeChip} onClearAll={clearAll} />
+
+      {sorted.length === 0 ? (
+        <EmptyFilterState
+          title="No feedback matches"
+          hint="Try widening the NPS band or clearing the tag filter."
+          onClear={clearAll}
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {sorted.map((f) => {
+            const isNegative = f.rating < 7;
+            return (
+              <Card
+                key={f.id}
+                tone="raised"
+                className={cn(isNegative && "border-red-300/70 ring-1 ring-red-200")}
+              >
+                <CardContent className="py-5 space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-medium text-text">{f.patientName}</p>
+                      <p className="text-[11px] text-text-subtle">
+                        {new Date(f.submittedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Badge tone={ratingTone(f.rating)}>NPS {f.rating}/10</Badge>
+                  </div>
+                  <p className="text-sm text-text-muted">&ldquo;{f.excerpt}&rdquo;</p>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge tone={f.status === "resolved" ? "success" : f.status === "in_progress" ? "warning" : "neutral"}>
+                      {f.status.replace("_", " ")}
+                    </Badge>
+                    {f.tag && <Badge tone="accent">{TAG_LABELS[f.tag]}</Badge>}
+                  </div>
+                  <div className="flex items-center gap-2 pt-2 border-t border-border/60 flex-wrap">
+                    <Button size="sm" variant="secondary" onClick={() => draftReply(f)}>
+                      Respond
+                    </Button>
+                    <select
+                      value={f.tag ?? ""}
+                      onChange={(e) => {
+                        const val = e.target.value as FeedbackTag | "";
+                        if (val) setTag(f.id, val);
+                      }}
+                      className="rounded-md border border-border-strong bg-surface px-2 h-9 text-xs text-text-muted"
+                    >
+                      <option value="">Tag…</option>
+                      <option value="reviewed">Reviewed</option>
+                      <option value="action_taken">Action taken</option>
+                      <option value="not_actionable">Not actionable</option>
+                    </select>
+                  </div>
+                  {f.responseDraft && (
+                    <details className="mt-1">
+                      <summary className="text-[11px] text-text-subtle cursor-pointer">
+                        Draft reply saved
+                      </summary>
+                      <p className="mt-2 text-xs text-text-muted whitespace-pre-line">{f.responseDraft}</p>
+                    </details>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
 
       {responding && (
         <div

--- a/src/app/(operator)/ops/incidents/incidents-view.tsx
+++ b/src/app/(operator)/ops/incidents/incidents-view.tsx
@@ -6,6 +6,14 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input, Textarea } from "@/components/ui/input";
 import {
+  EmptyFilterState,
+  FilterChips,
+  MultiSelectFilter,
+  SavedViewsBar,
+  SortMenu,
+  type ActiveChip,
+} from "@/components/ui/filter-bar";
+import {
   INCIDENT_CATEGORY_LABELS,
   type IncidentCategory,
   type IncidentReport,
@@ -28,12 +36,43 @@ const SEVERITY_LABELS: Record<IncidentSeverity, string> = {
 };
 
 const SEVERITY_ORDER: IncidentSeverity[] = ["low", "medium", "high", "critical"];
+const SEVERITY_RANK: Record<IncidentSeverity, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
 const CATEGORY_OPTIONS = Object.keys(INCIDENT_CATEGORY_LABELS) as IncidentCategory[];
+
+type StatusFilter = "open" | "resolved";
+type SortKey = "newest" | "oldest" | "severity-desc" | "severity-asc";
+
+type ViewState = {
+  severities: IncidentSeverity[];
+  categories: IncidentCategory[];
+  statuses: StatusFilter[];
+  patientAffectedOnly: boolean;
+  sort: SortKey;
+};
+
+const DEFAULT_STATE: ViewState = {
+  severities: [],
+  categories: [],
+  statuses: [],
+  patientAffectedOnly: false,
+  sort: "newest",
+};
+
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest first" },
+  { value: "oldest", label: "Oldest first" },
+  { value: "severity-desc", label: "Severity (high to low)" },
+  { value: "severity-asc", label: "Severity (low to high)" },
+] as const;
 
 export function IncidentsView({ initialIncidents }: { initialIncidents: IncidentReport[] }) {
   const [incidents, setIncidents] = useState<IncidentReport[]>(initialIncidents);
-  const [severityFilter, setSeverityFilter] = useState<"all" | IncidentSeverity>("all");
-  const [categoryFilter, setCategoryFilter] = useState<"all" | IncidentCategory>("all");
+  const [state, setState] = useState<ViewState>(DEFAULT_STATE);
   const [formOpen, setFormOpen] = useState(false);
   const [resolving, setResolving] = useState<IncidentReport | null>(null);
   const [resolutionNotes, setResolutionNotes] = useState("");
@@ -46,11 +85,90 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
   });
 
   const filtered = useMemo(() => {
-    return incidents
-      .filter((i) => (severityFilter === "all" ? true : i.severity === severityFilter))
-      .filter((i) => (categoryFilter === "all" ? true : i.category === categoryFilter))
-      .sort((a, b) => b.reportedAt.localeCompare(a.reportedAt));
-  }, [incidents, severityFilter, categoryFilter]);
+    const list = incidents.filter((i) => {
+      if (state.severities.length > 0 && !state.severities.includes(i.severity)) {
+        return false;
+      }
+      if (state.categories.length > 0 && !state.categories.includes(i.category)) {
+        return false;
+      }
+      if (state.statuses.length > 0) {
+        const status: StatusFilter = i.resolvedAt ? "resolved" : "open";
+        if (!state.statuses.includes(status)) return false;
+      }
+      if (state.patientAffectedOnly && !i.patientAffected) return false;
+      return true;
+    });
+    return list.sort((a, b) => {
+      switch (state.sort) {
+        case "newest":
+          return b.reportedAt.localeCompare(a.reportedAt);
+        case "oldest":
+          return a.reportedAt.localeCompare(b.reportedAt);
+        case "severity-desc":
+          return SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+        case "severity-asc":
+          return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+      }
+    });
+  }, [incidents, state]);
+
+  const chips: ActiveChip[] = [];
+  if (state.severities.length > 0) {
+    chips.push({
+      id: "severities",
+      label: "Severity",
+      value: state.severities.map((s) => SEVERITY_LABELS[s]),
+    });
+  }
+  if (state.categories.length > 0) {
+    chips.push({
+      id: "categories",
+      label: "Category",
+      value: state.categories.map((c) => INCIDENT_CATEGORY_LABELS[c]),
+    });
+  }
+  if (state.statuses.length > 0) {
+    chips.push({
+      id: "statuses",
+      label: "Status",
+      value: state.statuses.map((s) => (s === "open" ? "Open" : "Resolved")),
+    });
+  }
+  if (state.patientAffectedOnly) {
+    chips.push({ id: "patient", label: "Flag", value: "Patient affected" });
+  }
+
+  function removeChip(id: string) {
+    setState((s) => {
+      switch (id) {
+        case "severities":
+          return { ...s, severities: [] };
+        case "categories":
+          return { ...s, categories: [] };
+        case "statuses":
+          return { ...s, statuses: [] };
+        case "patient":
+          return { ...s, patientAffectedOnly: false };
+        default:
+          return s;
+      }
+    });
+  }
+
+  function clearAll() {
+    setState({ ...DEFAULT_STATE, sort: state.sort });
+  }
+
+  function isDefault(s: ViewState) {
+    return (
+      s.severities.length === 0 &&
+      s.categories.length === 0 &&
+      s.statuses.length === 0 &&
+      !s.patientAffectedOnly &&
+      s.sort === DEFAULT_STATE.sort
+    );
+  }
 
   function submit() {
     if (!draft.title.trim()) return;
@@ -84,33 +202,78 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
 
   return (
     <div className="space-y-5">
+      <SavedViewsBar
+        storageKey="ops.incidents"
+        currentState={state}
+        isDefault={isDefault}
+        onApply={(s) => setState(s)}
+        onReset={() => setState(DEFAULT_STATE)}
+      />
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2 flex-wrap">
-          <select
-            value={severityFilter}
-            onChange={(e) => setSeverityFilter(e.target.value as "all" | IncidentSeverity)}
-            className="rounded-md border border-border-strong bg-surface px-3 h-9 text-sm text-text"
+          <MultiSelectFilter
+            label="Severity"
+            options={SEVERITY_ORDER.map((s) => ({
+              value: s,
+              label: SEVERITY_LABELS[s],
+            }))}
+            selected={state.severities}
+            onChange={(next) =>
+              setState((s) => ({ ...s, severities: next as IncidentSeverity[] }))
+            }
+            placeholder="All severities"
+          />
+          <MultiSelectFilter
+            label="Category"
+            options={CATEGORY_OPTIONS.map((c) => ({
+              value: c,
+              label: INCIDENT_CATEGORY_LABELS[c],
+            }))}
+            selected={state.categories}
+            onChange={(next) =>
+              setState((s) => ({ ...s, categories: next as IncidentCategory[] }))
+            }
+            placeholder="All categories"
+          />
+          <MultiSelectFilter
+            label="Status"
+            options={[
+              { value: "open", label: "Open" },
+              { value: "resolved", label: "Resolved" },
+            ]}
+            selected={state.statuses}
+            onChange={(next) =>
+              setState((s) => ({ ...s, statuses: next as StatusFilter[] }))
+            }
+            placeholder="Open & resolved"
+          />
+          <button
+            type="button"
+            onClick={() =>
+              setState((s) => ({ ...s, patientAffectedOnly: !s.patientAffectedOnly }))
+            }
+            className={cn(
+              "h-9 px-3 rounded-md border text-sm transition-colors",
+              state.patientAffectedOnly
+                ? "border-danger bg-red-50 text-danger font-medium"
+                : "border-border-strong bg-surface text-text-muted hover:bg-surface-muted/60",
+            )}
           >
-            <option value="all">All severities</option>
-            {SEVERITY_ORDER.map((s) => (
-              <option key={s} value={s}>{SEVERITY_LABELS[s]}</option>
-            ))}
-          </select>
-          <select
-            value={categoryFilter}
-            onChange={(e) => setCategoryFilter(e.target.value as "all" | IncidentCategory)}
-            className="rounded-md border border-border-strong bg-surface px-3 h-9 text-sm text-text"
-          >
-            <option value="all">All categories</option>
-            {CATEGORY_OPTIONS.map((c) => (
-              <option key={c} value={c}>{INCIDENT_CATEGORY_LABELS[c]}</option>
-            ))}
-          </select>
+            Patient affected
+          </button>
+          <SortMenu
+            options={[...SORT_OPTIONS]}
+            value={state.sort}
+            onChange={(next) => setState((s) => ({ ...s, sort: next as SortKey }))}
+          />
         </div>
         <Button size="sm" onClick={() => setFormOpen(true)}>
           Report new incident
         </Button>
       </div>
+
+      <FilterChips chips={chips} onRemove={removeChip} onClearAll={clearAll} />
 
       <Card tone="raised">
         <div className="overflow-x-auto">
@@ -168,15 +331,17 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
                   </td>
                 </tr>
               ))}
-              {filtered.length === 0 && (
-                <tr>
-                  <td colSpan={6} className="px-5 py-12 text-center text-text-subtle text-sm">
-                    No incidents match your filters.
-                  </td>
-                </tr>
-              )}
             </tbody>
           </table>
+          {filtered.length === 0 && (
+            <div className="p-4">
+              <EmptyFilterState
+                title="No incidents match"
+                hint="Try widening severity or status, or clear the patient-affected toggle."
+                onClear={clearAll}
+              />
+            </div>
+          )}
         </div>
       </Card>
 

--- a/src/app/(operator)/ops/vendors/vendors-view.tsx
+++ b/src/app/(operator)/ops/vendors/vendors-view.tsx
@@ -5,6 +5,14 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input } from "@/components/ui/input";
+import {
+  EmptyFilterState,
+  FilterChips,
+  MultiSelectFilter,
+  SavedViewsBar,
+  SortMenu,
+  type ActiveChip,
+} from "@/components/ui/filter-bar";
 import type { Vendor } from "@/lib/domain/overnight-batch";
 import { cn } from "@/lib/utils/cn";
 
@@ -21,7 +29,6 @@ const CATEGORIES = [
 
 // Today is 2026-04-16 per CLAUDE.md
 const TODAY = new Date("2026-04-16T00:00:00Z");
-const THIRTY_DAYS_MS = 30 * 86_400_000;
 
 function daysUntil(end?: string): number | null {
   if (!end) return null;
@@ -29,10 +36,33 @@ function daysUntil(end?: string): number | null {
   return Math.round((d.getTime() - TODAY.getTime()) / 86_400_000);
 }
 
+type SortKey = "name-asc" | "ends-asc" | "ends-desc" | "cost-desc" | "cost-asc";
+
+type ViewState = {
+  query: string;
+  categories: string[];
+  expiringOnly: boolean;
+  sort: SortKey;
+};
+
+const DEFAULT_STATE: ViewState = {
+  query: "",
+  categories: [],
+  expiringOnly: false,
+  sort: "name-asc",
+};
+
+const SORT_OPTIONS = [
+  { value: "name-asc", label: "Name (A-Z)" },
+  { value: "ends-asc", label: "Contract ends (soonest)" },
+  { value: "ends-desc", label: "Contract ends (latest)" },
+  { value: "cost-desc", label: "Monthly cost (high to low)" },
+  { value: "cost-asc", label: "Monthly cost (low to high)" },
+] as const;
+
 export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
   const [vendors, setVendors] = useState<Vendor[]>(initialVendors);
-  const [query, setQuery] = useState("");
-  const [category, setCategory] = useState<"all" | string>("all");
+  const [state, setState] = useState<ViewState>(DEFAULT_STATE);
   const [showAdd, setShowAdd] = useState(false);
   const [draft, setDraft] = useState({
     name: "",
@@ -45,9 +75,15 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
   });
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return vendors.filter((v) => {
-      if (category !== "all" && v.category !== category) return false;
+    const q = state.query.trim().toLowerCase();
+    const list = vendors.filter((v) => {
+      if (state.categories.length > 0 && !state.categories.includes(v.category)) {
+        return false;
+      }
+      if (state.expiringOnly) {
+        const d = daysUntil(v.contractEnds);
+        if (d === null || d < 0 || d > 30) return false;
+      }
       if (!q) return true;
       return (
         v.name.toLowerCase().includes(q) ||
@@ -55,7 +91,28 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
         (v.email ?? "").toLowerCase().includes(q)
       );
     });
-  }, [vendors, query, category]);
+
+    return list.sort((a, b) => {
+      switch (state.sort) {
+        case "name-asc":
+          return a.name.localeCompare(b.name);
+        case "ends-asc": {
+          const ad = daysUntil(a.contractEnds) ?? Infinity;
+          const bd = daysUntil(b.contractEnds) ?? Infinity;
+          return ad - bd;
+        }
+        case "ends-desc": {
+          const ad = daysUntil(a.contractEnds) ?? -Infinity;
+          const bd = daysUntil(b.contractEnds) ?? -Infinity;
+          return bd - ad;
+        }
+        case "cost-desc":
+          return (b.monthlyCost ?? 0) - (a.monthlyCost ?? 0);
+        case "cost-asc":
+          return (a.monthlyCost ?? 0) - (b.monthlyCost ?? 0);
+      }
+    });
+  }, [vendors, state]);
 
   const expiring = useMemo(
     () =>
@@ -65,6 +122,43 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
       }),
     [vendors],
   );
+
+  const chips: ActiveChip[] = [];
+  if (state.query.trim()) {
+    chips.push({ id: "query", label: "Search", value: state.query.trim() });
+  }
+  if (state.categories.length > 0) {
+    chips.push({
+      id: "categories",
+      label: "Category",
+      value: state.categories,
+    });
+  }
+  if (state.expiringOnly) {
+    chips.push({ id: "expiring", label: "Status", value: "Expiring ≤ 30 days" });
+  }
+
+  function removeChip(id: string) {
+    setState((s) => {
+      if (id === "query") return { ...s, query: "" };
+      if (id === "categories") return { ...s, categories: [] };
+      if (id === "expiring") return { ...s, expiringOnly: false };
+      return s;
+    });
+  }
+
+  function clearAll() {
+    setState({ ...DEFAULT_STATE, sort: state.sort });
+  }
+
+  function isDefault(s: ViewState) {
+    return (
+      s.query === "" &&
+      s.categories.length === 0 &&
+      !s.expiringOnly &&
+      s.sort === DEFAULT_STATE.sort
+    );
+  }
 
   function addVendor() {
     if (!draft.name.trim()) return;
@@ -96,41 +190,78 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     <div className="space-y-5">
       {expiring.length > 0 && (
         <Card tone="raised" className="border-amber-300/60 bg-amber-50/60">
-          <CardContent className="py-4">
-            <p className="text-sm font-medium text-amber-900">
-              {expiring.length} {expiring.length === 1 ? "contract" : "contracts"} expiring in 30 days
-            </p>
-            <p className="text-xs text-amber-800/80 mt-1">
-              {expiring.map((v) => `${v.name} (${v.contractEnds})`).join(" · ")}
-            </p>
+          <CardContent className="py-4 flex items-center justify-between gap-3 flex-wrap">
+            <div>
+              <p className="text-sm font-medium text-amber-900">
+                {expiring.length} {expiring.length === 1 ? "contract" : "contracts"} expiring in 30 days
+              </p>
+              <p className="text-xs text-amber-800/80 mt-1">
+                {expiring.map((v) => `${v.name} (${v.contractEnds})`).join(" · ")}
+              </p>
+            </div>
+            {!state.expiringOnly && (
+              <button
+                type="button"
+                onClick={() => setState((s) => ({ ...s, expiringOnly: true }))}
+                className="text-xs font-medium text-amber-900 underline underline-offset-2 hover:no-underline"
+              >
+                Show only expiring →
+              </button>
+            )}
           </CardContent>
         </Card>
       )}
+
+      <SavedViewsBar
+        storageKey="ops.vendors"
+        currentState={state}
+        isDefault={isDefault}
+        onApply={(s) => setState(s)}
+        onReset={() => setState(DEFAULT_STATE)}
+      />
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2 flex-wrap">
           <Input
             type="search"
             placeholder="Search vendors…"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="md:w-64"
+            value={state.query}
+            onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
+            className="md:w-64 h-9"
           />
-          <select
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            className="rounded-md border border-border-strong bg-surface px-3 h-9 text-sm text-text"
+          <MultiSelectFilter
+            label="Category"
+            options={CATEGORIES.map((c) => ({ value: c, label: c }))}
+            selected={state.categories}
+            onChange={(next) => setState((s) => ({ ...s, categories: next }))}
+            placeholder="All categories"
+          />
+          <button
+            type="button"
+            onClick={() =>
+              setState((s) => ({ ...s, expiringOnly: !s.expiringOnly }))
+            }
+            className={cn(
+              "h-9 px-3 rounded-md border text-sm transition-colors",
+              state.expiringOnly
+                ? "border-accent bg-accent-soft text-accent font-medium"
+                : "border-border-strong bg-surface text-text-muted hover:bg-surface-muted/60",
+            )}
           >
-            <option value="all">All categories</option>
-            {CATEGORIES.map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
+            Expiring ≤ 30d
+          </button>
+          <SortMenu
+            options={[...SORT_OPTIONS]}
+            value={state.sort}
+            onChange={(next) => setState((s) => ({ ...s, sort: next as SortKey }))}
+          />
         </div>
         <Button size="sm" onClick={() => setShowAdd(true)}>
           Add vendor
         </Button>
       </div>
+
+      <FilterChips chips={chips} onRemove={removeChip} onClearAll={clearAll} />
 
       <Card tone="raised">
         <div className="overflow-x-auto">
@@ -147,7 +278,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
             <tbody>
               {filtered.map((v) => {
                 const d = daysUntil(v.contractEnds);
-                const expiring = d !== null && d >= 0 && d <= 30;
+                const isExpiring = d !== null && d >= 0 && d <= 30;
                 return (
                   <tr key={v.id} className="border-b border-border/40 hover:bg-surface-muted/40">
                     <td className="px-5 py-3.5">
@@ -165,14 +296,14 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
                     <td className="px-5 py-3.5 text-right tabular-nums">
                       {v.monthlyCost ? `$${v.monthlyCost.toLocaleString()}` : "—"}
                     </td>
-                    <td className={cn("px-5 py-3.5 text-xs", expiring ? "text-[color:var(--highlight-hover)]" : "text-text-muted")}>
+                    <td className={cn("px-5 py-3.5 text-xs", isExpiring ? "text-[color:var(--highlight-hover)]" : "text-text-muted")}>
                       {v.contractEnds ? (
                         <>
                           <div>{v.contractEnds}</div>
                           {d !== null && (
                             <div className="text-[10px] text-text-subtle">
                               {d < 0 ? "expired" : `${d} days`}
-                              {expiring && " — renew soon"}
+                              {isExpiring && " — renew soon"}
                             </div>
                           )}
                         </>
@@ -181,15 +312,17 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
                   </tr>
                 );
               })}
-              {filtered.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="px-5 py-12 text-center text-text-subtle text-sm">
-                    No vendors match your filters.
-                  </td>
-                </tr>
-              )}
             </tbody>
           </table>
+          {filtered.length === 0 && (
+            <div className="p-4">
+              <EmptyFilterState
+                title="No vendors match your filters"
+                hint="Try removing a category or the expiring-only toggle."
+                onClear={clearAll}
+              />
+            </div>
+          )}
         </div>
       </Card>
 

--- a/src/components/ui/filter-bar.tsx
+++ b/src/components/ui/filter-bar.tsx
@@ -1,0 +1,643 @@
+"use client";
+
+// FilterBar — shared filter/sort primitives for operator surfaces.
+//
+// Built to bring Monday/Linear-tier polish to data tables and lists across
+// the (operator) and (super-admin) routes. Three composable pieces:
+//
+//   - <FilterChips>        — active-filter chips with per-chip X + Clear all
+//   - <MultiSelectFilter>  — categorical multi-select with checkbox popover
+//   - <SortMenu>           — sort dropdown (key + direction)
+//   - <SavedViewsBar>      — saved view stub backed by localStorage
+//   - <EmptyFilterState>   — warm zero-result state with "Clear filters" CTA
+//
+// All primitives are unstyled-leaning Tailwind, lean on existing tokens
+// (surface, border, accent, text-muted) so they inherit the EMR look.
+// Tap targets are >= 36px (h-9) per the spec.
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------- chips
+
+export type ActiveChip = {
+  /** Stable id used as React key and to identify the chip for onRemove. */
+  id: string;
+  /** Filter family — shown in muted weight before the value. */
+  label: string;
+  /** Selected value(s) — shown in regular weight. Array renders "a, b". */
+  value: string | string[];
+};
+
+export function FilterChips({
+  chips,
+  onRemove,
+  onClearAll,
+  className,
+}: {
+  chips: ActiveChip[];
+  onRemove: (id: string) => void;
+  onClearAll?: () => void;
+  className?: string;
+}) {
+  if (chips.length === 0) return null;
+  return (
+    <div
+      role="region"
+      aria-label="Active filters"
+      className={cn("flex flex-wrap items-center gap-2", className)}
+    >
+      {chips.map((chip) => {
+        const valueText = Array.isArray(chip.value)
+          ? chip.value.join(", ")
+          : chip.value;
+        return (
+          <span
+            key={chip.id}
+            className={cn(
+              "inline-flex items-center gap-1.5 h-9 pl-3 pr-1 rounded-full",
+              "bg-accent-soft text-accent border border-accent/25",
+              "text-xs font-medium",
+            )}
+          >
+            <span className="text-accent/70 font-normal">{chip.label}:</span>
+            <span className="max-w-[180px] truncate">{valueText}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(chip.id)}
+              aria-label={`Remove ${chip.label} filter`}
+              className={cn(
+                "inline-flex items-center justify-center h-7 w-7 rounded-full",
+                "text-accent/70 hover:text-accent hover:bg-accent/10",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                "transition-colors",
+              )}
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M3 3L9 9M9 3L3 9"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          </span>
+        );
+      })}
+      {onClearAll && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className={cn(
+            "h-9 px-3 rounded-full text-xs font-medium",
+            "text-text-muted hover:text-text underline-offset-2 hover:underline",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            "transition-colors",
+          )}
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ------------------------------------------------------- multi-select
+
+export type MultiSelectOption = {
+  value: string;
+  label: string;
+};
+
+export function MultiSelectFilter({
+  label,
+  options,
+  selected,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  options: MultiSelectOption[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  /** Shown when no values are selected. Defaults to label. */
+  placeholder?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click. Cheap — no portal, no body scroll lock.
+  React.useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  function toggle(value: string) {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  }
+
+  const hint =
+    selected.length === 0
+      ? (placeholder ?? label)
+      : selected.length === 1
+        ? (options.find((o) => o.value === selected[0])?.label ?? selected[0])
+        : `${selected.length} selected`;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          "inline-flex items-center gap-2 h-9 px-3 rounded-md",
+          "border border-border-strong bg-surface text-sm text-text",
+          "hover:bg-surface-muted/60",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          "transition-colors",
+          selected.length > 0 && "border-accent/40 bg-accent-soft/40",
+        )}
+      >
+        <span className="text-text-muted text-xs">{label}</span>
+        <span className="font-medium">{hint}</span>
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path
+            d="M2 3.5L5 6.5L8 3.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            fill="none"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          aria-label={label}
+          className={cn(
+            "absolute z-30 mt-1 min-w-[200px] max-h-[280px] overflow-y-auto",
+            "rounded-lg border border-border-strong bg-surface shadow-lg",
+            "py-1",
+          )}
+        >
+          {options.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-text-subtle">
+              No options
+            </div>
+          ) : (
+            options.map((opt) => {
+              const checked = selected.includes(opt.value);
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="option"
+                  aria-selected={checked}
+                  onClick={() => toggle(opt.value)}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 h-9",
+                    "text-sm text-text text-left",
+                    "hover:bg-accent-soft/50",
+                    "focus-visible:outline-none focus-visible:bg-accent-soft/60",
+                    "transition-colors",
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "inline-flex items-center justify-center h-4 w-4 rounded",
+                      "border",
+                      checked
+                        ? "border-accent bg-accent text-white"
+                        : "border-border-strong bg-surface",
+                    )}
+                  >
+                    {checked && (
+                      <svg
+                        width="10"
+                        height="10"
+                        viewBox="0 0 10 10"
+                        aria-hidden="true"
+                      >
+                        <path
+                          d="M2 5L4.5 7.5L8 3"
+                          stroke="currentColor"
+                          strokeWidth="1.75"
+                          fill="none"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    )}
+                  </span>
+                  <span className="flex-1">{opt.label}</span>
+                </button>
+              );
+            })
+          )}
+          {selected.length > 0 && (
+            <>
+              <div className="my-1 border-t border-border" />
+              <button
+                type="button"
+                onClick={() => onChange([])}
+                className={cn(
+                  "flex w-full items-center px-3 h-9 text-xs text-text-muted",
+                  "hover:bg-surface-muted/60 hover:text-text",
+                  "transition-colors",
+                )}
+              >
+                Clear {label.toLowerCase()}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ----------------------------------------------------------- sort menu
+
+export type SortOption = {
+  value: string;
+  label: string;
+};
+
+export function SortMenu({
+  label = "Sort",
+  options,
+  value,
+  onChange,
+}: {
+  label?: string;
+  options: SortOption[];
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const current = options.find((o) => o.value === value)?.label ?? value;
+  return (
+    <label className="inline-flex items-center gap-2 text-sm text-text-muted">
+      <span className="text-xs">{label}</span>
+      <span className="relative">
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          aria-label={label}
+          className={cn(
+            "appearance-none h-9 pl-3 pr-8 rounded-md",
+            "border border-border-strong bg-surface text-sm text-text",
+            "hover:bg-surface-muted/60",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            "transition-colors",
+          )}
+        >
+          {options.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          aria-hidden="true"
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none"
+        >
+          <path
+            d="M2 3.5L5 6.5L8 3.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            fill="none"
+            strokeLinecap="round"
+          />
+        </svg>
+        <span className="sr-only">{current}</span>
+      </span>
+    </label>
+  );
+}
+
+// --------------------------------------------------------- saved views
+
+export type SavedView<S> = {
+  id: string;
+  name: string;
+  state: S;
+};
+
+/**
+ * Saved-view bar backed by localStorage.
+ *
+ * Stub — no schema work. Stores under `lj.savedViews.<key>` so each surface
+ * gets its own namespace. The active view is also persisted under
+ * `lj.savedViews.<key>.active`.
+ *
+ * SSR-safe: reads localStorage lazily inside an effect, returns null while
+ * hydrating to avoid mismatches.
+ */
+export function SavedViewsBar<S>({
+  storageKey,
+  currentState,
+  isDefault,
+  onApply,
+  onReset,
+  serialize = (s) => JSON.stringify(s),
+  className,
+}: {
+  storageKey: string;
+  currentState: S;
+  /** Returns true if state matches the implicit "default" view (no filters). */
+  isDefault: (s: S) => boolean;
+  onApply: (state: S) => void;
+  onReset: () => void;
+  serialize?: (s: S) => string;
+  className?: string;
+}) {
+  const [hydrated, setHydrated] = React.useState(false);
+  const [views, setViews] = React.useState<SavedView<S>[]>([]);
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [naming, setNaming] = React.useState(false);
+  const [draftName, setDraftName] = React.useState("");
+
+  const lsKey = `lj.savedViews.${storageKey}`;
+  const lsActiveKey = `${lsKey}.active`;
+
+  React.useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(lsKey);
+      if (raw) setViews(JSON.parse(raw) as SavedView<S>[]);
+      const active = window.localStorage.getItem(lsActiveKey);
+      if (active) setActiveId(active);
+    } catch {
+      // ignore — corrupt JSON or storage blocked
+    }
+    setHydrated(true);
+  }, [lsKey, lsActiveKey]);
+
+  // Detect when the active view's state diverges from current.
+  const activeView = views.find((v) => v.id === activeId);
+  const dirty = activeView
+    ? serialize(activeView.state) !== serialize(currentState)
+    : !isDefault(currentState);
+
+  function persist(next: SavedView<S>[]) {
+    setViews(next);
+    try {
+      window.localStorage.setItem(lsKey, JSON.stringify(next));
+    } catch {
+      // ignore
+    }
+  }
+
+  function setActive(id: string | null) {
+    setActiveId(id);
+    try {
+      if (id) window.localStorage.setItem(lsActiveKey, id);
+      else window.localStorage.removeItem(lsActiveKey);
+    } catch {
+      // ignore
+    }
+  }
+
+  function save() {
+    const name = draftName.trim();
+    if (!name) return;
+    const v: SavedView<S> = {
+      id: `v-${Date.now()}`,
+      name,
+      state: currentState,
+    };
+    persist([...views, v]);
+    setActive(v.id);
+    setNaming(false);
+    setDraftName("");
+  }
+
+  function remove(id: string) {
+    persist(views.filter((v) => v.id !== id));
+    if (activeId === id) setActive(null);
+  }
+
+  if (!hydrated) return null;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1.5", className)}>
+      <span className="text-[10px] uppercase tracking-wider text-text-subtle mr-1">
+        Views
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          setActive(null);
+          onReset();
+        }}
+        className={cn(
+          "h-9 px-3 rounded-full text-xs font-medium border transition-colors",
+          activeId === null && isDefault(currentState)
+            ? "bg-text text-surface border-text"
+            : "bg-surface text-text-muted border-border hover:bg-surface-muted/60 hover:text-text",
+        )}
+      >
+        Default
+      </button>
+      {views.map((v) => {
+        const active = activeId === v.id;
+        return (
+          <span
+            key={v.id}
+            className={cn(
+              "inline-flex items-stretch rounded-full border overflow-hidden",
+              active
+                ? "border-text"
+                : "border-border hover:border-border-strong",
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                setActive(v.id);
+                onApply(v.state);
+              }}
+              className={cn(
+                "h-9 pl-3 pr-2 text-xs font-medium transition-colors",
+                active
+                  ? "bg-text text-surface"
+                  : "bg-surface text-text-muted hover:bg-surface-muted/60 hover:text-text",
+              )}
+            >
+              {v.name}
+            </button>
+            <button
+              type="button"
+              onClick={() => remove(v.id)}
+              aria-label={`Delete view ${v.name}`}
+              className={cn(
+                "inline-flex items-center justify-center w-7 transition-colors",
+                active
+                  ? "bg-text text-surface/70 hover:text-surface"
+                  : "bg-surface text-text-subtle hover:text-text hover:bg-surface-muted/60",
+              )}
+            >
+              <svg width="10" height="10" viewBox="0 0 12 12" aria-hidden="true">
+                <path
+                  d="M3 3L9 9M9 3L3 9"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          </span>
+        );
+      })}
+      {dirty && !naming && (
+        <button
+          type="button"
+          onClick={() => setNaming(true)}
+          className={cn(
+            "h-9 px-3 rounded-full text-xs font-medium",
+            "border border-dashed border-accent/50 text-accent",
+            "hover:bg-accent-soft/50 transition-colors",
+          )}
+        >
+          + Save current as view
+        </button>
+      )}
+      {naming && (
+        <span className="inline-flex items-stretch rounded-full border border-accent overflow-hidden">
+          <input
+            autoFocus
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") save();
+              if (e.key === "Escape") {
+                setNaming(false);
+                setDraftName("");
+              }
+            }}
+            placeholder="View name"
+            className={cn(
+              "h-9 px-3 bg-surface text-xs text-text outline-none",
+              "w-32",
+            )}
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={!draftName.trim()}
+            className={cn(
+              "h-9 px-3 text-xs font-medium bg-accent text-surface",
+              "hover:bg-accent/90 disabled:opacity-50 transition-colors",
+            )}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setNaming(false);
+              setDraftName("");
+            }}
+            className="h-9 px-2 text-xs text-text-subtle hover:text-text bg-surface"
+          >
+            Cancel
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// -------------------------------------------------- empty filter state
+
+export function EmptyFilterState({
+  title = "No matches",
+  hint = "Try removing one of the active filters above.",
+  onClear,
+  className,
+}: {
+  title?: string;
+  hint?: string;
+  onClear: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center text-center px-6 py-14",
+        "rounded-lg border border-dashed border-border bg-surface-muted/30",
+        className,
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "mb-3 inline-flex items-center justify-center h-12 w-12 rounded-full",
+          "bg-surface border border-border text-text-subtle",
+        )}
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <circle
+            cx="9"
+            cy="9"
+            r="6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <path
+            d="M14 14L17 17"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M6 9L12 9"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+      <p className="font-display text-base text-text">{title}</p>
+      <p className="text-xs text-text-muted mt-1 max-w-sm">{hint}</p>
+      <button
+        type="button"
+        onClick={onClear}
+        className={cn(
+          "mt-4 h-9 px-4 rounded-full text-xs font-medium",
+          "bg-text text-surface hover:bg-text/90",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          "transition-colors",
+        )}
+      >
+        Clear filters
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Bring Monday/Linear-tier polish to operator data tables. Adds a shared FilterBar primitive and applies it to three operator surfaces — all of which previously had inconsistent, single-select, or absent filter UI.

### New shared primitive: `src/components/ui/filter-bar.tsx`
- `<FilterChips>` — active-filter chips with per-chip X button and "Clear all" link
- `<MultiSelectFilter>` — categorical multi-select with checkbox popover (closes on outside-click / Esc)
- `<SortMenu>` — sort dropdown with chevron
- `<SavedViewsBar>` — localStorage-backed saved views, namespaced per surface
- `<EmptyFilterState>` — warm zero-result state with "Clear filters" CTA

All controls are >= 36px tall (h-9) per the brief. Existing tokens reused (surface, border, accent, text-muted), no new deps.

### Surfaces upgraded
- **`/ops/vendors`** — was single category dropdown + basic search. Now: multi-select category, expiring-only toggle, 5-way sort (name, contract end asc/desc, monthly cost asc/desc), chips, saved views, "show only expiring" CTA wired into the banner.
- **`/ops/incidents`** — was two single-select dropdowns. Now: multi-select severity/category/status, patient-affected toggle, severity-aware sort, chips, saved views.
- **`/ops/feedback`** — was status tabs only. Now: search by name/excerpt, NPS band multi-select (detractor/passive/promoter), tag multi-select including "untagged", 5-way sort with "detractors first" smart default, chips, saved views.

### Out of scope (intentionally untouched)
- `/admin/audit` already has good URL-driven chip UX (would be churn).
- `/ops/supplies` — open PR #438 draft.
- `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, auth, manifests, CLAUDE.md.
- No server-side surfaces converted (all three were client-state only; polished chrome rather than rewrite).

## Test plan

- [ ] Visit `/ops/vendors`, multi-select two categories, confirm chips appear with per-chip X and "Clear all"
- [ ] Save current view as "Critical only" — refresh — confirm view persists, click "Default" to reset
- [ ] Filter to zero results — confirm empty-filter state shows with working "Clear filters" CTA
- [ ] Visit `/ops/incidents`, toggle "Patient affected" plus a multi-select severity — verify chip composition
- [ ] Visit `/ops/feedback`, search a name fragment, multi-select tag = "Untagged", change sort to "Rating (low to high)"
- [ ] Tab through filter controls — verify focus rings visible, Esc closes popovers, all targets >= 36px

🤖 Generated with [Claude Code](https://claude.com/claude-code)