### PR TITLE
EMR-653: /telehealth pre-visit checklist leaf indicators

### DIFF
--- a/src/app/(clinician)/telehealth/pre-visit-checklist-client.tsx
+++ b/src/app/(clinician)/telehealth/pre-visit-checklist-client.tsx
@@ -168,20 +168,27 @@ export function PreVisitChecklistClient() {
 }
 
 function LeafIndicator({ state }: { state: ProbeState }) {
-  // `text-success` / `text-danger` are CSS-variable utilities the design
-  // system already exposes; both clear WCAG AA against the surface bg in
-  // light and dark themes.
   const color =
     state === "pass"
       ? "text-success"
       : state === "fail"
         ? "text-[color:var(--leaf-dry,#8b5a2b)]"
         : "text-text-subtle";
-  // A withered leaf reads as "broken" — drop the opacity and skew the
-  // veins so it visibly droops vs. the upright healthy leaf.
+
+  const stateLabel =
+    state === "pass" ? "passed" : state === "fail" ? "failed" : "checking";
+
   return (
     <span
-      className={`mt-0.5 shrink-0 ${color} ${state === "fail" ? "opacity-80 rotate-12" : ""}`}
+      aria-label={stateLabel}
+      className={[
+        "mt-0.5 shrink-0 transition-transform duration-300",
+        color,
+        state === "fail" ? "opacity-80 rotate-12" : "",
+        state === "pending" ? "animate-pulse" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
     >
       <LeafSprig size={14} className="text-current" />
     </span>


### PR DESCRIPTION
Implements EMR-653.

## What changed
- `LeafIndicator` in `pre-visit-checklist-client.tsx` now animates with `animate-pulse` while a probe is in the `pending` state, giving a clear "checking in progress" signal instead of a static gray leaf that could be mistaken for a result.
- Added `aria-label` (`"checking"` / `"passed"` / `"failed"`) on each indicator span so screen readers announce the probe outcome without relying on color alone.
- Added `transition-transform duration-300` so the `rotate-12` tilt for the `fail` (withered-leaf) state eases in smoothly rather than snapping.

## How to verify
1. Visit `/telehealth` — on page load you should see the four checklist leaves **pulsing** while probes run.
2. Once probes resolve: green upright leaf = pass, brown tilted leaf = fail (if a permission is denied), smooth transition between states.
3. With a screen reader, each leaf indicator reads "checking", "passed", or "failed" aloud.

## Notes
- All typecheck and lint errors in `pre-visit-checklist-client.tsx` are pre-existing environment-level errors (no `react` / `next` type declarations in this container) — identical to the errors present before this change. No new logical errors introduced.
- EMR-645 (counts as links; threads non-clickable) was investigated first but found to be fully implemented in `origin/main` already — the `StatusDot` components for Patients today / Notes to sign / Approvals have `href` props; Threads has none. No code change was needed.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkD36BDzLTuZAqMZkxREW5)_