### PR TITLE
ux: content-aware loading skeletons for 6 high-traffic routes

### DIFF
--- a/src/app/(clinician)/clinic/loading.tsx
+++ b/src/app/(clinician)/clinic/loading.tsx
@@ -1,40 +1,16 @@
+import { PageShell } from "@/components/shell/PageHeader";
+import { DashboardSkeleton } from "@/components/ui/skeletons";
+
+/**
+ * Clinic landing — content-aware skeleton mirroring the command strip,
+ * patient queue rail, and two-column activity + sidebar layout. Replaces
+ * the inline animate-pulse rectangles with the shared composite, which
+ * honors `prefers-reduced-motion`.
+ */
 export default function Loading() {
   return (
-    <div className="px-6 lg:px-12 py-10">
-      <div className="mx-auto w-full max-w-[1400px]">
-        <div className="animate-pulse">
-          {/* Command strip */}
-          <div className="h-20 rounded-xl bg-surface-muted mb-8" />
-
-          {/* Patient queue rail */}
-          <div className="flex gap-4 mb-8 overflow-hidden">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="w-56 h-36 rounded-xl bg-surface-muted shrink-0" />
-            ))}
-          </div>
-
-          {/* Two column: activity feed + sidebar */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-2 rounded-xl bg-surface-muted overflow-hidden">
-              <div className="px-6 pt-6 pb-3 space-y-2">
-                <div className="h-5 w-32 rounded bg-border/50" />
-                <div className="h-3.5 w-56 rounded bg-border/30" />
-              </div>
-              <div className="px-6 pb-6 pt-4 space-y-4">
-                {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="h-12 rounded-lg bg-border/30" />
-                ))}
-              </div>
-            </div>
-            <div className="space-y-4">
-              <div className="h-24 rounded-xl bg-surface-muted" />
-              <div className="h-24 rounded-xl bg-surface-muted" />
-              <div className="h-24 rounded-xl bg-surface-muted" />
-              <div className="h-48 rounded-xl bg-surface-muted" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <PageShell maxWidth="max-w-[1400px]">
+      <DashboardSkeleton />
+    </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/messages/loading.tsx
+++ b/src/app/(clinician)/clinic/messages/loading.tsx
@@ -1,0 +1,20 @@
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { MessageListSkeleton } from "@/components/ui/skeletons";
+
+/**
+ * Smart Inbox loading skeleton — mirrors the triaged thread list with
+ * avatars, priority chips, and snippets. Header is rendered as static
+ * copy so the eyebrow + title don't pop in.
+ */
+export default function Loading() {
+  return (
+    <PageShell maxWidth="max-w-[1400px]">
+      <PageHeader
+        eyebrow="Messages"
+        title="Smart Inbox"
+        description="Triage your conversations by urgency and category."
+      />
+      <MessageListSkeleton rows={8} />
+    </PageShell>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/loading.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/loading.tsx
@@ -1,17 +1,14 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { PageShell } from "@/components/shell/PageHeader";
+import { ChartSkeleton } from "@/components/ui/skeletons";
 
+/**
+ * Patient chart shell — mirrors identity header, vitals strip, tab rail,
+ * and the two-column note feed + sidebar that the live chart renders.
+ */
 export default function Loading() {
   return (
-    <div className="px-6 lg:px-12 py-10">
-      <div className="mx-auto max-w-[1280px] space-y-6">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-48 w-full rounded-xl" />
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Skeleton className="h-32 rounded-xl" />
-          <Skeleton className="h-32 rounded-xl" />
-          <Skeleton className="h-32 rounded-xl" />
-        </div>
-      </div>
-    </div>
+    <PageShell maxWidth="max-w-[1280px]">
+      <ChartSkeleton />
+    </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/patients/loading.tsx
+++ b/src/app/(clinician)/clinic/patients/loading.tsx
@@ -1,0 +1,20 @@
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { PatientRosterSkeleton } from "@/components/ui/skeletons";
+
+/**
+ * Patient roster loading skeleton — mirrors the search bar, action
+ * button, and the bordered list of patient rows the live roster
+ * eventually renders.
+ */
+export default function Loading() {
+  return (
+    <PageShell maxWidth="max-w-[1200px]">
+      <PageHeader
+        eyebrow="Clinic"
+        title="Patient Roster"
+        description="Search, filter, and open any patient's chart."
+      />
+      <PatientRosterSkeleton rows={12} />
+    </PageShell>
+  );
+}

--- a/src/app/(patient)/portal/loading.tsx
+++ b/src/app/(patient)/portal/loading.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "@/components/shell/PageHeader";
 export default function Loading() {
   return (
     <PageShell maxWidth="max-w-[1040px]">
-      <div className="animate-pulse space-y-6 md:space-y-8">
+      <div className="animate-pulse motion-reduce:animate-none space-y-6 md:space-y-8">
         
         {/* ── Hero greeting card skeleton ── */}
         <div className="h-56 md:h-64 rounded-2xl md:rounded-3xl bg-gradient-to-r from-surface-muted to-surface-raised border border-border/50" />

--- a/src/app/marketplace/loading.tsx
+++ b/src/app/marketplace/loading.tsx
@@ -1,0 +1,22 @@
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { MarketplaceSkeleton } from "@/components/ui/skeletons";
+
+/**
+ * Marketplace loading skeleton — keeps the marketing chrome
+ * (SiteHeader / SiteFooter) static so it doesn't flicker, and
+ * fills the body with a responsive product-card grid placeholder.
+ */
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-bg relative overflow-hidden">
+      <SiteHeader />
+      <main id="main-content">
+        <section className="max-w-[1320px] mx-auto px-4 sm:px-6 lg:px-12 pt-10 pb-16">
+          <MarketplaceSkeleton cards={12} />
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,8 +1,16 @@
 import { cn } from "@/lib/utils/cn";
 
 /**
- * Shimmer-based skeleton placeholder. Used in loading.tsx files
- * across the operator dashboards.
+ * Skeleton — single animated placeholder rectangle used in `loading.tsx`
+ * across the operator, clinician, and patient dashboards.
+ *
+ * - Apple-iOS aesthetic: subtle pulse on a tinted parchment surface
+ *   (`bg-surface-muted`), ~1.5s cycle via Tailwind's `animate-pulse`.
+ * - Honors `prefers-reduced-motion: reduce` and the `.reduce-motion`
+ *   user toggle (see `globals.css`) — the pulse collapses to a static
+ *   dim block via `motion-reduce:animate-none`.
+ * - The default shape is `rounded-md`; pass `rounded-xl` / `rounded-full`
+ *   / etc. via `className` to override.
  */
 export function Skeleton({
   className,
@@ -10,11 +18,59 @@ export function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      aria-hidden="true"
       className={cn(
-        "animate-pulse rounded-md bg-surface-muted",
+        "animate-pulse motion-reduce:animate-none rounded-md bg-surface-muted",
         className,
       )}
       {...props}
+    />
+  );
+}
+
+/**
+ * SkeletonText — a stacked column of skeleton lines, sized like text.
+ * Last line is slightly shorter so it reads as a paragraph, not a block.
+ */
+export function SkeletonText({
+  lines = 3,
+  className,
+}: {
+  lines?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className={cn(
+            "h-3.5 rounded",
+            i === lines - 1 ? "w-2/3" : "w-full",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * SkeletonCircle — round avatar/icon placeholder. `size` is in pixels.
+ * Uses inline style instead of dynamic Tailwind classes so it survives
+ * the JIT class-name purge.
+ */
+export function SkeletonCircle({
+  size = 40,
+  className,
+}: {
+  /** Diameter in pixels. Default 40px. */
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <Skeleton
+      style={{ width: size, height: size }}
+      className={cn("rounded-full shrink-0", className)}
     />
   );
 }

--- a/src/components/ui/skeletons.tsx
+++ b/src/components/ui/skeletons.tsx
@@ -1,0 +1,284 @@
+import { Skeleton, SkeletonCircle } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Composite skeletons — content-aware loading placeholders that mirror
+ * the eventual page layout. Used in `loading.tsx` across the highest-
+ * traffic clinician, patient, and marketplace surfaces.
+ *
+ * Apple-iOS aesthetic: tinted parchment surfaces, subtle pulse,
+ * `prefers-reduced-motion` honored via the underlying <Skeleton> primitive.
+ */
+
+/* ───────────────────────── MessageListSkeleton ─────────────────────── */
+
+/**
+ * Mirrors `/clinic/messages` Smart Inbox: a vertical list of triaged
+ * thread rows with avatar, priority chip, subject line, and snippet.
+ */
+export function MessageListSkeleton({
+  rows = 8,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-start gap-3 rounded-xl border border-border/60 bg-surface px-4 py-3"
+        >
+          <SkeletonCircle size={36} />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3.5 w-32 rounded" />
+              <Skeleton className="h-3 w-16 rounded-full" />
+              <Skeleton className="ml-auto h-3 w-10 rounded" />
+            </div>
+            <Skeleton className="h-3 w-3/4 rounded" />
+            <Skeleton className="h-2.5 w-1/2 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─────────────────────── PatientRosterSkeleton ─────────────────────── */
+
+/**
+ * Mirrors `/clinic/patients` roster: search bar, then a list of patient
+ * rows with avatar, identity, chart summary tags, and a pain sparkline.
+ */
+export function PatientRosterSkeleton({
+  rows = 12,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 flex-1 rounded-lg" />
+        <Skeleton className="h-10 w-32 rounded-lg" />
+      </div>
+      <div className="rounded-xl border border-border/60 bg-surface overflow-hidden">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "flex items-center gap-4 px-4 py-3",
+              i !== rows - 1 && "border-b border-border/40",
+            )}
+          >
+            <SkeletonCircle size={40} />
+            <div className="flex-1 min-w-0 space-y-1.5">
+              <Skeleton className="h-3.5 w-44 rounded" />
+              <Skeleton className="h-3 w-28 rounded" />
+            </div>
+            <div className="hidden md:flex items-center gap-2">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────── DashboardSkeleton ────────────────────────── */
+
+/**
+ * Mirrors `/clinic` landing: command strip, queue rail, two-column
+ * activity feed + sidebar tiles. Matches the existing layout block.
+ */
+export function DashboardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-8", className)}>
+      <Skeleton className="h-20 w-full rounded-xl" />
+
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-36 w-56 shrink-0 rounded-xl" />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 rounded-xl bg-surface-muted overflow-hidden">
+          <div className="px-6 pt-6 pb-3 space-y-2">
+            <Skeleton className="h-5 w-32 rounded" />
+            <Skeleton className="h-3.5 w-56 rounded" />
+          </div>
+          <div className="px-6 pb-6 pt-4 space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 rounded-lg" />
+            ))}
+          </div>
+        </div>
+        <div className="space-y-4">
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-48 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── ChartSkeleton ──────────────────────────── */
+
+/**
+ * Mirrors the patient chart shell at `/clinic/patients/[id]`: identity
+ * header card, vitals strip, tabbed section with note rows + sidebar.
+ */
+export function ChartSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Identity header card */}
+      <div className="rounded-2xl border border-border/60 bg-surface p-5">
+        <div className="flex items-center gap-4">
+          <SkeletonCircle size={56} />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-5 w-56 rounded" />
+            <Skeleton className="h-3.5 w-40 rounded" />
+          </div>
+          <Skeleton className="h-9 w-28 rounded-lg" />
+        </div>
+      </div>
+
+      {/* Vitals strip */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 rounded-xl" />
+        ))}
+      </div>
+
+      {/* Tabs + body */}
+      <div className="flex items-center gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-24 rounded-full" />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <div className="lg:col-span-2 space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-border/60 bg-surface p-4 space-y-2"
+            >
+              <Skeleton className="h-4 w-40 rounded" />
+              <Skeleton className="h-3 w-full rounded" />
+              <Skeleton className="h-3 w-5/6 rounded" />
+              <Skeleton className="h-3 w-2/3 rounded" />
+            </div>
+          ))}
+        </div>
+        <div className="space-y-3">
+          <Skeleton className="h-32 rounded-xl" />
+          <Skeleton className="h-32 rounded-xl" />
+          <Skeleton className="h-40 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────── QueueSkeleton ─────────────────────────── */
+
+/**
+ * Mirrors Today's Queue: header strip + cards stacked by visit slot.
+ */
+export function QueueSkeleton({
+  rows = 6,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-6 w-40 rounded" />
+        <Skeleton className="h-8 w-28 rounded-lg" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-xl border border-border/60 bg-surface px-4 py-3"
+          >
+            <Skeleton className="h-10 w-14 rounded-md" />
+            <SkeletonCircle size={36} />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-44 rounded" />
+              <Skeleton className="h-3 w-32 rounded" />
+            </div>
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-8 w-20 rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────── MarketplaceSkeleton ────────────────────────── */
+
+/**
+ * Mirrors `/marketplace`: hero band + filter chips + responsive product
+ * grid (1/2/3/4 cols at sm/lg/xl).
+ */
+export function MarketplaceSkeleton({
+  cards = 12,
+  className,
+}: {
+  cards?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-8", className)}>
+      {/* Hero */}
+      <div className="space-y-3">
+        <Skeleton className="h-3 w-24 rounded" />
+        <Skeleton className="h-9 w-2/3 max-w-xl rounded" />
+        <Skeleton className="h-4 w-full max-w-2xl rounded" />
+      </div>
+
+      {/* Filter chips */}
+      <div className="flex flex-wrap items-center gap-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-24 rounded-full" />
+        ))}
+        <Skeleton className="ml-auto h-9 w-40 rounded-lg" />
+      </div>
+
+      {/* Product grid */}
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {Array.from({ length: cards }).map((_, i) => (
+          <li
+            key={i}
+            className="rounded-2xl border border-border/60 bg-surface overflow-hidden"
+          >
+            <Skeleton className="h-44 w-full rounded-none" />
+            <div className="p-4 space-y-2">
+              <Skeleton className="h-3 w-20 rounded" />
+              <Skeleton className="h-4 w-3/4 rounded" />
+              <Skeleton className="h-3 w-1/2 rounded" />
+              <div className="flex items-center justify-between pt-2">
+                <Skeleton className="h-5 w-16 rounded" />
+                <Skeleton className="h-8 w-20 rounded-lg" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Polish loading UX across the clinic, patient portal, and marketplace surfaces to Monday/Linear/Stripe level. Previous `loading.tsx` files were either bare spinners or inline `animate-pulse` rectangles that didn't mirror the eventual layout — pages would jolt on hydrate. This PR introduces a shared composite-skeleton library whose shapes match the live UI, and wires it into the six highest-traffic routes.

- **`<Skeleton>` primitive**: now honors `prefers-reduced-motion` (and the `.reduce-motion` user toggle) by collapsing the pulse to a static tinted block via `motion-reduce:animate-none`. Adds `<SkeletonText>` and `<SkeletonCircle>` helpers.
- **`src/components/ui/skeletons.tsx`**: six layout-aware composites — `MessageListSkeleton`, `PatientRosterSkeleton`, `DashboardSkeleton`, `ChartSkeleton`, `QueueSkeleton`, `MarketplaceSkeleton`.
- **Routes wired**:
  - `/clinic` → `DashboardSkeleton`
  - `/clinic/messages` → `MessageListSkeleton` (new)
  - `/clinic/patients` → `PatientRosterSkeleton` (new)
  - `/clinic/patients/[id]` → `ChartSkeleton` (upgraded from a 3-block stub)
  - `/portal` → existing content-aware sketch + `motion-reduce:animate-none`
  - `/marketplace` → `MarketplaceSkeleton` (new, keeps SiteHeader/SiteFooter static)

No new deps. No prisma migrations. No page.tsx server components touched — purely presentational.

## Test plan

- [ ] `npx prisma generate` clean (verified)
- [ ] `npm run typecheck` clean (verified)
- [ ] `npm run lint` no new warnings (verified)
- [ ] Manual: throttle network to Slow 3G and navigate to each of the 6 routes; confirm skeleton matches eventual layout
- [ ] Manual: enable OS `Reduce motion` (or toggle `.reduce-motion` class on `<html>`); confirm pulse collapses to a static dim block

Generated with Claude Code