### PR TITLE
feat: navigation drawer pinned & overlay modes and global-setup timeout

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -19,7 +19,7 @@
 
 import type { FullConfig } from "@playwright/test";
 
-const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export default async function globalSetup(_config: FullConfig): Promise<void> {
   const baseUrl = process.env.BASE_URL || "http://localhost:3000";


### PR DESCRIPTION
## Summary
- Configured local storage state and relative/absolute positioning toggles for navigation drawer modes (pinned/docked vs unpinned/floating).
- Updated PillarNav layout spacer and ContextDrawer listeners/classes to prevent layout reflow when drawer is unpinned.
- Increased E2E health check timeout in global-setup.ts to 30 seconds to support Next.js compilation during cold starts.

## Test Plan
- Run unit tests: `npm test`
- Run typecheck: `npm run typecheck`
- Run health smoke tests: `npx playwright test e2e/health.spec.ts --project=chromium-public`