### PR TITLE
ux: 404/500/global-error pages polish + route-specific not-founds

### DIFF
--- a/src/app/(clinician)/error.tsx
+++ b/src/app/(clinician)/error.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
+import { useReportError } from "@/components/error-pages/use-report-error";
+
+/**
+ * Clinician route-group error boundary. Catches anything thrown inside
+ * /clinic/* that isn't handled by a more specific boundary. "Go home"
+ * routes to the clinician's Today screen.
+ */
 export default function ClinicianError({
   error,
   reset,
@@ -9,21 +17,36 @@ export default function ClinicianError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useReportError(error);
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh] p-8">
-      <div className="text-center max-w-md">
-        <p className="text-3xl mb-4">🌿</p>
-        <h2 className="font-display text-xl text-text mb-3">
-          Something went wrong
-        </h2>
-        <p className="text-sm text-text-muted mb-6 leading-relaxed">
-          We hit an unexpected issue loading this page. Your patients&apos;
-          data is safe. Try refreshing — if it keeps happening, let us know.
+    <div className="flex items-center justify-center min-h-[70vh] p-8">
+      <div className="text-center max-w-md animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-danger mb-3">
+          Clinic &middot; Unexpected error
         </p>
-        <Button onClick={reset}>Try again</Button>
+        <h1 className="font-display text-2xl md:text-3xl text-text tracking-tight leading-tight mb-3">
+          Something didn&rsquo;t go as planned.
+        </h1>
+        <p className="text-[15px] text-text-muted mb-8 leading-relaxed">
+          We hit an unexpected issue loading this page. Your patients&rsquo;
+          data is safe — this is a display problem, not a data problem.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button size="lg" onClick={reset} className="min-w-[140px]">
+            Try again
+          </Button>
+          <Link href="/clinic">
+            <Button size="lg" variant="secondary" className="min-w-[140px]">
+              Go to Today
+            </Button>
+          </Link>
+        </div>
+
         {error.digest && (
-          <p className="text-[10px] text-text-subtle mt-4">
-            Ref: {error.digest}
+          <p className="mt-8 font-mono text-[11px] tracking-tight text-text-subtle">
+            Reference: {error.digest}
           </p>
         )}
       </div>

--- a/src/app/(operator)/error.tsx
+++ b/src/app/(operator)/error.tsx
@@ -1,29 +1,52 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
-export default function ClinicianError({
+import { Button } from "@/components/ui/button";
+import { useReportError } from "@/components/error-pages/use-report-error";
+
+/**
+ * Operator route-group error boundary. Catches anything thrown inside
+ * /ops/* that isn't handled by a more specific boundary. "Go home"
+ * routes back to the operator queue.
+ */
+export default function OperatorError({
   error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useReportError(error);
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh] p-8">
-      <div className="text-center max-w-md">
-        <p className="text-3xl mb-4">🌿</p>
-        <h2 className="font-display text-xl text-text mb-3">
-          Something went wrong
-        </h2>
-        <p className="text-sm text-text-muted mb-6 leading-relaxed">
-          We hit an unexpected issue loading this page. Your patients&apos;
-          data is safe. Try refreshing — if it keeps happening, let us know.
+    <div className="flex items-center justify-center min-h-[70vh] p-8">
+      <div className="text-center max-w-md animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-danger mb-3">
+          Ops &middot; Unexpected error
         </p>
-        <Button onClick={reset}>Try again</Button>
+        <h1 className="font-display text-2xl md:text-3xl text-text tracking-tight leading-tight mb-3">
+          Something didn&rsquo;t go as planned.
+        </h1>
+        <p className="text-[15px] text-text-muted mb-8 leading-relaxed">
+          We hit an unexpected issue loading this page. Queues, claims,
+          and dispensary data are all safe — this is a display problem.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button size="lg" onClick={reset} className="min-w-[140px]">
+            Try again
+          </Button>
+          <Link href="/ops">
+            <Button size="lg" variant="secondary" className="min-w-[140px]">
+              Back to ops
+            </Button>
+          </Link>
+        </div>
+
         {error.digest && (
-          <p className="text-[10px] text-text-subtle mt-4">
-            Ref: {error.digest}
+          <p className="mt-8 font-mono text-[11px] tracking-tight text-text-subtle">
+            Reference: {error.digest}
           </p>
         )}
       </div>

--- a/src/app/(patient)/error.tsx
+++ b/src/app/(patient)/error.tsx
@@ -1,29 +1,53 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
-export default function ClinicianError({
+import { Button } from "@/components/ui/button";
+import { useReportError } from "@/components/error-pages/use-report-error";
+
+/**
+ * Patient route-group error boundary. Catches anything thrown inside
+ * /portal/* that isn't handled by a more specific boundary. "Go home"
+ * routes back to the patient portal dashboard.
+ */
+export default function PatientError({
   error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useReportError(error);
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh] p-8">
-      <div className="text-center max-w-md">
-        <p className="text-3xl mb-4">🌿</p>
-        <h2 className="font-display text-xl text-text mb-3">
-          Something went wrong
-        </h2>
-        <p className="text-sm text-text-muted mb-6 leading-relaxed">
-          We hit an unexpected issue loading this page. Your patients&apos;
-          data is safe. Try refreshing — if it keeps happening, let us know.
+    <div className="flex items-center justify-center min-h-[70vh] p-8">
+      <div className="text-center max-w-md animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-danger mb-3">
+          Portal &middot; Unexpected error
         </p>
-        <Button onClick={reset}>Try again</Button>
+        <h1 className="font-display text-2xl md:text-3xl text-text tracking-tight leading-tight mb-3">
+          Something didn&rsquo;t go as planned.
+        </h1>
+        <p className="text-[15px] text-text-muted mb-8 leading-relaxed">
+          We hit a hiccup loading this page. Your records and messages
+          are safe. Try again, or message your care team if this keeps
+          happening.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button size="lg" onClick={reset} className="min-w-[140px]">
+            Try again
+          </Button>
+          <Link href="/portal">
+            <Button size="lg" variant="secondary" className="min-w-[140px]">
+              Back to dashboard
+            </Button>
+          </Link>
+        </div>
+
         {error.digest && (
-          <p className="text-[10px] text-text-subtle mt-4">
-            Ref: {error.digest}
+          <p className="mt-8 font-mono text-[11px] tracking-tight text-text-subtle">
+            Reference: {error.digest}
           </p>
         )}
       </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { useReportError } from "@/components/error-pages/use-report-error";
+
+/**
+ * Root error boundary. Catches anything thrown above the (clinician) /
+ * (patient) / (operator) route groups, including unmatched root routes.
+ * Group-level boundaries take precedence inside their own subtrees and
+ * have their own copy + home target.
+ */
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useReportError(error);
+
+  return (
+    <div className="min-h-screen relative flex items-center justify-center overflow-hidden bg-bg px-6">
+      <div className="absolute inset-0 ambient pointer-events-none" />
+
+      <main className="relative z-10 flex flex-col items-center text-center max-w-lg py-20 animate-in fade-in slide-in-from-bottom-3 duration-700">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-danger mb-3">
+          Unexpected error
+        </p>
+
+        <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.08] mb-4">
+          Something didn&rsquo;t go as planned.
+        </h1>
+
+        <p className="text-[16px] text-text-muted leading-relaxed mb-10 max-w-md">
+          We hit an unexpected issue rendering this page. Your data is
+          safe — this is a display problem, not a data problem. Try
+          again, and if it keeps happening, let us know.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+          <Button size="lg" onClick={reset} className="min-w-[160px]">
+            Try again
+          </Button>
+          <Link href="/" className="w-full sm:w-auto">
+            <Button size="lg" variant="secondary" className="w-full min-w-[160px]">
+              Go home
+            </Button>
+          </Link>
+        </div>
+
+        {error.digest && (
+          <p className="mt-10 font-mono text-[11px] tracking-tight text-text-subtle">
+            Reference: {error.digest}
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+import { useEffect } from "react";
+
 /**
- * Global error boundary — catches unhandled errors in server components.
- * Shows a friendly message instead of raw stack traces. NEVER exposes
- * internal error details to the user.
+ * Global error boundary — catches errors thrown above app/error.tsx,
+ * which means it MUST render its own <html> + <body> and cannot rely
+ * on the root layout, providers, or design-system styles. Stays
+ * inline-styled and dependency-free on purpose.
+ *
+ * Anything we'd normally do in a layout (analytics, sentry) has to be
+ * inlined here. We capture to Sentry via dynamic import so a bundling
+ * failure of @sentry/nextjs can't take down the last-resort screen.
  */
 export default function GlobalError({
   error,
@@ -12,70 +19,158 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const Sentry = await import("@sentry/nextjs");
+        if (cancelled) return;
+        Sentry.captureException(error, {
+          tags: { boundary: "global-error" },
+          extra: { digest: error.digest },
+        });
+      } catch {
+        // Sentry unavailable — silently swallow; this is the last-resort screen.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [error]);
+
   return (
-    <html>
+    <html lang="en">
       <body
         style={{
-          fontFamily: "system-ui, sans-serif",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
           backgroundColor: "#FEFCF6",
-          color: "#2C3E2D",
+          color: "#1F2A1F",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
           minHeight: "100vh",
           padding: "2rem",
+          margin: 0,
         }}
       >
-        <div style={{ textAlign: "center", maxWidth: "420px" }}>
-          <div style={{ fontSize: "3rem", marginBottom: "1rem" }}>🌿</div>
-          <h1
+        <main style={{ textAlign: "center", maxWidth: "440px" }}>
+          {/* Inline monochrome leaf — no external assets allowed here. */}
+          <svg
+            width="56"
+            height="56"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            style={{ color: "#3A8560", marginBottom: "1.25rem" }}
+          >
+            <path
+              d="M12 4.5 C 15 8, 15 13.5, 12 19.5 C 9 13.5, 9 8, 12 4.5 Z"
+              stroke="currentColor"
+              strokeWidth="1.25"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M12 6.5 L12 18"
+              stroke="currentColor"
+              strokeWidth="0.9"
+              strokeLinecap="round"
+            />
+          </svg>
+
+          <p
             style={{
-              fontSize: "1.5rem",
-              fontWeight: 600,
-              marginBottom: "0.75rem",
+              fontSize: "0.7rem",
+              fontWeight: 500,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: "#9CA89E",
+              margin: "0 0 0.75rem 0",
             }}
           >
-            Something went wrong
+            Unexpected error
+          </p>
+
+          <h1
+            style={{
+              fontSize: "1.65rem",
+              fontWeight: 600,
+              letterSpacing: "-0.01em",
+              margin: "0 0 0.75rem 0",
+              lineHeight: 1.15,
+            }}
+          >
+            Something didn&rsquo;t go as planned.
           </h1>
+
           <p
             style={{
               fontSize: "0.95rem",
               color: "#6B7D6E",
               lineHeight: 1.6,
-              marginBottom: "1.5rem",
+              margin: "0 0 1.75rem 0",
             }}
           >
-            We hit an unexpected issue. Your data is safe — this is a
-            display problem, not a data problem. Try refreshing, or
-            contact your care team if it keeps happening.
+            Your data is safe — this is a display problem, not a data
+            problem. Try refreshing, or contact your care team if it
+            keeps happening.
           </p>
-          <button
-            onClick={reset}
+
+          <div
             style={{
-              padding: "0.625rem 1.5rem",
-              borderRadius: "0.5rem",
-              border: "1px solid #3A8560",
-              backgroundColor: "#3A8560",
-              color: "white",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              cursor: "pointer",
+              display: "flex",
+              gap: "0.625rem",
+              justifyContent: "center",
+              flexWrap: "wrap",
             }}
           >
-            Try again
-          </button>
+            <button
+              onClick={reset}
+              style={{
+                padding: "0.75rem 1.5rem",
+                borderRadius: "0.5rem",
+                border: "1px solid #3A8560",
+                backgroundColor: "#3A8560",
+                color: "white",
+                fontSize: "0.9rem",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            <a
+              href="/"
+              style={{
+                padding: "0.75rem 1.5rem",
+                borderRadius: "0.5rem",
+                border: "1px solid #D6DCD2",
+                backgroundColor: "#FFFFFF",
+                color: "#1F2A1F",
+                fontSize: "0.9rem",
+                fontWeight: 500,
+                textDecoration: "none",
+              }}
+            >
+              Go home
+            </a>
+          </div>
+
           {error.digest && (
             <p
               style={{
-                marginTop: "1.5rem",
+                marginTop: "1.75rem",
+                fontFamily:
+                  "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
                 fontSize: "0.7rem",
                 color: "#9CA89E",
               }}
             >
-              Error reference: {error.digest}
+              Reference: {error.digest}
             </p>
           )}
-        </div>
+        </main>
       </body>
     </html>
   );

--- a/src/app/marketplace/products/[slug]/not-found.tsx
+++ b/src/app/marketplace/products/[slug]/not-found.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Eyebrow } from "@/components/ui/ornament";
+
+/**
+ * Segment-level 404 for /marketplace/products/[slug]. Triggered when the
+ * slug doesn't map to a curated product — usually because the listing
+ * was retired, the URL was hand-edited, or an old link is being shared.
+ *
+ * The app-wide 404 ("This page wandered off") is technically correct
+ * here but unhelpful: the path itself is valid, the product is gone.
+ * Sending shoppers back to the catalog is more useful than home.
+ */
+export default function MarketplaceProductNotFound() {
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center px-6 py-16">
+      <Card tone="raised" className="max-w-[640px] w-full">
+        <CardContent className="py-10 text-center">
+          <Eyebrow className="justify-center mb-3">Marketplace</Eyebrow>
+
+          <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.08]">
+            This product is no longer listed.
+          </h1>
+
+          <p className="text-[15px] text-text-muted mt-4 max-w-md mx-auto leading-relaxed">
+            The catalog rotates — this item may have been retired, gone
+            out of stock, or moved to a different listing. Browse the
+            full marketplace to find what you&rsquo;re looking for.
+          </p>
+
+          <div className="mt-8 flex flex-col sm:flex-row justify-center gap-3">
+            <Link href="/marketplace">
+              <Button size="lg" className="min-w-[180px]">
+                Browse marketplace
+              </Button>
+            </Link>
+            <Link href="/">
+              <Button size="lg" variant="secondary" className="min-w-[140px]">
+                Go home
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,34 +1,52 @@
 import Link from "next/link";
-import { EmptyIllustration } from "@/components/ui/ornament";
-import { Button } from "@/components/ui/button";
 
+import { Button } from "@/components/ui/button";
+import { OpenCommandPaletteButton } from "@/components/error-pages/open-command-palette-button";
+import { WanderingLeafIllustration } from "@/components/error-pages/wandering-leaf-illustration";
+
+/**
+ * App-wide 404. Reached when no segment claims the URL.
+ *
+ * We can't read the session here (this file is rendered statically by
+ * Next at build time for many paths), so "Go home" routes to `/`, which
+ * the root page already redirects to the role-appropriate dashboard.
+ */
 export default function NotFoundPage() {
   return (
-    <div className="min-h-screen relative flex items-center justify-center overflow-hidden">
+    <div className="min-h-screen relative flex items-center justify-center overflow-hidden bg-bg">
       {/* Ambient background wash */}
       <div className="absolute inset-0 ambient pointer-events-none" />
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[var(--bg)] pointer-events-none" />
 
-      <div className="relative z-10 flex flex-col items-center text-center px-6 py-20 max-w-lg">
-        <EmptyIllustration size={160} className="mb-8 opacity-80" />
+      <main className="relative z-10 flex flex-col items-center text-center px-6 py-20 max-w-xl animate-in fade-in slide-in-from-bottom-3 duration-700">
+        <WanderingLeafIllustration size={176} className="mb-10 opacity-90" />
 
-        <h1 className="font-display text-4xl md:text-5xl text-text tracking-tight leading-[1.08] mb-4">
-          This path doesn&rsquo;t lead anywhere.
-        </h1>
-
-        <p className="text-[15px] text-text-muted leading-relaxed mb-8 max-w-sm">
-          The page you were looking for could not be found. It may have been
-          moved, or perhaps it was never planted here at all.
-        </p>
-
-        <Link href="/">
-          <Button size="lg">Go home</Button>
-        </Link>
-
-        <p className="text-xs text-text-subtle mt-10 tracking-wide uppercase">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-text-subtle mb-3">
           404 &middot; Not found
         </p>
-      </div>
+
+        <h1 className="font-display text-4xl md:text-5xl text-text tracking-tight leading-[1.05] mb-4">
+          This page wandered off.
+        </h1>
+
+        <p className="text-[17px] text-text-muted leading-relaxed mb-10 max-w-md">
+          The link may be stale, or the page may have moved. Try the
+          command palette, or head home and we&rsquo;ll point you the
+          right way.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+          <Link href="/" className="w-full sm:w-auto">
+            <Button size="lg" className="w-full sm:w-auto min-w-[160px]">
+              Go home
+            </Button>
+          </Link>
+          <OpenCommandPaletteButton
+            label="Search"
+            className="w-full sm:w-auto min-w-[180px]"
+          />
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/components/error-pages/open-command-palette-button.tsx
+++ b/src/components/error-pages/open-command-palette-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Tiny client-side CTA used inside error / not-found screens to surface
+ * the global command palette. Synthesises a ⌘K KeyboardEvent so we don't
+ * have to plumb a context through every error boundary — the palette
+ * already listens for that hotkey globally.
+ *
+ * Detects platform and shows ⌘K vs Ctrl+K accordingly.
+ */
+export function OpenCommandPaletteButton({
+  label = "Open command palette",
+  className,
+}: {
+  label?: string;
+  className?: string;
+}) {
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /mac|iphone|ipad|ipod/i.test(navigator.platform);
+  const hint = isMac ? "⌘K" : "Ctrl+K";
+
+  return (
+    <Button
+      variant="secondary"
+      size="lg"
+      className={className}
+      onClick={() => {
+        // Re-use the palette's own hotkey handler instead of reaching into
+        // its internals. Works in every route group, including ones where
+        // the palette mounts conditionally.
+        const evt = new KeyboardEvent("keydown", {
+          key: "k",
+          code: "KeyK",
+          metaKey: isMac,
+          ctrlKey: !isMac,
+          bubbles: true,
+        });
+        window.dispatchEvent(evt);
+      }}
+      trailingIcon={
+        <kbd
+          className="ml-1 inline-flex items-center rounded border border-border-strong/70 bg-surface-muted px-1.5 py-0.5 font-mono text-[10px] tracking-tight text-text-muted"
+          aria-hidden="true"
+        >
+          {hint}
+        </kbd>
+      }
+    >
+      {label}
+    </Button>
+  );
+}

--- a/src/components/error-pages/use-report-error.ts
+++ b/src/components/error-pages/use-report-error.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Reports an `error.tsx` boundary error to Sentry exactly once per error
+ * instance, even across React StrictMode double-invokes. We key the
+ * effect on `error.digest` (set by Next.js for the boundary) and fall
+ * back to the message+stack pair when the digest is absent (dev mode).
+ *
+ * Imported dynamically so the bundle can be tree-shaken in environments
+ * where @sentry/nextjs is stubbed out. Failing to load Sentry must NEVER
+ * break the error screen itself — that's the user's last good surface.
+ */
+export function useReportError(error: Error & { digest?: string }) {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const Sentry = await import("@sentry/nextjs");
+        if (cancelled) return;
+        Sentry.captureException(error, {
+          tags: { boundary: "app-error" },
+          extra: { digest: error.digest },
+        });
+      } catch {
+        // Sentry not installed / not initialised — log silently and move on.
+        if (process.env.NODE_ENV !== "production") {
+          // eslint-disable-next-line no-console
+          console.warn("[useReportError] Sentry unavailable", error);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error?.digest, error?.message]);
+}

--- a/src/components/error-pages/wandering-leaf-illustration.tsx
+++ b/src/components/error-pages/wandering-leaf-illustration.tsx
@@ -1,0 +1,114 @@
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Monochrome + accent illustration used on the app-wide 404 screen.
+ * A compass rose with a single botanical sprig drifting off-axis —
+ * "the page wandered off". Pure SVG, no images, no animation cost,
+ * scales with the surrounding type.
+ */
+export function WanderingLeafIllustration({
+  size = 168,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 168 168"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("text-accent", className)}
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id="wl-mist" cx="50%" cy="55%" r="55%">
+          <stop offset="0%" stopColor="var(--accent-soft)" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="var(--accent-soft)" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      {/* Soft mist halo */}
+      <circle cx="84" cy="88" r="64" fill="url(#wl-mist)" />
+
+      {/* Compass ring */}
+      <circle
+        cx="84"
+        cy="84"
+        r="48"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        opacity="0.45"
+      />
+      <circle
+        cx="84"
+        cy="84"
+        r="36"
+        stroke="currentColor"
+        strokeWidth="0.75"
+        strokeDasharray="2 4"
+        opacity="0.35"
+      />
+
+      {/* Cardinal ticks */}
+      <g
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinecap="round"
+        opacity="0.6"
+      >
+        <line x1="84" y1="34" x2="84" y2="40" />
+        <line x1="84" y1="128" x2="84" y2="134" />
+        <line x1="34" y1="84" x2="40" y2="84" />
+        <line x1="128" y1="84" x2="134" y2="84" />
+      </g>
+
+      {/* Compass needle, slightly off-true */}
+      <g transform="rotate(18 84 84)">
+        <path
+          d="M84 50 L90 84 L84 118 L78 84 Z"
+          fill="currentColor"
+          opacity="0.18"
+        />
+        <path
+          d="M84 50 L90 84 L84 84 Z"
+          fill="currentColor"
+          opacity="0.85"
+        />
+        <circle cx="84" cy="84" r="3" fill="var(--bg)" stroke="currentColor" strokeWidth="1" />
+      </g>
+
+      {/* Drifting leaf — the page that wandered off */}
+      <g transform="translate(118 36) rotate(28)">
+        <path
+          d="M0 8 C 4 0, 12 0, 16 8 C 12 16, 4 16, 0 8 Z"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          fill="var(--highlight)"
+          fillOpacity="0.18"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M2 8 L14 8"
+          stroke="currentColor"
+          strokeWidth="0.8"
+          strokeLinecap="round"
+          opacity="0.7"
+        />
+      </g>
+
+      {/* Trail of small dots from compass center out to drifting leaf */}
+      <g fill="currentColor" opacity="0.55">
+        <circle cx="98" cy="74" r="1.2" />
+        <circle cx="108" cy="62" r="1" />
+        <circle cx="116" cy="52" r="0.9" />
+      </g>
+
+      {/* Highlight glints */}
+      <circle cx="46" cy="50" r="1.5" fill="var(--highlight)" opacity="0.7" />
+      <circle cx="132" cy="118" r="1.25" fill="var(--highlight)" opacity="0.55" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Stripe/Vercel-tier polish on the EMR error surface. The previous 404 was already pretty good; the rest were duplicated stubs or default Next.js fallbacks. This pass unifies the look and adds the missing affordances.

### Shipped

- **`src/app/not-found.tsx`** — new copy ("This page wandered off"), inline monochrome+accent SVG illustration (compass + drifting leaf), two CTAs: **Go home** + **Search** (opens ⌘K / Ctrl+K palette via synthesised keydown).
- **`src/app/error.tsx`** (NEW) — root error boundary with friendly copy, `error.digest` reference, Try again / Go home buttons.
- **`src/app/global-error.tsx`** — polished, dependency-free inline-styled fallback. Renders own `<html>`/`<body>`, inlines a leaf SVG, includes Go-home link, and captures to Sentry via dynamic import.
- **`src/app/(clinician)/error.tsx`** — role-aware: "Go to Today" → `/clinic`.
- **`src/app/(patient)/error.tsx`** — role-aware: "Back to dashboard" → `/portal`.
- **`src/app/(operator)/error.tsx`** — role-aware: "Back to ops" → `/ops`.
- **`src/app/marketplace/products/[slug]/not-found.tsx`** (NEW) — "This product is no longer listed", routes back to `/marketplace`.

### Shared helpers (new)

- `src/components/error-pages/open-command-palette-button.tsx` — synthesises ⌘K / Ctrl+K KeyboardEvent (platform-detected), reuses the existing global palette hotkey handler.
- `src/components/error-pages/wandering-leaf-illustration.tsx` — pure-SVG compass + drifting leaf.
- `src/components/error-pages/use-report-error.ts` — Sentry `captureException` hook, dynamic-imports `@sentry/nextjs`, guards against load failure (the error screen must never error).

### Sentry wiring — YES

All four `error.tsx` boundaries call `Sentry.captureException(error, { tags: { boundary }, extra: { digest } })` exactly once on mount via `useReportError`. `global-error.tsx` does its own inline capture.

### Out of scope

- The existing patient `[id]/not-found.tsx` was already well-written; left untouched.
- Did not modify `prisma/schema.prisma`, `src/middleware.ts`, `src/lib/auth/`, or workflows per brief.

## Test plan

- [ ] Visit a non-existent route (e.g. `/this-is-not-real`) — root 404 renders with command palette CTA.
- [ ] Click "Search" — ⌘K palette opens.
- [ ] Visit `/marketplace/products/does-not-exist` — marketplace 404 renders, "Browse marketplace" returns to `/marketplace`.
- [ ] Trigger an error in `/clinic/*` — clinician error boundary renders, "Go to Today" routes to `/clinic`, Sentry receives the exception (tag `boundary=app-error`).
- [ ] Same for `/portal/*` and `/ops/*`.
- [ ] `npm run typecheck` clean (verified).
- [ ] `npm run lint` clean for changed files (verified — only pre-existing warnings remain).

Auto-merge enabled on green per UX run brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)