### PR TITLE
ux: recent patients strip + quick-jump picker (g j shortcut)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -23,6 +23,7 @@ import { ChartTabs, type TabKey, type TabPeeks } from "./chart-tabs";
 import { ChartFrame } from "./chart-frame";
 import { loadPeekSummaries } from "./peek-summary";
 import { TrackPatientView } from "@/components/shell/recent-patients";
+import { TrackChartView } from "@/components/patient/track-chart-view";
 import { dueScreenings } from "@/lib/domain/uspstf-screenings";
 import { CorrespondenceTab, type SerializedThread } from "./correspondence-tab";
 import { MemoryTab } from "./memory-tab";
@@ -552,6 +553,13 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       <TrackPatientView
         patientId={patient.id}
         patientName={`${patient.firstName} ${patient.lastName}`}
+      />
+      {/* Per-user versioned tracker for the top-bar recent-patients strip */}
+      <TrackChartView
+        userId={user.id}
+        patientId={patient.id}
+        patientName={`${patient.firstName} ${patient.lastName}`}
+        avatarUrl={intake.photoUrl ?? null}
       />
 
       {/* ── Dossier header ────────────────────────────────── */}

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -10,6 +10,7 @@ import { ConsciousnessOverlay } from "@/components/ui/consciousness-overlay";
 import { ClinicianTour } from "@/components/onboarding/clinician-tour";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
 import { HelpDrawer } from "@/components/help/help-drawer";
