### PR TITLE
EMR-671: /clinic/library Drug interactions — clickable leaves

### DIFF
--- a/src/app/(clinician)/clinic/library/interaction-bubbles.tsx
+++ b/src/app/(clinician)/clinic/library/interaction-bubbles.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils/cn";
+import { LeafSprig } from "@/components/ui/ornament";
 import { InteractionBadge } from "@/components/ui/interaction-badge";
 import type { DrugInteraction, Severity } from "@/lib/domain/drug-interactions";
 
@@ -11,22 +12,22 @@ const GROUPS: { severity: Severity; heading: string }[] = [
   { severity: "green", heading: "No known interaction" },
 ];
 
-const BUBBLE: Record<Severity, string> = {
+const LEAF: Record<Severity, string> = {
   red: "bg-red-50 border-red-200 text-danger hover:bg-red-100",
   yellow: "bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100",
   green: "bg-emerald-50 border-emerald-200 text-emerald-700 hover:bg-emerald-100",
+};
+
+const LEAF_ICON: Record<Severity, string> = {
+  red: "text-danger/60",
+  yellow: "text-amber-500/70",
+  green: "text-emerald-600/70",
 };
 
 const RING: Record<Severity, string> = {
   red: "ring-2 ring-danger/40 ring-offset-1",
   yellow: "ring-2 ring-amber-400/50 ring-offset-1",
   green: "ring-2 ring-emerald-400/50 ring-offset-1",
-};
-
-const DOT: Record<Severity, string> = {
-  red: "bg-danger",
-  yellow: "bg-amber-400",
-  green: "bg-emerald-500",
 };
 
 export function InteractionBubbles({
@@ -64,14 +65,20 @@ export function InteractionBubbles({
                     onClick={() => toggle(key)}
                     aria-expanded={isOpen}
                     className={cn(
-                      "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full border transition-colors capitalize",
-                      BUBBLE[severity],
+                      "inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium border transition-all capitalize",
+                      "rounded-tl-sm rounded-br-sm rounded-tr-3xl rounded-bl-3xl",
+                      "hover:-rotate-1 hover:scale-[1.03]",
+                      LEAF[severity],
                       isOpen && RING[severity],
                     )}
                   >
-                    <span
-                      className={cn("h-1.5 w-1.5 rounded-full shrink-0", DOT[severity])}
-                      aria-hidden="true"
+                    <LeafSprig
+                      size={12}
+                      className={cn(
+                        "shrink-0 transition-transform",
+                        LEAF_ICON[severity],
+                        isOpen && "rotate-12",
+                      )}
                     />
                     {interaction.drug}
                     <span className="opacity-50 font-normal text-[10px]">


### PR DESCRIPTION
Implements EMR-671.

## What changed
- Restyled the drug interaction reference on `/clinic/library` from circular pill buttons to leaf-shaped elements, matching the botanical design language used throughout the app (LeafSprig ornament, EditorialRule, etc.)
- Each button now uses an asymmetric `border-radius` (`rounded-tl-sm rounded-br-sm rounded-tr-3xl rounded-bl-3xl`) to produce an organic leaf silhouette
- The severity dot indicator is replaced by a small `LeafSprig` icon tinted by severity (red/amber/green at 60–70% opacity); the icon rotates 12° when that entry's detail panel is open, giving a visual "opening" cue
- Added `hover:-rotate-1 hover:scale-[1.03]` micro-animations for the Apple-iOS tactile feel called for in CLAUDE.md
- All expand/collapse logic, the mechanism + recommendation detail panel, severity grouping headings, and `Close ✕` are unchanged — one file modified (`interaction-bubbles.tsx`)

## How to verify
1. Navigate to `/clinic/library`
2. Scroll to "Drug interaction reference"
3. Confirm the bubbles now have a leaf silhouette shape (two round corners, two flat corners, organic feel) rather than fully circular pills
4. Confirm a small leaf icon (green/amber/red tinted) appears at the left of each label
5. Hover any leaf — should gently tilt and scale up
6. Click a leaf (e.g. "warfarin THC") — detail panel expands below the group and the leaf icon rotates 12°; click again or "Close ✕" to dismiss

## Notes
- All typecheck/lint errors in this environment are pre-existing (`@types/react`, `@types/node`, `@prisma/client` missing, `next` CLI not in PATH) — the same error categories present on every prior PR in this lane. No new error categories introduced.
- Diff: 19 insertions, 12 deletions — single file, under 35 LOC net.
- No new dependencies, no schema changes, no auth or middleware touches.

## Follow-up
- None for this ticket. All eight tickets in the lane (EMR-614 → EMR-671) now have PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsQ7JYYae3HqLeDM6RVRYJ)_