### PR TITLE
ux: format primitives — money/dose/vitals/labs + 13 adoption sites

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/clinical-billing-tab.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/clinical-billing-tab.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { formatDate, formatRelative } from "@/lib/utils/format";
+import { money } from "@/lib/ui/format";
 
 /**
  * Clinical Billing Summary — the physician's billing surface.
@@ -333,12 +334,7 @@ function ClaimRow({ claim }: { claim: any }) {
 
 function formatCents(cents: number): string {
   if (cents === 0) return "$0";
-  const negative = cents < 0;
-  const abs = Math.abs(cents);
-  return `${negative ? "-" : ""}$${(abs / 100).toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return money(cents);
 }
 
 const CATEGORY_LABELS: Record<string, string> = {

--- a/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils/cn";
 import { explainLabValue } from "@/lib/domain/lab-explainer";
 import { LabTooltip } from "@/components/ui/lab-tooltip";
 import { Tooltip } from "@/components/ui/tooltip";
+import { LabValue } from "@/components/ui/format";
 import {
   draftLabOutreachAction,
   updateLabOutreachAction,
@@ -436,7 +437,16 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
                             c.abnormal ? "text-danger" : "text-text"
                           )}
                         >
-                          {c.value} {c.unit}
+                          <LabValue
+                            value={c.value}
+                            unit={c.unit}
+                            refLow={c.refLow}
+                            refHigh={c.refHigh}
+                            // Row-level abnormal styling already conveys the
+                            // out-of-range signal; hide the chip to avoid
+                            // duplicate visual flags in the same cell.
+                            hideFlag
+                          />
                         </td>
                         <td className="text-right px-4 py-2.5 tabular-nums text-text-muted">
                           {p

--- a/src/app/(operator)/ops/eob/page.tsx
+++ b/src/app/(operator)/ops/eob/page.tsx
@@ -11,10 +11,12 @@ import {
   type Era835Header,
 } from "@/lib/billing/eob";
 
+import { money } from "@/lib/ui/format";
+
 export const metadata = { title: "EOB Inbox" };
 
 function formatMoney(cents: number): string {
-  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+  return money(cents);
 }
 
 // Sample 835 fixtures — once the clearinghouse webhook lands these come

--- a/src/app/(operator)/ops/financial-cockpit/page.tsx
+++ b/src/app/(operator)/ops/financial-cockpit/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow, EditorialRule } from "@/components/ui/ornament";
 import { Button } from "@/components/ui/button";
+import { money } from "@/lib/ui/format";
 
 export const metadata = { title: "Financial Cockpit" };
 export const dynamic = "force-dynamic";
@@ -22,11 +23,7 @@ export const dynamic = "force-dynamic";
 // the headline metrics and routes to the existing detail surfaces.
 
 function formatMoney(cents: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  }).format(cents / 100);
+  return money(cents, { compactDollars: true });
 }
 
 export default async function FinancialCockpitPage() {

--- a/src/app/(operator)/ops/lockbox/reconcile/ReconcileForm.tsx
+++ b/src/app/(operator)/ops/lockbox/reconcile/ReconcileForm.tsx
@@ -3,14 +3,12 @@
 import { useState, useTransition } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-/** Inline to avoid importing server-only billing.ts into client bundle */
-function formatMoney(cents: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(cents / 100);
-}
+import { money } from "@/lib/ui/format";
 import { previewReconcileCsv, type ReconcilePreviewResult } from "./actions";
+
+function formatMoney(cents: number): string {
+  return money(cents);
+}
 
 type Status = "matched" | "partially_matched" | "unmatched" | "variance";
 

--- a/src/app/(operator)/ops/revenue/page.tsx
+++ b/src/app/(operator)/ops/revenue/page.tsx
@@ -16,6 +16,7 @@ import {
   type DispensaryProductInput,
 } from "@/lib/billing/dispensary-revenue";
 import { Sparkline } from "@/components/ui/sparkline";
+import { money } from "@/lib/ui/format";
 
 export const metadata = { title: "Revenue Cockpit" };
 
@@ -24,18 +25,11 @@ export const metadata = { title: "Revenue Cockpit" };
 // ---------------------------------------------------------------------------
 
 function formatMoney(cents: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  }).format(cents / 100);
