### PR TITLE
ux: Calendar primitive (Month/Week/Day) + 3 schedule surface adoptions

### DIFF
--- a/src/app/(clinician)/clinic/schedule/month/month-view.tsx
+++ b/src/app/(clinician)/clinic/schedule/month/month-view.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Calendar, type CalendarEvent } from "@/components/ui/calendar";
+
+type Props = {
+  initialDateIso: string;
+  events: CalendarEvent[];
+};
+
+export function MonthView({ initialDateIso, events }: Props) {
+  const router = useRouter();
+  const [value, setValue] = React.useState<Date>(new Date(initialDateIso));
+  const [view, setView] = React.useState<"month" | "week" | "day">("month");
+
+  function onChange(d: Date) {
+    setValue(d);
+    // Sync deep-link so back/forward & sharing work.
+    const iso = d.toISOString().slice(0, 10);
+    router.replace(`/clinic/schedule/month?month=${iso}`, { scroll: false });
+  }
+
+  function onCreate(start: Date) {
+    // Hand off to the existing week-grid scheduler.
+    const iso = start.toISOString().slice(0, 10);
+    router.push(`/clinic/schedule?week=${iso}&view=day`);
+  }
+
+  return (
+    <Calendar
+      value={value}
+      onChange={onChange}
+      view={view}
+      onViewChange={setView}
+      events={events}
+      onCreate={onCreate}
+    />
+  );
+}

--- a/src/app/(clinician)/clinic/schedule/month/page.tsx
+++ b/src/app/(clinician)/clinic/schedule/month/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { MonthView } from "./month-view";
+import type { CalendarEvent } from "@/components/ui/calendar";
+
+export const metadata = { title: "Schedule — Month" };
+
+function startOfMonth(d: Date) {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+function startOfWeek(d: Date) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  x.setDate(x.getDate() - x.getDay());
+  return x;
+}
+
+export default async function ClinicianScheduleMonthPage({
+  searchParams,
+}: {
+  searchParams: { month?: string };
+}) {
+  const user = await requireUser();
+  const orgId = user.organizationId!;
+
+  const anchor = searchParams.month
+    ? new Date(searchParams.month + "T12:00:00")
+    : new Date();
+  if (Number.isNaN(anchor.getTime())) anchor.setTime(Date.now());
+
+  // Render 6 weeks (42 days) starting from the Sunday before the 1st.
+  const monthStart = startOfMonth(anchor);
+  const gridStart = startOfWeek(monthStart);
+  const gridEnd = new Date(gridStart);
+  gridEnd.setDate(gridEnd.getDate() + 42);
+
+  const appointments = await prisma.appointment.findMany({
+    where: {
+      patient: { organizationId: orgId },
+      startAt: { gte: gridStart, lt: gridEnd },
+    },
+    orderBy: { startAt: "asc" },
+    include: {
+      patient: { select: { id: true, firstName: true, lastName: true } },
+    },
+  });
+
+  const events: CalendarEvent[] = appointments.map((a) => {
+    const isBlock = `${a.patient.firstName} ${a.patient.lastName}`.includes(
+      "System CalendarBlock"
+    );
+    const title = isBlock
+      ? a.notes?.replace(/\[CalendarBlock:.*?\]/, "").trim() || "Blocked"
+      : `${a.patient.firstName} ${a.patient.lastName}`;
+    return {
+      id: a.id,
+      start: a.startAt.toISOString(),
+      end: a.endAt.toISOString(),
+      title,
+      patientId: a.patient.id,
+      href: isBlock ? undefined : `/clinic/patients/${a.patient.id}`,
+      color: isBlock
+        ? "neutral"
+        : a.status === "cancelled" || a.status === "no_show"
+          ? "danger"
+          : a.status === "confirmed"
+            ? "accent"
+            : "info",
+    };
+  });
+
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <PageHeader
+        eyebrow="Schedule"
+        title="Month view"
+        description="Cross-week overview of clinic appointments."
+        actions={
+          <Link
+            href="/clinic/schedule"
+            className="text-xs font-medium text-accent hover:underline"
+          >
+            Back to Week →
+          </Link>
+        }
+      />
+      <MonthView initialDateIso={anchor.toISOString()} events={events} />
+    </PageShell>
+  );
+}

