### PR TITLE
ux: comments + @mentions primitives + one adoption (chart notes)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils/format";
 import { NoteEditor } from "./note-editor";
+import { NoteCommentsPanel } from "@/components/collaboration/note-comments-panel";
 
 interface PageProps {
   params: { id: string; noteId: string };
@@ -104,6 +105,11 @@ export default async function NoteDetailPage({ params }: PageProps) {
             : null
         }
       />
+
+      {/* ux/comments-mentions-collab — inline collaboration on chart notes */}
+      <div className="mt-8">
+        <NoteCommentsPanel noteId={note.id} patientId={params.id} />
+      </div>
     </PageShell>
   );
 }

--- a/src/app/actions/collaborationActions.ts
+++ b/src/app/actions/collaborationActions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+/**
+ * Server actions for the collaboration primitives.
+ *
+ * WIP — Prisma schema is off-limits in this PR, so the only durable action
+ * here is `listOrgMembersForMention`, which simply returns the existing
+ * `User` roster scoped to the caller's org. Comment create/update/delete
+ * live in localStorage on the client until a `Comment` model lands.
+ */
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import type { CommentAuthor } from "@/lib/collaboration/comments";
+
+/**
+ * Return the org's user roster for @mention autocomplete. Excludes the
+ * caller (you can't mention yourself usefully) and any soft-deleted users.
+ * Cheap to call: a single indexed query on `organizationId`.
+ */
+export async function listOrgMembersForMention(): Promise<CommentAuthor[]> {
+  const user = await requireUser();
+  if (!user.organizationId) return [];
+
+  const members = await prisma.user.findMany({
+    where: {
+      memberships: {
+        some: { organizationId: user.organizationId },
+      },
+      id: { not: user.id },
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+    },
+    orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+    take: 200,
+  });
+
+  return members.map((m) => ({
+    id: m.id,
+    firstName: m.firstName,
+    lastName: m.lastName,
+    email: m.email,
+    avatarUrl: null,
+  }));
+}
+
+/**
+ * Return a `CommentAuthor` payload for the currently-signed-in user. The
+ * comment thread component uses this to stamp new comments without having
+ * to round-trip auth state through the client.
+ */
+export async function getCurrentCommentAuthor(): Promise<CommentAuthor> {
+  const user = await requireUser();
+  return {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    avatarUrl: null,
+  };
+}

