### PR TITLE
EMR-642: EMR-wide modal close pattern — ModalShell component

### DIFF
--- a/src/app/(clinician)/clinic/communications/comms-recent-client.tsx
+++ b/src/app/(clinician)/clinic/communications/comms-recent-client.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ModalShell } from "@/components/ui/modal-shell";
 import { formatRelative } from "@/lib/utils/format";
 
 export type CallRow = {
@@ -54,33 +55,22 @@ function badgeTone(status: string): "success" | "warning" | "danger" | "neutral"
   }
 }
 
+const DETAIL_TITLES: Record<ModalItem["kind"], string> = {
+  call: "Call details",
+  fax: "Fax details",
+  broadcast: "Broadcast details",
+};
+
 function DetailModal({ item, onClose }: { item: ModalItem; onClose: () => void }) {
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
-      onClick={onClose}
+    <ModalShell
+      open={true}
+      onClose={onClose}
+      title={DETAIL_TITLES[item.kind]}
+      placement="center"
+      maxWidth="max-w-md"
     >
-      <div
-        className="w-full max-w-md bg-surface-raised rounded-xl border border-border shadow-xl p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-      >
-        <div className="flex items-start justify-between gap-3">
-          <h3 className="font-display text-lg text-text">
-            {item.kind === "call" && "Call details"}
-            {item.kind === "fax" && "Fax details"}
-            {item.kind === "broadcast" && "Broadcast details"}
-          </h3>
-          <button
-            onClick={onClose}
-            className="text-text-subtle hover:text-text text-xl leading-none shrink-0"
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
-
+      <div className="px-6 py-5 space-y-4">
         <dl className="space-y-2 text-sm">
           {item.kind === "call" && (
             <>
@@ -111,7 +101,7 @@ function DetailModal({ item, onClose }: { item: ModalItem; onClose: () => void }
           )}
         </dl>
 
-        <div className="flex items-center gap-2 pt-2">
+        <div className="flex items-center gap-2 pt-2 flex-wrap">
           {item.kind === "call" && item.data.patientId && (
             <Link href={`/clinic/patients/${item.data.patientId}`}>
               <Button size="sm" variant="secondary">View chart</Button>
@@ -135,7 +125,7 @@ function DetailModal({ item, onClose }: { item: ModalItem; onClose: () => void }
           <Button size="sm" variant="ghost" onClick={onClose}>Close</Button>
         </div>
       </div>
-    </div>
+    </ModalShell>
   );
 }
 

--- a/src/components/ui/modal-shell.tsx
+++ b/src/components/ui/modal-shell.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+/**
+ * EMR-642 — Canonical modal close pattern.
+ *
+ * Guarantees:
+ *   • Visible X button, always in the top-right corner of the header.
+ *   • Backdrop click and Escape key close immediately when the form is
+ *     pristine; when isDirty=true they surface an inline "Discard changes?"
+ *     confirmation bar instead.
+ *   • Body scroll is locked while the modal is open.
+ */
+
+import * as React from "react";
+import { useEffect, useId, useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface ModalShellProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Small all-caps label above the title (e.g. "Refill request"). */
+  eyebrow?: string;
+  description?: string;
+  /**
+   * When true, closing via X / backdrop / Escape shows an inline
+   * "Discard changes?" guard rather than immediately dismissing.
+   */
+  isDirty?: boolean;
+  /** `"sheet"` (default) slides up from bottom on mobile, centers on sm+.
+   *  `"center"` is always centred. */
+  placement?: "sheet" | "center";
+  maxWidth?: string;
+  className?: string;
+  /** Optional sticky footer rendered below the scrollable body. */
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export function ModalShell({
+  open,
+  onClose,
+  title,
+  eyebrow,
+  description,
+  isDirty = false,
+  placement = "sheet",
+  maxWidth = "max-w-lg",
+  className,
+  footer,
+  children,
+}: ModalShellProps) {
+  const titleId = useId();
+  const [confirming, setConfirming] = useState(false);
+
+  function requestClose() {
+    if (isDirty) {
+      setConfirming(true);
+    } else {
+      onClose();
+    }
+  }
+
+  useEffect(() => {
+    if (!open) {
+      setConfirming(false);
+      return;
+    }
+
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      if (isDirty) {
+        setConfirming(true);
+      } else {
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, isDirty, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-50 flex justify-center bg-black/40 backdrop-blur-sm",
+        "animate-in fade-in duration-200",
+        placement === "center"
+          ? "items-center p-4"
+          : "items-end sm:items-center sm:p-4",
+      )}
+      onClick={requestClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        className={cn(
+          "w-full flex flex-col bg-bg border border-border shadow-2xl",
+          "max-h-[90vh]",
+          placement === "center"
+            ? "rounded-2xl"
+            : "rounded-t-2xl sm:rounded-2xl",
+          "animate-in slide-in-from-bottom-4 sm:zoom-in-95 duration-300",
+          maxWidth,
+          className,
+        )}
+      >
+        {/* ── Header ───────────────────────────────────────────────────── */}
+        <div className="flex items-start justify-between gap-4 px-6 py-5 border-b border-border shrink-0">
+          <div className="min-w-0">
+            {eyebrow && (
+              <p className="text-xs uppercase tracking-wider text-text-subtle font-medium mb-1">
+                {eyebrow}
+              </p>
+            )}
+            <h2
+              id={titleId}
+              className="font-display text-xl text-text leading-tight tracking-tight"
+            >
+              {title}
+            </h2>
+            {description && (
+              <p className="text-sm text-text-muted mt-0.5">{description}</p>
+            )}
+          </div>
+
+          {/* Visible X close button — EMR-642 */}
+          <button
+            type="button"
+            onClick={requestClose}
+            aria-label="Close"
+            className={cn(
+              "shrink-0 h-8 w-8 rounded-full flex items-center justify-center",
+              "bg-surface-muted hover:bg-surface-raised text-text-muted hover:text-text",
+              "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
+            )}
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* ── Discard confirmation bar — shown when isDirty + requestClose ─ */}
+        {confirming && (
+          <div className="flex items-center justify-between gap-3 px-6 py-3 bg-amber-50 border-b border-amber-200 shrink-0">
+            <p className="text-sm font-medium text-amber-800">
+              Discard unsaved changes?
+            </p>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                className="text-xs font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
+              >
+                Keep editing
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirming(false);
+                  onClose();
+                }}
+                className="text-xs font-medium px-3 py-1.5 rounded-lg bg-amber-700 text-white hover:bg-amber-800 transition-colors"
+              >
+                Discard
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Body ─────────────────────────────────────────────────────── */}
+        <div className="overflow-y-auto flex-1">{children}</div>
+
+        {/* ── Footer (optional, stays pinned below the scroll area) ─────── */}
+        {footer && (
+          <div className="shrink-0 border-t border-border bg-surface-muted/40">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements EMR-642.

## What changed

- **New:** `src/components/ui/modal-shell.tsx` — canonical modal wrapper for the entire EMR. Enforces two invariants from EMR-642:
  1. **Visible X button** — always rendered in the top-right corner of the modal header, styled as a rounded icon button (not a raw `×` character).
  2. **Outside-click / Esc guard** — when `isDirty=true`, clicking the backdrop, pressing Escape, or clicking X shows an inline amber "Discard unsaved changes?" bar with "Keep editing" / "Discard" choices instead of immediately dismissing. When `isDirty=false` (default), close is immediate.
  3. **Body scroll lock** — `document.body.style.overflow = "hidden"` while open, restored on unmount.
  4. **Accessible** — `role="dialog"`, `aria-modal="true"`, `aria-labelledby` wired to the rendered `<h2>`.

- **Migrated:** `DetailModal` in `comms-recent-client.tsx` — replaces the hand-rolled backdrop `<div>`, `×` character button, and duplicate role/aria attributes with `<ModalShell>`. First live consumer of the new component.

### API surface

```tsx
<ModalShell
  open={boolean}
  onClose={() => void}
  title="Patient name"
  eyebrow="Refill request"        // optional all-caps label above title
  description="Lisinopril 10 mg"  // optional subtitle
  isDirty={denyReason.length > 0} // triggers "Are you sure?" guard
  placement="center"              // "sheet" (default) or "center"
  maxWidth="max-w-2xl"            // Tailwind max-w class
  footer={<div>...</div>}         // optional sticky footer
>
  {/* scrollable body */}
</ModalShell>
```

## How to verify

1. Navigate to `/clinic/communications` and click any call, fax, or broadcast row — the detail modal opens with a proper rounded X button in the top right.
2. Click the X or the backdrop — it closes immediately (no dirty state).
3. Press Escape — same.
4. In a future modal that passes `isDirty={true}`: clicking X/backdrop/Escape shows the amber "Discard unsaved changes?" bar; "Keep editing" dismisses it; "Discard" closes.

## Notes

- **Follow-up:** `KeyboardHelpModal`, `LabOverlay` (sign-off/labs), and the `FeedbackWidget` compose modal should each be migrated to `ModalShell` in subsequent small PRs. The pattern is established here.
- Lint (`npm run lint`) is broken in this environment (ESLint 10 + old `.eslintrc.json` config, and `next` CLI not on PATH). Typecheck (`npm run typecheck`) passes without introducing new errors — the changed files add 0 net new type errors vs baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B7rKBma1XN1gJkVFPZwrC)_