### PR TITLE
ux: FileUpload primitive (drag-drop queue, progress, retry) + 5 adoptions

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/documents/clinician-upload-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/documents/clinician-upload-form.tsx
@@ -1,8 +1,49 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
-import { Button } from "@/components/ui/button";
+/**
+ * ClinicianUploadForm — patient document upload.
+ *
+ * Adopts the shared `FileUpload` primitive (EMR-???/UX run) so clinicians
+ * can drop multiple lab PDFs, scans, COAs, etc. into a chart in one
+ * action. Each file is uploaded independently against the existing
+ * `uploadClinicianDocumentAction` server action; per-file failures stay
+ * inline and don't blow up the rest of the queue.
+ */
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import {
+  FileUpload,
+  type FileUploadHandler,
+  type UploadedFile,
+} from "@/components/ui/file-upload";
+import {
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE_BYTES,
+} from "@/lib/storage/document-types";
 import { uploadClinicianDocumentAction } from "./actions";
+
+const MAX_SIZE_MB = Math.round(MAX_FILE_SIZE_BYTES / (1024 * 1024));
+// Express the server's MIME allowlist as an `accept` token list — matches
+// what the picker offered before, plus image/heic, plus a few extensions
+// for browsers that drop MIME on drag-drop (e.g. Safari for .heic).
+const ACCEPT = [
+  ...Array.from(ALLOWED_MIME_TYPES),
+  ".pdf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".heic",
+  ".heif",
+  ".gif",
+  ".webp",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".csv",
+  ".txt",
+].join(",");
 
 export function ClinicianUploadForm({
   patientId,
@@ -11,47 +52,39 @@ export function ClinicianUploadForm({
   patientId: string;
   onDone?: () => void;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
-  const [success, setSuccess] = useState(false);
+  const router = useRouter();
 
-  function handleSubmit() {
-    const file = inputRef.current?.files?.[0];
-    if (!file) return;
-
-    setError(null);
-    startTransition(async () => {
+  const handler: FileUploadHandler = useCallback(
+    async (file): Promise<UploadedFile> => {
       const fd = new FormData();
       fd.append("patientId", patientId);
       fd.append("file", file);
       const result = await uploadClinicianDocumentAction(fd);
-      if (result.ok) {
-        setSuccess(true);
-        if (inputRef.current) inputRef.current.value = "";
-        setTimeout(() => {
-          setSuccess(false);
-          onDone?.();
-        }, 1500);
-      } else {
-        setError(result.error);
+      if (!result.ok) {
+        throw new Error(result.error);
       }
-    });
-  }
+      // The server action doesn't currently return the document id; that
+      // is fine — FileUpload uses the local file name when no URL is
+      // available, and a chart refresh surfaces the new row.
+      router.refresh();
+      return { id: file.name, name: file.name };
+    },
+    [patientId, router],
+  );
 
   return (
-    <div className="space-y-2">
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".pdf,.png,.jpg,.jpeg,.gif,.doc,.docx,.xlsx,.xls,.csv,.txt,.heic"
-        className="block w-full text-sm text-text file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:bg-surface-muted file:text-text file:text-sm file:font-medium hover:file:bg-surface-muted/70"
-      />
-      {error && <p className="text-xs text-danger">{error}</p>}
-      {success && <p className="text-xs text-accent">Uploaded!</p>}
-      <Button size="sm" onClick={handleSubmit} disabled={isPending}>
-        {isPending ? "Uploading\u2026" : "Upload"}
-      </Button>
-    </div>
+    <FileUpload
+      accept={ACCEPT}
+      maxFiles={20}
+      maxSizeMB={MAX_SIZE_MB}
+      concurrency={3}
+      label="Drop chart documents here or click to browse"
+      hint={`PDF · images · Word · Excel · CSV — up to ${MAX_SIZE_MB} MB per file`}
+      onUpload={handler}
+      onComplete={(items) => {
+        const anyOk = items.some((i) => i.status === "uploaded");
+        if (anyOk) onDone?.();
+      }}
+    />
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input, Textarea, FieldGroup } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { FileUpload, type FileUploadItem } from "@/components/ui/file-upload";
 import { LAB_CATALOG } from "@/lib/domain/clinical-orders";
 import { COMMON_PROBLEMS } from "@/lib/domain/problem-list";
 import { cn } from "@/lib/utils/cn";
@@ -21,6 +22,7 @@ export function LabOrderForm({ patientName }: Props) {
   const [icd10Query, setIcd10Query] = useState("");
   const [icd10Selected, setIcd10Selected] = useState<string[]>([]);
   const [priority, setPriority] = useState<Priority>("routine");
+  const [attachments, setAttachments] = useState<FileUploadItem[]>([]);
   const [submitted, setSubmitted] = useState<{
     orderId: string;
     when: string;
@@ -271,6 +273,37 @@ export function LabOrderForm({ patientName }: Props) {
               )}
             </div>
 
+            <FieldGroup label="Supporting attachments (optional)">
+              <p className="text-[11px] text-text-subtle -mt-1 mb-2">
+                Prior result PDFs, requisition forms, or insurance cards.
+                They&apos;ll travel with the order to the lab.
+              </p>
+              {/*
+                Server-side TODO: there is no /api/labs/orders/[id]/attachments
+                endpoint yet. The handler below resolves locally so the UI
+                ships ready-to-wire — once a real upload route is in place,
+                replace the resolve with `createFetchUploadHandler({ url: ... })`.
+              */}
+              <FileUpload
+                accept=".pdf,.png,.jpg,.jpeg,.heic,.webp"
+                maxFiles={5}
+                maxSizeMB={15}
+                concurrency={2}
+                label="Drop requisitions or prior results"
+                hint="PDF or image — up to 15 MB per file"
+                onUpload={async (file, { onProgress }) => {
+                  // Local-only: simulate the upload so the queue UI is
+                  // exercisable today. Replace once the server route lands.
+                  for (let p = 0; p <= 100; p += 20) {
+                    onProgress?.(p);
+                    await new Promise((r) => setTimeout(r, 80));
+                  }
+                  return { id: `local-${file.name}`, name: file.name };
+                }}
+                onComplete={(items) => setAttachments(items)}
+              />
+            </FieldGroup>
+
             <FieldGroup label="Priority">
               <div className="flex gap-2">
                 {(["routine", "stat"] as Priority[]).map((p) => (
@@ -299,6 +332,8 @@ export function LabOrderForm({ patientName }: Props) {
       <div className="flex items-center justify-end gap-3">
         <p className="text-xs text-text-subtle">
           {selected.length} lab{selected.length !== 1 ? "s" : ""} selected
+          {attachments.filter((a) => a.status === "uploaded").length > 0 &&
+            ` · ${attachments.filter((a) => a.status === "uploaded").length} attachment${attachments.filter((a) => a.status === "uploaded").length !== 1 ? "s" : ""}`}
         </p>
         <Button
           onClick={submit}

--- a/src/app/(patient)/portal/records/upload-form.tsx
+++ b/src/app/(patient)/portal/records/upload-form.tsx
@@ -1,223 +1,67 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
-import { useFormState } from "react-dom";
-import { uploadDocumentAction, type UploadResult } from "./actions";
-import { Button } from "@/components/ui/button";
-import { LeafSprig } from "@/components/ui/ornament";
-import { SubmitButton } from "@/lib/ui/form-helpers";
+/**
+ * Patient portal — Upload records form.
+ *
+ * Adopts the shared `FileUpload` primitive so patients can drop multiple
+ * scans or lab PDFs in one shot. Each file is dispatched independently
+ * against `uploadDocumentAction`, so a single bad upload no longer
+ * aborts the rest.
+ */
 
-function UploadButton() {
-  return <SubmitButton size="sm" idleLabel="Upload" pendingLabel="Uploading\u2026" />;
-}
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  FileUpload,
+  type FileUploadHandler,
+  type UploadedFile,
+} from "@/components/ui/file-upload";
+import { uploadDocumentAction } from "./actions";
+import { Button } from "@/components/ui/button";
 
 export function UploadForm({ onClose }: { onClose?: () => void }) {
-  const [state, formAction] = useFormState<UploadResult | null, FormData>(
-    uploadDocumentAction,
-    null,
-  );
+  const router = useRouter();
+  const [completedCount, setCompletedCount] = useState(0);
 
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [file, setFile] = useState<File | null>(null);
-  const [dragOver, setDragOver] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [simulating, setSimulating] = useState(false);
-
-  const handleFile = useCallback((f: File) => {
-    setFile(f);
-    if (inputRef.current) {
-      const dt = new DataTransfer();
-      dt.items.add(f);
-      inputRef.current.files = dt.files;
+  const handler: FileUploadHandler = useCallback(async (file): Promise<UploadedFile> => {
+    const fd = new FormData();
+    fd.append("file", file);
+    const result = await uploadDocumentAction(null, fd);
+    if (!result.ok) {
+      throw new Error(result.error);
     }
-    setSimulating(true);
-    setProgress(0);
-    let current = 0;
-    const interval = setInterval(() => {
-      current += Math.random() * 25 + 10;
-      if (current >= 100) {
-        current = 100;
-        clearInterval(interval);
-        setSimulating(false);
-      }
-      setProgress(Math.min(current, 100));
-    }, 200);
+    return { id: result.documentId, name: file.name };
   }, []);
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragOver(false);
-      const f = e.dataTransfer.files[0];
-      if (f) handleFile(f);
-    },
-    [handleFile],
-  );
-
-  const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const f = e.target.files?.[0];
-      if (f) handleFile(f);
-    },
-    [handleFile],
-  );
-
-  const formatSize = (bytes: number) => {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  };
-
-  // Success state
-  if (state?.ok) {
-    return (
-      <div className="rounded-2xl border border-border bg-surface p-8 text-center">
-        <div className="flex justify-center mb-3">
-          <div className="h-12 w-12 rounded-full bg-accent-soft flex items-center justify-center">
-            <svg
-              className="h-6 w-6 text-accent"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M4.5 12.75l6 6 9-13.5"
-              />
-            </svg>
-          </div>
-        </div>
-        <h3 className="font-display text-lg text-text mb-1">Uploaded!</h3>
-        <p className="text-sm text-text-muted max-w-xs mx-auto">
-          Our system is classifying your document. You&apos;ll see it
-          organized in your records momentarily.
-        </p>
-        <div className="mt-5">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              setFile(null);
-              setProgress(0);
-              onClose?.();
-            }}
-          >
-            Done
-          </Button>
-        </div>
-      </div>
-    );
+  if (completedCount > 0 && !onClose) {
+    // Page-mounted variant — refresh in place so the records list picks
+    // up the new entries.
+    router.refresh();
   }
 
   return (
-    <form action={formAction} className="space-y-4">
-      {/* File is carried by the named input below; no metadata fields needed */}
-
-      {/* Drop zone */}
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={() => inputRef.current?.click()}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            inputRef.current?.click();
-          }
+    <div className="space-y-4">
+      <FileUpload
+        accept=".pdf,.png,.jpg,.jpeg,.heic,.heif,.gif,.webp,.doc,.docx,.xls,.xlsx,.csv,.txt"
+        maxFiles={15}
+        maxSizeMB={25}
+        concurrency={2}
+        label="Drop files here or click to browse"
+        hint="PDF, images, or scanned documents — up to 25 MB"
+        onUpload={handler}
+        onComplete={(items) => {
+          const ok = items.filter((i) => i.status === "uploaded").length;
+          setCompletedCount(ok);
+          if (ok > 0) router.refresh();
         }}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragOver(true);
-        }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={handleDrop}
-        className={`
-          relative flex flex-col items-center justify-center gap-3 rounded-2xl
-          border-2 border-dashed cursor-pointer
-          px-6 py-10 transition-colors duration-200
-          ${
-            dragOver
-              ? "border-accent bg-accent-soft/40"
-              : "border-border-strong bg-surface-muted/50 hover:bg-surface-muted/80"
-          }
-        `}
-      >
-        <LeafSprig size={36} className="text-accent/60" />
-        <div className="text-center">
-          <p className="text-sm font-medium text-text">
-            Drop files here or click to browse
-          </p>
-          <p className="text-xs text-text-subtle mt-1">
-            PDF, images, or scanned documents
-          </p>
-        </div>
-        <input
-          ref={inputRef}
-          name="file"
-          type="file"
-          className="hidden"
-          accept=".pdf,.png,.jpg,.jpeg,.gif,.tiff,.doc,.docx,.xlsx,.xls,.csv,.txt,.heic"
-          onChange={handleInputChange}
-        />
-      </div>
-
-      {/* Selected file preview */}
-      {file && (
-        <div className="rounded-xl border border-border bg-surface p-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-text truncate">
-                {file.name}
-              </p>
-              <p className="text-xs text-text-subtle mt-0.5">
-                {formatSize(file.size)} &middot; {file.type || "unknown type"}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                setFile(null);
-                setProgress(0);
-                if (inputRef.current) inputRef.current.value = "";
-              }}
-              className="text-text-subtle hover:text-text transition-colors text-xs"
-            >
-              Remove
-            </button>
-          </div>
-
-          {/* Progress bar */}
-          <div className="mt-3 h-2 w-full rounded-full bg-surface-muted overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-300 ease-smooth bg-gradient-to-r from-accent to-accent-strong"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          <p className="text-xs text-text-subtle mt-1.5">
-            {simulating
-              ? `Processing\u2026 ${Math.round(progress)}%`
-              : progress >= 100
-                ? "Ready to upload"
-                : "Waiting\u2026"}
-          </p>
-        </div>
-      )}
-
-      {/* Error state */}
-      {state?.ok === false && (
-        <p className="text-sm text-danger">{state.error}</p>
-      )}
-
-      {/* Actions */}
-      <div className="flex items-center justify-end gap-2">
-        {onClose && (
+      />
+      {onClose && (
+        <div className="flex justify-end">
           <Button type="button" variant="ghost" size="sm" onClick={onClose}>
-            Cancel
+            Done
           </Button>
-        )}
-        {file && !simulating && progress >= 100 && <UploadButton />}
-      </div>
-    </form>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/feedback/UniversalFeedbackFab.tsx
+++ b/src/components/feedback/UniversalFeedbackFab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils/cn";
 import { useToast } from "@/components/ui/toast";
+import { FileUpload, type FileUploadItem } from "@/components/ui/file-upload";
 
 // EMR-128 — universal feedback FAB. Mounted once at the root layout so
 // every route in every role sees the same pulse-of-the-product channel.
@@ -19,6 +20,7 @@ export function UniversalFeedbackFab() {
   const [comment, setComment] = useState("");
   const [area, setArea] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [attachments, setAttachments] = useState<FileUploadItem[]>([]);
   const { toast } = useToast();
 
   // Persist a stable client-id per browser to dedupe repeats / retries.
@@ -42,6 +44,7 @@ export function UniversalFeedbackFab() {
     setComment("");
     setArea("");
     setError(null);
+    setAttachments([]);
   }
 
   async function submit() {
@@ -56,6 +59,9 @@ export function UniversalFeedbackFab() {
     setState("submitting");
     setError(null);
     try {
+      const attachmentNames = attachments
+        .filter((a) => a.status === "uploaded")
+        .map((a) => a.file.name);
       const payload = {
         clientId: clientIdRef.current,
         pageUrl: window.location.href,
@@ -64,6 +70,7 @@ export function UniversalFeedbackFab() {
         userAgent: navigator.userAgent,
         viewport: { width: window.innerWidth, height: window.innerHeight },
         occurredAt: new Date().toISOString(),
+        attachments: attachmentNames,
       };
       const res = await fetch("/api/feedback/whisper", {
         method: "POST",
@@ -185,6 +192,33 @@ export function UniversalFeedbackFab() {
                 placeholder="Loved it? Confused? Frustrated? Tell us in your own words."
                 className="w-full rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text placeholder:text-text-subtle focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
               />
+
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-text-subtle font-semibold mb-1.5">
+                  Attachments (optional)
+                </p>
+                {/*
+                  Server-side TODO: /api/feedback/whisper accepts JSON only.
+                  Screenshots are queued locally; once the route accepts
+                  multipart, swap the local handler for createFetchUploadHandler.
+                */}
+                <FileUpload
+                  accept="image/*,.pdf"
+                  maxFiles={3}
+                  maxSizeMB={8}
+                  concurrency={2}
+                  label="Drop a screenshot or attach a doc"
+                  hint="Helps us see what you saw — PNG, JPG, or PDF"
+                  onUpload={async (file, { onProgress }) => {
+                    for (let p = 0; p <= 100; p += 33) {
+                      onProgress?.(Math.min(p, 100));
+                      await new Promise((r) => setTimeout(r, 50));
+                    }
+                    return { id: `local-${file.name}`, name: file.name };
+                  }}
+                  onComplete={(items) => setAttachments(items)}
+                />
+              </div>
 
               <p className="text-[11px] text-text-subtle">
                 We'll capture the page URL automatically. Any voice memos attached are auto-deleted after 30 days for privacy.

--- a/src/components/leafmart/VendorApplicationForm.tsx
+++ b/src/components/leafmart/VendorApplicationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FileUpload, type FileUploadItem } from "@/components/ui/file-upload";
 
 const PRODUCT_TYPES = [
   { slug: "tinctures", label: "Tinctures" },
@@ -45,6 +46,7 @@ export function VendorApplicationForm() {
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const [topError, setTopError] = useState<string | null>(null);
+  const [documents, setDocuments] = useState<FileUploadItem[]>([]);
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((f) => ({ ...f, [key]: value }));
@@ -301,6 +303,46 @@ export function VendorApplicationForm() {
           <p role="alert" className="mt-2 text-[12.5px] text-[var(--danger)]">{errors.hasCoa}</p>
         )}
       </fieldset>
+
+      <div>
+        <p className="text-[13px] font-semibold text-[var(--ink)] mb-2">
+          Documents (optional)
+        </p>
+        <p className="text-[12.5px] text-[var(--muted)] mb-3">
+          Drop your latest COA, W-9, or product spec sheets. PDF or image,
+          up to 15 MB each. We&apos;ll request anything else we need
+          during review.
+        </p>
+        {/*
+          Server-side TODO: /api/leafmart/vendor-apply currently accepts
+          JSON only. Once the route gains a multipart variant (or a
+          paired /attachments endpoint), swap the local handler for
+          `createFetchUploadHandler({ url: "/api/leafmart/vendor-apply/attachments" })`.
+        */}
+        <FileUpload
+          accept=".pdf,.png,.jpg,.jpeg,.webp"
+          maxFiles={6}
+          maxSizeMB={15}
+          concurrency={2}
+          label="Drop COA / tax documents"
+          hint="PDF or image — up to 15 MB per file"
+          onUpload={async (file, { onProgress }) => {
+            for (let p = 0; p <= 100; p += 25) {
+              onProgress?.(p);
+              await new Promise((r) => setTimeout(r, 60));
+            }
+            return { id: `local-${file.name}`, name: file.name };
+          }}
+          onComplete={(items) => setDocuments(items)}
+        />
+        {documents.filter((d) => d.status === "uploaded").length > 0 && (
+          <p className="mt-2 text-[12.5px] text-[var(--leaf)]">
+            {documents.filter((d) => d.status === "uploaded").length} document
+            {documents.filter((d) => d.status === "uploaded").length !== 1 ? "s" : ""}
+            {" "}attached.
+          </p>
+        )}
+      </div>
 
       <FormField label="Tell us about your products" htmlFor="vf-desc" error={errors.description} required>
         <textarea

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -1,0 +1,773 @@
+"use client";
+
+/**
+ * FileUpload — multi-file drag-drop primitive with queue, progress, retry.
+ *
+ * Used across LeafJourney for chart attachments, lab uploads, COA docs,
+ * fax attachments, vendor tax forms, feedback screenshots, and more. It is
+ * deliberately backend-agnostic: callers supply an `onUpload(file)` that
+ * returns the persisted `{ id, url }` and the primitive handles the
+ * choreography — concurrency, retry, cancellation, validation, a11y.
+ *
+ * Why a single primitive?
+ *   • Today there are 4+ bespoke dropzones, each with subtly different
+ *     validation, error UX, and aesthetic. That fragmentation hurts both
+ *     users and reviewers. One primitive, one mental model.
+ *   • A surgical surface area (one prop bag, one render slot) makes
+ *     adoption mechanical: replace the bespoke <input type=file> with
+ *     <FileUpload onUpload={...}/> and ship.
+ *
+ * Apple-iOS aesthetic:
+ *   • Hairline borders, generous whitespace, soft accent for drag-over.
+ *   • Smooth (cubic-bezier) progress animation.
+ *   • Reduced-motion friendly.
+ *   • Min 44pt tap targets for retry / cancel / remove buttons.
+ *
+ * Accessibility:
+ *   • Drop zone has `aria-label` + keyboard activation (Enter/Space).
+ *   • File list is `role="list"` with `role="listitem"` children.
+ *   • Per-row status announces via `aria-live="polite"` region.
+ *   • Hidden <input> is keyboard-focusable through the visible button.
+ *
+ * No new dependencies. Pure React.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+
+// ───────────────────────────────────────────────────────────────────────
+// Public types
+// ───────────────────────────────────────────────────────────────────────
+
+export type FileUploadStatus =
+  | "queued"
+  | "uploading"
+  | "uploaded"
+  | "failed"
+  | "canceled";
+
+export interface UploadedFile {
+  /** Server-assigned id (storage key, db id, etc.) */
+  id: string;
+  /** A URL the client can use to preview / link. May be a signed URL. */
+  url?: string;
+  /** Optional server-supplied display name. Falls back to the local name. */
+  name?: string;
+}
+
+export interface FileUploadHandlerArgs {
+  /** Reports progress 0..100. Optional — handlers without progress data
+   *  should call once with 100 on success. */
+  onProgress?: (pct: number) => void;
+  /** AbortSignal — handler should fetch with `{ signal }` to support
+   *  cancel. */
+  signal: AbortSignal;
+}
+
+export type FileUploadHandler = (
+  file: File,
+  args: FileUploadHandlerArgs,
+) => Promise<UploadedFile>;
+
+export interface FileUploadItem {
+  /** Stable local key — also used as React key. */
+  id: string;
+  file: File;
+  status: FileUploadStatus;
+  progress: number;
+  error?: string;
+  result?: UploadedFile;
+}
+
+export interface FileUploadProps {
+  /** Comma-separated `accept` value — e.g. ".pdf,image/*". Also enforced
+   *  client-side via extension + MIME check. */
+  accept?: string;
+  /** Max simultaneous files in the queue. Excess files are rejected with
+   *  an inline error and never enter the queue. */
+  maxFiles?: number;
+  /** Per-file size cap in megabytes. */
+  maxSizeMB?: number;
+  /** Concurrency cap for in-flight uploads. */
+  concurrency?: number;
+  /** Allow multi-select / multi-drop. Defaults to true. Set false to lock
+   *  the picker to one file. */
+  multiple?: boolean;
+  /** Hide the drop zone label / icon (when host UI supplies its own). */
+  bare?: boolean;
+  /** Headline shown in the drop zone. */
+  label?: string;
+  /** Helper line under the headline. */
+  hint?: string;
+  /** Disable the entire control. */
+  disabled?: boolean;
+  /** className for the outer wrapper. */
+  className?: string;
+  /** Per-file uploader. Throw / reject to flip the row to `failed`. */
+  onUpload: FileUploadHandler;
+  /** Fired once after every batch settles (succeeds or fails). */
+  onComplete?: (items: FileUploadItem[]) => void;
+  /** Render a custom row in place of the default. */
+  renderFile?: (item: FileUploadItem, controls: FileRowControls) => React.ReactNode;
+}
+
+export interface FileRowControls {
+  retry: () => void;
+  cancel: () => void;
+  remove: () => void;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function getExtension(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx === -1 ? "" : name.slice(idx).toLowerCase();
+}
+
+/** Returns null when accepted, or a reason string when rejected. */
+function validateAccept(file: File, accept: string | undefined): string | null {
+  if (!accept) return null;
+  const tokens = accept
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  if (tokens.length === 0) return null;
+  const ext = getExtension(file.name);
+  const mime = (file.type || "").toLowerCase();
+  for (const token of tokens) {
+    if (token.startsWith(".")) {
+      if (ext === token) return null;
+      continue;
+    }
+    if (token.endsWith("/*")) {
+      const prefix = token.slice(0, -1); // keep "image/"
+      if (mime.startsWith(prefix)) return null;
+      continue;
+    }
+    if (token === mime) return null;
+  }
+  return `Type not accepted (${mime || ext || "unknown"})`;
+}
+
+let __seq = 0;
+function nextId(): string {
+  __seq += 1;
+  return `fu-${Date.now().toString(36)}-${__seq}`;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Component
+// ───────────────────────────────────────────────────────────────────────
+
+export function FileUpload({
+  accept,
+  maxFiles = 10,
+  maxSizeMB = 25,
+  concurrency = 3,
+  multiple = true,
+  bare = false,
+  label = "Drop files here or click to browse",
+  hint,
+  disabled = false,
+  className,
+  onUpload,
+  onComplete,
+  renderFile,
+}: FileUploadProps) {
+  const [items, setItems] = React.useState<FileUploadItem[]>([]);
+  const [dragOver, setDragOver] = React.useState(false);
+  const [globalError, setGlobalError] = React.useState<string | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const dropRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Abort controllers, keyed by item id, so cancel() can abort in-flight
+  // fetches and retry() can spin up a fresh one.
+  const controllers = React.useRef<Map<string, AbortController>>(new Map());
+
+  // Single source of truth for the queue, mirrored for the worker loop so
+  // it never reads stale React state.
+  const itemsRef = React.useRef<FileUploadItem[]>([]);
+  React.useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  // Stable refs for callbacks so the worker loop doesn't restart when the
+  // parent re-renders with new prop identities.
+  const onUploadRef = React.useRef(onUpload);
+  const onCompleteRef = React.useRef(onComplete);
+  React.useEffect(() => {
+    onUploadRef.current = onUpload;
+  }, [onUpload]);
+  React.useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  const maxBytes = maxSizeMB * 1024 * 1024;
+
+  // ───── intake ─────
+  const intake = React.useCallback(
+    (incoming: FileList | File[]) => {
+      if (disabled) return;
+      const incomingArr = Array.from(incoming);
+      const accepted: FileUploadItem[] = [];
+      const rejectedReasons: string[] = [];
+      const existing = itemsRef.current;
+      let slots = Math.max(0, maxFiles - existing.length);
+
+      for (const file of incomingArr) {
+        if (slots <= 0) {
+          rejectedReasons.push(`Skipped "${file.name}" — queue is full (${maxFiles} max)`);
+          continue;
+        }
+        if (file.size === 0) {
+          rejectedReasons.push(`"${file.name}" is empty`);
+          continue;
+        }
+        if (file.size > maxBytes) {
+          rejectedReasons.push(`"${file.name}" is ${formatBytes(file.size)} (max ${maxSizeMB} MB)`);
+          continue;
+        }
+        const typeReason = validateAccept(file, accept);
+        if (typeReason) {
+          rejectedReasons.push(`"${file.name}": ${typeReason}`);
+          continue;
+        }
+        accepted.push({
+          id: nextId(),
+          file,
+          status: "queued",
+          progress: 0,
+        });
+        slots -= 1;
+      }
+
+      if (accepted.length > 0) {
+        setItems((prev) => [...prev, ...accepted]);
+      }
+      setGlobalError(rejectedReasons.length > 0 ? rejectedReasons.join(" · ") : null);
+    },
+    [accept, disabled, maxBytes, maxFiles, maxSizeMB],
+  );
+
+  // ───── worker loop ─────
+  // Whenever the queue changes, top up the in-flight slots up to
+  // `concurrency`. Each upload is launched as its own async task; the
+  // loop is reentrant-safe because we mark "uploading" before awaiting.
+  React.useEffect(() => {
+    let canceled = false;
+    const tick = () => {
+      if (canceled) return;
+      const snap = itemsRef.current;
+      const inFlight = snap.filter((i) => i.status === "uploading").length;
+      const free = Math.max(0, concurrency - inFlight);
+      if (free <= 0) return;
+      const nextBatch = snap.filter((i) => i.status === "queued").slice(0, free);
+      if (nextBatch.length === 0) return;
+
+      // Mark them as uploading before awaiting to claim the slot.
+      setItems((prev) =>
+        prev.map((i) =>
+          nextBatch.find((n) => n.id === i.id) ? { ...i, status: "uploading", progress: 0 } : i,
+        ),
+      );
+
+      for (const item of nextBatch) {
+        const controller = new AbortController();
+        controllers.current.set(item.id, controller);
+        void (async () => {
+          try {
+            const result = await onUploadRef.current(item.file, {
+              signal: controller.signal,
+              onProgress: (pct) => {
+                if (canceled) return;
+                const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+                setItems((prev) =>
+                  prev.map((i) =>
+                    i.id === item.id && i.status === "uploading"
+                      ? { ...i, progress: clamped }
+                      : i,
+                  ),
+                );
+              },
+            });
+            if (canceled) return;
+            setItems((prev) =>
+              prev.map((i) =>
+                i.id === item.id
+                  ? { ...i, status: "uploaded", progress: 100, result, error: undefined }
+                  : i,
+              ),
+            );
+          } catch (err) {
+            if (canceled) return;
+            // Abort → "canceled", everything else → "failed".
+            const aborted =
+              (err instanceof DOMException && err.name === "AbortError") ||
+              controller.signal.aborted;
+            const message =
+              err instanceof Error ? err.message : typeof err === "string" ? err : "Upload failed";
+            setItems((prev) =>
+              prev.map((i) =>
+                i.id === item.id
+                  ? {
+                      ...i,
+                      status: aborted ? "canceled" : "failed",
+                      error: aborted ? undefined : message,
+                    }
+                  : i,
+              ),
+            );
+          } finally {
+            controllers.current.delete(item.id);
+          }
+        })();
+      }
+    };
+    tick();
+    return () => {
+      canceled = true;
+    };
+  }, [items, concurrency]);
+
+  // Fire onComplete once nothing is queued or in-flight (and we have any
+  // results to report).
+  const completeReportedRef = React.useRef(0);
+  React.useEffect(() => {
+    if (items.length === 0) {
+      completeReportedRef.current = 0;
+      return;
+    }
+    const settled = items.every(
+      (i) => i.status === "uploaded" || i.status === "failed" || i.status === "canceled",
+    );
+    if (settled && completeReportedRef.current !== items.length) {
+      completeReportedRef.current = items.length;
+      onCompleteRef.current?.(items);
+    }
+  }, [items]);
+
+  // ───── per-row controls ─────
+  const retry = React.useCallback((id: string) => {
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === id && (i.status === "failed" || i.status === "canceled")
+          ? { ...i, status: "queued", progress: 0, error: undefined }
+          : i,
+      ),
+    );
+  }, []);
+
+  const cancel = React.useCallback((id: string) => {
+    const ctrl = controllers.current.get(id);
+    if (ctrl) ctrl.abort();
+    // Optimistically mark canceled — the catch arm above will confirm.
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === id && (i.status === "uploading" || i.status === "queued")
+          ? { ...i, status: "canceled" }
+          : i,
+      ),
+    );
+  }, []);
+
+  const remove = React.useCallback((id: string) => {
+    const ctrl = controllers.current.get(id);
+    if (ctrl) ctrl.abort();
+    controllers.current.delete(id);
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }, []);
+
+  // ───── DOM handlers ─────
+  const onBrowse = () => {
+    if (disabled) return;
+    inputRef.current?.click();
+  };
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) intake(e.target.files);
+    // Reset so picking the same file twice re-fires onChange.
+    e.target.value = "";
+  };
+
+  const onDragEnter = (e: React.DragEvent) => {
+    if (disabled) return;
+    e.preventDefault();
+    setDragOver(true);
+  };
+  const onDragOver = (e: React.DragEvent) => {
+    if (disabled) return;
+    e.preventDefault();
+    if (!dragOver) setDragOver(true);
+  };
+  const onDragLeave = (e: React.DragEvent) => {
+    // Only clear when leaving the dropzone itself, not its children.
+    if (e.target === dropRef.current) setDragOver(false);
+  };
+  const onDrop = (e: React.DragEvent) => {
+    if (disabled) return;
+    e.preventDefault();
+    setDragOver(false);
+    if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+      intake(e.dataTransfer.files);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onBrowse();
+    }
+  };
+
+  // ───── render ─────
+  const hintCopy =
+    hint ?? `${accept ? accept.replace(/\./g, "").toUpperCase() + " · " : ""}up to ${maxSizeMB} MB · ${maxFiles} files max`;
+
+  return (
+    <div className={cn("w-full space-y-3", className)}>
+      <div
+        ref={dropRef}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={label}
+        aria-disabled={disabled || undefined}
+        onClick={onBrowse}
+        onKeyDown={onKeyDown}
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        className={cn(
+          "relative flex flex-col items-center justify-center gap-2",
+          "rounded-2xl border-2 border-dashed",
+          "px-6 py-8 text-center cursor-pointer select-none",
+          "transition-colors duration-200 ease-out",
+          dragOver
+            ? "border-accent bg-accent-soft/40"
+            : "border-border-strong bg-surface-muted/40 hover:bg-surface-muted/70",
+          disabled && "cursor-not-allowed opacity-60",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-2",
+        )}
+      >
+        {!bare && (
+          <>
+            <UploadGlyph className={cn("h-7 w-7", dragOver ? "text-accent" : "text-text-subtle")} />
+            <p className="text-sm font-medium text-text">{label}</p>
+            <p className="text-[11px] text-text-subtle">{hintCopy}</p>
+          </>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={onInputChange}
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+      </div>
+
+      {globalError && (
+        <p role="alert" className="text-xs text-danger">
+          {globalError}
+        </p>
+      )}
+
+      {items.length > 0 && (
+        <ul
+          role="list"
+          aria-label="Upload queue"
+          className="divide-y divide-border/60 rounded-xl border border-border bg-surface"
+        >
+          {items.map((item) =>
+            renderFile ? (
+              <li role="listitem" key={item.id}>
+                {renderFile(item, {
+                  retry: () => retry(item.id),
+                  cancel: () => cancel(item.id),
+                  remove: () => remove(item.id),
+                })}
+              </li>
+            ) : (
+              <FileRow
+                key={item.id}
+                item={item}
+                onRetry={() => retry(item.id)}
+                onCancel={() => cancel(item.id)}
+                onRemove={() => remove(item.id)}
+              />
+            ),
+          )}
+        </ul>
+      )}
+
+      {/* Live region — announces status changes for screen readers. */}
+      <div className="sr-only" aria-live="polite" role="status">
+        {items
+          .filter((i) => i.status === "uploaded" || i.status === "failed")
+          .map((i) =>
+            i.status === "uploaded"
+              ? `${i.file.name} uploaded.`
+              : `${i.file.name} failed: ${i.error ?? "unknown error"}.`,
+          )
+          .join(" ")}
+      </div>
+    </div>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Default row
+// ───────────────────────────────────────────────────────────────────────
+
+function FileRow({
+  item,
+  onRetry,
+  onCancel,
+  onRemove,
+}: {
+  item: FileUploadItem;
+  onRetry: () => void;
+  onCancel: () => void;
+  onRemove: () => void;
+}) {
+  const statusCopy: Record<FileUploadStatus, string> = {
+    queued: "Queued",
+    uploading: `Uploading… ${item.progress}%`,
+    uploaded: "Uploaded",
+    failed: item.error ? `Failed — ${item.error}` : "Failed",
+    canceled: "Canceled",
+  };
+
+  const isDone = item.status === "uploaded";
+  const isFail = item.status === "failed" || item.status === "canceled";
+  const isBusy = item.status === "uploading" || item.status === "queued";
+
+  return (
+    <li role="listitem" className="flex items-center gap-3 px-3 py-2.5">
+      <FileIcon mime={item.file.type} className="h-9 w-9 shrink-0 text-text-subtle" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-sm font-medium text-text">{item.file.name}</p>
+          <span
+            className={cn(
+              "shrink-0 text-[10px] uppercase tracking-wider font-semibold",
+              isDone && "text-accent",
+              isFail && "text-danger",
+              isBusy && "text-text-subtle",
+            )}
+          >
+            {statusCopy[item.status]}
+          </span>
+        </div>
+        <p className="text-[11px] text-text-subtle mt-0.5">
+          {formatBytes(item.file.size)}
+          {item.file.type ? ` · ${item.file.type}` : ""}
+        </p>
+        {/* Progress bar — animated while uploading, locked at 100% on
+            success, hidden on terminal failure. */}
+        {(isBusy || isDone) && (
+          <div
+            className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-muted"
+            aria-hidden="true"
+          >
+            <div
+              className={cn(
+                "h-full rounded-full transition-[width] duration-300 ease-out",
+                isDone ? "bg-accent" : "bg-gradient-to-r from-accent to-accent-strong",
+              )}
+              style={{ width: `${isDone ? 100 : item.progress}%` }}
+            />
+          </div>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {item.status === "uploading" && (
+          <RowButton onClick={onCancel} label={`Cancel ${item.file.name}`}>
+            Cancel
+          </RowButton>
+        )}
+        {isFail && (
+          <RowButton onClick={onRetry} label={`Retry ${item.file.name}`} accent>
+            Retry
+          </RowButton>
+        )}
+        {!isBusy && (
+          <RowButton onClick={onRemove} label={`Remove ${item.file.name}`} subtle>
+            Remove
+          </RowButton>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function RowButton({
+  children,
+  onClick,
+  label,
+  accent,
+  subtle,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  label: string;
+  accent?: boolean;
+  subtle?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        "inline-flex h-9 min-w-[44px] items-center justify-center rounded-md px-2 text-xs font-medium",
+        "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
+        accent && "text-accent hover:bg-accent-soft/60",
+        subtle && "text-text-subtle hover:text-text hover:bg-surface-muted",
+        !accent && !subtle && "text-text hover:bg-surface-muted",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Glyphs
+// ───────────────────────────────────────────────────────────────────────
+
+function UploadGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12 16V4M12 4l-4 4M12 4l4 4" />
+      <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+    </svg>
+  );
+}
+
+function FileIcon({ mime, className }: { mime: string; className?: string }) {
+  const m = mime.toLowerCase();
+  if (m.startsWith("image/")) {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+        <rect
+          x="3"
+          y="4"
+          width="18"
+          height="16"
+          rx="2.5"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+        <circle cx="9" cy="10" r="1.5" fill="currentColor" />
+        <path
+          d="M21 16l-5-5-8 8"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
+      <path
+        d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M14 3v5h5" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Helpers consumers may want: a tiny FormData-fetch handler factory.
+// ───────────────────────────────────────────────────────────────────────
+
+export interface FetchUploadHandlerOptions {
+  /** URL or endpoint to POST. */
+  url: string;
+  /** Field name for the file in the FormData. Defaults to "file". */
+  fieldName?: string;
+  /** Extra form fields appended on every request. */
+  extra?: Record<string, string>;
+  /** Map the JSON response shape to `UploadedFile`. */
+  pickResult?: (json: unknown) => UploadedFile;
+}
+
+/**
+ * Build a FileUpload handler that POSTs a multipart/form-data body via
+ * XMLHttpRequest (the only browser API that exposes real upload progress).
+ * Aborts when the FileUpload signals cancel.
+ */
+export function createFetchUploadHandler(
+  opts: FetchUploadHandlerOptions,
+): FileUploadHandler {
+  return function fetchUpload(file, { signal, onProgress }) {
+    return new Promise<UploadedFile>((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("POST", opts.url, true);
+      xhr.responseType = "json";
+
+      const fd = new FormData();
+      fd.append(opts.fieldName ?? "file", file, file.name);
+      if (opts.extra) {
+        for (const [k, v] of Object.entries(opts.extra)) fd.append(k, v);
+      }
+
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable && onProgress) {
+          onProgress((e.loaded / e.total) * 100);
+        }
+      };
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const json = xhr.response as unknown;
+            const picked = opts.pickResult
+              ? opts.pickResult(json)
+              : (json as UploadedFile);
+            resolve(picked);
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error("Bad response"));
+          }
+        } else {
+          const msg =
+            (xhr.response && (xhr.response as { error?: string }).error) ||
+            `HTTP ${xhr.status}`;
+          reject(new Error(msg));
+        }
+      };
+      xhr.onerror = () => reject(new Error("Network error"));
+      xhr.onabort = () => reject(new DOMException("Aborted", "AbortError"));
+
+      signal.addEventListener("abort", () => xhr.abort(), { once: true });
+      xhr.send(fd);
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- New `<FileUpload>` primitive at `src/components/ui/file-upload.tsx` — multi-file drag-drop queue with per-row progress, retry, cancel, concurrency cap (default 3), client-side size + MIME + extension validation, inline rejection reasons, keyboard activation, role=list/listitem rows, aria-live status announcements, and an Apple-iOS aesthetic. No new dependencies.
- Bonus helper: `createFetchUploadHandler()` — XHR-backed handler factory that reports **real** upload progress and respects `AbortSignal`.
- Five adoption surfaces:
  1. Clinician patient documents (`ClinicianUploadForm`) — now multi-file against existing `uploadClinicianDocumentAction`.
  2. Patient portal records — same primitive, same `uploadDocumentAction`; drop a folder of PDFs.
  3. Lab order form — new "Supporting attachments" card (requisitions, prior results). **Server-side TODO documented inline**.
  4. Vendor application (Leafmart) — COA / tax document slot. **Server-side TODO documented inline**.
  5. UniversalFeedbackFab — optional screenshot attachment; whisper payload now includes attachment names.

## Why a primitive?
Four bespoke dropzones had drifted apart on validation, error UX, and aesthetic. One primitive, one mental model, mechanical adoption.

## Server-side wiring
- Patient docs + portal records: wired to existing server actions (Supabase storage path already in place).
- Lab attachments, vendor COA, feedback screenshots: UI is ready, handler is local-only with explicit `TODO` comments pointing to the routes that need to land. Swap the local handler for `createFetchUploadHandler({ url: ... })` once each route exists.

## Out of scope
- `imaging-upload-dropzone.tsx` (DICOM modality metadata) and `avatar-upload.tsx` (square-crop modal) are deliberately left intact — they have specialized UX the primitive shouldn't subsume yet.

## Test plan
- [ ] Drag 5+ files onto each adopted surface; verify queue, progress, retry-on-fail, cancel-mid-upload behave correctly.
- [ ] Confirm too-large / wrong-type files surface inline rejection without blocking the rest of the batch.
- [ ] Keyboard: tab into drop zone, Enter to open picker; tab through retry/cancel/remove buttons.
- [ ] Screen reader: verify per-file status changes are announced via the aria-live region.
- [ ] `npx prisma generate && npm run typecheck && npm run lint` — all clean (no new warnings; pre-existing warnings unchanged).

Constraints respected: no edits to prisma/schema, middleware, workflows, manifests, auth, CLAUDE.md, or `/ops/supplies`. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)