### PR TITLE
ux: density-mode hook + adoption in 6-8 list/dashboard surfaces

### DIFF
--- a/src/app/(clinician)/clinic/audit-trail/audit-view.tsx
+++ b/src/app/(clinician)/clinic/audit-trail/audit-view.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
+import { useDensity, densityClass } from "@/lib/ui/density";
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -181,8 +182,10 @@ export function AuditTrailView({
     URL.revokeObjectURL(url);
   }, [filteredLogs]);
 
+  const { density } = useDensity();
+
   return (
-    <div>
+    <div className={densityClass(density)}>
       {/* Header */}
       <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-5 mb-10">
         <div className="max-w-2xl">
@@ -338,7 +341,10 @@ export function AuditTrailView({
 
                     return (
                       <tr key={log.id} className="group">
-                        <td className="py-3 px-5" colSpan={6}>
+                        <td
+                          className="py-3 px-5 [.density-dense_&]:py-1.5 [.density-dense_&]:px-3"
+                          colSpan={6}
+                        >
                           <div className="flex items-start gap-4">
                             {/* Expand button */}
                             <button

--- a/src/app/(clinician)/clinic/communications/channels-density-frame.tsx
+++ b/src/app/(clinician)/clinic/communications/channels-density-frame.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { useDensity, densityClass } from "@/lib/ui/density";
+
+/**
+ * Thin client wrapper that toggles a density class on the
+ * communications-hub channel card grid so each Card's children pick up
+ * the tighter padding via the descendant selectors in `kpi-card.tsx`
+ * pattern, plus the `--density-card-gap` variable for inter-card spacing.
+ */
+export function ChannelsDensityFrame({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { density } = useDensity();
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 lg:grid-cols-3 density-grid mb-8",
+        densityClass(density),
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/communications/page.tsx
+++ b/src/app/(clinician)/clinic/communications/page.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { MetricTile } from "@/components/ui/metric-tile";
 import { CommsRecentClient } from "./comms-recent-client";
+import { ChannelsDensityFrame } from "./channels-density-frame";
 
 export const metadata = { title: "Communications" };
 
@@ -164,7 +165,7 @@ export default async function CommunicationsPage() {
         </Link>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
+      <ChannelsDensityFrame>
         <ChannelCard
           title="Text — Patient Inbox"
           description="AI-triaged secure messaging with patients."
@@ -211,7 +212,7 @@ export default async function CommunicationsPage() {
           href="/clinic/communications/broadcasts"
           cta="Open broadcast"
         />
-      </div>
+      </ChannelsDensityFrame>
 
       <CommsRecentClient
         calls={recentCalls.map((call) => ({
@@ -265,8 +266,13 @@ function ChannelCard({
   cta: string;
   highlight?: boolean;
 }) {
+  // When mounted inside `.density-dense`, collapse the default Card
+  // header/content padding so more channel tiles fit above the fold.
   return (
-    <Card tone={highlight ? "raised" : "default"}>
+    <Card
+      tone={highlight ? "raised" : "default"}
+      className="[.density-dense_&]:[&_>div]:py-2 [.density-dense_&]:[&_>div]:px-4"
+    >
       <CardHeader>
         <CardTitle className="text-base">{title}</CardTitle>
         <CardDescription>{description}</CardDescription>

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -39,6 +39,7 @@ import { ExportModal, type ExportableMessage } from "./export-modal";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { BulkActionBar, useBulkSelection } from "@/components/ui/bulk-action-bar";
 import { useToast } from "@/components/ui/toast";
+import { useDensity, densityClass } from "@/lib/ui/density";
 import {
   useContextMenu,
   ContextMenuIcons,
@@ -897,7 +898,7 @@ function ThreadInboxRow({
         onTouchEnd={ctx.triggerProps.onTouchEnd}
         onTouchMove={ctx.triggerProps.onTouchMove}
         className={cn(
-          "w-full text-left px-4 py-3 border-b border-border/60 transition-colors hover:bg-surface-muted",
+          "w-full text-left density-row border-b border-border/60 transition-colors hover:bg-surface-muted",
           "border-l-[3px]",
           PRIORITY_BORDER_COLORS[t.priority],
           isSelected && "bg-surface-muted",
@@ -1007,6 +1008,10 @@ export function SmartInboxView({
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>(initialPriority);
   const [categoryFilter, setCategoryFilter] = useState<MessageCategory | "all">("all");
   const [search, setSearch] = useState("");
+  // Inbox respects the user's global Comfortable/Dense preference —
+  // each thread row reads `--density-row-py` to compute its vertical
+  // padding (see smart-inbox thread <button> classname).
+  const { density } = useDensity();
   // EMR-DnD: clinician-pinned threads bubble to the top of the list,
   // beating priority-based smart sort. Persisted in localStorage as a
   // Set<threadId>. TODO(schema): mirror to a `MessageThread.pinnedBy`
@@ -1360,7 +1365,7 @@ export function SmartInboxView({
           }}
         />
       )}
-    <div className="space-y-4">
+    <div className={cn("space-y-4", densityClass(density))}>
       {/* Top bar: filters + stats */}
       <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
         {/* Left: priority pills + category + search */}

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/empty-illustrations";
 import { Button } from "@/components/ui/button";
 import { patientMatchesQuery } from "@/lib/search/patient-search";
+import { useDensity, densityClass } from "@/lib/ui/density";
+import { cn } from "@/lib/utils/cn";
 import { UniversalPatientSearch } from "@/components/clinic/UniversalPatientSearch";
 import { BulkActionBar, useBulkSelection } from "@/components/ui/bulk-action-bar";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -331,6 +333,9 @@ export function PatientListClient({
   const [search, setSearch] = useState(initialSearch);
   const [powerFilter, setPowerFilter] = useState<PowerFilter>("all");
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  // Density preference — propagates to the roster cards' vertical
+  // breathing room via CSS variables defined in globals.css.
+  const { density } = useDensity();
   // Shared motion: stagger the roster fan-in. No-op under reduced motion.
   const reduceMotion = useReducedMotion() ?? false;
   const listStaggerProps = useMemo(() => listStagger(reduceMotion), [reduceMotion]);
@@ -589,7 +594,7 @@ export function PatientListClient({
   /*  Render                                                           */
   /* ---------------------------------------------------------------- */
   return (
-    <div className="space-y-6">
+    <div className={cn("space-y-6", densityClass(density))}>
       {/* Summary metric tiles */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <MetricTile
@@ -746,7 +751,7 @@ export function PatientListClient({
                         handleRowToggle(p.id, { shift: true });
                       }
                     }}
-                    className={`card-hover flex items-center gap-4 px-5 py-4 transition-colors duration-150 group ${
+                    className={`card-hover flex items-center gap-4 density-row transition-colors duration-150 group ${
                       isSelected
                         ? "bg-accent-soft/40"
                         : "hover:bg-surface-muted/50"

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/cn";
+import { useDensity, densityClass } from "@/lib/ui/density";
 
 export type SignOffRow = {
   id: string;
@@ -46,6 +47,7 @@ function formatRelative(iso: string): string {
 export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState<Set<SignOffRow["kind"]>>(new Set());
+  const { density } = useDensity();
 
   const selected = rows.find((r) => r.id === selectedId) ?? null;
 
@@ -65,7 +67,7 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
   };
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className={cn("flex h-full overflow-hidden", densityClass(density))}>
       {/* Tree (left) */}
       <div className="w-72 shrink-0 border-r border-border overflow-y-auto bg-surface">
         {groups.map((group) => {
@@ -104,7 +106,7 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
                         type="button"
                         onClick={() => setSelectedId(item.id === selectedId ? null : item.id)}
                         className={cn(
-                          "w-full text-left px-4 py-2.5 border-b border-border/40 transition-colors",
+                          "w-full text-left density-row border-b border-border/40 transition-colors",
                           selectedId === item.id
                             ? "bg-accent/10"
                             : "hover:bg-surface-muted/60"

--- a/src/app/(operator)/ops/queue/queue-board.tsx
+++ b/src/app/(operator)/ops/queue/queue-board.tsx
@@ -19,6 +19,7 @@ import {
   ContextMenuIcons,
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
+import { useDensity, densityClass } from "@/lib/ui/density";
 
 const COLUMN_ORDER: QueueStatus[] = [
   "scheduled",
@@ -57,6 +58,9 @@ function formatTime(iso: string): string {
 
 export function QueueBoard({ entries }: { entries: QueueEntry[] }) {
   const router = useRouter();
+  // Density preference — tightens both per-column gutters and per-card
+  // padding via the descendant selector on `QueueCard`.
+  const { density } = useDensity();
   // Bumping this state forces React to re-render the wait-time calculations
   // every minute without doing a full server round-trip in between refreshes.
   const [, setTick] = useState(0);
@@ -103,7 +107,12 @@ export function QueueBoard({ entries }: { entries: QueueEntry[] }) {
         description={`${inRooms} in rooms · ${waiting} waiting · ${done} completed today`}
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
+      <div
+        className={cn(
+          "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 density-grid",
+          densityClass(density),
+        )}
+      >
         {COLUMN_ORDER.map((status) => (
           <QueueColumn
             key={status}
@@ -241,7 +250,10 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
   return (
     <Card
       tone="raised"
-      className="px-3 py-2.5"
+      // Comfortable keeps the original feel; Dense halves vertical
+      // padding so the front-desk board can show ~50% more cards per
+      // column without scroll.
+      className="px-3 py-2.5 [.density-dense_&]:px-2 [.density-dense_&]:py-1.5"
       onContextMenu={ctx.triggerProps.onContextMenu}
       onTouchStart={ctx.triggerProps.onTouchStart}
       onTouchEnd={ctx.triggerProps.onTouchEnd}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1162,3 +1162,55 @@
     page-break-inside: avoid;
   }
 }
+
+/* -------------------------------------------------------------------
+ * Density-mode utilities (PR-follow-through to PR #467 / PR #460).
+ *
+ * Surfaces opt in by toggling `density-comfortable` or `density-dense`
+ * on their container (typically via `useDensity()` in
+ * `src/lib/ui/density.ts`). The CSS variables below let nested rows /
+ * tiles / cards consume a single tunable "step" instead of authoring
+ * two parallel className strings per surface.
+ * ------------------------------------------------------------------- */
+
+.density-comfortable {
+  --density-row-py: 0.875rem;   /* 14px — matches DataTable comfortable */
+  --density-row-px: 1rem;       /* 16px */
+  --density-row-gap: 0.625rem;  /* 10px */
+  --density-tile-py: 1rem;      /* 16px */
+  --density-tile-px: 1.25rem;   /* 20px */
+  --density-card-gap: 1rem;     /* 16px */
+  --density-stack-gap: 0.75rem; /* 12px */
+}
+
+.density-dense {
+  --density-row-py: 0.4375rem;  /* 7px — halves comfortable */
+  --density-row-px: 0.75rem;    /* 12px */
+  --density-row-gap: 0.375rem;  /* 6px */
+  --density-tile-py: 0.625rem;  /* 10px */
+  --density-tile-px: 0.875rem;  /* 14px */
+  --density-card-gap: 0.625rem; /* 10px */
+  --density-stack-gap: 0.5rem;  /* 8px */
+}
+
+/* Convenience helpers; surfaces can compose these without redefining
+ * every padding/gap rule. Authors are free to read the variables
+ * directly when they need to scope to a specific child. */
+.density-row {
+  padding-top: var(--density-row-py);
+  padding-bottom: var(--density-row-py);
+  padding-left: var(--density-row-px);
+  padding-right: var(--density-row-px);
+}
+.density-tile {
+  padding-top: var(--density-tile-py);
+  padding-bottom: var(--density-tile-py);
+  padding-left: var(--density-tile-px);
+  padding-right: var(--density-tile-px);
+}
+.density-stack > * + * {
+  margin-top: var(--density-stack-gap);
+}
+.density-grid {
+  gap: var(--density-card-gap);
+}

--- a/src/components/operator/kpi-card.tsx
+++ b/src/components/operator/kpi-card.tsx
@@ -75,7 +75,10 @@ export function KpiCard({
         "shadow-sm transition-all duration-200 ease-smooth",
         "hover:shadow-md hover:-translate-y-0.5 hover:border-border-strong",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-        "px-6 py-6",
+        // Padding falls back to the previous fixed 24px tile; when the
+        // tile is rendered inside a density container (`.density-*` on
+        // an ancestor) the CSS vars take over for a tighter dense pass.
+        "px-6 py-6 [.density-dense_&]:px-4 [.density-dense_&]:py-4",
         className,
       )}
     >

--- a/src/components/operator/owner-dashboard-density-frame.tsx
+++ b/src/components/operator/owner-dashboard-density-frame.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { useDensity, densityClass } from "@/lib/ui/density";
+
+/**
+ * Thin client wrapper so the otherwise-server-only OwnerDashboard can
+ * adopt the user's Comfortable/Dense preference without forcing the
+ * whole tree (and its KpiCard children) to become client components.
+ *
+ * Just toggles a density class on the grid container; the KpiCard
+ * descendant selector `[.density-dense_&]` in `kpi-card.tsx` handles
+ * the actual padding swap.
+ */
+export function OwnerDashboardDensityFrame({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { density } = useDensity();
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 density-grid",
+        densityClass(density),
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/operator/owner-dashboard.tsx
+++ b/src/components/operator/owner-dashboard.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { KpiCard, type KpiSeverity, type KpiTrend } from "./kpi-card";
+import { OwnerDashboardDensityFrame } from "./owner-dashboard-density-frame";
 import {
   computeTrend,
   denialSeverity,
@@ -140,13 +141,13 @@ export function OwnerDashboard({ snapshot }: OwnerDashboardProps) {
   };
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <OwnerDashboardDensityFrame>
       <KpiCard {...revenueCard} />
       <KpiCard {...denialsCard} />
       <KpiCard {...scheduleCard} />
       <KpiCard {...agentsCard} />
       <KpiCard {...patientsCard} />
       <KpiCard {...arCard} />
-    </div>
+    </OwnerDashboardDensityFrame>
   );
 }

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -46,6 +46,7 @@ import {
   useContextMenu,
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
+import { useDensity } from "@/lib/ui/density";
 
 // ----------------------------------------------------------------- types
 
@@ -252,10 +253,19 @@ export function DataTable<Row>({
   rowClassName,
   contextMenuItems,
 }: DataTableProps<Row>) {
-  // Density: support both controlled (prop) and uncontrolled-with-toggle.
+  // Density precedence (highest → lowest):
+  //   1. Explicit `density` prop (controlled by caller).
+  //   2. In-table density toggle (`internalDensity`) once the user clicks it.
+  //   3. The user's saved global preference from `useDensity()`.
+  //
+  // The global preference syncs across tabs and other surfaces, so a user
+  // who set "Dense" in /settings/preferences sees every DataTable in
+  // dense mode without per-table opt-in.
+  const { density: preferenceDensity } = useDensity();
   const [internalDensity, setInternalDensity] =
-    React.useState<DataTableDensity>("comfortable");
-  const density: DataTableDensity = densityProp ?? internalDensity;
+    React.useState<DataTableDensity | null>(null);
+  const density: DataTableDensity =
+    densityProp ?? internalDensity ?? preferenceDensity;
 
   // Tri-state sort: asc → desc → null.
   const [sort, setSort] = React.useState<SortState | null>(null);

--- a/src/lib/ui/density.ts
+++ b/src/lib/ui/density.ts
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * useDensity — single source of truth for the Comfortable / Dense UI mode.
+ *
+ * Reads/writes `localStorage.emr.prefs.v1.density` (same key as the
+ * preferences screen in `src/app/(clinician)/settings/preferences/`).
+ *
+ * Cross-tab/in-tab sync:
+ *   - `storage` events: native cross-tab.
+ *   - Custom DOM event `emr:density-change`: dispatched on every setter,
+ *     so other consumers in the SAME tab pick up changes immediately
+ *     (the native `storage` event does NOT fire in the originating tab).
+ *
+ * SSR-safe: defaults to "comfortable" until first useEffect runs.
+ */
+
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+export type Density = "comfortable" | "dense";
+
+export const DENSITY_STORAGE_KEY = "emr.prefs.v1.density";
+const DENSITY_EVENT = "emr:density-change";
+
+function isDensity(v: unknown): v is Density {
+  return v === "comfortable" || v === "dense";
+}
+
+function readDensity(): Density {
+  if (typeof window === "undefined") return "comfortable";
+  try {
+    const v = window.localStorage.getItem(DENSITY_STORAGE_KEY);
+    return isDensity(v) ? v : "comfortable";
+  } catch {
+    return "comfortable";
+  }
+}
+
+function writeDensity(next: Density): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DENSITY_STORAGE_KEY, next);
+  } catch {
+    // Safari private mode etc. — silently no-op.
+  }
+  try {
+    window.dispatchEvent(
+      new CustomEvent<Density>(DENSITY_EVENT, { detail: next }),
+    );
+  } catch {
+    // Ancient browsers — sync still happens on next render.
+  }
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === DENSITY_STORAGE_KEY) callback();
+  };
+  const onCustom = () => callback();
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(DENSITY_EVENT, onCustom as EventListener);
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(DENSITY_EVENT, onCustom as EventListener);
+  };
+}
+
+function getServerSnapshot(): Density {
+  return "comfortable";
+}
+
+/**
+ * Subscribe to the persisted density preference.
+ *
+ * - `density` updates whenever localStorage is mutated (here, in another
+ *   tab via `storage`, or anywhere via the custom event).
+ * - `setDensity(next)` persists + broadcasts.
+ */
+export function useDensity(): {
+  density: Density;
+  setDensity: (next: Density) => void;
+} {
+  const density = useSyncExternalStore(subscribe, readDensity, getServerSnapshot);
+
+  const setDensity = useCallback((next: Density) => {
+    writeDensity(next);
+  }, []);
+
+  // Keep <html data-density> mirrored so global CSS can hook on it if it
+  // wants to (preferences page already does this on its own mount, but
+  // any other route that hydrates first should also reflect the choice).
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.setAttribute("data-density", density);
+  }, [density]);
+
+  return { density, setDensity };
+}
+
+/**
+ * Resolve a class name for a container that should adopt density.
+ * Pass to `cn()` alongside your other classes.
+ */
+export function densityClass(density: Density): string {
+  return density === "dense" ? "density-dense" : "density-comfortable";
+}

--- a/src/lib/ui/density.ts
+++ b/src/lib/ui/density.ts
@@ -19,7 +19,7 @@ import { useCallback, useEffect, useSyncExternalStore } from "react";
 
 export type Density = "comfortable" | "dense";
 
-export const DENSITY_STORAGE_KEY = "emr.prefs.v1.density";
+export const DENSITY_STORAGE_KEY = "emr.prefs.v1.density"; // gitleaks:allow
 const DENSITY_EVENT = "emr:density-change";
 
 function isDensity(v: unknown): v is Density {


### PR DESCRIPTION
## Summary

Threads the Comfortable/Dense density preference (introduced in PR #467 for user preferences and PR #460 for the DataTable primitive) into more list/grid/dashboard surfaces.

- New `useDensity()` hook in `src/lib/ui/density.ts` reads `localStorage.emr.prefs.v1.density` (same key as PR #467), broadcasts a same-tab custom event for instant in-app sync and listens to native `storage` events for cross-tab sync.
- DataTable now falls back to the hook when no explicit `density` prop is passed — backwards compatible.
- New CSS variables in `globals.css` (`--density-row-py`, `--density-tile-py`, `--density-card-gap`, etc.) plus `density-row`, `density-tile`, `density-grid`, `density-stack` utility classes for surfaces to consume.

## Adopted surfaces

1. Patient roster cards (`/clinic/patients`)
2. Smart inbox thread rows (`/clinic/messages`)
3. Sign-off queue tree rows (`/clinic/sign-off`)
4. Owner dashboard KPI tiles (`/ops`) — via small client frame so the server-rendered dashboard can still adopt without becoming client-only
5. Communications hub channel cards (`/clinic/communications`)
6. Operator queue board cards (`/ops/queue`)
7. Audit log rows (`/clinic/audit-trail`)

## Test plan

- [ ] Toggle Density in `/settings/preferences` and verify each surface above visibly tightens.
- [ ] Open the app in two tabs; flip density in one — the other should re-render (cross-tab `storage` event).
- [ ] Existing DataTable callers without `density` prop now follow the global pref; callers that pass an explicit prop still win.
- [ ] Comfortable matches today's visual baseline; Dense halves vertical padding without overflowing avatars or controls.

## Out of scope

- No schema changes (no `User.preferences` column yet — preserves PR #467's localStorage-only stance).
- No new dependencies.
- `/ops/supplies` intentionally untouched (PR #438 territory).