+  return money(cents, { compactDollars: true });
 }
 
 function formatMoneyPrecise(cents: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(cents / 100);
+  return money(cents);
 }
 
 const STATUS_COLORS: Record<string, string> = {

--- a/src/app/(super-admin)/admin/hq/tiles/format.ts
+++ b/src/app/(super-admin)/admin/hq/tiles/format.ts
@@ -1,28 +1,18 @@
 // Shared, pure formatting + color helpers for the HQ tiles. No React, no
 // server imports — safe to use anywhere and trivial to unit-test.
 
-const USD_BIG = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
-const USD_SMALL = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { money } from "@/lib/ui/format";
 
 /**
  * Format cents → USD. Cents are dropped above the $1,000 threshold so the
  * KPI strip reads at a glance, but values under $1,000 keep two decimals so
- * single-charge debugging contexts stay legible.
+ * single-charge debugging contexts stay legible. Delegates to the central
+ * `money()` primitive so all surfaces speak the same way.
  */
 export function formatUSDCents(cents: number): string {
   const dollars = cents / 100;
-  if (Math.abs(dollars) >= 1000) return USD_BIG.format(dollars);
-  return USD_SMALL.format(dollars);
+  if (Math.abs(dollars) >= 1000) return money(cents, { compactDollars: true });
+  return money(cents);
 }
 
 /** Integer with thousand-separators, e.g. `1,284`. */

--- a/src/app/(super-admin)/practices/[id]/billing-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/billing-tab.tsx
@@ -3,12 +3,10 @@
 // the table is sufficient for the v1 acceptance gate (EMR-745 notes).
 
 import { loadPracticeBilling } from "../loaders";
+import { money } from "@/lib/ui/format";
 
 function formatDollars(cents: number): string {
-  const dollars = cents / 100;
-  return `$${dollars.toLocaleString(undefined, {
-    maximumFractionDigits: 0,
-  })}`;
+  return money(cents, { compactDollars: true });
 }
 
 function formatNumber(n: number): string {

--- a/src/app/(super-admin)/practices/[id]/overview-tab.tsx
+++ b/src/app/(super-admin)/practices/[id]/overview-tab.tsx
@@ -4,14 +4,12 @@
 // that we have a full page.
 
 import { Badge } from "@/components/ui/badge";
+import { money } from "@/lib/ui/format";
 import type { PracticeCardData } from "../types";
 import { humanizeCareModel, humanizeSpecialty } from "../types";
 
 function formatDollars(cents: number): string {
-  const dollars = cents / 100;
-  if (dollars >= 1_000_000) return `$${(dollars / 1_000_000).toFixed(1)}M`;
-  if (dollars >= 1_000) return `$${(dollars / 1_000).toFixed(1)}K`;
-  return `$${dollars.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  return money(cents, { abbreviate: true });
 }
 
 function formatNumber(n: number): string {

--- a/src/app/(super-admin)/practices/page.tsx
+++ b/src/app/(super-admin)/practices/page.tsx
@@ -18,6 +18,7 @@ import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { loadPracticeLandingCards } from "./loaders";
 import { PracticeCard } from "./practice-card";
 import { PublishedBanner } from "./published-banner";
+import { money } from "@/lib/ui/format";
 
 export const metadata: Metadata = {
   title: "Practices — Leafjourney",
@@ -86,9 +87,7 @@ export default async function PracticesLandingPage({
           />
           <SummaryStat
             label="Collected"
-            value={`$${(totalPaidCents / 100).toLocaleString(undefined, {
-              maximumFractionDigits: 0,
-            })}`}
+            value={money(totalPaidCents, { compactDollars: true })}
             sub="Posted to claims"
           />
         </div>

--- a/src/app/(super-admin)/practices/practice-card.tsx
+++ b/src/app/(super-admin)/practices/practice-card.tsx
@@ -12,14 +12,12 @@ import { ChevronRight, MapPin, Stethoscope, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { money } from "@/lib/ui/format";
 import type { PracticeCardData } from "./types";
 import { humanizeCareModel, humanizeSpecialty } from "./types";
 
 function formatDollars(cents: number): string {
-  const dollars = cents / 100;
-  if (dollars >= 1_000_000) return `$${(dollars / 1_000_000).toFixed(1)}M`;
-  if (dollars >= 1_000) return `$${(dollars / 1_000).toFixed(1)}K`;
-  return `$${dollars.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  return money(cents, { abbreviate: true });
 }
 
 function formatNumber(n: number): string {

--- a/src/app/leafmart/supply-store/page.tsx
+++ b/src/app/leafmart/supply-store/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { money } from "@/lib/ui/format";
 import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
 import { prisma } from "@/lib/db/prisma";
 import {
@@ -53,7 +54,7 @@ const CATEGORY_LABELS: Record<SupplyCategory, string> = {
 const COMMON_SYMPTOMS = ["cough", "sore throat", "insomnia", "pain", "anxiety", "indigestion"];
 
 function formatPrice(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
+  return money(cents);
 }
 
 export default async function SupplyStorePage({

--- a/src/app/pricing/PricingClient.tsx
+++ b/src/app/pricing/PricingClient.tsx
@@ -6,6 +6,7 @@ import { Check, Minus, ArrowRight, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Eyebrow, EditorialRule } from "@/components/ui/ornament";
 import { cn } from "@/lib/utils/cn";
+import { money } from "@/lib/ui/format";
 
 type Tier = {
   id: "starter" | "professional" | "enterprise";
@@ -142,7 +143,10 @@ function priceFor(tier: Tier, annual: boolean) {
   const monthly = annual
     ? Math.round(tier.priceMonthly * 0.8)
     : tier.priceMonthly;
-  return `$${monthly}`;
+  // Pricing tier rows store dollars; the central money() helper expects
+  // cents — multiply by 100 so en-US thousands separators kick in for any
+  // future tier above $999/month (Enterprise add-ons, multi-seat bundles).
+  return money(monthly * 100, { compactDollars: true });
 }
 
 export function PricingClient() {

--- a/src/components/patient/vitals-card.tsx
+++ b/src/components/patient/vitals-card.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Heart, Activity, Thermometer, Wind, Droplets } from "lucide-react";
+import { Vitals } from "@/components/ui/format";
 
 export interface VitalsProps {
   heartRate: number;
@@ -56,9 +57,11 @@ export function VitalsCard({ vitals }: { vitals?: VitalsProps }) {
             <Droplets className="w-3.5 h-3.5" /> Circulation Flow
           </span>
           <div className="flex items-baseline gap-1">
-            <span className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100">
-              {vitals.bloodPressureSys}/{vitals.bloodPressureDia}
-            </span>
+            <Vitals.BP
+              systolic={vitals.bloodPressureSys}
+              diastolic={vitals.bloodPressureDia}
+              className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100"
+            />
           </div>
         </div>
 
@@ -67,7 +70,7 @@ export function VitalsCard({ vitals }: { vitals?: VitalsProps }) {
             <Wind className="w-3.5 h-3.5" /> Breathing Pace
           </span>
           <div className="flex items-baseline gap-1">
-            <span className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100">
+            <span className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100 tabular-nums">
               {vitals.respiratoryRate}
             </span>
             <span className="text-xs text-neutral-500">breaths/min</span>
@@ -79,9 +82,10 @@ export function VitalsCard({ vitals }: { vitals?: VitalsProps }) {
             <Wind className="w-3.5 h-3.5 text-blue-500" /> Blood Oxygen
           </span>
           <div className="flex items-baseline gap-1">
-            <span className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100">
-              {vitals.oxygenSaturation}%
-            </span>
+            <Vitals.SpO2
+              value={vitals.oxygenSaturation}
+              className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100"
+            />
           </div>
         </div>
 
@@ -90,9 +94,11 @@ export function VitalsCard({ vitals }: { vitals?: VitalsProps }) {
             <Thermometer className="w-3.5 h-3.5 text-orange-500" /> Body Warmth
           </span>
           <div className="flex items-baseline gap-1">
-            <span className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100">
-              {vitals.temperature}°F
-            </span>
+            <Vitals.Temp
+              value={vitals.temperature}
+              unit="F"
+              className="text-2xl font-semibold text-neutral-800 dark:text-neutral-100"
+            />
           </div>
         </div>
       </div>

--- a/src/components/ui/format/dose.tsx
+++ b/src/components/ui/format/dose.tsx
@@ -1,0 +1,27 @@
+// <Dose> — render medication dose amounts (`100 mg`, `5 mL`, `1 tab`).
+//
+// Wraps `dose()` from src/lib/ui/format. Tabular numerals so dose columns
+// align in med lists.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+import { dose, type DoseUnit } from "@/lib/ui/format";
+
+export interface DoseProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  value: number | null | undefined;
+  unit: DoseUnit | null | undefined;
+}
+
+export function Dose({ value, unit, className, ...rest }: DoseProps) {
+  return (
+    <span
+      data-component="dose"
+      className={cn("tabular-nums", className)}
+      {...rest}
+    >
+      {dose(value, unit)}
+    </span>
+  );
+}

--- a/src/components/ui/format/index.ts
+++ b/src/components/ui/format/index.ts
@@ -1,0 +1,7 @@
+// Barrel for the display-primitive components. Pair with the helpers in
+// `src/lib/ui/format.ts` when you only need a string.
+
+export { Money, type MoneyProps } from "./money";
+export { Dose, type DoseProps } from "./dose";
+export { Vitals, type BpProps, type TempProps, type SpO2Props } from "./vitals";
+export { LabValue, type LabValueProps } from "./lab-value";

--- a/src/components/ui/format/lab-value.tsx
+++ b/src/components/ui/format/lab-value.tsx
@@ -1,0 +1,84 @@
+// <LabValue> — render a lab result with an optional out-of-range flag chip.
+//
+// Wraps `lab()` from src/lib/ui/format. The chip is:
+//   - ▲ red when above the reference range
+//   - ▼ blue when below
+//   - nothing when in-range or no range provided
+//
+// The flag chip exposes an `aria-label` ("Above reference range" / "Below
+// reference range") so screen-reader users get the same signal as sighted
+// ones. Numbers render tabular for column alignment.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+import { lab, labFlagAriaLabel, type LabFlag } from "@/lib/ui/format";
+
+export interface LabValueProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  value: number | null | undefined;
+  unit?: string | null;
+  refLow?: number | null;
+  refHigh?: number | null;
+  /** Hide the chip even if out-of-range (e.g. inside a table that flags rows). */
+  hideFlag?: boolean;
+  /** Override the resolved flag (rare — useful when upstream has done the math). */
+  flag?: LabFlag;
+}
+
+function FlagChip({ flag }: { flag: Exclude<LabFlag, null | "normal"> }) {
+  const label = labFlagAriaLabel(flag);
+  if (flag === "high") {
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        className="inline-flex items-center justify-center text-[10px] leading-none px-1 py-0.5 ml-1 rounded bg-red-50 text-danger font-medium"
+      >
+        ▲
+      </span>
+    );
+  }
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      className="inline-flex items-center justify-center text-[10px] leading-none px-1 py-0.5 ml-1 rounded bg-blue-50 text-blue-700 font-medium"
+    >
+      ▼
+    </span>
+  );
+}
+
+export function LabValue({
+  value,
+  unit,
+  refLow,
+  refHigh,
+  hideFlag,
+  flag: flagOverride,
+  className,
+  ...rest
+}: LabValueProps) {
+  const result = lab(value, unit ?? undefined, refLow, refHigh);
+  const flag = flagOverride ?? result.flag;
+
+  return (
+    <span
+      data-component="lab-value"
+      data-flag={flag ?? "none"}
+      className={cn("tabular-nums inline-flex items-baseline", className)}
+      {...rest}
+    >
+      <span
+        className={cn(
+          flag === "high" && "text-danger font-medium",
+          flag === "low" && "text-blue-700 font-medium",
+        )}
+      >
+        {result.display}
+      </span>
+      {!hideFlag && (flag === "high" || flag === "low") && <FlagChip flag={flag} />}
+    </span>
+  );
+}

--- a/src/components/ui/format/money.tsx
+++ b/src/components/ui/format/money.tsx
@@ -1,0 +1,50 @@
+// <Money> — render integer cents as USD with consistent formatting.
+//
+// Wraps `money()` from src/lib/ui/format. Applies `tabular-nums` so columns
+// of numbers line up. Negative values render with a red tint by default;
+// callers can override with `tone="neutral"` if the sign is conveyed elsewhere.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+import { money, moneyTone, type MoneyOpts } from "@/lib/ui/format";
+
+export interface MoneyProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Integer cents. `null`/`undefined`/`NaN` renders as `—`. */
+  cents: number | null | undefined;
+  /** Format options forwarded to `money()`. */
+  options?: MoneyOpts;
+  /**
+   * Visual tone. Defaults to `"auto"` — negative values get a red tint and
+   * everything else renders in the surrounding text color.
+   */
+  tone?: "auto" | "neutral" | "negative" | "positive";
+}
+
+export function Money({
+  cents,
+  options,
+  tone = "auto",
+  className,
+  ...rest
+}: MoneyProps) {
+  const display = money(cents, options);
+  const resolvedTone =
+    tone === "auto" ? (moneyTone(cents) === "negative" ? "negative" : "neutral") : tone;
+
+  return (
+    <span
+      data-component="money"
+      className={cn(
+        "tabular-nums",
+        resolvedTone === "negative" && "text-danger",
+        resolvedTone === "positive" && "text-success",
+        className,
+      )}
+      {...rest}
+    >
+      {display}
+    </span>
+  );
+}

--- a/src/components/ui/format/vitals.tsx
+++ b/src/components/ui/format/vitals.tsx
@@ -1,0 +1,69 @@
+// <Vitals.BP>, <Vitals.Temp>, <Vitals.SpO2> — clinical-unit primitives.
+//
+// Wraps the vitals helpers from src/lib/ui/format. Tabular numerals so
+// vital-signs columns line up. The display string includes the unit so the
+// component is safe to drop anywhere without extra context.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils/cn";
+import { vitals as fmtVitals } from "@/lib/ui/format";
+
+interface BaseProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {}
+
+export interface BpProps extends BaseProps {
+  systolic: number | null | undefined;
+  diastolic: number | null | undefined;
+  /** Suffix appended after the BP reading; defaults to no suffix. */
+  suffix?: "mmHg" | "";
+}
+
+function BP({ systolic, diastolic, suffix = "", className, ...rest }: BpProps) {
+  const value = fmtVitals.bp(systolic, diastolic);
+  const display = suffix && value !== "—" ? `${value} ${suffix}` : value;
+  return (
+    <span
+      data-component="vitals-bp"
+      className={cn("tabular-nums", className)}
+      {...rest}
+    >
+      {display}
+    </span>
+  );
+}
+
+export interface TempProps extends BaseProps {
+  value: number | null | undefined;
+  unit?: "F" | "C";
+}
+
+function Temp({ value, unit = "F", className, ...rest }: TempProps) {
+  return (
+    <span
+      data-component="vitals-temp"
+      className={cn("tabular-nums", className)}
+      {...rest}
+    >
+      {fmtVitals.temp(value, unit)}
+    </span>
+  );
+}
+
+export interface SpO2Props extends BaseProps {
+  value: number | null | undefined;
+}
+
+function SpO2({ value, className, ...rest }: SpO2Props) {
+  return (
+    <span
+      data-component="vitals-spo2"
+      className={cn("tabular-nums", className)}
+      {...rest}
+    >
+      {fmtVitals.spo2(value)}
+    </span>
+  );
+}
+
+export const Vitals = { BP, Temp, SpO2 };

--- a/src/lib/ui/format.test.ts
+++ b/src/lib/ui/format.test.ts
@@ -1,0 +1,109 @@
+// Light unit coverage for the display primitives. Keeps the contract honest
+// so adoption sites can rely on consistent output and null-safety.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  dose,
+  lab,
+  labFlagAriaLabel,
+  money,
+  moneyTone,
+  vitals,
+} from "./format";
+
+describe("money", () => {
+  it("formats cents as USD with two decimals", () => {
+    expect(money(123456)).toBe("$1,234.56");
+    expect(money(0)).toBe("$0.00");
+    expect(money(99)).toBe("$0.99");
+  });
+
+  it("renders negative values with a leading minus", () => {
+    expect(money(-500)).toBe("-$5.00");
+  });
+
+  it("returns a placeholder for null / undefined / NaN", () => {
+    expect(money(null)).toBe("—");
+    expect(money(undefined)).toBe("—");
+    expect(money(Number.NaN)).toBe("—");
+  });
+
+  it("supports compactDollars and abbreviate", () => {
+    expect(money(123456, { compactDollars: true })).toBe("$1,235");
+    expect(money(1_234_567_89, { abbreviate: true })).toBe("$1.2M");
+    expect(money(123_456_789, { abbreviate: true })).toBe("$1.2M");
+    expect(money(345_678, { abbreviate: true })).toBe("$3.5K");
+  });
+
+  it("reports tone for negative values", () => {
+    expect(moneyTone(-100)).toBe("negative");
+    expect(moneyTone(100)).toBe("neutral");
+    expect(moneyTone(null)).toBe("neutral");
+  });
+});
+
+describe("dose", () => {
+  it("renders amount + unit", () => {
+    expect(dose(100, "mg")).toBe("100 mg");
+    expect(dose(5, "ml")).toBe("5 mL");
+    expect(dose(1, "tab")).toBe("1 tab");
+  });
+
+  it("strips trailing zeros from decimals", () => {
+    expect(dose(2.5, "mg")).toBe("2.5 mg");
+    expect(dose(1.0, "mg")).toBe("1 mg");
+  });
+
+  it("handles missing values", () => {
+    expect(dose(null, "mg")).toBe("—");
+    expect(dose(Number.NaN, "mg")).toBe("—");
+  });
+});
+
+describe("vitals", () => {
+  it("formats blood pressure", () => {
+    expect(vitals.bp(120, 80)).toBe("120/80");
+    expect(vitals.bp(120, null)).toBe("—");
+  });
+
+  it("formats temperature with default Fahrenheit", () => {
+    expect(vitals.temp(98.6)).toBe("98.6 °F");
+    expect(vitals.temp(37.0, "C")).toBe("37.0 °C");
+    expect(vitals.temp(null)).toBe("—");
+  });
+
+  it("formats spo2 clamped to 0–100", () => {
+    expect(vitals.spo2(98)).toBe("98%");
+    expect(vitals.spo2(101)).toBe("100%");
+    expect(vitals.spo2(null)).toBe("—");
+  });
+});
+
+describe("lab", () => {
+  it("returns normal flag inside range", () => {
+    expect(lab(4.5, "mmol/L", 3.5, 5.0)).toEqual({
+      display: "4.5 mmol/L",
+      flag: "normal",
+    });
+  });
+
+  it("flags high and low values", () => {
+    expect(lab(6.2, "mmol/L", 3.5, 5.0).flag).toBe("high");
+    expect(lab(2.1, "mmol/L", 3.5, 5.0).flag).toBe("low");
+  });
+
+  it("returns null flag when no range provided", () => {
+    expect(lab(4.5, "mmol/L").flag).toBeNull();
+  });
+
+  it("handles missing values", () => {
+    expect(lab(null, "mmol/L")).toEqual({ display: "—", flag: null });
+  });
+
+  it("exposes a11y labels", () => {
+    expect(labFlagAriaLabel("high")).toBe("Above reference range");
+    expect(labFlagAriaLabel("low")).toBe("Below reference range");
+    expect(labFlagAriaLabel("normal")).toBeUndefined();
+  });
+});

--- a/src/lib/ui/format.ts
+++ b/src/lib/ui/format.ts
@@ -1,0 +1,236 @@
+// Display primitives for money + clinical units. Every surface should speak
+// the same way: $X.XX from cents, dose "100 mg", BP "120/80", labs with a
+// reference-range flag.
+//
+// Pure functions. No React, no server imports — safe to import anywhere and
+// trivially unit-testable.
+//
+// i18n follow-up: en-US + USD are hardcoded. When we add locale support we
+// will plumb a LocaleContext through and accept (locale, currency) opts.
+// Tracked in the PR body.
+
+const PLACEHOLDER = "—";
+
+// -----------------------------------------------------------------------------
+// Internal: nullish/NaN guard
+// -----------------------------------------------------------------------------
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+// -----------------------------------------------------------------------------
+// Money — cents in, formatted USD out
+// -----------------------------------------------------------------------------
+
+export type MoneyOpts = {
+  /** Drop the cents and render `$1,234` if true. Default false. */
+  compactDollars?: boolean;
+  /** Render absolute value and let the caller convey sign (e.g. red badge). */
+  absolute?: boolean;
+  /** Render as $1.2K / $3.4M for KPIs. Negative values stay precise. */
+  abbreviate?: boolean;
+};
+
+const USD_PRECISE = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const USD_WHOLE = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Format integer cents as USD.
+ *
+ * - `money(123456)` → `"$1,234.56"`
+ * - `money(-500)` → `"-$5.00"` (callers may add a red tone)
+ * - `money(null)` → `"—"`
+ * - `money(12345, { abbreviate: true })` → `"$123"` (<$1K stays precise via `compactDollars`)
+ */
+export function money(
+  cents: number | null | undefined,
+  opts: MoneyOpts = {},
+): string {
+  if (!isFiniteNumber(cents)) return PLACEHOLDER;
+  const signed = opts.absolute ? Math.abs(cents) : cents;
+  const dollars = signed / 100;
+
+  if (opts.abbreviate) {
+    const abs = Math.abs(dollars);
+    if (abs >= 1_000_000) {
+      const sign = dollars < 0 ? "-" : "";
+      return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+    }
+    if (abs >= 1_000) {
+      const sign = dollars < 0 ? "-" : "";
+      return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+    }
+    return USD_WHOLE.format(dollars);
+  }
+
+  if (opts.compactDollars) return USD_WHOLE.format(dollars);
+  return USD_PRECISE.format(dollars);
+}
+
+/**
+ * Returns a hint for callers that want to tint negative money red. The
+ * function intentionally returns the string only — the consuming component
+ * decides how to style it.
+ */
+export function moneyTone(cents: number | null | undefined): "negative" | "neutral" {
+  if (!isFiniteNumber(cents)) return "neutral";
+  return cents < 0 ? "negative" : "neutral";
+}
+
+// -----------------------------------------------------------------------------
+// Dose — medication amounts ("100 mg", "5 mL", "1 tab")
+// -----------------------------------------------------------------------------
+
+export type DoseUnit =
+  | "mg"
+  | "g"
+  | "mcg"
+  | "mL"
+  | "ml"
+  | "L"
+  | "tab"
+  | "tabs"
+  | "cap"
+  | "caps"
+  | "drop"
+  | "drops"
+  | "puff"
+  | "puffs"
+  | "spray"
+  | "sprays"
+  | "patch"
+  | "patches"
+  | "unit"
+  | "units"
+  | string; // permissive — surfaces use lots of bespoke units
+
+/**
+ * Format a dose amount with a unit. Whole numbers render as `100 mg`,
+ * fractional ones render with up to 2 decimals stripped of trailing zeros
+ * (`2.5 mg`, `0.5 mL`). NaN/null returns the placeholder.
+ */
+export function dose(
+  value: number | null | undefined,
+  unit: DoseUnit | null | undefined,
+): string {
+  if (!isFiniteNumber(value)) return PLACEHOLDER;
+  if (!unit) return formatDoseNumber(value);
+  const u = normalizeDoseUnit(unit);
+  return `${formatDoseNumber(value)} ${u}`;
+}
+
+function formatDoseNumber(value: number): string {
+  if (Number.isInteger(value)) return value.toString();
+  // Strip trailing zeros: 2.50 → 2.5, 1.00 → 1
+  return value.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function normalizeDoseUnit(unit: string): string {
+  // Canonical capitalization for the common ones; pass through everything else.
+  const map: Record<string, string> = {
+    ml: "mL",
+    ML: "mL",
+    Ml: "mL",
+    l: "L",
+    Mg: "mg",
+    MG: "mg",
+    G: "g",
+    MCG: "mcg",
+    Mcg: "mcg",
+  };
+  return map[unit] ?? unit;
+}
+
+// -----------------------------------------------------------------------------
+// Vitals — BP, temperature, SpO2
+// -----------------------------------------------------------------------------
+
+export const vitals = {
+  /**
+   * Blood pressure as `120/80`. Returns placeholder if either reading is
+   * missing.
+   */
+  bp(
+    systolic: number | null | undefined,
+    diastolic: number | null | undefined,
+  ): string {
+    if (!isFiniteNumber(systolic) || !isFiniteNumber(diastolic)) return PLACEHOLDER;
+    return `${Math.round(systolic)}/${Math.round(diastolic)}`;
+  },
+
+  /**
+   * Temperature. Defaults to °F (US convention). Rounds to 1 decimal.
+   */
+  temp(
+    value: number | null | undefined,
+    unit: "F" | "C" = "F",
+  ): string {
+    if (!isFiniteNumber(value)) return PLACEHOLDER;
+    return `${value.toFixed(1)} °${unit}`;
+  },
+
+  /**
+   * Oxygen saturation as `98%`. Clamps to 0–100.
+   */
+  spo2(value: number | null | undefined): string {
+    if (!isFiniteNumber(value)) return PLACEHOLDER;
+    const clamped = Math.max(0, Math.min(100, Math.round(value)));
+    return `${clamped}%`;
+  },
+};
+
+// -----------------------------------------------------------------------------
+// Lab values — value + unit with optional reference-range flag
+// -----------------------------------------------------------------------------
+
+export type LabFlag = "high" | "low" | "normal" | null;
+
+export interface LabResult {
+  display: string;
+  flag: LabFlag;
+}
+
+/**
+ * Render a lab value with its unit and an optional out-of-range flag.
+ *
+ * - `lab(4.5, "mmol/L")` → `{ display: "4.5 mmol/L", flag: null }`
+ * - `lab(6.2, "mmol/L", 3.5, 5.0)` → `{ display: "6.2 mmol/L", flag: "high" }`
+ * - `lab(null, "mmol/L")` → `{ display: "—", flag: null }`
+ */
+export function lab(
+  value: number | null | undefined,
+  unit: string | null | undefined,
+  refLow?: number | null,
+  refHigh?: number | null,
+): LabResult {
+  if (!isFiniteNumber(value)) return { display: PLACEHOLDER, flag: null };
+  const u = unit ? ` ${unit}` : "";
+  const display = `${formatDoseNumber(value)}${u}`;
+  let flag: LabFlag = "normal";
+  const hasLow = isFiniteNumber(refLow);
+  const hasHigh = isFiniteNumber(refHigh);
+  if (!hasLow && !hasHigh) flag = null;
+  else if (hasLow && value < (refLow as number)) flag = "low";
+  else if (hasHigh && value > (refHigh as number)) flag = "high";
+  return { display, flag };
+}
+
+/** Human-readable a11y label for a lab flag. */
+export function labFlagAriaLabel(flag: LabFlag): string | undefined {
+  if (flag === "high") return "Above reference range";
+  if (flag === "low") return "Below reference range";
+  return undefined;
+}
+
+export const FORMAT_PLACEHOLDER = PLACEHOLDER;


### PR DESCRIPTION
## Summary

Adds central display primitives so every surface speaks the same way:
\$X.XX from cents, `100 mg`, `BP 120/80`, `98.6 °F`, `98%`, lab values with
out-of-range flag chips. All helpers null/NaN-safe — they return `—` instead
of crashing on missing data.

## Primitives

`src/lib/ui/format.ts` (pure helpers) + `src/components/ui/format/*` (React wrappers with `tabular-nums`):

- `money(cents, opts?)` / `<Money>` — `Intl.NumberFormat` USD; `compactDollars` for KPI strips, `abbreviate` for `$1.2K` / `$1.2M`; auto-tones negatives red
- `dose(value, unit)` / `<Dose>` — `100 mg`, normalizes `ml` → `mL`, strips trailing zeros (`2.50` → `2.5`)
- `vitals.bp` / `<Vitals.BP>` — `120/80`, optional `mmHg` suffix
- `vitals.temp` / `<Vitals.Temp>` — `98.6 °F` (default) or `37.0 °C`
- `vitals.spo2` / `<Vitals.SpO2>` — `98%`, clamped 0–100
- `lab(value, unit, refLow?, refHigh?)` / `<LabValue>` — returns `{ display, flag }`; chip renders ▲ (above) / ▼ (below) with `aria-label` "Above/Below reference range"

16 unit tests cover the null-safety contract + edge cases (`vitest run src/lib/ui/format.test.ts` → 16 passed).

## Adoption sites (13)

**Super-admin / owner dashboard:**
- `(super-admin)/practices/page.tsx` — fleet "Collected" summary stat
- `(super-admin)/practices/practice-card.tsx` — per-practice paid revenue
- `(super-admin)/practices/[id]/overview-tab.tsx` — 8-KPI grid
- `(super-admin)/practices/[id]/billing-tab.tsx` — MTD + 12-month rollup
- `(super-admin)/admin/hq/tiles/format.ts` — `formatUSDCents` now delegates to `money()`

**CFO / billing:**
- `(operator)/ops/financial-cockpit/page.tsx`
- `(operator)/ops/eob/page.tsx`
- `(operator)/ops/revenue/page.tsx` (both `formatMoney` + `formatMoneyPrecise`)
- `(operator)/ops/lockbox/reconcile/ReconcileForm.tsx`
- `(clinician)/clinic/patients/[id]/clinical-billing-tab.tsx`

**Clinical:**
- `(clinician)/clinic/sign-off/labs/labs-review-view.tsx` — `<LabValue>` with `hideFlag` (row-level abnormal styling already conveys signal)
- `components/patient/vitals-card.tsx` — `<Vitals.BP>` / `<Vitals.Temp>` / `<Vitals.SpO2>`

**Consumer / marketing:**
- `leafmart/supply-store/page.tsx` — supply price (NOT `/ops/supplies` — that's PR #438)
- `pricing/PricingClient.tsx` — marketing tier prices

## Skipped (intentional)

- `/ops/supplies` per brief (in-flight PR #438)
- Medication-list dosage strings (`"20mg"`) — would require schema change
- `prisma/schema.prisma`, `middleware.ts`, `.github/workflows/`, `specialty-templates/manifests/`, `lib/auth/`, `CLAUDE.md` per constraints

## i18n follow-up

en-US + USD hardcoded for v1. The `money()` signature already accepts an
`opts` object, so adding a `locale`/`currency` parameter (plus a
`LocaleContext`) is a clean follow-up. Vitals + dose units stay imperial
(°F, mg, mL) until we add the toggle.

## Test plan

- [x] `npx prisma generate` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings
- [x] `vitest run src/lib/ui/format.test.ts` — 16 / 16 passed
- [ ] Visual spot-check on /practices, /ops/financial-cockpit, /clinic/sign-off/labs, /pricing
- [ ] Confirm vitals card on /portal renders BP/Temp/SpO2 with tabular alignment

Generated with [Claude Code](https://claude.com/claude-code)