### PR TITLE
EMR-670: /clinic/library ChatCB AI evidence assistant

### DIFF
--- a/src/app/(clinician)/clinic/library/page.tsx
+++ b/src/app/(clinician)/clinic/library/page.tsx
@@ -6,10 +6,17 @@ import Link from "next/link";
 import { getAllInteractions } from "@/lib/domain/drug-interactions";
 import { PdfExportButton } from "./pdf-export-button";
 import { InteractionBubbles } from "./interaction-bubbles";
+import { getCurrentUser } from "@/lib/auth/session";
+import { isModalityEnabled } from "@/lib/modality/server";
+import { ChatCB } from "../research/chat-cb";
 
 export const metadata = { title: "Clinical Library" };
 
-export default function LibraryPage() {
+export default async function LibraryPage() {
+  const user = await getCurrentUser();
+  const cannabisEnabled = user?.organizationId
+    ? await isModalityEnabled(user.organizationId, "cannabis-medicine")
+    : false;
   const interactions = getAllInteractions();
   return (
     <PageShell maxWidth="max-w-[960px]">
@@ -202,6 +209,16 @@ export default function LibraryPage() {
           <InteractionBubbles interactions={interactions} />
         </CardContent>
       </Card>
+
+      {/* ChatCB — AI evidence assistant, cannabis-modality only */}
+      {cannabisEnabled && (
+        <div className="mb-6">
+          <p className="text-xs font-medium text-text-subtle uppercase tracking-wide mb-3">
+            AI evidence assistant
+          </p>
+          <ChatCB />
+        </div>
+      )}
 
       {/* Justin Kander's book (EMR-036) */}
       <Card tone="ambient" className="mb-6">


### PR DESCRIPTION
Implements EMR-670.

## What changed
- **ChatCB on `/clinic/library`** — the existing `ChatCB` conversational AI component (already live on `/clinic/research`) is now also rendered on the library page, gated on the `cannabis-medicine` modality via `isModalityEnabled`. Non-cannabis practices see no change.
- **Page made `async`** — required to `await getCurrentUser()` and `isModalityEnabled()` for the modality check.
- **PDF export + terpene pharmacology** — both were already present on `main` from prior merged PRs (EMR-616); this PR completes the remaining EMR-670 scope (ChatCB).

## How to verify
1. Navigate to `/clinic/library` on a cannabis-medicine practice — an "AI evidence assistant" label and the ChatCB chat widget should appear between the drug interactions card and the Kander book card.
2. Type a question (e.g. "CBD for anxiety") and press **Ask** — the ChatCB should call `/api/agents/chat-cb` and return a synthesised response.
3. On a non-cannabis practice, confirm the ChatCB section does not appear and the rest of the library renders identically to before.
4. Confirm "Export to PDF" button in the page header still works (triggers `window.print()`).
5. Confirm the terpene pharmacology table is present (Myrcene, Limonene, Pinene, Linalool, Beta-Caryophyllene).

## Notes
- All typecheck errors in this environment are pre-existing (missing `@types/react`, `@types/node`, `@prisma/client`) — the same error categories that appear on every prior PR in this lane. No new error types introduced.
- The `ChatCB` component is imported from `../research/chat-cb` (crossing the route boundary is fine; it's a plain client component). No new files created.
- Diff is 22 lines, single file.

## Follow-up
- EMR-671: `/clinic/library` drug interactions — clickable leaves enhancement

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6MootHnR1bB9PtNHPDYTF)_