### PR TITLE
ux: PatientActivityTimeline — unified per-patient event feed (filterable, grouped)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -14,6 +14,12 @@ import { useChartFrame, type ChartTabPosition } from "./chart-frame";
 const TABS = [
   { key: "demographics", label: "Demographics", dot: "bg-[color:var(--info)]", group: "Overview" },
   { key: "memory", label: "Memory", dot: "bg-accent", group: "Overview" },
+  // Unified chronological feed of every meaningful chart event
+  // (visits, messages, notes, labs, refills, tasks). Filterable and
+  // grouped by day — Linear/Notion style activity rail. Lives in
+  // Overview because it answers "what happened recently?" the same
+  // way Memory answers "what do we know?".
+  { key: "timeline", label: "Timeline", dot: "bg-[color:var(--info)]", group: "Overview" },
   { key: "notes", label: "Notes", dot: "bg-[color:var(--highlight)]", group: "Clinical" },
   // EMR-588 — Confidential clinician-only notes (private provider
   // notes). NOT part of the legal chart, never released to the patient

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -53,6 +53,8 @@ import {
 } from "@/lib/utils/patient-age";
 import { CarePlanSection } from "@/components/patient/CarePlanSection";
 import { ChartTaskList } from "@/components/patient/ChartTaskList";
+import { PatientActivityTimeline } from "@/components/patient/PatientActivityTimeline";
+import { loadPatientActivity } from "@/lib/domain/patient-activity";
 import { UnresolvedFollowUpsPanel } from "@/components/patient/UnresolvedFollowUpsPanel";
 import { buildUnresolvedFollowUps } from "@/lib/domain/unresolved-followups";
 import { logger } from "@/lib/observability/log";
@@ -341,9 +343,21 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       })
     : [];
 
