### PR TITLE
ux: ConfirmDialog + useConfirm hook (3 severity tiers + typed confirmation) + 8 adoptions

### DIFF
--- a/src/app/(clinician)/clinic/messages/resolve-button.tsx
+++ b/src/app/(clinician)/clinic/messages/resolve-button.tsx
@@ -8,6 +8,7 @@
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { resolveThread } from "./actions";
 
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
 export function ResolveButton({ threadId, isResolved }: Props) {
   const [pending, startTransition] = useTransition();
   const router = useRouter();
+  const confirm = useConfirm();
 
   if (isResolved) {
     return (
@@ -29,10 +31,14 @@ export function ResolveButton({ threadId, isResolved }: Props) {
     );
   }
 
-  const onClick = () => {
-    const ok = window.confirm(
-      "Mark this thread as resolved? It will be removed from the inbox until the patient sends a new message.",
-    );
+  const onClick = async () => {
+    const ok = await confirm({
+      title: "Mark this thread as resolved?",
+      description:
+        "It drops out of the inbox until the patient sends a new message.",
+      severity: "info",
+      confirmLabel: "Resolve",
+    });
     if (!ok) return;
     const fd = new FormData();
     fd.set("threadId", threadId);

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -38,6 +38,7 @@ import { ResolveButton } from "./resolve-button";
 import { ExportModal, type ExportableMessage } from "./export-modal";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { BulkActionBar, useBulkSelection } from "@/components/ui/bulk-action-bar";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useToast } from "@/components/ui/toast";
 import {
   useContextMenu,
@@ -1048,6 +1049,7 @@ export function SmartInboxView({
   const reduceMotion = useReducedMotion() ?? false;
   const listStaggerProps = useMemo(() => listStagger(reduceMotion), [reduceMotion]);
   const childVariants = useMemo(() => listStaggerChild(reduceMotion), [reduceMotion]);
+  const confirm = useConfirm();
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(
     initialThreadId ?? triaged[0]?.threadId ?? null,
   );
@@ -1526,15 +1528,16 @@ export function SmartInboxView({
                         setSelectedThreadId(t.threadId);
                       }}
                       onArchive={() => {
-                        if (
-                          typeof window !== "undefined" &&
-                          !window.confirm(
-                            `Archive the thread with ${t.patientName}? You can find it later under Archived.`,
-                          )
-                        ) {
-                          return;
-                        }
-                        setSelectedThreadId(null);
+                        void (async () => {
+                          const ok = await confirm({
+                            title: `Archive the thread with ${t.patientName}?`,
+                            description:
+                              "It moves off the active inbox. You can pull it back from Archived if they reply.",
+                            severity: "danger",
+                            confirmLabel: "Archive thread",
+                          });
+                          if (ok) setSelectedThreadId(null);
+                        })();
                       }}
                       onCopyLink={() => {
                         try {

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-preview.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-preview.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { formatSig, DEMO_PHARMACIES } from "@/lib/domain/e-prescribe";
 
 // EMR-350 — DEA schedule + controlled-substance gating.
@@ -79,21 +80,32 @@ export function RxPreview({
   const today = new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
   const deaSchedule = deriveDeaSchedule(productType, thcMg, cbdMg);
   const isControlled = deaSchedule !== null;
+  const confirm = useConfirm();
 
-  function handleSignClick() {
+  async function handleSignClick() {
     if (signing || signed) return;
     if (isControlled) {
       // Required confirmation step before signing a controlled prescription.
-      // Browser confirm() keeps the cleanup change small; we can swap in a
-      // bespoke modal once the prescribing surface gets its next pass.
-      const ok = window.confirm(
-        `This prescription is for a controlled substance (DEA Schedule ${deaSchedule}).\n\n` +
-          `By continuing you confirm:\n` +
-          `  • The patient and indication are correct\n` +
-          `  • Quantity and refills follow Schedule ${deaSchedule} limits\n` +
-          `  • You are authorized to prescribe this schedule in this state\n\n` +
-          `Sign and transmit?`,
-      );
+      // ConfirmDialog gives us accessible focus + theme-aware copy; the
+      // server-side DEA gate is still the source of truth.
+      const ok = await confirm({
+        title: `Sign Schedule ${deaSchedule} prescription?`,
+        description: (
+          <span>
+            This is a controlled substance. By continuing you attest that:
+            <ul className="mt-2 ml-4 list-disc space-y-0.5">
+              <li>the patient and indication are correct,</li>
+              <li>quantity and refills follow Schedule {deaSchedule} limits,</li>
+              <li>
+                you are authorized to prescribe Schedule {deaSchedule} in this
+                state.
+              </li>
+            </ul>
+          </span>
+        ),
+        severity: "warning",
+        confirmLabel: "Sign and transmit",
+      });
       if (!ok) return;
     }
     onSign();

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -30,6 +30,7 @@ import {
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
 import { useRouter } from "next/navigation";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -243,6 +244,7 @@ function PatientRosterRow({
   children: ReactNode;
 }) {
   const router = useRouter();
+  const confirm = useConfirm();
   const items: ContextMenuItem[] = [
     {
       label: "Open chart",
@@ -289,18 +291,23 @@ function PatientRosterRow({
       icon: ContextMenuIcons.Archive,
       danger: true,
       onSelect: (c) => {
-        if (
-          typeof window !== "undefined" &&
-          window.confirm(
-            `Archive ${patient.firstName} ${patient.lastName}? They will be hidden from the roster but their chart will be preserved.`,
-          )
-        ) {
+        // Close the context menu before opening the confirm so focus and
+        // overlay layering stay clean.
+        c();
+        void (async () => {
+          const ok = await confirm({
+            title: `Archive ${patient.firstName} ${patient.lastName}?`,
+            description:
+              "They drop off the active roster. The chart and all records stay intact — you can unarchive from their profile later.",
+            severity: "danger",
+            confirmLabel: "Archive patient",
+          });
+          if (!ok) return;
           // Mutation hook to be wired into the existing actions.ts —
           // for now we simply navigate to the chart so the clinician
           // can complete archival from the canonical surface.
           router.push(`/clinic/patients/${patient.id}?archive=1`);
-        }
-        c();
+        })();
       },
     },
   ];

--- a/src/app/(operator)/ops/api-keys/keys-view.tsx
+++ b/src/app/(operator)/ops/api-keys/keys-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input, FieldGroup } from "@/components/ui/input";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils/cn";
 
 type Scope = "read-only" | "read-write" | "admin";
@@ -224,23 +225,30 @@ export function KeysView() {
         </Modal>
       )}
 
-      {revokeTarget && (
-        <Modal onClose={() => setRevokeTarget(null)}>
-          <h2 className="font-display text-xl text-text mb-2">Revoke this key?</h2>
-          <p className="text-sm text-text-muted mb-4">
-            Revoking <span className="font-medium">{revokeTarget.label}</span> will immediately
-            invalidate any integration using it. This cannot be undone.
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={() => setRevokeTarget(null)}>
-              Cancel
-            </Button>
-            <Button variant="danger" onClick={confirmRevoke}>
-              Revoke key
-            </Button>
-          </div>
-        </Modal>
-      )}
+      {/* Revoke confirmation — uses the shared ConfirmDialog with a typed
+          confirmation gate so the operator has to retype the key label
+          before the destructive button enables. Stripe / GitHub pattern. */}
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={confirmRevoke}
+        title="Revoke this API key?"
+        description={
+          revokeTarget ? (
+            <span>
+              Any integration using{" "}
+              <span className="font-medium text-text">{revokeTarget.label}</span>{" "}
+              stops working the instant you revoke it. The key cannot be reissued
+              — you&rsquo;ll have to generate a new one.
+            </span>
+          ) : (
+            ""
+          )
+        }
+        severity="danger"
+        confirmLabel="Revoke key"
+        requireTypedConfirmation={revokeTarget?.label}
+      />
     </div>
   );
 }

--- a/src/app/(operator)/ops/queue/queue-board.tsx
+++ b/src/app/(operator)/ops/queue/queue-board.tsx
@@ -19,6 +19,7 @@ import {
   ContextMenuIcons,
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 const COLUMN_ORDER: QueueStatus[] = [
   "scheduled",
@@ -171,6 +172,7 @@ function QueueColumn({
 
 function QueueCard({ entry }: { entry: QueueEntry }) {
   const router = useRouter();
+  const confirm = useConfirm();
   const wait = entry.minutesWaiting;
   const waitClass = waitToneClass(wait);
 
@@ -226,13 +228,21 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
       icon: ContextMenuIcons.Archive,
       danger: true,
       onSelect: (c) => {
-        if (
-          typeof window !== "undefined" &&
-          window.confirm(`Cancel ${entry.patientName}'s visit?`)
-        ) {
-          router.refresh();
-        }
+        // Close the context menu first so the confirm dialog can take focus
+        // cleanly. Then prompt — if confirmed, refresh the board so the
+        // entry drops out of the column.
         c();
+        void (async () => {
+          const ok = await confirm({
+            title: `Cancel ${entry.patientName}'s visit?`,
+            description:
+              "They'll be removed from today's queue. You'll need to reschedule from their chart if they still want to be seen.",
+            severity: "danger",
+            confirmLabel: "Cancel visit",
+            cancelLabel: "Keep on queue",
+          });
+          if (ok) router.refresh();
+        })();
       },
     },
   ];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { UniversalFeedbackFab } from "@/components/feedback/UniversalFeedbackFab
 import { ClerkProvider } from "@clerk/nextjs";
 import { CookieConsent } from "@/components/layout/CookieConsent";
 import { ToastProvider } from "@/components/ui/toast";
+import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 
 export const metadata: Metadata = {
   title: {
@@ -93,9 +94,11 @@ export default function RootLayout({
           Skip to content
         </a>
         <ToastProvider>
-          {children}
-          <UniversalFeedbackFab />
-          <CookieConsent />
+          <ConfirmProvider>
+            {children}
+            <UniversalFeedbackFab />
+            <CookieConsent />
+          </ConfirmProvider>
         </ToastProvider>
       </body>
     </html>

--- a/src/app/leafmart/account/addresses/page.tsx
+++ b/src/app/leafmart/account/addresses/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 import { AccountSidebar } from "@/components/leafmart/AccountSidebar";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 interface Address {
   id: string;
@@ -52,6 +53,7 @@ function labelClass() {
 }
 
 export default function AddressesPage() {
+  const confirm = useConfirm();
   const [addresses, setAddresses] = useState<Address[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -141,7 +143,14 @@ export default function AddressesPage() {
   }
 
   async function remove(id: string) {
-    if (!window.confirm("Delete this address?")) return;
+    const ok = await confirm({
+      title: "Delete this address?",
+      description:
+        "Future orders won't be able to ship here. You can always add it again.",
+      severity: "danger",
+      confirmLabel: "Delete address",
+    });
+    if (!ok) return;
     await fetch(`/api/leafmart/addresses/${id}`, { method: "DELETE" });
     await refresh();
   }

--- a/src/components/super-admin/view-as-practice-button.tsx
+++ b/src/components/super-admin/view-as-practice-button.tsx
@@ -18,6 +18,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 
 interface Props {
   /**
@@ -32,18 +33,21 @@ interface Props {
 
 export function ViewAsPracticeButton({ practiceOrgId, practiceName }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  function handleClick() {
+  async function handleClick() {
     // Confirm to prevent accidental clicks — impersonation writes an
     // audit row that the user can't undo, so making the action
     // intentional is cheap insurance.
-    const ok = window.confirm(
-      `Enter "View as practice" mode for ${practiceName}?\n\n` +
-        "Your super-admin identity remains the audit attribution. " +
-        "Session auto-expires in 30 minutes.",
-    );
+    const ok = await confirm({
+      title: `View as ${practiceName}?`,
+      description:
+        "Your super-admin identity stays attached to every action in the audit log. The impersonation session auto-expires in 30 minutes.",
+      severity: "warning",
+      confirmLabel: "Enter view-as mode",
+    });
     if (!ok) return;
 
     setError(null);

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+// ConfirmDialog + useConfirm — UX confirmation primitive
+// -----------------------------------------------------------------------------
+//
+// A higher-level pattern on top of the canonical <Dialog> primitive (see
+// src/components/ui/dialog.tsx + PR #461) for the dozens of destructive /
+// irreversible flows scattered across the EMR. Replaces:
+//
+//   - window.confirm("…")            ← inaccessible, ugly, ignores theme
+//   - bespoke <div> overlays         ← drifty copy, drifty visual language
+//   - one-off Modal({onClose,...})   ← e.g. /ops/api-keys keys-view.tsx
+//
+// Three severity tiers with consistent visual language:
+//
+//   • info     — blue accent + Info icon          (Cancel / Continue)
+//   • warning  — amber accent + AlertTriangle      (Cancel / Continue)
+//                e.g. "Discard unsaved changes?"
+//   • danger   — red accent + Trash2/AlertTriangle (Cancel / Delete)
+//                e.g. archive patient, revoke API key, delete chart task
+//
+// Optional Stripe / GitHub-style typed-confirmation: pass
+// `requireTypedConfirmation="Acme Clinic"` and the confirm button stays
+// disabled until the user types that string verbatim (trimmed, case-insensitive).
+//
+// Two ways to use it:
+//   1. Declarative   — <ConfirmDialog open={…} onConfirm={…} … /> in JSX.
+//   2. Imperative    — `const ok = await useConfirm()({ … })` for one-shot
+//                      destructive prompts triggered from event handlers
+//                      (context menus, bulk-action bars, dropdown items).
+//
+// Behaviors inherited from Dialog (PR #461):
+//   - focus trap, focus restore on close (a11y: WCAG 2.4.3)
+//   - Esc dismisses
+//   - click backdrop = Cancel (NOT confirm — destructive defaults to
+//     non-destructive on accidental click-out)
+//
+// Behaviors specific to ConfirmDialog:
+//   - typed-confirmation gate
+//   - severity-driven icon + accent colors + button variant
+//   - confirm button auto-focuses (or the typed-confirmation input does
+//     when present, so keyboard users land on the gating control)
+//   - Esc / backdrop / Cancel all resolve to `false`, only the confirm
+//     button resolves to `true` — useConfirm() relies on this.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { AlertTriangle, Info, Trash2 } from "lucide-react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+export type ConfirmSeverity = "info" | "warning" | "danger";
+
+export interface ConfirmDialogProps {
+  /** Controls visibility. */
+  open: boolean;
+  /** Called for any non-confirm dismissal (Esc, backdrop, Cancel button). */
+  onClose: () => void;
+  /** Called when the user confirms (and typed-confirmation passes, if required). */
+  onConfirm: () => void;
+  /** Short, sentence-case title. e.g. "Archive Maya Reyes?" */
+  title: string;
+  /**
+   * One- or two-sentence description. State the concrete consequence —
+   * "This kills active sessions" beats "Are you sure?". May be a string
+   * or a ReactNode if you need to embed strong tags / patient names.
+   */
+  description: ReactNode;
+  /** Visual + tonal severity. Default "info". */
+  severity?: ConfirmSeverity;
+  /** Confirm button copy. Defaults: info/warning="Continue", danger="Delete". */
+  confirmLabel?: string;
+  /** Cancel button copy. Default "Cancel". */
+  cancelLabel?: string;
+  /**
+   * When provided, the confirm button stays disabled until the user types
+   * this string exactly (trim + case-insensitive). Use for high-blast-radius
+   * actions — Stripe / GitHub repo-delete pattern.
+   */
+  requireTypedConfirmation?: string;
+  /**
+   * When the confirm action is async (e.g. fetch) the caller can set this
+   * to keep the dialog open and show a pending state on the confirm button.
+   */
+  busy?: boolean;
+}
+
+const SEVERITY_STYLES: Record<
+  ConfirmSeverity,
+  {
+    icon: typeof Info;
+    iconWrapClass: string;
+    iconClass: string;
+    confirmVariant: "primary" | "danger";
+    defaultConfirmLabel: string;
+    accentBorder: string;
+  }
+> = {
+  info: {
+    icon: Info,
+    iconWrapClass: "bg-accent/10",
+    iconClass: "text-accent",
+    confirmVariant: "primary",
+    defaultConfirmLabel: "Continue",
+    accentBorder: "",
+  },
+  warning: {
+    icon: AlertTriangle,
+    iconWrapClass: "bg-amber-100 dark:bg-amber-900/30",
+    iconClass: "text-amber-600 dark:text-amber-400",
+    confirmVariant: "primary",
+    defaultConfirmLabel: "Continue",
+    accentBorder: "",
+  },
+  danger: {
+    icon: Trash2,
+    iconWrapClass: "bg-red-100 dark:bg-red-900/30",
+    iconClass: "text-danger",
+    confirmVariant: "danger",
+    defaultConfirmLabel: "Delete",
+    // Subtle red hairline to visually flag the modal as destructive at a
+    // glance — matches the Emergency revoke dialog (EMR-727) styling.
+    accentBorder: "border-danger/40",
+  },
+};
+
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  severity = "info",
+  confirmLabel,
+  cancelLabel = "Cancel",
+  requireTypedConfirmation,
+  busy = false,
+}: ConfirmDialogProps) {
+  const styles = SEVERITY_STYLES[severity];
+  const IconComponent = styles.icon;
+  const [typed, setTyped] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const descId = useId();
+
+  // Reset the typed-confirmation field whenever the dialog re-opens — a
+  // stale value from a previous open would otherwise enable the destructive
+  // button before the operator re-states intent.
+  useEffect(() => {
+    if (open) setTyped("");
+  }, [open]);
+
+  // Park focus on the gating control: typed-confirmation input if present,
+  // else the confirm button. Without this Dialog's auto-focus heuristic
+  // can land on the Cancel button (the second focusable), which feels
+  // weird for a single-action confirm and steals the keyboard "Enter to
+  // confirm" muscle memory.
+  useEffect(() => {
+    if (!open) return;
+    // Defer one tick so Dialog's own focus-into runs first; otherwise
+    // we'd race it and lose.
+    const id = window.setTimeout(() => {
+      if (requireTypedConfirmation && inputRef.current) {
+        inputRef.current.focus();
+      } else if (confirmRef.current && !confirmRef.current.disabled) {
+        confirmRef.current.focus();
+      }
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [open, requireTypedConfirmation]);
+
+  const typedOk =
+    !requireTypedConfirmation ||
+    typed.trim().toLowerCase() ===
+      requireTypedConfirmation.trim().toLowerCase();
+  const canConfirm = typedOk && !busy;
+
+  const handleConfirm = () => {
+    if (!canConfirm) return;
+    onConfirm();
+  };
+
+  // Enter inside the typed-confirmation input should fire confirm so the
+  // keyboard flow is one continuous motion (type → Enter).
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && canConfirm) {
+      event.preventDefault();
+      handleConfirm();
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (next) return;
+        // Block close mid-flight so an async confirm can't be torn down by
+        // an accidental Esc / backdrop.
+        if (busy) return;
+        onClose();
+      }}
+    >
+      <DialogContent
+        className={cn("max-w-md", styles.accentBorder)}
+        aria-describedby={descId}
+        // Override the standard p-6 to give the icon+title row a tighter
+        // hug.
+      >
+        <div className="flex items-start gap-3">
+          <div
+            className={cn(
+              "flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full",
+              styles.iconWrapClass,
+            )}
+            aria-hidden
+          >
+            <IconComponent className={cn("h-5 w-5", styles.iconClass)} />
+          </div>
+          <div className="flex-1 min-w-0 pt-1">
+            {/* We render an <h2> manually rather than using DialogTitle so
+                the icon row reads as a single visual unit. DialogContent
+                uses its own titleId for aria-labelledby — we wire it up by
+                also passing aria-describedby on the description below. */}
+            <h2 className="text-base font-semibold text-text leading-snug">
+              {title}
+            </h2>
+            <div
+              id={descId}
+              className="mt-1.5 text-sm text-text-muted leading-relaxed"
+            >
+              {description}
+            </div>
+          </div>
+        </div>
+
+        {requireTypedConfirmation && (
+          <div className="mt-4">
+            <label
+              htmlFor={`${descId}-typed`}
+              className="block text-xs font-medium uppercase tracking-wide text-text-muted"
+            >
+              Type{" "}
+              <code className="rounded bg-surface-muted px-1 py-0.5 text-text">
+                {requireTypedConfirmation}
+              </code>{" "}
+              to confirm
+            </label>
+            <input
+              ref={inputRef}
+              id={`${descId}-typed`}
+              type="text"
+              value={typed}
+              onChange={(event) => setTyped(event.target.value)}
+              onKeyDown={handleInputKeyDown}
+              placeholder={requireTypedConfirmation}
+              autoComplete="off"
+              spellCheck={false}
+              aria-invalid={typed.length > 0 && !typedOk ? true : undefined}
+              className={cn(
+                "mt-1 w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text",
+                "focus:outline-none focus:ring-2",
+                severity === "danger"
+                  ? "focus:border-danger focus:ring-danger/20"
+                  : severity === "warning"
+                    ? "focus:border-amber-500 focus:ring-amber-500/20"
+                    : "focus:border-accent focus:ring-accent/20",
+              )}
+            />
+          </div>
+        )}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              if (busy) return;
+              onClose();
+            }}
+            disabled={busy}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            ref={confirmRef}
+            variant={styles.confirmVariant}
+            size="sm"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            aria-disabled={!canConfirm}
+          >
+            {busy
+              ? "Working…"
+              : (confirmLabel ?? styles.defaultConfirmLabel)}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// useConfirm() — imperative API
+// -----------------------------------------------------------------------------
+//
+// Mounts a single ConfirmDialog per provider and exposes a function that
+// returns a Promise<boolean>. Resolves true on confirm, false on any
+// other dismissal (Esc, backdrop, Cancel). Sample:
+//
+//   const confirm = useConfirm();
+//   const ok = await confirm({
+//     title: "Archive Maya Reyes?",
+//     description: "They'll drop off the active roster. The chart stays.",
+//     severity: "danger",
+//     confirmLabel: "Archive",
+//   });
+//   if (!ok) return;
+//   doArchive();
+//
+// The provider is mounted once in src/app/layout.tsx alongside ToastProvider.
+
+export type ConfirmOptions = Omit<
+  ConfirmDialogProps,
+  "open" | "onClose" | "onConfirm" | "busy"
+>;
+
+type ConfirmContextValue = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmContextValue | null>(null);
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<{
+    options: ConfirmOptions;
+    resolve: (value: boolean) => void;
+  } | null>(null);
+
+  const confirm = useCallback<ConfirmContextValue>((options) => {
+    return new Promise<boolean>((resolve) => {
+      setState({ options, resolve });
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setState((current) => {
+      current?.resolve(false);
+      return null;
+    });
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    setState((current) => {
+      current?.resolve(true);
+      return null;
+    });
+  }, []);
+
+  // Memoize so consumers that destructure `confirm` don't see a new
+  // reference on every parent render.
+  const value = useMemo(() => confirm, [confirm]);
+
+  return (
+    <ConfirmContext.Provider value={value}>
+      {children}
+      {state && (
+        <ConfirmDialog
+          {...state.options}
+          open
+          onClose={handleClose}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+}
+
+/**
+ * Imperative confirmation hook. Returns a function that opens the shared
+ * ConfirmDialog and resolves to `true` on confirm or `false` on any
+ * dismissal. Throws if used outside <ConfirmProvider>.
+ */
+export function useConfirm(): ConfirmContextValue {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error(
+      "useConfirm() must be used inside <ConfirmProvider>. Mount it once in src/app/layout.tsx.",
+    );
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary

Higher-level confirmation primitive on top of the canonical Dialog (PR #461) so destructive / irreversible flows stop reaching for `window.confirm` or rolling bespoke overlays. Two ergonomics: declarative `<ConfirmDialog ...>` for stateful surfaces, plus an imperative `const ok = await confirm({})` for event handlers (context menus, dropdowns, bulk actions).

### Severity tiers

| Tier      | Icon            | Accent | Default confirm | Used for |
|-----------|-----------------|--------|-----------------|----------|
| `info`    | Info            | Blue   | Continue        | Mark thread resolved |
| `warning` | AlertTriangle   | Amber  | Continue        | Impersonate practice, sign Schedule III/V Rx |
| `danger`  | Trash2          | Red    | Delete          | Archive patient/thread, delete address, cancel visit, revoke API key |

### Typed-confirmation gate

Stripe / GitHub pattern: pass `requireTypedConfirmation="Acme Clinic"` and the destructive button stays disabled until the operator types that exact string (trim, case-insensitive). Enter inside the input fires confirm so it's a single typing motion. Used on operator API-key revoke; ready for org-delete, super-admin grant rejection, etc.

### Behaviors inherited from Dialog (PR #461)

- Focus trap + restore-on-close (a11y WCAG 2.4.3)
- Esc dismisses
- Backdrop click = Cancel (never Confirm — destructive defaults to non-destructive on accidental click-out)

### Adoptions (8)

| Site | Severity | Notes |
|------|----------|-------|
| `clinic/patients` archive (context menu) | danger | replaces `window.confirm` |
| `clinic/messages` thread archive (smart-inbox) | danger | replaces `window.confirm` |
| `clinic/messages` thread resolve | info | replaces `window.confirm` |
| `ops/queue` cancel visit (context menu) | danger | replaces `window.confirm` |
| `leafmart/account/addresses` delete | danger | replaces `window.confirm` |
| `super-admin` view-as-practice impersonation | warning | replaces `window.confirm` |
| Controlled-substance Rx sign attestation | warning | replaces `window.confirm` |
| `ops/api-keys` revoke | danger + typed | replaces bespoke Modal |

### Intentionally not migrated

- Emergency revoke (EMR-727) keeps its specialized dialog — reason-field + audit-log shape doesn't fit a generic confirm.
- `/ops/supplies` skipped per brief (PR #438 collision avoidance).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on all touched files (only pre-existing warnings remain elsewhere)
- [x] `npm test` — 1881 tests pass (180 files)
- [ ] Manual smoke: open patient archive context menu, confirm dialog appears with red Trash2 icon, Esc cancels, click confirm archives
- [ ] Manual smoke: revoke an API key, verify typed-confirmation gates the destructive button until key label is typed verbatim
- [ ] Manual smoke: backdrop click on any ConfirmDialog resolves to Cancel (not Confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)