### PR TITLE
ux: unified Tooltip + Popover primitives + 8 adoptions

### DIFF
--- a/src/app/(clinician)/clinic/queue-rail-client.tsx
+++ b/src/app/(clinician)/clinic/queue-rail-client.tsx
@@ -26,6 +26,7 @@
 
 import * as React from "react";
 import { SortableList, reorder } from "@/components/ui/sortable";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils/cn";
 
 export interface QueueRailCard {
@@ -133,18 +134,23 @@ export function QueueRailClient({ cards, dayKey }: Props) {
                 hover or while dragging. Spreading dragHandleProps here
                 makes only the grip itself the drag source so the rest
                 of the card (links, Prepare button) stay clickable. */}
-            <span
-              {...dragHandleProps}
-              className={cn(
-                dragHandleProps.className,
-                "absolute top-1.5 left-1.5 z-10 p-1 rounded bg-surface/80 backdrop-blur",
-                "opacity-0 group-hover:opacity-100 focus:opacity-100",
-                "aria-grabbed:opacity-100",
-              )}
-              title="Drag to reorder (or Space + arrow keys)"
+            <Tooltip
+              content="Drag to reorder (or Space + arrow keys)"
+              side="right"
+              delay={400}
             >
-              <DragGripIcon />
-            </span>
+              <span
+                {...dragHandleProps}
+                className={cn(
+                  dragHandleProps.className,
+                  "absolute top-1.5 left-1.5 z-10 p-1 rounded bg-surface/80 backdrop-blur",
+                  "opacity-0 group-hover:opacity-100 focus:opacity-100",
+                  "aria-grabbed:opacity-100",
+                )}
+              >
+                <DragGripIcon />
+              </span>
+            </Tooltip>
             {card.node}
           </div>
         )}

--- a/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
@@ -9,6 +9,7 @@ import { Printer } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { explainLabValue } from "@/lib/domain/lab-explainer";
 import { LabTooltip } from "@/components/ui/lab-tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   draftLabOutreachAction,
   updateLabOutreachAction,
@@ -357,16 +358,17 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
                 The dedicated route uses the shared PrintDocument frame so
                 the page lands on the printer as a clean clinical document
                 (no modal chrome, no batch tray, no glass blur). */}
-            <a
-              href={`/clinic/sign-off/labs/${row.id}/print`}
-              target="_blank"
-              rel="noopener"
-              className="text-text-subtle hover:text-text p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
-              aria-label="Print / Save as PDF"
-              title="Print / Save as PDF"
-            >
-              <Printer className="h-4 w-4" aria-hidden="true" />
-            </a>
+            <Tooltip content="Print / Save as PDF">
+              <a
+                href={`/clinic/sign-off/labs/${row.id}/print`}
+                target="_blank"
+                rel="noopener"
+                className="text-text-subtle hover:text-text p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
+                aria-label="Print / Save as PDF"
+              >
+                <Printer className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </Tooltip>
             <button
               onClick={onClose}
               className="text-text-subtle hover:text-text text-xl leading-none px-2"

--- a/src/components/scheduling/CalendarGrid.tsx
+++ b/src/components/scheduling/CalendarGrid.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils/cn";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export type CalendarView = "day" | "week" | "month";
 
@@ -672,28 +673,30 @@ function AppointmentChip({ appt }: { appt: CalendarAppointment }) {
     Math.round((end.getTime() - start.getTime()) / (SLOT_MIN * 60_000)),
   );
   const tone = toneFor(appt.modality);