+  // Activity timeline (Linear/Notion-style chart event feed). We only
+  // hit the timeline aggregator when the tab is actually open — every
+  // other render keeps its zero-cost baseline. The count shown on the
+  // tab badge is an approximation derived from data we already have so
+  // it doesn't require its own query on every chart open.
+  const activityEvents = tab === "timeline"
+    ? await loadPatientActivity(prisma, params.id, { limit: 200 })
+    : [];
+  const timelineCount =
+    patient.encounters.length + threads.length + allNotes.length;
+
   const counts = {
     demographics: 1,
     memory: patientMemories.length + openObservationCount,
+    timeline: timelineCount,
     records: recordDocs.length,
     images: imageDocs.length,
     labs: labDocs.length + assessmentResponses.length,
@@ -830,6 +844,9 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
           observations={clinicalObservations}
           patientFirstName={patient.firstName}
         />
+      )}
+      {tab === "timeline" && (
+        <PatientActivityTimeline events={activityEvents} />
       )}
       {tab === "correspondence" && (
         <CorrespondenceTab

--- a/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
@@ -19,6 +19,10 @@ import { logger } from "@/lib/observability/log";
 const TAB_LABELS: Record<TabKey, string> = {
   demographics: "Demographics",
   memory: "Memory",
+  // Activity feed tab — currently no peek/summary is wired (the
+  // timeline IS the summary). Label kept so the Record type stays
+  // exhaustive against TabKey.
+  timeline: "Timeline",
   records: "Records",
   images: "Images",
   labs: "Labs",

--- a/src/components/patient/PatientActivityTimeline.tsx
+++ b/src/components/patient/PatientActivityTimeline.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+// PatientActivityTimeline — Linear/Notion-grade chronological feed for the
+// patient chart. One vertical rail, circular icon nodes joined by a
+// hairline, sticky day headers, color-coded by event kind. Designed to
+// drop into the Timeline chart tab; consumers feed it the array returned
+// by `loadPatientActivity()` and the component owns all filter state.
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { formatRelative } from "@/lib/utils/format";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton, SkeletonCircle } from "@/components/ui/skeleton";
+import {
+  groupActivityByDay,
+  type PatientActivityEvent,
+  type PatientActivityKind,
+} from "@/lib/domain/patient-activity";
+
+interface PatientActivityTimelineProps {
+  events: PatientActivityEvent[];
+  /** Optional initial filter — handy when deep-linking from another surface. */
+  initialKind?: ChipKey;
+  /** Render the skeleton view instead of `events`. Used during streaming SSR. */
+  loading?: boolean;
+}
+
+type ChipKey =
+  | "all"
+  | "visit"
+  | "message"
+  | "note"
+  | "lab"
+  | "refill"
+  | "task";
+
+interface ChipDef {
+  key: ChipKey;
+  label: string;
+  /** Kind(s) this chip activates. `all` is the empty-set escape hatch. */
+  match: (e: PatientActivityEvent) => boolean;
+}
+
+const CHIPS: ChipDef[] = [
+  { key: "all", label: "All", match: () => true },
+  { key: "visit", label: "Visits", match: (e) => e.kind === "visit" },
+  { key: "message", label: "Messages", match: (e) => e.kind === "message" },
+  { key: "note", label: "Notes", match: (e) => e.kind === "note" },
+  { key: "lab", label: "Labs", match: (e) => e.kind === "lab" },
+  { key: "refill", label: "Refills", match: (e) => e.kind === "refill" },
+  { key: "task", label: "Tasks", match: (e) => e.kind === "task" },
+];
+
+interface KindStyle {
+  /** Background for the circular icon node. */
+  nodeBg: string;
+  /** Foreground icon color. */
+  nodeFg: string;
+  /** A subtle accent stripe on the left edge of the card on hover. */
+  accent: string;
+  icon: React.ReactNode;
+}
+
+// Apple-iOS-y palette: muted, single-pop saturation per kind. We lean on
+// Tailwind color tokens so the rail looks at home next to the rest of the
+// chart cards without inventing new design tokens.
+const KIND_STYLES: Record<PatientActivityKind, KindStyle> = {
+  visit: {
+    nodeBg: "bg-emerald-100 dark:bg-emerald-950/40",
+    nodeFg: "text-emerald-700 dark:text-emerald-300",
+    accent: "bg-emerald-400/60",
+    icon: <Icon path="M9 12l2 2 4-4" circle />,
+  },
+  message: {
+    nodeBg: "bg-sky-100 dark:bg-sky-950/40",
+    nodeFg: "text-sky-700 dark:text-sky-300",
+    accent: "bg-sky-400/60",
+    icon: <Icon path="M4 5h16v11H7l-3 3V5z" />,
+  },
+  note: {
+    nodeBg: "bg-stone-100 dark:bg-stone-800/60",
+    nodeFg: "text-stone-700 dark:text-stone-200",
+    accent: "bg-stone-400/60",
+    icon: <Icon path="M5 4h11l3 3v13H5V4zM8 9h8M8 13h8M8 17h5" />,
+  },
+  lab: {
+    nodeBg: "bg-amber-100 dark:bg-amber-950/40",
+    nodeFg: "text-amber-700 dark:text-amber-300",
+    accent: "bg-amber-400/60",
+    icon: <Icon path="M9 3v6l-4 8a3 3 0 002.7 4.3h8.6A3 3 0 0019 17l-4-8V3M9 3h6" />,
+  },
+  refill: {
+    nodeBg: "bg-violet-100 dark:bg-violet-950/40",
+    nodeFg: "text-violet-700 dark:text-violet-300",
+    accent: "bg-violet-400/60",
+    icon: <Icon path="M4 12a8 8 0 0114-5l2-2v6h-6l2-2a5 5 0 100 7" />,
+  },
+  task: {
+    nodeBg: "bg-zinc-100 dark:bg-zinc-800/60",
+    nodeFg: "text-zinc-700 dark:text-zinc-200",
+    accent: "bg-zinc-400/60",
+    icon: <Icon path="M5 12l4 4 10-10" />,
+  },
+  system: {
+    nodeBg: "bg-zinc-100 dark:bg-zinc-800/60",
+    nodeFg: "text-zinc-500 dark:text-zinc-400",
+    accent: "bg-zinc-300/60",
+    icon: <Icon path="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />,
+  },
+};
+
+function Icon({ path, circle }: { path: string; circle?: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-3.5 w-3.5"
+      aria-hidden="true"
+    >
+      {circle ? <circle cx="12" cy="12" r="9" /> : null}
+      <path d={path} />
+    </svg>
+  );
+}
+
+function toInputDate(d?: Date): string {
+  if (!d) return "";
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function parseInputDate(s: string): Date | undefined {
+  if (!s) return undefined;
+  // Avoid the UTC-midnight gotcha: build a local-tz date so the range
+  // lines up with what the clinician picked in the picker.
+  const [y, m, d] = s.split("-").map(Number);
+  if (!y || !m || !d) return undefined;
+  return new Date(y, m - 1, d);
+}
+
+export function PatientActivityTimeline({
+  events,
+  initialKind = "all",
+  loading = false,
+}: PatientActivityTimelineProps) {
+  const [activeChip, setActiveChip] = React.useState<ChipKey>(initialKind);
+  const [since, setSince] = React.useState<Date | undefined>(undefined);
+  const [until, setUntil] = React.useState<Date | undefined>(undefined);
+
+  const counts = React.useMemo(() => {
+    const out: Record<ChipKey, number> = {
+      all: events.length,
+      visit: 0,
+      message: 0,
+      note: 0,
+      lab: 0,
+      refill: 0,
+      task: 0,
+    };
+    for (const e of events) {
+      if (e.kind in out) (out as any)[e.kind]++;
+    }
+    return out;
+  }, [events]);
+
+  const filtered = React.useMemo(() => {
+    const chip = CHIPS.find((c) => c.key === activeChip) ?? CHIPS[0];
+    return events.filter((e) => {
+      if (!chip.match(e)) return false;
+      const t = new Date(e.occurredAt).getTime();
+      if (since && t < since.getTime()) return false;
+      // Until is inclusive of the picked day — bump to end-of-day.
+      if (until) {
+        const end = new Date(until);
+        end.setHours(23, 59, 59, 999);
+        if (t > end.getTime()) return false;
+      }
+      return true;
+    });
+  }, [events, activeChip, since, until]);
+
+  const groups = React.useMemo(() => groupActivityByDay(filtered), [filtered]);
+
+  const clearFilters = () => {
+    setActiveChip("all");
+    setSince(undefined);
+    setUntil(undefined);
+  };
+  const filtersActive =
+    activeChip !== "all" || since !== undefined || until !== undefined;
+
+  return (
+    <section
+      aria-label="Patient activity timeline"
+      className="flex flex-col gap-4"
+    >
+      {/* ── Filters ──────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div role="tablist" aria-label="Filter timeline by event kind" className="flex flex-wrap gap-1.5">
+          {CHIPS.map((chip) => {
+            const isActive = chip.key === activeChip;
+            const count = counts[chip.key];
+            return (
+              <button
+                key={chip.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveChip(chip.key)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                  isActive
+                    ? "border-text bg-text text-surface"
+                    : "border-border-strong/40 bg-surface text-text-muted hover:border-border-strong hover:text-text",
+                )}
+              >
+                <span>{chip.label}</span>
+                {count > 0 && (
+                  <span
+                    className={cn(
+                      "rounded-full px-1.5 text-[10px] tabular-nums leading-4",
+                      isActive ? "bg-surface/20" : "bg-surface-muted text-text-muted",
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-text-muted">
+          <label className="flex items-center gap-1.5">
+            <span className="sr-only">From</span>
+            <input
+              type="date"
+              value={toInputDate(since)}
+              max={toInputDate(until) || undefined}
+              onChange={(e) => setSince(parseInputDate(e.target.value))}
+              className="rounded-md border border-border-strong/40 bg-surface px-2 py-1 text-xs text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+              aria-label="From date"
+            />
+          </label>
+          <span aria-hidden>—</span>
+          <label className="flex items-center gap-1.5">
+            <span className="sr-only">To</span>
+            <input
+              type="date"
+              value={toInputDate(until)}
+              min={toInputDate(since) || undefined}
+              onChange={(e) => setUntil(parseInputDate(e.target.value))}
+              className="rounded-md border border-border-strong/40 bg-surface px-2 py-1 text-xs text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+              aria-label="To date"
+            />
+          </label>
+          {filtersActive && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="rounded-md px-2 py-1 text-xs text-text-muted hover:bg-surface-muted hover:text-text"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Body ────────────────────────────────────────────── */}
+      {loading ? (
+        <TimelineSkeleton />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          title="Nothing on this slice of the timeline"
+          description={
+            filtersActive
+              ? "Try widening the date range or switching back to All."
+              : "Events will appear here as visits, messages, notes, labs, and refills land on this chart."
+          }
+          primaryAction={
+            filtersActive ? (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="rounded-md border border-border-strong/40 bg-surface px-3 py-1.5 text-xs font-medium text-text hover:bg-surface-muted"
+              >
+                Reset filters
+              </button>
+            ) : undefined
+          }
+        />
+      ) : (
+        <ol className="relative flex flex-col gap-6" aria-live="polite">
+          {groups.map((group) => (
+            <li key={group.dayKey} className="flex flex-col gap-2">
+              <div className="sticky top-0 z-10 -mx-2 bg-surface/85 px-2 py-1 backdrop-blur supports-[backdrop-filter]:bg-surface/70">
+                <h3 className="font-display text-[11px] uppercase tracking-[0.12em] text-text-muted">
+                  {group.label}
+                </h3>
+              </div>
+              <ul className="relative flex flex-col">
+                {/* The hairline rail — sits behind the icon nodes. */}
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-[15px] top-2 bottom-2 w-px bg-border-strong/30"
+                />
+                {group.items.map((evt) => (
+                  <TimelineRow key={evt.id} event={evt} />
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function TimelineRow({ event }: { event: PatientActivityEvent }) {
+  const style = KIND_STYLES[event.kind] ?? KIND_STYLES.system;
+  const body = (
+    <div className="group relative flex gap-3 py-2">
+      <div
+        className={cn(
+          "relative z-[1] flex h-[31px] w-[31px] shrink-0 items-center justify-center rounded-full ring-4 ring-surface",
+          style.nodeBg,
+          style.nodeFg,
+        )}
+        aria-hidden="true"
+      >
+        {style.icon}
+      </div>
+      <div className="min-w-0 flex-1 rounded-lg px-3 py-1.5 transition-colors group-hover:bg-surface-muted/60">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="truncate text-sm font-medium text-text">{event.title}</p>
+          <time
+            dateTime={event.occurredAt}
+            title={new Date(event.occurredAt).toLocaleString()}
+            className="shrink-0 text-[11px] tabular-nums text-text-muted"
+          >
+            {formatRelative(event.occurredAt)}
+          </time>
+        </div>
+        {event.description && (
+          <p className="mt-0.5 truncate text-xs text-text-muted">{event.description}</p>
+        )}
+        <p className="mt-0.5 text-[11px] text-text-muted/80">{event.actorLabel}</p>
+      </div>
+    </div>
+  );
+  return (
+    <li className="list-none">
+      {event.href ? (
+        <Link
+          href={event.href}
+          className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        >
+          {body}
+        </Link>
+      ) : (
+        body
+      )}
+    </li>
+  );
+}
+
+function TimelineSkeleton() {
+  return (
+    <div className="flex flex-col gap-6" aria-hidden="true">
+      {[0, 1].map((g) => (
+        <div key={g} className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-20" />
+          <div className="relative flex flex-col">
+            <div className="pointer-events-none absolute left-[15px] top-2 bottom-2 w-px bg-border-strong/30" />
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex gap-3 py-2">
+                <SkeletonCircle size={31} className="ring-4 ring-surface" />
+                <div className="flex-1 space-y-1.5 px-3 py-1.5">
+                  <Skeleton className="h-3.5 w-2/3" />
+                  <Skeleton className="h-3 w-1/2" />
+                  <Skeleton className="h-2.5 w-1/4" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/domain/patient-activity.ts
+++ b/src/lib/domain/patient-activity.ts
@@ -1,0 +1,403 @@
+// Per-patient activity timeline loader.
+//
+// Pulls a chronological feed of meaningful events for a single patient
+// (encounters, messages, notes, lab results, refill requests, tasks) and
+// returns them as a uniform `PatientActivityEvent[]` ready for the
+// `<PatientActivityTimeline />` chart tab.
+//
+// Designed to be tolerant of partially-migrated schemas: every source
+// query is wrapped so a missing table or migration drift cannot blank
+// the whole feed — the timeline degrades gracefully to whatever the
+// database actually exposes today.
+
+import type { PrismaClient } from "@prisma/client";
+
+export type PatientActivityKind =
+  | "visit"
+  | "message"
+  | "note"
+  | "lab"
+  | "refill"
+  | "task"
+  | "system";
+
+export interface PatientActivityEvent {
+  id: string;
+  kind: PatientActivityKind;
+  /** ISO-8601 timestamp; events are sorted descending on this field. */
+  occurredAt: string;
+  title: string;
+  description?: string;
+  /** Display-ready label for the person (or agent) that produced the event. */
+  actorLabel: string;
+  /** Optional deep-link target — usually a chart tab or sign-off page. */
+  href?: string;
+}
+
+export interface LoadPatientActivityOptions {
+  /** Lower-bound cutoff (inclusive). Events older than this are dropped. */
+  since?: Date;
+  /** Upper-bound cutoff (inclusive). Events newer than this are dropped. */
+  until?: Date;
+  /**
+   * Restrict to the listed event kinds. `undefined` (or empty array)
+   * returns everything. Unknown kinds are silently ignored.
+   */
+  kinds?: ReadonlyArray<PatientActivityKind | string>;
+  /** Soft cap on returned events. Defaults to 200. */
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 200;
+const PER_SOURCE_TAKE = 60; // most-recent-N from each source before global merge
+
+/**
+ * Best-effort fetch from a Prisma model that may not exist (yet) in the
+ * connected schema. Returns `[]` on any failure (missing table, RBAC
+ * filter mismatch, transient driver error) so the timeline still renders.
+ */
+async function safeFind<T>(fn: () => Promise<T[]>): Promise<T[]> {
+  try {
+    return await fn();
+  } catch {
+    return [];
+  }
+}
+
+function actorFromUser(u?: { firstName?: string | null; lastName?: string | null } | null): string {
+  if (!u) return "System";
+  const name = `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim();
+  return name.length > 0 ? name : "System";
+}
+
+function withinWindow(iso: string, since?: Date, until?: Date): boolean {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return false;
+  if (since && t < since.getTime()) return false;
+  if (until && t > until.getTime()) return false;
+  return true;
+}
+
+/**
+ * Load a unified activity feed for `patientId`. Always returns most-
+ * recent-first. Soft-fails per source so a single broken table never
+ * collapses the whole timeline.
+ */
+export async function loadPatientActivity(
+  prisma: PrismaClient,
+  patientId: string,
+  opts: LoadPatientActivityOptions = {},
+): Promise<PatientActivityEvent[]> {
+  const { since, until, kinds, limit = DEFAULT_LIMIT } = opts;
+  const wantedKinds = kinds && kinds.length > 0 ? new Set(kinds) : null;
+  const wants = (k: PatientActivityKind) => !wantedKinds || wantedKinds.has(k);
+
+  const dateFilter: { gte?: Date; lte?: Date } | undefined = (() => {
+    if (!since && !until) return undefined;
+    const f: { gte?: Date; lte?: Date } = {};
+    if (since) f.gte = since;
+    if (until) f.lte = until;
+    return f;
+  })();
+
+  const events: PatientActivityEvent[] = [];
+
+  /* ── Visits (Encounter) ───────────────────────────────────── */
+  if (wants("visit")) {
+    const encounters = await safeFind(() =>
+      (prisma as any).encounter.findMany({
+        where: {
+          patientId,
+          ...(dateFilter
+            ? {
+                OR: [
+                  { completedAt: dateFilter },
+                  { startedAt: dateFilter },
+                  { scheduledFor: dateFilter },
+                ],
+              }
+            : {}),
+        },
+        orderBy: { scheduledFor: "desc" },
+        take: PER_SOURCE_TAKE,
+        include: { provider: { include: { user: true } } },
+      }),
+    );
+    for (const e of encounters as any[]) {
+      const ts =
+        e.completedAt ?? e.startedAt ?? e.scheduledFor ?? e.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const statusLabel =
+        e.status === "complete"
+          ? "Visit completed"
+          : e.status === "in_progress"
+            ? "Visit in progress"
+            : e.status === "scheduled"
+              ? "Visit scheduled"
+              : e.status === "cancelled" || e.status === "no_show"
+                ? "Visit cancelled"
+                : "Visit";
+      events.push({
+        id: `visit:${e.id}`,
+        kind: "visit",
+        occurredAt: iso,
+        title: statusLabel,
+        description:
+          [e.modality, e.reason].filter(Boolean).join(" · ") || undefined,
+        actorLabel: actorFromUser(e.provider?.user),
+        href: `/clinic/patients/${patientId}?tab=notes`,
+      });
+    }
+  }
+
+  /* ── Messages (MessageThread) ─────────────────────────────── */
+  if (wants("message")) {
+    const threads = await safeFind(() =>
+      (prisma as any).messageThread.findMany({
+        where: {
+          patientId,
+          ...(dateFilter ? { lastMessageAt: dateFilter } : {}),
+        },
+        orderBy: { lastMessageAt: "desc" },
+        take: PER_SOURCE_TAKE,
+        include: {
+          messages: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            include: { sender: true },
+          },
+        },
+      }),
+    );
+    for (const t of threads as any[]) {
+      const ts = t.lastMessageAt ?? t.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const last = t.messages?.[0];
+      const preview = typeof last?.body === "string"
+        ? last.body.slice(0, 140)
+        : undefined;
+      events.push({
+        id: `message:${t.id}`,
+        kind: "message",
+        occurredAt: iso,
+        title: t.subject || "Patient message",
+        description: preview,
+        actorLabel: last?.sender
+          ? actorFromUser(last.sender)
+          : last?.senderAgent
+            ? `${last.senderAgent} (AI)`
+            : "Patient",
+        href: `/clinic/patients/${patientId}?tab=correspondence`,
+      });
+    }
+  }
+
+  /* ── Notes (Note via Encounter) ───────────────────────────── */
+  if (wants("note")) {
+    const notes = await safeFind(() =>
+      (prisma as any).note.findMany({
+        where: {
+          encounter: { patientId },
+          ...(dateFilter
+            ? {
+                OR: [
+                  { finalizedAt: dateFilter },
+                  { createdAt: dateFilter },
+                ],
+              }
+            : {}),
+        },
+        orderBy: { createdAt: "desc" },
+        take: PER_SOURCE_TAKE,
+      }),
+    );
+    for (const n of notes as any[]) {
+      const ts = n.finalizedAt ?? n.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const blocks = n.blocks as { chiefComplaint?: unknown } | undefined;
+      const chief =
+        blocks && typeof blocks.chiefComplaint === "string"
+          ? blocks.chiefComplaint.trim()
+          : "";
+      const title =
+        n.status === "finalized"
+          ? "Note finalized"
+          : n.status === "amended"
+            ? "Note amended"
+            : n.status === "pending_cosign"
+              ? "Note pending cosign"
+              : "Note drafted";
+      events.push({
+        id: `note:${n.id}`,
+        kind: "note",
+        occurredAt: iso,
+        title,
+        description:
+          chief ||
+          (typeof n.narrative === "string"
+            ? n.narrative.slice(0, 140)
+            : undefined),
+        actorLabel: n.aiDrafted && !n.finalizedAt ? "Scribe (AI)" : "Clinician",
+        href: `/clinic/patients/${patientId}?tab=notes`,
+      });
+    }
+  }
+
+  /* ── Labs (LabResult) ─────────────────────────────────────── */
+  if (wants("lab")) {
+    const labs = await safeFind(() =>
+      (prisma as any).labResult.findMany({
+        where: {
+          patientId,
+          ...(dateFilter ? { receivedAt: dateFilter } : {}),
+        },
+        orderBy: { receivedAt: "desc" },
+        take: PER_SOURCE_TAKE,
+        include: { signedBy: true },
+      }),
+    );
+    for (const l of labs as any[]) {
+      const ts = l.signedAt ?? l.receivedAt ?? l.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const title = l.signedAt
+        ? `${l.panelName || "Lab"} signed off`
+        : `${l.panelName || "Lab"} received`;
+      events.push({
+        id: `lab:${l.id}`,
+        kind: "lab",
+        occurredAt: iso,
+        title,
+        description: l.abnormalFlag ? "Abnormal markers flagged" : undefined,
+        actorLabel: l.signedBy ? actorFromUser(l.signedBy) : "Lab system",
+        href: `/clinic/patients/${patientId}?tab=labs`,
+      });
+    }
+  }
+
+  /* ── Refills (RefillRequest) ──────────────────────────────── */
+  if (wants("refill")) {
+    const refills = await safeFind(() =>
+      (prisma as any).refillRequest.findMany({
+        where: {
+          patientId,
+          ...(dateFilter ? { receivedAt: dateFilter } : {}),
+        },
+        orderBy: { receivedAt: "desc" },
+        take: PER_SOURCE_TAKE,
+        include: { signedBy: true, medication: true },
+      }),
+    );
+    for (const r of refills as any[]) {
+      const ts = r.signedAt ?? r.receivedAt ?? r.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const medName = r.medication?.name ?? "medication";
+      const title =
+        r.status === "approved" || r.status === "sent"
+          ? `Refill approved — ${medName}`
+          : r.status === "denied"
+            ? `Refill denied — ${medName}`
+            : `Refill requested — ${medName}`;
+      events.push({
+        id: `refill:${r.id}`,
+        kind: "refill",
+        occurredAt: iso,
+        title,
+        description: r.pharmacyName ? `Pharmacy: ${r.pharmacyName}` : undefined,
+        actorLabel: r.signedBy ? actorFromUser(r.signedBy) : "Pharmacy",
+        href: `/clinic/patients/${patientId}?tab=rx`,
+      });
+    }
+  }
+
+  /* ── Tasks ────────────────────────────────────────────────── */
+  if (wants("task")) {
+    const tasks = await safeFind(() =>
+      (prisma as any).task.findMany({
+        where: {
+          patientId,
+          ...(dateFilter
+            ? {
+                OR: [
+                  { completedAt: dateFilter },
+                  { createdAt: dateFilter },
+                ],
+              }
+            : {}),
+        },
+        orderBy: { createdAt: "desc" },
+        take: PER_SOURCE_TAKE,
+      }),
+    );
+    for (const t of tasks as any[]) {
+      const ts = t.completedAt ?? t.createdAt;
+      if (!ts) continue;
+      const iso = new Date(ts).toISOString();
+      if (!withinWindow(iso, since, until)) continue;
+      const title = t.completedAt ? `Task completed — ${t.title}` : `Task opened — ${t.title}`;
+      events.push({
+        id: `task:${t.id}`,
+        kind: "task",
+        occurredAt: iso,
+        title,
+        description: t.description ?? undefined,
+        actorLabel: t.assigneeRole ? String(t.assigneeRole) : "Care team",
+        href: `/clinic/patients/${patientId}`,
+      });
+    }
+  }
+
+  // Global merge, most recent first.
+  events.sort((a, b) => (a.occurredAt < b.occurredAt ? 1 : -1));
+  return events.slice(0, limit);
+}
+
+/**
+ * Group an event list by calendar day (using the viewer's local zone via
+ * `toDateString`). Returns ordered groups, most-recent day first.
+ *
+ * Exposed so the timeline component (and any future export view) share
+ * the same bucketing logic.
+ */
+export function groupActivityByDay(
+  events: PatientActivityEvent[],
+): Array<{ dayKey: string; label: string; items: PatientActivityEvent[] }> {
+  const groups = new Map<string, PatientActivityEvent[]>();
+  for (const e of events) {
+    const d = new Date(e.occurredAt);
+    const key = d.toDateString(); // e.g. "Tue May 21 2026" — stable per day in local tz
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(e);
+    else groups.set(key, [e]);
+  }
+
+  const today = new Date().toDateString();
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toDateString();
+
+  return Array.from(groups.entries())
+    .sort((a, b) => (new Date(a[0]).getTime() < new Date(b[0]).getTime() ? 1 : -1))
+    .map(([key, items]) => {
+      let label: string;
+      if (key === today) label = "Today";
+      else if (key === yesterday) label = "Yesterday";
+      else {
+        const d = new Date(key);
+        const sameYear = d.getFullYear() === new Date().getFullYear();
+        label = d.toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          ...(sameYear ? {} : { year: "numeric" }),
+        });
+      }
+      return { dayKey: key, label, items };
+    });
+}


### PR DESCRIPTION
## Summary

Adds a Linear / Notion-grade **activity timeline** to the clinician patient chart. A new **Timeline** tab in the Overview group renders a single-column chronological rail that merges every meaningful event for a patient into one place — visits, messages, notes, labs, refills, and tasks — grouped by day with sticky headers, color-coded icon nodes, relative timestamps, actor labels, and deep links back to the originating chart tab.

### What ships
- **`src/lib/domain/patient-activity.ts`** — `loadPatientActivity(prisma, patientId, opts)` returns a unified `PatientActivityEvent[]`. Sources: `Encounter`, `MessageThread`, `Note`, `LabResult`, `RefillRequest`, `Task`. Every source is wrapped in `safeFind` so a missing or renamed table degrades gracefully instead of blanking the whole feed. Also exports `groupActivityByDay` so consumers (or a future PDF export) share the bucketing logic.
- **`src/components/patient/PatientActivityTimeline.tsx`** — client component owning all filter state:
  - 7 filter chips: **All / Visits / Messages / Notes / Labs / Refills / Tasks** (with per-chip counts)
  - From/To date range (native date inputs, since no DatePicker primitive is in main yet)
  - Color-coded events (visits = emerald, messages = sky, notes = stone, labs = amber, refills = violet, tasks = zinc)
  - Sticky day headers (`Today` / `Yesterday` / `May 19` / `May 19, 2025`)
  - 31px ring-bordered circular icon nodes joined by a hairline rail (Apple-iOS aesthetic)
  - `EmptyState` for zero-result filter view, `Skeleton` + `SkeletonCircle` for loading shape
  - Keyboard- and reduced-motion-friendly; chips render as a `role="tablist"`
- **Chart adoption** — `chart-tabs.tsx` gains a `timeline` entry in the Overview group; `page.tsx` loads activity **only when `?tab=timeline`** so every other chart open stays cost-neutral; `peek-summary.ts` `TAB_LABELS` updated to keep the `Record<TabKey, string>` exhaustive.

### Why
The chart aggregates plenty of per-domain views already, but answering "what's happened with this patient lately?" still meant tab-hopping. A unified feed is the answer most clinicians actually want first.

### What did not change
- No prisma schema changes, no new dependencies, no edits to middleware / auth / specialty manifests / workflows / CLAUDE.md.
- No existing tabs ripped out; timeline is purely additive.

## Test plan
- [ ] Navigate to `/clinic/patients/{id}?tab=timeline` — events render newest-first, grouped by day
- [ ] Filter chips reduce the list and the empty-state reset button appears when a filter zeroes it out
- [ ] Date-range inputs filter correctly (inclusive on the `until` day)
- [ ] Each row's CTA deep-links back to the right chart tab (Notes / Correspondence / Labs / Rx)
- [ ] Other chart tabs unchanged; no extra DB load on `?tab=demographics`
- [ ] Reduced-motion mode collapses the skeleton pulse (verify with `prefers-reduced-motion: reduce`)

Generated with [Claude Code](https://claude.com/claude-code)