### PR TITLE
EMR-672: /clinic/communications Zoom → Beam rebrand + copy edits

### DIFF
--- a/src/app/(clinician)/clinic/communications/beam/actions.ts
+++ b/src/app/(clinician)/clinic/communications/beam/actions.ts
@@ -11,7 +11,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
-import { scheduleHipaaZoomMeeting } from "@/lib/communications/zoom";
+import { scheduleHipaaBeamMeeting } from "@/lib/communications/zoom";
 import { encryptMessageBody } from "@/lib/communications/message-crypto";
 
 const scheduleSchema = z
@@ -27,20 +27,20 @@ const scheduleSchema = z
     "Pick exactly one counterparty (patient OR provider).",
   );
 
-export type ScheduleZoomResult =
+export type ScheduleBeamResult =
   | { ok: true; callId: string; meetingId: string; mode: "live" | "dev-shim" }
   | { ok: false; error: string };
 
-export async function scheduleZoomMeetingAction(
-  _prev: ScheduleZoomResult | null,
+export async function scheduleBeamMeetingAction(
+  _prev: ScheduleBeamResult | null,
   formData: FormData,
-): Promise<ScheduleZoomResult> {
+): Promise<ScheduleBeamResult> {
   const user = await requireUser();
   if (!user.organizationId) {
     return { ok: false, error: "No organization context." };
   }
   if (!user.roles.some((r) => r === "clinician" || r === "practice_owner")) {
-    return { ok: false, error: "Only providers can schedule Zoom visits." };
+    return { ok: false, error: "Only providers can schedule Beam visits." };
   }
 
   const parsed = scheduleSchema.safeParse({
@@ -84,7 +84,7 @@ export async function scheduleZoomMeetingAction(
     if (!provider) return { ok: false, error: "Provider not in your org." };
   }
 
-  const meeting = await scheduleHipaaZoomMeeting({
+  const meeting = await scheduleHipaaBeamMeeting({
     topic: parsed.data.topic,
     scheduledFor,
     durationMinutes: parsed.data.durationMinutes,
@@ -130,7 +130,7 @@ export async function scheduleZoomMeetingAction(
 
 const cancelSchema = z.object({ callId: z.string().min(1) });
 
-export async function cancelZoomMeetingAction(
+export async function cancelBeamMeetingAction(
   formData: FormData,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const user = await requireUser();

--- a/src/app/(clinician)/clinic/communications/beam/page.tsx
+++ b/src/app/(clinician)/clinic/communications/beam/page.tsx
@@ -23,13 +23,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { decryptMessageBodySafe } from "@/lib/communications/message-crypto";
-import { formatZoomMeetingId } from "@/lib/communications/zoom";
+import { formatBeamMeetingId } from "@/lib/communications/zoom";
 import { formatRelative } from "@/lib/utils/format";
-import { ZoomScheduleForm } from "./schedule-form";
+import { BeamScheduleForm } from "./schedule-form";
 
 export const metadata = { title: "Beam telehealth" };
 
-export default async function ZoomPage() {
+export default async function BeamPage() {
   const user = await requireUser();
   const orgId = user.organizationId;
   if (!orgId) {
@@ -112,7 +112,7 @@ export default async function ZoomPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <ZoomScheduleForm providerOptions={recipientOptions} />
+              <BeamScheduleForm providerOptions={recipientOptions} />
             </CardContent>
           </Card>
 
@@ -189,7 +189,7 @@ export default async function ZoomPage() {
                             Meeting ID:{" "}
                             <span className="tabular-nums">
                               {call.zoomMeetingId
-                                ? formatZoomMeetingId(call.zoomMeetingId)
+                                ? formatBeamMeetingId(call.zoomMeetingId)
                                 : "—"}
                             </span>
                             {passcode && (

--- a/src/app/(clinician)/clinic/communications/beam/schedule-form.tsx
+++ b/src/app/(clinician)/clinic/communications/beam/schedule-form.tsx
@@ -16,8 +16,8 @@ import { useRef, useState, useEffect } from "react";
 import { Input, Label } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
-  scheduleZoomMeetingAction,
-  type ScheduleZoomResult,
+  scheduleBeamMeetingAction,
+  type ScheduleBeamResult,
 } from "./actions";
 
 interface ProviderOption {
@@ -38,13 +38,13 @@ const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) => (i + 1) * 5);
 // HIPAA-compliant encrypted care-team call, up to 10 total members.
 const MAX_GROUP_CALL_MEMBERS = 10;
 
-export function ZoomScheduleForm({
+export function BeamScheduleForm({
   providerOptions,
 }: {
   providerOptions: ProviderOption[];
 }) {
-  const [state, formAction] = useFormState<ScheduleZoomResult | null, FormData>(
-    scheduleZoomMeetingAction,
+  const [state, formAction] = useFormState<ScheduleBeamResult | null, FormData>(
+    scheduleBeamMeetingAction,
     null,
   );
   const formRef = useRef<HTMLFormElement>(null);

--- a/src/app/(clinician)/clinic/communications/page.tsx
+++ b/src/app/(clinician)/clinic/communications/page.tsx
@@ -37,7 +37,7 @@ export default async function CommunicationsPage() {
     pendingTranscripts,
     pendingFaxes,
     activeCampaigns,
-    upcomingZoom,
+    upcomingBeam,
     newVoicemails,
     recentCalls,
     recentFaxes,
@@ -120,8 +120,8 @@ export default async function CommunicationsPage() {
         <Link href="/clinic/communications/beam" className="block group">
           <MetricTile
             label="BEAM UPCOMING"
-            value={upcomingZoom}
-            accent={upcomingZoom > 0 ? "forest" : "none"}
+            value={upcomingBeam}
+            accent={upcomingBeam > 0 ? "forest" : "none"}
             hint="HIPAA-compliant Beam visits"
             className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
           />
@@ -182,8 +182,8 @@ export default async function CommunicationsPage() {
           title="Beam telehealth"
           description="HIPAA-compliant video visits — E2EE, waiting room, no cloud recording."
           href="/clinic/communications/beam"
-          cta={upcomingZoom > 0 ? `${upcomingZoom} upcoming` : "Schedule"}
-          highlight={upcomingZoom > 0}
+          cta={upcomingBeam > 0 ? `${upcomingBeam} upcoming` : "Schedule"}
+          highlight={upcomingBeam > 0}
         />
         <ChannelCard
           title="Voicemail"

--- a/src/lib/communications/zoom.ts
+++ b/src/lib/communications/zoom.ts
@@ -210,8 +210,8 @@ async function fetchServerToServerToken(creds: S2SCreds): Promise<string> {
 }
 
 /**
- * Format a Zoom meeting id (e.g. 81234567890) as the
- * "812 3456 7890" layout Zoom uses in its emails.
+ * Format a Beam meeting id (e.g. 81234567890) as the
+ * "812 3456 7890" layout used in meeting invites.
  */
 export function formatZoomMeetingId(id: string): string {
   const digits = id.replace(/\D/g, "");
@@ -221,3 +221,7 @@ export function formatZoomMeetingId(id: string): string {
   }
   return `${digits.slice(0, 3)} ${digits.slice(3, 7)} ${digits.slice(7)}`;
 }
+
+// Beam-branded aliases — prefer these in new code.
+export { scheduleHipaaZoomMeeting as scheduleHipaaBeamMeeting };
+export { formatZoomMeetingId as formatBeamMeetingId };


### PR DESCRIPTION
Implements EMR-672.

## What changed
- **`beam/actions.ts`** — Renamed exported type `ScheduleZoomResult` → `ScheduleBeamResult`, action `scheduleZoomMeetingAction` → `scheduleBeamMeetingAction`, action `cancelZoomMeetingAction` → `cancelBeamMeetingAction`, and internal call to `scheduleHipaaBeamMeeting`. Updated error message "Only providers can schedule Zoom visits." → "…Beam visits."
- **`beam/schedule-form.tsx`** — Renamed component `ZoomScheduleForm` → `BeamScheduleForm`; updated imports to match the renamed action and type.
- **`beam/page.tsx`** — Renamed page function `ZoomPage` → `BeamPage`; updated import of `formatBeamMeetingId` (was `formatZoomMeetingId`) and component reference `<BeamScheduleForm>`.
- **`communications/page.tsx`** — Renamed private variable `upcomingZoom` → `upcomingBeam` for consistency (3 occurrences; already had Beam copy in the UI tiles).
- **`lib/communications/zoom.ts`** — Added stable re-export aliases `scheduleHipaaBeamMeeting` and `formatBeamMeetingId` so callers outside this PR are unaffected. Original exports kept as-is.

## How to verify
1. Navigate to `/clinic/communications` — metric tile reads "BEAM UPCOMING", channel card reads "Beam telehealth" (no change in rendered copy, only internal naming).
2. Navigate to `/clinic/communications/beam` — page loads, schedule form renders, "Schedule HIPAA Beam" button works.
3. Navigate to `/clinic/communications/zoom` — still redirects to `/clinic/communications/beam` (redirect stub unchanged).
4. No visible regressions in recent calls, fax, or broadcast tiles.

## Notes
- DB column names (`zoomMeetingId`, `zoomScheduledAt`, etc.) are intentionally unchanged — those are schema identifiers outside this PR's scope.
- All typecheck errors in the diff are pre-existing infrastructure errors (missing `node_modules` / `@prisma/client` in the CI env) — same TS2307/TS7026/TS7006 pattern present throughout the codebase.
- No schema changes, no new dependencies, no middleware touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5x8tK8FoKdgkTmrAFZcju)_