--- a/src/components/collaboration/comment-thread.tsx
+++ b/src/components/collaboration/comment-thread.tsx
@@ -1,0 +1,611 @@
+"use client";
+
+/**
+ * `CommentThread` — collaborative comments + @mentions for any entity.
+ *
+ * Generic over the anchor:
+ *   <CommentThread
+ *     targetType="chart_note"
+ *     targetId={note.id}
+ *     comments={comments}
+ *     roster={roster}
+ *     currentAuthor={me}
+ *     onSubmit={...}
+ *     onResolve={...}
+ *   />
+ *
+ * Surfaces it works on today:
+ *   - chart_note (adopted in PR-on-deck)
+ *   - encounter / lab_result / order / patient (drop in via props)
+ *
+ * Visual rules (per Apple-iOS aesthetic directive in CLAUDE.md):
+ *   - Resolved threads collapse into a single "Resolved" pill with a
+ *     "View" affordance — they never disappear, never block the list.
+ *   - Reply box is inline under each thread, lazy-mounted on click.
+ *   - Avatar/name/timestamp/body row mirrors the rest of the EMR's
+ *     audit-trail style (see private-notes-tab.tsx) for consistency.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { Avatar } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { MentionInput } from "./mention-input";
+import {
+  buildThreads,
+  extractMentions,
+  type Comment,
+  type CommentAuthor,
+  type CommentTargetType,
+  type CommentThread as CommentThreadType,
+} from "@/lib/collaboration/comments";
+
+interface CommentThreadProps {
+  targetType: CommentTargetType;
+  targetId: string;
+  comments: Comment[];
+  roster: CommentAuthor[];
+  currentAuthor: CommentAuthor | null;
+  /**
+   * Called when the user submits a new comment (root or reply). The handler
+   * receives a fully-formed `Comment` (id, mentions, timestamps already
+   * baked) so the parent only needs to persist + dispatch notifications.
+   */
+  onSubmit: (comment: Comment) => void | Promise<void>;
+  /** Toggle the `resolvedAt` state for a thread root. */
+  onResolve?: (commentId: string, resolved: boolean) => void | Promise<void>;
+  /** Edit the body of a previously-authored comment. */
+  onEdit?: (commentId: string, nextBody: string) => void | Promise<void>;
+  /** Soft-delete a comment. UI replaces body with a tombstone. */
+  onDelete?: (commentId: string) => void | Promise<void>;
+  /** Optional surface label for empty state and aria. */
+  surfaceLabel?: string;
+  className?: string;
+}
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: now - date.getTime() > 365 * 24 * 3600_000 ? "numeric" : undefined,
+  });
+}
+
+/** Render a comment body, highlighting @mention spans in accent color. */
+function renderBody(comment: Comment): React.ReactNode {
+  if (comment.deletedAt) {
+    return (
+      <span className="italic text-text-muted">[comment deleted]</span>
+    );
+  }
+  if (comment.mentions.length === 0) {
+    return <span className="whitespace-pre-wrap">{comment.body}</span>;
+  }
+  // Splice mentions back into the rendered body. We walk left-to-right so
+  // the offsets stay valid relative to the original string.
+  const segments: React.ReactNode[] = [];
+  let cursor = 0;
+  const sorted = comment.mentions
+    .slice()
+    .sort((a, b) => a.offset - b.offset);
+  sorted.forEach((mention, i) => {
+    if (mention.offset > cursor) {
+      segments.push(comment.body.slice(cursor, mention.offset));
+    }
+    const token = comment.body.slice(
+      mention.offset,
+      mention.offset + mention.length,
+    );
+    segments.push(
+      <span
+        key={`m-${i}`}
+        className="rounded px-1 py-0.5 bg-accent-soft text-accent font-medium"
+        title={mention.display}
+      >
+        {token}
+      </span>,
+    );
+    cursor = mention.offset + mention.length;
+  });
+  if (cursor < comment.body.length) {
+    segments.push(comment.body.slice(cursor));
+  }
+  return <span className="whitespace-pre-wrap">{segments}</span>;
+}
+
+interface CommentRowProps {
+  comment: Comment;
+  currentAuthor: CommentAuthor | null;
+  onStartReply?: () => void;
+  onEdit?: (next: string) => void;
+  onDelete?: () => void;
+  onResolveToggle?: () => void;
+  roster: CommentAuthor[];
+  isThreadRoot: boolean;
+  isResolved: boolean;
+}
+
+function CommentRow({
+  comment,
+  currentAuthor,
+  onStartReply,
+  onEdit,
+  onDelete,
+  onResolveToggle,
+  roster,
+  isThreadRoot,
+  isResolved,
+}: CommentRowProps) {
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState(comment.body);
+  const isAuthor = currentAuthor?.id === comment.author.id;
+  const canEdit = isAuthor && onEdit && !comment.deletedAt;
+  const canDelete = isAuthor && onDelete && !comment.deletedAt;
+
+  function commitEdit() {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === comment.body) {
+      setEditing(false);
+      setDraft(comment.body);
+      return;
+    }
+    onEdit?.(trimmed);
+    setEditing(false);
+  }
+
+  return (
+    <div className="flex gap-3">
+      <Avatar
+        firstName={comment.author.firstName}
+        lastName={comment.author.lastName}
+        size="sm"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="text-sm font-medium text-text">
+            {comment.author.firstName} {comment.author.lastName}
+          </span>
+          <span className="text-xs text-text-muted">
+            {formatTimestamp(comment.createdAt)}
+            {comment.updatedAt && comment.updatedAt !== comment.createdAt && (
+              <span className="ml-1 italic">(edited)</span>
+            )}
+          </span>
+          {isResolved && isThreadRoot && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-success/10 text-success font-medium">
+              Resolved
+            </span>
+          )}
+        </div>
+
+        {editing ? (
+          <div className="mt-1">
+            <MentionInput
+              value={draft}
+              onChange={setDraft}
+              roster={roster}
+              size="sm"
+              rows={2}
+              onSubmit={commitEdit}
+              ariaLabel="Edit comment"
+            />
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" onClick={commitEdit} disabled={!draft.trim()}>
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setEditing(false);
+                  setDraft(comment.body);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-1 text-sm text-text leading-relaxed">
+            {renderBody(comment)}
+          </div>
+        )}
+
+        {!editing && !comment.deletedAt && (
+          <div className="flex gap-3 mt-1 text-xs">
+            {onStartReply && (
+              <button
+                type="button"
+                onClick={onStartReply}
+                className="text-text-muted hover:text-accent transition-colors"
+              >
+                Reply
+              </button>
+            )}
+            {canEdit && (
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="text-text-muted hover:text-accent transition-colors"
+              >
+                Edit
+              </button>
+            )}
+            {canDelete && (
+              <button
+                type="button"
+                onClick={onDelete}
+                className="text-text-muted hover:text-danger transition-colors"
+              >
+                Delete
+              </button>
+            )}
+            {isThreadRoot && onResolveToggle && (
+              <button
+                type="button"
+                onClick={onResolveToggle}
+                className="text-text-muted hover:text-success transition-colors"
+              >
+                {isResolved ? "Reopen" : "Resolve"}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CommentThread({
+  targetType,
+  targetId,
+  comments,
+  roster,
+  currentAuthor,
+  onSubmit,
+  onResolve,
+  onEdit,
+  onDelete,
+  surfaceLabel = "this item",
+  className,
+}: CommentThreadProps) {
+  const threads = React.useMemo(() => buildThreads(comments), [comments]);
+  const [rootDraft, setRootDraft] = React.useState("");
+  const [replyingTo, setReplyingTo] = React.useState<string | null>(null);
+  const [replyDraft, setReplyDraft] = React.useState("");
+  const [expandedResolved, setExpandedResolved] = React.useState<Set<string>>(
+    new Set(),
+  );
+  const [submitting, setSubmitting] = React.useState(false);
+
+  function buildComment(body: string, parentId: string | null): Comment | null {
+    const trimmed = body.trim();
+    if (!trimmed || !currentAuthor) return null;
+    const now = new Date().toISOString();
+    return {
+      id: `c_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+      targetType,
+      targetId,
+      author: currentAuthor,
+      body: trimmed,
+      mentions: extractMentions(trimmed, roster),
+      createdAt: now,
+      parentId,
+      resolvedAt: null,
+      resolvedBy: null,
+      deletedAt: null,
+    };
+  }
+
+  async function submitRoot() {
+    const c = buildComment(rootDraft, null);
+    if (!c) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(c);
+      setRootDraft("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function submitReply(parentId: string) {
+    const c = buildComment(replyDraft, parentId);
+    if (!c) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(c);
+      setReplyDraft("");
+      setReplyingTo(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function toggleResolvedExpanded(id: string) {
+    setExpandedResolved((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const openThreads = threads.filter((t) => !t.root.resolvedAt);
+  const resolvedThreads = threads.filter((t) => t.root.resolvedAt);
+
+  return (
+    <section
+      aria-label={`Comments on ${surfaceLabel}`}
+      className={cn("rounded-2xl border border-border bg-surface", className)}
+    >
+      <header className="px-5 py-4 border-b border-border flex items-baseline justify-between">
+        <h3 className="font-display text-base text-text">
+          Comments
+          {threads.length > 0 && (
+            <span className="ml-2 text-xs text-text-muted font-sans">
+              {openThreads.length} open
+              {resolvedThreads.length > 0 &&
+                ` · ${resolvedThreads.length} resolved`}
+            </span>
+          )}
+        </h3>
+      </header>
+
+      {/* Root composer */}
+      {currentAuthor ? (
+        <div className="p-5 border-b border-border bg-surface-raised/30">
+          <div className="flex gap-3">
+            <Avatar
+              firstName={currentAuthor.firstName}
+              lastName={currentAuthor.lastName}
+              size="sm"
+            />
+            <div className="flex-1">
+              <MentionInput
+                value={rootDraft}
+                onChange={setRootDraft}
+                roster={roster}
+                placeholder={`Add a comment on ${surfaceLabel}… use @ to mention a teammate`}
+                onSubmit={submitRoot}
+                disabled={submitting}
+                ariaLabel="New comment"
+              />
+              <div className="flex justify-between items-center mt-2">
+                <p className="text-xs text-text-muted">
+                  Use @ to mention · ⌘⏎ to send
+                </p>
+                <Button
+                  size="sm"
+                  onClick={submitRoot}
+                  disabled={!rootDraft.trim() || submitting}
+                >
+                  Comment
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="p-5 text-sm text-text-muted">
+          Sign in to add comments.
+        </div>
+      )}
+
+      {/* Thread list */}
+      <div className="p-5 space-y-6">
+        {openThreads.length === 0 && resolvedThreads.length === 0 && (
+          <p className="text-sm text-text-muted text-center py-6">
+            No comments yet. Be the first to start a conversation.
+          </p>
+        )}
+
+        {openThreads.map((thread) => (
+          <ThreadBlock
+            key={thread.root.id}
+            thread={thread}
+            currentAuthor={currentAuthor}
+            roster={roster}
+            replyingTo={replyingTo}
+            replyDraft={replyDraft}
+            setReplyDraft={setReplyDraft}
+            setReplyingTo={setReplyingTo}
+            submitting={submitting}
+            onSubmitReply={() => submitReply(thread.root.id)}
+            onResolve={onResolve}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            collapsed={false}
+          />
+        ))}
+
+        {resolvedThreads.length > 0 && (
+          <div className="pt-4 border-t border-border space-y-3">
+            <p className="text-xs uppercase tracking-wide text-text-muted">
+              Resolved
+            </p>
+            {resolvedThreads.map((thread) => {
+              const expanded = expandedResolved.has(thread.root.id);
+              return (
+                <div
+                  key={thread.root.id}
+                  className="rounded-xl border border-border bg-surface-raised/30 px-4 py-3"
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleResolvedExpanded(thread.root.id)}
+                    className="w-full text-left flex items-center justify-between gap-3"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Avatar
+                        firstName={thread.root.author.firstName}
+                        lastName={thread.root.author.lastName}
+                        size="sm"
+                      />
+                      <span className="text-sm text-text-muted truncate">
+                        <span className="font-medium text-text">
+                          {thread.root.author.firstName}
+                        </span>
+                        {": "}
+                        {thread.root.body.slice(0, 80)}
+                        {thread.root.body.length > 80 ? "…" : ""}
+                      </span>
+                    </div>
+                    <span className="text-xs text-accent shrink-0">
+                      {expanded ? "Collapse" : "View"}
+                    </span>
+                  </button>
+                  {expanded && (
+                    <div className="mt-3 pt-3 border-t border-border">
+                      <ThreadBlock
+                        thread={thread}
+                        currentAuthor={currentAuthor}
+                        roster={roster}
+                        replyingTo={replyingTo}
+                        replyDraft={replyDraft}
+                        setReplyDraft={setReplyDraft}
+                        setReplyingTo={setReplyingTo}
+                        submitting={submitting}
+                        onSubmitReply={() => submitReply(thread.root.id)}
+                        onResolve={onResolve}
+                        onEdit={onEdit}
+                        onDelete={onDelete}
+                        collapsed
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+interface ThreadBlockProps {
+  thread: CommentThreadType;
+  currentAuthor: CommentAuthor | null;
+  roster: CommentAuthor[];
+  replyingTo: string | null;
+  replyDraft: string;
+  setReplyDraft: (s: string) => void;
+  setReplyingTo: (id: string | null) => void;
+  submitting: boolean;
+  onSubmitReply: () => void;
+  onResolve?: (commentId: string, resolved: boolean) => void | Promise<void>;
+  onEdit?: (commentId: string, nextBody: string) => void | Promise<void>;
+  onDelete?: (commentId: string) => void | Promise<void>;
+  collapsed: boolean;
+}
+
+function ThreadBlock({
+  thread,
+  currentAuthor,
+  roster,
+  replyingTo,
+  replyDraft,
+  setReplyDraft,
+  setReplyingTo,
+  submitting,
+  onSubmitReply,
+  onResolve,
+  onEdit,
+  onDelete,
+  collapsed,
+}: ThreadBlockProps) {
+  const isResolved = Boolean(thread.root.resolvedAt);
+  const showReplyBox = replyingTo === thread.root.id;
+
+  return (
+    <div className="space-y-4">
+      <CommentRow
+        comment={thread.root}
+        currentAuthor={currentAuthor}
+        roster={roster}
+        isThreadRoot
+        isResolved={isResolved}
+        onStartReply={
+          collapsed
+            ? undefined
+            : () => {
+                setReplyingTo(thread.root.id);
+                setReplyDraft("");
+              }
+        }
+        onEdit={
+          onEdit ? (next) => onEdit(thread.root.id, next) : undefined
+        }
+        onDelete={onDelete ? () => onDelete(thread.root.id) : undefined}
+        onResolveToggle={
+          onResolve ? () => onResolve(thread.root.id, !isResolved) : undefined
+        }
+      />
+
+      {thread.replies.length > 0 && (
+        <div className="pl-10 space-y-4 border-l-2 border-border ml-3">
+          {thread.replies.map((reply) => (
+            <CommentRow
+              key={reply.id}
+              comment={reply}
+              currentAuthor={currentAuthor}
+              roster={roster}
+              isThreadRoot={false}
+              isResolved={isResolved}
+              onEdit={
+                onEdit ? (next) => onEdit(reply.id, next) : undefined
+              }
+              onDelete={onDelete ? () => onDelete(reply.id) : undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      {showReplyBox && currentAuthor && !collapsed && (
+        <div className="pl-10 ml-3">
+          <MentionInput
+            value={replyDraft}
+            onChange={setReplyDraft}
+            roster={roster}
+            placeholder="Write a reply…"
+            size="sm"
+            rows={2}
+            onSubmit={onSubmitReply}
+            disabled={submitting}
+            ariaLabel="Reply to comment"
+          />
+          <div className="flex gap-2 mt-2">
+            <Button
+              size="sm"
+              onClick={onSubmitReply}
+              disabled={!replyDraft.trim() || submitting}
+            >
+              Reply
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setReplyingTo(null);
+                setReplyDraft("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/collaboration/mention-input.tsx
+++ b/src/components/collaboration/mention-input.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+/**
+ * `MentionInput` — reusable mention-aware textarea.
+ *
+ * Behaviour:
+ *   - Typing `@` opens a popover anchored under the caret.
+ *   - The popover lists org members whose first/last name or email handle
+ *     prefix-matches the query after `@`.
+ *   - ↑/↓ moves the selection, Enter / Tab inserts, Esc closes.
+ *   - Inserting a member writes `@firstname` (lowercased) and a trailing
+ *     space so the next keystroke is normal typing.
+ *
+ * The component is fully controlled (`value` / `onChange`) so callers can
+ * persist or echo the body however they like. The roster is supplied as a
+ * prop — the parent decides whether to fetch from a server action or
+ * preload statically.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { Avatar } from "@/components/ui/avatar";
+import type { CommentAuthor } from "@/lib/collaboration/comments";
+
+interface MentionInputProps {
+  value: string;
+  onChange: (next: string) => void;
+  roster: CommentAuthor[];
+  placeholder?: string;
+  /** Number of rows for the underlying textarea. */
+  rows?: number;
+  /** When provided, Cmd/Ctrl+Enter fires this (submit shortcut). */
+  onSubmit?: () => void;
+  /** Disable the input entirely (e.g. while submitting). */
+  disabled?: boolean;
+  className?: string;
+  /** ARIA label for screen readers. */
+  ariaLabel?: string;
+  /** Render at a smaller scale (used for reply boxes nested under threads). */
+  size?: "sm" | "md";
+}
+
+interface MatchState {
+  /** True when the popover should be visible. */
+  open: boolean;
+  /** Char offset of the `@` that started the query. */
+  triggerAt: number;
+  /** Lowercase query string after the `@` (no leading sigil). */
+  query: string;
+  /** Highlighted index within the filtered roster. */
+  index: number;
+}
+
+const INITIAL_MATCH: MatchState = {
+  open: false,
+  triggerAt: -1,
+  query: "",
+  index: 0,
+};
+
+/** Walk backward from `caret` to find an `@` that anchors a mention query. */
+function detectTrigger(value: string, caret: number): MatchState | null {
+  // Cap the scan at 50 chars so a giant body doesn't iterate the whole thing.
+  const start = Math.max(0, caret - 50);
+  for (let i = caret - 1; i >= start; i--) {
+    const ch = value[i];
+    if (ch === "@") {
+      // Mention must be at start-of-string or after whitespace / newline.
+      const prev = i === 0 ? " " : value[i - 1];
+      if (!/\s/.test(prev) && i !== 0) return null;
+      const query = value.slice(i + 1, caret);
+      // A space or newline inside the query terminates it.
+      if (/\s/.test(query)) return null;
+      return { open: true, triggerAt: i, query: query.toLowerCase(), index: 0 };
+    }
+    if (/\s/.test(ch)) return null;
+  }
+  return null;
+}
+
+function filterRoster(
+  roster: CommentAuthor[],
+  query: string,
+): CommentAuthor[] {
+  if (!query) return roster.slice(0, 8);
+  const q = query.toLowerCase();
+  return roster
+    .filter((u) => {
+      const first = u.firstName.toLowerCase();
+      const last = u.lastName.toLowerCase();
+      const handle = u.email?.toLowerCase().split("@")[0] ?? "";
+      return (
+        first.startsWith(q) ||
+        last.startsWith(q) ||
+        handle.startsWith(q) ||
+        `${first} ${last}`.includes(q)
+      );
+    })
+    .slice(0, 8);
+}
+
+export function MentionInput({
+  value,
+  onChange,
+  roster,
+  placeholder = "Write a comment… use @ to mention",
+  rows = 3,
+  onSubmit,
+  disabled = false,
+  className,
+  ariaLabel,
+  size = "md",
+}: MentionInputProps) {
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const [match, setMatch] = React.useState<MatchState>(INITIAL_MATCH);
+
+  const filtered = React.useMemo(
+    () => (match.open ? filterRoster(roster, match.query) : []),
+    [match.open, match.query, roster],
+  );
+
+  // Clamp the highlight index whenever the filtered list shrinks (e.g. user
+  // keeps typing past the last match).
+  React.useEffect(() => {
+    if (!match.open) return;
+    if (match.index >= filtered.length && filtered.length > 0) {
+      setMatch((m) => ({ ...m, index: filtered.length - 1 }));
+    }
+  }, [filtered.length, match.open, match.index]);
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = e.target.value;
+    onChange(next);
+    const caret = e.target.selectionStart ?? next.length;
+    const detected = detectTrigger(next, caret);
+    setMatch(detected ?? INITIAL_MATCH);
+  }
+
+  function insertMention(member: CommentAuthor) {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    if (!match.open || match.triggerAt < 0) return;
+    const caret = ta.selectionStart ?? value.length;
+    const before = value.slice(0, match.triggerAt);
+    const after = value.slice(caret);
+    const token = `@${member.firstName.toLowerCase()}`;
+    const next = `${before}${token} ${after}`;
+    onChange(next);
+    setMatch(INITIAL_MATCH);
+    // Restore the caret after the inserted token + space.
+    requestAnimationFrame(() => {
+      if (!textareaRef.current) return;
+      const pos = before.length + token.length + 1;
+      textareaRef.current.setSelectionRange(pos, pos);
+      textareaRef.current.focus();
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Submit shortcut works regardless of popover state.
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && onSubmit) {
+      e.preventDefault();
+      onSubmit();
+      return;
+    }
+    if (!match.open || filtered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setMatch((m) => ({ ...m, index: (m.index + 1) % filtered.length }));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setMatch((m) => ({
+        ...m,
+        index: (m.index - 1 + filtered.length) % filtered.length,
+      }));
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      insertMention(filtered[match.index]);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setMatch(INITIAL_MATCH);
+    }
+  }
+
+  const padded = size === "sm" ? "px-3 py-2 text-sm" : "px-4 py-3 text-sm";
+
+  return (
+    <div className={cn("relative", className)}>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        disabled={disabled}
+        aria-label={ariaLabel ?? "Comment editor with mention support"}
+        className={cn(
+          "w-full rounded-xl border border-border bg-surface text-text",
+          "placeholder:text-text-muted",
+          "focus:outline-none focus:ring-2 focus:ring-accent-soft focus:border-accent",
+          "transition-shadow duration-150 resize-y",
+          padded,
+          disabled && "opacity-60 cursor-not-allowed",
+        )}
+      />
+
+      {match.open && filtered.length > 0 && (
+        <div
+          role="listbox"
+          aria-label="Mention suggestions"
+          className={cn(
+            "absolute left-0 right-0 z-30 mt-1",
+            "rounded-xl border border-border bg-surface-raised shadow-lg",
+            "max-h-64 overflow-y-auto p-1",
+          )}
+        >
+          {filtered.map((member, i) => (
+            <button
+              key={member.id}
+              type="button"
+              role="option"
+              aria-selected={i === match.index}
+              onMouseDown={(e) => {
+                // Prevent textarea blur — we need the caret intact to splice.
+                e.preventDefault();
+                insertMention(member);
+              }}
+              onMouseEnter={() => setMatch((m) => ({ ...m, index: i }))}
+              className={cn(
+                "w-full flex items-center gap-3 px-3 py-2 rounded-lg",
+                "text-left text-sm transition-colors duration-150",
+                i === match.index
+                  ? "bg-accent-soft text-text"
+                  : "text-text hover:bg-surface",
+              )}
+            >
+              <Avatar
+                firstName={member.firstName}
+                lastName={member.lastName}
+                size="sm"
+              />
+              <span className="flex-1">
+                <span className="font-medium">
+                  {member.firstName} {member.lastName}
+                </span>
+                {member.email && (
+                  <span className="ml-2 text-xs text-text-muted">
+                    @{member.firstName.toLowerCase()}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/collaboration/note-comments-panel.tsx
+++ b/src/components/collaboration/note-comments-panel.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+/**
+ * `NoteCommentsPanel` — adoption wrapper for the chart-note detail surface.
+ *
+ * Owns the localStorage prototype state, fetches the org roster once on
+ * mount, stamps comments with the current author, and fans out @mention
+ * notifications via the prototype dispatcher (PR #464 will swap this for
+ * a real backend later).
+ *
+ * Keep this file thin: real product logic lives in <CommentThread/>. This
+ * wrapper is the seam where the durable backend lands when the schema is
+ * unblocked.
+ */
+
+import * as React from "react";
+import { CommentThread } from "./comment-thread";
+import {
+  buildMentionNotifications,
+  extractMentions,
+  type Comment,
+  type CommentAuthor,
+} from "@/lib/collaboration/comments";
+import { commentStore } from "@/lib/collaboration/comment-store";
+import { dispatchMentionNotifications } from "@/lib/collaboration/mention-notifications";
+import {
+  getCurrentCommentAuthor,
+  listOrgMembersForMention,
+} from "@/app/actions/collaborationActions";
+
+interface NoteCommentsPanelProps {
+  noteId: string;
+  patientId: string;
+  className?: string;
+}
+
+export function NoteCommentsPanel({
+  noteId,
+  patientId,
+  className,
+}: NoteCommentsPanelProps) {
+  const [comments, setComments] = React.useState<Comment[]>([]);
+  const [roster, setRoster] = React.useState<CommentAuthor[]>([]);
+  const [currentAuthor, setCurrentAuthor] =
+    React.useState<CommentAuthor | null>(null);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  // Hydrate from localStorage + server-side roster on mount.
+  React.useEffect(() => {
+    setComments(commentStore.list("chart_note", noteId));
+    setHydrated(true);
+    let cancelled = false;
+    Promise.all([
+      listOrgMembersForMention(),
+      getCurrentCommentAuthor(),
+    ])
+      .then(([members, me]) => {
+        if (cancelled) return;
+        setRoster(members);
+        setCurrentAuthor(me);
+      })
+      .catch(() => {
+        // Roster fetch failure shouldn't break the comment view — users just
+        // won't get autocomplete suggestions.
+        if (!cancelled) setRoster([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [noteId]);
+
+  const handleSubmit = React.useCallback(
+    (comment: Comment) => {
+      commentStore.add("chart_note", noteId, comment);
+      setComments((prev) => [...prev, comment]);
+      if (comment.mentions.length > 0) {
+        const href = `/clinic/patients/${patientId}/notes/${noteId}`;
+        const surfaceLabel = "Chart note comment";
+        dispatchMentionNotifications(
+          buildMentionNotifications(comment, surfaceLabel, href),
+        );
+      }
+    },
+    [noteId, patientId],
+  );
+
+  const handleResolve = React.useCallback(
+    (commentId: string, resolved: boolean) => {
+      const now = new Date().toISOString();
+      commentStore.update("chart_note", noteId, commentId, {
+        resolvedAt: resolved ? now : null,
+        resolvedBy: resolved ? currentAuthor : null,
+      });
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === commentId
+            ? {
+                ...c,
+                resolvedAt: resolved ? now : null,
+                resolvedBy: resolved ? currentAuthor : null,
+              }
+            : c,
+        ),
+      );
+    },
+    [noteId, currentAuthor],
+  );
+
+  const handleEdit = React.useCallback(
+    (commentId: string, nextBody: string) => {
+      const now = new Date().toISOString();
+      // Re-extract mentions from the new body so the highlights / fan-out
+      // stay in sync.
+      if (!comments.some((c) => c.id === commentId)) return;
+      const mentions = extractMentions(nextBody, roster);
+      commentStore.update("chart_note", noteId, commentId, {
+        body: nextBody,
+        mentions,
+        updatedAt: now,
+      });
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === commentId
+            ? { ...c, body: nextBody, mentions, updatedAt: now }
+            : c,
+        ),
+      );
+    },
+    [comments, noteId, roster],
+  );
+
+  const handleDelete = React.useCallback(
+    (commentId: string) => {
+      commentStore.softDelete("chart_note", noteId, commentId);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === commentId
+            ? { ...c, deletedAt: new Date().toISOString(), body: "", mentions: [] }
+            : c,
+        ),
+      );
+    },
+    [noteId],
+  );
+
+  // Avoid hydration-mismatch flicker: SSR renders zero comments, then we
+  // patch in from localStorage after mount. Render a stable wrapper either
+  // way so the layout doesn't jump.
+  return (
+    <div className={className}>
+      <div className="mb-2 text-xs text-text-muted italic">
+        WIP prototype: comments are stored locally in your browser until the
+        durable backend ships. @mentions queue into the notification center
+        inbox.
+      </div>
+      <CommentThread
+        targetType="chart_note"
+        targetId={noteId}
+        comments={hydrated ? comments : []}
+        roster={roster}
+        currentAuthor={currentAuthor}
+        onSubmit={handleSubmit}
+        onResolve={handleResolve}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        surfaceLabel="this chart note"
+      />
+    </div>
+  );
+}

--- a/src/lib/collaboration/comment-store.ts
+++ b/src/lib/collaboration/comment-store.ts
@@ -1,0 +1,97 @@
+/**
+ * Client-side localStorage prototype for comment threads.
+ *
+ * WIP — see `src/lib/collaboration/comments.ts` for the durable plan.
+ * This module exists ONLY because the Prisma schema is off-limits in this
+ * PR. The function surface (`list / add / update / softDelete / resolve`)
+ * intentionally mirrors what a server action would expose so we can drop
+ * in a real store later without changing the React components.
+ *
+ * Keys are namespaced `lj.comments.v1.<targetType>.<targetId>` so different
+ * surfaces never collide and a future migration can scan + clear by prefix.
+ */
+import type { Comment, CommentTargetType } from "./comments";
+
+const PREFIX = "lj.comments.v1";
+
+function key(targetType: CommentTargetType, targetId: string): string {
+  return `${PREFIX}.${targetType}.${targetId}`;
+}
+
+function safeRead(targetType: CommentTargetType, targetId: string): Comment[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(key(targetType, targetId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as Comment[]) : [];
+  } catch {
+    // A corrupted blob shouldn't take down the chart note view — silently
+    // reset and return an empty list.
+    return [];
+  }
+}
+
+function safeWrite(
+  targetType: CommentTargetType,
+  targetId: string,
+  comments: Comment[],
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      key(targetType, targetId),
+      JSON.stringify(comments),
+    );
+  } catch {
+    // Quota errors are non-fatal in the prototype — surface in console only.
+    // eslint-disable-next-line no-console
+    console.warn("[comment-store] localStorage write failed; comment lost");
+  }
+}
+
+export const commentStore = {
+  list(targetType: CommentTargetType, targetId: string): Comment[] {
+    return safeRead(targetType, targetId);
+  },
+
+  add(targetType: CommentTargetType, targetId: string, comment: Comment): void {
+    const existing = safeRead(targetType, targetId);
+    safeWrite(targetType, targetId, [...existing, comment]);
+  },
+
+  update(
+    targetType: CommentTargetType,
+    targetId: string,
+    commentId: string,
+    patch: Partial<Comment>,
+  ): void {
+    const existing = safeRead(targetType, targetId);
+    safeWrite(
+      targetType,
+      targetId,
+      existing.map((c) => (c.id === commentId ? { ...c, ...patch } : c)),
+    );
+  },
+
+  softDelete(
+    targetType: CommentTargetType,
+    targetId: string,
+    commentId: string,
+  ): void {
+    const now = new Date().toISOString();
+    commentStore.update(targetType, targetId, commentId, {
+      deletedAt: now,
+      body: "",
+      mentions: [],
+    });
+  },
+
+  /**
+   * Generate a sortable id. Real backend will assign uuids; until then we
+   * concatenate `ms.random` so client-side ordering by id matches createdAt.
+   */
+  nextId(): string {
+    return `c_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  },
+};

--- a/src/lib/collaboration/comments.ts
+++ b/src/lib/collaboration/comments.ts
@@ -1,0 +1,159 @@
+/**
+ * Comment + @mention primitives for clinician collaboration.
+ *
+ * WIP / prototype scope (2026-05):
+ *   - No Prisma `Comment` model exists yet (schema is off-limits in this PR).
+ *   - The reusable React primitives live under `src/components/collaboration/`
+ *     and accept comments via props, so the storage layer can be swapped from
+ *     localStorage to a real server-backed table without UI churn.
+ *   - When the durable schema lands, this file's types become the wire shape.
+ *
+ * Sibling: PR #464 (`ux/notification-center-bell-linear`) introduces the
+ * in-app notification model. We import its `Notification` shape directly so
+ * @mention fan-out drops into that center as soon as a real persistence
+ * layer is in place.
+ */
+import type { Notification } from "@/lib/domain/notifications";
+
+/** Anchor surface a comment thread is attached to. */
+export type CommentTargetType =
+  | "chart_note"
+  | "encounter"
+  | "lab_result"
+  | "patient"
+  | "order"
+  | "task"
+  | "document";
+
+/** Lightweight org-member shape for @mention autocomplete + author display. */
+export interface CommentAuthor {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email?: string;
+  avatarUrl?: string | null;
+}
+
+/** A single mention reference inside a comment body. */
+export interface Mention {
+  userId: string;
+  /** Display label used at insertion time (e.g. "Maya R."). */
+  display: string;
+  /** Char offset within `body` where the @handle starts. */
+  offset: number;
+  /** Length of the rendered `@handle` token (inclusive of the leading `@`). */
+  length: number;
+}
+
+export interface Comment {
+  id: string;
+  targetType: CommentTargetType;
+  targetId: string;
+  author: CommentAuthor;
+  body: string;
+  mentions: Mention[];
+  createdAt: string;
+  updatedAt?: string;
+  /** Resolved threads collapse in the UI. A resolved root collapses replies too. */
+  resolvedAt?: string | null;
+  resolvedBy?: CommentAuthor | null;
+  /** Top-level comments have `parentId === null`. */
+  parentId: string | null;
+  /** Soft-delete tombstone so reply threading survives. */
+  deletedAt?: string | null;
+}
+
+/** UI-ready tree node: a root comment plus its flat reply list. */
+export interface CommentThread {
+  root: Comment;
+  replies: Comment[];
+}
+
+/**
+ * Group a flat list into root threads. Replies are sorted oldest-first under
+ * each root. Roots are sorted newest-first so active conversations float up.
+ */
+export function buildThreads(comments: Comment[]): CommentThread[] {
+  const roots = comments.filter((c) => c.parentId === null);
+  const byParent = new Map<string, Comment[]>();
+  for (const c of comments) {
+    if (c.parentId) {
+      const arr = byParent.get(c.parentId) ?? [];
+      arr.push(c);
+      byParent.set(c.parentId, arr);
+    }
+  }
+  return roots
+    .slice()
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+    .map((root) => ({
+      root,
+      replies: (byParent.get(root.id) ?? []).sort((a, b) =>
+        a.createdAt < b.createdAt ? -1 : 1,
+      ),
+    }));
+}
+
+/**
+ * Extract `@firstname` tokens from a body and resolve them against the org
+ * roster. Tokens that don't match any member are silently dropped — we never
+ * want a stale handle to fire a phantom notification.
+ */
+export function extractMentions(
+  body: string,
+  roster: CommentAuthor[],
+): Mention[] {
+  const out: Mention[] = [];
+  // Match a leading `@` followed by 1-40 word chars / dashes / dots. We stop
+  // at whitespace so multi-word names are addressed by first name only.
+  const re = /@([\w.-]{1,40})/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const handle = m[1].toLowerCase();
+    const match = roster.find(
+      (u) =>
+        u.firstName.toLowerCase() === handle ||
+        `${u.firstName}.${u.lastName}`.toLowerCase() === handle ||
+        u.email?.toLowerCase().split("@")[0] === handle,
+    );
+    if (match) {
+      out.push({
+        userId: match.id,
+        display: `${match.firstName} ${match.lastName}`.trim(),
+        offset: m.index,
+        length: m[0].length,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the in-app `Notification` payload that should fan out to each
+ * mentioned user. We funnel into the `system` channel because PR #464 hasn't
+ * landed a dedicated `mention` type yet — and `system` is the explicit
+ * catch-all in `NOTIFICATION_CONFIG`.
+ */
+export function buildMentionNotifications(
+  comment: Comment,
+  surfaceLabel: string,
+  href: string,
+): Notification[] {
+  return comment.mentions.map((mention) => ({
+    id: `mention_${comment.id}_${mention.userId}`,
+    userId: mention.userId,
+    type: "system",
+    priority: "normal",
+    title: `${comment.author.firstName} ${comment.author.lastName} mentioned you`.trim(),
+    body: `${surfaceLabel}: ${comment.body.slice(0, 140)}${comment.body.length > 140 ? "…" : ""}`,
+    href,
+    read: false,
+    createdAt: comment.createdAt,
+    metadata: {
+      source: "comment_mention",
+      commentId: comment.id,
+      targetType: comment.targetType,
+      targetId: comment.targetId,
+    },
+  }));
+}

--- a/src/lib/collaboration/mention-notifications.ts
+++ b/src/lib/collaboration/mention-notifications.ts
@@ -1,0 +1,68 @@
+/**
+ * Client-side fan-out for @mention notifications.
+ *
+ * WIP — PR #464 (`ux/notification-center-bell-linear`) is still open and its
+ * notification center currently reads from in-memory demo data. Until that
+ * PR lands a real source, we buffer mention notifications in localStorage
+ * under a stable key so:
+ *
+ *   1. The center can pick them up on its next refactor by reading from the
+ *      same key (`lj.notifications.v1.inbox.<userId>`),
+ *   2. We can verify the wire shape end-to-end without touching Clerk /
+ *      Prisma / the schema in this PR.
+ *
+ * When the durable backend lands this entire module collapses to a single
+ * server action call.
+ */
+import type { Notification } from "@/lib/domain/notifications";
+
+const INBOX_PREFIX = "lj.notifications.v1.inbox";
+
+function inboxKey(userId: string): string {
+  return `${INBOX_PREFIX}.${userId}`;
+}
+
+function readInbox(userId: string): Notification[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(inboxKey(userId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as Notification[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeInbox(userId: string, items: Notification[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(inboxKey(userId), JSON.stringify(items));
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn("[mention-notifications] inbox write failed");
+  }
+}
+
+/**
+ * Append notifications to each target user's prototype inbox. Idempotent on
+ * `id` — mentions edited and re-saved won't double-fire.
+ */
+export function dispatchMentionNotifications(items: Notification[]): void {
+  if (typeof window === "undefined" || items.length === 0) return;
+  const byUser = new Map<string, Notification[]>();
+  for (const n of items) {
+    const arr = byUser.get(n.userId) ?? [];
+    arr.push(n);
+    byUser.set(n.userId, arr);
+  }
+  for (const [userId, additions] of byUser.entries()) {
+    const existing = readInbox(userId);
+    const seen = new Set(existing.map((n) => n.id));
+    const merged = [
+      ...existing,
+      ...additions.filter((n) => !seen.has(n.id)),
+    ];
+    writeInbox(userId, merged);
+  }
+}


### PR DESCRIPTION
## Summary

Adds two collaboration primitives and adopts them on the chart-note detail surface.

- **`<CommentThread>`** — generic over `targetType` (chart_note / encounter / lab_result / patient / order / task / document). Roots + nested replies, avatar/name/timestamp/body row, Reply / Edit / Delete / Resolve affordances. **Resolved threads collapse** into a single pill with a View toggle.
- **`<MentionInput>`** — reusable mention-aware textarea. Typing `@` opens an autocomplete popover under the caret with org-member matches (↑↓ navigate, Enter/Tab insert, Esc close, ⌘⏎ submit).
- **Server actions** — `listOrgMembersForMention` queries the existing `Membership` join table (schema untouched); `getCurrentCommentAuthor` stamps the caller for new comments.
- **@mention fan-out** — each mention generates a `Notification` in the exact shape exported by `src/lib/domain/notifications.ts` (PR #464), routed through the `system` channel, and buffered in `lj.notifications.v1.inbox.<userId>` so the notification center can pick them up once it has a real source.
- **Adoption surface** — chart-note detail view (`/clinic/patients/[id]/notes/[noteId]`) renders `<NoteCommentsPanel>` under the editor.

## Schema status

**WIP / prototype.** Prisma `Comment` model is intentionally **out of scope** for this PR (`prisma/schema.prisma` is off-limits per the brief). Comments persist to `localStorage` under a versioned, namespaced key (`lj.comments.v1.<targetType>.<targetId>`). The component API mirrors what a real server action would expose, so the durable backend lands as a one-file swap inside `NoteCommentsPanel`. A clear inline "WIP prototype" banner appears above the panel.

## Constraints honored

- No `prisma/schema.prisma` / `src/middleware.ts` / `.github/workflows/` / `src/lib/specialty-templates/manifests/` / `src/lib/auth/` / `CLAUDE.md` changes.
- No new dependencies.
- No `/ops/supplies` work.

## Files touched

- `src/components/collaboration/comment-thread.tsx` (new)
- `src/components/collaboration/mention-input.tsx` (new)
- `src/components/collaboration/note-comments-panel.tsx` (new)
- `src/lib/collaboration/comments.ts` (new — domain types + mention extraction + notification builder)
- `src/lib/collaboration/comment-store.ts` (new — localStorage prototype)
- `src/lib/collaboration/mention-notifications.ts` (new — notification inbox buffer)
- `src/app/actions/collaborationActions.ts` (new — `listOrgMembersForMention`, `getCurrentCommentAuthor`)
- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx` (adoption — adds `<NoteCommentsPanel>`)

## Test plan

- [ ] Open any chart note detail page; verify the **Comments** panel renders below the note editor with a "WIP prototype" banner.
- [ ] Type a comment and press **Comment** (or ⌘⏎). Confirm it appears with avatar + name + timestamp.
- [ ] Type `@` in the editor. Confirm the autocomplete popover shows org members. Verify ↑/↓ moves the highlight, Enter inserts `@firstname`, Esc closes.
- [ ] Submit a comment containing an `@firstname` token. Reopen DevTools → `Application → Local Storage` and confirm a `lj.notifications.v1.inbox.<userId>` key exists with the mention payload (shape matches `Notification` from `src/lib/domain/notifications.ts`).
- [ ] Click **Reply** on a comment; submit. Confirm the reply nests under the root and the reply box collapses.
- [ ] Click **Resolve** on a thread. Confirm it collapses to a single pill in a "Resolved" section. Click **View** to expand; **Reopen** to un-resolve.
- [ ] Edit your own comment. Verify the body updates and an `(edited)` marker appears. Edit to include a new `@mention`; verify mention highlights update.
- [ ] Delete your own comment. Confirm it tombstones to `[comment deleted]` and replies remain visible.
- [ ] Reload the page. Confirm comments persist (localStorage round-trip).
- [ ] `npx prisma generate && npm run typecheck && npm run lint` — green (no new errors/warnings in collaboration files).

## Follow-ups (out of scope here)

- Land the durable `Comment` / `CommentMention` / `CommentResolution` tables (separate PR).
- Swap `commentStore` calls in `NoteCommentsPanel` for server actions backed by Prisma.
- Adopt on additional surfaces: lab-result detail, encounter detail, order detail.
- When the clinician-side notification bell ships, point it at `lj.notifications.v1.inbox.<userId>` (or whatever the durable source becomes).