--- a/src/app/(clinician)/clinic/schedule/schedule-calendar.tsx
+++ b/src/app/(clinician)/clinic/schedule/schedule-calendar.tsx
@@ -229,6 +229,12 @@ export function ScheduleCalendar({
           <Button variant="ghost" size="sm" onClick={() => goWeek(1)}>
             Next →
           </Button>
+          <Link
+            href="/clinic/schedule/month"
+            className="text-xs font-medium text-text-subtle hover:text-text underline-offset-4 hover:underline ml-1"
+          >
+            Month view
+          </Link>
         </div>
       </div>
 

--- a/src/app/(clinician)/telehealth/page.tsx
+++ b/src/app/(clinician)/telehealth/page.tsx
@@ -16,6 +16,8 @@ import { EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { PreVisitChecklistClient } from "./pre-visit-checklist-client";
 import { AmbientMicToggle } from "./ambient-mic-toggle";
 import { LaunchVideoPopup } from "./launch-video-popup";
+import { VisitWeekCalendar } from "./visit-week-calendar";
+import type { CalendarEvent } from "@/components/ui/calendar";
 
 export const metadata = { title: "Telehealth" };
 
@@ -99,6 +101,31 @@ export default async function TelehealthDashboardPage() {
     (e) => e.status === "scheduled",
   ).length;
 
+  // Build CalendarEvents for the week-view widget. Includes today (live +
+  // scheduled) plus upcoming.
+  const weekEvents: CalendarEvent[] = [...todaysVisits, ...upcoming]
+    .filter((v) => v.scheduledFor)
+    .map((v) => {
+      const start = v.scheduledFor!;
+      // Encounter rows store scheduledFor only; assume 30-min slots.
+      const end = new Date(start.getTime() + 30 * 60_000);
+      return {
+        id: v.id,
+        start: start.toISOString(),
+        end: end.toISOString(),
+        title: `${v.patient.firstName} ${v.patient.lastName}`,
+        description: v.reason ?? undefined,
+        patientId: v.patient.id,
+        href: `/clinic/patients/${v.patient.id}/telehealth`,
+        color:
+          v.status === "in_progress"
+            ? "danger"
+            : v.status === "complete"
+              ? "neutral"
+              : "info",
+      };
+    });
+
   return (
     <PageShell maxWidth="max-w-[1200px]">
       <PageHeader
@@ -150,6 +177,20 @@ export default async function TelehealthDashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 space-y-4">
+          {weekEvents.length > 0 && (
+            <Card tone="raised">
+              <CardHeader>
+                <CardTitle className="text-base">This week</CardTitle>
+                <CardDescription>
+                  All scheduled and live video visits this week.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="overflow-x-auto p-0">
+                <VisitWeekCalendar events={weekEvents} />
+              </CardContent>
+            </Card>
+          )}
+
           <Card tone="raised">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">

--- a/src/app/(clinician)/telehealth/visit-week-calendar.tsx
+++ b/src/app/(clinician)/telehealth/visit-week-calendar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+/**
+ * Week mini-calendar of upcoming telehealth visits.
+ * Adopts the shared <CalendarWeek> primitive — no drag-create needed here.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { CalendarWeek, type CalendarEvent } from "@/components/ui/calendar";
+
+export function VisitWeekCalendar({ events }: { events: CalendarEvent[] }) {
+  const router = useRouter();
+  const [value] = React.useState<Date>(new Date());
+  return (
+    <CalendarWeek
+      value={value}
+      events={events}
+      onEventClick={(ev) => {
+        if (ev.href) router.push(ev.href);
+      }}
+      startHour={7}
+      endHour={20}
+    />
+  );
+}

--- a/src/app/(patient)/portal/appointments/appointments-calendar.tsx
+++ b/src/app/(patient)/portal/appointments/appointments-calendar.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+import { Calendar, type CalendarEvent } from "@/components/ui/calendar";
+
+export function AppointmentsCalendar({ events }: { events: CalendarEvent[] }) {
+  const [value, setValue] = React.useState<Date>(new Date());
+  const [view, setView] = React.useState<"month" | "week" | "day">("month");
+
+  return (
+    <Calendar
+      value={value}
+      onChange={setValue}
+      view={view}
+      onViewChange={setView}
+      events={events}
+      // Patients don't create appointments by drag — they go through booking.
+    />
+  );
+}

--- a/src/app/(patient)/portal/appointments/page.tsx
+++ b/src/app/(patient)/portal/appointments/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db/prisma";
+import { requireRole } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { EmptyState } from "@/components/ui/empty-state";
+import { AppointmentsCalendar } from "./appointments-calendar";
+import type { CalendarEvent } from "@/components/ui/calendar";
+
+export const metadata = { title: "Appointments" };
+
+export default async function PortalAppointmentsPage() {
+  const user = await requireRole("patient");
+
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, deletedAt: null },
+  });
+  if (!patient) redirect("/portal/intake");
+
+  // Pull a generous window so month/week navigation has data.
+  const now = new Date();
+  const windowStart = new Date(now);
+  windowStart.setDate(windowStart.getDate() - 14);
+  const windowEnd = new Date(now);
+  windowEnd.setDate(windowEnd.getDate() + 60);
+
+  const appointments = await prisma.appointment.findMany({
+    where: {
+      patientId: patient.id,
+      startAt: { gte: windowStart, lt: windowEnd },
+    },
+    orderBy: { startAt: "asc" },
+    include: {
+      provider: {
+        select: {
+          title: true,
+          user: { select: { firstName: true, lastName: true } },
+        },
+      },
+    },
+  });
+
+  const events: CalendarEvent[] = appointments.map((a) => {
+    const providerName = a.provider?.user
+      ? `${a.provider.title ?? ""} ${a.provider.user.firstName ?? ""} ${a.provider.user.lastName ?? ""}`
+          .replace(/\s+/g, " ")
+          .trim()
+      : "Visit";
+    return {
+      id: a.id,
+      start: a.startAt.toISOString(),
+      end: a.endAt.toISOString(),
+      title: providerName,
+      description: a.notes ?? undefined,
+      color:
+        a.status === "cancelled" || a.status === "no_show"
+          ? "danger"
+          : a.status === "confirmed"
+            ? "accent"
+            : "info",
+    };
+  });
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Appointments"
+        title="Your visits"
+        description="See upcoming and recent appointments at a glance."
+        actions={
+          <Link
+            href="/portal/schedule"
+            className="inline-flex h-9 items-center rounded-md bg-accent px-3 text-xs font-semibold text-accent-ink hover:bg-accent-hover transition-colors"
+          >
+            Book new visit
+          </Link>
+        }
+      />
+      {events.length === 0 ? (
+        <EmptyState
+          title="No appointments yet"
+          description="Once you book a visit it will show up on the calendar here."
+        />
+      ) : (
+        <AppointmentsCalendar events={events} />
+      )}
+    </PageShell>
+  );
+}

--- a/src/components/ui/calendar/calendar-day.tsx
+++ b/src/components/ui/calendar/calendar-day.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+/**
+ * CalendarDay — single-day timeline with half-hour increments
+ * ------------------------------------------------------------
+ * Drag a half-hour slot to create. Click event for detail.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import type { CalendarEvent } from "./types";
+import { EventBlock } from "./event-block";
+import {
+  eventEnd,
+  eventStart,
+  formatDayLong,
+  isSameDay,
+  startOfDay,
+  useReducedMotion,
+} from "./utils";
+
+export interface CalendarDayProps {
+  value: Date;
+  events?: CalendarEvent[];
+  onCreate?: (start: Date, end: Date) => void;
+  onEventClick?: (event: CalendarEvent) => void;
+  startHour?: number;
+  endHour?: number;
+  /** Pixels per hour, default 64. */
+  hourHeight?: number;
+  className?: string;
+}
+
+const HALF_HOUR_MIN = 30;
+
+export function CalendarDay({
+  value,
+  events = [],
+  onCreate,
+  onEventClick,
+  startHour = 7,
+  endHour = 20,
+  hourHeight = 64,
+  className,
+}: CalendarDayProps) {
+  const totalMinutes = (endHour - startHour) * 60;
+  const dayEvents = events.filter((ev) => isSameDay(eventStart(ev), value));
+  const reduced = useReducedMotion();
+
+  const hours = React.useMemo(() => {
+    const out: number[] = [];
+    for (let h = startHour; h < endHour; h++) out.push(h);
+    return out;
+  }, [startHour, endHour]);
+  const totalPx = hours.length * hourHeight;
+
+  const [drag, setDrag] = React.useState<{ startMin: number; endMin: number } | null>(null);
+  const colRef = React.useRef<HTMLDivElement | null>(null);
+
+  function pointerMinutes(e: React.PointerEvent<HTMLDivElement>): number {
+    const el = colRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    const y = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+    const minutes = (y / rect.height) * totalMinutes + startHour * 60;
+    return Math.round(minutes / HALF_HOUR_MIN) * HALF_HOUR_MIN;
+  }
+
+  function commitDrag() {
+    if (!drag || !onCreate) {
+      setDrag(null);
+      return;
+    }
+    const lo = Math.min(drag.startMin, drag.endMin);
+    const hi = Math.max(drag.startMin, drag.endMin);
+    if (hi - lo < HALF_HOUR_MIN) {
+      setDrag(null);
+      return;
+    }
+    const s = startOfDay(value);
+    s.setMinutes(lo);
+    const e = startOfDay(value);
+    e.setMinutes(hi);
+    onCreate(s, e);
+    setDrag(null);
+  }
+
+  // Now line
+  const [now, setNow] = React.useState<Date>(() => new Date());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  const isToday = isSameDay(value, now);
+  const minutesNow = now.getHours() * 60 + now.getMinutes();
+  const showNowLine =
+    isToday && minutesNow >= startHour * 60 && minutesNow <= endHour * 60;
+  const nowOffset = ((minutesNow - startHour * 60) / totalMinutes) * totalPx;
+
+  return (
+    <div className={cn("rounded-xl border border-border bg-surface overflow-hidden", className)}>
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-border/60 bg-surface-muted/30">
+        <h3 className="text-sm font-semibold text-text">{formatDayLong(value)}</h3>
+      </div>
+
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `64px 1fr` }}
+      >
+        {/* Time gutter */}
+        <div className="relative">
+          {hours.map((h) => (
+            <div
+              key={h}
+              style={{ height: hourHeight }}
+              className="relative border-t border-border/40 first:border-t-0"
+            >
+              <span className="absolute -top-2 right-2 text-[10px] tabular-nums text-text-subtle bg-surface px-1">
+                {formatHour(h)}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Body column */}
+        <div
+          ref={colRef}
+          onPointerDown={(e) => {
+            if (!onCreate) return;
+            if (e.button !== 0) return;
+            if ((e.target as HTMLElement).closest("[data-event-block]")) return;
+            e.preventDefault();
+            (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+            const m = pointerMinutes(e);
+            setDrag({ startMin: m, endMin: m + HALF_HOUR_MIN });
+          }}
+          onPointerMove={(e) => {
+            if (!drag) return;
+            const m = pointerMinutes(e);
+            setDrag((cur) => (cur ? { ...cur, endMin: m } : cur));
+          }}
+          onPointerUp={commitDrag}
+          onPointerCancel={() => setDrag(null)}
+          className={cn("relative border-l border-border/60 select-none touch-none", isToday && "bg-accent-soft/20")}
+          style={{ height: totalPx }}
+        >
+          {hours.map((_, i) => (
+            <React.Fragment key={i}>
+              <div
+                className="absolute left-0 right-0 border-t border-border/40"
+                style={{ top: i * hourHeight }}
+              />
+              <div
+                className="absolute left-0 right-0 border-t border-dashed border-border/25"
+                style={{ top: i * hourHeight + hourHeight / 2 }}
+              />
+            </React.Fragment>
+          ))}
+
+          {showNowLine && (
+            <div
+              className="absolute left-0 right-0 z-10 pointer-events-none"
+              style={{ top: nowOffset }}
+            >
+              <div className="relative h-px bg-rose-500">
+                <span className="absolute -left-1 -top-[3px] h-[7px] w-[7px] rounded-full bg-rose-500" />
+              </div>
+            </div>
+          )}
+
+          {dayEvents.map((ev) => {
+            const s = eventStart(ev);
+            const e = eventEnd(ev);
+            const sm = clamp(
+              s.getHours() * 60 + s.getMinutes(),
+              startHour * 60,
+              endHour * 60
+            );
+            const em = clamp(
+              e.getHours() * 60 + e.getMinutes(),
+              startHour * 60,
+              endHour * 60
+            );
+            const top = ((sm - startHour * 60) / totalMinutes) * totalPx;
+            const height = Math.max(24, ((em - sm) / totalMinutes) * totalPx - 2);
+            return (
+              <div
+                key={ev.id}
+                data-event-block
+                className="absolute left-2 right-2 z-[2]"
+                style={{
+                  top,
+                  height,
+                  transition: reduced ? "none" : "top 120ms ease, height 120ms ease",
+                }}
+              >
+                <EventBlock event={ev} variant="block" onClick={onEventClick} />
+              </div>
+            );
+          })}
+
+          {drag && (
+            <div
+              aria-hidden="true"
+              className="absolute left-2 right-2 z-[1] rounded-lg border-2 border-dashed border-accent/60 bg-accent-soft/40 pointer-events-none"
+              style={{
+                top:
+                  ((Math.min(drag.startMin, drag.endMin) - startHour * 60) /
+                    totalMinutes) *
+                  totalPx,
+                height:
+                  (Math.abs(drag.endMin - drag.startMin) / totalMinutes) * totalPx,
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+function formatHour(h: number): string {
+  const d = new Date();
+  d.setHours(h, 0, 0, 0);
+  return d.toLocaleTimeString(undefined, { hour: "numeric" });
+}

--- a/src/components/ui/calendar/calendar-month.tsx
+++ b/src/components/ui/calendar/calendar-month.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * CalendarMonth — 6-week month grid
+ * ----------------------------------
+ * Apple-Calendar styling: hairline grid, weekend tinted, today subtly
+ * highlighted. Click a day to select; hover for preview. Keyboard arrow
+ * keys move selection; Enter opens the day (caller decides via onSelect).
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import type { CalendarEvent } from "./types";
+import { EventBlock } from "./event-block";
+import {
+  addDays,
+  eventsForDay,
+  formatDayNum,
+  isSameDay,
+  isSameMonth,
+  isWeekend,
+  startOfMonth,
+  startOfWeek,
+  weekdayLabels,
+} from "./utils";
+
+export interface CalendarMonthProps {
+  /** Anchor date — any day within the displayed month. */
+  value: Date;
+  onChange?: (date: Date) => void;
+  events?: CalendarEvent[];
+  /** Maximum chips to render per day before showing "+N more". */
+  maxEventsPerDay?: number;
+  /** Called when user opens an event (click or Enter). */
+  onEventClick?: (event: CalendarEvent) => void;
+  /** Called when user activates a day (Enter or double-click). */
+  onDayActivate?: (date: Date) => void;
+  className?: string;
+}
+
+export function CalendarMonth({
+  value,
+  onChange,
+  events = [],
+  maxEventsPerDay = 3,
+  onEventClick,
+  onDayActivate,
+  className,
+}: CalendarMonthProps) {
+  const monthStart = startOfMonth(value);
+  const gridStart = startOfWeek(monthStart);
+  const labels = React.useMemo(() => weekdayLabels(), []);
+  const today = React.useMemo(() => new Date(), []);
+
+  // 6 rows × 7 days = 42 cells — stable layout
+  const cells = React.useMemo<Date[]>(() => {
+    const arr: Date[] = [];
+    for (let i = 0; i < 42; i++) arr.push(addDays(gridStart, i));
+    return arr;
+  }, [gridStart]);
+
+  // Bucket events per ISO date string once
+  const eventsByDay = React.useMemo<Map<string, CalendarEvent[]>>(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const day of cells) {
+      const list = eventsForDay(events, day);
+      if (list.length) map.set(day.toDateString(), list);
+    }
+    return map;
+  }, [cells, events]);
+
+  const [cursor, setCursor] = React.useState<Date>(value);
+  React.useEffect(() => setCursor(value), [value]);
+
+  function move(deltaDays: number) {
+    const next = addDays(cursor, deltaDays);
+    setCursor(next);
+    onChange?.(next);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-7);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      move(7);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      onDayActivate?.(cursor);
+    }
+  }
+
+  return (
+    <div
+      role="grid"
+      aria-label="Month calendar"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      className={cn(
+        "w-full select-none rounded-xl border border-border bg-surface overflow-hidden",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30",
+        className
+      )}
+    >
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 border-b border-border/60 bg-surface-muted/40">
+        {labels.map((lab, i) => (
+          <div
+            key={lab}
+            className={cn(
+              "text-[10px] font-semibold uppercase tracking-wider text-text-subtle text-center py-2",
+              (i === 0 || i === 6) && "text-text-subtle/70"
+            )}
+          >
+            {lab}
+          </div>
+        ))}
+      </div>
+
+      {/* 6-week grid */}
+      <div className="grid grid-cols-7 grid-rows-6">
+        {cells.map((day, idx) => {
+          const inMonth = isSameMonth(day, monthStart);
+          const isToday = isSameDay(day, today);
+          const isSelected = isSameDay(day, cursor);
+          const dayEvents = eventsByDay.get(day.toDateString()) ?? [];
+          const overflow = dayEvents.length - maxEventsPerDay;
+          const isLastCol = idx % 7 === 6;
+          const isLastRow = idx >= 35;
+
+          return (
+            <button
+              key={idx}
+              type="button"
+              role="gridcell"
+              aria-current={isToday ? "date" : undefined}
+              aria-selected={isSelected}
+              onClick={() => {
+                setCursor(day);
+                onChange?.(day);
+              }}
+              onDoubleClick={() => onDayActivate?.(day)}
+              className={cn(
+                "relative flex flex-col items-stretch min-h-[88px] p-1.5 text-left",
+                "border-b border-r border-border/60",
+                isLastCol && "border-r-0",
+                isLastRow && "border-b-0",
+                isWeekend(day) && "bg-surface-muted/30",
+                !inMonth && "bg-surface-muted/10 text-text-subtle/60",
+                isSelected && "ring-2 ring-inset ring-accent/40 z-[1]",
+                "hover:bg-surface-muted/50 transition-colors focus:outline-none"
+              )}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span
+                  className={cn(
+                    "inline-flex items-center justify-center text-[12px] tabular-nums font-semibold leading-none",
+                    isToday
+                      ? "h-6 w-6 rounded-full bg-accent text-accent-ink"
+                      : inMonth
+                        ? "text-text"
+                        : "text-text-subtle/50"
+                  )}
+                >
+                  {formatDayNum(day)}
+                </span>
+                {dayEvents.length > 0 && (
+                  <span className="text-[9px] tabular-nums text-text-subtle">
+                    {dayEvents.length}
+                  </span>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-0.5 overflow-hidden">
+                {dayEvents.slice(0, maxEventsPerDay).map((ev) => (
+                  <EventBlock
+                    key={ev.id}
+                    event={ev}
+                    variant="chip"
+                    onClick={onEventClick}
+                  />
+                ))}
+                {overflow > 0 && (
+                  <span className="text-[10px] text-text-subtle pl-1">
+                    +{overflow} more
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/calendar/calendar-toolbar.tsx
+++ b/src/components/ui/calendar/calendar-toolbar.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * CalendarToolbar — header bar for the calendar primitive
+ * --------------------------------------------------------
+ * Layout (left → right):
+ *   [← Today →]   [Month label]   [Date picker]   [Month | Week | Day]
+ *
+ * Reuses the project's DatePicker primitive (PR #463). No new deps.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { DatePicker, toISODate, fromISODate } from "@/components/ui/date-picker";
+import type { CalendarView } from "./types";
+import {
+  addDays,
+  addMonths,
+  formatMonthYear,
+  formatWeekRange,
+  formatDayLong,
+} from "./utils";
+
+export interface CalendarToolbarProps {
+  value: Date;
+  view: CalendarView;
+  onChange: (date: Date) => void;
+  onViewChange?: (view: CalendarView) => void;
+  /** Hide the view switcher (when the surface only supports one view). */
+  views?: CalendarView[];
+  className?: string;
+}
+
+export function CalendarToolbar({
+  value,
+  view,
+  onChange,
+  onViewChange,
+  views = ["month", "week", "day"],
+  className,
+}: CalendarToolbarProps) {
+  const isoValue = toISODate(value);
+
+  function step(delta: number) {
+    if (view === "month") onChange(addMonths(value, delta));
+    else if (view === "week") onChange(addDays(value, delta * 7));
+    else onChange(addDays(value, delta));
+  }
+
+  const label =
+    view === "month"
+      ? formatMonthYear(value)
+      : view === "week"
+        ? formatWeekRange(addDays(value, -value.getDay()))
+        : formatDayLong(value);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 flex-wrap",
+        className
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <div className="inline-flex items-center rounded-md border border-border bg-surface overflow-hidden">
+          <button
+            type="button"
+            onClick={() => step(-1)}
+            aria-label="Previous"
+            className="h-9 px-2.5 text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
+          >
+            <svg viewBox="0 0 20 20" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 4 6 10l6 6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => onChange(new Date())}
+            className="h-9 px-3 text-sm font-medium text-text border-l border-r border-border hover:bg-surface-muted transition-colors"
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            onClick={() => step(1)}
+            aria-label="Next"
+            className="h-9 px-2.5 text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
+          >
+            <svg viewBox="0 0 20 20" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M8 4l6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </div>
+        <h2 className="text-base font-display font-semibold text-text tracking-tight ml-1">
+          {label}
+        </h2>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="w-44">
+          <DatePicker
+            value={isoValue}
+            onChange={(v) => {
+              const d = fromISODate(v);
+              if (d) onChange(d);
+            }}
+          />
+        </div>
+        {onViewChange && views.length > 1 && (
+          <div className="inline-flex rounded-md border border-border bg-surface p-0.5">
+            {views.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => onViewChange(v)}
+                className={cn(
+                  "h-8 px-3 text-xs font-semibold rounded-[5px] capitalize transition-colors",
+                  view === v
+                    ? "bg-accent text-accent-ink"
+                    : "text-text-subtle hover:text-text"
+                )}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/calendar/calendar-week.tsx
+++ b/src/components/ui/calendar/calendar-week.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+/**
+ * CalendarWeek — 7-column day grid with hour rows
+ * ------------------------------------------------
+ * Drag the empty grid to create a block (calls `onCreate(start, end)`).
+ * Click an event to open detail. Today is subtly highlighted. Weekend
+ * columns tinted. Hairline grid throughout.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import type { CalendarEvent } from "./types";
+import { EventBlock } from "./event-block";
+import {
+  addDays,
+  eventEnd,
+  eventStart,
+  isSameDay,
+  isWeekend,
+  startOfDay,
+  startOfWeek,
+  useReducedMotion,
+} from "./utils";
+
+export interface CalendarWeekProps {
+  /** Any date — the surrounding week (Sun..Sat) is rendered. */
+  value: Date;
+  events?: CalendarEvent[];
+  onCreate?: (start: Date, end: Date) => void;
+  onEventClick?: (event: CalendarEvent) => void;
+  /** Earliest displayed hour, default 7. */
+  startHour?: number;
+  /** Latest displayed hour (exclusive), default 20. */
+  endHour?: number;
+  /** Pixels per hour, default 56. */
+  hourHeight?: number;
+  className?: string;
+}
+
+const HALF_HOUR_MIN = 30;
+
+export function CalendarWeek({
+  value,
+  events = [],
+  onCreate,
+  onEventClick,
+  startHour = 7,
+  endHour = 20,
+  hourHeight = 56,
+  className,
+}: CalendarWeekProps) {
+  const weekStart = React.useMemo(() => startOfWeek(value), [value]);
+  const days = React.useMemo(
+    () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
+    [weekStart]
+  );
+  const totalMinutes = (endHour - startHour) * 60;
+  const reduced = useReducedMotion();
+
+  // Drag-to-create state
+  const [drag, setDrag] = React.useState<{
+    dayIdx: number;
+    startMin: number;
+    endMin: number;
+  } | null>(null);
+
+  const colRefs = React.useRef<Array<HTMLDivElement | null>>([]);
+
+  function pointerMinutes(e: React.PointerEvent<HTMLDivElement>, dayIdx: number): number {
+    const el = colRefs.current[dayIdx];
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    const y = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+    const minutes = (y / rect.height) * totalMinutes + startHour * 60;
+    // Snap to half-hour increments
+    return Math.round(minutes / HALF_HOUR_MIN) * HALF_HOUR_MIN;
+  }
+
+  function commitDrag() {
+    if (!drag || !onCreate) {
+      setDrag(null);
+      return;
+    }
+    const day = days[drag.dayIdx];
+    const lo = Math.min(drag.startMin, drag.endMin);
+    const hi = Math.max(drag.startMin, drag.endMin);
+    if (hi - lo < HALF_HOUR_MIN) {
+      setDrag(null);
+      return;
+    }
+    const s = startOfDay(day);
+    s.setMinutes(lo);
+    const e = startOfDay(day);
+    e.setMinutes(hi);
+    onCreate(s, e);
+    setDrag(null);
+  }
+
+  const hours = React.useMemo(() => {
+    const out: number[] = [];
+    for (let h = startHour; h < endHour; h++) out.push(h);
+    return out;
+  }, [startHour, endHour]);
+
+  // Current-time indicator
+  const [now, setNow] = React.useState<Date>(() => new Date());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-surface overflow-hidden",
+        className
+      )}
+    >
+      {/* Day header row */}
+      <div
+        className="grid border-b border-border/60 bg-surface-muted/30"
+        style={{ gridTemplateColumns: `64px repeat(7, minmax(0, 1fr))` }}
+      >
+        <div className="h-12" />
+        {days.map((d, i) => {
+          const isToday = isSameDay(d, new Date());
+          return (
+            <div
+              key={i}
+              className={cn(
+                "h-12 flex flex-col items-center justify-center border-l border-border/60",
+                isWeekend(d) && "bg-surface-muted/40"
+              )}
+            >
+              <span
+                className={cn(
+                  "text-[10px] uppercase tracking-wider font-semibold",
+                  isToday ? "text-accent" : "text-text-subtle"
+                )}
+              >
+                {d.toLocaleDateString(undefined, { weekday: "short" })}
+              </span>
+              <span
+                className={cn(
+                  "text-base font-semibold tabular-nums leading-none mt-0.5",
+                  isToday
+                    ? "inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent text-accent-ink"
+                    : "text-text"
+                )}
+              >
+                {d.getDate()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Body */}
+      <div
+        className="grid relative"
+        style={{ gridTemplateColumns: `64px repeat(7, minmax(0, 1fr))` }}
+      >
+        {/* Time gutter */}
+        <div className="relative">
+          {hours.map((h) => (
+            <div
+              key={h}
+              style={{ height: hourHeight }}
+              className="relative border-t border-border/40 first:border-t-0"
+            >
+              <span className="absolute -top-2 right-2 text-[10px] tabular-nums text-text-subtle bg-surface px-1">
+                {formatHour(h)}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {days.map((d, dayIdx) => (
+          <DayColumn
+            key={dayIdx}
+            ref={(el) => {
+              colRefs.current[dayIdx] = el;
+            }}
+            day={d}
+            dayIdx={dayIdx}
+            events={events.filter((ev) => isSameDay(eventStart(ev), d))}
+            startHour={startHour}
+            endHour={endHour}
+            hourHeight={hourHeight}
+            hours={hours}
+            now={now}
+            onEventClick={onEventClick}
+            drag={drag?.dayIdx === dayIdx ? drag : null}
+            reduced={reduced}
+            onPointerDown={(e) => {
+              if (!onCreate) return;
+              if (e.button !== 0) return;
+              if ((e.target as HTMLElement).closest("[data-event-block]")) return;
+              e.preventDefault();
+              (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+              const m = pointerMinutes(e, dayIdx);
+              setDrag({ dayIdx, startMin: m, endMin: m + HALF_HOUR_MIN });
+            }}
+            onPointerMove={(e) => {
+              if (!drag || drag.dayIdx !== dayIdx) return;
+              const m = pointerMinutes(e, dayIdx);
+              setDrag((cur) => (cur ? { ...cur, endMin: m } : cur));
+            }}
+            onPointerUp={commitDrag}
+            onPointerCancel={() => setDrag(null)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const DayColumn = React.forwardRef<
+  HTMLDivElement,
+  {
+    day: Date;
+    dayIdx: number;
+    events: CalendarEvent[];
+    startHour: number;
+    endHour: number;
+    hourHeight: number;
+    hours: number[];
+    now: Date;
+    onEventClick?: (ev: CalendarEvent) => void;
+    drag: { dayIdx: number; startMin: number; endMin: number } | null;
+    reduced: boolean;
+    onPointerDown: React.PointerEventHandler<HTMLDivElement>;
+    onPointerMove: React.PointerEventHandler<HTMLDivElement>;
+    onPointerUp: React.PointerEventHandler<HTMLDivElement>;
+    onPointerCancel: React.PointerEventHandler<HTMLDivElement>;
+  }
+>(function DayColumn(
+  {
+    day,
+    events,
+    startHour,
+    endHour,
+    hourHeight,
+    hours,
+    now,
+    onEventClick,
+    drag,
+    reduced,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  },
+  ref
+) {
+  const totalMinutes = (endHour - startHour) * 60;
+  const totalPx = hours.length * hourHeight;
+  const isToday = isSameDay(day, now);
+  const minutesNow = now.getHours() * 60 + now.getMinutes();
+  const showNowLine =
+    isToday && minutesNow >= startHour * 60 && minutesNow <= endHour * 60;
+  const nowOffset = ((minutesNow - startHour * 60) / totalMinutes) * totalPx;
+
+  return (
+    <div
+      ref={ref}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      className={cn(
+        "relative border-l border-border/60 select-none touch-none",
+        isWeekend(day) && "bg-surface-muted/30",
+        isToday && "bg-accent-soft/20"
+      )}
+      style={{ height: totalPx }}
+    >
+      {/* Half-hour grid lines */}
+      {hours.map((_, i) => (
+        <React.Fragment key={i}>
+          <div
+            className="absolute left-0 right-0 border-t border-border/40"
+            style={{ top: i * hourHeight }}
+          />
+          <div
+            className="absolute left-0 right-0 border-t border-dashed border-border/25"
+            style={{ top: i * hourHeight + hourHeight / 2 }}
+          />
+        </React.Fragment>
+      ))}
+
+      {/* Now-line */}
+      {showNowLine && (
+        <div
+          className="absolute left-0 right-0 z-10 pointer-events-none"
+          style={{ top: nowOffset }}
+        >
+          <div className="relative h-px bg-rose-500">
+            <span className="absolute -left-1 -top-[3px] h-[7px] w-[7px] rounded-full bg-rose-500" />
+          </div>
+        </div>
+      )}
+
+      {/* Events */}
+      {events.map((ev) => {
+        const s = eventStart(ev);
+        const e = eventEnd(ev);
+        const sm = clamp(
+          s.getHours() * 60 + s.getMinutes(),
+          startHour * 60,
+          endHour * 60
+        );
+        const em = clamp(
+          e.getHours() * 60 + e.getMinutes(),
+          startHour * 60,
+          endHour * 60
+        );
+        const top = ((sm - startHour * 60) / totalMinutes) * totalPx;
+        const height = Math.max(
+          22,
+          ((em - sm) / totalMinutes) * totalPx - 2
+        );
+        return (
+          <div
+            key={ev.id}
+            data-event-block
+            className="absolute left-1 right-1 z-[2]"
+            style={{
+              top,
+              height,
+              transition: reduced ? "none" : "top 120ms ease, height 120ms ease",
+            }}
+          >
+            <EventBlock event={ev} variant="block" onClick={onEventClick} />
+          </div>
+        );
+      })}
+
+      {/* Drag preview */}
+      {drag && (
+        <div
+          aria-hidden="true"
+          className="absolute left-1 right-1 z-[1] rounded-lg border-2 border-dashed border-accent/60 bg-accent-soft/40 pointer-events-none"
+          style={{
+            top:
+              ((Math.min(drag.startMin, drag.endMin) - startHour * 60) /
+                totalMinutes) *
+              totalPx,
+            height:
+              ((Math.abs(drag.endMin - drag.startMin)) / totalMinutes) * totalPx,
+          }}
+        />
+      )}
+    </div>
+  );
+});
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function formatHour(h: number): string {
+  // 12-hour style with AM/PM, matches iOS Calendar gutter.
+  const d = new Date();
+  d.setHours(h, 0, 0, 0);
+  return d.toLocaleTimeString(undefined, { hour: "numeric" });
+}

--- a/src/components/ui/calendar/calendar.tsx
+++ b/src/components/ui/calendar/calendar.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * <Calendar> — composed primitive
+ * --------------------------------
+ * Drop-in surface that wires the toolbar to the three views. Use this when
+ * a page just wants "give me a calendar"; reach for the lower-level pieces
+ * (CalendarMonth / CalendarWeek / CalendarDay) when you need to compose
+ * something custom.
+ */
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import type { CalendarEvent, CalendarView } from "./types";
+import { CalendarMonth } from "./calendar-month";
+import { CalendarWeek } from "./calendar-week";
+import { CalendarDay } from "./calendar-day";
+import { CalendarToolbar } from "./calendar-toolbar";
+
+export interface CalendarProps {
+  /** Current displayed/selected date. */
+  value?: Date;
+  defaultValue?: Date;
+  onChange?: (date: Date) => void;
+  /** Current view; controlled. */
+  view?: CalendarView;
+  defaultView?: CalendarView;
+  onViewChange?: (view: CalendarView) => void;
+  views?: CalendarView[];
+  events?: CalendarEvent[];
+  onEventClick?: (event: CalendarEvent) => void;
+  onCreate?: (start: Date, end: Date) => void;
+  /** Hide the toolbar entirely (callers can render their own). */
+  hideToolbar?: boolean;
+  className?: string;
+  /** Forwarded to CalendarWeek/Day. */
+  startHour?: number;
+  endHour?: number;
+}
+
+export function Calendar({
+  value,
+  defaultValue,
+  onChange,
+  view,
+  defaultView = "week",
+  onViewChange,
+  views = ["month", "week", "day"],
+  events = [],
+  onEventClick,
+  onCreate,
+  hideToolbar,
+  className,
+  startHour,
+  endHour,
+}: CalendarProps) {
+  const [internalDate, setInternalDate] = React.useState<Date>(
+    defaultValue ?? new Date()
+  );
+  const date = value ?? internalDate;
+  function setDate(d: Date) {
+    if (value === undefined) setInternalDate(d);
+    onChange?.(d);
+  }
+
+  const [internalView, setInternalView] = React.useState<CalendarView>(defaultView);
+  const currentView = view ?? internalView;
+  function setView(v: CalendarView) {
+    if (view === undefined) setInternalView(v);
+    onViewChange?.(v);
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      {!hideToolbar && (
+        <CalendarToolbar
+          value={date}
+          view={currentView}
+          onChange={setDate}
+          onViewChange={setView}
+          views={views}
+        />
+      )}
+
+      {currentView === "month" && (
+        <CalendarMonth
+          value={date}
+          onChange={setDate}
+          events={events}
+          onEventClick={onEventClick}
+          onDayActivate={(d) => {
+            setDate(d);
+            setView("day");
+          }}
+        />
+      )}
+      {currentView === "week" && (
+        <CalendarWeek
+          value={date}
+          events={events}
+          onCreate={onCreate}
+          onEventClick={onEventClick}
+          startHour={startHour}
+          endHour={endHour}
+        />
+      )}
+      {currentView === "day" && (
+        <CalendarDay
+          value={date}
+          events={events}
+          onCreate={onCreate}
+          onEventClick={onEventClick}
+          startHour={startHour}
+          endHour={endHour}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/calendar/event-block.tsx
+++ b/src/components/ui/calendar/event-block.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * EventBlock — single rendered event chip
+ * ----------------------------------------
+ * Used by all three views (Month/Week/Day). Color-coded by `event.color`,
+ * dimmed when the event has ended. If `href` is set it renders an <a>; else
+ * it renders a <button> that fires `onClick`.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import type { CalendarEvent } from "./types";
+import { eventColorClasses, formatTime, eventStart, eventEnd, isEventPast } from "./utils";
+
+export type EventBlockVariant = "chip" | "block";
+
+export interface EventBlockProps {
+  event: CalendarEvent;
+  onClick?: (event: CalendarEvent) => void;
+  /** "chip" = single-line month-grid pill, "block" = stacked block for week/day */
+  variant?: EventBlockVariant;
+  /** Optional inline style (used by week/day grids for positioning). */
+  style?: React.CSSProperties;
+  className?: string;
+  draggable?: boolean;
+  onDragStart?: React.DragEventHandler<HTMLElement>;
+  /** Hide the time label (useful for very short chips). */
+  hideTime?: boolean;
+}
+
+export function EventBlock({
+  event,
+  onClick,
+  variant = "chip",
+  style,
+  className,
+  draggable,
+  onDragStart,
+  hideTime,
+}: EventBlockProps) {
+  const colors = eventColorClasses(event.color);
+  const past = isEventPast(event);
+  const start = eventStart(event);
+  const end = eventEnd(event);
+
+  const content = (
+    <>
+      {variant === "block" && (
+        <span
+          aria-hidden="true"
+          className={cn("absolute left-0 top-1 bottom-1 w-[3px] rounded-r", colors.bar)}
+        />
+      )}
+      <span
+        className={cn(
+          "block truncate font-semibold leading-tight",
+          variant === "chip" ? "text-[11px]" : "text-[12px]"
+        )}
+      >
+        {event.title}
+      </span>
+      {!hideTime && variant === "block" && (
+        <span className="block truncate text-[10px] opacity-80 mt-0.5 tabular-nums">
+          {formatTime(start)} – {formatTime(end)}
+        </span>
+      )}
+      {variant === "chip" && !hideTime && (
+        <span className="ml-1 text-[10px] opacity-70 tabular-nums shrink-0">
+          {formatTime(start)}
+        </span>
+      )}
+    </>
+  );
+
+  const baseClass = cn(
+    "relative overflow-hidden text-left transition-colors",
+    variant === "block"
+      ? "block w-full rounded-lg border pl-2.5 pr-2 py-1.5 shadow-sm"
+      : "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 max-w-full",
+    colors.bg,
+    colors.border,
+    variant === "block" && "border",
+    colors.text,
+    "hover:brightness-95 dark:hover:brightness-110",
+    past && "opacity-55 saturate-50",
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+    className
+  );
+
+  const title = `${event.title} · ${formatTime(start)}–${formatTime(end)}${event.description ? ` · ${event.description}` : ""}`;
+
+  if (event.href) {
+    return (
+      <Link
+        href={event.href}
+        title={title}
+        className={baseClass}
+        style={style}
+        draggable={draggable}
+        onDragStart={onDragStart}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <button
+      type="button"
+      title={title}
+      className={baseClass}
+      style={style}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onClick={() => onClick?.(event)}
+    >
+      {content}
+    </button>
+  );
+}

--- a/src/components/ui/calendar/index.ts
+++ b/src/components/ui/calendar/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @leafjourney/ui/calendar — public surface
+ *
+ * Composable Apple-Calendar-flavored primitive. No new deps; built on
+ * React + Tailwind + the existing DatePicker (PR #463).
+ *
+ * Usage:
+ *   import { Calendar, CalendarMonth, type CalendarEvent } from "@/components/ui/calendar";
+ */
+
+export { Calendar } from "./calendar";
+export type { CalendarProps } from "./calendar";
+
+export { CalendarMonth } from "./calendar-month";
+export type { CalendarMonthProps } from "./calendar-month";
+
+export { CalendarWeek } from "./calendar-week";
+export type { CalendarWeekProps } from "./calendar-week";
+
+export { CalendarDay } from "./calendar-day";
+export type { CalendarDayProps } from "./calendar-day";
+
+export { CalendarToolbar } from "./calendar-toolbar";
+export type { CalendarToolbarProps } from "./calendar-toolbar";
+
+export { EventBlock } from "./event-block";
+export type { EventBlockProps } from "./event-block";
+
+export type {
+  CalendarEvent,
+  CalendarEventColor,
+  CalendarView,
+} from "./types";
+
+export {
+  eventsForDay,
+  eventOnDay,
+  isEventPast,
+  formatTime,
+  formatMonthYear,
+  formatWeekRange,
+  formatDayLong,
+  startOfWeek,
+  startOfMonth,
+  startOfDay,
+  addDays,
+  addMonths,
+  isSameDay,
+  isSameMonth,
+} from "./utils";

--- a/src/components/ui/calendar/types.ts
+++ b/src/components/ui/calendar/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Calendar primitive — shared types
+ * ----------------------------------
+ * A thin, framework-agnostic CalendarEvent shape. Intentionally does NOT
+ * mirror a Prisma model — callers map their domain entities (Appointment,
+ * TelehealthVisit, etc.) into this interface at the edge.
+ *
+ * Times are ISO 8601 strings to keep server -> client transport simple.
+ */
+
+export type CalendarEventColor =
+  | "accent"
+  | "warning"
+  | "danger"
+  | "neutral"
+  | "info";
+
+export interface CalendarEvent {
+  id: string;
+  /** ISO 8601 start instant. */
+  start: string;
+  /** ISO 8601 end instant. Must be > start. */
+  end: string;
+  title: string;
+  description?: string;
+  color?: CalendarEventColor;
+  /** Optional EMR patient handle for linking. */
+  patientId?: string;
+  /** Optional click-through href. If absent, onClick fires instead. */
+  href?: string;
+}
+
+export type CalendarView = "month" | "week" | "day";

--- a/src/components/ui/calendar/utils.ts
+++ b/src/components/ui/calendar/utils.ts
@@ -1,0 +1,217 @@
+/**
+ * Calendar primitive — date math + utility helpers
+ * -------------------------------------------------
+ * All dates are LOCAL. We deliberately avoid date-fns / dayjs (no new deps).
+ */
+
+import * as React from "react";
+import type { CalendarEvent, CalendarEventColor } from "./types";
+
+// ── Basic date math ─────────────────────────────────────────────
+
+export function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+export function endOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+
+export function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
+}
+
+export function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+
+export function startOfWeek(d: Date): Date {
+  // Sunday-first to match iOS Calendar default.
+  const x = startOfDay(d);
+  x.setDate(x.getDate() - x.getDay());
+  return x;
+}
+
+export function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+export function isWeekend(d: Date): boolean {
+  const w = d.getDay();
+  return w === 0 || w === 6;
+}
+
+export function isPast(d: Date): boolean {
+  return d.getTime() < Date.now();
+}
+
+// ── Event helpers ───────────────────────────────────────────────
+
+export function eventStart(ev: CalendarEvent): Date {
+  return new Date(ev.start);
+}
+export function eventEnd(ev: CalendarEvent): Date {
+  return new Date(ev.end);
+}
+
+/** True if the event intersects the given local day. */
+export function eventOnDay(ev: CalendarEvent, day: Date): boolean {
+  const s = eventStart(ev);
+  const e = eventEnd(ev);
+  const dayStart = startOfDay(day);
+  const dayEnd = endOfDay(day);
+  return s <= dayEnd && e >= dayStart;
+}
+
+export function eventsForDay(events: CalendarEvent[], day: Date): CalendarEvent[] {
+  return events
+    .filter((ev) => eventOnDay(ev, day))
+    .sort((a, b) => a.start.localeCompare(b.start));
+}
+
+/** True if the event has already ended relative to now. */
+export function isEventPast(ev: CalendarEvent): boolean {
+  return eventEnd(ev).getTime() < Date.now();
+}
+
+// ── Formatting ──────────────────────────────────────────────────
+
+const timeFmt = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function formatTime(d: Date): string {
+  return timeFmt.format(d);
+}
+
+const monthYearFmt = new Intl.DateTimeFormat(undefined, {
+  month: "long",
+  year: "numeric",
+});
+
+export function formatMonthYear(d: Date): string {
+  return monthYearFmt.format(d);
+}
+
+const weekdayShortFmt = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+const dayNumFmt = new Intl.DateTimeFormat(undefined, { day: "numeric" });
+
+export function formatWeekday(d: Date): string {
+  return weekdayShortFmt.format(d);
+}
+export function formatDayNum(d: Date): string {
+  return dayNumFmt.format(d);
+}
+
+/** Pretty "Apr 7 – 13, 2025" style range, collapsing same-month dashes. */
+export function formatWeekRange(start: Date): string {
+  const end = addDays(start, 6);
+  const sameMonth = start.getMonth() === end.getMonth();
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const a = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  }).format(start);
+  const b = new Intl.DateTimeFormat(undefined, {
+    month: sameMonth ? undefined : "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(end);
+  return `${a} – ${b}`;
+}
+
+export function formatDayLong(d: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(d);
+}
+
+// ── Sunday-first weekday labels (e.g. "Sun", "Mon"…) ────────────
+
+export function weekdayLabels(): string[] {
+  const anchor = new Date(2024, 0, 7); // a Sunday
+  return Array.from({ length: 7 }, (_, i) =>
+    weekdayShortFmt.format(addDays(anchor, i))
+  );
+}
+
+// ── Color → tailwind class mapping for event blocks ─────────────
+
+export function eventColorClasses(color: CalendarEventColor = "accent") {
+  switch (color) {
+    case "warning":
+      return {
+        bg: "bg-amber-100/80 dark:bg-amber-950/40",
+        border: "border-amber-300/60 dark:border-amber-800/60",
+        text: "text-amber-900 dark:text-amber-100",
+        bar: "bg-amber-500",
+      };
+    case "danger":
+      return {
+        bg: "bg-rose-100/80 dark:bg-rose-950/40",
+        border: "border-rose-300/60 dark:border-rose-800/60",
+        text: "text-rose-900 dark:text-rose-100",
+        bar: "bg-rose-500",
+      };
+    case "info":
+      return {
+        bg: "bg-sky-100/80 dark:bg-sky-950/40",
+        border: "border-sky-300/60 dark:border-sky-800/60",
+        text: "text-sky-900 dark:text-sky-100",
+        bar: "bg-sky-500",
+      };
+    case "neutral":
+      return {
+        bg: "bg-neutral-100/80 dark:bg-neutral-900/60",
+        border: "border-neutral-300/60 dark:border-neutral-800/60",
+        text: "text-neutral-900 dark:text-neutral-100",
+        bar: "bg-neutral-500",
+      };
+    case "accent":
+    default:
+      return {
+        bg: "bg-accent-soft",
+        border: "border-accent/20",
+        text: "text-accent",
+        bar: "bg-accent",
+      };
+  }
+}
+
+// ── Reduced motion hook ─────────────────────────────────────────
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
## Summary
- Ship `src/components/ui/calendar/` — composable Apple-Calendar-tier primitive (Month/Week/Day + EventBlock + Toolbar + Calendar shell). No new deps; built on React + Tailwind + the existing DatePicker from PR #463.
- Thin `CalendarEvent` interface (id/start/end/title/description?/color?/patientId?/href?) — no Prisma schema model added; callers map their domain at the edge.
- Apple-iOS aesthetic: hairline grid, weekend tinted, today subtly highlighted, half-hour grid lines, live now-line.
- Drag-to-create on Week/Day (snaps to 30-min increments) → `onCreate(start, end)`.
- Keyboard nav in Month view (arrows move cursor, Enter activates day).
- `prefers-reduced-motion` honored via `useReducedMotion` hook — transitions are instant when set.

## Adoption sites
- **`/clinic/schedule/month`** *(new)* — clinician month overview, deep-linkable via `?month=YYYY-MM-DD`, drag-to-create hands off to the existing week scheduler.
- **`/clinic/schedule`** *(existing)* — added "Month view" link in the toolbar.
- **`/telehealth`** *(existing)* — new "This week" mini-calendar card showing live + scheduled video visits, click-through to the patient telehealth room.
- **`/portal/appointments`** *(new)* — patient-facing visits calendar with month/week/day switcher.

## Constraints respected
- No new dependencies (no `react-big-calendar`, no `@fullcalendar/*`).
- No touch to `prisma/schema.prisma`, `src/middleware.ts`, workflows, auth, manifests, or `CLAUDE.md`.
- Avoided `/ops/supplies` (PR #438) surfaces.

## Test plan
- [ ] Visit `/clinic/schedule/month` — month grid renders 6 rows, today is highlighted, weekend columns are tinted, appointments appear as chips.
- [ ] Click "Month view" from `/clinic/schedule` toolbar — navigates correctly.
- [ ] Visit `/telehealth` with at least one scheduled video visit — "This week" card renders and clicking an event opens the telehealth page.
- [ ] Visit `/portal/appointments` as a patient — month view default, view switcher swaps to Week and Day correctly.
- [ ] Drag on an empty Week-view slot — selection preview snaps to 30-min increments; release calls `onCreate`.
- [ ] Enable `prefers-reduced-motion` — event-block transitions are instant (no slide).
- [ ] Keyboard: focus the month grid, press arrow keys → cursor moves; Enter activates day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)