### PR TITLE
ux: DataTable primitive (sticky headers, sort, selection, density) + 4 adoption sites

### DIFF
--- a/src/app/(clinician)/[orgId]/settings/members/page.tsx
+++ b/src/app/(clinician)/[orgId]/settings/members/page.tsx
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { MoreHorizontal, Plus, Shield, User as UserIcon } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
@@ -18,6 +19,15 @@ function initials(firstName: string | null, lastName: string | null): string {
   const a = (firstName ?? "").trim().charAt(0).toUpperCase();
   const b = (lastName ?? "").trim().charAt(0).toUpperCase();
   return a + b || "?";
+}
+
+interface MemberRow {
+  id: string;
+  firstName: string;
+  lastName: string;
+  specialtyLabel: string;
+  isAdmin: boolean;
+  lastLoginAt: Date | null;
 }
 
 export default async function MembersPage({
@@ -61,7 +71,103 @@ export default async function MembersPage({
     notFound();
   }
 
-  const providers = organization.providers;
+  const rows: MemberRow[] = organization.providers.map((provider) => ({
+    id: provider.id,
+    firstName: provider.user.firstName ?? "",
+    lastName: provider.user.lastName ?? "",
+    specialtyLabel: provider.specialties[0] ?? provider.title ?? "Provider",
+    // TODO: surface the provider's actual platform role by joining
+    // Membership(role) for this user × this org. Showing "Clinician"
+    // universally is honest given today's schema doesn't stash a
+    // per-provider admin flag — better than the fake `id.endsWith("a")`
+    // heuristic the prior version used.
+    isAdmin: false,
+    lastLoginAt: provider.user.lastLoginAt,
+  }));
+
+  // Column defs are inferred against MemberRow so each `cell(row)`
+  // gets full IntelliSense.
+  const columns: ColumnDef<MemberRow>[] = [
+    {
+      key: "name",
+      label: "Name",
+      sortable: true,
+      sortFn: (a, b) =>
+        `${a.lastName}${a.firstName}`.localeCompare(
+          `${b.lastName}${b.firstName}`,
+        ),
+      cell: (row) => (
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-[var(--accent)]/10 text-[var(--accent)] flex items-center justify-center font-medium">
+            {initials(row.firstName, row.lastName)}
+          </div>
+          <div>
+            <div className="font-medium text-text">
+              Dr. {row.firstName} {row.lastName}
+            </div>
+            <div className="text-text-muted text-xs">{row.specialtyLabel}</div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "role",
+      label: "Role",
+      sortable: true,
+      sortFn: (a, b) => Number(b.isAdmin) - Number(a.isAdmin),
+      cell: (row) => (
+        <div className="flex items-center gap-1.5 text-text-muted">
+          {row.isAdmin ? (
+            <>
+              <Shield className="w-3.5 h-3.5" /> Admin
+            </>
+          ) : (
+            <>
+              <UserIcon className="w-3.5 h-3.5" /> Clinician
+            </>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      label: "Status",
+      cell: () => (
+        <Badge tone="success" className="text-[10px]">
+          Active
+        </Badge>
+      ),
+    },
+    {
+      key: "lastActive",
+      label: "Last Active",
+      sortable: true,
+      sortFn: (a, b) =>
+        (a.lastLoginAt?.getTime() ?? 0) - (b.lastLoginAt?.getTime() ?? 0),
+      cell: (row) => (
+        <span className="text-text-muted tabular-nums">
+          {row.lastLoginAt ? row.lastLoginAt.toLocaleString() : "—"}
+        </span>
+      ),
+      hideOnMobile: true,
+    },
+    {
+      key: "actions",
+      label: "",
+      align: "right",
+      width: "64px",
+      cell: () => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-text-muted"
+          aria-label="Actions"
+        >
+          <MoreHorizontal className="w-4 h-4" />
+        </Button>
+      ),
+    },
+  ];
 
   return (
     <PageShell maxWidth="max-w-[1000px]">
@@ -77,90 +183,13 @@ export default async function MembersPage({
         </Button>
       </div>
 
-      <div className="bg-white border border-[var(--border)] rounded-2xl overflow-hidden shadow-sm">
-        <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-[var(--surface-muted)] border-b border-[var(--border)] text-text-subtle">
-              <tr>
-                <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Name</th>
-                <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Role</th>
-                <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Status</th>
-                <th className="px-6 py-4 font-medium uppercase tracking-wider text-xs">Last Active</th>
-                <th className="px-6 py-4 text-right"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-[var(--border)]">
-              {providers.map((provider) => {
-                const firstName = provider.user.firstName ?? "";
-                const lastName = provider.user.lastName ?? "";
-                const specialtyLabel =
-                  provider.specialties[0] ?? provider.title ?? "Provider";
-                // TODO: surface the provider's actual platform role by
-                // joining Membership(role) for this user × this org.
-                // Showing "Clinician" universally is honest given today's
-                // schema doesn't stash a per-provider admin flag — better
-                // than the fake `id.endsWith("a")` heuristic the prior
-                // version used.
-                const isAdmin = false;
-                const lastLoginAt = provider.user.lastLoginAt
-                  ? provider.user.lastLoginAt.toLocaleString()
-                  : "—";
-                return (
-                  <tr
-                    key={provider.id}
-                    className="hover:bg-[var(--surface-muted)]/50 transition-colors"
-                  >
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-full bg-[var(--accent)]/10 text-[var(--accent)] flex items-center justify-center font-medium">
-                          {initials(firstName, lastName)}
-                        </div>
-                        <div>
-                          <div className="font-medium text-text">
-                            Dr. {firstName} {lastName}
-                          </div>
-                          <div className="text-text-muted text-xs">
-                            {specialtyLabel}
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-1.5 text-text-muted">
-                        {isAdmin ? (
-                          <>
-                            <Shield className="w-3.5 h-3.5" /> Admin
-                          </>
-                        ) : (
-                          <>
-                            <UserIcon className="w-3.5 h-3.5" /> Clinician
-                          </>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4">
-                      <Badge tone="success" className="text-[10px]">
-                        Active
-                      </Badge>
-                    </td>
-                    <td className="px-6 py-4 text-text-muted">{lastLoginAt}</td>
-                    <td className="px-6 py-4 text-right">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 w-8 p-0 text-text-muted"
-                        aria-label="Actions"
-                      >
-                        <MoreHorizontal className="w-4 h-4" />
-                      </Button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <DataTable<MemberRow>
+        columns={columns}
+        rows={rows}
+        rowKey={(row) => row.id}
+        ariaLabel="Team members"
+        showDensityToggle
+      />
     </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/cme-ledger/ledger-view.tsx
+++ b/src/app/(clinician)/clinic/cme-ledger/ledger-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/cn";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import {
   type CmeCredit,
   type CmeBoard,
@@ -73,58 +74,13 @@ export function CmeLedgerView({
         <CardHeader>
           <CardTitle>Research sessions</CardTitle>
         </CardHeader>
-        <CardContent>
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wider">
-                <th className="pb-2 font-medium">Topic</th>
-                <th className="pb-2 font-medium">Engaged</th>
-                <th className="pb-2 font-medium">Refs</th>
-                <th className="pb-2 font-medium">Credit</th>
-                <th className="pb-2 font-medium">Status</th>
-                <th className="pb-2 font-medium text-right">Action</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {credits.map((c) => {
-                const s = sessionById.get(c.sessionId);
-                const minutes = s ? Math.round((new Date(s.endedAt).getTime() - new Date(s.startedAt).getTime()) / 60000) : 0;
-                return (
-                  <tr key={c.id}>
-                    <td className="py-3 align-top">
-                      <p className="text-text">{c.topic}</p>
-                      <p className="text-[11px] text-text-subtle font-mono">{c.attestationHash.slice(0, 12)}…</p>
-                    </td>
-                    <td className="py-3 align-top text-text-muted tabular-nums">{minutes}m</td>
-                    <td className="py-3 align-top text-text-muted tabular-nums">{s?.referencesViewed ?? "—"}</td>
-                    <td className="py-3 align-top text-text-muted tabular-nums">
-                      {c.creditMinutes === 0 ? (
-                        <span className="text-[11px] text-text-subtle">below floor</span>
-                      ) : (
-                        formatCreditHours(c.creditMinutes)
-                      )}
-                    </td>
-                    <td className="py-3 align-top">
-                      <Badge tone={STATUS_TONE[c.status]}>{c.status}</Badge>
-                    </td>
-                    <td className="py-3 align-top text-right">
-                      {c.status === "pending" && c.creditMinutes > 0 && (
-                        <Button size="sm" variant="secondary" onClick={() => attest(c.id)}>
-                          Attest
-                        </Button>
-                      )}
-                      {c.status === "earned" && (
-                        <SubmitMenu onSubmit={(b) => submit(c.id, b)} />
-                      )}
-                      {(c.status === "submitted" || c.status === "verified") && (
-                        <span className="text-[11px] text-text-subtle">to {c.submittedTo}</span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+        <CardContent className="px-0 sm:px-0">
+          <CreditsTable
+            credits={credits}
+            sessionById={sessionById}
+            attest={attest}
+            submit={submit}
+          />
         </CardContent>
       </Card>
 
@@ -143,6 +99,122 @@ export function CmeLedgerView({
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+// ---------------------------------------------------------- credits table
+//
+// Pulled out into its own component so the column defs (and the
+// per-credit derived fields like "engaged minutes") can live behind a
+// single useMemo without crowding the host view.
+
+function CreditsTable({
+  credits,
+  sessionById,
+  attest,
+  submit,
+}: {
+  credits: CmeCredit[];
+  sessionById: Map<string, ResearchSession>;
+  attest: (id: string) => void;
+  submit: (id: string, board: CmeBoard) => void;
+}) {
+  type Row = CmeCredit & { _minutes: number; _refs: number | null };
+  const rows: Row[] = useMemo(
+    () =>
+      credits.map((c) => {
+        const s = sessionById.get(c.sessionId);
+        const minutes = s
+          ? Math.round(
+              (new Date(s.endedAt).getTime() - new Date(s.startedAt).getTime()) / 60000,
+            )
+          : 0;
+        return { ...c, _minutes: minutes, _refs: s?.referencesViewed ?? null };
+      }),
+    [credits, sessionById],
+  );
+
+  const columns: ColumnDef<Row>[] = [
+    {
+      key: "topic",
+      label: "Topic",
+      sortable: true,
+      sortFn: (a, b) => a.topic.localeCompare(b.topic),
+      cell: (c) => (
+        <>
+          <p className="text-text">{c.topic}</p>
+          <p className="text-[11px] text-text-subtle font-mono">
+            {c.attestationHash.slice(0, 12)}…
+          </p>
+        </>
+      ),
+    },
+    {
+      key: "_minutes",
+      label: "Engaged",
+      sortable: true,
+      align: "right",
+      cell: (c) => <span className="text-text-muted">{c._minutes}m</span>,
+    },
+    {
+      key: "_refs",
+      label: "Refs",
+      sortable: true,
+      align: "right",
+      hideOnMobile: true,
+      cell: (c) => (
+        <span className="text-text-muted">{c._refs ?? "—"}</span>
+      ),
+    },
+    {
+      key: "creditMinutes",
+      label: "Credit",
+      sortable: true,
+      align: "right",
+      cell: (c) =>
+        c.creditMinutes === 0 ? (
+          <span className="text-[11px] text-text-subtle">below floor</span>
+        ) : (
+          <span className="text-text-muted">{formatCreditHours(c.creditMinutes)}</span>
+        ),
+    },
+    {
+      key: "status",
+      label: "Status",
+      sortable: true,
+      sortFn: (a, b) => a.status.localeCompare(b.status),
+      cell: (c) => <Badge tone={STATUS_TONE[c.status]}>{c.status}</Badge>,
+    },
+    {
+      key: "action",
+      label: "Action",
+      align: "right",
+      cell: (c) => (
+        <>
+          {c.status === "pending" && c.creditMinutes > 0 && (
+            <Button size="sm" variant="secondary" onClick={() => attest(c.id)}>
+              Attest
+            </Button>
+          )}
+          {c.status === "earned" && (
+            <SubmitMenu onSubmit={(b) => submit(c.id, b)} />
+          )}
+          {(c.status === "submitted" || c.status === "verified") && (
+            <span className="text-[11px] text-text-subtle">to {c.submittedTo}</span>
+          )}
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable<Row>
+      columns={columns}
+      rows={rows}
+      rowKey={(c) => c.id}
+      ariaLabel="CME credits"
+      className="border-0 rounded-none shadow-none"
+    />
   );
 }
 

--- a/src/app/(operator)/ops/analytics-lab/providers/leaderboard-view.tsx
+++ b/src/app/(operator)/ops/analytics-lab/providers/leaderboard-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import {
   Card,
   CardHeader,
@@ -9,6 +9,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils/cn";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 
 export interface ProviderRow {
   id: string;
@@ -28,12 +29,12 @@ type SortKey =
   | "revenue"
   | "agentAcceptance";
 
-const COLUMNS: { key: SortKey; label: string; suffix?: string }[] = [
+const COLUMNS: { key: SortKey; label: string }[] = [
   { key: "patientsThisMonth", label: "Patients this month" },
-  { key: "notesOnTimePct", label: "Notes <24h", suffix: "%" },
+  { key: "notesOnTimePct", label: "Notes <24h" },
   { key: "satisfactionNps", label: "Satisfaction (NPS)" },
-  { key: "revenue", label: "Revenue", suffix: "$" },
-  { key: "agentAcceptance", label: "Agent acceptance", suffix: "%" },
+  { key: "revenue", label: "Revenue" },
+  { key: "agentAcceptance", label: "Agent acceptance" },
 ];
 
 const TROPHIES = ["🥇", "🥈", "🥉"];
@@ -45,18 +46,9 @@ function formatCell(key: SortKey, value: number): string {
 }
 
 export function LeaderboardView({ rows }: { rows: ProviderRow[] }) {
-  const [sortKey, setSortKey] = useState<SortKey>("patientsThisMonth");
-  const [dir, setDir] = useState<"asc" | "desc">("desc");
-
-  const sorted = useMemo(() => {
-    const copy = [...rows];
-    copy.sort((a, b) =>
-      dir === "desc" ? b[sortKey] - a[sortKey] : a[sortKey] - b[sortKey]
-    );
-    return copy;
-  }, [rows, sortKey, dir]);
-
-  // Top-3 per column (independent of current sort)
+  // Top-3 per column (independent of current sort) — feeds the trophy
+  // glyphs so the visual cue stays anchored to the underlying data, not
+  // to whichever column the operator happens to be sorting by.
   const topByColumn = useMemo(() => {
     const result: Record<SortKey, string[]> = {
       patientsThisMonth: [],
@@ -75,6 +67,51 @@ export function LeaderboardView({ rows }: { rows: ProviderRow[] }) {
     return result;
   }, [rows]);
 
+  // Build column defs against ProviderRow — the primitive picks up the
+  // generic so every cell(row) is fully typed.
+  const columns: ColumnDef<ProviderRow>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        label: "Provider",
+        sortable: true,
+        sortFn: (a, b) => a.name.localeCompare(b.name),
+        cell: (row) => (
+          <>
+            <p className="font-medium text-text">{row.name}</p>
+            <p className="text-xs text-text-subtle">{row.specialty}</p>
+          </>
+        ),
+      },
+      ...COLUMNS.map<ColumnDef<ProviderRow>>((col) => ({
+        key: col.key,
+        label: col.label,
+        sortable: true,
+        align: "right" as const,
+        sortFn: (a, b) => a[col.key] - b[col.key],
+        cell: (row) => {
+          const topIdx = topByColumn[col.key].indexOf(row.id);
+          return (
+            <>
+              <span
+                className={cn(
+                  "font-medium",
+                  topIdx === 0 && "text-emerald-600",
+                )}
+              >
+                {formatCell(col.key, row[col.key])}
+              </span>
+              {topIdx >= 0 && (
+                <span className="ml-1.5">{TROPHIES[topIdx]}</span>
+              )}
+            </>
+          );
+        },
+      })),
+    ],
+    [topByColumn],
+  );
+
   return (
     <Card tone="raised">
       <CardHeader>
@@ -83,78 +120,15 @@ export function LeaderboardView({ rows }: { rows: ProviderRow[] }) {
           Click any column header to sort. 🥇🥈🥉 mark the top 3 in each column.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto -mx-6">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left">
-                <th className="px-6 py-3 text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
-                  Provider
-                </th>
-                {COLUMNS.map((col) => (
-                  <th
-                    key={col.key}
-                    className="px-4 py-3 text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle text-right select-none"
-                  >
-                    <button
-                      onClick={() => {
-                        if (sortKey === col.key) {
-                          setDir(dir === "desc" ? "asc" : "desc");
-                        } else {
-                          setSortKey(col.key);
-                          setDir("desc");
-                        }
-                      }}
-                      className={cn(
-                        "inline-flex items-center gap-1 hover:text-text transition-colors",
-                        sortKey === col.key && "text-accent"
-                      )}
-                    >
-                      {col.label}
-                      {sortKey === col.key && (
-                        <span>{dir === "desc" ? "↓" : "↑"}</span>
-                      )}
-                    </button>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {sorted.map((row) => (
-                <tr
-                  key={row.id}
-                  className="hover:bg-surface-muted/50 transition-colors"
-                >
-                  <td className="px-6 py-4">
-                    <p className="font-medium text-text">{row.name}</p>
-                    <p className="text-xs text-text-subtle">{row.specialty}</p>
-                  </td>
-                  {COLUMNS.map((col) => {
-                    const topIdx = topByColumn[col.key].indexOf(row.id);
-                    return (
-                      <td
-                        key={col.key}
-                        className="px-4 py-4 text-right tabular-nums"
-                      >
-                        <span
-                          className={cn(
-                            "font-medium",
-                            topIdx === 0 && "text-emerald-600"
-                          )}
-                        >
-                          {formatCell(col.key, row[col.key])}
-                        </span>
-                        {topIdx >= 0 && (
-                          <span className="ml-1.5">{TROPHIES[topIdx]}</span>
-                        )}
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+      <CardContent className="px-0 sm:px-0">
+        <DataTable<ProviderRow>
+          columns={columns}
+          rows={rows}
+          rowKey={(row) => row.id}
+          ariaLabel="Provider performance leaderboard"
+          className="border-0 rounded-none shadow-none"
+          showDensityToggle
+        />
       </CardContent>
     </Card>
   );

--- a/src/app/(operator)/ops/inventory/inventory-view.tsx
+++ b/src/app/(operator)/ops/inventory/inventory-view.tsx
@@ -3,8 +3,8 @@
 import { useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Input, FieldGroup, Textarea } from "@/components/ui/input";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import {
   classifyStatus,
   STATUS_STYLES,
@@ -257,89 +257,118 @@ export function InventoryView({ initialItems }: { initialItems: InventoryItem[] 
         </Card>
       )}
 
-      {/* Table */}
-      <Card tone="raised">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-[10px] uppercase tracking-wider text-text-subtle border-b border-border">
-                <th className="px-5 py-3 font-medium">Product</th>
-                <th className="px-5 py-3 font-medium">Brand</th>
-                <th className="px-5 py-3 font-medium">Type</th>
-                <th className="px-5 py-3 font-medium">SKU / UPC</th>
-                <th className="px-5 py-3 font-medium text-right">Quantity</th>
-                <th className="px-5 py-3 font-medium">Status</th>
-                <th className="px-5 py-3 font-medium text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={7}
-                    className="px-5 py-12 text-center text-text-subtle text-sm"
-                  >
-                    No items match your filters.
-                  </td>
-                </tr>
-              )}
-              {filtered.map((item) => {
-                const style = STATUS_STYLES[item.status];
-                return (
-                  <tr
-                    key={item.id}
-                    className="border-b border-border/40 hover:bg-surface-muted/40 transition-colors"
-                  >
-                    <td className="px-5 py-3.5">
-                      <p className="font-medium text-text">{item.productName}</p>
-                      <p className="text-[11px] text-text-subtle">
-                        Reorder at {item.reorderPoint} {item.unit}
-                      </p>
-                    </td>
-                    <td className="px-5 py-3.5 text-text-muted">{item.brand ?? "—"}</td>
-                    <td className="px-5 py-3.5 text-text-muted">{item.productType}</td>
-                    <td className="px-5 py-3.5">
-                      <p className="text-[11px] font-mono text-text-muted">
-                        {item.sku ?? "—"}
-                      </p>
-                      <p className="text-[10px] font-mono text-text-subtle">
-                        {item.upc ?? ""}
-                      </p>
-                    </td>
-                    <td className="px-5 py-3.5 text-right tabular-nums">
-                      <span className="font-medium text-text">{item.currentQuantity}</span>{" "}
-                      <span className="text-xs text-text-subtle">{item.unit}</span>
-                    </td>
-                    <td className="px-5 py-3.5">
-                      <span
-                        className={cn(
-                          "inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium",
-                          style.bg,
-                          style.text,
-                        )}
-                      >
-                        {style.label}
-                      </span>
-                    </td>
-                    <td className="px-5 py-3.5 text-right">
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => {
-                          setRestockTarget(item);
-                          setRestockQty(item.reorderQuantity);
-                        }}
-                      >
-                        Restock
-                      </Button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </Card>
+      {/* Table — adopts the DataTable primitive so sort, sticky header,
+          and density toggle come for free. */}
+      <DataTable<InventoryItem>
+        rows={filtered}
+        rowKey={(it) => it.id}
+        ariaLabel="Inventory items"
+        showDensityToggle
+        emptyState={
+          <p className="text-center text-text-subtle text-sm">
+            No items match your filters.
+          </p>
+        }
+        columns={[
+          {
+            key: "productName",
+            label: "Product",
+            sortable: true,
+            cell: (item) => (
+              <>
+                <p className="font-medium text-text">{item.productName}</p>
+                <p className="text-[11px] text-text-subtle">
+                  Reorder at {item.reorderPoint} {item.unit}
+                </p>
+              </>
+            ),
+          },
+          {
+            key: "brand",
+            label: "Brand",
+            sortable: true,
+            hideOnMobile: true,
+            cell: (item) => (
+              <span className="text-text-muted">{item.brand ?? "—"}</span>
+            ),
+          },
+          {
+            key: "productType",
+            label: "Type",
+            sortable: true,
+            hideOnMobile: true,
+            cell: (item) => (
+              <span className="text-text-muted">{item.productType}</span>
+            ),
+          },
+          {
+            key: "sku",
+            label: "SKU / UPC",
+            hideOnMobile: true,
+            cell: (item) => (
+              <>
+                <p className="text-[11px] font-mono text-text-muted">
+                  {item.sku ?? "—"}
+                </p>
+                <p className="text-[10px] font-mono text-text-subtle">
+                  {item.upc ?? ""}
+                </p>
+              </>
+            ),
+          },
+          {
+            key: "currentQuantity",
+            label: "Quantity",
+            sortable: true,
+            align: "right",
+            cell: (item) => (
+              <>
+                <span className="font-medium text-text">
+                  {item.currentQuantity}
+                </span>{" "}
+                <span className="text-xs text-text-subtle">{item.unit}</span>
+              </>
+            ),
+          },
+          {
+            key: "status",
+            label: "Status",
+            sortable: true,
+            sortFn: (a, b) => a.status.localeCompare(b.status),
+            cell: (item) => {
+              const style = STATUS_STYLES[item.status];
+              return (
+                <span
+                  className={cn(
+                    "inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium",
+                    style.bg,
+                    style.text,
+                  )}
+                >
+                  {style.label}
+                </span>
+              );
+            },
+          },
+          {
+            key: "actions",
+            label: "Actions",
+            align: "right",
+            cell: (item) => (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setRestockTarget(item);
+                  setRestockQty(item.reorderQuantity);
+                }}
+              >
+                Restock
+              </Button>
+            ),
+          },
+        ] as ColumnDef<InventoryItem>[]}
+      />
 
       {/* Restock modal */}
       {restockTarget && (

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,0 +1,671 @@
+"use client";
+
+// DataTable — the lightweight, Monday/Linear-tier table primitive that
+// every operator, admin, and clinician roster surface should adopt.
+//
+// Design goals (kept bespoke — explicitly no @tanstack/react-table):
+//
+//   - One generic <DataTable<Row>> with full TypeScript inference on
+//     every column's `cell(row)`.
+//   - Sticky header that floats over a scroll container (`position:
+//     sticky; top: 0`).
+//   - Tri-state sort on click: asc → desc → cleared (back to the
+//     incoming row order). Arrow indicator is ▲ / ▼ at 60% opacity so it
+//     never dominates the header text. Pass `sortFn` for custom
+//     compares; otherwise the column's `key` is read off the row and
+//     compared with `localeCompare` (strings) or numeric subtraction.
+//   - Optional row selection. Controlled via
+//     `{ selected: Set<string>, onChange, rowKey }`. Renders a checkbox
+//     column with header tri-state for "select all visible".
+//   - Density toggle (`comfortable` default | `dense`). Apple-iOS
+//     `comfortable` = generous row padding (44px tap target on touch),
+//     subtle dividers; `dense` halves vertical padding for power users.
+//   - Loading state via the `isLoading` flag — renders skeleton rows
+//     sized to the column set (uses the existing <Skeleton> primitive
+//     from PR #456 so the parchment shimmer matches the rest of the
+//     app).
+//   - Empty state slot. If `emptyState` is supplied (typically the
+//     existing <EmptyState> from PR #457) it renders inside a single
+//     full-width row when `rows.length === 0`.
+//   - Optional row click (`onRowClick(row)`). When set, every row gets
+//     `cursor: pointer` + a subtle `hover:bg-surface-muted/50` overlay.
+//   - Keyboard nav: arrow up/down moves the row focus ring, Enter
+//     toggles selection when a `selection` prop is set, Space toggles
+//     selection on the focused row. Focus is intrinsic to the table
+//     (tab in once) — we don't trap, we just route arrows internally.
+//   - Numerics get `tabular-nums` automatically when `align: "right"`.
+//
+// The primitive ships zero filtering / pagination / virtualisation —
+// the caller is expected to slice/filter upstream (the operator filter
+// chrome from PR #446 sits above us). One job, done well.
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ----------------------------------------------------------------- types
+
+export type DataTableAlign = "left" | "center" | "right";
+
+export type DataTableDensity = "comfortable" | "dense";
+
+export interface ColumnDef<Row> {
+  /** Stable column id. Also used as the field accessor on `row` when no
+   *  custom `cell` or `sortFn` is supplied. Pass a string that's safe to
+   *  use as a React key. */
+  key: string;
+  /** Visible header text. Override with `headerCell` for chrome. */
+  label: string;
+  /** When true, header is clickable to tri-state sort the column. */
+  sortable?: boolean;
+  /** Custom comparator. Receives the two row objects in the table's
+   *  current order; should return < 0 / 0 / > 0 like Array.prototype.sort. */
+  sortFn?: (a: Row, b: Row) => number;
+  /** Optional fixed width (CSS value). Useful for checkbox / actions cols. */
+  width?: string;
+  /** Cell + header alignment. Defaults to "left" — "right" auto-enables
+   *  `tabular-nums` for clean numeric columns. */
+  align?: DataTableAlign;
+  /** Cell renderer. Defaults to `(row) => row[key]`. */
+  cell?: (row: Row, ctx: { index: number }) => React.ReactNode;
+  /** Header renderer override. The default already provides sort UI. */
+  headerCell?: () => React.ReactNode;
+  /** Hide on mobile (<= sm). Useful for secondary numeric columns. */
+  hideOnMobile?: boolean;
+}
+
+export interface DataTableSelection<Row> {
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+  rowKey: (row: Row) => string;
+}
+
+export interface DataTableProps<Row> {
+  columns: ColumnDef<Row>[];
+  rows: Row[];
+  /** Stable per-row key. Defaults to `selection.rowKey` if supplied,
+   *  otherwise to the row's index — pass an explicit `rowKey` for stable
+   *  React reconciliation on filtered lists. */
+  rowKey?: (row: Row, index: number) => string;
+  selection?: DataTableSelection<Row>;
+  density?: DataTableDensity;
+  /** Show a density toggle in the upper-right of the table header. */
+  showDensityToggle?: boolean;
+  /** Callback when a whole row is clicked. Triggers `cursor-pointer`. */
+  onRowClick?: (row: Row, index: number) => void;
+  isLoading?: boolean;
+  /** Number of skeleton rows to render while loading. */
+  loadingRowCount?: number;
+  /** Slot for an empty-state element (use `<EmptyState>` from PR #457). */
+  emptyState?: React.ReactNode;
+  /** Optional caption rendered above the table, after the toolbar. */
+  caption?: React.ReactNode;
+  /** Toolbar slot — rendered above the table, e.g. filter chips. */
+  toolbar?: React.ReactNode;
+  /** Sticky header — defaults to true. Disable for short tables nested
+   *  inside other scroll containers. */
+  stickyHeader?: boolean;
+  /** Max height for the scroll container (e.g. "60vh"). When set, the
+   *  table scrolls internally and the header sticks to its top. */
+  maxHeight?: string;
+  /** Aria label for screen readers. Required when caption is absent. */
+  ariaLabel?: string;
+  className?: string;
+  /** Extra row className resolver — useful for highlighting alerts. */
+  rowClassName?: (row: Row, index: number) => string | undefined;
+}
+
+interface SortState {
+  key: string;
+  dir: "asc" | "desc";
+}
+
+// ----------------------------------------------------------- comparators
+
+function defaultCompare<Row>(key: keyof Row & string, a: Row, b: Row): number {
+  const av = (a as Record<string, unknown>)[key];
+  const bv = (b as Record<string, unknown>)[key];
+  if (av == null && bv == null) return 0;
+  if (av == null) return -1;
+  if (bv == null) return 1;
+  if (typeof av === "number" && typeof bv === "number") return av - bv;
+  if (av instanceof Date && bv instanceof Date) {
+    return av.getTime() - bv.getTime();
+  }
+  return String(av).localeCompare(String(bv), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+// ----------------------------------------------------------- ▲/▼ glyphs
+
+function SortGlyph({ dir }: { dir: "asc" | "desc" | null }) {
+  if (!dir) {
+    return (
+      <span
+        aria-hidden="true"
+        className="ml-1 inline-block w-2.5 text-[9px] leading-none text-text-subtle/50 select-none"
+      >
+        ⇅
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className="ml-1 inline-block w-2.5 text-[9px] leading-none text-accent select-none"
+    >
+      {dir === "asc" ? "▲" : "▼"}
+    </span>
+  );
+}
+
+// ----------------------------------------- header / row class composition
+
+function paddingForDensity(density: DataTableDensity, kind: "row" | "head") {
+  if (kind === "head") {
+    return density === "dense" ? "px-3 py-2" : "px-4 py-3";
+  }
+  return density === "dense" ? "px-3 py-2" : "px-4 py-3.5";
+}
+
+function alignClass(align: DataTableAlign | undefined): string {
+  switch (align) {
+    case "right":
+      return "text-right tabular-nums";
+    case "center":
+      return "text-center";
+    default:
+      return "text-left";
+  }
+}
+
+// ------------------------------------------------------------ select cell
+
+interface SelectionContext {
+  isSelected: (key: string) => boolean;
+  toggle: (key: string) => void;
+  toggleAll: (visibleKeys: string[]) => void;
+  visibleAllSelected: boolean;
+  visibleSomeSelected: boolean;
+}
+
+function SelectionCheckbox({
+  checked,
+  indeterminate,
+  onToggle,
+  ariaLabel,
+}: {
+  checked: boolean;
+  indeterminate?: boolean;
+  onToggle: () => void;
+  ariaLabel: string;
+}) {
+  const ref = React.useRef<HTMLInputElement | null>(null);
+  React.useEffect(() => {
+    if (ref.current) ref.current.indeterminate = !!indeterminate && !checked;
+  }, [indeterminate, checked]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onToggle}
+      onClick={(e) => e.stopPropagation()}
+      aria-label={ariaLabel}
+      className={cn(
+        "h-4 w-4 rounded border-border-strong text-accent",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        "transition-colors cursor-pointer",
+      )}
+    />
+  );
+}
+
+// ------------------------------------------------------------- DataTable
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  rowKey,
+  selection,
+  density: densityProp,
+  showDensityToggle = false,
+  onRowClick,
+  isLoading = false,
+  loadingRowCount = 6,
+  emptyState,
+  caption,
+  toolbar,
+  stickyHeader = true,
+  maxHeight,
+  ariaLabel,
+  className,
+  rowClassName,
+}: DataTableProps<Row>) {
+  // Density: support both controlled (prop) and uncontrolled-with-toggle.
+  const [internalDensity, setInternalDensity] =
+    React.useState<DataTableDensity>("comfortable");
+  const density: DataTableDensity = densityProp ?? internalDensity;
+
+  // Tri-state sort: asc → desc → null.
+  const [sort, setSort] = React.useState<SortState | null>(null);
+
+  function cycleSort(colKey: string) {
+    setSort((prev) => {
+      if (!prev || prev.key !== colKey) return { key: colKey, dir: "asc" };
+      if (prev.dir === "asc") return { key: colKey, dir: "desc" };
+      return null; // back to natural order
+    });
+  }
+
+  // Per-row stable key resolver — selection.rowKey wins if available.
+  const keyFor = React.useCallback(
+    (row: Row, index: number) => {
+      if (rowKey) return rowKey(row, index);
+      if (selection) return selection.rowKey(row);
+      return String(index);
+    },
+    [rowKey, selection],
+  );
+
+  // Apply sort. Empty `sort` ⇒ identity slice.
+  const sortedRows = React.useMemo(() => {
+    if (!sort) return rows;
+    const col = columns.find((c) => c.key === sort.key);
+    if (!col) return rows;
+    const cmp = col.sortFn ?? ((a: Row, b: Row) => defaultCompare(col.key as keyof Row & string, a, b));
+    const copy = [...rows];
+    copy.sort((a, b) => (sort.dir === "asc" ? cmp(a, b) : -cmp(a, b)));
+    return copy;
+  }, [rows, columns, sort]);
+
+  // ---- Selection helpers --------------------------------------------------
+  const selectionCtx: SelectionContext | null = React.useMemo(() => {
+    if (!selection) return null;
+    const visibleKeys = sortedRows.map((r) => selection.rowKey(r));
+    const visibleAllSelected =
+      visibleKeys.length > 0 &&
+      visibleKeys.every((k) => selection.selected.has(k));
+    const visibleSomeSelected = visibleKeys.some((k) =>
+      selection.selected.has(k),
+    );
+    return {
+      isSelected: (k) => selection.selected.has(k),
+      toggle: (k) => {
+        const next = new Set(selection.selected);
+        if (next.has(k)) next.delete(k);
+        else next.add(k);
+        selection.onChange(next);
+      },
+      toggleAll: (keys) => {
+        const next = new Set(selection.selected);
+        const everySelected = keys.every((k) => next.has(k));
+        if (everySelected) keys.forEach((k) => next.delete(k));
+        else keys.forEach((k) => next.add(k));
+        selection.onChange(next);
+      },
+      visibleAllSelected,
+      visibleSomeSelected,
+    };
+  }, [selection, sortedRows]);
+
+  // ---- Keyboard nav state -------------------------------------------------
+  const [focusedIndex, setFocusedIndex] = React.useState<number | null>(null);
+  const tableContainerRef = React.useRef<HTMLDivElement | null>(null);
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (sortedRows.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((i) =>
+        i == null ? 0 : Math.min(sortedRows.length - 1, i + 1),
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((i) => (i == null ? 0 : Math.max(0, i - 1)));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setFocusedIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setFocusedIndex(sortedRows.length - 1);
+    } else if (
+      (e.key === " " || e.key === "Enter") &&
+      focusedIndex != null &&
+      selection &&
+      selectionCtx
+    ) {
+      e.preventDefault();
+      const row = sortedRows[focusedIndex];
+      selectionCtx.toggle(selection.rowKey(row));
+    }
+  }
+
+  // Reset focus when the row set identity changes (e.g. after re-filter).
+  React.useEffect(() => {
+    setFocusedIndex(null);
+  }, [rows]);
+
+  // ---- Render -------------------------------------------------------------
+
+  const totalCols = columns.length + (selection ? 1 : 0);
+  const showEmpty = !isLoading && sortedRows.length === 0 && !!emptyState;
+
+  return (
+    <div
+      className={cn(
+        // Apple-iOS card: tinted parchment, subtle border + shadow.
+        "relative overflow-hidden rounded-2xl border border-border/70 bg-surface",
+        "shadow-sm",
+        className,
+      )}
+    >
+      {(toolbar || showDensityToggle) && (
+        <div
+          className={cn(
+            "flex items-center gap-3 border-b border-border/60",
+            "px-4 py-2.5",
+          )}
+        >
+          <div className="flex-1 min-w-0">{toolbar}</div>
+          {showDensityToggle && (
+            <DensityToggle
+              value={density}
+              onChange={(v) => {
+                // If parent passed a controlled density, this is a no-op
+                // (we still call setInternalDensity so the toggle visually
+                // reflects intent even under control — but the prop wins).
+                setInternalDensity(v);
+              }}
+              disabled={densityProp != null}
+            />
+          )}
+        </div>
+      )}
+
+      <div
+        ref={tableContainerRef}
+        tabIndex={selection ? 0 : -1}
+        onKeyDown={onKeyDown}
+        role="region"
+        aria-label={ariaLabel}
+        className={cn(
+          "relative overflow-auto",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        )}
+        style={maxHeight ? { maxHeight } : undefined}
+      >
+        <table
+          className="w-full border-collapse text-sm"
+          aria-label={ariaLabel}
+        >
+          {caption && (
+            <caption className="sr-only">
+              {typeof caption === "string" ? caption : "Data table"}
+            </caption>
+          )}
+
+          <thead
+            className={cn(
+              "bg-surface-muted/60 text-text-subtle",
+              stickyHeader && "sticky top-0 z-10",
+              "backdrop-blur-[2px]",
+            )}
+          >
+            <tr className="border-b border-border/60">
+              {selection && selectionCtx && (
+                <th
+                  scope="col"
+                  className={cn(
+                    paddingForDensity(density, "head"),
+                    "w-10 align-middle",
+                  )}
+                >
+                  <SelectionCheckbox
+                    checked={selectionCtx.visibleAllSelected}
+                    indeterminate={
+                      selectionCtx.visibleSomeSelected &&
+                      !selectionCtx.visibleAllSelected
+                    }
+                    onToggle={() =>
+                      selectionCtx.toggleAll(
+                        sortedRows.map((r) => selection.rowKey(r)),
+                      )
+                    }
+                    ariaLabel="Select all visible rows"
+                  />
+                </th>
+              )}
+              {columns.map((col) => {
+                const isSorted = sort?.key === col.key;
+                const dir = isSorted ? sort!.dir : null;
+                const headerContent = col.headerCell ? (
+                  col.headerCell()
+                ) : (
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-0.5",
+                      "text-[11px] font-medium uppercase tracking-[0.12em]",
+                      isSorted ? "text-text" : "text-text-subtle",
+                    )}
+                  >
+                    {col.label}
+                    {col.sortable && <SortGlyph dir={dir} />}
+                  </span>
+                );
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    style={col.width ? { width: col.width } : undefined}
+                    className={cn(
+                      paddingForDensity(density, "head"),
+                      alignClass(col.align),
+                      "font-medium",
+                      col.hideOnMobile && "hidden sm:table-cell",
+                    )}
+                    aria-sort={
+                      isSorted
+                        ? dir === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : col.sortable
+                          ? "none"
+                          : undefined
+                    }
+                  >
+                    {col.sortable ? (
+                      <button
+                        type="button"
+                        onClick={() => cycleSort(col.key)}
+                        className={cn(
+                          "inline-flex items-center",
+                          "transition-colors hover:text-text",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 rounded-sm",
+                        )}
+                      >
+                        {headerContent}
+                      </button>
+                    ) : (
+                      headerContent
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody className="divide-y divide-border/50">
+            {isLoading && (
+              <SkeletonRows
+                rowCount={loadingRowCount}
+                columns={columns}
+                density={density}
+                hasSelection={!!selection}
+              />
+            )}
+
+            {!isLoading && showEmpty && (
+              <tr>
+                <td colSpan={totalCols} className="px-0 py-0">
+                  <div className="p-6 sm:p-8">{emptyState}</div>
+                </td>
+              </tr>
+            )}
+
+            {!isLoading &&
+              !showEmpty &&
+              sortedRows.map((row, idx) => {
+                const k = keyFor(row, idx);
+                const selected = selectionCtx?.isSelected(k) ?? false;
+                const focused = focusedIndex === idx;
+                const interactive = !!onRowClick;
+                const extraRowClass = rowClassName?.(row, idx);
+                return (
+                  <tr
+                    key={k}
+                    onClick={() => onRowClick?.(row, idx)}
+                    onMouseEnter={() => setFocusedIndex(idx)}
+                    className={cn(
+                      "transition-colors",
+                      interactive && "cursor-pointer",
+                      focused && "bg-accent-soft/30",
+                      selected && "bg-accent-soft/50",
+                      !selected && !focused && "hover:bg-surface-muted/40",
+                      extraRowClass,
+                    )}
+                    aria-selected={selection ? selected : undefined}
+                  >
+                    {selection && selectionCtx && (
+                      <td
+                        className={cn(
+                          paddingForDensity(density, "row"),
+                          "align-middle",
+                        )}
+                      >
+                        <SelectionCheckbox
+                          checked={selected}
+                          onToggle={() =>
+                            selectionCtx.toggle(selection.rowKey(row))
+                          }
+                          ariaLabel={`Select row ${idx + 1}`}
+                        />
+                      </td>
+                    )}
+                    {columns.map((col) => {
+                      const content = col.cell
+                        ? col.cell(row, { index: idx })
+                        : (row as Record<string, React.ReactNode>)[col.key];
+                      return (
+                        <td
+                          key={col.key}
+                          className={cn(
+                            paddingForDensity(density, "row"),
+                            alignClass(col.align),
+                            "align-middle text-text",
+                            col.hideOnMobile && "hidden sm:table-cell",
+                          )}
+                        >
+                          {content as React.ReactNode}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ------------------------------------------------------------- skeleton
+
+function SkeletonRows<Row>({
+  rowCount,
+  columns,
+  density,
+  hasSelection,
+}: {
+  rowCount: number;
+  columns: ColumnDef<Row>[];
+  density: DataTableDensity;
+  hasSelection: boolean;
+}) {
+  return (
+    <>
+      {Array.from({ length: rowCount }).map((_, r) => (
+        <tr key={`sk-${r}`}>
+          {hasSelection && (
+            <td className={paddingForDensity(density, "row")}>
+              <Skeleton className="h-4 w-4 rounded" />
+            </td>
+          )}
+          {columns.map((col) => (
+            <td
+              key={col.key}
+              className={cn(
+                paddingForDensity(density, "row"),
+                alignClass(col.align),
+                col.hideOnMobile && "hidden sm:table-cell",
+              )}
+            >
+              <Skeleton
+                className={cn(
+                  "h-3.5 rounded",
+                  col.align === "right" ? "ml-auto w-16" : "w-3/4",
+                )}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ---------------------------------------------------------- density toggle
+
+function DensityToggle({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: DataTableDensity;
+  onChange: (next: DataTableDensity) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Row density"
+      className={cn(
+        "inline-flex items-center rounded-full border border-border bg-surface p-0.5",
+        disabled && "opacity-50 pointer-events-none",
+      )}
+    >
+      {(["comfortable", "dense"] as DataTableDensity[]).map((opt) => {
+        const active = value === opt;
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onChange(opt)}
+            aria-pressed={active}
+            className={cn(
+              "h-7 px-3 rounded-full text-[11px] font-medium transition-colors",
+              active
+                ? "bg-text text-surface"
+                : "text-text-muted hover:text-text",
+            )}
+          >
+            {opt === "comfortable" ? "Comfortable" : "Dense"}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Introduces a lightweight, bespoke table primitive at `src/components/ui/data-table.tsx` that brings Monday.com / Linear chrome to operator, admin, and clinician tabular surfaces. Sits below the `filter-bar.tsx` primitive from PR #446 — filter chrome on top, table primitive on the bottom. Composes with `EmptyState` (PR #457) and the `Skeleton` primitive (PR #456). Zero new dependencies — explicitly **not** `@tanstack/react-table`.

## API

```ts
<DataTable<Row>
  columns={[
    { key, label, sortable?, sortFn?, width?, align?, cell?, headerCell?, hideOnMobile? }
  ]}
  rows={Row[]}
  rowKey={(row) => string}
  selection?={ selected: Set<string>, onChange, rowKey }
  density?="comfortable" | "dense"      // default: comfortable
  showDensityToggle?                     // renders pill toggle in toolbar
  onRowClick?={(row, i) => void}
  isLoading?
  loadingRowCount?
  emptyState?={<EmptyState … />}
  toolbar?
  caption?
  stickyHeader?                          // default: true
  maxHeight?                             // e.g. "60vh"
  rowClassName?
  ariaLabel
/>
```

### Features
- Generic `<DataTable<Row>>` with full TS inference on every `cell(row)`
- Tri-state sortable columns (asc → desc → cleared) with subtle ▲ / ▼ at 60% opacity
- Sticky header (`position: sticky; top: 0`) with `backdrop-blur` for legibility
- Optional row selection with header tri-state "select all visible" checkbox
- Density toggle (`comfortable` = 44px Apple-iOS tap target; `dense` halves vertical padding)
- Loading state with `<Skeleton>` rows sized to the column set
- Empty state slot wraps `<EmptyState>` from PR #457 in a single full-width row
- Keyboard nav: ArrowUp/Down + Home/End move focus; Space / Enter toggle selection
- Auto `tabular-nums` on right-aligned columns
- `hideOnMobile` flag for secondary columns
- Compatible with URL-driven filters from PR #446 — the table just renders rows it's given

## Adoption sites (4)

| Surface | File |
|---|---|
| Team members roster | `src/app/(clinician)/[orgId]/settings/members/page.tsx` |
| CME ledger credits | `src/app/(clinician)/clinic/cme-ledger/ledger-view.tsx` |
| Provider analytics leaderboard | `src/app/(operator)/ops/analytics-lab/providers/leaderboard-view.tsx` |
| Operator inventory roster | `src/app/(operator)/ops/inventory/inventory-view.tsx` |

### Intentionally left alone
- **Super-admin audit log** (`/admin/audit`) — bespoke j/k + expand-row semantics + per-row JSON metadata expansion that the primitive doesn't model. Migration path is open via the `cell()` slot but warrants a dedicated follow-up.
- **Clinician patient roster** — renders a visual UL with sparklines and multi-line subtitles, not strictly tabular. The primitive is a drop-in if/when that surface warrants a tabular refactor.

## Test plan
- [ ] Sort each column on /admin… leaderboard; verify asc → desc → cleared cycle and ▲/▼ glyph
- [ ] Toggle Comfortable / Dense — row padding should visibly halve in dense
- [ ] Verify sticky header at /(operator)/ops/inventory while scrolling table rows
- [ ] Verify CME ledger keeps Attest / Submit affordances on each row
- [ ] Verify keyboard ArrowDown/Up moves focus ring on rows
- [ ] Verify the new Members table still hits the same `/settings/members/[orgId]` URL and renders for clinicians + practice_admin + super_admin
- [ ] Verify no regression to PR #446's URL-driven filters (the table only renders what it's handed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)