### PR TITLE
ux: SortableList primitive + 3 adoption sites (HTML5 DnD + keyboard reorder)

### DIFF
--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -835,6 +835,42 @@ export function SmartInboxView({
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>(initialPriority);
   const [categoryFilter, setCategoryFilter] = useState<MessageCategory | "all">("all");
   const [search, setSearch] = useState("");
+  // EMR-DnD: clinician-pinned threads bubble to the top of the list,
+  // beating priority-based smart sort. Persisted in localStorage as a
+  // Set<threadId>. TODO(schema): mirror to a `MessageThread.pinnedBy`
+  // join table so pins survive a logout / device swap.
+  const [pinnedThreadIds, setPinnedThreadIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("inbox:pinned:v1");
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+          setPinnedThreadIds(new Set(parsed as string[]));
+        }
+      }
+    } catch {
+      // ignore — bad JSON or unavailable storage.
+    }
+  }, []);
+  const togglePinned = (threadId: string) => {
+    setPinnedThreadIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(threadId)) next.delete(threadId);
+      else next.add(threadId);
+      try {
+        window.localStorage.setItem(
+          "inbox:pinned:v1",
+          JSON.stringify(Array.from(next)),
+        );
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  };
   // Shared motion: subtle stagger on the triaged list. No-op under
   // prefers-reduced-motion. Variants are stable across renders.
   const reduceMotion = useReducedMotion() ?? false;
@@ -911,14 +947,19 @@ export function SmartInboxView({
 
     // EMR-657 — smart sort: urgent+unread first, then high+unread, etc.;
     // within the same score bucket, fall back to recency (newest first).
+    // EMR-DnD — pinned threads sort above all unpinned threads regardless
+    // of priority, then the existing smart-sort logic resolves ties.
     list = [...list].sort((a, b) => {
+      const aPinned = pinnedThreadIds.has(a.threadId) ? 0 : 1;
+      const bPinned = pinnedThreadIds.has(b.threadId) ? 0 : 1;
+      if (aPinned !== bPinned) return aPinned - bPinned;
       const scoreDiff = smartScore(a) - smartScore(b);
       if (scoreDiff !== 0) return scoreDiff;
       return b.lastMessageAt.localeCompare(a.lastMessageAt);
     });
 
     return list;
-  }, [triaged, priorityFilter, categoryFilter, search]);
+  }, [triaged, priorityFilter, categoryFilter, search, pinnedThreadIds]);
 
   // Active thread detail
   const selectedTriage = triaged.find((t) => t.threadId === selectedThreadId);