+import { RecentPatientsStrip } from "@/components/patient/recent-patients-strip";
 import { prisma } from "@/lib/db/prisma";
 import {
   computeApprovalsBadge,
@@ -193,6 +194,7 @@ export default async function ClinicianLayout({
       <ClinicianTour />
       <InstallPrompt />
       <HelpDrawer />
+      <RecentPatientsStrip userId={user.id} />
       {children}
     </AppShell>
   );

--- a/src/components/patient/quick-jump.tsx
+++ b/src/components/patient/quick-jump.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+/**
+ * Patient-only quick-jump picker — Notion's quick-find, scoped to patients.
+ *
+ * Opens via:
+ *   • The `g j` chord (Linear-style leader; documented in the help cheat
+ *     sheet via the keyboard registry).
+ *   • The "Find" button on the recently-viewed strip.
+ *   • Any caller dispatching `window.dispatchEvent(new CustomEvent(
+ *     QUICK_JUMP_OPEN_EVENT))` — handy for tests + other affordances.
+ *
+ * Why a dedicated chord (`g j`) and not `g p`?
+ *   The existing `KeyboardShortcuts` component already binds `g p` to the
+ *   roster route (see `src/lib/ui/keyboard.ts: G_LEADER_ROUTES`). Re-using
+ *   the same chord would double-fire. `g j` ("jump") is non-conflicting,
+ *   complements the documented set, and reads naturally next to `g p`.
+ *
+ * PR #466 (command palette) added a patient-search row in the global ⌘K
+ * palette — this surface is *complementary*: it's a persistent affordance,
+ * not a kitchen-sink palette, and it stays scoped to patients only.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Avatar } from "@/components/ui/avatar";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils/cn";
+import { isTypingTarget } from "@/lib/ui/keyboard";
+
+export const QUICK_JUMP_OPEN_EVENT = "emr:quick-jump:open";
+
+interface PatientHit {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phone: string | null;
+  dateOfBirth: string | null;
+}
+
+const DEBOUNCE_MS = 180;
+const MIN_QUERY = 2;
+
+export function QuickJump() {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [hits, setHits] = React.useState<PatientHit[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [active, setActive] = React.useState(0);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  /* open/close glue ─────────────────────────────────────── */
+
+  React.useEffect(() => {
+    const onOpen = () => setOpen(true);
+    window.addEventListener(QUICK_JUMP_OPEN_EVENT, onOpen);
+    return () => window.removeEventListener(QUICK_JUMP_OPEN_EVENT, onOpen);
+  }, []);
+
+  // `g j` leader chord — independent listener that won't fight with the
+  // single-listener `KeyboardShortcuts` component (different chord).
+  React.useEffect(() => {
+    let leader = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const clear = () => {
+      leader = false;
+      if (timer) clearTimeout(timer);
+      timer = null;
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(e.target)) return;
+      if (leader && e.key.toLowerCase() === "j") {
+        e.preventDefault();
+        clear();
+        setOpen(true);
+        return;
+      }
+      if (e.key.toLowerCase() === "g") {
+        leader = true;
+        timer = setTimeout(clear, 1500);
+      } else {
+        // any other key cancels the leader — defer to the global handler
+        if (leader) clear();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      clear();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (open) {
+      setQuery("");
+      setHits([]);
+      setActive(0);
+      // Focus the input on next tick so the dialog has rendered.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 30);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [open]);
+
+  /* debounced search ───────────────────────────────────── */
+
+  React.useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY) {
+      setHits([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const controller = new AbortController();
+    const id = window.setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/patients/search?q=${encodeURIComponent(trimmed)}`,
+          { signal: controller.signal, headers: { Accept: "application/json" } },
+        );
+        if (!res.ok) {
+          setHits([]);
+        } else {
+          const json = (await res.json()) as { patients?: PatientHit[] };
+          setHits(Array.isArray(json.patients) ? json.patients : []);
+        }
+      } catch (err) {
+        // Aborted searches are normal as the user keeps typing.
+        if ((err as { name?: string } | undefined)?.name !== "AbortError") {
+          setHits([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(id);
+    };
+  }, [open, query]);
+
+  /* keyboard nav inside the picker ─────────────────────── */
+
+  const navigateTo = React.useCallback(
+    (p: PatientHit) => {
+      setOpen(false);
+      router.push(`/clinic/patients/${p.id}`);
+    },
+    [router],
+  );
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (hits.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => (i + 1) % hits.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => (i - 1 + hits.length) % hits.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const hit = hits[active];
+      if (hit) navigateTo(hit);
+    }
+  };
+
+  const showEmpty = query.trim().length >= MIN_QUERY && !loading && hits.length === 0;
+  const showPrompt = query.trim().length < MIN_QUERY;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        className={cn(
+          "max-w-lg w-full p-0 overflow-hidden",
+          "rounded-2xl border border-border bg-surface shadow-2xl",
+        )}
+      >
+        <DialogTitle className="sr-only">Quick-jump to a patient</DialogTitle>
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-border/70">
+          <SearchIcon className="h-4 w-4 text-text-muted shrink-0" />
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setActive(0);
+            }}
+            onKeyDown={onInputKeyDown}
+            placeholder="Search patients by name, phone, email, or DOB…"
+            aria-label="Search patients"
+            className={cn(
+              "flex-1 bg-transparent outline-none text-[15px] placeholder:text-text-subtle text-text",
+            )}
+          />
+          <kbd className="hidden md:inline font-mono text-[10px] text-text-subtle bg-surface-muted px-1.5 py-0.5 rounded">
+            esc
+          </kbd>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto">
+          {showPrompt && (
+            <div className="px-4 py-6 text-center text-sm text-text-subtle">
+              Type at least {MIN_QUERY} characters to find a patient.
+            </div>
+          )}
+          {loading && !showPrompt && (
+            <div className="px-4 py-6 text-center text-sm text-text-subtle">
+              Searching…
+            </div>
+          )}
+          {showEmpty && (
+            <div className="px-4 py-6 text-center text-sm text-text-subtle">
+              No patients match "{query}".
+            </div>
+          )}
+          {!showPrompt && !loading && hits.length > 0 && (
+            <ul role="listbox" aria-label="Patient matches" className="py-1">
+              {hits.map((p, i) => {
+                const isActive = i === active;
+                return (
+                  <li key={p.id} role="option" aria-selected={isActive}>
+                    <button
+                      type="button"
+                      onMouseEnter={() => setActive(i)}
+                      onClick={() => navigateTo(p)}
+                      className={cn(
+                        "w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors",
+                        isActive
+                          ? "bg-accent-soft/40"
+                          : "hover:bg-surface-muted/60",
+                      )}
+                    >
+                      <Avatar
+                        firstName={p.firstName}
+                        lastName={p.lastName}
+                        size="sm"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-text truncate">
+                          {p.firstName} {p.lastName}
+                        </div>
+                        <div className="text-[11px] text-text-subtle truncate">
+                          {p.dateOfBirth ? `DOB ${p.dateOfBirth}` : ""}
+                          {p.dateOfBirth && (p.email || p.phone) ? " · " : ""}
+                          {p.email ?? p.phone ?? ""}
+                        </div>
+                      </div>
+                      {isActive && (
+                        <kbd className="font-mono text-[10px] text-text-subtle bg-surface-muted px-1.5 py-0.5 rounded">
+                          ↵
+                        </kbd>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="px-4 py-2 border-t border-border/70 flex items-center justify-between text-[10px] text-text-subtle">
+          <span>
+            <kbd className="font-mono">↑↓</kbd> navigate{" "}
+            <kbd className="font-mono ml-1">↵</kbd> open
+          </span>
+          <span>Quick-jump · g j</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ───────────────────────────────────────── tiny inline icon */
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M13.5 13.5L10.5 10.5" />
+    </svg>
+  );
+}

--- a/src/components/patient/recent-patients-strip.tsx
+++ b/src/components/patient/recent-patients-strip.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * Recently-viewed patients strip — Linear's recent-pages strip × Notion's
+ * quick-find affordance, mounted under the main nav inside the clinician
+ * layout. Pairs with `<QuickJump />` (this same folder) for the search
+ * picker; the two share `src/lib/patient/recent-patients-store.ts`.
+ *
+ * Design notes:
+ *   • Horizontal scroll, hairline border, sticky in the clinician top bar.
+ *   • Per-user localStorage key — versioned + scoped to userId so a shared
+ *     workstation never bleeds chips across providers.
+ *   • Pinned chips stick to the left (max 3); pin/unpin via the chip X.
+ *   • Empty state with a soft prompt to open the picker.
+ *   • Apple-iOS feel: subtle hover lift, hairline borders, snug spacing.
+ *   • Reduced-motion: instant chip animations (no Y-translate, no spring).
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { Avatar } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils/cn";
+import {
+  MAX_PINS,
+  STRIP_VISIBLE,
+  formatChipTimestamp,
+  readRecents,
+  removeRecent,
+  subscribeToRecents,
+  togglePin,
+  type RecentPatient,
+} from "@/lib/patient/recent-patients-store";
+import { QuickJump, QUICK_JUMP_OPEN_EVENT } from "./quick-jump";
+
+export interface RecentPatientsStripProps {
+  userId: string;
+  className?: string;
+}
+
+function splitName(name: string): { first: string; last: string } {
+  const [first, ...rest] = name.split(" ");
+  return { first: first ?? "", last: rest.join(" ") };
+}
+
+function openQuickJump() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(QUICK_JUMP_OPEN_EVENT));
+}
+
+export function RecentPatientsStrip({
+  userId,
+  className,
+}: RecentPatientsStripProps) {
+  const [items, setItems] = React.useState<RecentPatient[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+  // Re-render every 60s so timestamps stay fresh without a heavy event bus.
+  const [, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    setItems(readRecents(userId));
+    setHydrated(true);
+    const unsub = subscribeToRecents(userId, () =>
+      setItems(readRecents(userId)),
+    );
+    const tick = window.setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => {
+      unsub();
+      window.clearInterval(tick);
+    };
+  }, [userId]);
+
+  // Avoid SSR/CSR hydration mismatch — strip is purely client-side.
+  if (!hydrated) {
+    return (
+      <div
+        aria-hidden="true"
+        className={cn(
+          "h-12 border-b border-border/60 bg-surface/60 backdrop-blur",
+          className,
+        )}
+      />
+    );
+  }
+
+  const visible = items.slice(0, STRIP_VISIBLE);
+  const pinnedCount = items.filter((it) => it.pinnedAt !== null).length;
+  const isEmpty = visible.length === 0;
+
+  return (
+    <>
+      <div
+        data-testid="recent-patients-strip"
+        className={cn(
+          // hairline border + iOS-style frosted surface
+          "border-b border-border/60 bg-surface/70 backdrop-blur supports-[backdrop-filter]:bg-surface/55",
+          className,
+        )}
+      >
+        <div className="flex items-center gap-2 px-4 py-2 overflow-x-auto scrollbar-thin">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-text-subtle shrink-0 mr-1">
+            Recent
+          </span>
+
+          {isEmpty ? (
+            <button
+              type="button"
+              onClick={openQuickJump}
+              className={cn(
+                "shrink-0 inline-flex items-center gap-2 rounded-full px-3 py-1.5",
+                "text-xs text-text-muted bg-surface-muted/60 border border-dashed border-border",
+                "hover:text-text hover:bg-surface-muted transition-colors",
+              )}
+            >
+              <span aria-hidden="true">＋</span>
+              <span>Jump to a patient to start your history</span>
+            </button>
+          ) : (
+            <ul
+              className="flex items-center gap-1.5 shrink-0"
+              role="list"
+              aria-label="Recently viewed patients"
+            >
+              {visible.map((p) => (
+                <li key={p.id}>
+                  <RecentChip
+                    patient={p}
+                    canPinMore={pinnedCount < MAX_PINS}
+                    userId={userId}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="flex-1 min-w-2" aria-hidden="true" />
+
+          <button
+            type="button"
+            onClick={openQuickJump}
+            className={cn(
+              "shrink-0 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1",
+              "text-[11px] font-medium text-text-muted",
+              "hover:text-text hover:bg-surface-muted/70 transition-colors",
+            )}
+            aria-label="Open patient quick-jump (g j)"
+            title="Quick-jump (g j)"
+          >
+            <SearchIcon className="h-3.5 w-3.5" />
+            <span>Find</span>
+            <kbd className="hidden md:inline font-mono text-[10px] text-text-subtle bg-surface-muted px-1 py-0.5 rounded ml-0.5">
+              g j
+            </kbd>
+          </button>
+
+          <Link
+            href="/clinic/patients"
+            className="shrink-0 text-[11px] font-medium text-accent hover:underline px-2 py-1"
+          >
+            View all →
+          </Link>
+        </div>
+      </div>
+
+      <QuickJump />
+    </>
+  );
+}
+
+/* ───────────────────────────────────────── chip */
+
+function RecentChip({
+  patient,
+  canPinMore,
+  userId,
+}: {
+  patient: RecentPatient;
+  canPinMore: boolean;
+  userId: string;
+}) {
+  const reduce = useReducedMotion() ?? false;
+  const { first, last } = splitName(patient.name);
+  const isPinned = patient.pinnedAt !== null;
+
+  const handleSecondary = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isPinned) {
+      togglePin(userId, patient.id);
+      return;
+    }
+    // Unpinned: try to pin (until cap); if cap reached, dismiss instead.
+    if (canPinMore) {
+      togglePin(userId, patient.id);
+    } else {
+      removeRecent(userId, patient.id);
+    }
+  };
+
+  return (
+    <motion.div
+      initial={reduce ? false : { opacity: 0, y: 4 }}
+      animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      transition={reduce ? { duration: 0 } : { duration: 0.18, ease: "easeOut" }}
+      whileHover={reduce ? undefined : { y: -1 }}
+      className="relative group"
+    >
+      <Link
+        href={`/clinic/patients/${patient.id}`}
+        className={cn(
+          "inline-flex items-center gap-2 pl-1.5 pr-2.5 py-1 rounded-full",
+          "bg-surface border border-border",
+          "hover:border-border-strong hover:shadow-sm transition-all",
+          isPinned && "ring-1 ring-accent/30 border-accent/40",
+        )}
+      >
+        <Avatar
+          firstName={first}
+          lastName={last}
+          size="sm"
+          src={patient.avatarUrl ?? undefined}
+        />
+        <span className="flex flex-col leading-tight">
+          <span className="text-xs font-medium text-text truncate max-w-[140px]">
+            {patient.name}
+          </span>
+          <span className="text-[10px] text-text-subtle">
+            {isPinned ? "Pinned" : formatChipTimestamp(patient.viewedAt)}
+          </span>
+        </span>
+      </Link>
+
+      <button
+        type="button"
+        onClick={handleSecondary}
+        title={
+          isPinned
+            ? "Unpin"
+            : canPinMore
+            ? `Pin (max ${MAX_PINS})`
+            : "Dismiss"
+        }
+        aria-label={
+          isPinned
+            ? `Unpin ${patient.name}`
+            : canPinMore
+            ? `Pin ${patient.name} (max ${MAX_PINS} pins)`
+            : `Dismiss ${patient.name}`
+        }
+        className={cn(
+          "absolute -top-1 -right-1 h-4 w-4 rounded-full",
+          "bg-surface border border-border text-[9px] leading-none",
+          "text-text-muted hover:text-text hover:border-border-strong",
+          "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity",
+          "flex items-center justify-center",
+        )}
+      >
+        {isPinned ? "📌" : canPinMore ? "+" : "×"}
+      </button>
+    </motion.div>
+  );
+}
+
+/* ───────────────────────────────────────── tiny inline icon */
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M13.5 13.5L10.5 10.5" />
+    </svg>
+  );
+}

--- a/src/components/patient/track-chart-view.tsx
+++ b/src/components/patient/track-chart-view.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * Thin client effect that pushes the current patient chart to the
+ * versioned per-user "recently viewed" store consumed by
+ * `<RecentPatientsStrip />` and `<QuickJump />`.
+ *
+ * The patient chart `page.tsx` runs server-side — this drop-in tracker
+ * lets the server hand us the resolved patient details and we record the
+ * view on mount. The store itself dedupes views within 30s so a
+ * re-render of the chart page doesn't churn the recents list.
+ *
+ * This is *additional* to the older `<TrackPatientView />` shell tracker
+ * (which feeds the sidebar's name-only list). Both are no-cost effects.
+ */
+
+import * as React from "react";
+import { recordPatientView } from "@/lib/patient/recent-patients-store";
+
+export interface TrackChartViewProps {
+  userId: string;
+  patientId: string;
+  patientName: string;
+  avatarUrl?: string | null;
+}
+
+export function TrackChartView({
+  userId,
+  patientId,
+  patientName,
+  avatarUrl,
+}: TrackChartViewProps) {
+  React.useEffect(() => {
+    recordPatientView(userId, patientId, patientName, avatarUrl ?? null);
+  }, [userId, patientId, patientName, avatarUrl]);
+  return null;
+}

--- a/src/lib/patient/recent-patients-store.ts
+++ b/src/lib/patient/recent-patients-store.ts
@@ -1,0 +1,199 @@
+"use client";
+
+/**
+ * Per-user, versioned localStorage store for the "recently viewed patients"
+ * strip + quick-jump picker. Distinct from the older sidebar tracker in
+ * `src/components/shell/recent-patients.tsx` — that one keeps a flat,
+ * un-versioned list of 5 names with no pins or avatars; this one carries
+ * avatar URLs, pin state, viewedAt timestamps, and is keyed by user so a
+ * shared workstation never bleeds one clinician's recents into another's.
+ *
+ * Storage shape (JSON under `emr.recents.patients.v1.<userId>`):
+ *   { version: 1, items: RecentPatient[] }
+ *
+ * Order: pinned-first (in pin order), then unpinned newest-first.
+ * Caps: MAX_PINS = 3, MAX_TOTAL = 12 (strip shows 8 + headroom for pins).
+ */
+
+export const RECENTS_VERSION = 1;
+export const MAX_PINS = 3;
+export const MAX_TOTAL = 12;
+export const STRIP_VISIBLE = 8;
+/** Skip duplicate writes within this many ms — prevents re-render churn. */
+export const DEDUPE_MS = 30_000;
+/** Custom event name the strip listens on for same-tab updates. */
+export const UPDATE_EVENT = "emr:recents:patients:updated";
+
+export interface RecentPatient {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  viewedAt: number;
+  /** When pinned: position in the pin ordering (smaller = leftmost). */
+  pinnedAt: number | null;
+}
+
+function storageKey(userId: string): string {
+  // Anonymous / unauthed fallback so SSR rendering doesn't blow up.
+  const safe = userId && userId.length > 0 ? userId : "anon";
+  return `emr.recents.patients.v${RECENTS_VERSION}.${safe}`;
+}
+
+function safeRead(userId: string): RecentPatient[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      parsed.version !== RECENTS_VERSION ||
+      !Array.isArray(parsed.items)
+    ) {
+      return [];
+    }
+    return parsed.items.filter(
+      (it: unknown): it is RecentPatient =>
+        !!it &&
+        typeof it === "object" &&
+        typeof (it as RecentPatient).id === "string" &&
+        typeof (it as RecentPatient).name === "string" &&
+        typeof (it as RecentPatient).viewedAt === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function safeWrite(userId: string, items: RecentPatient[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      storageKey(userId),
+      JSON.stringify({ version: RECENTS_VERSION, items }),
+    );
+    window.dispatchEvent(new CustomEvent(UPDATE_EVENT));
+  } catch {
+    /* quota / private mode — silently skip */
+  }
+}
+
+/**
+ * Sort: pinned first by `pinnedAt` ascending (older pins to the left),
+ * then unpinned by `viewedAt` descending (most recent first).
+ */
+function sortRecents(items: RecentPatient[]): RecentPatient[] {
+  return [...items].sort((a, b) => {
+    if (a.pinnedAt && b.pinnedAt) return a.pinnedAt - b.pinnedAt;
+    if (a.pinnedAt) return -1;
+    if (b.pinnedAt) return 1;
+    return b.viewedAt - a.viewedAt;
+  });
+}
+
+/**
+ * Push a fresh view to the front of the recents list. If the patient was
+ * viewed within `DEDUPE_MS`, this is a no-op (prevents re-render duplicates).
+ */
+export function recordPatientView(
+  userId: string,
+  patientId: string,
+  name: string,
+  avatarUrl: string | null = null,
+): void {
+  if (!patientId || !name) return;
+  const current = safeRead(userId);
+  const existing = current.find((p) => p.id === patientId);
+  const now = Date.now();
+  if (existing && now - existing.viewedAt < DEDUPE_MS) return;
+
+  const withoutThis = current.filter((p) => p.id !== patientId);
+  const next: RecentPatient = {
+    id: patientId,
+    name,
+    avatarUrl: avatarUrl ?? existing?.avatarUrl ?? null,
+    viewedAt: now,
+    pinnedAt: existing?.pinnedAt ?? null,
+  };
+
+  // Pinned entries are preserved verbatim except for the just-viewed one.
+  const merged = sortRecents([...withoutThis, next]).slice(0, MAX_TOTAL);
+  safeWrite(userId, merged);
+}
+
+export function readRecents(userId: string): RecentPatient[] {
+  return sortRecents(safeRead(userId));
+}
+
+/**
+ * Toggle pin state for a patient already in the list. Caps the total
+ * pinned count at MAX_PINS — calling pin on a 4th patient is a no-op.
+ */
+export function togglePin(userId: string, patientId: string): void {
+  const current = safeRead(userId);
+  const idx = current.findIndex((p) => p.id === patientId);
+  if (idx < 0) return;
+  const target = current[idx];
+  if (!target) return;
+
+  const isPinned = target.pinnedAt !== null;
+  if (!isPinned) {
+    const pinnedCount = current.filter((p) => p.pinnedAt !== null).length;
+    if (pinnedCount >= MAX_PINS) return; // honor cap silently
+  }
+
+  const updated: RecentPatient = {
+    ...target,
+    pinnedAt: isPinned ? null : Date.now(),
+  };
+  const next = sortRecents([
+    ...current.slice(0, idx),
+    updated,
+    ...current.slice(idx + 1),
+  ]);
+  safeWrite(userId, next);
+}
+
+/**
+ * Remove a patient from the recents list entirely.
+ * Used by the strip's "unpin and dismiss" affordance (chip X when unpinned).
+ */
+export function removeRecent(userId: string, patientId: string): void {
+  const next = safeRead(userId).filter((p) => p.id !== patientId);
+  safeWrite(userId, next);
+}
+
+/** Friendly relative-time label suitable for chip subtitles. */
+export function formatChipTimestamp(viewedAt: number, now: number = Date.now()): string {
+  const diffMs = Math.max(0, now - viewedAt);
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 1) return "Just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks}w ago`;
+  return new Date(viewedAt).toLocaleDateString();
+}
+
+/** Convenience helper to subscribe to storage changes for a given user. */
+export function subscribeToRecents(
+  userId: string,
+  cb: () => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const sameTab = () => cb();
+  const crossTab = (e: StorageEvent) => {
+    if (e.key === storageKey(userId)) cb();
+  };
+  window.addEventListener(UPDATE_EVENT, sameTab);
+  window.addEventListener("storage", crossTab);
+  return () => {
+    window.removeEventListener(UPDATE_EVENT, sameTab);
+    window.removeEventListener("storage", crossTab);
+  };
+}

--- a/src/lib/ui/keyboard.ts
+++ b/src/lib/ui/keyboard.ts
@@ -52,6 +52,7 @@ export const GLOBAL_SHORTCUTS: ShortcutDescriptor[] = [
   { section: "Navigation", keys: "g h", label: "Go home", description: "Open the clinic overview" },
   { section: "Navigation", keys: "g m", label: "Go to messages", description: "Open the clinical inbox" },
   { section: "Navigation", keys: "g p", label: "Go to patients", description: "Open the patient roster" },
+  { section: "Navigation", keys: "g j", label: "Quick-jump to patient", description: "Open the patient quick-jump picker" },
   { section: "Navigation", keys: "g s", label: "Go to sign-off", description: "Open the unified sign-off queue" },
   { section: "Navigation", keys: "g a", label: "Go to approvals", description: "Open AI draft approvals" },
   { section: "Navigation", keys: "g b", label: "Go to morning brief", description: "Open today's agenda" },


### PR DESCRIPTION
## Summary

Persistent patient-navigation affordances mounted in the clinician shell, complementary to the command palette's patient search row (PR #466).

- **`<RecentPatientsStrip />`** — horizontal scrollable strip under the clinician top nav. Shows the last 8 patients the clinician viewed, with avatar (initials fallback) + name + relative timestamp ("3m ago", "Yesterday"). Pinned chips stick to the left (max 3); chip X toggles pin / dismiss. Right-edge "View all" links to roster.
- **`<QuickJump />`** — patient-only modal picker. Debounced server search against `/api/patients/search`, keyboard nav (`↑↓`, `↵`), opens via `g j` chord or the strip's "Find" button. Returns name, DOB, contact.
- **Per-user versioned localStorage** — `emr.recents.patients.v1.<userId>`. Shared workstations never bleed history across providers.
- **30s dedupe** in the chart-view tracker prevents re-render churn.

### Files
- `src/lib/patient/recent-patients-store.ts` — versioned, per-user store with pin cap + sort + same-tab/cross-tab subscribe.
- `src/components/patient/recent-patients-strip.tsx`
- `src/components/patient/quick-jump.tsx`
- `src/components/patient/track-chart-view.tsx`
- Integration: `src/app/(clinician)/layout.tsx` (mount), `src/app/(clinician)/clinic/patients/[id]/page.tsx` (record view), `src/lib/ui/keyboard.ts` (documents `g j`).

### Why `g j` and not `g p`
`g p` already routes to `/clinic/patients` (the roster) via `G_LEADER_ROUTES`. Re-binding it would double-fire. `g j` ("jump") is non-conflicting, complements the documented set, and is registered in the keyboard help cheat sheet.

### Style
Hairline border under the strip, frosted iOS-style surface, subtle hover lift on chips. `useReducedMotion` honored — animations collapse to instant.

## Test plan
- [ ] Open any patient chart → patient appears as leftmost chip on next page load
- [ ] Re-render same chart within 30s → no duplicate write
- [ ] Pin a chip → moves to the left and persists on reload
- [ ] Pin a 4th chip → silently rejected (cap = 3)
- [ ] Press `g j` (no modifier, no input focus) → picker opens
- [ ] Type ≥2 chars → debounced fetch, `↑↓` navigates, `↵` opens chart
- [ ] Reduced-motion preference → chips appear without translate/spring
- [ ] Sign in as a different user → empty strip (per-user key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)