### PR TITLE
ux: dark mode — tokens + ThemeProvider + 3-state toggle + spot-checked surfaces

### DIFF
--- a/src/app/(patient)/portal/settings/page.tsx
+++ b/src/app/(patient)/portal/settings/page.tsx
@@ -32,15 +32,15 @@ export default async function SettingsPage() {
           <CardHeader>
             <CardTitle>Appearance</CardTitle>
             <CardDescription>
-              Choose between light and dark mode. Your preference is saved locally.
+              Choose Light, Dark, or follow your system preference. Your choice is saved locally.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-4 flex-wrap">
               <div>
                 <p className="text-sm font-medium text-text">Theme</p>
                 <p className="text-xs text-text-subtle mt-0.5">
-                  Toggle between light and dark mode
+                  Light, Dark, or System (follows OS)
                 </p>
               </div>
               <ThemeToggle />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,9 +49,13 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600&family=Instrument+Serif:ital@1&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap"
           rel="stylesheet"
         />
+        {/* Theme bootstrap — runs before paint to prevent FOUC.
+            Reads localStorage("leafjourney-theme") which can be
+            "light" | "dark" | "system" (default: "system").
+            Resolves "system" against prefers-color-scheme. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem("leafjourney-theme");if(t==="dark"){document.documentElement.setAttribute("data-theme","dark")}}catch(e){}})();`,
+            __html: `(function(){try{var t=localStorage.getItem("leafjourney-theme")||"system";var d=t==="dark"||(t==="system"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches);if(d){document.documentElement.setAttribute("data-theme","dark")}else{document.documentElement.removeAttribute("data-theme")}}catch(e){}})();`,
           }}
         />
       </head>

--- a/src/components/leafmart/ThemeToggle.tsx
+++ b/src/components/leafmart/ThemeToggle.tsx
@@ -2,12 +2,28 @@
 
 import { useEffect, useState } from "react";
 
-const STORAGE_KEY = "leafmart-theme";
+// Unified with the main app toggle so user preference persists
+// when navigating between leafmart and the clinician/patient shells.
+const STORAGE_KEY = "leafjourney-theme";
+const LEGACY_KEY = "leafmart-theme";
 
 type ThemeMode = "light" | "dark";
 
 function getStoredMode(): ThemeMode | null {
   if (typeof window === "undefined") return null;
+  // Migrate any pre-existing "leafmart-theme" value once, so users who
+  // toggled before the unification don't lose their preference.
+  try {
+    const legacy = window.localStorage.getItem(LEGACY_KEY);
+    if (legacy === "dark" || legacy === "light") {
+      if (!window.localStorage.getItem(STORAGE_KEY)) {
+        window.localStorage.setItem(STORAGE_KEY, legacy);
+      }
+      window.localStorage.removeItem(LEGACY_KEY);
+    }
+  } catch {
+    // ignore
+  }
   const v = window.localStorage.getItem(STORAGE_KEY);
   return v === "dark" || v === "light" ? v : null;
 }
@@ -24,6 +40,14 @@ function applyMode(mode: ThemeMode) {
   wrappers.forEach((el) => {
     el.classList.toggle("dark", mode === "dark");
   });
+  // Also flip the data-theme attribute on <html> so the unified
+  // bootstrap script (src/app/layout.tsx) and tailwind's dark:
+  // selector see the same source of truth across the whole app.
+  if (mode === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
 }
 
 export function ThemeToggle() {

--- a/src/components/marketing/SiteFooter.tsx
+++ b/src/components/marketing/SiteFooter.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { Wordmark } from "@/components/ui/logo";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 type FooterLink = { label: string; href?: string; external?: boolean };
 
@@ -263,9 +264,10 @@ export function SiteFooter() {
             <span>&copy; {new Date().getFullYear()} Leafjourney Health.</span>
             <BackToTop />
           </div>
-          <div className="flex flex-col sm:flex-row gap-1 sm:gap-4">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
             <span>Hemp-derived products ship nationally where permitted.</span>
             <span>Licensed cannabis available intrastate only.</span>
+            <ThemeToggle />
           </div>
         </div>
       </div>

--- a/src/components/shell/RailIdentityMenu.tsx
+++ b/src/components/shell/RailIdentityMenu.tsx
@@ -5,6 +5,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { SignOutButton } from "@clerk/nextjs";
 import type { AuthedUser } from "@/lib/auth/session";
 import { cn } from "@/lib/utils/cn";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export function RailIdentityMenu({
   user,
@@ -62,6 +63,15 @@ export function RailIdentityMenu({
           </div>
 
           <div className="mt-2 border-t border-border/70 pt-2">
+            <div className="px-3 pb-2">
+              <p className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+                Appearance
+              </p>
+              <ThemeToggle className="w-full justify-between" />
+            </div>
+          </div>
+
+          <div className="mt-1 border-t border-border/70 pt-2">
             {typeof window !== "undefined" && !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ? (
               <SignOutButton redirectUrl="/sign-in">
                 <button

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,88 +1,282 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { cn } from "@/lib/utils/cn";
 
-type Theme = "light" | "dark";
+/**
+ * Three-state theme toggle: Light · Dark · System.
+ *
+ * - Persists choice in localStorage("leafjourney-theme") as
+ *   "light" | "dark" | "system".
+ * - When "system", follows `prefers-color-scheme` and updates live
+ *   if the OS preference changes.
+ * - SSR-safe: renders a stable shell, hydrates real state on mount
+ *   to avoid hydration mismatches.
+ * - Works in lockstep with the inline bootstrap script in
+ *   `src/app/layout.tsx` which prevents FOUC by applying the
+ *   resolved theme to <html> before paint.
+ */
 
-export function ThemeToggle({ className }: { className?: string }) {
-  const [theme, setTheme] = useState<Theme>("light");
+type ThemeMode = "light" | "dark" | "system";
+
+const STORAGE_KEY = "leafjourney-theme";
+
+function getStoredMode(): ThemeMode {
+  if (typeof window === "undefined") return "system";
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (v === "light" || v === "dark" || v === "system") return v;
+  } catch {
+    // localStorage unavailable — fall back to system
+  }
+  return "system";
+}
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+}
+
+function applyMode(mode: ThemeMode) {
+  if (typeof document === "undefined") return;
+  const resolved =
+    mode === "dark" || (mode === "system" && getSystemPrefersDark())
+      ? "dark"
+      : "light";
+  if (resolved === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
+type Variant = "segmented" | "icon";
+
+export function ThemeToggle({
+  className,
+  variant = "segmented",
+}: {
+  className?: string;
+  variant?: Variant;
+}) {
+  const [mode, setMode] = useState<ThemeMode>("system");
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("leafjourney-theme") as Theme | null;
-    const current = stored ?? "light";
-    setTheme(current);
-    document.documentElement.setAttribute("data-theme", current);
+    const initial = getStoredMode();
+    setMode(initial);
+    applyMode(initial);
+    setMounted(true);
   }, []);
 
-  function toggle() {
-    const next: Theme = theme === "light" ? "dark" : "light";
-    setTheme(next);
-    document.documentElement.setAttribute("data-theme", next);
-    localStorage.setItem("leafjourney-theme", next);
+  // Live-react to OS scheme changes while in "system" mode.
+  useEffect(() => {
+    if (!mounted) return;
+    const mq = window.matchMedia?.("(prefers-color-scheme: dark)");
+    if (!mq) return;
+    const handler = () => {
+      if (getStoredMode() === "system") applyMode("system");
+    };
+    mq.addEventListener?.("change", handler);
+    return () => mq.removeEventListener?.("change", handler);
+  }, [mounted]);
+
+  const choose = useCallback((next: ThemeMode) => {
+    setMode(next);
+    applyMode(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // keep visual change even if storage fails
+    }
+  }, []);
+
+  if (variant === "icon") {
+    return (
+      <IconCycleToggle
+        mode={mode}
+        mounted={mounted}
+        onCycle={choose}
+        className={className}
+      />
+    );
   }
 
   return (
-    <button
-      onClick={toggle}
+    <div
+      role="radiogroup"
+      aria-label="Theme"
       className={cn(
-        "relative inline-flex items-center justify-center h-9 w-9 rounded-md",
-        "text-text-muted hover:text-text hover:bg-surface-muted",
-        "transition-colors duration-200",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-        className
+        "inline-flex items-center gap-1 rounded-full border border-border bg-surface-muted p-1",
+        className,
       )}
-      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-      title={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
     >
-      {/* Sun icon — shown in dark mode */}
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className={cn(
-          "absolute transition-all duration-300",
-          theme === "dark"
-            ? "opacity-100 rotate-0 scale-100"
-            : "opacity-0 rotate-90 scale-0"
-        )}
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="5" />
-        <line x1="12" y1="1" x2="12" y2="3" />
-        <line x1="12" y1="21" x2="12" y2="23" />
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-        <line x1="1" y1="12" x2="3" y2="12" />
-        <line x1="21" y1="12" x2="23" y2="12" />
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-      </svg>
-      {/* Moon icon — shown in light mode */}
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className={cn(
-          "absolute transition-all duration-300",
-          theme === "light"
-            ? "opacity-100 rotate-0 scale-100"
-            : "opacity-0 -rotate-90 scale-0"
-        )}
-        aria-hidden="true"
-      >
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-      </svg>
+      <SegmentButton
+        label="Light"
+        active={mounted && mode === "light"}
+        onClick={() => choose("light")}
+        icon={<SunIcon />}
+      />
+      <SegmentButton
+        label="System"
+        active={mounted && mode === "system"}
+        onClick={() => choose("system")}
+        icon={<SystemIcon />}
+      />
+      <SegmentButton
+        label="Dark"
+        active={mounted && mode === "dark"}
+        onClick={() => choose("dark")}
+        icon={<MoonIcon />}
+      />
+    </div>
+  );
+}
+
+function SegmentButton({
+  label,
+  active,
+  onClick,
+  icon,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        active
+          ? "bg-surface text-text shadow-sm"
+          : "text-text-subtle hover:text-text",
+      )}
+      title={`${label} theme`}
+    >
+      <span aria-hidden="true" className="inline-flex">
+        {icon}
+      </span>
+      <span>{label}</span>
     </button>
+  );
+}
+
+/**
+ * Compact icon variant — single button that cycles Light → System → Dark.
+ * Useful in dense headers / nav rails where a segmented control won't fit.
+ */
+function IconCycleToggle({
+  mode,
+  mounted,
+  onCycle,
+  className,
+}: {
+  mode: ThemeMode;
+  mounted: boolean;
+  onCycle: (next: ThemeMode) => void;
+  className?: string;
+}) {
+  const order: ThemeMode[] = ["light", "system", "dark"];
+  const next = () => {
+    const idx = order.indexOf(mode);
+    const n = order[(idx + 1) % order.length];
+    onCycle(n);
+  };
+  const label =
+    mode === "light"
+      ? "Light theme (click for system)"
+      : mode === "dark"
+        ? "Dark theme (click for light)"
+        : "System theme (click for dark)";
+  return (
+    <button
+      type="button"
+      onClick={next}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex h-9 w-9 items-center justify-center rounded-md",
+        "text-text-muted transition-colors hover:bg-surface-muted hover:text-text",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        className,
+      )}
+    >
+      {/* Render a single icon, but render nothing until mounted so SSR
+          and first client render match (avoids hydration warnings). */}
+      {mounted && mode === "light" && <SunIcon />}
+      {mounted && mode === "dark" && <MoonIcon />}
+      {mounted && mode === "system" && <SystemIcon />}
+      {!mounted && <span className="block h-[14px] w-[14px]" aria-hidden="true" />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="4" />
+      <line x1="12" y1="20" x2="12" y2="22" />
+      <line x1="4.93" y1="4.93" x2="6.34" y2="6.34" />
+      <line x1="17.66" y1="17.66" x2="19.07" y2="19.07" />
+      <line x1="2" y1="12" x2="4" y2="12" />
+      <line x1="20" y1="12" x2="22" y2="12" />
+      <line x1="4.93" y1="19.07" x2="6.34" y2="17.66" />
+      <line x1="17.66" y1="6.34" x2="19.07" y2="4.93" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function SystemIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="12" rx="2" />
+      <line x1="8" y1="20" x2="16" y2="20" />
+      <line x1="12" y1="16" x2="12" y2="20" />
+    </svg>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,12 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: ["./src/**/*.{ts,tsx}"],
+  // Dark-mode tokens are switched at runtime by setting
+  // `data-theme="dark"` on <html> (see src/app/layout.tsx).
+  // Using a selector strategy ensures tailwind's `dark:` variants
+  // match the same source of truth our CSS vars already use, so a
+  // single toggle flips both token-driven and class-driven styles.
+  darkMode: ["selector", '[data-theme="dark"]'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- Finishes the dark-mode pass that was already extensively scaffolded: token system in `globals.css` already had a full `data-theme="dark"` block (surfaces, text, accents, semantic, pastel shelves, glass) and ~30 files use tailwind `dark:` variants. What was missing: `prefers-color-scheme` / system support, a true 3-state toggle, and a consistent mount point across shells.
- Tailwind now uses `darkMode: ["selector", '[data-theme="dark"]']` so tailwind `dark:` variants and the CSS-var tokens flip from the same source of truth — one toggle, every surface.
- Inline pre-paint bootstrap script in `src/app/layout.tsx` upgraded to resolve `"system"` against `prefers-color-scheme: dark` — no FOUC when a user's OS is dark but they haven't explicitly chosen.
- New 3-state segmented control (Light · System · Dark) in `src/components/ui/theme-toggle.tsx` with SSR-safe hydration, live-reacts to OS scheme changes in "system" mode, and an optional compact `variant="icon"` cycle button.
- Mounted in `RailIdentityMenu` (covers clinician + patient + operator shells via `AppShell`) and in the marketing `SiteFooter`. Patient portal `/portal/settings` already exposed the toggle; copy updated to mention System.
- Legacy `src/components/leafmart/ThemeToggle.tsx` unified onto the same `leafjourney-theme` storage key (with one-time migration from `leafmart-theme`) and now also flips `data-theme` on `<html>` so leafmart and the EMR shell stay in sync.

## Scope
- **Finish, not from-scratch.** Existing dark-mode token coverage was extensive (851-line `globals.css` with full dark `data-theme="dark"` block; ~30 files using tailwind `dark:` classes). This PR closes the remaining gaps: system preference, true 3-state toggle, consistent mount, tailwind selector strategy, FOUC-free system resolution.

## Surfaces spot-checked
- `/clinic` dashboard, `/clinic/messages`, `/clinic/sign-off`, `/clinic/patients/[id]` chart — clean (no hardcoded white/black/gray in these dirs).
- `/portal/*` (patient portal) — clean except acceptable semi-transparent overlays (`bg-white/35`) and intentionally-white print surfaces (`/print`, superbill PDF).
- `/marketplace` — clean.
- `(auth)` login/sign-up — clean.
- `/portal/settings` — toggle already mounted, copy refreshed.

## Test plan
- [ ] Open in light OS, default `system` → light renders; flip OS to dark → app flips live.
- [ ] Choose `Dark` in the rail identity menu → reload → stays dark, no FOUC.
- [ ] Choose `System` → unset OS preference → page resolves to light without flash.
- [ ] Toggle from marketing footer on `/` → state persists into `/clinic` and `/portal`.
- [ ] Legacy leafmart toggle still works on `/leafmart` and now syncs to the EMR shell.
- [ ] Tailwind `dark:` classes in existing files (e.g. `dark:bg-surface`) all respond.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)