### PR TITLE
ux: animated counters, delta indicators, sparklines + 5+ tile adoptions

### DIFF
--- a/src/components/operator/kpi-card.tsx
+++ b/src/components/operator/kpi-card.tsx
@@ -23,7 +23,14 @@ export interface KpiTrend {
 
 export interface KpiCardProps {
   eyebrow: string;
-  headline: string;
+  /**
+   * Headline shown as the big number. Accepts a string for static rendering
+   * or a ReactNode (e.g. `<AnimatedNumber value={...} />`) for tweened
+   * counters. Either way the wrapper applies tabular-nums for width stability.
+   */
+  headline: React.ReactNode;
+  /** Optional fallback string for aria-label when `headline` is a ReactNode. */
+  headlineLabel?: string;
   subtext?: string;
   href: string;
   trend?: KpiTrend;
@@ -42,6 +49,7 @@ const SEVERITY_DOT: Record<KpiSeverity, string> = {
 export function KpiCard({
   eyebrow,
   headline,
+  headlineLabel,
   subtext,
   href,
   trend,
@@ -49,10 +57,19 @@ export function KpiCard({
   pulse,
   className,
 }: KpiCardProps) {
+  // Stringify a ReactNode for screen-reader aria-label fallback when caller
+  // didn't pass an explicit headlineLabel. We only need a sane string — the
+  // AnimatedNumber primitive already exposes its own aria-label internally.
+  const headlineAria =
+    headlineLabel ??
+    (typeof headline === "string" || typeof headline === "number"
+      ? String(headline)
+      : "");
+
   return (
     <Link
       href={href}
-      aria-label={`${eyebrow}: ${headline}`}
+      aria-label={`${eyebrow}: ${headlineAria}`}
       className={cn(
         "group relative block rounded-2xl border border-border/80 bg-surface-raised",
         "shadow-sm transition-all duration-200 ease-smooth",

--- a/src/components/operator/owner-dashboard.tsx
+++ b/src/components/operator/owner-dashboard.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/domain/owner-kpis";
 import { formatMoneyCompact, formatMoney } from "@/lib/domain/billing";
 import { agentRegistry } from "@/lib/agents";
+import { AnimatedNumber } from "@/components/ui/animated-number";
 
 // ---------------------------------------------------------------------------
 // OwnerDashboard — composes the 6 KPI tiles in a 1/2/3-column grid.
@@ -29,7 +30,16 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   );
   const revenueCard = {
     eyebrow: "Revenue this week",
-    headline: formatMoneyCompact(snapshot.revenueThisWeekCents),
+    // Animate revenue from prior-week → this-week so the tile feels alive
+    // on refresh. We format the *interpolated* cents value with the same
+    // compact-money helper used everywhere else for consistency.
+    headline: (
+      <AnimatedNumber
+        value={snapshot.revenueThisWeekCents}
+        format={(n) => formatMoneyCompact(Math.round(n))}
+      />
+    ),
+    headlineLabel: formatMoneyCompact(snapshot.revenueThisWeekCents),
     subtext:
       snapshot.revenuePriorWeekCents > 0
         ? `${formatMoneyCompact(snapshot.revenuePriorWeekCents)} prior 7 days`
@@ -46,7 +56,8 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   const denialsSev: KpiSeverity = denialSeverity(snapshot.denials);
   const denialsCard = {
     eyebrow: "Denials queue",
-    headline: snapshot.denials.unresolvedCount.toString(),
+    headline: <AnimatedNumber value={snapshot.denials.unresolvedCount} />,
+    headlineLabel: snapshot.denials.unresolvedCount.toString(),
     subtext:
       snapshot.denials.unresolvedCount === 0
         ? "All denials resolved"
@@ -79,7 +90,8 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   const baseAgentSubtext = `${snapshot.agents.running} processing, ${snapshot.agents.completedToday} completed today`;
   const agentsCard = {
     eyebrow: "Agent fleet",
-    headline: snapshot.agents.running.toString(),
+    headline: <AnimatedNumber value={snapshot.agents.running} />,
+    headlineLabel: snapshot.agents.running.toString(),
     subtext: hasPracticeManagerAgent
       ? `${baseAgentSubtext} • incl. Practice Manager`
       : baseAgentSubtext,
@@ -94,7 +106,8 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   );
   const patientsCard = {
     eyebrow: "New patients (7d)",
-    headline: snapshot.newPatientsThisWeek.toString(),
+    headline: <AnimatedNumber value={snapshot.newPatientsThisWeek} />,
+    headlineLabel: snapshot.newPatientsThisWeek.toString(),
     subtext:
       snapshot.newPatientsPriorWeek > 0
         ? `${snapshot.newPatientsPriorWeek} in the prior 7 days`

--- a/src/components/ui/animated-number.tsx
+++ b/src/components/ui/animated-number.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------------------
+// AnimatedNumber — rolls from the previously-displayed value to a new value
+// using requestAnimationFrame and an ease-out curve. Respects
+// `prefers-reduced-motion` (sets the next value instantly).
+//
+// When a new `value` prop arrives we tween from the *current displayed*
+// value — never from 0 — so KPI tiles feel smooth on live re-renders.
+//
+// Formatting is stable: defaults to Intl.NumberFormat so digit widths
+// align under tabular-nums. Callers can override with `format` for money,
+// percent, units, etc.
+// ---------------------------------------------------------------------------
+
+export interface AnimatedNumberProps {
+  /** Target numeric value */
+  value: number;
+  /** Animation duration in ms (default 1200) */
+  duration?: number;
+  /** Decimal places when using the default formatter */
+  decimals?: number;
+  /** Optional custom formatter — receives the *interpolated* number */
+  format?: (n: number) => string;
+  /** Pre-pended to the formatted number (e.g. "$") */
+  prefix?: string;
+  /** Appended to the formatted number (e.g. "%") */
+  suffix?: string;
+  /** Apply tabular-nums + leading-none (default true) */
+  tabular?: boolean;
+  className?: string;
+  /** Optional aria-label override; otherwise the final value is announced */
+  ariaLabel?: string;
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [prefers, setPrefers] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefers(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return prefers;
+}
+
+export function AnimatedNumber({
+  value,
+  duration = 1200,
+  decimals = 0,
+  format,
+  prefix,
+  suffix,
+  tabular = true,
+  className,
+  ariaLabel,
+}: AnimatedNumberProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  // displayed value drives the rendered string; we lazy-init to the target so
+  // SSR/CSR hydration emits the same final markup. The animation only kicks in
+  // on *subsequent* value changes, which is the smooth-tween behaviour we want.
+  const [displayed, setDisplayed] = React.useState<number>(value);
+  const fromRef = React.useRef<number>(value);
+  const rafRef = React.useRef<number | null>(null);
+  const startRef = React.useRef<number>(0);
+
+  // Stable formatter — falls back to Intl.NumberFormat with caller-controlled decimals.
+  const formatter = React.useMemo(() => {
+    if (format) return format;
+    const nf = new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+    return (n: number) => nf.format(n);
+  }, [format, decimals]);
+
+  React.useEffect(() => {
+    // Cancel any in-flight tween before starting a new one
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+
+    if (prefersReducedMotion || duration <= 0 || displayed === value) {
+      setDisplayed(value);
+      fromRef.current = value;
+      return;
+    }
+
+    fromRef.current = displayed;
+    startRef.current = performance.now();
+    const from = fromRef.current;
+    const to = value;
+
+    const tick = (now: number) => {
+      const elapsed = now - startRef.current;
+      const t = Math.min(1, elapsed / duration);
+      const eased = easeOutCubic(t);
+      const next = from + (to - from) * eased;
+      setDisplayed(next);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        rafRef.current = null;
+        fromRef.current = to;
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+    // We intentionally exclude `displayed` — it changes every frame.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, duration, prefersReducedMotion]);
+
+  const text = formatter(displayed);
+  const finalText = formatter(value);
+
+  return (
+    <span
+      className={cn(tabular && "tabular-nums leading-none", className)}
+      aria-label={ariaLabel ?? `${prefix ?? ""}${finalText}${suffix ?? ""}`}
+    >
+      {prefix}
+      {text}
+      {suffix}
+    </span>
+  );
+}

--- a/src/components/ui/delta-indicator.tsx
+++ b/src/components/ui/delta-indicator.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------------------
+// DeltaIndicator — small inline up/down arrow + percent change badge.
+//
+// • Green for "good" direction, red for "bad", muted gray for flat
+// • Subtle scale-in animation on first render (skipped under
+//   prefers-reduced-motion)
+// • Tooltip (native title attr) shows the absolute change
+//
+// `goodWhen` lets callers configure semantics: revenue ↑ is good, denials
+// ↑ is bad. Defaults to "up" (most common — bigger is better).
+// ---------------------------------------------------------------------------
+
+export interface DeltaIndicatorProps {
+  /** Current value */
+  current: number;
+  /** Previous-period value for comparison */
+  previous: number;
+  /** Which direction is considered favourable */
+  goodWhen?: "up" | "down" | "either";
+  /** Format helper for the *absolute* change shown in the tooltip */
+  format?: (n: number) => string;
+  /** Override the percent formatter (defaults to one decimal) */
+  formatPercent?: (pct: number) => string;
+  /** Show "new" when previous === 0 (default true) */
+  showNew?: boolean;
+  className?: string;
+}
+
+function defaultPercent(pct: number): string {
+  return `${Math.abs(pct).toFixed(Math.abs(pct) < 10 ? 1 : 0)}%`;
+}
+
+export function DeltaIndicator({
+  current,
+  previous,
+  goodWhen = "up",
+  format,
+  formatPercent = defaultPercent,
+  showNew = true,
+  className,
+}: DeltaIndicatorProps) {
+  const absChange = current - previous;
+
+  let direction: "up" | "down" | "flat";
+  if (absChange > 0) direction = "up";
+  else if (absChange < 0) direction = "down";
+  else direction = "flat";
+
+  const isNew = previous === 0 && current !== 0;
+  const percent =
+    previous === 0 ? null : ((current - previous) / Math.abs(previous)) * 100;
+
+  // Semantic color: green when moving the "good" direction, red when bad,
+  // muted when flat. Uses theme tokens to stay on-palette in light/dark.
+  const isGood =
+    goodWhen === "either"
+      ? true
+      : (goodWhen === "up" && direction === "up") ||
+        (goodWhen === "down" && direction === "down");
+  const colorClass =
+    direction === "flat"
+      ? "text-text-muted"
+      : isGood
+        ? "text-accent"
+        : "text-[color:var(--danger)]";
+
+  const arrow =
+    direction === "up" ? "▲" : direction === "down" ? "▼" : "→";
+
+  const label =
+    isNew && showNew
+      ? "new"
+      : percent === null
+        ? "—"
+        : formatPercent(percent);
+
+  const tooltip =
+    previous === 0
+      ? `New (prior period: 0)`
+      : `${absChange > 0 ? "+" : ""}${format ? format(absChange) : absChange.toLocaleString()} vs prior`;
+
+  return (
+    <span
+      title={tooltip}
+      className={cn(
+        "inline-flex items-center gap-1 text-xs font-medium tabular-nums",
+        "animate-in fade-in zoom-in-95 duration-300 ease-out",
+        colorClass,
+        className,
+      )}
+      aria-label={`${direction === "up" ? "up" : direction === "down" ? "down" : "no change"} ${label}, ${tooltip}`}
+    >
+      <span aria-hidden="true" className="text-[0.7em] leading-none">
+        {arrow}
+      </span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/components/ui/metric-tile.tsx
+++ b/src/components/ui/metric-tile.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils/cn";
+import { AnimatedNumber } from "./animated-number";
+import { MiniSparkline } from "./mini-sparkline";
 
 export function MetricTile({
   label,
@@ -8,6 +10,10 @@ export function MetricTile({
   hint,
   accent,
   className,
+  /** Optional 7-ish point trend series rendered as an inline mini sparkline. */
+  trend,
+  /** When `value` is a plain number, animate it 0 → value (or prev → next on update). */
+  animate = true,
 }: {
   label: string;
   value: React.ReactNode;
@@ -15,6 +21,8 @@ export function MetricTile({
   hint?: string;
   accent?: "forest" | "amber" | "none";
   className?: string;
+  trend?: number[];
+  animate?: boolean;
 }) {
   const accentClass =
     accent === "forest"
@@ -22,6 +30,17 @@ export function MetricTile({
       : accent === "amber"
         ? "before:bg-highlight"
         : "before:bg-border-strong/50";
+
+  // If value is a plain finite number, route it through AnimatedNumber so we
+  // get a smooth ease-out tween + tabular-nums width-stability for free.
+  // Everything else (strings, JSX, "$1.2k", "84%") renders as-is — the
+  // upstream caller has already done bespoke formatting.
+  const renderedValue =
+    animate && typeof value === "number" && Number.isFinite(value) ? (
+      <AnimatedNumber value={value} />
+    ) : (
+      value
+    );
 
   return (
     <div
@@ -37,10 +56,15 @@ export function MetricTile({
       </p>
       <div className="mt-2 flex items-baseline gap-2">
         <span className="font-display text-3xl font-medium text-text tabular-nums leading-none">
-          {value}
+          {renderedValue}
         </span>
         {delta && (
           <span className="text-xs text-text-muted tabular-nums">{delta}</span>
+        )}
+        {trend && trend.length > 1 && (
+          <span className="ml-auto self-center opacity-80">
+            <MiniSparkline values={trend} />
+          </span>
         )}
       </div>
       {hint && <p className="text-xs text-text-subtle mt-2">{hint}</p>}

--- a/src/components/ui/mini-sparkline.tsx
+++ b/src/components/ui/mini-sparkline.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------------------
+// MiniSparkline — a tiny inline SVG line, sized for KPI tile use (~60×16 px).
+// Designed to sit next to a headline number, not as a stand-alone chart.
+//
+// We already have a larger area-fill `Sparkline` (src/components/ui/sparkline.tsx)
+// for analytics panels; this is the inline-with-text micro-variant. Pure SVG,
+// no chart library, direction-aware color via theme tokens.
+//
+// Naming intentionally different (`values`, not `data`) so callers can grep
+// for tile usage independently of the larger panel chart.
+// ---------------------------------------------------------------------------
+
+export interface MiniSparklineProps {
+  values: number[];
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+  /** "auto" picks accent / danger / muted based on first→last delta */
+  stroke?: "auto" | string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function MiniSparkline({
+  values,
+  width = 60,
+  height = 16,
+  strokeWidth = 1.5,
+  stroke = "auto",
+  ariaLabel,
+  className,
+}: MiniSparklineProps) {
+  if (!values || values.length < 2) {
+    return (
+      <span
+        className={cn("inline-block", className)}
+        style={{ width, height }}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const pad = strokeWidth;
+  const w = width - pad * 2;
+  const h = height - pad * 2;
+  const stepX = w / (values.length - 1);
+
+  const points = values.map((v, i) => {
+    const x = pad + i * stepX;
+    const y = pad + h - ((v - min) / range) * h;
+    return [x, y] as const;
+  });
+
+  const pathD = points
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(" ");
+
+  // Direction-aware default color.
+  let strokeColor = stroke;
+  if (stroke === "auto") {
+    const first = values[0];
+    const last = values[values.length - 1];
+    if (last > first) strokeColor = "var(--accent)";
+    else if (last < first) strokeColor = "var(--danger)";
+    else strokeColor = "var(--text-muted)";
+  }
+
+  const label =
+    ariaLabel ??
+    `Trend over ${values.length} points, latest ${values[values.length - 1].toLocaleString()}`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn("inline-block align-middle", className)}
+      role="img"
+      aria-label={label}
+    >
+      <path
+        d={pathD}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle
+        cx={points[points.length - 1][0]}
+        cy={points[points.length - 1][1]}
+        r={Math.max(1, strokeWidth)}
+        fill={strokeColor}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Three iOS-feel micro-primitives that make KPI tiles feel alive instead of static, plus tile-wide adoption across the EMR.

### New primitives (`src/components/ui/`)
- **`animated-number.tsx`** — `<AnimatedNumber value duration={1200} format={...} prefix suffix decimals />` tweens from the previously displayed value to the new value with a `requestAnimationFrame` + `easeOutCubic` curve. Honors `prefers-reduced-motion` (instant set). `Intl.NumberFormat` under `tabular-nums` for width stability. On re-renders animates from old→new (never from 0).
- **`delta-indicator.tsx`** — `<DeltaIndicator current previous goodWhen format />` shows ▲/▼/→ + percent change, green/red/muted via `goodWhen` semantics. Subtle `zoom-in-95` on first paint, native title tooltip with absolute change.
- **`mini-sparkline.tsx`** — `<MiniSparkline values />` 60×16 inline SVG line, direction-aware color via theme tokens (`--accent`/`--danger`/`--text-muted`). Pure SVG; no new deps. Sibling to the existing larger `Sparkline`.

### Tile adoption
- **`MetricTile`** — auto-routes finite-number `value` through `AnimatedNumber` and accepts a new optional `trend?: number[]` for an inline mini sparkline. Existing string/JSX callers untouched.
- **`KpiCard`** — `headline` is now `ReactNode` (with `headlineLabel` for a11y) so callers can drop in `<AnimatedNumber />`.
- **Owner dashboard** (`src/components/operator/owner-dashboard.tsx`) — animates revenue (with `formatMoneyCompact` over the interpolated cents), denials, agents-running, new-patients.
- **Communications hub** — 6 MetricTiles (calls / Beam / voicemail / transcripts / fax / outreach) auto-animate.
- **Mission control** — 5 queue counters (pending / running / needs-approval / succeeded / failed) auto-animate.
- **Agent fleet** (`/clinic/agents/[name]`) — 4 MetricTiles auto-animate.
- **Patient roster summary** — 2 numeric tiles auto-animate.

### Constraints honored
- No new deps; pure SVG sparkline; existing `Sparkline` (data-prop variant) untouched.
- No edits to `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, manifests, auth, or `CLAUDE.md`.

## Test plan
- [ ] Owner dashboard: refresh and confirm revenue / denials / agents / new-patients counters tween smoothly without flashing 0
- [ ] Communications hub: load page; the 6 channel tiles animate up on first paint
- [ ] Mission control: load `/ops/mission-control` and confirm queue counters animate
- [ ] Toggle macOS Reduce Motion → counters snap to final value
- [ ] `npx prisma generate && npm run typecheck && npm run lint` (all clean)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)