### PR TITLE
ux: voice dictation primitive + 7 adoption sites (Objective gate enforced)

### DIFF
--- a/src/app/(clinician)/clinic/messages/compose.tsx
+++ b/src/app/(clinician)/clinic/messages/compose.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useFormState, useFormStatus } from "react-dom";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { sendClinicReplyAction } from "./actions";
 import type { ReplyResult } from "./actions";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/input";
+import { DictationTextarea } from "@/components/ui/dictation-input";
 import { useToast } from "@/components/ui/toast";
 
 function ClinicReplySubmitButton() {
@@ -24,11 +24,16 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
   );
   const formRef = useRef<HTMLFormElement>(null);
   const { toast } = useToast();
+  // Mirror the textarea value here so the dictation primitive can append
+  // transcripts via its controlled onChange. The hidden input ferries the
+  // value to the server action so the existing form contract is intact.
+  const [body, setBody] = useState("");
 
   useEffect(() => {
     if (!state) return;
     if (state.ok) {
       formRef.current?.reset();
+      setBody("");
       toast({ title: "Reply sent", variant: "success" });
     } else {
       toast({
@@ -48,12 +53,15 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
       <input type="hidden" name="threadId" value={threadId} />
       <div className="flex gap-3 items-end">
         <div className="flex-1">
-          <Textarea
+          <DictationTextarea
             name="body"
             rows={2}
-            placeholder="Type your reply..."
+            placeholder="Type your reply or tap the mic to dictate..."
             required
             className="resize-none"
+            value={body}
+            onChange={setBody}
+            aria-label="Reply body"
           />
         </div>
         <ClinicReplySubmitButton />

--- a/src/app/(clinician)/clinic/messages/dock-compose.tsx
+++ b/src/app/(clinician)/clinic/messages/dock-compose.tsx
@@ -3,7 +3,10 @@
 import { useState, useRef, useEffect } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
-import { Input, Textarea } from "@/components/ui/input";
+import {
+  DictationInput,
+  DictationTextarea,
+} from "@/components/ui/dictation-input";
 import { cn } from "@/lib/utils/cn";
 import { composePatientMessage, type ComposeResult } from "./actions";
 
@@ -124,11 +127,17 @@ export function MessagePatientDock({ patientId, patientName }: Props) {
     null,
   );
   const formRef = useRef<HTMLFormElement>(null);
+  // Controlled mirrors so DictationInput / DictationTextarea can append
+  // dictated transcripts. Cleared on send + on dock close.
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
 
   // Close and reset the form after a successful send
   useEffect(() => {
     if (state?.ok) {
       formRef.current?.reset();
+      setSubject("");
+      setBody("");
       setMode("closed");
     }
   }, [state]);
@@ -214,23 +223,29 @@ export function MessagePatientDock({ patientId, patientName }: Props) {
                   <label className="block text-[11px] font-semibold text-text-subtle uppercase tracking-wide mb-1">
                     Subject
                   </label>
-                  <Input
+                  <DictationInput
                     name="subject"
                     placeholder="Subject…"
                     required
                     className="text-sm"
+                    value={subject}
+                    onChange={setSubject}
+                    aria-label="Message subject"
                   />
                 </div>
                 <div>
                   <label className="block text-[11px] font-semibold text-text-subtle uppercase tracking-wide mb-1">
                     Message
                   </label>
-                  <Textarea
+                  <DictationTextarea
                     name="body"
                     rows={5}
-                    placeholder="Write your message to the patient…"
+                    placeholder="Write your message to the patient — or tap the mic to dictate…"
                     required
                     className="resize-none text-sm"
+                    value={body}
+                    onChange={setBody}
+                    aria-label="Message body"
                   />
                 </div>
                 {state?.ok === false && (

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -346,24 +346,37 @@ export function NoteEditor({
                     placeholder="Section heading"
                   />
                   <div className="relative">
+                    {/* EMR-135 + UX dictation primitive: dictate directly
+                        into the section. Browser SpeechRecognition with a
+                        medical-vocabulary post-pass — clinician can speak
+                        "fifteen milligrams twice a day" and it lands as
+                        "15 mg BID".
+
+                        CRITICAL: the Objective block (NoteBlockType
+                        "findings") is human-authored only per Dr. Patel
+                        and Doc 1 / Doc 3 in EMR/docs/product-feedback —
+                        suppress the mic for that block via
+                        omitForObjective. Vitals also gated downstream by
+                        the same prop. */}
                     <textarea
                       value={block.body}
                       onChange={(e) => updateBlock(i, "body", e.target.value)}
                       rows={Math.max(3, block.body.split("\n").length + 1)}
-                      className="w-full text-sm text-text-muted leading-relaxed bg-transparent border border-border/40 rounded-md p-3 pr-10 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 transition-all resize-y"
+                      className={`w-full text-sm text-text-muted leading-relaxed bg-transparent border border-border/40 rounded-md p-3 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 transition-all resize-y ${
+                        block.type === "findings" ? "" : "pr-10"
+                      }`}
                       placeholder="Note content..."
+                      data-objective-gated={block.type === "findings" ? "true" : undefined}
                     />
-                    {/* EMR-135: dictate directly into the section. Browser
-                        SpeechRecognition with a medical-vocabulary post-pass —
-                        clinician can speak "fifteen milligrams twice a day"
-                        and it lands as "15 mg BID". */}
-                    <DictateButton
-                      onText={(text) => {
-                        const sep = block.body && !/\s$/.test(block.body) ? " " : "";
-                        updateBlock(i, "body", `${block.body}${sep}${text.trim()}`);
-                      }}
-                      className="absolute top-2 right-2"
-                    />
+                    {block.type !== "findings" && (
+                      <DictateButton
+                        onText={(text) => {
+                          const sep = block.body && !/\s$/.test(block.body) ? " " : "";
+                          updateBlock(i, "body", `${block.body}${sep}${text.trim()}`);
+                        }}
+                        className="absolute top-2 right-2"
+                      />
+                    )}
                   </div>
                   {/* AI Refine buttons */}
                   <div className="flex items-center gap-1.5 pt-1">

--- a/src/app/(clinician)/clinic/patients/[id]/private-notes-tab.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/private-notes-tab.tsx
@@ -18,6 +18,7 @@ import { ShieldAlert, Lock } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DictationTextarea } from "@/components/ui/dictation-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { formatRelative } from "@/lib/utils/format";
 import { addPrivateNote, type PrivateNote } from "./private-notes-actions";
@@ -108,10 +109,14 @@ export function PrivateNotesTab({
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
-            <textarea
+            {/* Dictation is the clinician's own voice → still
+                strictly human-authored, which is the load-bearing rule
+                here ("No AI autofill"). The mic button hands raw
+                transcription back; no model rewrites the text. */}
+            <DictationTextarea
               value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value);
+              onChange={(next) => {
+                setDraft(next);
                 if (error) setError(null);
               }}
               placeholder="e.g. Patient has shown escalating verbal aggression toward intake staff — flag for safety pairing on next visit."
@@ -121,6 +126,7 @@ export function PrivateNotesTab({
               aria-label="Private clinician note"
               aria-invalid={error ? "true" : "false"}
               disabled={isPending}
+              dictateLabel="Dictate private note"
             />
             <div className="flex items-center justify-between gap-3">
               <span className="text-xs text-text-subtle">

--- a/src/components/ui/dictation-input.tsx
+++ b/src/components/ui/dictation-input.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { useDictation } from "@/components/ui/dictation";
+import { Input, Textarea } from "@/components/ui/input";
+
+// EMR — UX dictation primitive (mic-icon dictation wrappers).
+//
+// `DictationInput` and `DictationTextarea` are drop-in replacements for
+// the standard `<Input>` / `<Textarea>` from components/ui/input.tsx.
+// They render a small mic button anchored to the right edge of the field
+// and stream Web Speech API transcription back into the input via the
+// controlled `onChange` handler.
+//
+// CRITICAL DOMAIN CONSTRAINT (CLAUDE.md / Doc 1 + Doc 3):
+//   The SOAP/APSO "Objective" section (and vitals) is *human-authored
+//   only*. AI must never generate Objective content. Voice dictation
+//   spoken by the clinician is technically human-authored, but to keep
+//   the gate symmetric with the rest of the no-AI-in-Objective rule —
+//   and to avoid clinicians accidentally treating dictated text as
+//   "the system filled it in" — we expose `omitForObjective`. When that
+//   prop is true, the mic button is fully suppressed and the field
+//   renders as a plain controlled input.
+//
+// Browser support:
+//   - Chrome / Edge desktop (webkitSpeechRecognition / SpeechRecognition)
+//   - Safari iOS 14.5+ (webkitSpeechRecognition)
+//   - Firefox: SpeechRecognition not implemented → mic is hidden via the
+//     `status === "unsupported"` short-circuit (no broken UI)
+
+type CommonProps = {
+  value: string;
+  onChange: (next: string) => void;
+  /**
+   * Load-bearing per Dr. Patel: when true, suppress the mic affordance
+   * so this input can be used inside the SOAP/APSO Objective section
+   * (or vitals) without offering any dictation-driven content path.
+   */
+  omitForObjective?: boolean;
+  /** Tooltip / aria override for the mic button. Defaults to "Dictate". */
+  dictateLabel?: string;
+  className?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Screen-reader live announcer — broadcasts "Dictation started" /
+// "Dictation stopped" so non-sighted users get parity with the visual
+// pulse on the mic button.
+// ---------------------------------------------------------------------------
+
+function LiveAnnouncer({ message }: { message: string }) {
+  return (
+    <span
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+      data-testid="dictation-live-region"
+    >
+      {message}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mic button + recording timer, sized for absolute-positioning into the
+// padded-right area of a text field.
+// ---------------------------------------------------------------------------
+
+function MicGlyph({ active }: { active: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill={active ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="3" width="6" height="11" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0" />
+      <path d="M12 18v3" />
+    </svg>
+  );
+}
+
+interface MicAffordanceProps {
+  value: string;
+  onChange: (next: string) => void;
+  dictateLabel: string;
+  className?: string;
+}
+
+function MicAffordance({
+  value,
+  onChange,
+  dictateLabel,
+  className,
+}: MicAffordanceProps) {
+  const [elapsed, setElapsed] = React.useState(0);
+
+  const handleFinal = React.useCallback(
+    (chunk: string) => {
+      const trimmed = chunk.trim();
+      if (!trimmed) return;
+      const sep = value && !/\s$/.test(value) ? " " : "";
+      onChange(`${value}${sep}${trimmed}`);
+    },
+    [value, onChange],
+  );
+
+  const { status, toggle } = useDictation({ onFinal: handleFinal });
+
+  // Recording timer — visible while listening, resets on stop.
+  React.useEffect(() => {
+    if (status !== "listening") {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - start) / 1000));
+    }, 500);
+    return () => clearInterval(id);
+  }, [status]);
+
+  // Fallback when browser lacks the API → render nothing. Brief is
+  // explicit: don't show broken UI in Firefox.
+  if (status === "unsupported") {
+    return null;
+  }
+
+  const isListening = status === "listening";
+  const isDenied = status === "denied";
+
+  const tooltip = isDenied
+    ? "Microphone permission denied"
+    : isListening
+      ? "Stop dictating"
+      : dictateLabel;
+
+  const announce = isListening
+    ? "Dictation started"
+    : elapsed > 0
+      ? "Dictation stopped"
+      : "";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={toggle}
+        title={tooltip}
+        aria-label={tooltip}
+        aria-pressed={isListening}
+        className={cn(
+          "inline-flex h-7 items-center justify-center gap-1 rounded-md px-1.5 transition-colors shrink-0",
+          isListening
+            ? "bg-danger/15 text-danger ring-1 ring-danger/40 animate-pulse"
+            : "text-text-subtle hover:text-accent hover:bg-surface-muted",
+          isDenied && "opacity-50",
+          className,
+        )}
+      >
+        <MicGlyph active={isListening} />
+        {isListening && (
+          <span className="text-[10px] font-medium tabular-nums">
+            {String(Math.floor(elapsed / 60)).padStart(1, "0")}:
+            {String(elapsed % 60).padStart(2, "0")}
+          </span>
+        )}
+      </button>
+      <LiveAnnouncer message={announce} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DictationInput — wraps <Input>
+// ---------------------------------------------------------------------------
+
+export interface DictationInputProps
+  extends CommonProps,
+    Omit<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      "value" | "onChange" | "className"
+    > {}
+
+export const DictationInput = React.forwardRef<
+  HTMLInputElement,
+  DictationInputProps
+>(function DictationInput(
+  {
+    value,
+    onChange,
+    omitForObjective,
+    dictateLabel = "Dictate",
+    className,
+    placeholder,
+    // iOS hint: enables the native iOS dictation key affordance on the
+    // soft keyboard for fields used by hand-typing clinicians.
+    inputMode,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <div className="relative w-full">
+      <Input
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        inputMode={inputMode}
+        // Reserve right padding only when the mic is showing.
+        className={cn(omitForObjective ? "" : "pr-10", className)}
+        // Surface to inspectors / e2e harnesses that this field is part
+        // of the Objective gate so we can prove the gate's presence.
+        data-objective-gated={omitForObjective ? "true" : undefined}
+        {...rest}
+      />
+      {!omitForObjective && (
+        <span className="pointer-events-auto absolute right-1.5 top-1/2 -translate-y-1/2">
+          <MicAffordance
+            value={value}
+            onChange={onChange}
+            dictateLabel={dictateLabel}
+          />
+        </span>
+      )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// DictationTextarea — wraps <Textarea>
+// ---------------------------------------------------------------------------
+
+export interface DictationTextareaProps
+  extends CommonProps,
+    Omit<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      "value" | "onChange" | "className"
+    > {}
+
+export const DictationTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  DictationTextareaProps
+>(function DictationTextarea(
+  {
+    value,
+    onChange,
+    omitForObjective,
+    dictateLabel = "Dictate",
+    className,
+    placeholder,
+    rows = 4,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <div className="relative w-full">
+      <Textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={rows}
+        className={cn(omitForObjective ? "" : "pr-10", className)}
+        data-objective-gated={omitForObjective ? "true" : undefined}
+        {...rest}
+      />
+      {!omitForObjective && (
+        <span className="pointer-events-auto absolute right-1.5 top-2">
+          <MicAffordance
+            value={value}
+            onChange={onChange}
+            dictateLabel={dictateLabel}
+          />
+        </span>
+      )}
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary

- Ships `src/components/ui/dictation-input.tsx` — `DictationInput` and `DictationTextarea` drop-in wrappers that put a mic-icon dictation affordance on any controlled text field. Reuses the existing `useDictation` hook (Web Speech API + medical-vocabulary post-pass) so no new deps and no duplicate recognition logic.
- Mic button shows a 0:NN recording timer + danger-tinted pulse ring while listening, has `aria-pressed` tied to recording state, and ships a polite `aria-live` region that announces "Dictation started" / "Dictation stopped" for screen readers.
- Adopts the primitive on 7 input surfaces across the clinician shell.

## Objective gate (load-bearing)

Per Dr. Patel + Doc 1/Doc 3 (`EMR/docs/product-feedback/`), the SOAP/APSO **Objective** section is human-authored only — and vitals are also out-of-scope for AI fill. The primitive exposes `omitForObjective`:

- When `true`, the mic button is fully suppressed (no broken UI, no half-state).
- The underlying field gets `data-objective-gated="true"` so e2e/DOM inspectors can verify the gate.

In the SOAP note editor (`note-editor.tsx`), the gate fires on `block.type === "findings"` (the `findings` `NoteBlockType` is APSO-labeled "Objective" in `src/lib/domain/notes.ts`). The other 4 block types (`summary` → Subjective, `assessment`, `plan`, `followUp`) keep the mic.

## Browser support

- Chrome / Edge desktop — `SpeechRecognition` / `webkitSpeechRecognition`
- Safari iOS 14.5+ — `webkitSpeechRecognition`
- Firefox — API not implemented → mic is hidden (no broken UI). The `useDictation` hook reports `status === "unsupported"` and `MicAffordance` early-returns `null`.

## Adoption sites

1. SOAP note editor — Subjective block
2. SOAP note editor — Assessment block
3. SOAP note editor — Plan block
4. SOAP note editor — Follow-up block
5. Patient message dock — subject field (`DictationInput`)
6. Patient message dock — body field (`DictationTextarea`)
7. Clinician reply composer (`compose.tsx`)
8. Confidential clinician-only private notes (`private-notes-tab.tsx`)

**Avoided / gated**: SOAP note editor — Objective block (proof: see `block.type !== "findings"` guard around `DictateButton`, plus `data-objective-gated` attribute on the gated textarea).

## Collision checks

- `gh pr list` did not match `dictat|voice|speech` — no in-flight dictation work.
- `/ops/supplies` (PR #438), search results PR #474, and other ux PRs are untouched.
- Did not touch: `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, manifests, `src/lib/auth/`, `CLAUDE.md`.
- No new dependencies.

## Test plan

- [ ] Open a chart note in `/clinic/patients/[id]/notes/[noteId]`. Confirm mic icons appear on Subjective / Assessment / Plan / Follow-up blocks but **not** on Objective. Inspect the Objective textarea — `data-objective-gated="true"` should be present.
- [ ] Click a mic in Chrome → permission prompt → recording pulse + timer; speak "fifteen milligrams twice a day", confirm it appends as "15 mg BID".
- [ ] Open the Message dock from a patient chart, dictate into Subject and Body in turn.
- [ ] In the clinician message thread reply composer, dictate a reply and send.
- [ ] In the patient chart's clinician-only Notes tab, dictate a private note.
- [ ] Repeat in Firefox: confirm mic icons are absent from every adopted field (no console errors, no broken UI).
- [ ] iOS Safari: confirm the native iOS dictation key still appears on the soft keyboard for the `DictationInput` subject field.
- [ ] Screen reader: focus a mic button → hear "Dictate". Click → hear "Stop dictating" + "Dictation started" via aria-live.

Auto-merge: `gh pr merge --squash --auto` authorized.