### PR TITLE
ux: FreshnessIndicator (Last updated + refresh + visibility-change auto) + 8 adoptions

### DIFF
--- a/src/app/(clinician)/clinic/communications/page.tsx
+++ b/src/app/(clinician)/clinic/communications/page.tsx
@@ -15,6 +15,7 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { MetricTile } from "@/components/ui/metric-tile";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { CommsRecentClient } from "./comms-recent-client";
 
 export const metadata = { title: "Communications" };
@@ -31,6 +32,9 @@ export default async function CommunicationsPage() {
   }
 
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  // Stamp the render time so the freshness chip can show "Updated Xm ago"
+  // for the tiles below. Re-renders (via router.refresh()) reset it.
+  const loadedAt = new Date().toISOString();
 
   const [
     callsThisWeek,
@@ -103,6 +107,7 @@ export default async function CommunicationsPage() {
         eyebrow="Communications"
         title="Communications Overlay"
         description="Text, video, fax, and HIPAA-compliant calling — all in one workspace. AI transcription captures only pertinent clinical info. Personal data is discarded before documented."
+        actions={<RouterRefreshFreshness since={loadedAt} />}
       />
 
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -871,7 +871,10 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
         />
       )}
       {tab === "timeline" && (
-        <PatientActivityTimeline events={activityEvents} />
+        <PatientActivityTimeline
+          events={activityEvents}
+          loadedAt={new Date().toISOString()}
+        />
       )}
       {tab === "correspondence" && (
         <CorrespondenceTab

--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { PatientListClient } from "./patient-list-client";
 import { NewPatientModal } from "@/components/clinic/NewPatientModal";
 import { RosterExportMenu } from "./roster-export-menu";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { logger } from "@/lib/observability/log";
 
 export const metadata = { title: "Patient Roster" };
@@ -139,6 +140,7 @@ export default async function PatientsPage({
         title="Patient roster"
         actions={
           <div className="flex items-center gap-3">
+            <RouterRefreshFreshness since={new Date().toISOString()} compact />
             <span className="text-sm text-text-muted tabular-nums">
               {patients.length} patient{patients.length === 1 ? "" : "s"}
             </span>

--- a/src/app/(operator)/ops/queue/page.tsx
+++ b/src/app/(operator)/ops/queue/page.tsx
@@ -89,7 +89,7 @@ export default async function QueueBoardPage() {
 
   return (
     <PageShell maxWidth="max-w-[1480px]">
-      <QueueBoard entries={entries} />
+      <QueueBoard entries={entries} loadedAt={new Date().toISOString()} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/queue/queue-board.tsx
+++ b/src/app/(operator)/ops/queue/queue-board.tsx
@@ -20,6 +20,7 @@ import {
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
 import { useConfirm } from "@/components/ui/confirm-dialog";
+import { FreshnessIndicator } from "@/components/ui/freshness-indicator";
 
 const COLUMN_ORDER: QueueStatus[] = [
   "scheduled",
@@ -56,8 +57,24 @@ function formatTime(iso: string): string {
   });
 }
 
-export function QueueBoard({ entries }: { entries: QueueEntry[] }) {
+export function QueueBoard({
+  entries,
+  loadedAt,
+}: {
+  entries: QueueEntry[];
+  /** ISO timestamp of the server fetch — drives the FreshnessIndicator chip. */
+  loadedAt?: string;
+}) {
   const router = useRouter();
+  const [refreshing, setRefreshing] = useState(false);
+  // Click handler for the FreshnessIndicator's ↻ button. Wraps
+  // router.refresh() in a tiny pending window so the spinner has somewhere
+  // to live; the 30s background poll keeps ticking independently.
+  const manualRefresh = () => {
+    setRefreshing(true);
+    router.refresh();
+    setTimeout(() => setRefreshing(false), 400);
+  };
   // Bumping this state forces React to re-render the wait-time calculations
   // every minute without doing a full server round-trip in between refreshes.
   const [, setTick] = useState(0);
@@ -102,6 +119,15 @@ export function QueueBoard({ entries }: { entries: QueueEntry[] }) {
         eyebrow="Front desk"
         title="Today's Queue"
         description={`${inRooms} in rooms · ${waiting} waiting · ${done} completed today`}
+        actions={
+          loadedAt ? (
+            <FreshnessIndicator
+              since={loadedAt}
+              onRefresh={manualRefresh}
+              status={refreshing ? "refreshing" : "idle"}
+            />
+          ) : undefined
+        }
       />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">

--- a/src/app/(operator)/ops/whisper-inbox/page.tsx
+++ b/src/app/(operator)/ops/whisper-inbox/page.tsx
@@ -2,6 +2,7 @@ import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { lex } from "@/lib/lexicon";
 import {
   classifyWhisper,
@@ -77,6 +78,10 @@ function buildDemoWhispers(): ClassifiedWhisper[] {
 export default async function WhisperInboxPage() {
   await requireUser();
   const whispers = buildDemoWhispers();
+  // Render-time stamp drives the FreshnessIndicator chip below. The demo
+  // payload is deterministic for now; once persistence lands the chip
+  // becomes a real "last fetched" signal without further wiring.
+  const loadedAt = new Date().toISOString();
 
   const cSuiteCount = whispers.filter((w) => w.cSuiteRoute).length;
   const negativeCount = whispers.filter((w) => w.sentiment === "negative").length;
@@ -87,6 +92,7 @@ export default async function WhisperInboxPage() {
         eyebrow={lex("program.feedback")}
         title="Whisper inbox"
         description="Universal feedback from every page, every role. Negative whispers are routed to the C-Suite inbox with a 72-hour first-response SLA."
+        actions={<RouterRefreshFreshness since={loadedAt} />}
       />
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/src/app/(super-admin)/admin/audit/page.tsx
+++ b/src/app/(super-admin)/admin/audit/page.tsx
@@ -30,6 +30,7 @@ import {
 import { AuditTableIsland, type AuditRowView } from "./keyboard-island";
 import { AuditExportMenu } from "./export-menu";
 import { DatePicker } from "@/components/ui/date-picker";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 
 export const dynamic = "force-dynamic";
 export const metadata = { title: "Audit log" };
@@ -110,6 +111,10 @@ export default async function AuditLogPage({
 
   const q = parseAuditQuery(searchParams ?? {});
   const result = await runAuditQuery(prisma, q);
+  // Render timestamp drives the FreshnessIndicator. Audit rows append
+  // fast during incidents — making the staleness of this view legible is
+  // exactly the point of the chip.
+  const loadedAt = new Date().toISOString();
 
   // Map raw rows to the view shape the island expects. Deep-links go to
   // /admin/console/users/<id> for users and /practices/<id> for
@@ -182,7 +187,12 @@ export default async function AuditLogPage({
         eyebrow="Internal"
         title="Audit log"
         description="Every controller mutation across every practice. Filter, expand, export."
-        actions={<AuditExportMenu query={exportQuery(q)} />}
+        actions={
+          <div className="flex items-center gap-2">
+            <RouterRefreshFreshness since={loadedAt} />
+            <AuditExportMenu query={exportQuery(q)} />
+          </div>
+        }
       />
 
       <form method="GET" className="mb-4 flex flex-wrap items-end gap-3">

--- a/src/app/(super-admin)/admin/hq/page.tsx
+++ b/src/app/(super-admin)/admin/hq/page.tsx
@@ -8,6 +8,7 @@ import { Eyebrow } from "@/components/ui/ornament";
 import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 
 import { loadAllHqData } from "./loaders";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { HeroStrip } from "./tiles/hero-strip";
 import { RevenueStrip } from "./tiles/revenue-strip";
 import { OnboardingFunnel } from "./tiles/onboarding-funnel";
@@ -36,6 +37,10 @@ const HQ_NAV: NavLink[] = [
 export default async function LeafjourneyHqPage() {
   const user = await requireUser();
   const snapshot = await loadAllHqData();
+  // Time the fleet snapshot was generated. The FreshnessIndicator on the
+  // page header reads this so operators know whether the KPI strip is 5s
+  // or 5 min old. router.refresh() re-runs loadAllHqData and replaces it.
+  const loadedAt = new Date().toISOString();
 
   return (
     <PageShell maxWidth="max-w-[1240px]">
@@ -55,10 +60,11 @@ export default async function LeafjourneyHqPage() {
             Fleet operations at a glance. Drill into any surface from the nav below.
           </p>
         </div>
-        <div className="flex flex-col items-start md:items-end text-xs text-text-subtle">
-          <span className="uppercase tracking-[0.18em] text-[10px] mb-1">Signed in</span>
+        <div className="flex flex-col items-start md:items-end gap-2 text-xs text-text-subtle">
+          <RouterRefreshFreshness since={loadedAt} />
+          <span className="uppercase tracking-[0.18em] text-[10px]">Signed in</span>
           <span className="text-sm text-text">{user.email}</span>
-          <span className="mt-1">Sign out from the sidebar identity menu.</span>
+          <span>Sign out from the sidebar identity menu.</span>
         </div>
       </header>
 

--- a/src/components/patient/PatientActivityTimeline.tsx
+++ b/src/components/patient/PatientActivityTimeline.tsx
@@ -8,10 +8,15 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 import { formatRelative } from "@/lib/utils/format";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton, SkeletonCircle } from "@/components/ui/skeleton";
+import {
+  FreshnessIndicator,
+  useStaleRefresh,
+} from "@/components/ui/freshness-indicator";
 import {
   groupActivityByDay,
   type PatientActivityEvent,
@@ -24,6 +29,10 @@ interface PatientActivityTimelineProps {
   initialKind?: ChipKey;
   /** Render the skeleton view instead of `events`. Used during streaming SSR. */
   loading?: boolean;
+  /** ISO timestamp of when `events` were fetched. When provided, the timeline
+   *  renders a FreshnessIndicator so the clinician can see how stale the view
+   *  is and re-pull on demand. */
+  loadedAt?: string;
 }
 
 type ChipKey =
@@ -149,10 +158,30 @@ export function PatientActivityTimeline({
   events,
   initialKind = "all",
   loading = false,
+  loadedAt,
 }: PatientActivityTimelineProps) {
+  const router = useRouter();
   const [activeChip, setActiveChip] = React.useState<ChipKey>(initialKind);
   const [since, setSince] = React.useState<Date | undefined>(undefined);
   const [until, setUntil] = React.useState<Date | undefined>(undefined);
+  const [refreshing, setRefreshing] = React.useState(false);
+
+  // Pull the latest events from the server. The timeline already lives
+  // inside the chart's `force-dynamic` server tree, so router.refresh()
+  // re-runs the loader and replays `events` from the top.
+  const refresh = React.useCallback(() => {
+    setRefreshing(true);
+    router.refresh();
+    setTimeout(() => setRefreshing(false), 300);
+  }, [router]);
+
+  // Auto-pull when the clinician comes back to the tab after 5+ min away.
+  useStaleRefresh({
+    since: loadedAt ?? new Date().toISOString(),
+    thresholdMs: 5 * 60 * 1000,
+    onRefresh: refresh,
+    enabled: !!loadedAt,
+  });
 
   const counts = React.useMemo(() => {
     const out: Record<ChipKey, number> = {
@@ -270,6 +299,14 @@ export function PatientActivityTimeline({
             >
               Clear
             </button>
+          )}
+          {loadedAt && (
+            <FreshnessIndicator
+              since={loadedAt}
+              onRefresh={refresh}
+              status={refreshing ? "refreshing" : "idle"}
+              compact
+            />
           )}
         </div>
       </div>

--- a/src/components/shell/practice-admin-shell.tsx
+++ b/src/components/shell/practice-admin-shell.tsx
@@ -32,6 +32,7 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import type { PracticeConfiguration } from "@/lib/practice-config/types";
 
 // EMR-410 (`@/lib/modality/registry`) is in flight in this storm but not yet
@@ -150,6 +151,7 @@ export function PracticeAdminShell({
         eyebrow="Practice admin"
         title={practice.brandName ?? practice.name}
         description="Read-only view of your practice's published configuration. To request a change, contact your LeafJourney implementation team."
+        actions={<RouterRefreshFreshness since={new Date().toISOString()} />}
       />
 
       <div className="grid grid-cols-1 gap-6">

--- a/src/components/ui/freshness-indicator.client.tsx
+++ b/src/components/ui/freshness-indicator.client.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import {
+  FreshnessIndicator,
+  useStaleRefresh,
+  type FreshnessIndicatorProps,
+} from "./freshness-indicator";
+
+/**
+ * RouterRefreshFreshness — adoption shim for Next.js server components.
+ *
+ * Server components can't pass a callback prop to a client component, so
+ * surfaces that just want "show staleness, on click re-run the page's
+ * server data fetch" should drop this in. It wires the click and the
+ * visibility-change auto-refresh to `router.refresh()` without forcing the
+ * host page to become a client component itself.
+ *
+ * Pattern:
+ *
+ *   // server page
+ *   const loadedAt = new Date().toISOString();
+ *   ...
+ *   <RouterRefreshFreshness since={loadedAt} />
+ *
+ * Pages that already manage their own fetch state should use the bare
+ * `<FreshnessIndicator />` directly and pass their own onRefresh.
+ */
+export function RouterRefreshFreshness(
+  props: Omit<FreshnessIndicatorProps, "onRefresh" | "status"> & {
+    /** Auto-refresh threshold in ms when the tab regains visibility. */
+    visibilityThresholdMs?: number;
+    /** Disable the visibility-change auto-refresh entirely. */
+    disableAutoRefresh?: boolean;
+  },
+) {
+  const {
+    since,
+    visibilityThresholdMs = 5 * 60 * 1000,
+    disableAutoRefresh = false,
+    ...rest
+  } = props;
+  const router = useRouter();
+  const [pending, startTransition] = React.useTransition();
+
+  const refresh = React.useCallback(() => {
+    return new Promise<void>((resolve) => {
+      startTransition(() => {
+        router.refresh();
+        // router.refresh resolves via the next render; we don't have a
+        // promise hook, so we settle on the next tick. Good enough to
+        // toggle the spinner off — the indicator's relative time will
+        // freshen as soon as the parent re-renders with a new `since`.
+        setTimeout(resolve, 250);
+      });
+    });
+  }, [router]);
+
+  useStaleRefresh({
+    since,
+    thresholdMs: visibilityThresholdMs,
+    onRefresh: refresh,
+    enabled: !disableAutoRefresh,
+  });
+
+  return (
+    <FreshnessIndicator
+      since={since}
+      onRefresh={refresh}
+      status={pending ? "refreshing" : "idle"}
+      {...rest}
+    />
+  );
+}
+
+RouterRefreshFreshness.displayName = "RouterRefreshFreshness";

--- a/src/components/ui/freshness-indicator.tsx
+++ b/src/components/ui/freshness-indicator.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * FreshnessIndicator — a small chip showing how stale a server-rendered
+ * data surface is, plus a click-to-refresh affordance.
+ *
+ * Why this exists:
+ * Many EMR surfaces (KPI tiles, audit log, queue, communications hub) are
+ * server-rendered with data fetched once on load. The user has no signal
+ * whether the numbers in front of them are 5 seconds or 50 minutes old,
+ * and no obvious way to ask for a re-fetch short of a full browser reload.
+ * This component gives them both: a relative-time label that auto-updates
+ * every 30s, and a refresh button that the caller wires to either
+ * `router.refresh()` (Next.js app router) or a server action.
+ *
+ * Deliberate non-features:
+ *   - No background polling. Refresh is human-triggered or, via the
+ *     companion `useStaleRefresh` hook, fires when the tab regains focus
+ *     after a configurable staleness threshold. We do NOT bang the server
+ *     on a setInterval — that's a footgun on data-heavy pages.
+ *   - No "live" optimistic strings. We only flip to a fresh `since` after
+ *     the caller hands us a new timestamp, otherwise the chip would lie
+ *     about freshness whenever a refresh failed silently.
+ */
+
+export type FreshnessStatus = "idle" | "refreshing" | "error";
+
+export interface FreshnessIndicatorProps {
+  /** ISO timestamp of when the underlying data was loaded. */
+  since: string;
+  /** Optional click handler. If omitted, the refresh button is hidden. */
+  onRefresh?: () => void | Promise<void>;
+  /** External status override (e.g. caller already has a pending action). */
+  status?: FreshnessStatus;
+  /** A11y label / tooltip on the refresh button. */
+  refreshLabel?: string;
+  /** Extra classes for the outer chip. */
+  className?: string;
+  /** Render compact (smaller padding, no dot). */
+  compact?: boolean;
+}
+
+/** Buckets we use to pick the dot colour and the verbose copy. */
+type Freshness = "fresh" | "neutral" | "stale";
+
+function bucket(ageMs: number): Freshness {
+  if (ageMs < 2 * 60_000) return "fresh";
+  if (ageMs < 15 * 60_000) return "neutral";
+  return "stale";
+}
+
+/**
+ * Format a relative time string. Intentionally inline — pulling in
+ * date-fns or Intl.RelativeTimeFormat for one widget is overkill, and
+ * inline lets us guarantee SSR/CSR text parity for the first paint.
+ */
+function relative(ageMs: number): string {
+  if (ageMs < 5_000) return "just now";
+  if (ageMs < 60_000) return `${Math.round(ageMs / 1000)}s ago`;
+  if (ageMs < 60 * 60_000) return `${Math.round(ageMs / 60_000)}m ago`;
+  if (ageMs < 24 * 60 * 60_000) return `${Math.round(ageMs / (60 * 60_000))}h ago`;
+  return `${Math.round(ageMs / (24 * 60 * 60_000))}d ago`;
+}
+
+const DOT_TONE: Record<Freshness, string> = {
+  fresh: "bg-emerald-500",
+  neutral: "bg-text-subtle",
+  stale: "bg-amber-500",
+};
+
+/**
+ * Calls onRefresh when the tab becomes visible after the page has been
+ * hidden (or simply blurred) for longer than `thresholdMs`. Designed to
+ * pair with FreshnessIndicator on dashboards — a clinician closes the
+ * laptop for an hour, walks back, the page silently re-pulls.
+ *
+ * Caller passes the most-recent `since` so the threshold is measured
+ * against the actual data age, not just visibility duration. We guard on
+ * `document.visibilityState === "visible"` so synthetic focus events
+ * (e.g. a focus on a popover) don't trigger spurious refreshes.
+ */
+export function useStaleRefresh(opts: {
+  since: string;
+  thresholdMs?: number;
+  onRefresh: () => void | Promise<void>;
+  enabled?: boolean;
+}): void {
+  const { since, thresholdMs = 5 * 60 * 1000, onRefresh, enabled = true } = opts;
+
+  // Stash the latest onRefresh in a ref so the effect doesn't re-bind every
+  // render when callers pass an inline arrow.
+  const refreshRef = React.useRef(onRefresh);
+  refreshRef.current = onRefresh;
+
+  React.useEffect(() => {
+    if (!enabled) return;
+    if (typeof document === "undefined") return;
+
+    let firing = false;
+    const handler = () => {
+      if (document.visibilityState !== "visible") return;
+      if (firing) return;
+      const ts = Date.parse(since);
+      if (!Number.isFinite(ts)) return;
+      const age = Date.now() - ts;
+      if (age < thresholdMs) return;
+      firing = true;
+      Promise.resolve(refreshRef.current())
+        .catch(() => {
+          /* swallow — caller surfaces errors via `status` */
+        })
+        .finally(() => {
+          firing = false;
+        });
+    };
+
+    document.addEventListener("visibilitychange", handler);
+    window.addEventListener("focus", handler);
+    return () => {
+      document.removeEventListener("visibilitychange", handler);
+      window.removeEventListener("focus", handler);
+    };
+  }, [since, thresholdMs, enabled]);
+}
+
+export function FreshnessIndicator({
+  since,
+  onRefresh,
+  status,
+  refreshLabel = "Refresh",
+  className,
+  compact = false,
+}: FreshnessIndicatorProps) {
+  // Internal pending state for when the caller didn't pass `status`. We
+  // still defer to the prop when present so a parent that already tracks
+  // a server action can control us.
+  const [internalPending, setInternalPending] = React.useState(false);
+  const refreshing = status === "refreshing" || internalPending;
+  const isError = status === "error";
+
+  // Tick a counter every 30s so the relative-time label re-renders. We
+  // tie the effect lifetime to mount, not to `since`, so the timer stays
+  // steady across re-renders.
+  const [, setTick] = React.useState(0);
+  React.useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const parsed = React.useMemo(() => Date.parse(since), [since]);
+  const ageMs = Number.isFinite(parsed) ? Math.max(0, Date.now() - parsed) : null;
+  const freshness: Freshness = ageMs == null ? "neutral" : bucket(ageMs);
+
+  const label = refreshing
+    ? "Updating…"
+    : ageMs == null
+      ? "Updated"
+      : `Updated ${relative(ageMs)}`;
+
+  const handleClick = React.useCallback(async () => {
+    if (!onRefresh || refreshing) return;
+    try {
+      setInternalPending(true);
+      await Promise.resolve(onRefresh());
+    } finally {
+      setInternalPending(false);
+    }
+  }, [onRefresh, refreshing]);
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border bg-surface-raised/70",
+        "text-xs text-text-muted select-none",
+        compact ? "px-2 py-0.5" : "px-2.5 py-1",
+        isError ? "border-danger/40 text-danger" : "border-border/60",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+      data-freshness={freshness}
+    >
+      {!compact && (
+        <span
+          className={cn(
+            "h-1.5 w-1.5 rounded-full",
+            isError ? "bg-danger" : DOT_TONE[freshness],
+            refreshing && "animate-pulse",
+          )}
+          aria-hidden="true"
+        />
+      )}
+      <span className="font-medium tracking-tight">
+        {isError ? "Update failed" : label}
+      </span>
+      {onRefresh && (
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={refreshing}
+          aria-label={refreshLabel}
+          title={refreshLabel}
+          className={cn(
+            "ml-0.5 inline-flex items-center justify-center rounded-full p-1",
+            "text-text-muted hover:text-text hover:bg-surface-muted",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          )}
+        >
+          <RefreshCw
+            className={cn("h-3.5 w-3.5", refreshing && "animate-spin")}
+            aria-hidden="true"
+          />
+        </button>
+      )}
+    </div>
+  );
+}
+
+FreshnessIndicator.displayName = "FreshnessIndicator";


### PR DESCRIPTION
## Summary

Many EMR surfaces are server-rendered with data fetched once on load. The user has no signal whether the numbers in front of them are 5 seconds or 50 minutes old, and no obvious way to ask for a re-fetch short of a full browser reload. This PR adds a small chip-style indicator (`Updated 3m ago` + refresh button) plus an opt-in visibility-change auto-refresh hook.

No new dependencies. No new setInterval polling — every refresh is human-triggered or visibility-triggered.

## Component

`src/components/ui/freshness-indicator.tsx`

- `<FreshnessIndicator since onRefresh status? compact? />` — chip with a colored dot, a relative-time label, and a refresh button.
- Color cues: green dot < 2m, neutral 2–15m, amber 15m+.
- Relative time auto-updates every 30s via a single mount-scoped `setInterval`.
- While refreshing: refresh icon spins, copy flips to `Updating…`, button is disabled to prevent double-fire.
- `useStaleRefresh({ since, thresholdMs, onRefresh, enabled })` hook listens for `visibilitychange` + `focus` and only fires when the data is older than the threshold (default 5 min) and the tab is actually visible.

`src/components/ui/freshness-indicator.client.tsx`

- `<RouterRefreshFreshness since />` adoption shim — wraps `FreshnessIndicator` and wires both the click and the visibility-change auto-refresh to `router.refresh()` inside a React transition. Lets server-component pages adopt in one line.

## Pattern

For Next.js server-component pages:

```tsx
import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";

<PageHeader
  title="Audit log"
  actions={<RouterRefreshFreshness since={new Date().toISOString()} />}
/>
```

For client components that already own a router (e.g. queue board, activity timeline), use the bare `<FreshnessIndicator />` and wire `onRefresh` to your own `router.refresh()` or server action.

## Adoption sites (8)

- `src/app/(super-admin)/admin/hq/page.tsx` — fleet KPI dashboard (owner dashboard)
- `src/components/shell/practice-admin-shell.tsx` — per-tenant practice-admin dashboard
- `src/app/(clinician)/clinic/communications/page.tsx` — comms hub (calls / Beam / voicemail / transcripts / fax tiles)
- `src/app/(operator)/ops/whisper-inbox/page.tsx` — smart inbox triage counts
- `src/app/(operator)/ops/queue/page.tsx` + `queue-board.tsx` — mission control (chip lives alongside the existing 30s background refresh)
- `src/app/(super-admin)/admin/audit/page.tsx` — audit log viewer
- `src/app/(clinician)/clinic/patients/page.tsx` — patient roster
- `src/components/patient/PatientActivityTimeline.tsx` — activity timeline (PR #469), now also fires visibility-change auto-refresh

## Test plan

- [ ] Open `/admin/hq` — see `Updated just now`. Wait 3 min, label flips to `Updated 3m ago` and dot turns neutral.
- [ ] Click the refresh button — icon spins, copy reads `Updating…`, button disabled. Server re-renders; label flips back to `Updated just now`.
- [ ] Open `/admin/audit`, switch to another tab for 6+ min, switch back — page auto-refreshes via visibilitychange.
- [ ] Open `/clinic/communications` on a small viewport — chip wraps gracefully into the actions slot.
- [ ] Verify no `setInterval` polling in DevTools network panel (only the queue board's pre-existing 30s loop should fire).
- [ ] `npm run typecheck` and `npm run lint` both clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>