### PR TITLE
ux: toast notification system + adoption in 7 server-action sites

### DIFF
--- a/src/app/(clinician)/clinic/messages/compose.tsx
+++ b/src/app/(clinician)/clinic/messages/compose.tsx
@@ -6,6 +6,7 @@ import { sendClinicReplyAction } from "./actions";
 import type { ReplyResult } from "./actions";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
 
 function ClinicReplySubmitButton() {
   const { pending } = useFormStatus();
@@ -22,12 +23,21 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
     null
   );
   const formRef = useRef<HTMLFormElement>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
-    if (state?.ok) {
+    if (!state) return;
+    if (state.ok) {
       formRef.current?.reset();
+      toast({ title: "Reply sent", variant: "success" });
+    } else {
+      toast({
+        title: "Couldn't send reply",
+        description: state.error,
+        variant: "error",
+      });
     }
-  }, [state]);
+  }, [state, toast]);
 
   return (
     <form
@@ -48,9 +58,6 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
         </div>
         <ClinicReplySubmitButton />
       </div>
-      {state?.ok === false && (
-        <p className="text-xs text-danger mt-2">{state.error}</p>
-      )}
     </form>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/assessments/quick-entry-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/assessments/quick-entry-form.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { recordAssessmentQuickEntry, type QuickEntryResult } from "./actions";
+import { useToast } from "@/components/ui/toast";
 
 // EMR-160 — quick-entry form, the "I'm in clinic with the paper form" flow.
 //
@@ -38,14 +38,27 @@ export function QuickEntryForm({
   const [slug, setSlug] = React.useState(instruments[0]?.slug ?? "");
   const formRef = React.useRef<HTMLFormElement | null>(null);
   const selected = instruments.find((i) => i.slug === slug);
+  const { toast } = useToast();
 
   React.useEffect(() => {
-    if (state?.ok && formRef.current) {
+    if (!state) return;
+    if (state.ok && formRef.current) {
       formRef.current.reset();
       // Restore the slug since reset() clears the controlled select too.
       setSlug(instruments[0]?.slug ?? "");
+      toast({
+        title: "Assessment recorded",
+        description: state.label,
+        variant: "success",
+      });
+    } else if (!state.ok) {
+      toast({
+        title: "Couldn't record assessment",
+        description: state.error,
+        variant: "error",
+      });
     }
-  }, [state, instruments]);
+  }, [state, instruments, toast]);
 
   return (
     <form
@@ -116,14 +129,6 @@ export function QuickEntryForm({
         </Field>
       </div>
 
-      {state && !state.ok && (
-        <p className="md:col-span-4 text-sm text-danger">{state.error}</p>
-      )}
-      {state?.ok && (
-        <p className="md:col-span-4 text-sm text-success flex items-center gap-2">
-          Recorded · <Badge tone="accent">{state.label}</Badge>
-        </p>
-      )}
     </form>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/correspondence-tab.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/correspondence-tab.tsx
@@ -16,6 +16,7 @@ import {
 import { resolveAgentMeta } from "@/lib/agents/ui-registry";
 import { formatRelative } from "@/lib/utils/format";
 import { sendChartReply, type ChartReplyResult } from "./correspondence-actions";
+import { useToast } from "@/components/ui/toast";
 
 /* ── Serialized types ─────────────────────────────────────────── */
 
@@ -108,12 +109,21 @@ function InlineReplyCompose({ threadId }: { threadId: string }) {
     null
   );
   const formRef = useRef<HTMLFormElement>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
-    if (state?.ok) {
+    if (!state) return;
+    if (state.ok) {
       formRef.current?.reset();
+      toast({ title: "Reply sent", variant: "success" });
+    } else {
+      toast({
+        title: "Couldn't send reply",
+        description: state.error,
+        variant: "error",
+      });
     }
-  }, [state]);
+  }, [state, toast]);
 
   return (
     <form
@@ -134,9 +144,6 @@ function InlineReplyCompose({ threadId }: { threadId: string }) {
         </div>
         <ReplySubmitButton />
       </div>
-      {state?.ok === false && (
-        <p className="text-xs text-danger mt-2">{state.error}</p>
-      )}
     </form>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/recommend/recommend-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/recommend/recommend-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import Link from "next/link";
 import {
@@ -8,6 +9,7 @@ import {
   type Recommendation,
 } from "./actions";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
 import {
   Card,
   CardContent,
@@ -154,6 +156,17 @@ export function RecommendForm({
     generateRecommendation,
     null
   );
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (state?.ok === false) {
+      toast({
+        title: "Couldn't generate recommendation",
+        description: state.error,
+        variant: "error",
+      });
+    }
+  }, [state, toast]);
 
   return (
     <div>
@@ -182,9 +195,6 @@ export function RecommendForm({
             </div>
           </CardContent>
           <CardFooter>
-            {state?.ok === false && (
-              <p className="text-sm text-danger">{state.error}</p>
-            )}
             <div className="ml-auto">
               <GenerateButton />
             </div>

--- a/src/app/(clinician)/clinic/sign-off/messages/approvals-list.tsx
+++ b/src/app/(clinician)/clinic/sign-off/messages/approvals-list.tsx
@@ -18,6 +18,7 @@ import {
   type ApprovalResult,
   type BatchResult,
 } from "./actions";
+import { useToast } from "@/components/ui/toast";
 
 // ---------------------------------------------------------------------------
 // Types — generic enough that future approval kinds (note drafts, claim
@@ -461,6 +462,33 @@ function ActionButtons({
     ApprovalResult | null,
     FormData
   >(rejectMessageDraft, null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!approveState) return;
+    if (approveState.ok) {
+      toast({ title: "Draft approved & sent", variant: "success" });
+    } else {
+      toast({
+        title: "Couldn't approve draft",
+        description: approveState.error,
+        variant: "error",
+      });
+    }
+  }, [approveState, toast]);
+
+  useEffect(() => {
+    if (!rejectState) return;
+    if (rejectState.ok) {
+      toast({ title: "Draft discarded", variant: "info" });
+    } else {
+      toast({
+        title: "Couldn't discard draft",
+        description: rejectState.error,
+        variant: "error",
+      });
+    }
+  }, [rejectState, toast]);
 
   return (
     <div className="flex items-center gap-2">
@@ -475,15 +503,6 @@ function ActionButtons({
         <input type="hidden" name="messageId" value={messageId} />
         <ApproveButton />
       </form>
-      {(approveState?.ok === false || rejectState?.ok === false) && (
-        <span className="text-[11px] text-danger ml-2">
-          {approveState?.ok === false
-            ? approveState.error
-            : rejectState?.ok === false
-              ? rejectState.error
-              : ""}
-        </span>
-      )}
     </div>
   );
 }
@@ -525,6 +544,22 @@ function EditApproveForm({
     editAndApproveMessageDraft,
     null,
   );
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!state) return;
+    if (state.ok) {
+      toast({ title: "Edits sent", variant: "success" });
+      onCancel();
+    } else {
+      toast({
+        title: "Couldn't send edits",
+        description: state.error,
+        variant: "error",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, toast]);
 
   return (
     <form action={formAction} className="flex items-center gap-2">
@@ -534,9 +569,6 @@ function EditApproveForm({
         Cancel
       </Button>
       <EditSubmitButton />
-      {state?.ok === false && (
-        <span className="text-[11px] text-danger ml-2">{state.error}</span>
-      )}
     </form>
   );
 }

--- a/src/app/(patient)/portal/profile/profile-form.tsx
+++ b/src/app/(patient)/portal/profile/profile-form.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useEffect } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import { saveProfileAction, type ProfileResult } from "./actions";
 import { Button } from "@/components/ui/button";
 import { Input, FieldGroup } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
 
 function SubmitButton() {
   const { pending } = useFormStatus();
@@ -48,6 +50,20 @@ export function ProfileForm({ initial }: { initial: ProfileValues }) {
     saveProfileAction,
     null,
   );
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!state) return;
+    if (state.ok) {
+      toast({ title: "Profile saved", variant: "success" });
+    } else {
+      toast({
+        title: "Couldn't save profile",
+        description: state.error,
+        variant: "error",
+      });
+    }
+  }, [state, toast]);
 
   // Calculate age from DOB
   let age: number | null = null;
@@ -228,14 +244,7 @@ export function ProfileForm({ initial }: { initial: ProfileValues }) {
         </FieldGroup>
       </section>
 
-      {/* ---- Feedback & submit ---- */}
-      {state?.ok === false && (
-        <p className="text-sm text-danger">{state.error}</p>
-      )}
-      {state?.ok && (
-        <p className="text-sm text-success">Profile saved successfully.</p>
-      )}
-
+      {/* ---- Submit ---- */}
       <div className="flex items-center justify-end gap-2 pt-2">
         <SubmitButton />
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -405,6 +405,11 @@
     from { opacity: 0; transform: translateX(-24px); }
     to   { opacity: 1; transform: translateX(0); }
   }
+  /* Toast notification entrance — subtle slide-up + fade. */
+  @keyframes toast-in {
+    from { opacity: 0; transform: translateY(12px) scale(0.98); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
   @keyframes lm-confirm-burst {
     0%   { opacity: 0.55; transform: scale(0.4); }
     70%  { opacity: 0.15; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { UniversalFeedbackFab } from "@/components/feedback/UniversalFeedbackFab";
 import { ClerkProvider } from "@clerk/nextjs";
 import { CookieConsent } from "@/components/layout/CookieConsent";
+import { ToastProvider } from "@/components/ui/toast";
 
 export const metadata: Metadata = {
   title: {
@@ -47,9 +48,11 @@ export default function RootLayout({
         >
           Skip to content
         </a>
-        {children}
-        <UniversalFeedbackFab />
-        <CookieConsent />
+        <ToastProvider>
+          {children}
+          <UniversalFeedbackFab />
+          <CookieConsent />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/components/feedback/UniversalFeedbackFab.tsx
+++ b/src/components/feedback/UniversalFeedbackFab.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils/cn";
+import { useToast } from "@/components/ui/toast";
 
 // EMR-128 — universal feedback FAB. Mounted once at the root layout so
 // every route in every role sees the same pulse-of-the-product channel.
@@ -18,6 +19,7 @@ export function UniversalFeedbackFab() {
   const [comment, setComment] = useState("");
   const [area, setArea] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
 
   // Persist a stable client-id per browser to dedupe repeats / retries.
   const clientIdRef = useRef<string>("");
@@ -75,6 +77,11 @@ export function UniversalFeedbackFab() {
         return;
       }
       setState("thanks");
+      toast({
+        title: "Thanks for the whisper",
+        description: "We'll route it to the right team.",
+        variant: "success",
+      });
       setTimeout(close, 2500);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Network error.");

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+/**
+ * Toast notification system — pure-React (no new deps).
+ *
+ * Goals:
+ *  - Variants: success / error / info / warning, mapped to design tokens.
+ *  - Auto-dismiss after 5s (configurable). Errors persist by default (duration: Infinity).
+ *  - Stacks vertically, max 5 visible (FIFO eviction).
+ *  - Optional action button slot (e.g. "Undo").
+ *  - Position: bottom-right on >= sm, bottom-center on mobile.
+ *  - Esc dismisses focused toast.
+ *  - Respects prefers-reduced-motion.
+ *  - aria-live="polite" for non-error, aria-live="assertive" for error.
+ *
+ * Usage:
+ *   <ToastProvider> wraps the tree (already mounted in src/app/layout.tsx).
+ *   const { toast } = useToast();
+ *   toast({ title: "Saved", variant: "success" });
+ *   toast({ title: "Failed", description: "...", variant: "error",
+ *           action: { label: "Retry", onClick: () => retry() } });
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils/cn";
+
+export type ToastVariant = "success" | "error" | "info" | "warning";
+
+export type ToastAction = {
+  label: string;
+  onClick: () => void;
+};
+
+export type ToastOptions = {
+  /** Required short headline. */
+  title: string;
+  /** Optional secondary line. */
+  description?: string;
+  /** Visual variant. Defaults to "info". */
+  variant?: ToastVariant;
+  /**
+   * Auto-dismiss after N ms. Default: 5000 for non-error, `Infinity` for error.
+   * Pass `Infinity` (or a non-finite number) to make the toast sticky.
+   */
+  duration?: number;
+  /** Optional action button (e.g. "Undo"). */
+  action?: ToastAction;
+  /** Stable id — if omitted, one is generated. Re-toasting the same id is a no-op. */
+  id?: string;
+};
+
+type ToastRecord = Required<Pick<ToastOptions, "title" | "variant">> &
+  Omit<ToastOptions, "title" | "variant"> & {
+    id: string;
+    createdAt: number;
+  };
+
+type ToastContextValue = {
+  toast: (opts: ToastOptions) => string;
+  dismiss: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const MAX_VISIBLE = 5;
+const DEFAULT_DURATION_MS = 5_000;
+
+let _idCounter = 0;
+function genId() {
+  _idCounter += 1;
+  return `t_${Date.now().toString(36)}_${_idCounter}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  const dismiss = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (opts: ToastOptions) => {
+      const id = opts.id ?? genId();
+      const variant = opts.variant ?? "info";
+      const duration =
+        typeof opts.duration === "number"
+          ? opts.duration
+          : variant === "error"
+            ? Number.POSITIVE_INFINITY
+            : DEFAULT_DURATION_MS;
+
+      setToasts((prev) => {
+        if (prev.some((t) => t.id === id)) return prev;
+        const next: ToastRecord = {
+          id,
+          title: opts.title,
+          description: opts.description,
+          variant,
+          duration,
+          action: opts.action,
+          createdAt: Date.now(),
+        };
+        // FIFO eviction so the newest toast is always visible.
+        const merged = [...prev, next];
+        if (merged.length > MAX_VISIBLE) {
+          const removed = merged.shift();
+          if (removed) {
+            const t = timersRef.current.get(removed.id);
+            if (t) {
+              clearTimeout(t);
+              timersRef.current.delete(removed.id);
+            }
+          }
+        }
+        return merged;
+      });
+
+      if (Number.isFinite(duration)) {
+        const timer = setTimeout(() => dismiss(id), duration);
+        timersRef.current.set(id, timer);
+      }
+
+      return id;
+    },
+    [dismiss],
+  );
+
+  // Clear any stragglers on unmount (mostly for HMR).
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ toast, dismiss }),
+    [toast, dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    // Soft-fallback so a stray useToast() never crashes a tree that forgot the provider.
+    if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[useToast] called outside <ToastProvider>; falling back to console.",
+      );
+    }
+    return {
+      toast: (opts) => {
+        if (typeof window !== "undefined") {
+          // eslint-disable-next-line no-console
+          console.info("[toast:noop]", opts);
+        }
+        return opts.id ?? "noop";
+      },
+      dismiss: () => {},
+    };
+  }
+  return ctx;
+}
+
+// ---------- presentation ----------
+
+function ToastViewport({
+  toasts,
+  onDismiss,
+}: {
+  toasts: ToastRecord[];
+  onDismiss: (id: string) => void;
+}) {
+  // Split errors (assertive) from the rest (polite) so screen readers route correctly.
+  const errorToasts = toasts.filter((t) => t.variant === "error");
+  const otherToasts = toasts.filter((t) => t.variant !== "error");
+
+  return (
+    <>
+      <div
+        aria-live="assertive"
+        aria-relevant="additions"
+        className={VIEWPORT_CLASSES}
+      >
+        {errorToasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+        ))}
+      </div>
+      <div
+        aria-live="polite"
+        aria-relevant="additions"
+        className={VIEWPORT_CLASSES}
+      >
+        {otherToasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+        ))}
+      </div>
+    </>
+  );
+}
+
+const VIEWPORT_CLASSES =
+  // Positioning: bottom-center mobile, bottom-right >= sm.
+  "fixed bottom-4 left-1/2 -translate-x-1/2 sm:left-auto sm:right-4 sm:translate-x-0 " +
+  "z-[120] flex flex-col gap-2 pointer-events-none " +
+  "w-[min(92vw,22rem)]";
+
+const VARIANT_CLASSES: Record<ToastVariant, string> = {
+  success:
+    "border-success/40 bg-success/10 text-text " +
+    "[--toast-accent:var(--success)]",
+  error:
+    "border-danger/40 bg-danger/10 text-text " +
+    "[--toast-accent:var(--danger)]",
+  info:
+    "border-info/40 bg-info/10 text-text " +
+    "[--toast-accent:var(--info)]",
+  warning:
+    "border-warning/40 bg-warning/10 text-text " +
+    "[--toast-accent:var(--warning)]",
+};
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastRecord;
+  onDismiss: (id: string) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onDismiss(toast.id);
+      }
+    },
+    [onDismiss, toast.id],
+  );
+
+  return (
+    <div
+      ref={ref}
+      role={toast.variant === "error" ? "alert" : "status"}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      className={cn(
+        // Layout & surface
+        "pointer-events-auto relative overflow-hidden rounded-lg border shadow-lg",
+        "bg-surface-raised backdrop-blur-sm",
+        "px-4 py-3 pr-10",
+        "flex items-start gap-3",
+        // Accent stripe on the left edge.
+        "before:absolute before:left-0 before:top-0 before:bottom-0 before:w-1",
+        "before:bg-[var(--toast-accent)]",
+        // Motion: slide-up + fade-in. Respects reduced-motion (no transform).
+        "animate-[toast-in_220ms_ease-out_both]",
+        "motion-reduce:animate-none",
+        // Focus ring for keyboard users.
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+        VARIANT_CLASSES[toast.variant],
+      )}
+      data-toast-variant={toast.variant}
+    >
+      <ToastIcon variant={toast.variant} />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold leading-snug text-text break-words">
+          {toast.title}
+        </p>
+        {toast.description ? (
+          <p className="text-xs leading-snug text-text-muted mt-0.5 break-words">
+            {toast.description}
+          </p>
+        ) : null}
+        {toast.action ? (
+          <button
+            type="button"
+            onClick={() => {
+              toast.action?.onClick();
+              onDismiss(toast.id);
+            }}
+            className={cn(
+              "mt-2 inline-flex items-center text-xs font-semibold",
+              "text-[var(--toast-accent)] hover:underline",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded",
+            )}
+          >
+            {toast.action.label}
+          </button>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={() => onDismiss(toast.id)}
+        className={cn(
+          "absolute right-2 top-2 rounded p-1 text-text-muted",
+          "hover:text-text hover:bg-surface-muted",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+        )}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 3l8 8M11 3l-8 8"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function ToastIcon({ variant }: { variant: ToastVariant }) {
+  const common =
+    "shrink-0 mt-0.5 size-4 text-[var(--toast-accent)]" as const;
+  switch (variant) {
+    case "success":
+      return (
+        <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={common}>
+          <path
+            d="M4 10.5l3.5 3.5L16 6"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case "error":
+      return (
+        <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={common}>
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M10 6v5M10 13.5v.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "warning":
+      return (
+        <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={common}>
+          <path
+            d="M10 3l8 14H2L10 3z"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M10 9v3M10 14.5v.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "info":
+    default:
+      return (
+        <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={common}>
+          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M10 9v5M10 6.5v.5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+  }
+}


### PR DESCRIPTION
## Summary

Unticketed UX run, parallel to the Gemini ticket swarm. Brings LeafJourney closer to Monday/Linear/Stripe polish on the notification surface.

- Adds a lightweight, pure-React toast primitive at `src/components/ui/toast.tsx` (no new deps — sonner / radix-toast not installed; not adding).
- `ToastProvider` mounts in `src/app/layout.tsx` so every route has access.
- `useToast()` returns `{ toast, dismiss }`; `toast({ title, description?, variant, duration?, action?, id? })`.
- Variants: `success` / `error` / `info` / `warning`, mapped to the existing `--success / --danger / --info / --warning` tokens.
- Auto-dismiss after 5s; errors default to sticky (`Infinity`).
- FIFO stacking, max 5 visible.
- Position: bottom-center on mobile, bottom-right on >= sm.
- Esc dismisses the focused toast; close button + optional action slot ("Undo", "Retry", ...).
- `aria-live="assertive"` viewport for errors, `aria-live="polite"` for everything else.
- Respects `prefers-reduced-motion` (no transform animation).

## Adoption sites (7)

Converts inline `text-danger` error copy and ad-hoc success lines to toasts:

1. `/clinic/messages` reply compose (`compose.tsx`)
2. `/clinic/patients` correspondence-tab reply (`correspondence-tab.tsx`)
3. `/clinic/patients` assessments quick-entry (`quick-entry-form.tsx`)
4. `/clinic/patients` recommend (error path) (`recommend-form.tsx`)
5. `/clinic/sign-off` messages approve / reject (`approvals-list.tsx :: ActionButtons`)
6. `/clinic/sign-off` messages edit-and-approve (`approvals-list.tsx :: EditApproveForm`)
7. `/portal/profile` save (`profile-form.tsx`)

Plus the Universal Feedback FAB now also fires a `success` toast on whisper submit so users get confirmation even after the modal closes.

## Skipped (deliberately)

- `/ops/supplies` — open draft PR #438 (EMR-791) is grinding there.
- `prescribe-form.tsx` — large surface; deferring to a dedicated pass.

## Test plan

- [ ] Submit invalid reply in `/clinic/messages` thread — see assertive error toast (sticky).
- [ ] Submit valid reply — see polite success toast, auto-dismiss in 5s.
- [ ] Save profile in `/portal/profile` — success toast.
- [ ] Approve & reject sign-off message drafts — see matching toasts.
- [ ] Trigger 6+ toasts rapidly — verify FIFO eviction at 5.
- [ ] Tab into a toast, press Esc — toast dismisses.
- [ ] OS-level "Reduce motion" — entrance animation disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)