### PR TITLE
EMR-662: /clinic/sign-off split-pane layout + Sign-Off tree restructure

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { type ComponentType } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { FileText, FlaskConical, LayoutGrid, MessageSquare, Pill } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 
 export type NavSection = {
@@ -9,6 +11,14 @@ export type NavSection = {
   href: string;
   count: number;
   hasUrgent: boolean;
+};
+
+const NAV_ICONS: Record<string, ComponentType<{ className?: string; "aria-hidden"?: boolean }>> = {
+  "/clinic/sign-off": LayoutGrid,
+  "/clinic/sign-off/labs": FlaskConical,
+  "/clinic/sign-off/refills": Pill,
+  "/clinic/sign-off/notes": FileText,
+  "/clinic/sign-off/messages": MessageSquare,
 };
 
 export function SignOffNav({ sections }: { sections: NavSection[] }) {
@@ -21,6 +31,7 @@ export function SignOffNav({ sections }: { sections: NavSection[] }) {
         const active = isAll
           ? pathname === "/clinic/sign-off"
           : pathname === s.href || pathname.startsWith(s.href + "/");
+        const Icon = NAV_ICONS[s.href] ?? LayoutGrid;
         return (
           <Link
             key={s.href}
@@ -32,7 +43,8 @@ export function SignOffNav({ sections }: { sections: NavSection[] }) {
                 : "text-text hover:bg-surface-muted"
             )}
           >
-            <span className="flex items-center gap-1.5 truncate">
+            <span className="flex items-center gap-2 truncate">
+              <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
               {s.hasUrgent && (
                 <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" aria-label="urgent items" />
               )}

--- a/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-nav.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { type ComponentType } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { FileText, FlaskConical, LayoutGrid, MessageSquare, Pill } from "lucide-react";
+import { FileText, FlaskConical, LayoutGrid, MessageSquare, Pill, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 
 export type NavSection = {
@@ -13,7 +12,7 @@ export type NavSection = {
   hasUrgent: boolean;
 };
 
-const NAV_ICONS: Record<string, ComponentType<{ className?: string; "aria-hidden"?: boolean }>> = {
+const NAV_ICONS: Record<string, LucideIcon> = {
   "/clinic/sign-off": LayoutGrid,
   "/clinic/sign-off/labs": FlaskConical,
   "/clinic/sign-off/refills": Pill,

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, type ComponentType } from "react";
+import { useState } from "react";
+import { type LucideIcon } from "lucide-react";
 import Link from "next/link";
 import {
   AlertTriangle,
@@ -33,7 +34,7 @@ const KIND_LABEL: Record<SignOffRow["kind"], string> = {
   message: "Messages",
 };
 
-const KIND_ICON: Record<SignOffRow["kind"], ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>> = {
+const KIND_ICON: Record<SignOffRow["kind"], LucideIcon> = {
   lab: FlaskConical,
   refill: Pill,
   note: FileText,
@@ -156,7 +157,7 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
     groupKey: string;
     urgentCount?: number;
     itemCount: number;
-    icon?: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+    icon?: LucideIcon;
   }) {
     const isCollapsed = collapsed.has(groupKey);
     const Chevron = isCollapsed ? ChevronRight : ChevronDown;

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ComponentType } from "react";
 import Link from "next/link";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  FlaskConical,
+  MessageSquare,
+  Pill,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/cn";
 
@@ -24,11 +33,25 @@ const KIND_LABEL: Record<SignOffRow["kind"], string> = {
   message: "Messages",
 };
 
+const KIND_ICON: Record<SignOffRow["kind"], ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>> = {
+  lab: FlaskConical,
+  refill: Pill,
+  note: FileText,
+  message: MessageSquare,
+};
+
 const KIND_TONE: Record<SignOffRow["kind"], string> = {
-  lab: "bg-[color:var(--info-soft)] text-[color:var(--info)]",
-  refill: "bg-success/10 text-success",
-  note: "bg-highlight-soft text-[color:var(--highlight-hover)]",
-  message: "bg-accent-soft text-accent",
+  lab: "bg-blue-50 text-info border-blue-200",
+  refill: "bg-emerald-50 text-success border-emerald-200",
+  note: "bg-highlight-soft text-[color:var(--highlight-hover)] border-highlight/25",
+  message: "bg-accent-soft text-accent border-accent/20",
+};
+
+const KIND_ICON_COLOR: Record<SignOffRow["kind"], string> = {
+  lab: "text-info",
+  refill: "text-success",
+  note: "text-[color:var(--highlight-hover)]",
+  message: "text-accent",
 };
 
 const KIND_ORDER: SignOffRow["kind"][] = ["lab", "refill", "note", "message"];
@@ -43,11 +66,69 @@ function formatRelative(iso: string): string {
   return `${Math.floor(hr / 24)}d ago`;
 }
 
+function PatientInitials({ name }: { name: string }) {
+  const parts = name.trim().split(" ");
+  const initials =
+    parts.length >= 2
+      ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+      : name.slice(0, 2);
+  return (
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent/15 text-[11px] font-semibold text-accent uppercase">
+      {initials}
+    </span>
+  );
+}
+
+function TreeItem({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: SignOffRow;
+  selected: boolean;
+  onSelect: () => void;
+  key?: string; // workaround: TS env lacks React.JSX.IntrinsicAttributes so `key` leaks into props check
+}) {
+  const Icon = KIND_ICON[item.kind];
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "w-full text-left px-3 py-2 border-b border-border/30 transition-colors flex items-start gap-2.5",
+          selected ? "bg-accent/10" : "hover:bg-surface-muted/60"
+        )}
+      >
+        <Icon
+          className={cn("mt-[3px] h-3.5 w-3.5 shrink-0", KIND_ICON_COLOR[item.kind])}
+          aria-hidden
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            {item.urgency === "high" && (
+              <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" aria-label="urgent" />
+            )}
+            <p className="text-[13px] font-medium text-text truncate leading-snug">
+              {item.title}
+            </p>
+          </div>
+          <p className="text-[11px] text-text-subtle mt-0.5 truncate">
+            {item.patientName} · {formatRelative(item.receivedAt)}
+          </p>
+        </div>
+      </button>
+    </li>
+  );
+}
+
 export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState<Set<SignOffRow["kind"]>>(new Set());
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const selected = rows.find((r) => r.id === selectedId) ?? null;
+
+  const urgentItems = rows.filter((r) => r.urgency === "high");
 
   const groups = KIND_ORDER.map((kind) => ({
     kind,
@@ -56,75 +137,101 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
     urgentCount: rows.filter((r) => r.kind === kind && r.urgency === "high").length,
   })).filter((g) => g.items.length > 0);
 
-  const toggleCollapse = (kind: SignOffRow["kind"]) => {
-    setCollapsed((prev) => {
+  const toggleCollapse = (key: string) => {
+    setCollapsed((prev: Set<string>) => {
       const next = new Set(prev);
-      next.has(kind) ? next.delete(kind) : next.add(kind);
+      next.has(key) ? next.delete(key) : next.add(key);
       return next;
     });
   };
 
+  function SectionHeader({
+    label,
+    groupKey,
+    urgentCount,
+    itemCount,
+    icon: Icon,
+  }: {
+    label: string;
+    groupKey: string;
+    urgentCount?: number;
+    itemCount: number;
+    icon?: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  }) {
+    const isCollapsed = collapsed.has(groupKey);
+    const Chevron = isCollapsed ? ChevronRight : ChevronDown;
+    return (
+      <button
+        type="button"
+        onClick={() => toggleCollapse(groupKey)}
+        className="w-full flex items-center justify-between px-3 py-2 bg-surface-muted/40 border-b border-border/60 hover:bg-surface-muted transition-colors sticky top-0 z-10"
+        aria-expanded={!isCollapsed}
+      >
+        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
+          {Icon && <Icon className="h-3 w-3" aria-hidden />}
+          {(urgentCount ?? 0) > 0 && (
+            <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
+          )}
+          {label}
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="text-[10px] text-text-subtle tabular-nums">{itemCount}</span>
+          <Chevron className="h-3 w-3 text-text-subtle" />
+        </span>
+      </button>
+    );
+  }
+
   return (
     <div className="flex h-full overflow-hidden">
-      {/* Tree (left) */}
+      {/* Tree panel */}
       <div className="w-72 shrink-0 border-r border-border overflow-y-auto bg-surface">
+        {/* Urgent group — shown only when urgent items exist */}
+        {urgentItems.length > 0 && (
+          <div>
+            <SectionHeader
+              label="Urgent"
+              groupKey="urgent"
+              urgentCount={urgentItems.length}
+              itemCount={urgentItems.length}
+              icon={AlertTriangle}
+            />
+            {!collapsed.has("urgent") && (
+              <ul>
+                {urgentItems.map((item) => (
+                  <TreeItem
+                    key={`urgent-${item.id}`}
+                    item={item}
+                    selected={selectedId === item.id}
+                    onSelect={() => { setSelectedId(item.id === selectedId ? null : item.id); }}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {/* Kind groups */}
         {groups.map((group) => {
-          const isCollapsed = collapsed.has(group.kind);
+          const Icon = KIND_ICON[group.kind];
           return (
             <div key={group.kind}>
-              <button
-                type="button"
-                onClick={() => toggleCollapse(group.kind)}
-                className="w-full flex items-center justify-between px-4 py-2.5 bg-surface-muted/40 border-b border-border/60 hover:bg-surface-muted transition-colors sticky top-0 z-10"
-                aria-expanded={!isCollapsed}
-              >
-                <span className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
-                  {group.urgentCount > 0 && (
-                    <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
-                  )}
-                  {group.label}
-                </span>
-                <span className="flex items-center gap-2">
-                  {group.urgentCount > 0 && (
-                    <Badge tone="danger" className="text-[9px] px-1 py-0">
-                      {group.urgentCount}
-                    </Badge>
-                  )}
-                  <span className="text-[10px] text-text-subtle select-none">
-                    {isCollapsed ? "▶" : "▼"}
-                  </span>
-                </span>
-              </button>
-
-              {!isCollapsed && (
+              <SectionHeader
+                label={group.label}
+                groupKey={group.kind}
+                urgentCount={group.urgentCount}
+                itemCount={group.items.length}
+                icon={Icon}
+              />
+              {!collapsed.has(group.kind) && (
                 <ul>
                   {group.items.map((item) => (
-                    <li key={item.id}>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedId(item.id === selectedId ? null : item.id)}
-                        className={cn(
-                          "w-full text-left px-4 py-2.5 border-b border-border/40 transition-colors",
-                          selectedId === item.id
-                            ? "bg-accent/10"
-                            : "hover:bg-surface-muted/60"
-                        )}
-                      >
-                        <div className="flex items-start gap-2">
-                          {item.urgency === "high" && (
-                            <span className="mt-[5px] h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
-                          )}
-                          <div className="min-w-0">
-                            <p className="text-sm font-medium text-text truncate leading-snug">
-                              {item.title}
-                            </p>
-                            <p className="text-[11px] text-text-subtle mt-0.5">
-                              {item.patientName} · {formatRelative(item.receivedAt)}
-                            </p>
-                          </div>
-                        </div>
-                      </button>
-                    </li>
+                    <TreeItem
+                      key={item.id}
+                      item={item}
+                      selected={selectedId === item.id}
+                      onSelect={() => { setSelectedId(item.id === selectedId ? null : item.id); }}
+                    />
                   ))}
                 </ul>
               )}
@@ -133,20 +240,22 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
         })}
 
         {groups.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+          <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+            <span className="text-3xl mb-3">✅</span>
             <p className="text-sm font-medium text-text">Queue clear</p>
             <p className="text-[12px] text-text-subtle mt-1">Nothing waiting on a signature</p>
           </div>
         )}
       </div>
 
-      {/* Detail panel (right) */}
-      <div className="flex-1 min-w-0 overflow-y-auto">
+      {/* Detail panel */}
+      <div className="flex-1 min-w-0 overflow-y-auto bg-surface-raised">
         {selected ? (
           <SignOffDetail row={selected} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full gap-2 text-text-subtle">
-            <p className="text-sm">Select an item from the tree to preview</p>
+            <span className="text-2xl opacity-40">←</span>
+            <p className="text-sm">Select an item to preview</p>
           </div>
         )}
       </div>
@@ -155,29 +264,43 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
 }
 
 function SignOffDetail({ row }: { row: SignOffRow }) {
+  const Icon = KIND_ICON[row.kind];
   return (
-    <div className="p-6 max-w-lg">
-      <div className="mb-4 flex items-center gap-2">
+    <div className="p-6 max-w-xl">
+      {/* Patient header */}
+      <div className="flex items-center gap-3 mb-5">
+        <PatientInitials name={row.patientName} />
+        <div>
+          <p className="text-[13px] font-semibold text-text leading-snug">{row.patientName}</p>
+          <p className="text-[11px] text-text-subtle">{formatRelative(row.receivedAt)}</p>
+        </div>
+      </div>
+
+      {/* Kind + urgency pills */}
+      <div className="flex items-center gap-2 mb-3">
         <span
           className={cn(
-            "inline-flex items-center justify-center text-[10px] font-medium uppercase tracking-wider rounded-md px-2 py-1",
+            "inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider rounded-full px-2.5 py-1 border",
             KIND_TONE[row.kind]
           )}
         >
+          <Icon className="h-3 w-3" aria-hidden />
           {KIND_LABEL[row.kind].replace(/s$/, "")}
         </span>
         {row.urgency === "high" && (
-          <Badge tone="danger" className="text-[10px]">Urgent</Badge>
+          <Badge tone="danger" className="text-[10px]">
+            Urgent
+          </Badge>
         )}
       </div>
 
-      <h2 className="font-display text-xl text-text tracking-tight leading-snug mb-1">
+      {/* Title */}
+      <h2 className="font-display text-xl text-text tracking-tight leading-snug mb-4">
         {row.title}
       </h2>
-      <p className="text-sm text-text-muted mb-1">{row.patientName}</p>
-      <p className="text-[12px] text-text-subtle mb-4">{formatRelative(row.receivedAt)}</p>
 
-      <div className="rounded-xl bg-surface-muted/60 border border-border/60 px-4 py-3 text-sm text-text mb-6">
+      {/* Hint card */}
+      <div className="rounded-xl bg-surface border border-border px-4 py-3 text-sm text-text mb-6">
         {row.hint}
       </div>
 


### PR DESCRIPTION
Implements EMR-662.

## What changed
- **Urgent cross-category group**: A pinned "Urgent" section appears at the top of the sign-off tree whenever any high-priority items exist across labs, refills, notes, or messages — so the provider sees the most important work immediately without scrolling through kind-specific sections.
- **Kind icons on every row**: Each tree item now leads with its kind's icon (FlaskConical for labs, Pill for refills, FileText for notes, MessageSquare for messages) in the matching accent color, making items scannable at a glance.
- **Section header polish**: Chevron icons (ChevronDown / ChevronRight from lucide) replace the raw ▶/▼ text; item count shown inline; AlertTriangle icon on the Urgent header.
- **Richer detail panel**: Clicking an item now shows a patient-initials avatar, a bordered kind pill with icon + label, an Urgent badge when applicable, and a cleaner hint card — all before the "Open full review →" CTA.
- **Nav icons**: `sign-off-nav.tsx` gains per-section icons (LayoutGrid for All items, then matching kind icons) so the left sidebar reads as clearly as the tree.

## How to verify
1. Navigate to `/clinic/sign-off` — the tree should show an "Urgent" group at the top if any abnormal labs, flagged refills, or low-confidence notes exist.
2. Expand/collapse each section — chevrons animate and the count shows in the header.
3. Click any item — the right panel shows patient initials, kind pill, urgency badge, hint, and "Open full review →".
4. Navigate to sub-routes (Labs, Refills, etc.) — the left nav sidebar shows icons beside each label.
5. Verify the empty-state ("Queue clear ✅") appears when the queue is empty.

## Notes
- No schema, auth, or middleware changes.
- `key?: string` is added to `TreeItem`'s inline props type as a workaround for the repo's typecheck environment lacking `React.JSX.IntrinsicAttributes`; this does not affect runtime behaviour.
- Follow-up (out of scope for this PR): consider making the split pane width user-resizable via a drag handle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh5DFyPs6GgUXc6avEy4gh)_