### PR TITLE
ux: searchable help drawer + 16 onboarding articles

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from "@/components/ui/command-palette";
 import { ConsciousnessOverlay } from "@/components/ui/consciousness-overlay";
 import { ClinicianTour } from "@/components/onboarding/clinician-tour";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
+import { HelpDrawer } from "@/components/help/help-drawer";
 import { prisma } from "@/lib/db/prisma";
 import {
   computeApprovalsBadge,
@@ -191,6 +192,7 @@ export default async function ClinicianLayout({
       <ConsciousnessOverlay />
       <ClinicianTour />
       <InstallPrompt />
+      <HelpDrawer />
       {children}
     </AppShell>
   );

--- a/src/components/help/help-drawer.tsx
+++ b/src/components/help/help-drawer.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+/**
+ * In-app help drawer.
+ *
+ * Surface (ux/help-docs-drawer-v2):
+ *   - Floating `?` trigger button in the TOP-right of the viewport.
+ *     We sit at top-right because the bottom-right corner is
+ *     already occupied by the Whisper FAB / Quote popup / Ask Cindy
+ *     / Consciousness overlay stack. Trigger button is z-30 so it
+ *     never sits above an active modal.
+ *   - 420px right-side panel slides in with a dimmed backdrop.
+ *   - Closes on Esc, click on backdrop, or X.
+ *   - Top: search input.
+ *   - Grouped article index, each article opens inline with a back
+ *     arrow to return to the index.
+ *
+ * Accessibility:
+ *   - `role="dialog"` + `aria-modal="true"` + `aria-labelledby`.
+ *   - Focus is moved to the first focusable element on open.
+ *   - A simple focus trap keeps Tab/Shift+Tab inside the panel.
+ *   - On close we restore focus to the trigger button.
+ *
+ * The component manages its own `open` state so it can be mounted
+ * once in the clinician layout without any prop wiring.
+ */
+
+import * as React from "react";
+import {
+  ArrowLeft,
+  ChevronRight,
+  HelpCircle,
+  Keyboard,
+  Search,
+  X,
+} from "lucide-react";
+import {
+  HELP_ARTICLES,
+  HELP_GROUPS,
+  articleById,
+  articlesByGroup,
+  searchHelp,
+  type HelpArticle,
+  type HelpGroupId,
+  type HelpSearchHit,
+} from "@/lib/help";
+import { MarkdownLite } from "@/components/help/markdown-lite";
+import { cn } from "@/lib/utils/cn";
+
+/** Tailwind selector for things we consider focusable inside the drawer. */
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+type View =
+  | { kind: "index" }
+  | { kind: "article"; id: string }
+  | { kind: "search" };
+
+export function HelpDrawer() {
+  const [open, setOpen] = React.useState(false);
+  const [view, setView] = React.useState<View>({ kind: "index" });
+  const [query, setQuery] = React.useState("");
+
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+  const searchInputRef = React.useRef<HTMLInputElement | null>(null);
+  const titleId = React.useId();
+
+  // Reset internal state every time the drawer closes so the user
+  // sees a clean index when they re-open.
+  React.useEffect(() => {
+    if (!open) {
+      setView({ kind: "index" });
+      setQuery("");
+    }
+  }, [open]);
+
+  // Body scroll lock.
+  React.useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Esc + focus management.
+  React.useEffect(() => {
+    if (!open) return;
+
+    const prevActive = document.activeElement as HTMLElement | null;
+    // Snapshot the trigger button ref so the cleanup function uses
+    // a stable reference, not a ref that may have changed by the
+    // time the effect re-runs.
+    const triggerSnapshot = triggerRef.current;
+
+    // Defer focus until after the slide-in transition starts so
+    // screen readers announce the dialog title.
+    const focusTimer = window.setTimeout(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const first = panel.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      first?.focus();
+    }, 30);
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("data-focus-trap-ignore"));
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.clearTimeout(focusTimer);
+      window.removeEventListener("keydown", handleKey);
+      // Restore focus to the trigger (or whatever opened the
+      // drawer), per WAI-ARIA dialog pattern.
+      const target = triggerSnapshot ?? prevActive;
+      target?.focus?.();
+    };
+  }, [open]);
+
+  // Switch to "search" view as soon as the user types.
+  React.useEffect(() => {
+    if (!open) return;
+    if (query.trim().length > 0) {
+      setView({ kind: "search" });
+    } else if (view.kind === "search") {
+      setView({ kind: "index" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, open]);
+
+  const searchHits: HelpSearchHit[] = React.useMemo(
+    () => (view.kind === "search" ? searchHelp(query) : []),
+    [view, query],
+  );
+
+  function openArticle(id: string) {
+    setQuery("");
+    setView({ kind: "article", id });
+    // Scroll the panel back to the top when navigating in.
+    requestAnimationFrame(() => {
+      panelRef.current?.querySelector("[data-help-body]")?.scrollTo({ top: 0 });
+    });
+  }
+
+  function backToIndex() {
+    setView({ kind: "index" });
+    requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+  }
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Open help drawer"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className={cn(
+          "fixed top-4 right-4 z-30",
+          "h-10 w-10 rounded-full",
+          "bg-surface-raised/90 backdrop-blur border border-border",
+          "shadow-md hover:shadow-lg",
+          "flex items-center justify-center",
+          "text-text-muted hover:text-text",
+          "transition-all hover:scale-105 active:scale-95",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+        )}
+      >
+        <HelpCircle className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <HelpDrawerPanel
+          ref={panelRef}
+          titleId={titleId}
+          view={view}
+          query={query}
+          searchInputRef={searchInputRef}
+          searchHits={searchHits}
+          onClose={() => setOpen(false)}
+          onQueryChange={setQuery}
+          onOpenArticle={openArticle}
+          onBackToIndex={backToIndex}
+        />
+      ) : null}
+    </>
+  );
+}
+
+interface PanelProps {
+  titleId: string;
+  view: View;
+  query: string;
+  searchInputRef: React.RefObject<HTMLInputElement>;
+  searchHits: HelpSearchHit[];
+  onClose: () => void;
+  onQueryChange: (q: string) => void;
+  onOpenArticle: (id: string) => void;
+  onBackToIndex: () => void;
+}
+
+const HelpDrawerPanel = React.forwardRef<HTMLDivElement, PanelProps>(
+  function HelpDrawerPanel(
+    {
+      titleId,
+      view,
+      query,
+      searchInputRef,
+      searchHits,
+      onClose,
+      onQueryChange,
+      onOpenArticle,
+      onBackToIndex,
+    },
+    ref,
+  ) {
+    const activeArticle: HelpArticle | undefined =
+      view.kind === "article" ? articleById(view.id) : undefined;
+
+    const headerTitle =
+      view.kind === "article" && activeArticle
+        ? activeArticle.title
+        : "Help & docs";
+
+    return (
+      <div
+        className="fixed inset-0 z-40"
+        // Outer div is the backdrop + container. We avoid `role`
+        // here and put the dialog semantics on the inner panel.
+      >
+        {/* Backdrop */}
+        <button
+          type="button"
+          aria-label="Close help drawer"
+          onClick={onClose}
+          data-focus-trap-ignore="true"
+          tabIndex={-1}
+          className={cn(
+            "absolute inset-0 bg-black/40 backdrop-blur-[2px]",
+            "animate-in fade-in duration-200",
+          )}
+        />
+
+        {/* Panel */}
+        <div
+          ref={ref}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          className={cn(
+            "absolute top-0 right-0 h-full w-[420px] max-w-[100vw]",
+            "bg-surface border-l border-border shadow-2xl",
+            "flex flex-col",
+            "animate-in slide-in-from-right duration-200",
+          )}
+        >
+          <header className="flex items-center gap-2 px-4 py-3 border-b border-border">
+            {view.kind === "article" ? (
+              <button
+                type="button"
+                aria-label="Back to help index"
+                onClick={onBackToIndex}
+                className={cn(
+                  "h-8 w-8 rounded-full flex items-center justify-center",
+                  "text-text-muted hover:text-text hover:bg-surface-raised",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                )}
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              </button>
+            ) : (
+              <HelpCircle
+                className="h-5 w-5 text-text-muted ml-1"
+                aria-hidden="true"
+              />
+            )}
+            <h2
+              id={titleId}
+              className="flex-1 text-sm font-semibold text-text truncate"
+            >
+              {headerTitle}
+            </h2>
+            <button
+              type="button"
+              aria-label="Close help drawer"
+              onClick={onClose}
+              className={cn(
+                "h-8 w-8 rounded-full flex items-center justify-center",
+                "text-text-muted hover:text-text hover:bg-surface-raised",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+              )}
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </header>
+
+          {view.kind === "article" && activeArticle ? (
+            <ArticleView article={activeArticle} />
+          ) : (
+            <IndexAndSearchView
+              query={query}
+              searchInputRef={searchInputRef}
+              searchHits={searchHits}
+              isSearching={view.kind === "search"}
+              onQueryChange={onQueryChange}
+              onOpenArticle={onOpenArticle}
+            />
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+interface IndexProps {
+  query: string;
+  searchInputRef: React.RefObject<HTMLInputElement>;
+  searchHits: HelpSearchHit[];
+  isSearching: boolean;
+  onQueryChange: (q: string) => void;
+  onOpenArticle: (id: string) => void;
+}
+
+function IndexAndSearchView({
+  query,
+  searchInputRef,
+  searchHits,
+  isSearching,
+  onQueryChange,
+  onOpenArticle,
+}: IndexProps) {
+  return (
+    <>
+      <div className="px-4 py-3 border-b border-border">
+        <label className="relative block">
+          <span className="sr-only">Search help articles</span>
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted pointer-events-none"
+            aria-hidden="true"
+          />
+          <input
+            ref={searchInputRef}
+            type="search"
+            value={query}
+            placeholder={`Search ${HELP_ARTICLES.length} articles…`}
+            onChange={(e) => onQueryChange(e.target.value)}
+            className={cn(
+              "w-full rounded-lg border border-border bg-bg",
+              "pl-9 pr-3 py-2 text-sm text-text",
+              "placeholder:text-text-muted",
+              "focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent",
+            )}
+          />
+        </label>
+      </div>
+
+      <div className="flex-1 overflow-y-auto" data-help-body>
+        {isSearching ? (
+          <SearchResults hits={searchHits} onOpenArticle={onOpenArticle} />
+        ) : (
+          <GroupIndex onOpenArticle={onOpenArticle} />
+        )}
+      </div>
+    </>
+  );
+}
+
+function SearchResults({
+  hits,
+  onOpenArticle,
+}: {
+  hits: HelpSearchHit[];
+  onOpenArticle: (id: string) => void;
+}) {
+  if (hits.length === 0) {
+    return (
+      <div className="px-4 py-10 text-center text-sm text-text-muted">
+        No articles match your search.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {hits.map((hit) => (
+        <li key={hit.article.id}>
+          <button
+            type="button"
+            onClick={() => onOpenArticle(hit.article.id)}
+            className={cn(
+              "w-full text-left px-4 py-3",
+              "hover:bg-surface-raised",
+              "focus:outline-none focus-visible:bg-surface-raised",
+            )}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-text truncate">
+                  {hit.article.title}
+                </p>
+                {hit.snippet ? (
+                  <p className="mt-1 text-xs text-text-muted line-clamp-2">
+                    {hit.snippet}
+                  </p>
+                ) : null}
+              </div>
+              <ChevronRight
+                className="h-4 w-4 text-text-muted shrink-0 mt-0.5"
+                aria-hidden="true"
+              />
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function GroupIndex({
+  onOpenArticle,
+}: {
+  onOpenArticle: (id: string) => void;
+}) {
+  return (
+    <div className="py-2">
+      {HELP_GROUPS.map((group) => {
+        const items = articlesByGroup(group.id);
+        return (
+          <section
+            key={group.id}
+            className="px-4 py-2"
+            aria-labelledby={`help-group-${group.id}`}
+          >
+            <h3
+              id={`help-group-${group.id}`}
+              className="text-[11px] font-semibold uppercase tracking-wider text-text-muted px-1 mb-1"
+            >
+              {group.label}
+            </h3>
+            {group.id === "shortcuts" ? (
+              <ShortcutsGroupEntry onOpenArticle={onOpenArticle} />
+            ) : (
+              <ul className="space-y-0.5">
+                {items.map((article) => (
+                  <li key={article.id}>
+                    <button
+                      type="button"
+                      onClick={() => onOpenArticle(article.id)}
+                      className={cn(
+                        "w-full text-left rounded-md px-2 py-2 flex items-center justify-between gap-2",
+                        "text-sm text-text hover:bg-surface-raised",
+                        "focus:outline-none focus-visible:bg-surface-raised",
+                      )}
+                    >
+                      <span className="truncate">{article.title}</span>
+                      <ChevronRight
+                        className="h-4 w-4 text-text-muted shrink-0"
+                        aria-hidden="true"
+                      />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        );
+      })}
+      <footer className="px-4 py-4 border-t border-border mt-2">
+        <p className="text-xs text-text-muted">
+          Looking for something else?  Email{" "}
+          <a
+            href="mailto:support@leafjourney.com"
+            className="text-accent hover:underline"
+          >
+            support@leafjourney.com
+          </a>
+          .
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+/**
+ * Special entry for the keyboard shortcuts group: in addition to
+ * the article (which is a primer), we expose a quick "open cheat
+ * sheet" action that fires the global `?` shortcut.
+ *
+ * We dispatch a regular `keydown` Shift+/ event on `document`
+ * rather than reach into the `KeyboardShortcuts` API directly —
+ * that way this stays decoupled from the PR #443 implementation.
+ */
+function ShortcutsGroupEntry({
+  onOpenArticle,
+}: {
+  onOpenArticle: (id: string) => void;
+}) {
+  function openCheatSheet() {
+    const event = new KeyboardEvent("keydown", {
+      key: "?",
+      shiftKey: true,
+      bubbles: true,
+    });
+    document.dispatchEvent(event);
+  }
+  const article = articleById("keyboard-shortcuts");
+  return (
+    <ul className="space-y-0.5">
+      <li>
+        <button
+          type="button"
+          onClick={openCheatSheet}
+          className={cn(
+            "w-full text-left rounded-md px-2 py-2 flex items-center justify-between gap-2",
+            "text-sm text-text hover:bg-surface-raised",
+            "focus:outline-none focus-visible:bg-surface-raised",
+          )}
+        >
+          <span className="flex items-center gap-2 truncate">
+            <Keyboard className="h-4 w-4 text-text-muted" aria-hidden="true" />
+            Open the full cheat sheet
+          </span>
+          <kbd className="text-[10px] font-mono text-text-muted bg-surface-raised border border-border rounded px-1.5 py-0.5">
+            ?
+          </kbd>
+        </button>
+      </li>
+      {article ? (
+        <li>
+          <button
+            type="button"
+            onClick={() => onOpenArticle(article.id)}
+            className={cn(
+              "w-full text-left rounded-md px-2 py-2 flex items-center justify-between gap-2",
+              "text-sm text-text hover:bg-surface-raised",
+              "focus:outline-none focus-visible:bg-surface-raised",
+            )}
+          >
+            <span className="truncate">{article.title}</span>
+            <ChevronRight
+              className="h-4 w-4 text-text-muted shrink-0"
+              aria-hidden="true"
+            />
+          </button>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+function ArticleView({ article }: { article: HelpArticle }) {
+  const group = HELP_GROUPS.find((g) => g.id === article.group);
+  return (
+    <div className="flex-1 overflow-y-auto" data-help-body>
+      <article className="px-5 py-5">
+        {group ? (
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-2">
+            {group.label}
+          </p>
+        ) : null}
+        <h1 className="text-lg font-semibold text-text mb-3">{article.title}</h1>
+        <MarkdownLite body={article.body} />
+        {article.tags.length > 0 ? (
+          <div className="mt-6 flex flex-wrap gap-1.5">
+            {article.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[11px] text-text-muted bg-surface-raised border border-border rounded-full px-2 py-0.5"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </article>
+    </div>
+  );
+}

--- a/src/components/help/markdown-lite.tsx
+++ b/src/components/help/markdown-lite.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * Tiny markdown renderer for help-drawer article bodies.
+ *
+ * Why a custom renderer rather than `react-markdown` /
+ * `next-mdx-remote`?  The brief explicitly forbids adding deps, and
+ * our articles use a narrow, predictable subset of markdown:
+ *
+ *   - paragraphs separated by blank lines
+ *   - bullet lists with leading `- `
+ *   - inline `**bold**` and `` `code` ``
+ *
+ * That's it. No headings, no images, no tables. If we ever need
+ * richer formatting we can swap this for `react-markdown` behind
+ * the same `<MarkdownLite>` interface.
+ */
+
+import * as React from "react";
+
+interface MarkdownLiteProps {
+  body: string;
+}
+
+interface Token {
+  type: "text" | "bold" | "code";
+  value: string;
+}
+
+/**
+ * Split a single line into bold / code / text tokens. We walk the
+ * string once and bite off the longest prefix that matches each
+ * pattern, falling through to literal text otherwise. This keeps
+ * the renderer dependency-free and small enough to audit.
+ */
+function tokenizeInline(line: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line.startsWith("**", i)) {
+      const end = line.indexOf("**", i + 2);
+      if (end !== -1) {
+        tokens.push({ type: "bold", value: line.slice(i + 2, end) });
+        i = end + 2;
+        continue;
+      }
+    }
+    if (line[i] === "`") {
+      const end = line.indexOf("`", i + 1);
+      if (end !== -1) {
+        tokens.push({ type: "code", value: line.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+    // Coalesce literal text up to the next special char.
+    let j = i;
+    while (j < line.length && line[j] !== "`" && !line.startsWith("**", j)) {
+      j++;
+    }
+    if (j > i) tokens.push({ type: "text", value: line.slice(i, j) });
+    if (j === i) j = i + 1; // safety against zero-width loop
+    i = j;
+  }
+  return tokens;
+}
+
+function renderInline(line: string, keyPrefix: string): React.ReactNode[] {
+  return tokenizeInline(line).map((tok, idx) => {
+    const key = `${keyPrefix}-${idx}`;
+    if (tok.type === "bold") {
+      return (
+        <strong key={key} className="font-semibold text-text">
+          {tok.value}
+        </strong>
+      );
+    }
+    if (tok.type === "code") {
+      return (
+        <code
+          key={key}
+          className="rounded bg-surface-raised px-1 py-[1px] font-mono text-[0.85em] text-text"
+        >
+          {tok.value}
+        </code>
+      );
+    }
+    return <React.Fragment key={key}>{tok.value}</React.Fragment>;
+  });
+}
+
+export function MarkdownLite({ body }: MarkdownLiteProps) {
+  // Split on blank lines to get blocks; each block is either a
+  // bullet list (every non-empty line begins with `- `) or a
+  // paragraph.
+  const blocks = body.split(/\n\s*\n/);
+
+  return (
+    <div className="space-y-3 text-sm leading-relaxed text-text-muted">
+      {blocks.map((block, blockIdx) => {
+        const lines = block.split("\n").filter((l) => l.trim().length > 0);
+        const isList = lines.length > 0 && lines.every((l) => l.trim().startsWith("- "));
+
+        if (isList) {
+          return (
+            <ul
+              key={`block-${blockIdx}`}
+              className="list-disc space-y-1 pl-5 marker:text-text-muted"
+            >
+              {lines.map((line, lineIdx) => (
+                <li key={`block-${blockIdx}-li-${lineIdx}`}>
+                  {renderInline(line.trim().slice(2), `b${blockIdx}-l${lineIdx}`)}
+                </li>
+              ))}
+            </ul>
+          );
+        }
+
+        return (
+          <p key={`block-${blockIdx}`}>
+            {lines.map((line, lineIdx) => (
+              <React.Fragment key={`p-${blockIdx}-${lineIdx}`}>
+                {lineIdx > 0 ? " " : null}
+                {renderInline(line, `p${blockIdx}-l${lineIdx}`)}
+              </React.Fragment>
+            ))}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/help/articles/account-preferences.ts
+++ b/src/lib/help/articles/account-preferences.ts
@@ -1,0 +1,17 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "account-preferences",
+  title: "Account & preferences",
+  group: "account",
+  tags: ["account", "settings", "preferences", "profile", "security"],
+  body: `From **Settings → Account** you can manage:
+
+- **Profile** — display name, credentials, NPI, signature image.
+- **Security** — password, MFA factors, active sessions.
+- **Notifications** — email, push, and pager channels.
+- **Appearance** — light/dark mode, font size, motion preferences (respects \`prefers-reduced-motion\`).
+- **Schedule defaults** — visit length, buffer time, telehealth link template.
+
+Practice-wide settings live under **Admin → Practice** and are only editable by a practice owner.`,
+};

--- a/src/lib/help/articles/charts-dictation.ts
+++ b/src/lib/help/articles/charts-dictation.ts
@@ -1,0 +1,16 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "charts-dictation",
+  title: "Dictating into a note",
+  group: "charts-soap",
+  tags: ["dictation", "voice", "microphone", "note"],
+  body: `Every editable note field supports voice dictation.
+
+- Click the microphone icon at the top-right of any section header, or press \`Cmd+Shift+D\` while focused inside a section.
+- Speak naturally — punctuation is added automatically.
+- A pulsing blue dot indicates active capture. Click again, press \`Escape\`, or stop speaking for ~3 seconds to end.
+- A transcript preview appears inline before it commits. Edit it freely before saving.
+
+Dictation never auto-saves; you always confirm.`,
+};

--- a/src/lib/help/articles/charts-signing.ts
+++ b/src/lib/help/articles/charts-signing.ts
@@ -1,0 +1,18 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "charts-signing",
+  title: "Signing notes, labs, and refills",
+  group: "charts-soap",
+  tags: ["sign-off", "signature", "attestation", "queue"],
+  body: `The unified **Sign-off** queue at \`/clinic/sign-off\` is your single end-of-day surface. It collapses four categories:
+
+- AI-drafted patient messages
+- Lab results awaiting clinician review
+- Refill requests waiting on a decision
+- Notes drafted from telehealth or intake
+
+Each item shows the originating context, a one-line summary, and an **Approve** / **Edit** / **Reject** triad. Bulk-approve is available when no item carries an emergency flag.
+
+Every sign-off writes a signed attestation row to the audit log.`,
+};

--- a/src/lib/help/articles/charts-soap-structure.ts
+++ b/src/lib/help/articles/charts-soap-structure.ts
@@ -1,0 +1,16 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "charts-soap-structure",
+  title: "How SOAP notes are structured",
+  group: "charts-soap",
+  tags: ["soap", "apso", "note", "chart", "structure"],
+  body: `LeafJourney follows the SOAP / APSO convention with one important rule: **the Objective section is human-only**.
+
+- **Subjective** — patient-reported. AI may draft from intake and prior notes.
+- **Objective** — vitals, exam findings. **No AI drafting.** You type or dictate this yourself.
+- **Assessment** — your clinical impression. AI may suggest, you decide.
+- **Plan** — orders, follow-up, patient-facing instructions. AI may draft; you sign.
+
+This load-bearing rule keeps the exam record clean and is enforced in the editor.`,
+};

--- a/src/lib/help/articles/charts-whisper.ts
+++ b/src/lib/help/articles/charts-whisper.ts
@@ -1,0 +1,17 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "charts-whisper",
+  title: "Visit discovery whispers",
+  group: "charts-soap",
+  tags: ["whisper", "ai", "discovery", "visit", "suggestions"],
+  body: `While you are in a chart, the Visit Discovery Whisperer surfaces short, dismissible suggestions in the bottom-right corner.
+
+Examples:
+
+- "Last A1c was 90 days ago — order today?"
+- "Patient reported new tinnitus in messages — add to Subjective?"
+- "Cannabis log shows worsening sleep — revisit dose?"
+
+Whispers never act on their own. Click a whisper to accept the suggestion into the note, or dismiss to log a "not now". Dismissals train the model down over time.`,
+};

--- a/src/lib/help/articles/getting-started-command-center.ts
+++ b/src/lib/help/articles/getting-started-command-center.ts
@@ -1,0 +1,15 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "getting-started-command-center",
+  title: "Your Command Center",
+  group: "getting-started",
+  tags: ["command-center", "dashboard", "today", "home"],
+  body: `The Command Center at \`/clinic/command\` is the single screen where LeafJourney expects you to start your day.
+
+- The top strip shows your next three appointments and any emergency messages.
+- The middle band surfaces the unified Sign-off queue: labs awaiting review, refills pending, AI-drafted notes, and AI-drafted messages.
+- The bottom band shows agent activity — what the Practice Manager Agent has done overnight on your behalf.
+
+Click any tile to drop into the relevant queue. Nothing on this screen is destructive.`,
+};

--- a/src/lib/help/articles/getting-started-first-chart.ts
+++ b/src/lib/help/articles/getting-started-first-chart.ts
@@ -1,0 +1,15 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "getting-started-first-chart",
+  title: "Opening your first chart",
+  group: "getting-started",
+  tags: ["chart", "patient", "roster", "intro"],
+  body: `From **Patients → Roster** you can:
+
+- Type any part of a patient's name, MRN, or DOB in the top search bar — results stream in as you type.
+- Use the filter chips on the right to narrow by visit type, last contact, or care team.
+- Click a row, or hit \`Enter\` on the keyboard-focused row, to open the chart in the right pane.
+
+Charts always open to the most recent encounter. Use the chart tabs to move between Problems, Meds, Labs, Notes, and Plan.`,
+};

--- a/src/lib/help/articles/getting-started-shell.ts
+++ b/src/lib/help/articles/getting-started-shell.ts
@@ -1,0 +1,17 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "getting-started-shell",
+  title: "Navigating the clinic shell",
+  group: "getting-started",
+  tags: ["navigation", "layout", "sidebar", "rail"],
+  body: `The clinician surface is organized into five pillars in the side rail:
+
+- **Today** — Overview, Command Center, Schedule, Telehealth.
+- **Patients** — your roster and chart search.
+- **Inbox** — Messages and the unified Sign-off queue (labs, refills, notes, messages).
+- **Reference** — Providers, Research, Library, Communications.
+- **Admin** — Audit Trail and Morning Brief.
+
+Badges on Inbox items reflect live counts of pending sign-offs and emergency-flagged drafts.`,
+};

--- a/src/lib/help/articles/getting-started-tour.ts
+++ b/src/lib/help/articles/getting-started-tour.ts
@@ -1,0 +1,15 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "getting-started-tour",
+  title: "Take the clinician tour",
+  group: "getting-started",
+  tags: ["tour", "onboarding", "intro", "walkthrough"],
+  body: `LeafJourney ships with a short guided tour that highlights the main surfaces of the clinic shell: Today, Patients, Inbox, Reference, and Admin.
+
+- Press \`?\` anywhere to open the keyboard cheat sheet, then click **Replay tour** at the bottom.
+- The tour pauses on each pillar of the side rail. Click **Next** or press \`Enter\` to step through.
+- You can re-run the tour at any time — it never modifies data.
+
+If the tour does not appear automatically on first login, your practice admin may have suppressed it in settings.`,
+};

--- a/src/lib/help/articles/keyboard-shortcuts.ts
+++ b/src/lib/help/articles/keyboard-shortcuts.ts
@@ -1,0 +1,20 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "keyboard-shortcuts",
+  title: "Keyboard shortcuts",
+  group: "shortcuts",
+  tags: ["shortcuts", "keyboard", "hotkeys", "productivity"],
+  body: `LeafJourney ships with a Linear-style cheat sheet covering every shortcut in the app.
+
+Press \`?\` anywhere to open it. Highlights:
+
+- \`g\` then \`i\` — go to Inbox
+- \`g\` then \`s\` — go to Sign-off
+- \`g\` then \`c\` — go to Command Center
+- \`Cmd+K\` — open the global command palette
+- \`Cmd+Shift+D\` — start dictation in the focused note section
+- \`Cmd+Enter\` — send the focused draft
+
+You can also replay the clinician tour from the cheat sheet.`,
+};

--- a/src/lib/help/articles/messages-ai-drafts.ts
+++ b/src/lib/help/articles/messages-ai-drafts.ts
@@ -1,0 +1,16 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "messages-ai-drafts",
+  title: "Reviewing AI-drafted replies",
+  group: "messages-inbox",
+  tags: ["messages", "ai", "drafts", "reply", "sign-off"],
+  body: `For routine and administrative threads, LeafJourney pre-drafts a reply for your review. Drafts are visibly tagged with a small sparkle icon and never auto-send.
+
+- Edit the draft inline before sending.
+- Hit \`Cmd+Enter\` to send as-is, or \`Cmd+Shift+E\` to edit fully.
+- **Reject** removes the draft and surfaces the empty composer.
+- Drafts on emergency threads are blocked — you write those.
+
+Every send and every rejection is captured in the audit log along with the original draft text.`,
+};

--- a/src/lib/help/articles/messages-emergency.ts
+++ b/src/lib/help/articles/messages-emergency.ts
@@ -1,0 +1,16 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "messages-emergency",
+  title: "Handling emergency-flagged threads",
+  group: "messages-inbox",
+  tags: ["emergency", "urgent", "escalation", "paging", "safety"],
+  body: `Emergency-flagged threads bypass normal queueing.
+
+- A red dot appears next to the thread and on the Inbox pillar badge. The thread floats to the top of the list.
+- If your practice has on-call paging configured, the on-call clinician receives a push notification within ~30 seconds.
+- AI drafting is disabled — you compose the reply yourself.
+- A safety banner reminds you that "call 911" instructions are still required where appropriate.
+
+Mis-classifications? Click the red dot to downgrade and explain in one line; the model learns.`,
+};

--- a/src/lib/help/articles/messages-templates.ts
+++ b/src/lib/help/articles/messages-templates.ts
@@ -1,0 +1,15 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "messages-templates",
+  title: "Saving and using message templates",
+  group: "messages-inbox",
+  tags: ["templates", "snippets", "messages", "reply", "macros"],
+  body: `You can promote any message you send into a reusable template.
+
+- Send a message, then click the **Save as template** link that appears next to the timestamp for ~10 seconds after send.
+- Give it a short name. Templates are scoped to you by default; practice owners can promote a template to the whole practice.
+- In the composer, type \`/\` to open the template picker. Up arrow and down arrow to choose, \`Enter\` to insert.
+
+Template variables like \`{{patient.firstName}}\` are interpolated at insert time.`,
+};

--- a/src/lib/help/articles/messages-triage.ts
+++ b/src/lib/help/articles/messages-triage.ts
@@ -1,0 +1,16 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "messages-triage",
+  title: "How inbox triage works",
+  group: "messages-inbox",
+  tags: ["messages", "triage", "urgency", "inbox", "emergency"],
+  body: `Inbound patient messages run through a triage classifier that tags each thread with one of four urgency levels:
+
+- **Emergency** — red dot, jumps to the top, paged to on-call if configured.
+- **Urgent** — orange, surfaces in the next-24h band.
+- **Routine** — neutral, falls into the regular queue.
+- **Administrative** — grey, routed to front office by default.
+
+You can re-classify any thread by clicking the urgency dot. Your correction trains the classifier for your practice.`,
+};

--- a/src/lib/help/articles/practice-manager-agent.ts
+++ b/src/lib/help/articles/practice-manager-agent.ts
@@ -1,0 +1,18 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "practice-manager-agent",
+  title: "What the Practice Manager Agent does overnight",
+  group: "practice-manager",
+  tags: ["agent", "automation", "overnight", "practice-manager", "pma"],
+  body: `The Practice Manager Agent (PMA) runs on a low-key schedule between visits and overnight. It never writes to the chart; it only stages.
+
+Typical PMA outputs:
+
+- **Drafts** for routine messages and refills, ready for your sign-off.
+- **Flags** on threads that look emergency-shaped.
+- **Backlog rollups** on your Morning Brief so you start the day knowing what is waiting.
+- **Quiet retries** of any external integration (labs, pharmacy) that bounced.
+
+You can see every action the PMA took in **Admin → Audit Trail**, filtered by actor \`practice-manager-agent\`.`,
+};

--- a/src/lib/help/articles/practice-manager-controls.ts
+++ b/src/lib/help/articles/practice-manager-controls.ts
@@ -1,0 +1,15 @@
+import type { HelpArticle } from "@/lib/help/types";
+
+export const article: HelpArticle = {
+  id: "practice-manager-controls",
+  title: "Configuring Practice Manager Agent autonomy",
+  group: "practice-manager",
+  tags: ["agent", "settings", "autonomy", "controls", "practice-manager"],
+  body: `In **Settings → Agents → Practice Manager**, practice owners can dial PMA autonomy per category:
+
+- **Off** — agent runs nothing in this category.
+- **Suggest** — drafts surface in Sign-off, nothing leaves the practice without a clinician.
+- **Auto-send (low-risk only)** — administrative replies and refill confirmations within your written protocols can go out without per-message sign-off; an attestation row is still written.
+
+Clinician-level overrides are honored: if you set messages to **Suggest** for yourself, the practice setting cannot raise it.`,
+};

--- a/src/lib/help/index.ts
+++ b/src/lib/help/index.ts
@@ -1,0 +1,132 @@
+/**
+ * Help drawer content index + client-side fuzzy search.
+ *
+ * Articles live as TypeScript modules under
+ * `src/lib/help/articles/` — each exports a single `article`
+ * `HelpArticle` literal. We aggregate them here and expose:
+ *
+ *   - `HELP_ARTICLES` / `HELP_GROUPS` — full content registry
+ *   - `articlesByGroup`, `articleById` — convenience lookups
+ *   - `searchHelp(query)` — zero-dep ranked search across
+ *     title + tags + body, with a body snippet for inline preview
+ *
+ * The drawer UI in `src/components/help/help-drawer.tsx` is the
+ * only caller. No server round-trip happens — search runs entirely
+ * in the browser bundle.
+ */
+
+import {
+  HELP_GROUPS,
+  type HelpArticle,
+  type HelpGroup,
+  type HelpGroupId,
+} from "@/lib/help/types";
+
+import { article as accountPreferences } from "@/lib/help/articles/account-preferences";
+import { article as chartsDictation } from "@/lib/help/articles/charts-dictation";
+import { article as chartsSigning } from "@/lib/help/articles/charts-signing";
+import { article as chartsSoapStructure } from "@/lib/help/articles/charts-soap-structure";
+import { article as chartsWhisper } from "@/lib/help/articles/charts-whisper";
+import { article as gettingStartedCommandCenter } from "@/lib/help/articles/getting-started-command-center";
+import { article as gettingStartedFirstChart } from "@/lib/help/articles/getting-started-first-chart";
+import { article as gettingStartedShell } from "@/lib/help/articles/getting-started-shell";
+import { article as gettingStartedTour } from "@/lib/help/articles/getting-started-tour";
+import { article as keyboardShortcuts } from "@/lib/help/articles/keyboard-shortcuts";
+import { article as messagesAiDrafts } from "@/lib/help/articles/messages-ai-drafts";
+import { article as messagesEmergency } from "@/lib/help/articles/messages-emergency";
+import { article as messagesTemplates } from "@/lib/help/articles/messages-templates";
+import { article as messagesTriage } from "@/lib/help/articles/messages-triage";
+import { article as practiceManagerAgent } from "@/lib/help/articles/practice-manager-agent";
+import { article as practiceManagerControls } from "@/lib/help/articles/practice-manager-controls";
+
+export { HELP_GROUPS };
+export type { HelpArticle, HelpGroup, HelpGroupId };
+
+export const HELP_ARTICLES: HelpArticle[] = [
+  gettingStartedTour,
+  gettingStartedShell,
+  gettingStartedCommandCenter,
+  gettingStartedFirstChart,
+  chartsSoapStructure,
+  chartsDictation,
+  chartsSigning,
+  chartsWhisper,
+  messagesTriage,
+  messagesAiDrafts,
+  messagesTemplates,
+  messagesEmergency,
+  practiceManagerAgent,
+  practiceManagerControls,
+  keyboardShortcuts,
+  accountPreferences,
+];
+
+export function articlesByGroup(group: HelpGroupId): HelpArticle[] {
+  return HELP_ARTICLES.filter((a) => a.group === group);
+}
+
+export function articleById(id: string): HelpArticle | undefined {
+  return HELP_ARTICLES.find((a) => a.id === id);
+}
+
+export interface HelpSearchHit {
+  article: HelpArticle;
+  score: number;
+  /** First body snippet that matched, for inline preview. */
+  snippet?: string;
+}
+
+/**
+ * Tiny ranked search:
+ *   - lowercase, split query on whitespace
+ *   - per-term: 8× title hit, 4× tag hit, 1× body hit
+ *   - require every term to hit at least one field
+ *
+ * No deps; perfectly fine for ~16 short articles.
+ */
+export function searchHelp(query: string): HelpSearchHit[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const terms = q.split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
+
+  const hits: HelpSearchHit[] = [];
+  for (const article of HELP_ARTICLES) {
+    const title = article.title.toLowerCase();
+    const tags = article.tags.map((t) => t.toLowerCase());
+    const body = article.body.toLowerCase();
+
+    let score = 0;
+    let allMatched = true;
+    let snippet: string | undefined;
+
+    for (const term of terms) {
+      let termScore = 0;
+      if (title.includes(term)) termScore += 8;
+      if (tags.some((t) => t.includes(term))) termScore += 4;
+      const bodyIdx = body.indexOf(term);
+      if (bodyIdx !== -1) {
+        termScore += 1;
+        if (!snippet) {
+          const start = Math.max(0, bodyIdx - 32);
+          const end = Math.min(body.length, bodyIdx + term.length + 64);
+          snippet =
+            (start > 0 ? "…" : "") +
+            article.body.slice(start, end).replace(/\s+/g, " ").trim() +
+            (end < body.length ? "…" : "");
+        }
+      }
+      if (termScore === 0) {
+        allMatched = false;
+        break;
+      }
+      score += termScore;
+    }
+
+    if (allMatched && score > 0) {
+      hits.push({ article, score, snippet });
+    }
+  }
+
+  return hits.sort((a, b) => b.score - a.score);
+}

--- a/src/lib/help/types.ts
+++ b/src/lib/help/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types for the in-app help drawer.
+ *
+ * Articles are authored as TypeScript modules under
+ * `src/lib/help/articles/` — each exports an `HelpArticle` literal.
+ * Keeping them as TS (rather than `.md` with a custom loader) means
+ * we don't have to touch the Next/webpack config to ship the
+ * drawer.
+ *
+ * Bodies are written in lightly-marked-down plain text:
+ *   - paragraphs separated by a blank line
+ *   - bullet lists with leading `- `
+ *   - `**bold**`, `` `code` `` are rendered with inline tokens
+ * The renderer lives in `src/components/help/markdown-lite.tsx`.
+ */
+
+export type HelpGroupId =
+  | "getting-started"
+  | "charts-soap"
+  | "messages-inbox"
+  | "practice-manager"
+  | "shortcuts"
+  | "account";
+
+export interface HelpGroup {
+  id: HelpGroupId;
+  label: string;
+  /** Short blurb shown under the group label on the index. */
+  blurb: string;
+}
+
+export interface HelpArticle {
+  id: string;
+  title: string;
+  group: HelpGroupId;
+  tags: string[];
+  /** Markdown-lite body (see top-of-file note). */
+  body: string;
+}
+
+export const HELP_GROUPS: HelpGroup[] = [
+  {
+    id: "getting-started",
+    label: "Getting started",
+    blurb: "Tour, layout, and your first chart.",
+  },
+  {
+    id: "charts-soap",
+    label: "Charts & SOAP notes",
+    blurb: "Note structure, dictation, sign-off, whispers.",
+  },
+  {
+    id: "messages-inbox",
+    label: "Messages & inbox",
+    blurb: "Triage, AI drafts, templates, emergencies.",
+  },
+  {
+    id: "practice-manager",
+    label: "Practice Manager Agent",
+    blurb: "What runs overnight and how to dial autonomy.",
+  },
+  {
+    id: "shortcuts",
+    label: "Keyboard shortcuts",
+    blurb: "Open the Linear-style cheat sheet.",
+  },
+  {
+    id: "account",
+    label: "Account & preferences",
+    blurb: "Profile, security, appearance.",
+  },
+];


### PR DESCRIPTION
## Summary

- New in-app help drawer at `src/components/help/help-drawer.tsx`, mounted globally in the clinician layout. A `?` floating button sits at top-right of the viewport (clear of the bottom-right Whisper / Quote / Ask Cindy / Consciousness stack) and slides in a 420px right-edge panel with a dimmed backdrop.
- 16 short articles (Getting started, Charts & SOAP notes, Messages & inbox, Practice Manager Agent, Keyboard shortcuts, Account & preferences) authored as typed TypeScript modules under `src/lib/help/articles/`. No new deps.
- Zero-dependency ranked fuzzy search across title + tags + body, with inline body snippets. Each article opens inline with a back arrow to return.
- Accessibility: `role="dialog"`, `aria-modal`, `aria-labelledby`, focus moved into panel on open, simple focus trap on Tab/Shift+Tab, focus restored to the trigger on close. Esc and backdrop-click both close. Body scroll locked while open.
- The Keyboard shortcuts group surfaces a quick action that dispatches the global `?` shortcut, so the existing cheat sheet from PR #443 stays the single source of truth.

## Out of scope / not touched

`prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, `src/lib/specialty-templates/manifests/`, `src/lib/auth/`, `CLAUDE.md`.

## Test plan

- [ ] `?` button appears top-right of the clinician shell on every clinic-floor page.
- [ ] Drawer opens; first focusable element receives focus; `aria-modal="true"`.
- [ ] Esc closes; backdrop click closes; X closes; focus returns to the `?` button.
- [ ] Tab and Shift+Tab cycle only inside the panel.
- [ ] Typing in search switches to ranked results; clearing returns to grouped index.
- [ ] Each group has its expected articles; opening an article shows back-arrow header.
- [ ] "Open the full cheat sheet" entry triggers the PR #443 keyboard modal.
- [ ] Trigger button does not visually collide with the Whisper FAB or any other bottom-right widget.

Generated with [Claude Code](https://claude.com/claude-code)