### PR TITLE
ux: SystemBanner primitive + admin viewer + global mount + static config source

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -11,6 +11,7 @@ import { ClinicianTour } from "@/components/onboarding/clinician-tour";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
 import { HelpDrawer } from "@/components/help/help-drawer";
 import { RecentPatientsStrip } from "@/components/patient/recent-patients-strip";
+import { SystemBannerRail } from "@/components/ui/system-banner";
 import { prisma } from "@/lib/db/prisma";
 import {
   computeApprovalsBadge,
@@ -179,7 +180,12 @@ export default async function ClinicianLayout({
   }
 
   return (
-    <AppShell
+    <>
+      {/* System-wide banners (status / maintenance / announcements).
+          Mounted above AppShell so the sticky-top banner spans the
+          viewport rather than being clipped by the role rail / drawer. */}
+      <SystemBannerRail surface="clinician" />
+      <AppShell
       user={user}
       activeRole="clinician"
       sections={sections}
@@ -197,5 +203,6 @@ export default async function ClinicianLayout({
       <RecentPatientsStrip userId={user.id} />
       {children}
     </AppShell>
+    </>
   );
 }

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { SystemBannerRail } from "@/components/ui/system-banner";
 import { ROLE_HOME, primaryRole } from "@/lib/rbac/roles";
 import { prisma } from "@/lib/db/prisma";
 import {
@@ -243,15 +244,20 @@ export default async function OperatorLayout({
   }
 
   return (
-    <AppShell
-      user={user}
-      activeRole="operator"
-      sections={sections}
-      roleLabel="Practice ops"
-      showNavPrefs={false}
-    >
-      <CommandPalette role="operator" userId={user.id} />
-      {children}
-    </AppShell>
+    <>
+      {/* System-wide banners. Mounted above AppShell so the sticky banner
+          spans the full viewport. */}
+      <SystemBannerRail surface="operator" />
+      <AppShell
+        user={user}
+        activeRole="operator"
+        sections={sections}
+        roleLabel="Practice ops"
+        showNavPrefs={false}
+      >
+        <CommandPalette role="operator" userId={user.id} />
+        {children}
+      </AppShell>
+    </>
   );
 }

--- a/src/app/(super-admin)/admin/banners/page.tsx
+++ b/src/app/(super-admin)/admin/banners/page.tsx
@@ -1,0 +1,259 @@
+import type { Metadata } from "next";
+
+import { requireUser } from "@/lib/auth/session";
+import { requireSuperAdmin } from "@/lib/auth/super-admin";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
+import { SYSTEM_BANNERS } from "@/lib/banners/config";
+import { getActiveSystemBanners } from "@/lib/banners/system-banner-source";
+
+export const metadata: Metadata = {
+  title: "System banners — LeafJourney",
+  description:
+    "Read-only view of system-wide banners declared in lib/banners/config.ts.",
+};
+
+export const dynamic = "force-dynamic";
+
+const SEVERITY_BADGE: Record<string, string> = {
+  info: "bg-sky-100 text-sky-900 border border-sky-300",
+  warning: "bg-amber-100 text-amber-900 border border-amber-300",
+  danger: "bg-red-100 text-red-900 border border-red-300",
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+  "system-health": "System health",
+  maintenance: "Scheduled maintenance",
+  announcement: "Announcement",
+  billing: "Billing notice",
+};
+
+export default async function SystemBannersAdminPage() {
+  // Super-admin gating: layout already runs requireSuperAdmin, but we
+  // double-check here so a routing regression cannot accidentally expose
+  // banner config to a non-super-admin.
+  await requireUser();
+  await requireSuperAdmin();
+
+  const allBanners = SYSTEM_BANNERS;
+  const activeClinician = getActiveSystemBanners({ surface: "clinician" });
+  const activeOperator = getActiveSystemBanners({ surface: "operator" });
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <Breadcrumbs
+        items={[
+          { label: "Operations", href: "/admin/hq" },
+          { label: "System banners" },
+        ]}
+      />
+
+      <header className="flex flex-col md:flex-row md:items-end md:justify-between gap-5 mb-10">
+        <div>
+          <Eyebrow className="mb-3">Internal</Eyebrow>
+          <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight leading-[1.1]">
+            System banners
+          </h1>
+          <p className="text-[15px] text-text-muted mt-3 leading-relaxed max-w-2xl">
+            Read-only viewer for the system-wide banner catalogue. Banners
+            are declared statically in{" "}
+            <code className="font-mono text-[13px] px-1 py-0.5 rounded bg-surface-raised border border-border">
+              src/lib/banners/config.ts
+            </code>{" "}
+            and ship with a deploy. Toasts and the per-user notification
+            center live elsewhere — this surface is reserved for
+            system-wide status, maintenance, announcements, and important
+            holds.
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Active right now</CardTitle>
+            <CardDescription>
+              Banners currently rendered for each surface. A banner is
+              active when <code className="font-mono text-[12px]">enabled: true</code>{" "}
+              and its optional time window contains the current moment.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <ActiveSurfaceList
+                heading="Clinician surface"
+                banners={activeClinician.map((b) => b.id)}
+              />
+              <ActiveSurfaceList
+                heading="Operator surface"
+                banners={activeOperator.map((b) => b.id)}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Catalogue</CardTitle>
+            <CardDescription>
+              Every banner declared in config. Order matches render order
+              (earlier entries render on top).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {allBanners.length === 0 ? (
+              <p className="text-sm text-text-muted">
+                No banners declared. Add one to{" "}
+                <code className="font-mono text-[12px]">SYSTEM_BANNERS</code>{" "}
+                in <code className="font-mono text-[12px]">src/lib/banners/config.ts</code>.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border">
+                {allBanners.map((b) => (
+                  <li
+                    key={b.id}
+                    className="py-4 flex flex-col md:flex-row md:items-start md:justify-between gap-3"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span
+                          className={
+                            "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide " +
+                            (SEVERITY_BADGE[b.severity] ?? "")
+                          }
+                        >
+                          {b.severity}
+                        </span>
+                        <span className="inline-flex items-center rounded-full bg-surface-raised border border-border px-2 py-0.5 text-[11px] font-medium text-text-muted">
+                          {CATEGORY_LABEL[b.category] ?? b.category}
+                        </span>
+                        <span
+                          className={
+                            "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium " +
+                            (b.enabled
+                              ? "bg-emerald-100 text-emerald-900 border border-emerald-300"
+                              : "bg-surface-raised text-text-subtle border border-border")
+                          }
+                        >
+                          {b.enabled ? "enabled" : "disabled"}
+                        </span>
+                        {b.dismissible ? (
+                          <span className="inline-flex items-center rounded-full bg-surface-raised border border-border px-2 py-0.5 text-[11px] font-medium text-text-muted">
+                            dismissible
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="mt-2 text-[14px] text-text font-medium">
+                        {b.message}
+                      </p>
+                      <p className="mt-1 text-[12px] text-text-subtle font-mono">
+                        id: {b.id}
+                      </p>
+                      {b.ctaLabel && b.ctaHref ? (
+                        <p className="mt-1 text-[12px] text-text-muted">
+                          CTA: <span className="font-medium">{b.ctaLabel}</span>{" "}
+                          → <code className="font-mono">{b.ctaHref}</code>
+                        </p>
+                      ) : null}
+                      {b.startsAt || b.endsAt ? (
+                        <p className="mt-1 text-[12px] text-text-muted">
+                          Window: {b.startsAt ?? "—"} → {b.endsAt ?? "—"}
+                        </p>
+                      ) : null}
+                      {b.surfaces && b.surfaces.length > 0 ? (
+                        <p className="mt-1 text-[12px] text-text-muted">
+                          Surfaces: {b.surfaces.join(", ")}
+                        </p>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>How to edit</CardTitle>
+            <CardDescription>
+              Persistence is a TypeScript module today. This is intentional
+              for v1.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ol className="list-decimal pl-5 space-y-2 text-[14px] text-text-muted leading-relaxed">
+              <li>
+                Open{" "}
+                <code className="font-mono text-[12px]">
+                  src/lib/banners/config.ts
+                </code>{" "}
+                and edit the{" "}
+                <code className="font-mono text-[12px]">SYSTEM_BANNERS</code>{" "}
+                array.
+              </li>
+              <li>
+                Bump the <code className="font-mono text-[12px]">id</code>{" "}
+                if you want users who previously dismissed the banner to
+                see it again (dismissal is keyed by id in{" "}
+                <code className="font-mono text-[12px]">localStorage</code>).
+              </li>
+              <li>Open a PR. Merge ships the banner to production.</li>
+            </ol>
+            <p className="mt-4 text-[12px] text-text-subtle border-l-2 border-border pl-3 leading-relaxed">
+              Follow-up — tracked, not blocking: promote to a DB-backed{" "}
+              <code className="font-mono">Banner</code> model + admin write
+              surface (create / edit / schedule / target by org or role)
+              when persistence requirements firm up. The hook contract in{" "}
+              <code className="font-mono">system-banner-source.ts</code> is
+              already shaped to swap the source from a static array to a
+              fetch against <code className="font-mono">/api/status</code>{" "}
+              or a future <code className="font-mono">/api/banners</code>{" "}
+              endpoint without changing call sites.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </PageShell>
+  );
+}
+
+function ActiveSurfaceList({
+  heading,
+  banners,
+}: {
+  heading: string;
+  banners: string[];
+}) {
+  return (
+    <div>
+      <h3 className="text-[13px] font-semibold uppercase tracking-wide text-text-muted mb-2">
+        {heading}
+      </h3>
+      {banners.length === 0 ? (
+        <p className="text-sm text-text-subtle italic">
+          No active banners.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {banners.map((id) => (
+            <li
+              key={id}
+              className="font-mono text-[13px] text-text px-2 py-1 rounded bg-surface-raised border border-border"
+            >
+              {id}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -37,6 +37,7 @@ const SUPER_ADMIN_SECTIONS: NavSection[] = [
       { label: "Practices", href: "/practices" },
       { label: "Onboarding", href: "/onboarding" },
       { label: "Templates", href: "/templates" },
+      { label: "System banners", href: "/admin/banners" },
       { label: "Cross-tenant search", href: "/admin/search" },
     ],
   },

--- a/src/components/ui/system-banner.tsx
+++ b/src/components/ui/system-banner.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+/**
+ * SystemBanner — full-width, sticky-to-top banner primitive for system
+ * status, scheduled maintenance, announcements, and important holds.
+ *
+ * Distinct from sibling primitives:
+ *   - <Toast/> (src/components/ui/toast.tsx) — transient, per-user,
+ *     bottom-of-viewport.
+ *   - <NotificationCenter/> (src/components/ui/notification-center.tsx)
+ *     — per-user inbox with read state.
+ *   - <SystemBanner/> — system-wide, sticky top, dismissed per-device.
+ *
+ * Usage (single banner):
+ *   <SystemBanner id="maint-2026-05-25" severity="warning"
+ *                 message="Scheduled maintenance Sunday 02:00 ET"
+ *                 ctaLabel="Details" ctaHref="/status" dismissible />
+ *
+ * Usage (active set, recommended for layouts):
+ *   <SystemBannerRail surface="clinician" />
+ *
+ * Behaviour:
+ *   - Sticky top, full-width, z-40 (just below dialog z-50).
+ *   - Severity drives colour + aria role.
+ *   - `dismissible` shows an X; dismissal persists per-banner-id in
+ *     localStorage under `emr.banners.dismissed.v1.<id>`.
+ *   - Honours `prefers-reduced-motion`: skips the slide-in animation.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils/cn";
+import {
+  useActiveSystemBanners,
+  type ActiveBannerSurface,
+} from "@/lib/banners/system-banner-source";
+
+export type SystemBannerSeverity = "info" | "warning" | "danger";
+
+export interface SystemBannerProps {
+  /** Stable id. Drives the localStorage dismissal key. */
+  id: string;
+  /** Visual + accessibility severity. */
+  severity?: SystemBannerSeverity;
+  /** Primary message line. */
+  message: ReactNode;
+  /** Optional CTA label rendered as a link. */
+  ctaLabel?: string;
+  /** Optional CTA target. */
+  ctaHref?: string;
+  /** When true, an X closes the banner and persists the dismissal. */
+  dismissible?: boolean;
+  /**
+   * Optional className passthrough. Use sparingly — the primitive owns
+   * its own colour + sticky + width contract.
+   */
+  className?: string;
+}
+
+const DISMISS_KEY_PREFIX = "emr.banners.dismissed.v1.";
+
+/**
+ * Severity -> Tailwind class bundles. Kept inline (no design-system token
+ * lookup) so the banner is uniformly loud regardless of role theme — same
+ * rationale as the impersonation banner.
+ */
+const SEVERITY_STYLES: Record<
+  SystemBannerSeverity,
+  { wrap: string; dot: string; cta: string; close: string }
+> = {
+  info: {
+    wrap: "bg-sky-500 text-white border-b border-sky-700/40",
+    dot: "bg-white/80",
+    cta: "underline decoration-white/70 underline-offset-2 hover:decoration-white",
+    close: "hover:bg-white/15 focus-visible:ring-white/70",
+  },
+  warning: {
+    wrap: "bg-amber-400 text-amber-950 border-b border-amber-600/40",
+    dot: "bg-amber-900",
+    cta:
+      "underline decoration-amber-900/70 underline-offset-2 hover:decoration-amber-900",
+    close: "hover:bg-amber-900/10 focus-visible:ring-amber-900/70",
+  },
+  danger: {
+    wrap: "bg-red-600 text-white border-b border-red-800/50",
+    dot: "bg-white/80",
+    cta: "underline decoration-white/70 underline-offset-2 hover:decoration-white",
+    close: "hover:bg-white/15 focus-visible:ring-white/70",
+  },
+};
+
+function readDismissed(id: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(DISMISS_KEY_PREFIX + id) === "1";
+  } catch {
+    // Private mode / quota / disabled storage — treat as not dismissed.
+    return false;
+  }
+}
+
+function writeDismissed(id: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DISMISS_KEY_PREFIX + id, "1");
+  } catch {
+    // Swallow — dismissal is best-effort.
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Single banner. Renders nothing once dismissed.
+ */
+export function SystemBanner({
+  id,
+  severity = "info",
+  message,
+  ctaLabel,
+  ctaHref,
+  dismissible = false,
+  className,
+}: SystemBannerProps) {
+  // Hydrate dismissed state from localStorage AFTER mount so SSR + first
+  // paint match. The banner briefly renders for ~1 frame on a dismissed
+  // session, then collapses — acceptable for a system banner, and avoids
+  // a hydration mismatch (server cannot read localStorage).
+  const [dismissed, setDismissed] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+    setDismissed(readDismissed(id));
+    setReduceMotion(prefersReducedMotion());
+  }, [id]);
+
+  const onClose = useCallback(() => {
+    setDismissed(true);
+    writeDismissed(id);
+  }, [id]);
+
+  if (hydrated && dismissed) return null;
+
+  const styles = SEVERITY_STYLES[severity];
+  // role="alert" interrupts the AT user — reserve for warning + danger.
+  const role = severity === "info" ? "status" : "alert";
+  const ariaLive = severity === "danger" ? "assertive" : "polite";
+
+  return (
+    <div
+      data-system-banner
+      data-banner-id={id}
+      data-severity={severity}
+      role={role}
+      aria-live={ariaLive}
+      className={cn(
+        "sticky top-0 z-40 w-full",
+        styles.wrap,
+        // Slide-in: skipped when prefers-reduced-motion is set OR before
+        // hydration (avoids animating SSR HTML on first paint).
+        hydrated && !reduceMotion && "animate-in slide-in-from-top-2 duration-200",
+        className,
+      )}
+    >
+      <div className="mx-auto flex items-center justify-between gap-4 px-4 py-2 max-w-[1600px]">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            aria-hidden
+            className={cn(
+              "inline-block h-2 w-2 rounded-full shrink-0",
+              styles.dot,
+              hydrated && !reduceMotion && "animate-pulse",
+            )}
+          />
+          <p className="text-[13px] font-semibold truncate">{message}</p>
+          {ctaLabel && ctaHref ? (
+            <a
+              href={ctaHref}
+              className={cn(
+                "text-[13px] font-semibold whitespace-nowrap shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 rounded-sm",
+                styles.cta,
+              )}
+            >
+              {ctaLabel}
+            </a>
+          ) : null}
+        </div>
+        {dismissible ? (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Dismiss banner"
+            className={cn(
+              "shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-md text-current focus-visible:outline-none focus-visible:ring-2",
+              styles.close,
+            )}
+          >
+            <svg
+              aria-hidden
+              viewBox="0 0 16 16"
+              className="h-3.5 w-3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+            >
+              <path d="M3.5 3.5l9 9M12.5 3.5l-9 9" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SystemBannerRail — renders every active banner for `surface`, stacked.
+ * Mount once per surface layout (above AppShell, like ImpersonationBanner).
+ */
+export interface SystemBannerRailProps {
+  surface: ActiveBannerSurface;
+}
+
+export function SystemBannerRail({ surface }: SystemBannerRailProps) {
+  const banners = useActiveSystemBanners({ surface });
+  // Memoise the rendered list — avoids re-creating React elements when
+  // the parent layout re-renders for unrelated reasons.
+  const rendered = useMemo(
+    () =>
+      banners.map((b) => (
+        <SystemBanner
+          key={b.id}
+          id={b.id}
+          severity={b.severity}
+          message={b.message}
+          ctaLabel={b.ctaLabel}
+          ctaHref={b.ctaHref}
+          dismissible={b.dismissible}
+        />
+      )),
+    [banners],
+  );
+
+  if (rendered.length === 0) return null;
+  return <>{rendered}</>;
+}

--- a/src/lib/banners/config.ts
+++ b/src/lib/banners/config.ts
@@ -1,0 +1,91 @@
+/**
+ * config.ts — static source of truth for system-wide banners.
+ *
+ * Edit this file to add, remove, or toggle a banner. Persistence at this
+ * stage is intentionally just a TS module so a deploy ships banner changes
+ * — no DB, no API, no admin write surface.
+ *
+ * v1 lifecycle:
+ *   1. Edit this file (or flip `enabled: false`).
+ *   2. Bump `id` if you want previously-dismissed users to see the banner
+ *      again (dismissal is keyed by id in localStorage).
+ *   3. Open a PR; merge ships the banner.
+ *
+ * Follow-up — tracked, not blocking:
+ *   - Promote to a DB-backed `Banner` model + admin write surface when
+ *     persistence requirements firm up (per-org banners, scheduled
+ *     publish windows, audience targeting beyond role layouts).
+ *   - Wire `useActiveSystemBanners()` to derive system-health banners
+ *     from `/api/status` (route lands in PR #479 follow-ups) so a real
+ *     degradation surfaces automatically instead of waiting on a deploy.
+ *
+ * Sibling primitives (do NOT collide):
+ *   - Toast (src/components/ui/toast.tsx) is transient + per-user.
+ *   - Notification center (src/components/ui/notification-center.tsx)
+ *     is per-user + persisted-read-state.
+ *   - SystemBanner is system-wide + dismissed-per-device.
+ */
+
+export type SystemBannerSeverity = "info" | "warning" | "danger";
+
+export type SystemBannerCategory =
+  | "system-health"
+  | "maintenance"
+  | "announcement"
+  | "billing";
+
+export interface SystemBannerConfig {
+  /** Stable, URL-safe id. Bump to re-show a banner that users dismissed. */
+  id: string;
+  /** Bucket for the admin viewer + future targeting. */
+  category: SystemBannerCategory;
+  /** Visual + accessibility severity. */
+  severity: SystemBannerSeverity;
+  /** Short human-readable line. Keep under ~140 chars. */
+  message: string;
+  /** Optional CTA label rendered as a link. */
+  ctaLabel?: string;
+  /** Optional CTA target. External links should be absolute URLs. */
+  ctaHref?: string;
+  /** When true, a close (X) is rendered and dismissal is persisted. */
+  dismissible?: boolean;
+  /** Set to false to keep the entry but hide it. */
+  enabled: boolean;
+  /**
+   * Optional ISO window. If `startsAt` is in the future or `endsAt` has
+   * passed, the banner is treated as inactive. Both bounds are inclusive
+   * of the active window.
+   */
+  startsAt?: string;
+  endsAt?: string;
+  /**
+   * Optional surface allowlist. If omitted, the banner shows on every
+   * surface that mounts <SystemBannerRail/>. Today the rail is mounted
+   * in the clinician + operator layouts.
+   */
+  surfaces?: Array<"clinician" | "operator" | "super-admin">;
+}
+
+/**
+ * Active banner catalogue. Order matters: earlier entries render on top.
+ *
+ * This array is intentionally exported as a plain const — no factory, no
+ * default-export — so a future migration to a DB read can swap the source
+ * without changing the type contract.
+ */
+export const SYSTEM_BANNERS: readonly SystemBannerConfig[] = [
+  // Example placeholder — flip `enabled` to true to surface in-app.
+  // Keep at least one disabled example here so the admin viewer has
+  // something to render in dev environments.
+  {
+    id: "welcome-v1",
+    category: "announcement",
+    severity: "info",
+    message:
+      "Welcome to LeafJourney. New here? The Help drawer (?) has a guided tour.",
+    ctaLabel: "View status",
+    ctaHref: "/status",
+    dismissible: true,
+    enabled: false,
+  },
+] as const;

--- a/src/lib/banners/system-banner-source.ts
+++ b/src/lib/banners/system-banner-source.ts
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * system-banner-source.ts — single hook that resolves the set of active
+ * system banners for the current surface.
+ *
+ * v1 derives strictly from `src/lib/banners/config.ts`. The hook is shaped
+ * around a future swap to `/api/status` (PR #479 follow-up):
+ *
+ *   useActiveSystemBanners({ surface }) ->
+ *     1. Filter SYSTEM_BANNERS by `enabled`.
+ *     2. Filter by surface (if a banner declares a `surfaces` allowlist).
+ *     3. Filter by active time window (`startsAt` / `endsAt`).
+ *     4. TODO(PR #479 follow-up): merge in system-health banners
+ *        derived from `/api/status` when overall state !== "operational".
+ *
+ * The hook is intentionally synchronous + dependency-free for v1 so it
+ * can render in any client component without a Suspense boundary.
+ */
+
+import { useMemo } from "react";
+import {
+  SYSTEM_BANNERS,
+  type SystemBannerConfig,
+} from "./config";
+
+export type ActiveBannerSurface = "clinician" | "operator" | "super-admin";
+
+export interface UseActiveSystemBannersOptions {
+  /** Which mount surface is asking. Used to gate `surfaces` allowlists. */
+  surface: ActiveBannerSurface;
+  /**
+   * Optional clock override for testing. Defaults to `Date.now()`. The
+   * hook does not subscribe to a clock tick — banners cross their
+   * start/end window on the next render rather than on the wall clock.
+   */
+  now?: number;
+}
+
+function isWithinWindow(b: SystemBannerConfig, now: number): boolean {
+  if (b.startsAt) {
+    const start = Date.parse(b.startsAt);
+    if (Number.isFinite(start) && now < start) return false;
+  }
+  if (b.endsAt) {
+    const end = Date.parse(b.endsAt);
+    if (Number.isFinite(end) && now > end) return false;
+  }
+  return true;
+}
+
+function matchesSurface(
+  b: SystemBannerConfig,
+  surface: ActiveBannerSurface,
+): boolean {
+  if (!b.surfaces || b.surfaces.length === 0) return true;
+  return b.surfaces.includes(surface);
+}
+
+/**
+ * Returns the banners that should render right now for `surface`.
+ * Stable identity across renders when inputs are unchanged.
+ */
+export function useActiveSystemBanners({
+  surface,
+  now,
+}: UseActiveSystemBannersOptions): readonly SystemBannerConfig[] {
+  return useMemo(() => {
+    const ts = now ?? Date.now();
+    return SYSTEM_BANNERS.filter(
+      (b) => b.enabled && matchesSurface(b, surface) && isWithinWindow(b, ts),
+    );
+  }, [surface, now]);
+}
+
+/**
+ * Server-friendly variant — same filter logic, but callable from a server
+ * component or a server action. Mirrors the hook signature so a future
+ * swap to `/api/status` can be slotted in here without touching callers.
+ */
+export function getActiveSystemBanners(
+  options: UseActiveSystemBannersOptions,
+): readonly SystemBannerConfig[] {
+  const ts = options.now ?? Date.now();
+  return SYSTEM_BANNERS.filter(
+    (b) =>
+      b.enabled && matchesSurface(b, options.surface) && isWithinWindow(b, ts),
+  );
+}


### PR DESCRIPTION
## Summary
Adds a system-wide banner primitive distinct from transient toasts (PR #458) and the per-user notification center (PR #464).

- `SystemBanner` (`src/components/ui/system-banner.tsx`) — sticky-top, full-width banner with `info` / `warning` / `danger` severities, optional CTA, optional dismiss (persisted per-id in `localStorage` as `emr.banners.dismissed.v1.<id>`).
- `SystemBannerRail` — mounts the active set for a given surface (`clinician` / `operator` / `super-admin`). Wired into both `(clinician)` and `(operator)` layouts above `AppShell` so the sticky banner spans the full viewport (mirrors the impersonation-banner pattern). Not mounted on marketing or auth — those have their own chrome.
- `useActiveSystemBanners()` + server-friendly `getActiveSystemBanners()` (`src/lib/banners/system-banner-source.ts`) — filters by `enabled`, optional surface allowlist, and optional time window. Shape preserved for a future `/api/status` source swap (PR #479 follow-up, `TODO` inline).
- Static config at `src/lib/banners/config.ts` is the v1 source of truth — a deploy ships banner changes. Ships with one disabled example for the admin viewer.
- Admin surface at `src/app/(super-admin)/admin/banners/page.tsx` — read-only list of the active set per surface + full catalogue + how-to-edit instructions. Linked from the super-admin Operations nav. Promote-to-DB follow-up documented inline.

## Severity tiers
- `info` — sky / blue, `role="status"`, `aria-live="polite"`
- `warning` — amber, `role="alert"`, `aria-live="polite"`
- `danger` — red, `role="alert"`, `aria-live="assertive"`

## Constraints honoured
- No new deps.
- No edits to `prisma/schema.prisma`, `src/middleware.ts`, `.github/workflows/`, `src/lib/specialty-templates/manifests/`, `src/lib/auth/`, or `CLAUDE.md`.
- Sticky `z-40` (just below dialog `z-50`).
- Honours `prefers-reduced-motion` (skips slide-in animation).
- Dismissal is best-effort (try/catch around `localStorage` for private-mode safety).
- No collision with toast (transient, `z-[120]`, bottom) or notification center (per-user inbox).

## Test plan
- [ ] Drop a banner in `SYSTEM_BANNERS` with `enabled: true` and verify it renders sticky on `/clinic/*` and `/ops/*`.
- [ ] Confirm marketing (`/`, `/about`, `/status`) and auth (`/sign-in`) do NOT render the banner.
- [ ] Dismiss a dismissible banner; reload and confirm it stays dismissed; bump the `id` and confirm it shows again.
- [ ] Toggle `prefers-reduced-motion` in OS / DevTools and confirm slide-in + pulse are suppressed.
- [ ] Visit `/admin/banners` as a super-admin and confirm active set + catalogue render correctly.
- [ ] Verify `role="alert"` is announced by VoiceOver / NVDA on a warning / danger banner.

## Follow-ups (tracked, not blocking)
- Swap `system-banner-source.ts` from the static array to `/api/status` once PR #479's authenticated route lands.
- Promote to a DB-backed `Banner` model + admin write surface when persistence requirements firm up (per-org banners, scheduled publish windows, audience targeting).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>