### PR TITLE
ux: warm Monday.com-tier empty states across 10+ surfaces

### DIFF
--- a/src/app/(clinician)/clinic/communications/comms-recent-client.tsx
+++ b/src/app/(clinician)/clinic/communications/comms-recent-client.tsx
@@ -161,7 +161,11 @@ export function CommsRecentClient({
           </CardHeader>
           <CardContent className="space-y-1">
             {calls.length === 0 ? (
-              <EmptyState title="No calls yet" description="Calls launched from the inbox or chart will appear here." />
+              <EmptyState
+                title="No calls yet today"
+                description="Phone and video sessions launched from the inbox or any patient chart will land here automatically."
+                className="p-6"
+              />
             ) : (
               calls.map((call) => (
                 <button
@@ -188,7 +192,11 @@ export function CommsRecentClient({
           </CardHeader>
           <CardContent className="space-y-1">
             {faxes.length === 0 ? (
-              <EmptyState title="No faxes yet" description="Send your first fax from the fax tab." />
+              <EmptyState
+                title="No faxes in flight"
+                description="Both inbound and outbound fax activity show up here, with page counts and delivery state."
+                className="p-6"
+              />
             ) : (
               faxes.map((fax) => (
                 <button
@@ -218,7 +226,11 @@ export function CommsRecentClient({
           </CardHeader>
           <CardContent className="space-y-1">
             {broadcasts.length === 0 ? (
-              <EmptyState title="No campaigns yet" description="Use SMS broadcast to message patient cohorts." />
+              <EmptyState
+                title="No broadcasts yet"
+                description="Send your first cohort SMS or email and we'll log delivery, opens, and replies here."
+                className="p-6"
+              />
             ) : (
               broadcasts.map((c) => (
                 <button

--- a/src/app/(clinician)/clinic/communications/fax/page.tsx
+++ b/src/app/(clinician)/clinic/communications/fax/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { FaxEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { formatRelative } from "@/lib/utils/format";
 import { FaxComposeForm } from "./fax-compose";
 
@@ -63,8 +64,14 @@ export default async function FaxPage() {
           <CardContent className="space-y-2 max-h-[640px] overflow-y-auto">
             {records.length === 0 ? (
               <EmptyState
-                title="No faxes yet"
-                description="Send your first fax to see it here."
+                illustration={<FaxEmptyIllustration />}
+                title="Nothing in flight"
+                description="Inbound and outbound faxes will show up here with delivery status, page count, and the patient they belong to."
+                tips={[
+                  "Outbound faxes ship through the practice's provider in seconds",
+                  "Delivery status updates live — no need to refresh the page",
+                  "Older entries archive automatically for 7 years per retention",
+                ]}
               />
             ) : (
               records.map((fax) => (

--- a/src/app/(clinician)/clinic/communications/transcripts/page.tsx
+++ b/src/app/(clinician)/clinic/communications/transcripts/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { TranscriptsEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { formatRelative } from "@/lib/utils/format";
 import { TranscriptReviewForm } from "./review-form";
 
@@ -79,8 +80,14 @@ export default async function TranscriptsPage() {
           </h2>
           {pending.length === 0 ? (
             <EmptyState
-              title="No transcripts to review"
-              description="Approved summaries appear in the recent decisions panel."
+              illustration={<TranscriptsEmptyIllustration />}
+              title="Queue clear — every transcript reviewed"
+              description="New AI-summarized calls land here for a quick approve or reject. Your approved summaries are already on the chart."
+              tips={[
+                "Approving attaches the redacted summary to the patient chart",
+                "Rejecting drops the AI summary — nothing reaches the chart",
+                "Decisions show up in the recent panel for the next 12 reviews",
+              ]}
             />
           ) : (
             pending.map((t) => {
@@ -151,7 +158,8 @@ export default async function TranscriptsPage() {
             {recent.length === 0 ? (
               <EmptyState
                 title="No decisions yet"
-                description="Approved or rejected transcripts appear here."
+                description="Once you approve or reject a transcript it will show up here so the team can see what was added to charts."
+                className="p-6"
               />
             ) : (
               recent.map((t) => (

--- a/src/app/(clinician)/clinic/communications/voicemail/page.tsx
+++ b/src/app/(clinician)/clinic/communications/voicemail/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { VoicemailEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { formatRelative } from "@/lib/utils/format";
 import { VoicemailRow } from "./row";
 import { LogVoicemailForm } from "./log-form";
@@ -93,8 +94,14 @@ export default async function VoicemailPage() {
           </h2>
           {active.length === 0 ? (
             <EmptyState
-              title="No voicemails to review"
-              description="Inbound recordings will appear here once a caller leaves a message."
+              illustration={<VoicemailEmptyIllustration />}
+              title="No new voicemails — you're all clear"
+              description="Inbound recordings show up here with an AI-redacted summary, so you only see clinical content. Personal data never reaches the chart unless you approve it."
+              tips={[
+                "Press play to listen — the original recording stays in secure storage",
+                "Reassign to a teammate if it belongs to someone else's panel",
+                "Archived voicemails auto-delete 30 days after recording",
+              ]}
             />
           ) : (
             active.map((vm) => (
@@ -163,7 +170,8 @@ export default async function VoicemailPage() {
               {archived.length === 0 ? (
                 <EmptyState
                   title="Nothing archived yet"
-                  description="Archived voicemails appear here for audit."
+                  description="Once you archive a voicemail it'll appear here for the next 30 days."
+                  className="p-6"
                 />
               ) : (
                 archived.map((vm) => (

--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -18,6 +18,7 @@ import { MessagesTile } from "@/components/command/messages-tile";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { QueueEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { formatRelative } from "@/lib/utils/format";
 import { RecentPatients } from "@/components/shell/recent-patients";
@@ -832,18 +833,25 @@ export default async function ClinicHomePage() {
         <Eyebrow className="mb-4">Today&apos;s queue</Eyebrow>
 
         {todaysEncounters.length === 0 ? (
-          <Card tone="outlined" className="py-10 px-6">
-            <div className="flex flex-col items-center text-center">
-              <LeafSprig size={32} className="text-accent/40 mb-3" />
-              <p className="font-display text-lg text-text">
-                Clear schedule.
-              </p>
-              <p className="text-sm text-text-muted mt-1 mb-6">
-                A good day to catch up on notes.
-              </p>
-              <RelaxPopup />
-            </div>
-          </Card>
+          <EmptyState
+            illustration={<QueueEmptyIllustration />}
+            title="Clear schedule — a good day to get ahead"
+            description="No visits on the books today. Perfect window to close out yesterday's notes, review labs, or knock out a quick CME."
+            primaryAction={<RelaxPopup />}
+            secondaryAction={
+              <Link
+                href="/clinic/sign-off/notes"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-muted transition-colors"
+              >
+                Open pending notes
+              </Link>
+            }
+            tips={[
+              "Sign off pending labs and refills while it's quiet",
+              "Tomorrow's pre-visit briefs are already prepped",
+              "Block off some focus time on your calendar — you earned it",
+            ]}
+          />
         ) : (
           <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin">
             {(todaysEncounters as any[])
@@ -991,8 +999,9 @@ export default async function ClinicHomePage() {
           <CardContent>
             {feed.length === 0 ? (
               <EmptyState
-                title="No recent activity"
-                description="Clinical events will appear here as they happen."
+                title="Nothing happening — yet"
+                description="Lab results, signed notes, messages, and refills will stream through here as your team works."
+                className="p-6"
               />
             ) : (
               <ul className="space-y-1 -mx-2">

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -7,6 +7,10 @@ import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { MetricTile } from "@/components/ui/metric-tile";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  PatientsEmptyIllustration,
+  ResearchEmptyIllustration,
+} from "@/components/ui/empty-illustrations";
 import { Button } from "@/components/ui/button";
 import { patientMatchesQuery } from "@/lib/search/patient-search";
 import { UniversalPatientSearch } from "@/components/clinic/UniversalPatientSearch";
@@ -406,15 +410,46 @@ export function PatientListClient({
           {patients.length === 0 ? (
             <div className="px-5 pb-6">
               <EmptyState
-                title="No patients in the system yet"
-                description="Add your first patient to get started with chart management."
+                illustration={<PatientsEmptyIllustration />}
+                title="Add your first patient"
+                description="Your roster lives here. Once you add a patient their charts, messages, and visits all roll up into a single timeline."
+                primaryAction={
+                  <Link href="/clinic/patients/new">
+                    <Button size="sm">Add patient</Button>
+                  </Link>
+                }
+                secondaryAction={
+                  <Link href="/clinic/patients/import">
+                    <Button size="sm" variant="ghost">
+                      Import from CSV
+                    </Button>
+                  </Link>
+                }
+                tips={[
+                  "Bulk import existing patients from a CSV export",
+                  "Front desk can intake new patients without touching the chart",
+                  "Every new patient gets an auto-generated portal invite",
+                ]}
               />
             </div>
           ) : filtered.length === 0 ? (
             <div className="px-5 pb-6">
               <EmptyState
-                title="No patients match your search"
-                description="Try adjusting your search terms or selecting a different filter chip."
+                illustration={<ResearchEmptyIllustration />}
+                title="No matches for that search"
+                description="We couldn't find anyone in your roster matching this query. Try a shorter search term, or clear your filter chips."
+                secondaryAction={
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      setSearch("");
+                      setPowerFilter("all");
+                    }}
+                  >
+                    Clear filters
+                  </Button>
+                }
               />
             </div>
           ) : (

--- a/src/app/(clinician)/clinic/research/page.tsx
+++ b/src/app/(clinician)/clinic/research/page.tsx
@@ -3,6 +3,7 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ResearchEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { LeafSprig } from "@/components/ui/ornament";
 import { ResearchSearchForm } from "./research-form";
 import { formatRelative } from "@/lib/utils/format";
@@ -182,8 +183,14 @@ export default async function ResearchConsolePage({
             </Card>
           ) : (
             <EmptyState
-              title="Run your first search"
-              description="Type a symptom, condition, or treatment keyword to query the research database."
+              illustration={<ResearchEmptyIllustration />}
+              title="Ask the literature anything"
+              description="Type a symptom, condition, or treatment keyword above and we'll surface ranked evidence with traceable citations in seconds."
+              tips={[
+                "Multi-word phrases work — try \"neuropathic pain CBD\" or \"insomnia low-dose THC\"",
+                "Results link out to PubMed, UpToDate, and Lexicomp in a new tab",
+                "Saved searches appear in the sidebar so you can come back later",
+              ]}
             />
           )}
         </div>
@@ -201,7 +208,9 @@ export default async function ResearchConsolePage({
             </CardHeader>
             <CardContent>
               {recent.length === 0 ? (
-                <p className="text-sm text-text-muted">No searches yet.</p>
+                <p className="text-sm text-text-muted leading-relaxed">
+                  Your recent searches will appear here once you run one. We&apos;ll save the last five so you can jump back without retyping.
+                </p>
               ) : (
                 <ul className="space-y-3 -mx-2">
                   {recent.map((q) => {

--- a/src/app/(clinician)/clinic/voicemail/page.tsx
+++ b/src/app/(clinician)/clinic/voicemail/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { VoicemailEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { formatRelative } from "@/lib/utils/format";
 import {
   buildCallbackQueue,
@@ -126,8 +127,14 @@ export default async function ClinicianVoicemailPage() {
 
       {queue.length === 0 && (
         <EmptyState
-          title="Inbox clear"
-          description="No callbacks waiting. Inbound voicemails appear here with a redacted clinical summary."
+          illustration={<VoicemailEmptyIllustration />}
+          title="Callback queue is clear — nice work"
+          description="No outstanding voicemails. Inbound recordings show up here with an AI-redacted clinical summary so you can triage in seconds."
+          tips={[
+            "Personal data is stripped before the recording is summarized",
+            "Reassign any voicemail to a teammate without losing the audit trail",
+            "Listened voicemails auto-move to follow-up until you close the loop",
+          ]}
         />
       )}
     </PageShell>

--- a/src/app/(patient)/portal/lifestyle/page.tsx
+++ b/src/app/(patient)/portal/lifestyle/page.tsx
@@ -6,6 +6,8 @@ import { PageShell } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LifestyleEmptyIllustration } from "@/components/ui/empty-illustrations";
 import { LIFESTYLE_DOMAINS, LIFESTYLE_TIPS } from "@/lib/domain/lifestyle";
 import {
   buildAchievements,
@@ -84,6 +86,38 @@ export default async function LifestylePage() {
           </p>
         </div>
       </Card>
+
+      {/* First-run empty state — shown until the patient has any outcome data */}
+      {patient.outcomeLogs.length === 0 && (
+        <div className="mb-8">
+          <EmptyState
+            illustration={<LifestyleEmptyIllustration />}
+            title="Welcome — your toolkit is ready"
+            description="Log how you feel just once and your plant starts growing, your streak begins, and the tips below sharpen to what actually helps you."
+            primaryAction={
+              <Link
+                href="/portal/journal"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-ink hover:bg-accent/90 transition-colors"
+              >
+                Log how you feel
+              </Link>
+            }
+            secondaryAction={
+              <Link
+                href="/portal/integrations"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-surface-muted transition-colors"
+              >
+                Connect a wearable
+              </Link>
+            }
+            tips={[
+              "One check-in unlocks your first achievement",
+              "Connecting Apple Health or Fitbit fills in steps, sleep, and HR automatically",
+              "Pick a single tip below — small steps beat perfect plans",
+            ]}
+          />
+        </div>
+      )}
 
       {/* Stat row — health score + streak + achievements */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">

--- a/src/app/(patient)/portal/messages/thread-view.tsx
+++ b/src/app/(patient)/portal/messages/thread-view.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { InboxZeroIllustration } from "@/components/ui/empty-illustrations";
 import { ReplyCompose, NewThreadCompose } from "./compose";
 import { formatRelative } from "@/lib/utils/format";
 import { cn } from "@/lib/utils/cn";
@@ -306,11 +307,17 @@ export function PatientMessagesView({ threads, currentUserId }: Props) {
 
       {threads.length === 0 && !showCompose ? (
         <EmptyState
-          title="No messages yet"
-          description="Your care team will reach out after your first visit. You can also start a conversation."
-          action={
-            <Button onClick={() => setShowCompose(true)}>New message</Button>
+          illustration={<InboxZeroIllustration />}
+          title="Your secure mailbox is ready"
+          description="This is the safest way to reach your care team for non-urgent questions. They'll usually reply within one business day."
+          primaryAction={
+            <Button onClick={() => setShowCompose(true)}>Start a message</Button>
           }
+          tips={[
+            "Use messages for refill requests, follow-up questions, or sharing symptoms",
+            "For anything urgent or after-hours, please call your care team or 911",
+            "Attachments and photos are end-to-end encrypted in transit",
+          ]}
         />
       ) : (
         <Card className="overflow-hidden">

--- a/src/components/ui/empty-illustrations.tsx
+++ b/src/components/ui/empty-illustrations.tsx
@@ -1,0 +1,343 @@
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Library of small (~80×80) SVG illustrations for empty states.
+ *
+ * Style rules: monochrome line work in `currentColor` with a single
+ * accent fill, soft rounded corners, ~1.4px stroke weights. Each
+ * illustration is purely decorative — `aria-hidden` and never relied on
+ * for meaning. The accent color picks up `var(--accent)` via Tailwind's
+ * `text-accent` utility on the wrapper.
+ */
+
+type IllustrationProps = {
+  size?: number;
+  className?: string;
+};
+
+function Frame({
+  size = 80,
+  className,
+  children,
+}: IllustrationProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 80 80"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("text-text-muted", className)}
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** Envelope with a soft check — for inbox-zero / no messages. */
+export function InboxZeroIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="14"
+        y="22"
+        width="52"
+        height="36"
+        rx="6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M14 26 L40 44 L66 26"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <circle cx="56" cy="22" r="9" fill="var(--accent)" opacity="0.18" />
+      <path
+        d="M52 22.5 L55 25.5 L60.5 19.5"
+        stroke="var(--accent)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Frame>
+  );
+}
+
+/** Person silhouette + plus — for empty patient roster. */
+export function PatientsEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <circle
+        cx="34"
+        cy="30"
+        r="9"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M18 60 C 20 49, 28 45, 34 45 C 40 45, 48 49, 50 60"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        fill="var(--surface)"
+      />
+      <circle cx="58" cy="54" r="10" fill="var(--accent)" opacity="0.18" />
+      <path
+        d="M58 49 L58 59 M53 54 L63 54"
+        stroke="var(--accent)"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </Frame>
+  );
+}
+
+/** Calendar with a single checkmark — for "today's queue is clear". */
+export function QueueEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="14"
+        y="20"
+        width="52"
+        height="44"
+        rx="6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M14 32 L66 32"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
+      <path
+        d="M24 16 L24 24 M40 16 L40 24 M56 16 L56 24"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <rect x="28" y="42" width="24" height="14" rx="4" fill="var(--accent)" opacity="0.18" />
+      <path
+        d="M32 49 L38 54 L48 44"
+        stroke="var(--accent)"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Frame>
+  );
+}
+
+/** Book/library — for saved articles. */
+export function LibraryEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="18"
+        y="18"
+        width="44"
+        height="50"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M18 26 L62 26 M18 38 L62 38 M18 50 L52 50 M18 60 L46 60"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity="0.7"
+      />
+      <path
+        d="M50 14 L62 18 L62 30 L50 26 Z"
+        fill="var(--accent)"
+        opacity="0.7"
+        stroke="var(--accent)"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </Frame>
+  );
+}
+
+/** Magnifying glass over a soft hex — for empty research. */
+export function ResearchEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <circle
+        cx="36"
+        cy="36"
+        r="18"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M49 49 L62 62"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+      />
+      <circle cx="36" cy="36" r="10" fill="var(--accent)" opacity="0.15" />
+      <path
+        d="M30 36 L34 40 L42 32"
+        stroke="var(--accent)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Frame>
+  );
+}
+
+/** Speech-to-text waveform card — for transcripts. */
+export function TranscriptsEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="14"
+        y="20"
+        width="52"
+        height="40"
+        rx="6"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <path
+        d="M22 40 L22 40 M28 34 L28 46 M34 30 L34 50 M40 36 L40 44 M46 28 L46 52 M52 34 L52 46 M58 38 L58 42"
+        stroke="var(--accent)"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+      />
+    </Frame>
+  );
+}
+
+/** Voicemail — phone receiver with a tape circle. */
+export function VoicemailEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="14"
+        y="30"
+        width="52"
+        height="22"
+        rx="11"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <circle cx="26" cy="41" r="6" fill="var(--accent)" opacity="0.5" />
+      <circle cx="54" cy="41" r="6" fill="var(--accent)" opacity="0.5" />
+      <path
+        d="M30 41 L50 41"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeDasharray="2 3"
+      />
+    </Frame>
+  );
+}
+
+/** Fax — sheet sliding out of a machine. */
+export function FaxEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect
+        x="14"
+        y="34"
+        width="52"
+        height="26"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--surface)"
+      />
+      <rect
+        x="24"
+        y="18"
+        width="32"
+        height="22"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fill="var(--accent)"
+        fillOpacity="0.18"
+      />
+      <path
+        d="M30 26 L50 26 M30 32 L46 32"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity="0.7"
+      />
+      <circle cx="56" cy="48" r="1.8" fill="var(--accent)" />
+      <circle cx="50" cy="48" r="1.8" fill="currentColor" opacity="0.4" />
+      <path
+        d="M20 56 L36 56"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </Frame>
+  );
+}
+
+/** Lifestyle — heart + sparkles. */
+export function LifestyleEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <path
+        d="M40 60 C 28 52, 18 44, 18 33 C 18 26, 24 22, 30 22 C 34 22, 38 24, 40 28 C 42 24, 46 22, 50 22 C 56 22, 62 26, 62 33 C 62 44, 52 52, 40 60 Z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        fill="var(--accent)"
+        fillOpacity="0.2"
+      />
+      <path
+        d="M16 16 L18 20 L22 22 L18 24 L16 28 L14 24 L10 22 L14 20 Z"
+        fill="var(--accent)"
+        opacity="0.75"
+      />
+      <path
+        d="M64 60 L65.5 63 L68.5 64.5 L65.5 66 L64 69 L62.5 66 L59.5 64.5 L62.5 63 Z"
+        fill="var(--accent)"
+        opacity="0.55"
+      />
+    </Frame>
+  );
+}
+
+/** Coach / chat — friendly chat bubble + sparkle. */
+export function CoachEmptyIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <path
+        d="M16 22 C 16 18, 19 16, 23 16 L 53 16 C 57 16, 60 18, 60 22 L 60 42 C 60 46, 57 48, 53 48 L 32 48 L 22 58 L 22 48 C 19 48, 16 46, 16 42 Z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        fill="var(--surface)"
+      />
+      <circle cx="27" cy="32" r="2" fill="currentColor" opacity="0.7" />
+      <circle cx="38" cy="32" r="2" fill="currentColor" opacity="0.7" />
+      <circle cx="49" cy="32" r="2" fill="currentColor" opacity="0.7" />
+      <path
+        d="M64 50 L66 54 L70 56 L66 58 L64 62 L62 58 L58 56 L62 54 Z"
+        fill="var(--accent)"
+        opacity="0.8"
+      />
+    </Frame>
+  );
+}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -2,34 +2,105 @@ import * as React from "react";
 import { cn } from "@/lib/utils/cn";
 import { EmptyIllustration } from "./ornament";
 
+/**
+ * Monday.com / Linear / Stripe-tier empty state.
+ *
+ * Supports an optional illustration (or icon), a short warm title, a one-to-two
+ * sentence description, optional primary + secondary CTAs, and an optional
+ * "What you can do next" tips list. Tone is encouraging, never sarcastic.
+ *
+ * For the simplest call site you can still just pass `title` and (optionally)
+ * `description` — every other prop is opt-in.
+ */
 export function EmptyState({
   icon,
+  illustration,
   title,
   description,
   action,
+  primaryAction,
+  secondaryAction,
+  tips,
+  align = "center",
   className,
 }: {
+  /** Legacy single-icon slot. Wins over `illustration` when both are provided. */
   icon?: React.ReactNode;
+  /** Preferred slot for an ~80×80 SVG illustration. */
+  illustration?: React.ReactNode;
   title: string;
-  description?: string;
+  description?: React.ReactNode;
+  /** Legacy single-action slot. Rendered after primary/secondary when present. */
   action?: React.ReactNode;
+  primaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+  /** Optional "What you can do next" hints. Each entry renders as a row. */
+  tips?: React.ReactNode[];
+  align?: "center" | "start";
   className?: string;
 }) {
+  const visual = icon ?? illustration ?? <EmptyIllustration size={80} />;
+  const isStart = align === "start";
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center text-center p-12 rounded-xl border border-dashed border-border-strong/60 bg-surface/60",
-        className
+        "rounded-xl border border-dashed border-border-strong/60 bg-surface/60 p-10 md:p-12",
+        isStart
+          ? "flex flex-col items-start text-left"
+          : "flex flex-col items-center text-center",
+        className,
       )}
+      role="status"
     >
-      <div className="mb-1">{icon ?? <EmptyIllustration size={96} />}</div>
-      <h3 className="font-display text-lg text-text">{title}</h3>
+      <div className={cn("mb-1", isStart ? "" : "")} aria-hidden="true">
+        {visual}
+      </div>
+      <h3 className="font-display text-lg text-text mt-2">{title}</h3>
       {description && (
-        <p className="text-sm text-text-muted mt-2 max-w-sm leading-relaxed">
+        <p
+          className={cn(
+            "text-sm text-text-muted mt-2 leading-relaxed",
+            isStart ? "max-w-xl" : "max-w-md",
+          )}
+        >
           {description}
         </p>
       )}
-      {action && <div className="mt-6">{action}</div>}
+      {(primaryAction || secondaryAction || action) && (
+        <div
+          className={cn(
+            "mt-6 flex flex-wrap gap-2",
+            isStart ? "justify-start" : "justify-center",
+          )}
+        >
+          {primaryAction}
+          {secondaryAction}
+          {action}
+        </div>
+      )}
+      {tips && tips.length > 0 && (
+        <div
+          className={cn(
+            "mt-7 w-full max-w-md rounded-lg border border-border/70 bg-surface/80 px-4 py-3",
+            isStart ? "" : "text-left",
+          )}
+        >
+          <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-text-muted">
+            What you can do next
+          </p>
+          <ul className="mt-2 space-y-1.5 text-sm text-text">
+            {tips.map((tip, i) => (
+              <li key={i} className="flex items-start gap-2">
+                <span
+                  aria-hidden="true"
+                  className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+                />
+                <span className="leading-snug">{tip}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces terse, slightly cold empty states with warm, encouraging Monday.com / Linear / Stripe-tier copy and small inline SVG illustrations across 10 surfaces.

The shared `EmptyState` component now supports:
- Optional ~80x80 SVG illustration (or legacy icon)
- Title (one short line)
- Description (one or two sentences, warm tone)
- Optional **primary** + **secondary** CTAs
- Optional **"What you can do next"** tips list
- `align="start" | "center"` for inline use

10 new dedicated illustrations live in `src/components/ui/empty-illustrations.tsx` (monochrome line + single accent fill, no external assets).

## Surfaces touched

| Surface | Before | After (title) |
|---|---|---|
| `/clinic` Today's queue | "Clear schedule." | "Clear schedule — a good day to get ahead" |
| `/clinic` Activity feed | "No recent activity" | "Nothing happening — yet" |
| `/clinic/patients` zero patients | "No patients in the system yet" | "Add your first patient" (+ CTA + import + tips) |
| `/clinic/patients` no matches | "No patients match your search" | "No matches for that search" (+ clear filters) |
| `/clinic/research` no query | "Run your first search" | "Ask the literature anything" (+ tips) |
| `/clinic/research` recent sidebar | "No searches yet." | warm one-liner |
| `/clinic/communications` calls | "No calls yet" | "No calls yet today" (descriptive) |
| `/clinic/communications` faxes | "No faxes yet" | "No faxes in flight" |
| `/clinic/communications` broadcasts | "No campaigns yet" | "No broadcasts yet" |
| `/clinic/communications/transcripts` pending | "No transcripts to review" | "Queue clear — every transcript reviewed" (+ tips) |
| `/clinic/communications/transcripts` recent | "No decisions yet" | warm explainer |
| `/clinic/communications/voicemail` inbox | "No voicemails to review" | "No new voicemails — you're all clear" (+ tips) |
| `/clinic/communications/voicemail` archived | "Nothing archived yet" | warm explainer |
| `/clinic/communications/fax` | "No faxes yet" | "Nothing in flight" (+ tips) |
| `/clinic/voicemail` callback queue | "Inbox clear" | "Callback queue is clear — nice work" (+ tips) |
| `/portal/lifestyle` first-run | (no state) | "Welcome — your toolkit is ready" (+ Log + Connect wearable + tips) |
| `/portal/messages` empty mailbox | "No messages yet" | "Your secure mailbox is ready" (+ Start + safety tips) |

## Out of scope (left untouched on purpose)

- `/ops/supplies` — open PR #438 is reworking this surface.
- `src/app/(clinician)/clinic/messages/smart-inbox.tsx` — touched by open PR #436.
- Anything outside the 10 surfaces above; this is a focused sweep, not a refactor.

## Test plan

- [x] `npx prisma generate`
- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (no new errors; only pre-existing warnings)
- [ ] Visual smoke: log in as clinician with an empty test org and click through Today's queue, patients, research, transcripts, voicemail, fax, comms.
- [ ] Visual smoke: log in as a patient with no outcome logs and confirm `/portal/lifestyle` + `/portal/messages` welcome states render.

Generated with [Claude Code](https://claude.com/claude-code)