+  const apptTip = `${appt.patientName} · ${formatTime(appt.startAtIso)}–${formatTime(appt.endAtIso)} · ${tone.label}`;
   return (
-    <Link
-      href={`/clinic/patients/${appt.patientId}`}
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer.setData("text/appt-id", appt.id);
-        e.dataTransfer.setData("text/drag-kind", "move");
-      }}
-      className={cn(
-        "block rounded-md px-2 py-1 mx-0.5 my-0.5 text-[11px] truncate cursor-grab active:cursor-grabbing border transition-colors",
-        tone.chip,
-      )}
-      style={{ height: slotCount * SQUARE - 4 }}
-      title={`${appt.patientName} · ${formatTime(appt.startAtIso)}–${formatTime(appt.endAtIso)} · ${tone.label}`}
-    >
-      <span className="font-medium truncate">{appt.patientName}</span>
-      {appt.providerName && (
-        <span className="block text-[9px] truncate opacity-80">
-          {appt.providerName}
-        </span>
-      )}
-    </Link>
+    <Tooltip content={apptTip}>
+      <Link
+        href={`/clinic/patients/${appt.patientId}`}
+        draggable
+        onDragStart={(e) => {
+          e.dataTransfer.setData("text/appt-id", appt.id);
+          e.dataTransfer.setData("text/drag-kind", "move");
+        }}
+        className={cn(
+          "block rounded-md px-2 py-1 mx-0.5 my-0.5 text-[11px] truncate cursor-grab active:cursor-grabbing border transition-colors",
+          tone.chip,
+        )}
+        style={{ height: slotCount * SQUARE - 4 }}
+      >
+        <span className="font-medium truncate">{appt.patientName}</span>
+        {appt.providerName && (
+          <span className="block text-[9px] truncate opacity-80">
+            {appt.providerName}
+          </span>
+        )}
+      </Link>
+    </Tooltip>
   );
 }
 

