### PR TITLE
ux: PWA manifest + iOS/Android install prompt + apple meta

### DIFF
--- a/public/icons/apple-touch-icon.svg
+++ b/public/icons/apple-touch-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Apple touch icon — iOS uses 180x180 by default. Apple historically
+  preferred PNG, but Safari has supported SVG apple-touch-icon since
+  iOS 12. We ship SVG here for crisp rendering; a designer pass should
+  add a 180x180 PNG fallback for older devices.
+-->
+<svg width="180" height="180" viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="LeafJourney">
+  <title>LeafJourney</title>
+  <rect width="180" height="180" rx="40" fill="#FFFCF7"/>
+  <g transform="translate(90 90)" fill="none" stroke="#1F4D37" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 14 -44 C 28 -34 36 -20 36 0 C 36 20 28 34 14 44 C 0 34 -8 20 -8 0 C -8 -20 0 -34 14 -44 Z" transform="rotate(-22)"/>
+    <path d="M 0 10 C -20 2 -34 -10 -40 -30" />
+    <path d="M -32 48 L 40 48" />
+  </g>
+</svg>

--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LeafJourney PWA icon — 192x192 "any" purpose.
+  Brand colors pulled from globals.css design tokens:
+    --bg #FFFCF7 (warm parchment)
+    --leaf / --accent #1F4D37 (deep forest)
+  Follow-up: designer pass + PNG variants (192/512) for older Android.
+-->
+<svg width="192" height="192" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="LeafJourney">
+  <title>LeafJourney</title>
+  <rect width="192" height="192" rx="42" fill="#FFFCF7"/>
+  <g transform="translate(96 96)" fill="none" stroke="#1F4D37" stroke-width="11" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Stylized cannabis-leaf / journey arc -->
+    <path d="M 16 -48 C 30 -38 40 -22 40 0 C 40 22 30 38 16 48 C 2 38 -8 22 -8 0 C -8 -22 2 -38 16 -48 Z" transform="rotate(-22)"/>
+    <path d="M 0 12 C -22 4 -38 -10 -44 -32" />
+    <path d="M -36 52 L 44 52" />
+  </g>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LeafJourney PWA icon — 512x512 "any" purpose.
+  Larger canvas for richer detail; same brand language as icon-192.svg.
+-->
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="LeafJourney">
+  <title>LeafJourney</title>
+  <rect width="512" height="512" rx="112" fill="#FFFCF7"/>
+  <g transform="translate(256 256)" fill="none" stroke="#1F4D37" stroke-width="28" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 44 -128 C 80 -100 108 -58 108 0 C 108 58 80 100 44 128 C 8 100 -20 58 -20 0 C -20 -58 8 -100 44 -128 Z" transform="rotate(-22)"/>
+    <path d="M 0 32 C -58 12 -100 -28 -116 -84" />
+    <path d="M -96 140 L 116 140" />
+  </g>
+</svg>

--- a/public/icons/icon-maskable-512.svg
+++ b/public/icons/icon-maskable-512.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LeafJourney PWA icon — 512x512 "maskable" purpose.
+  Maskable spec: the inner ~80% (the safe zone) must contain the full
+  recognizable mark; the outer 10% on each edge is reserved for the
+  platform's mask shape (circle, squircle, rounded square, etc.).
+  We fill the *entire* canvas with the brand parchment so any mask
+  the OS applies still reveals brand color.
+-->
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="LeafJourney">
+  <title>LeafJourney</title>
+  <!-- Full-bleed background = safe under any platform mask -->
+  <rect width="512" height="512" fill="#FFFCF7"/>
+  <!-- Glyph sits inside the 80% safe zone (centered, scaled to ~70%) -->
+  <g transform="translate(256 256)" fill="none" stroke="#1F4D37" stroke-width="24" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 36 -100 C 64 -78 88 -46 88 0 C 88 46 64 78 36 100 C 8 78 -16 46 -16 0 C -16 -46 8 -78 36 -100 Z" transform="rotate(-22)"/>
+    <path d="M 0 24 C -46 8 -80 -22 -92 -64" />
+    <path d="M -76 112 L 92 112" />
+  </g>
+</svg>

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -8,6 +8,7 @@ import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ConsciousnessOverlay } from "@/components/ui/consciousness-overlay";
 import { ClinicianTour } from "@/components/onboarding/clinician-tour";
