### PR TITLE
ux: /search global results page — patients/messages/notes/audit grouped + highlighting

### DIFF
--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,0 +1,46 @@
+// /search loading skeleton — mirrors the header / search bar / tab strip
+// / grouped-list layout so the page doesn't flash a different shape
+// when the data resolves. Honors prefers-reduced-motion via the shared
+// `Skeleton` primitive.
+
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Skeleton, SkeletonText } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Universal search"
+        title="Search"
+        description="Find patients, messages, notes, and audit events across your practice."
+      />
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <Skeleton className="flex-1 h-12 rounded-md" />
+        <Skeleton className="w-28 h-12 rounded-md" />
+      </div>
+
+      <div className="flex gap-3 border-b border-border pb-2 mb-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-5 w-16" />
+        ))}
+      </div>
+
+      {Array.from({ length: 3 }).map((_, group) => (
+        <section key={group} className="mb-10">
+          <div className="flex items-center gap-2 mb-2">
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="h-4 w-8 rounded-full" />
+          </div>
+          <div className="border border-border rounded-xl divide-y divide-border/70 bg-surface">
+            {Array.from({ length: 3 }).map((_, row) => (
+              <div key={row} className="px-4 py-3">
+                <SkeletonText lines={2} />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </PageShell>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,515 @@
+// UX run — /search global results page.
+//
+// Stripe / Linear-style universal results across patients, messages,
+// notes, and audit. Complements the ⌘K command palette (which is for
+// fast actions / jumps); this page is for deeper queries and "show me
+// every match" exploration.
+//
+// URL shape:
+//   /search?q=<query>&category=<all|patients|messages|notes|audit>&offset=<n>
+//
+// All four categories are clinician-data. We gate on the clinic-floor
+// role set, the same one the (clinician) layout uses. Sitting outside
+// the (clinician) route group lets the page live at a clean top-level
+// `/search` URL the command palette can deep-link to.
+//
+// Highlighting: every snippet runs through `highlightSegments()` and
+// matched chunks get wrapped in `<mark>` — the only HTML-shaped markup
+// emitted from user-controlled text.
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { prisma } from "@/lib/db/prisma";
+import { getCurrentUser } from "@/lib/auth/session";
+import { ROLE_HOME, primaryRole } from "@/lib/rbac/roles";
+import type { Role } from "@prisma/client";
+import {
+  GLOBAL_SEARCH_CATEGORIES,
+  GLOBAL_SEARCH_GROUP_PREVIEW,
+  GLOBAL_SEARCH_MIN_QUERY,
+  GLOBAL_SEARCH_PAGE_SIZE,
+  type GlobalSearchCategory,
+  type GlobalSearchCategoryFilter,
+  type GlobalSearchHit,
+  type GlobalSearchResults,
+  highlightSegments,
+  parseCategoryFilter,
+  parseLimit,
+  parseOffset,
+  searchAcrossEMR,
+  totalResults,
+} from "@/lib/domain/global-search";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Search" };
+
+const CLINIC_FLOOR_ROLES: Role[] = [
+  "clinician",
+  "midlevel",
+  "back_office",
+  "front_office",
+  "practice_owner",
+];
+
+const CATEGORY_TABS: Array<{
+  value: GlobalSearchCategoryFilter;
+  label: string;
+}> = [
+  { value: "all", label: "All" },
+  ...GLOBAL_SEARCH_CATEGORIES.map((c) => ({
+    value: c as GlobalSearchCategoryFilter,
+    label: c.charAt(0).toUpperCase() + c.slice(1),
+  })),
+];
+
+const CATEGORY_BADGE_TONE: Record<
+  GlobalSearchCategory,
+  "accent" | "info" | "success" | "neutral"
+> = {
+  patients: "accent",
+  messages: "info",
+  notes: "success",
+  audit: "neutral",
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function first(v: string | string[] | undefined): string | null {
+  if (Array.isArray(v)) return v[0] ?? null;
+  return v ?? null;
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  // Next 15: searchParams is async.
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const q = (first(params.q) ?? "").trim();
+  const category = parseCategoryFilter(first(params.category));
+  const offset = parseOffset(first(params.offset));
+  const limit = parseLimit(
+    first(params.limit),
+    category === "all" ? GLOBAL_SEARCH_GROUP_PREVIEW : GLOBAL_SEARCH_PAGE_SIZE,
+  );
+
+  // Auth — this surface holds patient PHI. Must be a clinic-floor role
+  // with an org. Anonymous → sign-in. Wrong role → home.
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect(`/sign-in?next=${encodeURIComponent(`/search?q=${q}`)}`);
+  }
+  if (!user.roles.some((r) => CLINIC_FLOOR_ROLES.includes(r))) {
+    redirect(ROLE_HOME[primaryRole(user.roles)] ?? "/");
+  }
+  const organizationId = user.organizationId;
+
+  // Empty-query short-circuit: render the chrome, no data fetch.
+  let results: GlobalSearchResults | null = null;
+  if (organizationId && q.length >= GLOBAL_SEARCH_MIN_QUERY) {
+    results = await searchAcrossEMR(prisma, q, organizationId, {
+      category,
+      limit,
+      offset,
+    });
+  }
+
+  const total = results ? totalResults(results) : 0;
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Universal search"
+        title="Search"
+        description="Find patients, messages, notes, and audit events across your practice."
+      />
+
+      {/* Search form. GET so URL stays shareable. */}
+      <form
+        action="/search"
+        method="get"
+        className="flex flex-col sm:flex-row gap-3 mb-6"
+        role="search"
+        aria-label="Global search"
+      >
+        <Input
+          name="q"
+          defaultValue={q}
+          placeholder="Search patients, messages, notes, audit…"
+          className="flex-1 h-12 text-base"
+          autoFocus
+          // Browser-level autocomplete is noisy for clinical lookups.
+          autoComplete="off"
+          aria-label="Search query"
+        />
+        <input type="hidden" name="category" value={category} />
+        <Button type="submit" size="md">
+          Search
+        </Button>
+      </form>
+
+      {/* Category tabs. Anchor-based so they survive a hard nav. */}
+      <CategoryTabs activeCategory={category} q={q} results={results} />
+
+      <div className="mt-6">
+        {q.length === 0 ? (
+          <StartState />
+        ) : q.length < GLOBAL_SEARCH_MIN_QUERY ? (
+          <ShortQueryState />
+        ) : !organizationId ? (
+          <EmptyState
+            title="No practice attached to your account"
+            description="Reach out to your practice admin to be added to an organization before searching."
+          />
+        ) : total === 0 && results ? (
+          <NoResultsState q={q} category={category} />
+        ) : (
+          results && (
+            <ResultsBody
+              q={q}
+              category={category}
+              results={results}
+              offset={offset}
+              limit={limit}
+            />
+          )
+        )}
+      </div>
+    </PageShell>
+  );
+}
+
+// ── Subcomponents ─────────────────────────────────────────────
+
+function CategoryTabs({
+  activeCategory,
+  q,
+  results,
+}: {
+  activeCategory: GlobalSearchCategoryFilter;
+  q: string;
+  results: GlobalSearchResults | null;
+}) {
+  const counts: Record<GlobalSearchCategoryFilter, number | null> = {
+    all: results ? totalResults(results) : null,
+    patients: results?.patients.total ?? null,
+    messages: results?.messages.total ?? null,
+    notes: results?.notes.total ?? null,
+    audit: results?.audit.total ?? null,
+  };
+  return (
+    <nav
+      role="tablist"
+      aria-label="Search categories"
+      className="flex flex-wrap gap-1 border-b border-border"
+    >
+      {CATEGORY_TABS.map((tab) => {
+        const isActive = tab.value === activeCategory;
+        const href = `/search?q=${encodeURIComponent(q)}&category=${tab.value}`;
+        const n = counts[tab.value];
+        return (
+          <Link
+            key={tab.value}
+            href={href}
+            role="tab"
+            aria-selected={isActive}
+            className={
+              "px-3 py-2 text-sm border-b-2 -mb-px transition-colors " +
+              (isActive
+                ? "border-accent text-accent font-medium"
+                : "border-transparent text-text-muted hover:text-text")
+            }
+          >
+            {tab.label}
+            {n !== null && (
+              <span className="ml-1.5 text-xs text-text-subtle">
+                {n}
+              </span>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function StartState() {
+  return (
+    <EmptyState
+      title="Type a query to search across your practice"
+      description="Patients by name, email or phone. Messages, notes, and audit events by their content. Press ⌘K for quick jumps and actions."
+      tips={[
+        "Try a partial last name — searches are case-insensitive.",
+        'Filter by category using the tabs above once you have results.',
+        "Audit search matches action names like \"note.finalized\".",
+      ]}
+    />
+  );
+}
+
+function ShortQueryState() {
+  return (
+    <EmptyState
+      title="Add one more character"
+      description={`Searches start at ${GLOBAL_SEARCH_MIN_QUERY} characters so we don't drown you in noise.`}
+    />
+  );
+}
+
+function NoResultsState({
+  q,
+  category,
+}: {
+  q: string;
+  category: GlobalSearchCategoryFilter;
+}) {
+  const isFiltered = category !== "all";
+  return (
+    <EmptyState
+      title={`No matches for "${q}"`}
+      description={
+        isFiltered
+          ? "Try widening to All, or rephrase your query — even a partial match across name, email or phone will surface a patient."
+          : "Try a shorter or differently spelled query, or check that you're looking in the right practice."
+      }
+      primaryAction={
+        isFiltered ? (
+          <Link
+            href={`/search?q=${encodeURIComponent(q)}&category=all`}
+            className="inline-flex items-center px-4 py-2 rounded-md bg-accent text-on-accent text-sm font-medium hover:bg-accent-hover transition-colors"
+          >
+            Search across all categories
+          </Link>
+        ) : undefined
+      }
+      tips={[
+        "Last-name and first-name searches are case-insensitive.",
+        "For audit events, try the action key (e.g. \"note.finalized\").",
+      ]}
+    />
+  );
+}
+
+function ResultsBody({
+  q,
+  category,
+  results,
+  offset,
+  limit,
+}: {
+  q: string;
+  category: GlobalSearchCategoryFilter;
+  results: GlobalSearchResults;
+  offset: number;
+  limit: number;
+}) {
+  // Single-category view: one section, paginated.
+  if (category !== "all") {
+    const group = results[category];
+    return (
+      <section aria-label={`${category} results`}>
+        <SectionHeader
+          category={category}
+          total={group.total}
+          showSeeAll={false}
+          q={q}
+        />
+        {group.items.length === 0 ? (
+          <p className="text-sm text-text-muted py-6 text-center">
+            No more results in this category.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border/70 border border-border rounded-xl bg-surface">
+            {group.items.map((hit) => (
+              <li key={`${hit.kind}:${hit.id}`}>
+                <ResultRow hit={hit} q={q} />
+              </li>
+            ))}
+          </ul>
+        )}
+        <Pagination
+          q={q}
+          category={category}
+          offset={offset}
+          limit={limit}
+          total={group.total}
+          shown={group.items.length}
+        />
+      </section>
+    );
+  }
+
+  // "All" view: top-N preview per group with "See all N →".
+  return (
+    <div className="space-y-10">
+      {(["patients", "messages", "notes", "audit"] as const).map((cat) => {
+        const group = results[cat];
+        if (group.total === 0) return null;
+        return (
+          <section key={cat} aria-label={`${cat} results`}>
+            <SectionHeader
+              category={cat}
+              total={group.total}
+              showSeeAll={group.total > group.items.length}
+              q={q}
+            />
+            <ul className="divide-y divide-border/70 border border-border rounded-xl bg-surface">
+              {group.items.map((hit) => (
+                <li key={`${hit.kind}:${hit.id}`}>
+                  <ResultRow hit={hit} q={q} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function SectionHeader({
+  category,
+  total,
+  showSeeAll,
+  q,
+}: {
+  category: GlobalSearchCategory;
+  total: number;
+  showSeeAll: boolean;
+  q: string;
+}) {
+  return (
+    <div className="flex items-end justify-between mb-2">
+      <div className="flex items-center gap-2">
+        <h2 className="font-display text-lg text-text">
+          {category.charAt(0).toUpperCase() + category.slice(1)}
+        </h2>
+        <Badge tone="neutral">{total}</Badge>
+      </div>
+      {showSeeAll && (
+        <Link
+          href={`/search?q=${encodeURIComponent(q)}&category=${category}`}
+          className="text-sm text-accent hover:underline"
+        >
+          See all {total} →
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function ResultRow({ hit, q }: { hit: GlobalSearchHit; q: string }) {
+  const dateLabel =
+    hit.kind === "message" || hit.kind === "note" || hit.kind === "audit"
+      ? hit.createdAt.toISOString().slice(0, 10)
+      : null;
+  return (
+    <Link
+      href={hit.href}
+      className="block px-4 py-3 hover:bg-surface-muted/60 transition-colors focus-visible:bg-surface-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-sm font-medium text-text truncate">
+              <Highlight text={hit.title} q={q} />
+            </p>
+            <Badge tone={CATEGORY_BADGE_TONE[hit.kind === "patient" ? "patients" : hit.kind === "message" ? "messages" : hit.kind === "note" ? "notes" : "audit"]}>
+              {hit.kind}
+            </Badge>
+          </div>
+          {hit.snippet && (
+            <p className="text-[13px] text-text-muted mt-1 leading-snug line-clamp-2">
+              <Highlight text={hit.snippet} q={q} />
+            </p>
+          )}
+        </div>
+        {dateLabel && (
+          <span className="text-[11px] text-text-subtle shrink-0 tabular-nums">
+            {dateLabel}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+/**
+ * Wraps every case-insensitive occurrence of `q` in <mark>. Renders via
+ * the pre-built segment list from the domain helper — no innerHTML, no
+ * dangerouslySetInnerHTML. The <mark> element gets a subtle background
+ * so it reads as a highlight rather than a yellow blob.
+ */
+function Highlight({ text, q }: { text: string; q: string }) {
+  const segments = highlightSegments(text, q);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.match ? (
+          <mark
+            key={i}
+            className="bg-highlight-soft text-text px-0.5 rounded-sm font-medium"
+          >
+            {seg.text}
+          </mark>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function Pagination({
+  q,
+  category,
+  offset,
+  limit,
+  total,
+  shown,
+}: {
+  q: string;
+  category: GlobalSearchCategory;
+  offset: number;
+  limit: number;
+  total: number;
+  shown: number;
+}) {
+  const hasPrev = offset > 0;
+  const hasNext = offset + shown < total;
+  if (!hasPrev && !hasNext) return null;
+  const prevOffset = Math.max(0, offset - limit);
+  const nextOffset = offset + limit;
+  return (
+    <div className="flex items-center justify-between mt-4 text-sm">
+      <span className="text-text-subtle">
+        Showing {offset + 1}–{offset + shown} of {total}
+      </span>
+      <div className="flex gap-2">
+        {hasPrev && (
+          <Link
+            href={`/search?q=${encodeURIComponent(q)}&category=${category}&offset=${prevOffset}`}
+            className="px-3 py-1.5 rounded-md border border-border hover:bg-surface-muted text-text"
+          >
+            ← Previous
+          </Link>
+        )}
+        {hasNext && (
+          <Link
+            href={`/search?q=${encodeURIComponent(q)}&category=${category}&offset=${nextOffset}`}
+            className="px-3 py-1.5 rounded-md border border-border hover:bg-surface-muted text-text"
+          >
+            Next →
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -346,8 +346,21 @@ export function CommandPalette({ role }: CommandPaletteProps = {}) {
     // Role-aware search passthrough. Clinician gets the existing roster
     // filter; operator gets the ops patients list; patient has nothing
     // searchable of that shape so no passthrough there.
+    //
+    // Clinic-floor roles ALSO get a top-of-list "Search everything" entry
+    // that hands the query off to the /search global results page — that's
+    // the deeper-search counterpart to ⌘K's quick-jump posture. Putting
+    // it above the per-row matches makes Enter-from-an-empty-result still
+    // feel useful.
     if (trimmed.length > 0) {
       if (role === "clinician" || role === undefined) {
+        out.unshift({
+          id: "search-all-results",
+          label: `Search everything: "${trimmed}"`,
+          hint: "Open /search — patients, messages, notes, audit",
+          group: "Search",
+          run: (r, q) => r.push(`/search?q=${encodeURIComponent(q)}`),
+        });
         out.unshift({
           id: "search-clinician-patients",
           label: `Search patients: "${trimmed}"`,
@@ -494,9 +507,13 @@ export function CommandPalette({ role }: CommandPaletteProps = {}) {
           )}
         </div>
 
-        <div className="px-4 py-2 border-t border-border bg-surface-muted/40 text-[11px] text-text-subtle flex items-center justify-between">
-          <span>↑ ↓ to navigate · ↵ to select</span>
-          <span>esc to close</span>
+        <div className="px-4 py-2 border-t border-border bg-surface-muted/40 text-[11px] text-text-subtle flex items-center justify-between gap-3">
+          <span>↑ ↓ navigate · ↵ select</span>
+          {query.trim().length > 0 && (role === "clinician" || role === undefined) ? (
+            <span>↵ on top row to search all results · esc to close</span>
+          ) : (
+            <span>esc to close</span>
+          )}
         </div>
       </Card>
     </div>

--- a/src/lib/domain/global-search.test.ts
+++ b/src/lib/domain/global-search.test.ts
@@ -1,0 +1,216 @@
+// Unit tests for the global-search domain module. The Prisma-dependent
+// branches are exercised via a hand-rolled fake `GlobalSearchPrisma` so
+// the tests stay snappy and don't require a running DB.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  GLOBAL_SEARCH_GROUP_PREVIEW,
+  GLOBAL_SEARCH_MIN_QUERY,
+  type GlobalSearchPrisma,
+  highlightSegments,
+  parseCategoryFilter,
+  parseLimit,
+  parseOffset,
+  searchAcrossEMR,
+  snippetAround,
+  totalResults,
+} from "./global-search";
+
+describe("parseCategoryFilter", () => {
+  it("returns 'all' for null/undefined/'all'", () => {
+    expect(parseCategoryFilter(null)).toBe("all");
+    expect(parseCategoryFilter(undefined)).toBe("all");
+    expect(parseCategoryFilter("all")).toBe("all");
+  });
+
+  it("accepts known categories verbatim", () => {
+    expect(parseCategoryFilter("patients")).toBe("patients");
+    expect(parseCategoryFilter("messages")).toBe("messages");
+    expect(parseCategoryFilter("notes")).toBe("notes");
+    expect(parseCategoryFilter("audit")).toBe("audit");
+  });
+
+  it("falls back to 'all' on bogus input", () => {
+    expect(parseCategoryFilter("orders")).toBe("all");
+    expect(parseCategoryFilter("")).toBe("all");
+  });
+});
+
+describe("parseOffset / parseLimit", () => {
+  it("clamps offset to zero on bad input", () => {
+    expect(parseOffset(null)).toBe(0);
+    expect(parseOffset("-5")).toBe(0);
+    expect(parseOffset("abc")).toBe(0);
+    expect(parseOffset("7")).toBe(7);
+  });
+
+  it("returns fallback when limit is missing", () => {
+    expect(parseLimit(undefined, 25)).toBe(25);
+    expect(parseLimit("0", 25)).toBe(25);
+  });
+
+  it("caps limit at the hard maximum", () => {
+    expect(parseLimit("99999", 25)).toBe(100);
+  });
+});
+
+describe("highlightSegments", () => {
+  it("returns a single non-match segment when term is empty", () => {
+    expect(highlightSegments("hello", "")).toEqual([
+      { text: "hello", match: false },
+    ]);
+  });
+
+  it("wraps every case-insensitive occurrence", () => {
+    const segs = highlightSegments("Maya MAYA maya", "may");
+    expect(segs).toEqual([
+      { text: "May", match: true },
+      { text: "a ", match: false },
+      { text: "MAY", match: true },
+      { text: "A ", match: false },
+      { text: "may", match: true },
+      { text: "a", match: false },
+    ]);
+  });
+
+  it("preserves original casing in matched segments", () => {
+    const segs = highlightSegments("Foo BAR baz", "bar");
+    expect(segs.find((s) => s.match)?.text).toBe("BAR");
+  });
+});
+
+describe("snippetAround", () => {
+  it("returns the body when no term", () => {
+    expect(snippetAround("short body", "")).toBe("short body");
+  });
+
+  it("centers the window on the first match", () => {
+    const body = "a".repeat(200) + "TARGET" + "b".repeat(200);
+    const snip = snippetAround(body, "TARGET", 20);
+    expect(snip.startsWith("…")).toBe(true);
+    expect(snip.endsWith("…")).toBe(true);
+    expect(snip).toContain("TARGET");
+  });
+
+  it("does not prefix ellipsis when match is near the start", () => {
+    const snip = snippetAround("hello world", "hello", 20);
+    expect(snip.startsWith("…")).toBe(false);
+  });
+});
+
+describe("searchAcrossEMR", () => {
+  function buildPrisma(): GlobalSearchPrisma {
+    return {
+      patient: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "p1",
+            firstName: "Maya",
+            lastName: "Reyes",
+            email: "maya@example.com",
+            phone: "415-555-0188",
+          },
+        ]),
+        count: vi.fn().mockResolvedValue(7),
+      },
+      message: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "m1",
+            threadId: "t1",
+            body: "Hello Maya, here is the lab result you asked about.",
+            createdAt: new Date("2026-05-01T10:00:00Z"),
+          },
+        ]),
+        count: vi.fn().mockResolvedValue(2),
+      },
+      note: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "n1",
+            encounterId: "e1",
+            status: "finalized",
+            narrative: "Patient Maya presented with chronic pain.",
+            finalizedAt: new Date("2026-04-29T00:00:00Z"),
+            createdAt: new Date("2026-04-29T00:00:00Z"),
+          },
+        ]),
+        count: vi.fn().mockResolvedValue(3),
+      },
+      auditLog: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "a1",
+            action: "note.finalized",
+            actorUserId: "u1",
+            actorAgent: null,
+            subjectType: "Note",
+            subjectId: "n1",
+            createdAt: new Date("2026-04-29T01:00:00Z"),
+          },
+        ]),
+        count: vi.fn().mockResolvedValue(11),
+      },
+    };
+  }
+
+  it("short-circuits below MIN_QUERY", async () => {
+    const db = buildPrisma();
+    const res = await searchAcrossEMR(db, "a", "org-1");
+    expect(res.patients.total).toBe(0);
+    expect(db.patient.findMany).not.toHaveBeenCalled();
+    expect(totalResults(res)).toBe(0);
+  });
+
+  it("fans out to all four categories when category='all'", async () => {
+    const db = buildPrisma();
+    const res = await searchAcrossEMR(db, "Maya", "org-1");
+    expect(db.patient.findMany).toHaveBeenCalled();
+    expect(db.message.findMany).toHaveBeenCalled();
+    expect(db.note.findMany).toHaveBeenCalled();
+    expect(db.auditLog.findMany).toHaveBeenCalled();
+    expect(res.patients.items[0].title).toBe("Maya Reyes");
+    expect(res.patients.items[0].href).toBe("/clinic/patients/p1");
+    expect(res.messages.items[0].kind).toBe("message");
+    expect(res.notes.items[0].kind).toBe("note");
+    expect(res.audit.items[0].title).toBe("note.finalized");
+    expect(totalResults(res)).toBe(7 + 2 + 3 + 11);
+  });
+
+  it("skips other categories when a category is selected", async () => {
+    const db = buildPrisma();
+    await searchAcrossEMR(db, "Maya", "org-1", { category: "patients" });
+    expect(db.patient.findMany).toHaveBeenCalled();
+    expect(db.message.findMany).not.toHaveBeenCalled();
+    expect(db.note.findMany).not.toHaveBeenCalled();
+    expect(db.auditLog.findMany).not.toHaveBeenCalled();
+  });
+
+  it("uses the preview limit by default in 'all' mode", async () => {
+    const db = buildPrisma();
+    await searchAcrossEMR(db, "Maya", "org-1");
+    const firstPatientCall = (db.patient.findMany as ReturnType<typeof vi.fn>)
+      .mock.calls[0]?.[0];
+    expect(firstPatientCall?.take).toBe(GLOBAL_SEARCH_GROUP_PREVIEW);
+    expect(firstPatientCall?.skip).toBe(0);
+  });
+
+  it("respects the requested offset for a single category", async () => {
+    const db = buildPrisma();
+    await searchAcrossEMR(db, "Maya", "org-1", {
+      category: "messages",
+      offset: 25,
+      limit: 10,
+    });
+    const call = (db.message.findMany as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0];
+    expect(call?.skip).toBe(25);
+    expect(call?.take).toBe(10);
+  });
+
+  it("constant MIN_QUERY is reasonable", () => {
+    // Sanity check — protects against an accidental 0 / 1 default.
+    expect(GLOBAL_SEARCH_MIN_QUERY).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/domain/global-search.ts
+++ b/src/lib/domain/global-search.ts
@@ -1,0 +1,532 @@
+// Global search core — Stripe/Linear-style "/search" results page (UX run).
+//
+// Pure(ish) async function over a prisma-shaped client. Returns grouped,
+// per-category results so the `/search` server component can render them
+// without any second-pass shaping. Highlighting (the `<mark>` wrapper) is
+// a UI concern and lives in the React tree — this module only emits
+// plain strings and the raw `matchedTerm` so the renderer can do its own
+// substring annotation deterministically.
+//
+// v1 categories: patients, messages, notes, audit. All four scoped to the
+// caller's organization. Soft-deleted patients are excluded. Provider
+// messages (the doc-to-doc channel) are intentionally out of scope here
+// because their bodies are ciphertext envelopes — see EMR-033.
+//
+// Why a domain module rather than just running the queries in the page?
+//   1. Keeps the server component a thin shell, easier to test the page.
+//   2. Lets a future /api/search route or the command palette re-use the
+//      exact same query shape without duplicating the OR predicates.
+//   3. Mirrors the pattern already established by
+//      `src/lib/admin/cross-tenant-search.ts` (super-admin search) — same
+//      file shape, same function-over-fake-prisma test ergonomics.
+
+import "server-only";
+
+import type { Prisma } from "@prisma/client";
+
+export const GLOBAL_SEARCH_CATEGORIES = [
+  "patients",
+  "messages",
+  "notes",
+  "audit",
+] as const;
+
+export type GlobalSearchCategory = (typeof GLOBAL_SEARCH_CATEGORIES)[number];
+
+export type GlobalSearchCategoryFilter = GlobalSearchCategory | "all";
+
+/**
+ * UI-facing minimum query length. Below this we just render the empty
+ * "type to search" state — running OR-of-contains across four tables
+ * for a 1-char query is wasteful and produces useless noise.
+ */
+export const GLOBAL_SEARCH_MIN_QUERY = 2;
+
+/**
+ * Default "show top N per group" when the user hasn't picked a category.
+ * Linear/Stripe-style "See all 47 →" affordance handles the rest.
+ */
+export const GLOBAL_SEARCH_GROUP_PREVIEW = 3;
+
+/**
+ * Per-category page size when a category IS selected. Larger than the
+ * preview to make the dedicated view feel substantive without paging.
+ */
+export const GLOBAL_SEARCH_PAGE_SIZE = 25;
+
+export const GLOBAL_SEARCH_MAX_LIMIT = 100;
+
+export function parseCategoryFilter(
+  raw: string | null | undefined,
+): GlobalSearchCategoryFilter {
+  if (!raw || raw === "all") return "all";
+  if ((GLOBAL_SEARCH_CATEGORIES as readonly string[]).includes(raw)) {
+    return raw as GlobalSearchCategory;
+  }
+  return "all";
+}
+
+export function parseOffset(raw: string | null | undefined): number {
+  if (!raw) return 0;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
+export function parseLimit(
+  raw: string | null | undefined,
+  fallback = GLOBAL_SEARCH_PAGE_SIZE,
+): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, GLOBAL_SEARCH_MAX_LIMIT);
+}
+
+// ── Result shapes ─────────────────────────────────────────────
+
+export interface PatientHit {
+  kind: "patient";
+  id: string;
+  title: string; // "Maya Reyes"
+  snippet: string; // "maya.reyes@example.com · (415) 555-0188"
+  href: string;
+}
+
+export interface MessageHit {
+  kind: "message";
+  id: string;
+  threadId: string;
+  title: string; // first line of body, trimmed
+  snippet: string; // body excerpt around match
+  createdAt: Date;
+  href: string;
+}
+
+export interface NoteHit {
+  kind: "note";
+  id: string;
+  encounterId: string;
+  title: string; // status + finalised date
+  snippet: string; // narrative excerpt around match
+  createdAt: Date;
+  href: string;
+}
+
+export interface AuditHit {
+  kind: "audit";
+  id: string;
+  title: string; // action label
+  snippet: string; // "actor → subjectType subjectId"
+  createdAt: Date;
+  href: string;
+}
+
+export type GlobalSearchHit = PatientHit | MessageHit | NoteHit | AuditHit;
+
+export interface GlobalSearchGroup<T extends GlobalSearchHit> {
+  /** Total matching rows for this category (used for "See all N →"). */
+  total: number;
+  /** Rows for the current offset window. */
+  items: T[];
+}
+
+export interface GlobalSearchResults {
+  query: string;
+  organizationId: string;
+  patients: GlobalSearchGroup<PatientHit>;
+  messages: GlobalSearchGroup<MessageHit>;
+  notes: GlobalSearchGroup<NoteHit>;
+  audit: GlobalSearchGroup<AuditHit>;
+}
+
+// ── Prisma surface we depend on ───────────────────────────────
+//
+// Typed narrowly so unit tests can supply a fake without booting Next.
+
+export interface GlobalSearchPrisma {
+  patient: {
+    findMany: (args: Prisma.PatientFindManyArgs) => Promise<
+      Array<{
+        id: string;
+        firstName: string;
+        lastName: string;
+        email: string | null;
+        phone: string | null;
+      }>
+    >;
+    count: (args: Prisma.PatientCountArgs) => Promise<number>;
+  };
+  message: {
+    findMany: (args: Prisma.MessageFindManyArgs) => Promise<
+      Array<{
+        id: string;
+        threadId: string;
+        body: string;
+        createdAt: Date;
+      }>
+    >;
+    count: (args: Prisma.MessageCountArgs) => Promise<number>;
+  };
+  note: {
+    findMany: (args: Prisma.NoteFindManyArgs) => Promise<
+      Array<{
+        id: string;
+        encounterId: string;
+        status: string;
+        narrative: string | null;
+        finalizedAt: Date | null;
+        createdAt: Date;
+      }>
+    >;
+    count: (args: Prisma.NoteCountArgs) => Promise<number>;
+  };
+  auditLog: {
+    findMany: (args: Prisma.AuditLogFindManyArgs) => Promise<
+      Array<{
+        id: string;
+        action: string;
+        actorUserId: string | null;
+        actorAgent: string | null;
+        subjectType: string | null;
+        subjectId: string | null;
+        createdAt: Date;
+      }>
+    >;
+    count: (args: Prisma.AuditLogCountArgs) => Promise<number>;
+  };
+}
+
+export interface SearchAcrossEMROptions {
+  /** Restrict to one category. "all" returns all four. */
+  category?: GlobalSearchCategoryFilter;
+  /** Per-category page size. Default = GLOBAL_SEARCH_GROUP_PREVIEW for "all",
+   *  GLOBAL_SEARCH_PAGE_SIZE for a specific category. */
+  limit?: number;
+  /** Per-category offset (only meaningful when category != "all"). */
+  offset?: number;
+}
+
+const EMPTY_GROUP = <T extends GlobalSearchHit>(): GlobalSearchGroup<T> => ({
+  total: 0,
+  items: [],
+});
+
+/**
+ * Run the global EMR search. Org-scoped. Always returns the full
+ * { patients, messages, notes, audit } envelope — categories not
+ * requested come back as empty groups so the renderer can be uniform.
+ */
+export async function searchAcrossEMR(
+  db: GlobalSearchPrisma,
+  query: string,
+  organizationId: string,
+  opts: SearchAcrossEMROptions = {},
+): Promise<GlobalSearchResults> {
+  const q = query.trim();
+  const category = opts.category ?? "all";
+  const isAll = category === "all";
+
+  const result: GlobalSearchResults = {
+    query: q,
+    organizationId,
+    patients: EMPTY_GROUP<PatientHit>(),
+    messages: EMPTY_GROUP<MessageHit>(),
+    notes: EMPTY_GROUP<NoteHit>(),
+    audit: EMPTY_GROUP<AuditHit>(),
+  };
+
+  if (q.length < GLOBAL_SEARCH_MIN_QUERY) return result;
+
+  const limit =
+    opts.limit ?? (isAll ? GLOBAL_SEARCH_GROUP_PREVIEW : GLOBAL_SEARCH_PAGE_SIZE);
+  const offset = isAll ? 0 : opts.offset ?? 0;
+
+  const wantPatients = isAll || category === "patients";
+  const wantMessages = isAll || category === "messages";
+  const wantNotes = isAll || category === "notes";
+  const wantAudit = isAll || category === "audit";
+
+  // Fan out concurrently — these are independent queries on independent
+  // tables, no need to serialise.
+  const [patients, messages, notes, audit] = await Promise.all([
+    wantPatients
+      ? searchPatientsGroup(db, q, organizationId, limit, offset)
+      : EMPTY_GROUP<PatientHit>(),
+    wantMessages
+      ? searchMessagesGroup(db, q, organizationId, limit, offset)
+      : EMPTY_GROUP<MessageHit>(),
+    wantNotes
+      ? searchNotesGroup(db, q, organizationId, limit, offset)
+      : EMPTY_GROUP<NoteHit>(),
+    wantAudit
+      ? searchAuditGroup(db, q, organizationId, limit, offset)
+      : EMPTY_GROUP<AuditHit>(),
+  ]);
+
+  result.patients = patients;
+  result.messages = messages;
+  result.notes = notes;
+  result.audit = audit;
+  return result;
+}
+
+// ── Per-category helpers ──────────────────────────────────────
+
+async function searchPatientsGroup(
+  db: GlobalSearchPrisma,
+  q: string,
+  organizationId: string,
+  limit: number,
+  offset: number,
+): Promise<GlobalSearchGroup<PatientHit>> {
+  const where: Prisma.PatientWhereInput = {
+    organizationId,
+    deletedAt: null,
+    OR: [
+      { firstName: { contains: q, mode: "insensitive" } },
+      { lastName: { contains: q, mode: "insensitive" } },
+      { email: { contains: q, mode: "insensitive" } },
+      { phone: { contains: q } },
+    ],
+  };
+  const [rows, total] = await Promise.all([
+    db.patient.findMany({
+      where,
+      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        phone: true,
+      },
+    }),
+    db.patient.count({ where }),
+  ]);
+  return {
+    total,
+    items: rows.map((p) => ({
+      kind: "patient" as const,
+      id: p.id,
+      title: `${p.firstName} ${p.lastName}`.trim() || "(unnamed patient)",
+      snippet: [p.email, p.phone].filter(Boolean).join(" · ") || "—",
+      href: `/clinic/patients/${p.id}`,
+    })),
+  };
+}
+
+async function searchMessagesGroup(
+  db: GlobalSearchPrisma,
+  q: string,
+  organizationId: string,
+  limit: number,
+  offset: number,
+): Promise<GlobalSearchGroup<MessageHit>> {
+  const where: Prisma.MessageWhereInput = {
+    body: { contains: q, mode: "insensitive" },
+    // Patient-thread messages are org-scoped via the thread → patient → org join.
+    thread: { patient: { organizationId } },
+  };
+  const [rows, total] = await Promise.all([
+    db.message.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        threadId: true,
+        body: true,
+        createdAt: true,
+      },
+    }),
+    db.message.count({ where }),
+  ]);
+  return {
+    total,
+    items: rows.map((m) => ({
+      kind: "message" as const,
+      id: m.id,
+      threadId: m.threadId,
+      title: firstLine(m.body) || "(empty message)",
+      snippet: snippetAround(m.body, q),
+      createdAt: m.createdAt,
+      href: `/clinic/messages?thread=${m.threadId}`,
+    })),
+  };
+}
+
+async function searchNotesGroup(
+  db: GlobalSearchPrisma,
+  q: string,
+  organizationId: string,
+  limit: number,
+  offset: number,
+): Promise<GlobalSearchGroup<NoteHit>> {
+  // Notes live under encounters, which carry organizationId. We search
+  // the free-form narrative column; the structured `blocks` JSON is
+  // intentionally out of scope for v1 (would need a custom JSON path
+  // expression and tends to over-match agent boilerplate).
+  const where: Prisma.NoteWhereInput = {
+    narrative: { contains: q, mode: "insensitive" },
+    encounter: { organizationId },
+  };
+  const [rows, total] = await Promise.all([
+    db.note.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        encounterId: true,
+        status: true,
+        narrative: true,
+        finalizedAt: true,
+        createdAt: true,
+      },
+    }),
+    db.note.count({ where }),
+  ]);
+  return {
+    total,
+    items: rows.map((n) => ({
+      kind: "note" as const,
+      id: n.id,
+      encounterId: n.encounterId,
+      title: `Note · ${n.status}${
+        n.finalizedAt ? ` · ${n.finalizedAt.toISOString().slice(0, 10)}` : ""
+      }`,
+      snippet: snippetAround(n.narrative ?? "", q),
+      createdAt: n.createdAt,
+      href: `/clinic/encounters/${n.encounterId}`,
+    })),
+  };
+}
+
+async function searchAuditGroup(
+  db: GlobalSearchPrisma,
+  q: string,
+  organizationId: string,
+  limit: number,
+  offset: number,
+): Promise<GlobalSearchGroup<AuditHit>> {
+  const where: Prisma.AuditLogWhereInput = {
+    organizationId,
+    OR: [
+      { action: { contains: q, mode: "insensitive" } },
+      { subjectType: { contains: q, mode: "insensitive" } },
+      { subjectId: { contains: q, mode: "insensitive" } },
+      { actorAgent: { contains: q, mode: "insensitive" } },
+      { actorUserId: { contains: q, mode: "insensitive" } },
+    ],
+  };
+  const [rows, total] = await Promise.all([
+    db.auditLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        action: true,
+        actorUserId: true,
+        actorAgent: true,
+        subjectType: true,
+        subjectId: true,
+        createdAt: true,
+      },
+    }),
+    db.auditLog.count({ where }),
+  ]);
+  return {
+    total,
+    items: rows.map((a) => {
+      const actor = a.actorAgent ?? a.actorUserId ?? "system";
+      const subject = [a.subjectType, a.subjectId].filter(Boolean).join(":");
+      return {
+        kind: "audit" as const,
+        id: a.id,
+        title: a.action,
+        snippet: subject ? `${actor} → ${subject}` : actor,
+        createdAt: a.createdAt,
+        href: `/clinic/audit-trail?focus=${a.id}`,
+      };
+    }),
+  };
+}
+
+// ── Text helpers ──────────────────────────────────────────────
+
+function firstLine(s: string): string {
+  const line = s.split(/\r?\n/, 1)[0] ?? "";
+  return line.length > 120 ? `${line.slice(0, 117)}…` : line;
+}
+
+/**
+ * Returns ~140 chars of `body` centred on the first case-insensitive
+ * occurrence of `term`. Falls back to the leading slice if `term` is
+ * absent (which shouldn't happen for a row that matched, but we guard
+ * against snippet-renderer surprises anyway).
+ */
+export function snippetAround(body: string, term: string, radius = 70): string {
+  if (!body) return "";
+  if (!term) return body.length > radius * 2 ? `${body.slice(0, radius * 2)}…` : body;
+  const idx = body.toLowerCase().indexOf(term.toLowerCase());
+  if (idx === -1) {
+    return body.length > radius * 2 ? `${body.slice(0, radius * 2)}…` : body;
+  }
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(body.length, idx + term.length + radius);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < body.length ? "…" : "";
+  return `${prefix}${body.slice(start, end)}${suffix}`;
+}
+
+/**
+ * Split `text` into alternating non-matching / matching segments around
+ * every case-insensitive occurrence of `term`. Used by the React tree
+ * to wrap matches in `<mark>` without doing any string interpolation
+ * (which would lose markup safety). Returns a flat array of
+ * `{ text, match }` segments preserving original casing.
+ *
+ * This is intentionally pure-string so it can be exercised in tests
+ * without React.
+ */
+export function highlightSegments(
+  text: string,
+  term: string,
+): Array<{ text: string; match: boolean }> {
+  if (!term) return [{ text, match: false }];
+  const t = text;
+  const needle = term.toLowerCase();
+  const haystack = t.toLowerCase();
+  const out: Array<{ text: string; match: boolean }> = [];
+  let cursor = 0;
+  while (cursor < t.length) {
+    const found = haystack.indexOf(needle, cursor);
+    if (found === -1) {
+      out.push({ text: t.slice(cursor), match: false });
+      break;
+    }
+    if (found > cursor) {
+      out.push({ text: t.slice(cursor, found), match: false });
+    }
+    out.push({ text: t.slice(found, found + needle.length), match: true });
+    cursor = found + needle.length;
+  }
+  return out;
+}
+
+/**
+ * Total result count across all four categories. Used by the page
+ * header and the empty-state branch.
+ */
+export function totalResults(r: GlobalSearchResults): number {
+  return (
+    r.patients.total + r.messages.total + r.notes.total + r.audit.total
+  );
+}


### PR DESCRIPTION
## Summary

- Adds the **/search** page — Stripe/Linear-style universal results across patients, messages, notes, and audit. Complements the ⌘K command palette (which stays focused on quick jumps / actions).
- New domain helper `searchAcrossEMR(prisma, query, orgId, opts)` in `src/lib/domain/global-search.ts` — org-scoped, fan-out across four tables, returns grouped `{ patients, messages, notes, audit }` with per-category totals.
- `<mark>`-based highlighting rendered via a pure string-segment helper (no `innerHTML` / `dangerouslySetInnerHTML`).
- Command-palette wiring: top-of-list "Search everything: \"<q>\"" entry and a footer hint that explains the deep-search affordance when a query is present.

## Surface

- URL: `/search?q=<query>&category=<all|patients|messages|notes|audit>&offset=<n>`
- Tabs: All / Patients / Messages / Notes / Audit (each tab shows match count once a search has run)
- In **All** mode: top 3 per category with "See all N →" link
- In a single-category mode: paginated list (25 per page)
- Empty states: zero-query, sub-min-length (<2 chars), no-matches, no-org-attached, all distinct and warm
- Loading: layout-matching skeleton (`src/app/search/loading.tsx`)
- Auth: clinic-floor role gate (clinician / midlevel / back_office / front_office / practice_owner) — same set the `(clinician)` layout uses
- All four categories scoped to the actor's `organizationId`; soft-deleted patients excluded

## Highlighting

- `highlightSegments(text, term)` returns `Array<{ text, match }>`; the page wraps `match: true` chunks in `<mark>`.
- Case-insensitive match, original casing preserved in output.
- `snippetAround(body, term, radius)` centres a 140-char window on the first occurrence so the snippet always shows context.

## Files

- `src/lib/domain/global-search.ts` (new) — domain helper
- `src/lib/domain/global-search.test.ts` (new) — 18 unit tests via fake Prisma
- `src/app/search/page.tsx` (new) — server component
- `src/app/search/loading.tsx` (new) — skeleton
- `src/components/ui/command-palette.tsx` (edit) — adds the "Search everything" command + footer hint

## Test plan

- [x] `npx prisma generate`
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings
- [x] `npx vitest run src/lib/domain/global-search.test.ts` — 18/18 pass
- [ ] Manual: hit `/search?q=maya` as a clinician, verify all four sections render with highlights
- [ ] Manual: hit `/search` with no `q`, verify start state with tips
- [ ] Manual: hit `/search?q=a` (too-short), verify ShortQueryState
- [ ] Manual: hit `/search?q=maya&category=messages`, verify pagination + Previous/Next
- [ ] Manual: open ⌘K, type a query, verify "Search everything: <q>" appears and routes to `/search?q=…`
- [ ] Manual: sign in as a non-clinic-floor role, verify redirect away from `/search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)