--- a/src/components/shell/PinButton.tsx
+++ b/src/components/shell/PinButton.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useNavPrefs } from "./NavPrefsContext";
 
 /**
@@ -39,13 +40,15 @@ export function PinButton({
     else prefs.pin({ href, label });
   };
 
+  const tip = pinned ? `Unpin ${label}` : `Pin ${label}`;
+
   return (
+    <Tooltip content={tip} side="right" delay={400}>
     <button
       type="button"
       onClick={onClick}
       aria-pressed={pinned}
-      aria-label={pinned ? `Unpin ${label}` : `Pin ${label}`}
-      title={pinned ? `Unpin ${label}` : `Pin ${label}`}
+      aria-label={tip}
       className={cn(
         "inline-flex items-center justify-center h-6 w-6 rounded-md text-text-subtle",
         "transition-all duration-150 ease-smooth",
@@ -71,5 +74,6 @@ export function PinButton({
         <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
       </svg>
     </button>
+    </Tooltip>
   );
 }

--- a/src/components/ui/cannabis-use-type-badge.tsx
+++ b/src/components/ui/cannabis-use-type-badge.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import * as React from "react";
 import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   USE_TYPE_LABEL,
   type CannabisUseType,
@@ -37,17 +40,20 @@ export function CannabisUseTypeBadge({
   showEmoji?: boolean;
 }) {
   return (
-    <span
-      title={USE_TYPE_LABEL[type]}
-      aria-label={`Cannabis use type: ${USE_TYPE_LABEL[type]}`}
-      className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide",
-        STYLES[type],
-        className,
-      )}
-    >
-      {showEmoji && <span aria-hidden>{EMOJI[type]}</span>}
-      {USE_TYPE_LABEL[type]}
-    </span>
+    <Tooltip content={USE_TYPE_LABEL[type]}>
+      <span
+        tabIndex={0}
+        aria-label={`Cannabis use type: ${USE_TYPE_LABEL[type]}`}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          STYLES[type],
+          className,
+        )}
+      >
+        {showEmoji && <span aria-hidden>{EMOJI[type]}</span>}
+        {USE_TYPE_LABEL[type]}
+      </span>
+    </Tooltip>
   );
 }

--- a/src/components/ui/delta-indicator.tsx
+++ b/src/components/ui/delta-indicator.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 
 // ---------------------------------------------------------------------------
 // DeltaIndicator — small inline up/down arrow + percent change badge.
@@ -85,20 +86,23 @@ export function DeltaIndicator({
       : `${absChange > 0 ? "+" : ""}${format ? format(absChange) : absChange.toLocaleString()} vs prior`;
 
   return (
-    <span
-      title={tooltip}
-      className={cn(
-        "inline-flex items-center gap-1 text-xs font-medium tabular-nums",
-        "animate-in fade-in zoom-in-95 duration-300 ease-out",
-        colorClass,
-        className,
-      )}
-      aria-label={`${direction === "up" ? "up" : direction === "down" ? "down" : "no change"} ${label}, ${tooltip}`}
-    >
-      <span aria-hidden="true" className="text-[0.7em] leading-none">
-        {arrow}
+    <Tooltip content={tooltip}>
+      <span
+        tabIndex={0}
+        className={cn(
+          "inline-flex items-center gap-1 text-xs font-medium tabular-nums",
+          "animate-in fade-in zoom-in-95 duration-300 ease-out",
+          "focus:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 rounded",
+          colorClass,
+          className,
+        )}
+        aria-label={`${direction === "up" ? "up" : direction === "down" ? "down" : "no change"} ${label}, ${tooltip}`}
+      >
+        <span aria-hidden="true" className="text-[0.7em] leading-none">
+          {arrow}
+        </span>
+        <span>{label}</span>
       </span>
-      <span>{label}</span>
-    </span>
+    </Tooltip>
   );
 }

--- a/src/components/ui/patient-tag-badge.tsx
+++ b/src/components/ui/patient-tag-badge.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 import { TAG_COLOR_CLASSES, type PatientTag } from "@/lib/domain/patient-tags";
 
 interface PatientTagBadgeProps {
@@ -15,14 +16,15 @@ interface PatientTagBadgeProps {
  * Colors come from TAG_COLOR_CLASSES in `@/lib/domain/patient-tags`.
  */
 export function PatientTagBadge({ tag, onRemove, className }: PatientTagBadgeProps) {
-  return (
+  const badge = (
     <span
+      tabIndex={tag.description ? 0 : -1}
       className={cn(
         "inline-flex items-center gap-1 pl-2.5 pr-2 py-0.5 text-[11px] font-medium rounded-full border tracking-wide",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
         TAG_COLOR_CLASSES[tag.color],
         className,
       )}
-      title={tag.description}
     >
       <span>{tag.label}</span>
       {onRemove && (
@@ -37,4 +39,6 @@ export function PatientTagBadge({ tag, onRemove, className }: PatientTagBadgePro
       )}
     </span>
   );
+  if (!tag.description) return badge;
+  return <Tooltip content={tag.description}>{badge}</Tooltip>;
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils/cn";
+import { tooltipPop, type TooltipSide } from "@/lib/ui/motion";
+
+// ---------------------------------------------------------------------------
+// Popover — click-triggered, richer-content sibling of <Tooltip>.
+//
+// Use for menus, info panels, mini-forms — anything that wants to be a
+// real floating surface rather than a hover hint.
+//
+// Features:
+//   • Portal to <body>, auto-flip, same motion language as Tooltip
+//   • Closes on click-outside or Esc
+//   • Focus trap when content contains focusable elements
+//   • Returns focus to trigger on close
+//
+// Usage:
+//   <Popover content={<MenuList />} side="bottom">
+//     <button>Actions</button>
+//   </Popover>
+//
+//   Controlled:
+//   <Popover open={open} onOpenChange={setOpen} content={<Form />}>
+//     <Button>Open</Button>
+//   </Popover>
+// ---------------------------------------------------------------------------
+
+const VIEWPORT_PAD = 8;
+const ARROW_SIZE = 6;
+
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"])';
+
+type Coords = { top: number; left: number; side: TooltipSide };
+
+export interface PopoverProps {
+  content: ReactNode;
+  side?: TooltipSide;
+  /** Controlled open. Omit for uncontrolled. */
+  open?: boolean;
+  onOpenChange?: (next: boolean) => void;
+  /** Defer open after click — usually 0 (immediate). */
+  delay?: number;
+  className?: string;
+  /** Single ReactElement child as the trigger. */
+  children: ReactElement;
+}
+
+function computePosition(
+  anchorRect: DOMRect,
+  panelRect: { width: number; height: number },
+  preferred: TooltipSide,
+): Coords {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 0;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+
+  const fitsTop = anchorRect.top - panelRect.height - ARROW_SIZE - VIEWPORT_PAD >= 0;
+  const fitsBottom = anchorRect.bottom + panelRect.height + ARROW_SIZE + VIEWPORT_PAD <= vh;
+  const fitsLeft = anchorRect.left - panelRect.width - ARROW_SIZE - VIEWPORT_PAD >= 0;
+  const fitsRight = anchorRect.right + panelRect.width + ARROW_SIZE + VIEWPORT_PAD <= vw;
+
+  let side: TooltipSide = preferred;
+  if (preferred === "top" && !fitsTop && fitsBottom) side = "bottom";
+  else if (preferred === "bottom" && !fitsBottom && fitsTop) side = "top";
+  else if (preferred === "left" && !fitsLeft && fitsRight) side = "right";
+  else if (preferred === "right" && !fitsRight && fitsLeft) side = "left";
+
+  let top = 0;
+  let left = 0;
+  if (side === "top") {
+    top = anchorRect.top - panelRect.height - ARROW_SIZE;
+    left = anchorRect.left + anchorRect.width / 2 - panelRect.width / 2;
+  } else if (side === "bottom") {
+    top = anchorRect.bottom + ARROW_SIZE;
+    left = anchorRect.left + anchorRect.width / 2 - panelRect.width / 2;
+  } else if (side === "left") {
+    top = anchorRect.top + anchorRect.height / 2 - panelRect.height / 2;
+    left = anchorRect.left - panelRect.width - ARROW_SIZE;
+  } else {
+    top = anchorRect.top + anchorRect.height / 2 - panelRect.height / 2;
+    left = anchorRect.right + ARROW_SIZE;
+  }
+
+  left = Math.max(VIEWPORT_PAD, Math.min(left, vw - panelRect.width - VIEWPORT_PAD));
+  top = Math.max(VIEWPORT_PAD, Math.min(top, vh - panelRect.height - VIEWPORT_PAD));
+  return { top, left, side };
+}
+
+export function Popover({
+  content,
+  side = "bottom",
+  open: controlledOpen,
+  onOpenChange,
+  delay = 0,
+  className,
+  children,
+}: PopoverProps) {
+  const id = useId();
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (controlledOpen === undefined) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlledOpen, onOpenChange],
+  );
+
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reduce = useReducedMotion() ?? false;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Recompute position on open + scroll/resize.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const anchor = anchorRef.current;
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+    const update = () => {
+      const ar = anchor.getBoundingClientRect();
+      const pr = panel.getBoundingClientRect();
+      setCoords(computePosition(ar, { width: pr.width, height: pr.height }, side));
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open, side, content]);
+
+  // Click-outside + Esc handling + focus trap + focus return.
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current =
+      typeof document !== "undefined"
+        ? (document.activeElement as HTMLElement | null)
+        : null;
+
+    // Move focus into the panel on open (first focusable, else panel root).
+    const focusInitial = () => {
+      const node = panelRef.current;
+      if (!node) return;
+      const focusable = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      const target = focusable[0] ?? node;
+      target.focus();
+    };
+    // Defer to next frame so the panel is fully laid out.
+    const raf = requestAnimationFrame(focusInitial);
+
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (panelRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const node = panelRef.current;
+      if (!node) return;
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !node.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKey);
+      // Restore focus to the trigger.
+      const prev = previouslyFocusedRef.current;
+      if (prev && typeof prev.focus === "function") {
+        queueMicrotask(() => prev.focus());
+      }
+    };
+  }, [open, setOpen]);
+
+  useEffect(
+    () => () => {
+      if (openTimer.current) clearTimeout(openTimer.current);
+    },
+    [],
+  );
+
+  if (!isValidElement(children)) {
+    return children;
+  }
+
+  type TriggerProps = {
+    ref?: React.Ref<HTMLElement>;
+    onClick?: (e: React.MouseEvent) => void;
+    "aria-haspopup"?: boolean | "dialog" | "menu" | "true" | "listbox" | "tree" | "grid";
+    "aria-expanded"?: boolean;
+    "aria-controls"?: string;
+  };
+  const existing = (children as ReactElement<TriggerProps>).props;
+  const cloned: TriggerProps & Record<string, unknown> = {
+    ref: (node: HTMLElement | null) => {
+      anchorRef.current = node;
+      const childRef = (children as unknown as { ref?: unknown }).ref;
+      if (typeof childRef === "function") {
+        (childRef as (n: HTMLElement | null) => void)(node);
+      } else if (childRef && typeof childRef === "object" && "current" in childRef) {
+        (childRef as React.MutableRefObject<HTMLElement | null>).current = node;
+      }
+    },
+    onClick: (e: React.MouseEvent) => {
+      existing.onClick?.(e);
+      if (e.defaultPrevented) return;
+      if (open) {
+        setOpen(false);
+        return;
+      }
+      if (delay > 0) {
+        if (openTimer.current) clearTimeout(openTimer.current);
+        openTimer.current = setTimeout(() => setOpen(true), delay);
+      } else {
+        setOpen(true);
+      }
+    },
+    "aria-haspopup": "dialog",
+    "aria-expanded": open,
+    "aria-controls": id,
+  };
+
+  const trigger = cloneElement(children as ReactElement, cloned);
+  const resolvedSide = coords?.side ?? side;
+  const motionProps = tooltipPop(reduce, resolvedSide);
+
+  const panelStyle: CSSProperties = coords
+    ? { position: "fixed", top: coords.top, left: coords.left, zIndex: 1000 }
+    : { position: "fixed", top: 0, left: 0, opacity: 0, zIndex: 1000 };
+
+  return (
+    <>
+      {trigger}
+      {mounted &&
+        createPortal(
+          <AnimatePresence>
+            {open && (
+              <motion.div
+                ref={panelRef}
+                id={id}
+                role="dialog"
+                aria-modal="false"
+                tabIndex={-1}
+                style={panelStyle}
+                {...motionProps}
+              >
+                <div
+                  className={cn(
+                    "min-w-[8rem] rounded-lg border border-border bg-surface-raised p-2 shadow-lg",
+                    "focus:outline-none",
+                    className,
+                  )}
+                >
+                  {content}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 
 /**
  * Three-state theme toggle: Light · Dark · System.
@@ -145,25 +146,26 @@ function SegmentButton({
   icon: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={active}
-      onClick={onClick}
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-        active
-          ? "bg-surface text-text shadow-sm"
-          : "text-text-subtle hover:text-text",
-      )}
-      title={`${label} theme`}
-    >
-      <span aria-hidden="true" className="inline-flex">
-        {icon}
-      </span>
-      <span>{label}</span>
-    </button>
+    <Tooltip content={`${label} theme`}>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={active}
+        onClick={onClick}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          active
+            ? "bg-surface text-text shadow-sm"
+            : "text-text-subtle hover:text-text",
+        )}
+      >
+        <span aria-hidden="true" className="inline-flex">
+          {icon}
+        </span>
+        <span>{label}</span>
+      </button>
+    </Tooltip>
   );
 }
 
@@ -195,11 +197,11 @@ function IconCycleToggle({
         ? "Dark theme (click for light)"
         : "System theme (click for dark)";
   return (
+    <Tooltip content={label}>
     <button
       type="button"
       onClick={next}
       aria-label={label}
-      title={label}
       className={cn(
         "inline-flex h-9 w-9 items-center justify-center rounded-md",
         "text-text-muted transition-colors hover:bg-surface-muted hover:text-text",
@@ -214,6 +216,7 @@ function IconCycleToggle({
       {mounted && mode === "system" && <SystemIcon />}
       {!mounted && <span className="block h-[14px] w-[14px]" aria-hidden="true" />}
     </button>
+    </Tooltip>
   );
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils/cn";
+import { tooltipPop, type TooltipSide } from "@/lib/ui/motion";
+
+// ---------------------------------------------------------------------------
+// Tooltip — Linear / Notion-tier hover/focus overlay primitive.
+//
+// One canonical implementation we adopt across EMR. Replaces:
+//   • native `title=""` HTML attributes (no styling, no keyboard, no a11y)
+//   • bespoke `:hover` divs with absolute positioning
+//   • ad-hoc inline popovers
+//
+// Features:
+//   • Portal to <body> so the overlay never gets clipped by overflow:hidden
+//   • Auto-flip when near viewport edge
+//   • Fade-in via shared motion preset (tooltipPop) — respects reduced motion
+//   • Keyboard: appears on focus, dismisses on blur / Esc
+//   • Touch: tap-and-hold (long press) shows tooltip
+//   • Wires `aria-describedby` onto the trigger so screen readers narrate it
+//
+// Usage:
+//   <Tooltip content="Pin this navigation item">
+//     <button>★</button>
+//   </Tooltip>
+//
+//   <Tooltip content={<span>Rich <b>content</b> ok</span>} side="bottom" delay={300}>
+//     <Badge>New</Badge>
+//   </Tooltip>
+// ---------------------------------------------------------------------------
+
+const VIEWPORT_PAD = 8;
+const ARROW_SIZE = 6;
+const LONG_PRESS_MS = 500;
+
+type Coords = { top: number; left: number; side: TooltipSide };
+
+export interface TooltipProps {
+  /** Tooltip body. String or node. Falsy = render children only (no-op). */
+  content: ReactNode;
+  /** Preferred side. Auto-flips to opposite when not enough room. */
+  side?: TooltipSide;
+  /** Hover open delay, ms. Default 500 — matches Linear/Notion. */
+  delay?: number;
+  /** Hover close delay, ms. Default 80 — feels snappy without flicker. */
+  closeDelay?: number;
+  /** Optional className for the floating panel. */
+  className?: string;
+  /** Optional id override (defaults to a generated one). */
+  id?: string;
+  /** Single ReactElement child the tooltip anchors to. */
+  children: ReactElement;
+  /** Disable entirely (still renders children). */
+  disabled?: boolean;
+}
+
+function computePosition(
+  anchorRect: DOMRect,
+  panelRect: { width: number; height: number },
+  preferred: TooltipSide,
+): Coords {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 0;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+
+  // Determine if preferred side fits; otherwise flip.
+  const fitsTop = anchorRect.top - panelRect.height - ARROW_SIZE - VIEWPORT_PAD >= 0;
+  const fitsBottom = anchorRect.bottom + panelRect.height + ARROW_SIZE + VIEWPORT_PAD <= vh;
+  const fitsLeft = anchorRect.left - panelRect.width - ARROW_SIZE - VIEWPORT_PAD >= 0;
+  const fitsRight = anchorRect.right + panelRect.width + ARROW_SIZE + VIEWPORT_PAD <= vw;
+
+  let side: TooltipSide = preferred;
+  if (preferred === "top" && !fitsTop && fitsBottom) side = "bottom";
+  else if (preferred === "bottom" && !fitsBottom && fitsTop) side = "top";
+  else if (preferred === "left" && !fitsLeft && fitsRight) side = "right";
+  else if (preferred === "right" && !fitsRight && fitsLeft) side = "left";
+
+  let top = 0;
+  let left = 0;
+
+  if (side === "top") {
+    top = anchorRect.top - panelRect.height - ARROW_SIZE;
+    left = anchorRect.left + anchorRect.width / 2 - panelRect.width / 2;
+  } else if (side === "bottom") {
+    top = anchorRect.bottom + ARROW_SIZE;
+    left = anchorRect.left + anchorRect.width / 2 - panelRect.width / 2;
+  } else if (side === "left") {
+    top = anchorRect.top + anchorRect.height / 2 - panelRect.height / 2;
+    left = anchorRect.left - panelRect.width - ARROW_SIZE;
+  } else {
+    // right
+    top = anchorRect.top + anchorRect.height / 2 - panelRect.height / 2;
+    left = anchorRect.right + ARROW_SIZE;
+  }
+
+  // Clamp horizontally / vertically so we never run off-screen.
+  left = Math.max(VIEWPORT_PAD, Math.min(left, vw - panelRect.width - VIEWPORT_PAD));
+  top = Math.max(VIEWPORT_PAD, Math.min(top, vh - panelRect.height - VIEWPORT_PAD));
+
+  return { top, left, side };
+}
+
+export function Tooltip({
+  content,
+  side = "top",
+  delay = 500,
+  closeDelay = 80,
+  className,
+  id,
+  children,
+  disabled = false,
+}: TooltipProps) {
+  const generatedId = useId();
+  const tipId = id ?? `tip-${generatedId}`;
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const [mounted, setMounted] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reduce = useReducedMotion() ?? false;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const clearTimers = useCallback(() => {
+    if (openTimer.current) {
+      clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const scheduleOpen = useCallback(() => {
+    if (disabled || !content) return;
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    if (openTimer.current) return;
+    openTimer.current = setTimeout(() => {
+      setOpen(true);
+      openTimer.current = null;
+    }, delay);
+  }, [delay, disabled, content]);
+
+  const scheduleClose = useCallback(() => {
+    if (openTimer.current) {
+      clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current) return;
+    closeTimer.current = setTimeout(() => {
+      setOpen(false);
+      closeTimer.current = null;
+    }, closeDelay);
+  }, [closeDelay]);
+
+  // Recompute position on open + on scroll/resize while open.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const anchor = anchorRef.current;
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+    const update = () => {
+      const ar = anchor.getBoundingClientRect();
+      const pr = panel.getBoundingClientRect();
+      setCoords(computePosition(ar, { width: pr.width, height: pr.height }, side));
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open, side, content]);
+
+  // Esc closes immediately while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        clearTimers();
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, clearTimers]);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  // Build the child clone with anchor ref + a11y wiring.
+  const child = useMemo<ReactElement>(() => {
+    if (!isValidElement(children)) return children;
+    type AnchorProps = {
+      ref?: React.Ref<HTMLElement>;
+      onMouseEnter?: (e: React.MouseEvent) => void;
+      onMouseLeave?: (e: React.MouseEvent) => void;
+      onFocus?: (e: React.FocusEvent) => void;
+      onBlur?: (e: React.FocusEvent) => void;
+      onTouchStart?: (e: React.TouchEvent) => void;
+      onTouchEnd?: (e: React.TouchEvent) => void;
+      onTouchCancel?: (e: React.TouchEvent) => void;
+      "aria-describedby"?: string;
+    };
+    const existing = (children as ReactElement<AnchorProps>).props;
+    const cloned: AnchorProps & Record<string, unknown> = {
+      ref: (node: HTMLElement | null) => {
+        anchorRef.current = node;
+        // Forward to the child's own ref if present.
+        const childRef = (children as unknown as { ref?: unknown }).ref;
+        if (typeof childRef === "function") {
+          (childRef as (n: HTMLElement | null) => void)(node);
+        } else if (childRef && typeof childRef === "object" && "current" in childRef) {
+          (childRef as React.MutableRefObject<HTMLElement | null>).current = node;
+        }
+      },
+      onMouseEnter: (e: React.MouseEvent) => {
+        existing.onMouseEnter?.(e);
+        scheduleOpen();
+      },
+      onMouseLeave: (e: React.MouseEvent) => {
+        existing.onMouseLeave?.(e);
+        scheduleClose();
+      },
+      onFocus: (e: React.FocusEvent) => {
+        existing.onFocus?.(e);
+        // Focus shows immediately — no hover delay for keyboard users.
+        if (disabled || !content) return;
+        clearTimers();
+        setOpen(true);
+      },
+      onBlur: (e: React.FocusEvent) => {
+        existing.onBlur?.(e);
+        clearTimers();
+        setOpen(false);
+      },
+      onTouchStart: (e: React.TouchEvent) => {
+        existing.onTouchStart?.(e);
+        if (disabled || !content) return;
+        if (longPressTimer.current) clearTimeout(longPressTimer.current);
+        longPressTimer.current = setTimeout(() => {
+          setOpen(true);
+          longPressTimer.current = null;
+        }, LONG_PRESS_MS);
+      },
+      onTouchEnd: (e: React.TouchEvent) => {
+        existing.onTouchEnd?.(e);
+        if (longPressTimer.current) {
+          clearTimeout(longPressTimer.current);
+          longPressTimer.current = null;
+        }
+      },
+      onTouchCancel: (e: React.TouchEvent) => {
+        existing.onTouchCancel?.(e);
+        if (longPressTimer.current) {
+          clearTimeout(longPressTimer.current);
+          longPressTimer.current = null;
+        }
+      },
+      "aria-describedby": open && content
+        ? [existing["aria-describedby"], tipId].filter(Boolean).join(" ")
+        : existing["aria-describedby"],
+    };
+    return cloneElement(children as ReactElement, cloned);
+  }, [children, scheduleOpen, scheduleClose, clearTimers, content, disabled, open, tipId]);
+
+  // Bail-out: no content or disabled — render children unchanged.
+  if (!content || disabled) {
+    return children;
+  }
+
+  const resolvedSide = coords?.side ?? side;
+  const motionProps = tooltipPop(reduce, resolvedSide);
+  const panelStyle: CSSProperties = coords
+    ? { position: "fixed", top: coords.top, left: coords.left, zIndex: 1000, pointerEvents: "none" }
+    : {
+        // First paint, before measurement — render hidden in top-left so we
+        // can measure without flashing on-screen.
+        position: "fixed",
+        top: 0,
+        left: 0,
+        opacity: 0,
+        zIndex: 1000,
+        pointerEvents: "none",
+      };
+
+  return (
+    <>
+      {child}
+      {mounted &&
+        createPortal(
+          <AnimatePresence>
+            {open && (
+              <motion.div
+                ref={panelRef}
+                id={tipId}
+                role="tooltip"
+                style={panelStyle}
+                onMouseEnter={() => {
+                  // Keep open if pointer enters the panel (rare — tooltips are
+                  // pointer-events:none — but harmless).
+                  if (closeTimer.current) {
+                    clearTimeout(closeTimer.current);
+                    closeTimer.current = null;
+                  }
+                }}
+                onMouseLeave={scheduleClose}
+                {...motionProps}
+              >
+                <div
+                  className={cn(
+                    "max-w-xs rounded-md border border-border bg-surface-raised px-2.5 py-1.5",
+                    "text-xs leading-snug text-text shadow-md",
+                    className,
+                  )}
+                >
+                  {content}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/lib/ui/motion.ts
+++ b/src/lib/ui/motion.ts
@@ -225,6 +225,51 @@ export function tapPress(reduce: boolean): MotionProps {
 }
 
 // ---------------------------------------------------------------------------
+// tooltipPop — preset shared by Tooltip + Popover primitives. A short, snappy
+// fade with a tiny axis-aware slide so the overlay feels "anchored" to its
+// trigger. Honors reduced motion (no-op).
+// ---------------------------------------------------------------------------
+
+export type TooltipSide = "top" | "bottom" | "left" | "right";
+
+const TOOLTIP_OFFSET = 4;
+
+function offsetForSide(side: TooltipSide): { x: number; y: number } {
+  switch (side) {
+    case "top":
+      return { x: 0, y: TOOLTIP_OFFSET };
+    case "bottom":
+      return { x: 0, y: -TOOLTIP_OFFSET };
+    case "left":
+      return { x: TOOLTIP_OFFSET, y: 0 };
+    case "right":
+      return { x: -TOOLTIP_OFFSET, y: 0 };
+  }
+}
+
+/**
+ * `tooltipPop(reduce, side)` — spread onto a `<motion.div>` rendered inside an
+ * `<AnimatePresence>`. Drops in from the anchor side and fades out in place.
+ */
+export function tooltipPop(reduce: boolean, side: TooltipSide = "top"): MotionProps {
+  if (reduce) {
+    return {
+      initial: { opacity: 1, x: 0, y: 0, scale: 1 },
+      animate: { opacity: 1, x: 0, y: 0, scale: 1 },
+      exit: { opacity: 1, x: 0, y: 0, scale: 1 },
+      transition: { duration: 0 },
+    };
+  }
+  const off = offsetForSide(side);
+  return {
+    initial: { opacity: 0, x: off.x, y: off.y, scale: 0.97 },
+    animate: { opacity: 1, x: 0, y: 0, scale: 1 },
+    exit: { opacity: 0, x: off.x * 0.5, y: off.y * 0.5, scale: 0.99 },
+    transition: { duration: DURATION.instant, ease: EASE_PREMIUM },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Constant ceiling so engineers don't reach for arbitrary numbers.
 // ---------------------------------------------------------------------------
 
@@ -234,4 +279,5 @@ export const MOTION_CONSTANTS = {
   SPRING_MODAL,
   LIST_STAGGER_STEP,
   LIST_STAGGER_CAP,
+  TOOLTIP_OFFSET,
 } as const;


### PR DESCRIPTION
## Summary

- New canonical `<Tooltip>` and `<Popover>` primitives in `src/components/ui/` (pure-React, framer-motion via the existing shared `tooltipPop` preset — no new deps).
- Both portal to `<body>` (never clipped by `overflow:hidden`), auto-flip when near a viewport edge, and respect `prefers-reduced-motion`.
- `<Tooltip>` — hover open w/ 500ms delay, focus open (instant for keyboard), `Esc`/blur close, tap-and-hold for touch, auto `aria-describedby` wiring on the cloned trigger.
- `<Popover>` — click trigger, click-outside / `Esc` close, focus trap on open, focus restoration to trigger on close. Controlled or uncontrolled.
- 8 adoption sites — replaces native `title=""` + ad-hoc divs:
  1. `CannabisUseTypeBadge` — medical/recreational pill
  2. `PatientTagBadge` — tag-description hint (only when description provided)
  3. `PinButton` (nav rail) — pin/unpin star
  4. `DeltaIndicator` — KPI delta absolute-change tooltip
  5. `ThemeToggle` (both segmented + icon variants)
  6. `CalendarGrid` — appointment chip (patient, time, modality)
  7. `QueueRailClient` — drag handle "Drag to reorder (or Space + arrow keys)"
  8. `Sign-off` labs review — Print / Save as PDF action

## Test plan

- [ ] Hover any patient-tag badge with a description → tooltip fades in after ~500ms
- [ ] Keyboard-tab onto a `PinButton` → tooltip appears immediately; `Esc` dismisses
- [ ] Resize viewport so an appointment chip near top edge would clip — tooltip auto-flips to `bottom`
- [ ] Toggle `prefers-reduced-motion` → tooltip appears/disappears without transform animation
- [ ] Mobile (touch) — long-press a DeltaIndicator → tooltip shows
- [ ] No regressions on existing `LabTooltip` (kept; lives alongside the new primitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)