+import { InstallPrompt } from "@/components/pwa/install-prompt";
 import { prisma } from "@/lib/db/prisma";
 import {
   computeApprovalsBadge,
@@ -189,6 +190,7 @@ export default async function ClinicianLayout({
       <CommandPalette role="clinician" userId={user.id} />
       <ConsciousnessOverlay />
       <ClinicianTour />
+      <InstallPrompt />
       {children}
     </AppShell>
   );

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -8,6 +8,7 @@ import { ChatCBInterface } from "@/components/ask-cindy/ChatCBInterface";
 import { PortalCustomizationProvider } from "@/components/portal/portal-customization-provider";
 import { ConfettiCanvas } from "@/components/portal/confetti-canvas";
 import { ServiceWorkerRegister } from "@/components/portal/service-worker-register";
+import { InstallPrompt } from "@/components/pwa/install-prompt";
 
 
 const PATIENT_SECTIONS: NavSection[] = [
@@ -132,6 +133,7 @@ export default async function PatientLayout({
         <CommandPalette role="patient" userId={user.id} />
         <ChatCBInterface />
         <ConfettiCanvas />
+        <InstallPrompt />
         {children}
       </AppShell>
     </PortalCustomizationProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,32 @@ export const metadata: Metadata = {
   description:
     "An AI-native care platform for modern cannabis medicine. Patient portal, clinician workspace, and practice operations in one unified system.",
   robots: { index: false, follow: false }, // private by default in V1
+  applicationName: "LeafJourney",
+  // PWA / iOS install polish — Next auto-emits `<link rel="manifest" …>`
+  // from src/app/manifest.ts, and Next's metadata API knows how to map
+  // these keys to the right `<meta>` / `<link>` tags. iOS Safari is
+  // the picky one: without `appleWebApp.capable=true` the home-screen
+  // install opens in mobile Safari with chrome instead of standalone.
+  appleWebApp: {
+    capable: true,
+    title: "LeafJourney",
+    statusBarStyle: "default",
+  },
+  icons: {
+    icon: [
+      { url: "/icon.svg", type: "image/svg+xml" },
+      { url: "/icons/icon-192.svg", sizes: "192x192", type: "image/svg+xml" },
+      { url: "/icons/icon-512.svg", sizes: "512x512", type: "image/svg+xml" },
+    ],
+    apple: [
+      { url: "/icons/apple-touch-icon.svg", sizes: "180x180", type: "image/svg+xml" },
+    ],
+  },
+  formatDetection: {
+    // Stop iOS from auto-linkifying phone numbers / dates in clinical
+    // text — we already render explicit `tel:` links where appropriate.
+    telephone: false,
+  },
 };
 
 // Mobile portrait iOS polish — `viewport-fit=cover` is required for

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,33 +1,40 @@
 import type { MetadataRoute } from "next";
 
 /**
- * PWA manifest — EMR-031
+ * PWA manifest — Next 14's `app/manifest.ts` route emits
+ * `/manifest.webmanifest` with the correct content-type.
  *
- * Drives the installable web-app experience for the patient portal +
- * clinician workspace. Next 14's `app/manifest.ts` route emits
- * `/manifest.webmanifest` with the correct content-type, so the only thing
- * we need to do here is shape the JSON. Icons live under /public/icons/* —
- * the entries below match the actual filenames so we don't ship a manifest
- * that points at 404s.
+ * Aesthetic: matches the "Verdant Apothecary" tokens in
+ * `src/app/globals.css` so the installed home-screen app reads as one
+ * piece with the web shell.
+ *   --bg      #FFFCF7  (warm parchment)
+ *   --leaf    #1F4D37  (deep forest accent)
  *
- * The standalone display + theme color make Leafjourney install with the
- * Apple-style chromeless feel called out in the data-collection directive.
+ * Icons live under `public/icons/*` as SVG (crisp on every density).
+ * Follow-ups (tracked in PR description, not blocking install):
+ *   - designer pass on the leaf glyph
+ *   - PNG fallback icons (192/512) for older Android launchers
+ *   - service-worker caching strategy (review-gated, separate PR)
  */
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Leafjourney — Modern cannabis care",
-    short_name: "Leafjourney",
+    name: "LeafJourney EMR",
+    short_name: "LeafJourney",
     description:
-      "AI-native cannabis care platform — patient portal, clinician workspace, and practice operations in one home.",
+      "AI-native specialty-adaptive EMR — patient portal, clinician workspace, and practice operations in one home.",
+    // "/" lets the auth gate route the user to the right surface
+    // (clinician → /clinic, patient → /portal, etc.) without forcing a
+    // role-specific landing for installs that come from public pages.
     start_url: "/",
     scope: "/",
     display: "standalone",
+    display_override: ["window-controls-overlay", "standalone", "minimal-ui"],
     orientation: "portrait",
-    background_color: "#f6f4ee",
-    theme_color: "#3f6e4f",
+    background_color: "#FFFCF7",
+    theme_color: "#1F4D37",
     lang: "en",
     dir: "ltr",
-    categories: ["health", "medical", "lifestyle", "productivity"],
+    categories: ["medical", "productivity", "health"],
     icons: [
       {
         src: "/icon.svg",
@@ -36,21 +43,21 @@ export default function manifest(): MetadataRoute.Manifest {
         purpose: "any",
       },
       {
-        src: "/icons/icon-192.png",
+        src: "/icons/icon-192.svg",
         sizes: "192x192",
-        type: "image/png",
-        purpose: "maskable",
-      },
-      {
-        src: "/icons/icon-512.png",
-        sizes: "512x512",
-        type: "image/png",
+        type: "image/svg+xml",
         purpose: "any",
       },
       {
-        src: "/icons/icon-512.png",
+        src: "/icons/icon-512.svg",
         sizes: "512x512",
-        type: "image/png",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/icons/icon-maskable-512.svg",
+        sizes: "512x512",
+        type: "image/svg+xml",
         purpose: "maskable",
       },
     ],

--- a/src/components/pwa/install-prompt.tsx
+++ b/src/components/pwa/install-prompt.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+/**
+ * PWA install prompt — patient + clinician shells.
+ *
+ * Two platforms, two flows:
+ *   1. Android / Chromium  — listens for the standard `beforeinstallprompt`
+ *      event, stashes it, then calls `prompt()` when the user clicks
+ *      "Install". This is the easy path; the browser handles UI confirm.
+ *   2. iOS Safari          — Apple does not fire `beforeinstallprompt`.
+ *      Install is manual: Share → Add to Home Screen. We detect iOS +
+ *      non-standalone and render a custom instruction sheet with a
+ *      labelled diagram.
+ *
+ * Dismiss persistence: localStorage key `lj.pwa.installPromptDismissedAt`
+ * stores an ISO timestamp. We don't re-prompt for 30 days. If the user
+ * actually installs (display-mode flips to `standalone` mid-session) we
+ * drop the prompt immediately and never show it again on this device.
+ *
+ * Mount once near the top of clinician + patient layouts; mounting it
+ * twice in the same render tree is safe — only the first instance to
+ * win the event listener gets the prompt.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+const DISMISS_KEY = "lj.pwa.installPromptDismissedAt";
+const SUPPRESS_DAYS = 30;
+const SUPPRESS_MS = SUPPRESS_DAYS * 24 * 60 * 60 * 1000;
+
+// Chromium's BeforeInstallPromptEvent isn't in lib.dom.d.ts yet.
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+type Platform = "android" | "ios" | "other";
+
+function detectPlatform(): Platform {
+  if (typeof navigator === "undefined") return "other";
+  const ua = navigator.userAgent || "";
+  // iPadOS 13+ reports as Mac with touch — disambiguate.
+  const isIPadOS =
+    /Mac/.test(ua) && typeof document !== "undefined" && "ontouchend" in document;
+  if (/iPhone|iPad|iPod/.test(ua) || isIPadOS) return "ios";
+  if (/Android/.test(ua)) return "android";
+  return "other";
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  // iOS exposes `navigator.standalone`; everyone else uses the media query.
+  // Cast through unknown — the iOS-only field isn't in standard typings.
+  const navStandalone = (navigator as unknown as { standalone?: boolean }).standalone;
+  if (navStandalone) return true;
+  return window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+}
+
+function isRecentlyDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    const ts = new Date(raw).getTime();
+    if (!Number.isFinite(ts)) return false;
+    return Date.now() - ts < SUPPRESS_MS;
+  } catch {
+    return false;
+  }
+}
+
+function rememberDismissal(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DISMISS_KEY, new Date().toISOString());
+  } catch {
+    // localStorage may be disabled (private browsing on iOS); silently no-op.
+  }
+}
+
+export function InstallPrompt() {
+  const [deferredEvent, setDeferredEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [platform, setPlatform] = useState<Platform>("other");
+  const [installed, setInstalled] = useState(false);
+  const [showIosSheet, setShowIosSheet] = useState(false);
+  // Defer first paint until after mount so we never SSR a CTA that
+  // tells the user something incorrect about their device.
+  const [ready, setReady] = useState(false);
+  // iOS banner needs to be shown without an event; gate it behind a
+  // small delay so we don't shove the prompt in the user's face on
+  // first paint of every navigation.
+  const [iosBannerVisible, setIosBannerVisible] = useState(false);
+
+  useEffect(() => {
+    setReady(true);
+    setPlatform(detectPlatform());
+    setInstalled(isStandalone());
+  }, []);
+
+  // Listen for the Chromium install event.
+  useEffect(() => {
+    if (!ready) return;
+    const onBeforeInstall = (event: Event) => {
+      // Stash the event so we can fire it on user gesture. Browsers
+      // require we preventDefault() to keep the deferred prompt alive
+      // past this tick.
+      event.preventDefault();
+      if (isRecentlyDismissed()) return;
+      setDeferredEvent(event as BeforeInstallPromptEvent);
+    };
+    const onInstalled = () => {
+      setInstalled(true);
+      setDeferredEvent(null);
+      setIosBannerVisible(false);
+    };
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, [ready]);
+
+  // For iOS, decide whether to show the static banner. Wait 4s so it
+  // doesn't compete with first-paint chrome.
+  useEffect(() => {
+    if (!ready) return;
+    if (platform !== "ios") return;
+    if (installed) return;
+    if (isRecentlyDismissed()) return;
+    const t = window.setTimeout(() => setIosBannerVisible(true), 4000);
+    return () => window.clearTimeout(t);
+  }, [ready, platform, installed]);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredEvent) return;
+    try {
+      await deferredEvent.prompt();
+      const choice = await deferredEvent.userChoice;
+      if (choice.outcome === "dismissed") {
+        rememberDismissal();
+      }
+    } catch {
+      // Some browsers throw if `prompt()` is called after the event
+      // is consumed. Either way, drop the reference.
+    } finally {
+      setDeferredEvent(null);
+    }
+  }, [deferredEvent]);
+
+  const handleDismiss = useCallback(() => {
+    rememberDismissal();
+    setDeferredEvent(null);
+    setIosBannerVisible(false);
+  }, []);
+
+  const handleShowIos = useCallback(() => setShowIosSheet(true), []);
+  const handleCloseIos = useCallback(() => setShowIosSheet(false), []);
+
+  if (!ready || installed) return null;
+
+  // ---- Android / Chromium native deferred prompt banner ----
+  if (deferredEvent) {
+    return (
+      <InstallBanner
+        title="Install LeafJourney"
+        copy="One-tap access — feels like a native app."
+        primaryLabel="Install"
+        onPrimary={handleInstall}
+        onDismiss={handleDismiss}
+      />
+    );
+  }
+
+  // ---- iOS Safari custom banner + instructions sheet ----
+  if (platform === "ios" && iosBannerVisible) {
+    return (
+      <>
+        <InstallBanner
+          title="Add LeafJourney to your Home Screen"
+          copy="Tap Share, then Add to Home Screen."
+          primaryLabel="Show me"
+          onPrimary={handleShowIos}
+          onDismiss={handleDismiss}
+        />
+        {showIosSheet ? <IosInstructionsSheet onClose={handleCloseIos} /> : null}
+      </>
+    );
+  }
+
+  return null;
+}
+
+// -----------------------------------------------------------------------------
+// Presentational sub-components
+// -----------------------------------------------------------------------------
+
+function InstallBanner({
+  title,
+  copy,
+  primaryLabel,
+  onPrimary,
+  onDismiss,
+}: {
+  title: string;
+  copy: string;
+  primaryLabel: string;
+  onPrimary: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-label="Install LeafJourney"
+      className={cn(
+        // Fixed bottom-sheet style so it doesn't push layout around;
+        // respects iOS safe-area-inset-bottom so the home indicator
+        // doesn't sit on the buttons.
+        "fixed inset-x-3 z-[80] bottom-3 sm:left-auto sm:right-4 sm:bottom-4 sm:w-[360px]",
+        "pb-[env(safe-area-inset-bottom)]",
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] shadow-xl",
+          "p-4 flex items-start gap-3",
+        )}
+      >
+        <div
+          aria-hidden="true"
+          className="shrink-0 mt-0.5 h-10 w-10 rounded-xl bg-[color:var(--leaf-soft)] flex items-center justify-center"
+        >
+          <span className="text-[color:var(--leaf)] text-lg font-semibold">LJ</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-[color:var(--text)] leading-tight">
+            {title}
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--text-muted)] leading-snug">{copy}</p>
+          <div className="mt-3 flex items-center gap-2">
+            <Button size="sm" onClick={onPrimary}>
+              {primaryLabel}
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onDismiss}>
+              Not now
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IosInstructionsSheet({ onClose }: { onClose: () => void }) {
+  // Lock background scroll while the sheet is up.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  // Close on Escape — iPads with keyboards should respect this.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="How to install LeafJourney on iOS"
+      className="fixed inset-0 z-[90] flex items-end sm:items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className={cn(
+          "w-full sm:max-w-md mx-0 sm:mx-4 bg-[color:var(--surface)] rounded-t-2xl sm:rounded-2xl shadow-2xl",
+          "p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]",
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-[color:var(--text)]">
+            Install LeafJourney
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-[color:var(--text-muted)] hover:text-[color:var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] rounded px-1"
+            aria-label="Close"
+          >
+            Close
+          </button>
+        </div>
+        <ol className="mt-4 space-y-3 text-sm text-[color:var(--text)]">
+          <li className="flex gap-3">
+            <Step n={1} />
+            <span>
+              Tap the <ShareIcon /> <strong>Share</strong> button in Safari&apos;s
+              toolbar.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <Step n={2} />
+            <span>
+              Scroll down and tap <strong>Add to Home Screen</strong>.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <Step n={3} />
+            <span>
+              Tap <strong>Add</strong> in the top right — LeafJourney lives on
+              your Home Screen now.
+            </span>
+          </li>
+        </ol>
+        <p className="mt-4 text-xs text-[color:var(--text-muted)]">
+          Note: Add to Home Screen only works in Safari, not in Chrome or
+          in-app browsers.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Step({ n }: { n: number }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="shrink-0 h-6 w-6 rounded-full bg-[color:var(--leaf-soft)] text-[color:var(--leaf)] text-xs font-semibold flex items-center justify-center"
+    >
+      {n}
+    </span>
+  );
+}
+
+function ShareIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      className="inline-block align-[-2px] mx-0.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 3v12" />
+      <path d="m8 7 4-4 4 4" />
+      <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-7" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Make LeafJourney installable on iOS and Android home screens with the Apple-style chromeless feel called out in CLAUDE.md.

- Rebuilt `src/app/manifest.ts` against the real design tokens (`--bg #FFFCF7`, `--leaf #1F4D37`). Added `display_override` (`window-controls-overlay`, `standalone`, `minimal-ui`), `categories: ["medical", "productivity", "health"]`, and stopped pointing icons at PNG paths that didn't exist on disk.
- Shipped SVG icon set under `public/icons/` (192, 512, maskable-512, apple-touch-icon-180) drawn from the existing brand glyph in `src/app/icon.svg`. **These are placeholder SVGs — a designer pass + PNG fallbacks for older Android launchers are tracked as follow-ups.**
- Wired iOS install metadata via Next's metadata API in `src/app/layout.tsx`: `appleWebApp.capable=true`, `statusBarStyle="default"`, icon + apple-touch-icon links, and `formatDetection.telephone=false` (stops iOS auto-linkifying numbers in clinical text). Light/dark `theme-color` media-query split was already wired via the `viewport` export.
- New `src/components/pwa/install-prompt.tsx`:
  - **Android / Chromium**: listens for `beforeinstallprompt`, renders a subtle bottom-right banner with Install / Not now buttons.
  - **iOS Safari**: detects iOS + non-standalone (Safari does not fire `beforeinstallprompt`), surfaces a custom "Add to Home Screen" instruction sheet with a Share-icon callout.
  - Persists dismissal in `localStorage` for 30 days; drops itself if `appinstalled` fires mid-session.
- Mounted in `(clinician)` + `(patient)` layouts only — per the brief, staff users (operator/admin) do not get install prompts.

## Out of scope (intentional)

- **Service worker** caching strategy is review-gated and ships in a separate PR. The existing `public/sw.js` + `ServiceWorkerRegister` (patient layout only) is untouched.
- PNG icon variants for older Android launchers (modern Chromium handles SVG manifests fine).

## Test plan

- [ ] Visit `/clinic` on desktop Chromium → DevTools → Application → Manifest renders all fields, no 404s on icons.
- [ ] Visit `/portal` on Android Chrome → `beforeinstallprompt` fires → banner appears → Install completes → `appinstalled` clears the banner.
- [ ] Visit `/portal` on iOS Safari (real device) → banner appears ~4s after load → tap "Show me" → instruction sheet renders Share icon + 3-step list.
- [ ] Dismiss the prompt → reload → banner does not reappear (localStorage 30-day suppression).
- [ ] Lighthouse PWA audit on `/portal` passes the "Installable" criteria.

[Generated with Claude Code]