@@ -1112,6 +1153,7 @@ export function SmartInboxView({
             ) : (
               filtered.map((t) => {
                 const isSelected = t.threadId === selectedThreadId;
+                const isPinned = pinnedThreadIds.has(t.threadId);
                 return (
                   <motion.button
                     key={t.threadId}
@@ -1122,6 +1164,7 @@ export function SmartInboxView({
                       "border-l-[3px]",
                       PRIORITY_BORDER_COLORS[t.priority],
                       isSelected && "bg-surface-muted",
+                      isPinned && "bg-accent-soft/30",
                     )}
                   >
                     <div className="flex items-start gap-3">
@@ -1132,6 +1175,39 @@ export function SmartInboxView({
                             {t.unreadCount > 0 && (
                               <span className="shrink-0 h-2 w-2 rounded-full bg-accent" />
                             )}
+                            {/* EMR-DnD: pin toggle. role=button on a
+                                span (not a real <button>) so we stay
+                                valid HTML inside the outer motion.button.
+                                Keyboard activated via Space/Enter. */}
+                            <span
+                              role="button"
+                              tabIndex={0}
+                              aria-pressed={isPinned}
+                              aria-label={isPinned ? "Unpin thread" : "Pin thread to top"}
+                              title={isPinned ? "Unpin thread" : "Pin thread to top"}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                togglePinned(t.threadId);
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === " " || e.key === "Enter") {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  togglePinned(t.threadId);
+                                }
+                              }}
+                              className={cn(
+                                "shrink-0 inline-flex items-center justify-center h-5 w-5 rounded transition-colors",
+                                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                                isPinned
+                                  ? "text-accent"
+                                  : "text-text-subtle/40 hover:text-text-subtle",
+                              )}
+                            >
+                              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                                <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .013 2.371c-.125.612-.413 1.27-.978 1.834a.5.5 0 0 1-.707 0L5.95 11.756 1.854 15.85a.5.5 0 1 1-.708-.707L5.243 11.05 2.475 8.28a.5.5 0 0 1 0-.706c.565-.565 1.222-.853 1.834-.978a5.93 5.93 0 0 1 2.372.013l3.134-3.134a2.97 2.97 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
+                              </svg>
+                            </span>
                             <p className="text-sm font-semibold text-text truncate">
                               {t.patientName}
                             </p>

--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -31,6 +31,7 @@ import {
   categorizeQueueItem,
   URGENCY_TAG_CONFIG,
 } from "@/lib/domain/queue-urgency";
+import { QueueRailClient, type QueueRailCard } from "./queue-rail-client";
 
 // EMR-205: guard the mission-control fan-out so a single hung query
 // can never wedge the Suspense boundary and strand clinicians on the
@@ -855,8 +856,11 @@ export default async function ClinicHomePage() {
             ]}
           />
         ) : (
-          <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin">
-            {(todaysEncounters as any[])
+          // EMR-DnD: clinicians can drag (or use Space + arrows) to pin
+          // their personal preferred order on top of the AI urgency
+          // ranking. Order persists per-day in localStorage.
+          (() => {
+            const queueCards: QueueRailCard[] = (todaysEncounters as any[])
               .map((enc: any) => ({
                 enc,
                 urgency: categorizeQueueItem({
@@ -881,8 +885,7 @@ export default async function ClinicHomePage() {
               const consultsCount = enc.patient.documents?.filter((d: any) => d.kind === "letter").length ?? 0;
               const imagesCount = enc.patient.documents?.filter((d: any) => d.kind === "image").length ?? 0;
 
-              return (
-                <div key={enc.id} className="shrink-0 snap-start">
+              const node = (
                   <Card
                     tone="raised"
                     className="w-64 card-hover flex flex-col justify-between p-4 group"
@@ -971,10 +974,13 @@ export default async function ClinicHomePage() {
                       </Link>
                     </div>
                   </Card>
-                </div>
               );
-            })}
-          </div>
+              return { id: enc.id, node };
+            });
+
+            const dayKey = startOfDay.toISOString().slice(0, 10);
+            return <QueueRailClient cards={queueCards} dayKey={dayKey} />;
+          })()
         )}
       </section>
 

--- a/src/app/(clinician)/clinic/queue-rail-client.tsx
+++ b/src/app/(clinician)/clinic/queue-rail-client.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+/**
+ * QueueRailClient — clinician-reorderable Today's Queue rail.
+ *
+ * Server-side we compute the urgency-sorted list of today's encounter
+ * cards. The clinician can then drag (or use Space + arrow keys) to
+ * pin their personal preferred order on top of the AI urgency score —
+ * Monday.com tier interaction inside the EMR.
+ *
+ * Persistence
+ * ───────────
+ *   Per-clinician, per-day. Stored under `clinic:queue-order:${date}`
+ *   in localStorage so each new day starts fresh on the AI's urgency
+ *   ranking. TODO(schema): introduce `Encounter.queueSortOrder Int?`
+ *   on the model so order can sync across devices and survive page
+ *   refreshes from another machine.
+ *
+ * Why client-only
+ * ───────────────
+ *   The original server page renders the rail with deeply-nested
+ *   Prisma includes that we don't want to plumb through props. We
+ *   accept the already-rendered list of card React nodes from the
+ *   server and just rearrange them client-side.
+ */
+
+import * as React from "react";
+import { SortableList, reorder } from "@/components/ui/sortable";
+import { cn } from "@/lib/utils/cn";
+
+export interface QueueRailCard {
+  /** Stable encounter id — used as the React key and persistence key. */
+  id: string;
+  /** Pre-rendered card content (server component output). */
+  node: React.ReactNode;
+}
+
+interface Props {
+  cards: QueueRailCard[];
+  /** YYYY-MM-DD — used to scope the localStorage key per day. */
+  dayKey: string;
+}
+
+const STORAGE_PREFIX = "clinic:queue-order:v1:";
+
+function DragGripIcon() {
+  return (
+    <svg
+      width="12"
+      height="18"
+      viewBox="0 0 12 18"
+      fill="currentColor"
+      aria-hidden="true"
+      className="opacity-70 group-hover:opacity-100 transition-opacity"
+    >
+      <circle cx="3" cy="3" r="1.2" />
+      <circle cx="3" cy="9" r="1.2" />
+      <circle cx="3" cy="15" r="1.2" />
+      <circle cx="9" cy="3" r="1.2" />
+      <circle cx="9" cy="9" r="1.2" />
+      <circle cx="9" cy="15" r="1.2" />
+    </svg>
+  );
+}
+
+export function QueueRailClient({ cards, dayKey }: Props) {
+  const storageKey = `${STORAGE_PREFIX}${dayKey}`;
+  // Track the manual override as an ordered list of ids. Cards not in
+  // the override fall back to the server-provided order.
+  const [order, setOrder] = React.useState<string[] | null>(null);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
+          setOrder(parsed as string[]);
+        }
+      }
+    } catch {
+      // ignore — corrupt JSON or unavailable storage.
+    }
+    setHydrated(true);
+  }, [storageKey]);
+
+  // Effective ordering: manual rank first, server order for the tail.
+  const arranged = React.useMemo(() => {
+    if (!order || order.length === 0) return cards;
+    const rank = new Map<string, number>();
+    order.forEach((id, i) => rank.set(id, i));
+    return cards.slice().sort((a, b) => {
+      const ra = rank.get(a.id);
+      const rb = rank.get(b.id);
+      if (ra == null && rb == null) return 0;
+      if (ra == null) return 1;
+      if (rb == null) return -1;
+      return ra - rb;
+    });
+  }, [cards, order]);
+
+  const handleReorder = (from: number, to: number) => {
+    const next = reorder(arranged, from, to);
+    const nextIds = next.map((c) => c.id);
+    setOrder(nextIds);
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(nextIds));
+    } catch {
+      // ignore
+    }
+  };
+
+  // Until hydrated, render the server order verbatim to avoid mismatch.
+  const renderCards = hydrated ? arranged : cards;
+
+  return (
+    <div className="overflow-x-auto pb-2 scrollbar-thin">
+      <SortableList
+        items={renderCards}
+        getKey={(c) => c.id}
+        onReorder={handleReorder}
+        ariaLabel="Today's queue — drag to reorder"
+        className="!space-y-0 flex flex-row gap-4 snap-x snap-mandatory"
+        renderItem={(card, { dragHandleProps, isDragging }) => (
+          <div
+            className={cn(
+              "relative shrink-0 snap-start group",
+              isDragging && "ring-2 ring-accent/40 rounded-xl",
+            )}
+          >
+            {/* Floating grip in the top-left corner, only visible on
+                hover or while dragging. Spreading dragHandleProps here
+                makes only the grip itself the drag source so the rest
+                of the card (links, Prepare button) stay clickable. */}
+            <span
+              {...dragHandleProps}
+              className={cn(
+                dragHandleProps.className,
+                "absolute top-1.5 left-1.5 z-10 p-1 rounded bg-surface/80 backdrop-blur",
+                "opacity-0 group-hover:opacity-100 focus:opacity-100",
+                "aria-grabbed:opacity-100",
+              )}
+              title="Drag to reorder (or Space + arrow keys)"
+            >
+              <DragGripIcon />
+            </span>
+            {card.node}
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/patient/ChartTaskList.tsx
+++ b/src/components/patient/ChartTaskList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 import { Badge } from "@/components/ui/badge";
 import { formatRelative } from "@/lib/utils/format";
+import { SortableList, reorder } from "@/components/ui/sortable";
 
 // EMR-180 — Chart Task List / To-Do on Open
 //
@@ -73,7 +74,32 @@ const CATEGORY_DOT: Record<ChartTaskCategory, string> = {
   result: "bg-[color:var(--info)]",
 };
 
+/** 6-dot vertical grip icon used as the drag handle. */
+function DragGripIcon() {
+  return (
+    <svg
+      width="10"
+      height="16"
+      viewBox="0 0 10 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <circle cx="2" cy="3" r="1" />
+      <circle cx="2" cy="8" r="1" />
+      <circle cx="2" cy="13" r="1" />
+      <circle cx="8" cy="3" r="1" />
+      <circle cx="8" cy="8" r="1" />
+      <circle cx="8" cy="13" r="1" />
+    </svg>
+  );
+}
+
 const STORAGE_KEY_PREFIX = "chart:task-list-dismissed:v1:";
+// EMR-DnD: per-patient manual ordering override. Stores an array of
+// `${category}:${id}` keys; any task not present falls back to the
+// default severity-sorted order at the bottom. TODO(schema): when a
+// `ChartTask.sortOrder` field lands on the model, persist server-side.
+const ORDER_KEY_PREFIX = "chart:task-list-order:v1:";
 
 export function ChartTaskList({
   patientId,
@@ -82,8 +108,12 @@ export function ChartTaskList({
   className,
 }: ChartTaskListProps) {
   const storageKey = `${STORAGE_KEY_PREFIX}${patientId}`;
+  const orderKey = `${ORDER_KEY_PREFIX}${patientId}`;
   const [dismissed, setDismissed] = React.useState(false);
   const [hydrated, setHydrated] = React.useState(false);
+  // Manual ordering applied on top of severity-bucket sort. Initialized
+  // from localStorage on mount so SSR markup stays stable.
+  const [manualOrder, setManualOrder] = React.useState<string[] | null>(null);
 
   // Hash the items so dismissals re-appear when something genuinely
   // *new* lands on the chart. Without this, dismissing a list with
@@ -101,8 +131,19 @@ export function ChartTaskList({
     } catch {
       // ignore — Safari private mode etc.
     }
+    try {
+      const rawOrder = window.localStorage.getItem(orderKey);
+      if (rawOrder) {
+        const parsed = JSON.parse(rawOrder);
+        if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+          setManualOrder(parsed as string[]);
+        }
+      }
+    } catch {
+      // ignore — bad JSON or private-mode storage; just fall back.
+    }
     setHydrated(true);
-  }, [storageKey, hash]);
+  }, [storageKey, hash, orderKey]);
 
   const handleDismiss = () => {
     setDismissed(true);
@@ -113,19 +154,51 @@ export function ChartTaskList({
     }
   };
 
+  // Base order: bucket by severity, surface the most urgent first.
+  // Then re-apply the clinician's manual ordering (if any) on top —
+  // we sort by manual rank when present, falling back to severity for
+  // anything new that hasn't been touched yet.
+  const taskKey = React.useCallback(
+    (t: ChartTask) => `${t.category}:${t.id}`,
+    [],
+  );
+  const sorted = React.useMemo(() => {
+    const baseSorted = items.slice().sort((a, b) => {
+      const order = { danger: 0, warning: 1, info: 2 } as const;
+      const sa = order[a.severity ?? "info"];
+      const sb = order[b.severity ?? "info"];
+      if (sa !== sb) return sa - sb;
+      return a.title.localeCompare(b.title);
+    });
+    if (!manualOrder || manualOrder.length === 0) return baseSorted;
+    const rank = new Map<string, number>();
+    manualOrder.forEach((k, i) => rank.set(k, i));
+    return baseSorted.slice().sort((a, b) => {
+      const ra = rank.get(taskKey(a));
+      const rb = rank.get(taskKey(b));
+      // Unknown (new) tasks float to the bottom, preserving severity order.
+      if (ra == null && rb == null) return 0;
+      if (ra == null) return 1;
+      if (rb == null) return -1;
+      return ra - rb;
+    });
+  }, [items, manualOrder, taskKey]);
+
+  const handleReorder = (from: number, to: number) => {
+    const next = reorder(sorted, from, to);
+    const nextKeys = next.map(taskKey);
+    setManualOrder(nextKeys);
+    try {
+      window.localStorage.setItem(orderKey, JSON.stringify(nextKeys));
+    } catch {
+      // ignore
+    }
+  };
+
   if (items.length === 0) return null;
   // Until hydration completes the SSR render and the client both show
   // the panel; flipping it on/off mid-paint causes layout shift.
   if (hydrated && dismissed) return null;
-
-  // Bucket by severity to surface the most urgent first.
-  const sorted = items.slice().sort((a, b) => {
-    const order = { danger: 0, warning: 1, info: 2 } as const;
-    const sa = order[a.severity ?? "info"];
-    const sb = order[b.severity ?? "info"];
-    if (sa !== sb) return sa - sb;
-    return a.title.localeCompare(b.title);
-  });
 
   const dangerCount = items.filter((i) => i.severity === "danger").length;
   const accentBorder = dangerCount > 0 ? "border-l-danger" : "border-l-highlight";
@@ -159,12 +232,32 @@ export function ChartTaskList({
         </button>
       </div>
 
-      <ul className="divide-y divide-border/40">
-        {sorted.map((item) => (
-          <li key={`${item.category}-${item.id}`} className="hover:bg-surface-muted/40 transition-colors">
+      {/* EMR-DnD: clinicians can drag tasks (or use Space + arrow keys) to
+          re-prioritize their punch list. Order persists per-patient in
+          localStorage. */}
+      <SortableList
+        items={sorted}
+        getKey={(item) => `${item.category}-${item.id}`}
+        onReorder={handleReorder}
+        ariaLabel={title}
+        className="divide-y divide-border/40 !space-y-0"
+        renderItem={(item, { dragHandleProps, isDragging }) => (
+          <div
+            className={cn(
+              "flex items-stretch gap-1 bg-surface hover:bg-surface-muted/40 transition-colors",
+              isDragging && "bg-surface-muted/60",
+            )}
+          >
+            <span
+              {...dragHandleProps}
+              className={cn(dragHandleProps.className, "px-2 py-3")}
+              title="Drag to reorder (or Space + arrow keys)"
+            >
+              <DragGripIcon />
+            </span>
             <Link
               href={item.href}
-              className="flex items-start gap-3 px-5 py-3"
+              className="flex items-start gap-3 px-3 py-3 flex-1 min-w-0"
             >
               <span
                 aria-hidden="true"
@@ -189,14 +282,14 @@ export function ChartTaskList({
                 )}
               </div>
               {item.dueAt && (
-                <span className="text-[11px] text-text-subtle shrink-0 tabular-nums whitespace-nowrap">
+                <span className="text-[11px] text-text-subtle shrink-0 tabular-nums whitespace-nowrap self-center pr-2">
                   due {formatRelative(item.dueAt)}
                 </span>
               )}
             </Link>
-          </li>
-        ))}
-      </ul>
+          </div>
+        )}
+      />
     </div>
   );
 }

--- a/src/components/ui/sortable.tsx
+++ b/src/components/ui/sortable.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+/**
+ * SortableList — lightweight drag-and-drop primitive for LeafJourney EMR.
+ *
+ * Goal: Monday.com / Trello / Linear-tier reorderable lists everywhere we
+ * have one. Zero new deps — pure React + the HTML5 drag-and-drop API +
+ * framer-motion (already in the bundle) for the lift animation.
+ *
+ * Design notes
+ * ────────────
+ *   • Drag handle is opt-in. The render prop receives `dragHandleProps`
+ *     that the caller spreads onto whichever element should grab the row.
+ *     If you spread it onto the entire row, the whole row is draggable.
+ *     If you spread it onto a tiny grip icon, the rest of the row stays
+ *     interactive (links, buttons, etc).
+ *   • Keyboard reorder, Monday-style:
+ *         Space (on handle)      → pick up
+ *         ↑ / ↓                  → move
+ *         Space / Enter          → drop
+ *         Esc                    → cancel and restore original index
+ *   • `prefers-reduced-motion`: no scale / shadow lift, instant snap.
+ *   • The component is **uncontrolled with respect to drag state** but
+ *     **controlled with respect to data**: callers own the `items`
+ *     array and respond to `onReorder(from, to)` by updating their own
+ *     state (optionally persisting). The primitive never owns truth.
+ *
+ * Accessibility
+ * ─────────────
+ *   • Each row exposes `aria-grabbed`/`aria-roledescription` while in
+ *     a keyboard reorder, mirroring W3C drag-and-drop guidance.
+ *   • A polite live region announces "Picked up item N of M", "Moved to
+ *     position K of M", "Dropped at position K", "Cancelled" so screen
+ *     reader users get feedback for an otherwise-visual interaction.
+ *
+ * Why not dnd-kit / react-beautiful-dnd?
+ *   We need ~150 lines, not a 90KB dependency. The HTML5 DnD API is
+ *   crusty but well-supported and good enough for vertical lists. If
+ *   we ever need multi-axis grids or virtualization we'll revisit.
+ */
+
+import * as React from "react";
+import {
+  motion,
+  AnimatePresence,
+  useReducedMotion,
+  type MotionProps,
+} from "framer-motion";
+import { cn } from "@/lib/utils/cn";
+import { EASE_PREMIUM, DURATION } from "@/lib/ui/motion";
+
+// ───────────────────────────────────────── Public types
+
+/**
+ * Props the primitive hands back to the caller's `renderItem`. Spread
+ * `dragHandleProps` onto the element that should initiate the drag —
+ * commonly a small grip icon, but spreading onto the row root works too.
+ */
+export interface DragHandleProps {
+  /** Mark the element as the drag source for HTML5 DnD. */
+  draggable: true;
+  /** Required for screen reader / keyboard discoverability. */
+  role: "button";
+  tabIndex: 0;
+  "aria-label": string;
+  "aria-grabbed": boolean;
+  "aria-roledescription": "sortable";
+  onDragStart: (e: React.DragEvent) => void;
+  onDragEnd: (e: React.DragEvent) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /** Cursor + subtle hover affordance. Tailwind class string. */
+  className: string;
+  /** So we can refocus the handle after a keyboard reorder. */
+  "data-sortable-handle-index": number;
+}
+
+export interface SortableRenderArgs {
+  /** Spread onto the element that should be the drag source. */
+  dragHandleProps: DragHandleProps;
+  /** True while this row is the one being dragged (mouse or keyboard). */
+  isDragging: boolean;
+  /** Index in the *current* items array. */
+  index: number;
+}
+
+export interface SortableListProps<T> {
+  /** Source-of-truth list. The caller owns mutations. */
+  items: readonly T[];
+  /** Stable key extractor — must be unique per item. */
+  getKey: (item: T, index: number) => string;
+  /** Called after a successful drop / keyboard drop. */
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  /** Renders each row. Spread `dragHandleProps` somewhere inside. */
+  renderItem: (item: T, args: SortableRenderArgs) => React.ReactNode;
+  /** Optional label for the list as a whole (announced to AT). */
+  ariaLabel?: string;
+  /** Optional className for the outer container. */
+  className?: string;
+  /** Disable drag for the entire list (e.g. while saving). */
+  disabled?: boolean;
+}
+
+// ───────────────────────────────────────── Component
+
+export function SortableList<T>({
+  items,
+  getKey,
+  onReorder,
+  renderItem,
+  ariaLabel,
+  className,
+  disabled = false,
+}: SortableListProps<T>) {
+  const reduce = useReducedMotion() ?? false;
+
+  // The index currently being dragged (mouse or keyboard).
+  const [dragIndex, setDragIndex] = React.useState<number | null>(null);
+  // The index hovered as a potential drop target (mouse drag).
+  const [overIndex, setOverIndex] = React.useState<number | null>(null);
+  // Keyboard-only: the in-flight target index while moving with arrow keys.
+  const [keyboardTarget, setKeyboardTarget] = React.useState<number | null>(
+    null,
+  );
+  // Polite live-region announcement.
+  const [announcement, setAnnouncement] = React.useState<string>("");
+
+  const containerRef = React.useRef<HTMLUListElement | null>(null);
+
+  // Stash these so handlers can read the latest without re-binding the
+  // window listener on every render.
+  const itemsRef = React.useRef(items);
+  itemsRef.current = items;
+
+  const announce = React.useCallback((msg: string) => {
+    setAnnouncement(""); // toggle to retrigger SR readout
+    // The next paint will see the new value. Using rAF instead of setTimeout
+    // so we don't depend on a flaky timer cadence.
+    requestAnimationFrame(() => setAnnouncement(msg));
+  }, []);
+
+  // ───── Mouse / HTML5 DnD ─────
+
+  const startMouseDrag = (e: React.DragEvent, index: number) => {
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+    setDragIndex(index);
+    setOverIndex(index);
+    // Firefox requires *some* data for the drag to actually start.
+    try {
+      e.dataTransfer.setData("text/plain", String(index));
+      e.dataTransfer.effectAllowed = "move";
+    } catch {
+      // Some test environments mock dataTransfer; failing here would
+      // wedge the drag so we swallow.
+    }
+  };
+
+  const endMouseDrag = () => {
+    if (dragIndex == null) return;
+    const from = dragIndex;
+    const to = overIndex ?? dragIndex;
+    setDragIndex(null);
+    setOverIndex(null);
+    if (from !== to && to >= 0 && to < itemsRef.current.length) {
+      onReorder(from, to);
+      announce(`Moved to position ${to + 1} of ${itemsRef.current.length}`);
+    }
+  };
+
+  const handleRowDragOver = (e: React.DragEvent, index: number) => {
+    if (dragIndex == null) return;
+    e.preventDefault(); // allow drop
+    if (overIndex !== index) setOverIndex(index);
+  };
+
+  // ───── Keyboard reorder ─────
+
+  const startKeyboardDrag = (index: number) => {
+    if (disabled) return;
+    setDragIndex(index);
+    setKeyboardTarget(index);
+    announce(`Picked up item ${index + 1} of ${itemsRef.current.length}`);
+  };
+
+  const moveKeyboardDrag = (delta: number) => {
+    if (dragIndex == null || keyboardTarget == null) return;
+    const next = Math.max(
+      0,
+      Math.min(itemsRef.current.length - 1, keyboardTarget + delta),
+    );
+    if (next === keyboardTarget) return;
+    setKeyboardTarget(next);
+    announce(`Moved to position ${next + 1} of ${itemsRef.current.length}`);
+  };
+
+  const dropKeyboardDrag = () => {
+    if (dragIndex == null || keyboardTarget == null) return;
+    const from = dragIndex;
+    const to = keyboardTarget;
+    setDragIndex(null);
+    setKeyboardTarget(null);
+    if (from !== to) {
+      onReorder(from, to);
+      announce(`Dropped at position ${to + 1} of ${itemsRef.current.length}`);
+    } else {
+      announce("Dropped — no change");
+    }
+    // Try to refocus the handle at the new position so a chain of moves
+    // feels continuous to keyboard users.
+    requestAnimationFrame(() => {
+      const handle = containerRef.current?.querySelector<HTMLElement>(
+        `[data-sortable-handle-index="${to}"]`,
+      );
+      handle?.focus();
+    });
+  };
+
+  const cancelKeyboardDrag = () => {
+    if (dragIndex == null) return;
+    setDragIndex(null);
+    setKeyboardTarget(null);
+    announce("Reorder cancelled");
+  };
+
+  const handleHandleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (disabled) return;
+    const isPickUpKey = e.key === " " || e.key === "Enter";
+
+    // Not currently dragging → Space/Enter picks up.
+    if (dragIndex == null) {
+      if (isPickUpKey) {
+        e.preventDefault();
+        startKeyboardDrag(index);
+      }
+      return;
+    }
+
+    // Currently dragging this row → handle nav keys.
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveKeyboardDrag(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveKeyboardDrag(-1);
+    } else if (isPickUpKey) {
+      e.preventDefault();
+      dropKeyboardDrag();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelKeyboardDrag();
+    } else if (e.key === "Tab") {
+      // Tab while picked up → treat as drop so focus can escape cleanly.
+      dropKeyboardDrag();
+    }
+  };
+
+  // While keyboard-dragging, the "displayed" order needs to reflect
+  // the in-flight target so the user sees the row move under their
+  // fingers. For mouse DnD the source row stays in place and we draw
+  // a drop-target indicator instead.
+  const displayItems = React.useMemo(() => {
+    if (dragIndex == null || keyboardTarget == null) return items;
+    if (dragIndex === keyboardTarget) return items;
+    const next = items.slice();
+    const [moved] = next.splice(dragIndex, 1);
+    if (moved !== undefined) next.splice(keyboardTarget, 0, moved);
+    return next;
+  }, [items, dragIndex, keyboardTarget]);
+
+  // Map the displayed index back to the underlying source index so
+  // mouse-DnD handlers still pass real indices to onReorder. For mouse
+  // drag we don't reshuffle displayItems so the mapping is identity.
+  const displayToSource = (displayIdx: number): number => {
+    if (dragIndex == null || keyboardTarget == null) return displayIdx;
+    if (dragIndex === keyboardTarget) return displayIdx;
+    // We rebuilt the array: the source item at `keyboardTarget` is
+    // the one originally at `dragIndex`. Everything else stays in
+    // relative order so we can derive: shift items between min/max.
+    if (displayIdx === keyboardTarget) return dragIndex;
+    const lo = Math.min(dragIndex, keyboardTarget);
+    const hi = Math.max(dragIndex, keyboardTarget);
+    if (displayIdx < lo || displayIdx > hi) return displayIdx;
+    return dragIndex < keyboardTarget ? displayIdx + 1 : displayIdx - 1;
+  };
+
+  const handleClassBase =
+    "inline-flex items-center justify-center select-none " +
+    "rounded text-text-subtle hover:text-text " +
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 " +
+    "cursor-grab active:cursor-grabbing aria-grabbed:cursor-grabbing " +
+    "transition-colors";
+
+  return (
+    <ul
+      ref={containerRef}
+      role="list"
+      aria-label={ariaLabel ?? "Sortable list"}
+      className={cn("space-y-1", className)}
+    >
+      {/* Polite live region for screen reader announcements. */}
+      <li className="sr-only" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </li>
+
+      <AnimatePresence initial={false}>
+        {displayItems.map((item, displayIdx) => {
+          const sourceIdx = displayToSource(displayIdx);
+          const key = getKey(item, sourceIdx);
+          const isBeingDragged = dragIndex === sourceIdx;
+          const isMouseDropTarget =
+            dragIndex != null &&
+            keyboardTarget == null &&
+            overIndex === displayIdx &&
+            dragIndex !== displayIdx;
+
+          const dragHandleProps: DragHandleProps = {
+            draggable: true,
+            role: "button",
+            tabIndex: 0,
+            "aria-label":
+              isBeingDragged && keyboardTarget != null
+                ? `Item ${displayIdx + 1} of ${displayItems.length}, picked up. Use arrow keys to move, Space to drop, Escape to cancel.`
+                : `Drag to reorder, item ${displayIdx + 1} of ${displayItems.length}. Press Space to pick up.`,
+            "aria-grabbed": isBeingDragged,
+            "aria-roledescription": "sortable",
+            onDragStart: (e) => startMouseDrag(e, displayIdx),
+            onDragEnd: endMouseDrag,
+            onKeyDown: (e) => handleHandleKeyDown(e, sourceIdx),
+            className: handleClassBase,
+            "data-sortable-handle-index": sourceIdx,
+          };
+
+          // Motion: subtle elevation when this row is being dragged.
+          // Reduced motion → no transform / no scale, just an outline.
+          const motionProps: MotionProps = reduce
+            ? {
+                initial: false,
+                animate: { opacity: isBeingDragged ? 0.9 : 1 },
+                transition: { duration: 0 },
+              }
+            : {
+                layout: true,
+                initial: false,
+                animate: {
+                  scale: isBeingDragged ? 1.015 : 1,
+                  boxShadow: isBeingDragged
+                    ? "0 8px 24px -8px rgba(0,0,0,0.18), 0 2px 4px -2px rgba(0,0,0,0.06)"
+                    : "0 0 0 rgba(0,0,0,0)",
+                  zIndex: isBeingDragged ? 5 : 1,
+                  opacity: isBeingDragged && keyboardTarget == null ? 0.85 : 1,
+                },
+                transition: { duration: DURATION.quick, ease: EASE_PREMIUM },
+              };
+
+          return (
+            <motion.li
+              key={key}
+              {...motionProps}
+              onDragOver={(e) => handleRowDragOver(e, displayIdx)}
+              onDrop={(e) => {
+                if (dragIndex == null) return;
+                e.preventDefault();
+                // endMouseDrag will consume overIndex.
+              }}
+              className={cn(
+                "relative list-none",
+                isMouseDropTarget &&
+                  "before:absolute before:left-0 before:right-0 before:-top-0.5 before:h-0.5 before:bg-accent before:rounded-full",
+              )}
+              aria-roledescription="sortable"
+            >
+              {renderItem(item, {
+                dragHandleProps,
+                isDragging: isBeingDragged,
+                index: displayIdx,
+              })}
+            </motion.li>
+          );
+        })}
+      </AnimatePresence>
+    </ul>
+  );
+}
+
+// ───────────────────────────────────────── KanbanBoard
+//
+// Optional second primitive: a horizontally-arranged set of SortableList
+// columns with cross-column moves wired through one callback. The
+// internal move state is kept here so a card can transition out of one
+// column and into another in one user gesture (mouse) — we route both
+// drag events through column-level dataTransfer payloads.
+
+export interface KanbanColumn<T> {
+  id: string;
+  title: string;
+  items: readonly T[];
+}
+
+export interface KanbanBoardProps<T> {
+  columns: readonly KanbanColumn<T>[];
+  /** Card key extractor (must be globally unique across columns). */
+  getKey: (item: T) => string;
+  /** Render each card; spread `dragHandleProps` for an opt-in drag handle. */
+  renderCard: (item: T, args: SortableRenderArgs) => React.ReactNode;
+  /** Optional column header renderer. */
+  renderColumnHeader?: (column: KanbanColumn<T>) => React.ReactNode;
+  /**
+   * Called after a card moves. `fromColumnId === toColumnId` for a
+   * within-column reorder; otherwise it's a cross-column move and the
+   * caller is responsible for splicing the card out of one column's
+   * state and into the other.
+   */
+  onMoveCard: (args: {
+    fromColumnId: string;
+    toColumnId: string;
+    fromIndex: number;
+    toIndex: number;
+  }) => void;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const KANBAN_DRAG_MIME = "application/x-leafjourney-kanban";
+
+interface KanbanDragPayload {
+  columnId: string;
+  index: number;
+}
+
+export function KanbanBoard<T>({
+  columns,
+  getKey,
+  renderCard,
+  renderColumnHeader,
+  onMoveCard,
+  className,
+  ariaLabel,
+}: KanbanBoardProps<T>) {
+  const reduce = useReducedMotion() ?? false;
+
+  // Stash the in-flight cross-column payload so column-level
+  // dragOver / drop handlers can know what's being moved without
+  // relying on dataTransfer.getData (which is empty during dragover
+  // for security reasons in most browsers).
+  const dragRef = React.useRef<KanbanDragPayload | null>(null);
+
+  const handleColumnDragOver = (e: React.DragEvent) => {
+    if (!dragRef.current) return;
+    if (e.dataTransfer.types.includes(KANBAN_DRAG_MIME)) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+    }
+  };
+
+  const handleColumnDrop = (e: React.DragEvent, toColumnId: string) => {
+    const payload = dragRef.current;
+    if (!payload) return;
+    e.preventDefault();
+    // Drop at end of column when no specific row was hovered.
+    const toColumn = columns.find((c) => c.id === toColumnId);
+    const toIndex = toColumn ? toColumn.items.length : 0;
+    if (payload.columnId !== toColumnId) {
+      onMoveCard({
+        fromColumnId: payload.columnId,
+        toColumnId,
+        fromIndex: payload.index,
+        toIndex,
+      });
+    }
+    dragRef.current = null;
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label={ariaLabel ?? "Kanban board"}
+      className={cn(
+        "flex gap-4 overflow-x-auto pb-2 snap-x scrollbar-thin",
+        className,
+      )}
+    >
+      {columns.map((column) => (
+        <div
+          key={column.id}
+          className="flex-shrink-0 w-72 snap-start rounded-lg border border-border bg-surface-muted/40 p-3"
+          onDragOver={handleColumnDragOver}
+          onDrop={(e) => handleColumnDrop(e, column.id)}
+        >
+          {renderColumnHeader ? (
+            renderColumnHeader(column)
+          ) : (
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-[11px] uppercase tracking-[0.14em] text-text-subtle font-medium">
+                {column.title}
+              </p>
+              <span className="text-[11px] text-text-subtle tabular-nums">
+                {column.items.length}
+              </span>
+            </div>
+          )}
+
+          <SortableList
+            items={column.items}
+            getKey={(item) => getKey(item)}
+            ariaLabel={`${column.title} column`}
+            onReorder={(from, to) =>
+              onMoveCard({
+                fromColumnId: column.id,
+                toColumnId: column.id,
+                fromIndex: from,
+                toIndex: to,
+              })
+            }
+            renderItem={(item, args) => {
+              // Patch the drag handle so cross-column DnD has the column
+              // context it needs. We wrap onDragStart to inject the
+              // payload and dataTransfer MIME.
+              const originalOnDragStart = args.dragHandleProps.onDragStart;
+              const onDragStart = (e: React.DragEvent) => {
+                dragRef.current = { columnId: column.id, index: args.index };
+                try {
+                  e.dataTransfer.setData(KANBAN_DRAG_MIME, column.id);
+                } catch {
+                  // ignore — test harnesses sometimes mock dataTransfer.
+                }
+                originalOnDragStart(e);
+              };
+              const patchedHandle: DragHandleProps = {
+                ...args.dragHandleProps,
+                onDragStart,
+              };
+              return renderCard(item, {
+                ...args,
+                dragHandleProps: patchedHandle,
+              });
+            }}
+          />
+        </div>
+      ))}
+      {/* Reduce-motion hint kept silent — handled by SortableList per row. */}
+      {reduce ? null : null}
+    </div>
+  );
+}
+
+// ───────────────────────────────────────── Convenience helpers
+
+/**
+ * Pure helper to move an item within an immutable list. Useful for
+ * `onReorder` consumers that just want `setItems(reorder(items, f, t))`.
+ */
+export function reorder<T>(list: readonly T[], from: number, to: number): T[] {
+  if (from === to) return list.slice();
+  const next = list.slice();
+  const [moved] = next.splice(from, 1);
+  if (moved === undefined) return next;
+  next.splice(to, 0, moved);
+  return next;
+}


### PR DESCRIPTION
## Summary

Brings Monday.com / Trello-tier drag-and-drop to LeafJourney EMR. Lightweight primitive, zero new deps, full keyboard accessibility.

- **`<SortableList>`** at `src/components/ui/sortable.tsx` — HTML5 DnD under the hood, opt-in drag handle via `dragHandleProps`, framer-motion lift animation, `prefers-reduced-motion` honored.
- **Keyboard reorder** — Space picks up, ↑/↓ moves, Space/Enter drops, Esc cancels. Polite live-region announces position changes for screen readers.
- **`<KanbanBoard>`** composes SortableLists per column with cross-column move callback (ready for surfaces that want it next).
- **`reorder(list, from, to)`** pure helper for immutable splices.

## Adoption (3 surfaces)

1. **Today's queue rail** (`src/app/(clinician)/clinic/page.tsx` → new `queue-rail-client.tsx`). Clinicians can drag their personal order on top of the AI urgency ranking. Persists per-day in localStorage.
2. **Chart task list** (`src/components/patient/ChartTaskList.tsx`). Drag to re-prioritize the chart punch list; per-patient localStorage override on top of severity-bucket sort.
3. **Smart inbox priority pinning** (`src/app/(clinician)/clinic/messages/smart-inbox.tsx`). Lightweight pin-to-top toggle per thread (intentionally not a full DnD reorder to stay clear of PR #436 surface area). Pinned threads bubble above all unpinned regardless of priority. `inbox:pinned:v1` localStorage.

## Persistence strategy

localStorage for v1 (no schema model has the right field for any of the three targets). TODOs left in code for the follow-up schema work:

- `Encounter.queueSortOrder Int?`
- `ChartTask.sortOrder Int?`
- `MessageThread.pinnedBy` join table

## Constraints honored

- No new deps (verified `framer-motion@12` already in package.json).
- No edits to `prisma/schema.prisma`, `src/middleware.ts`, workflows, manifests, auth, or CLAUDE.md.
- Stayed clear of `/ops/supplies` (PR #438) and avoided full smart-inbox list refactor (PRs #436/#449 nearby).

## Test plan

- [ ] `npm run typecheck` — clean (verified locally).
- [ ] `npm run lint` — only pre-existing warnings remain.
- [ ] Open `/clinic` with today's encounters present — drag a card, refresh, order persists for the day.
- [ ] Open a patient chart with open tasks — drag tasks, refresh, order persists per-patient.
- [ ] Tab to a queue-rail grip, press Space, use arrow keys, press Space again. Verify SR announcement.
- [ ] Toggle OS reduce-motion preference — drag still works, no scale animation, instant snap.
- [ ] Pin a thread in `/clinic/messages` — it bubbles to top across filter changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)