### PR TITLE
ux: tag system — ColorPicker + TagPill + TagInput + 4 surface adoptions

### DIFF
--- a/src/app/(clinician)/clinic/communications/broadcasts/page.tsx
+++ b/src/app/(clinician)/clinic/communications/broadcasts/page.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { formatRelative } from "@/lib/utils/format";
 import { CampaignComposeForm } from "./compose-form";
 import { SendNowButton } from "./send-now-button";
+import { EntityTagEditor } from "@/components/ui/entity-tag-editor";
 
 export const metadata = { title: "Outreach broadcasts" };
 
@@ -136,6 +137,14 @@ export default async function BroadcastsPage() {
                         · {formatRelative(c.createdAt.toISOString())}
                       </p>
                       {canSend ? <SendNowButton campaignId={c.id} /> : null}
+                    </div>
+                    {/* Per-campaign audience tags (education / marketing / …). */}
+                    <div className="mt-1.5">
+                      <EntityTagEditor
+                        scope="broadcast-campaign"
+                        entityId={c.id}
+                        compact
+                      />
                     </div>
                   </div>
                 );

--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -45,6 +45,8 @@ import {
   ContextMenuIcons,
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
+// Thread tagging — localStorage-backed until a server-side Tag model lands.
+import { EntityTagEditor, EntityTagStrip } from "@/components/ui/entity-tag-editor";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -979,6 +981,8 @@ function ThreadInboxRow({
                   Needs clinician
                 </span>
               )}
+              {/* Thread tags (read-only here; editor lives in the detail pane). */}
+              <EntityTagStrip scope="inbox-thread" entityId={t.threadId} />
             </div>
           </div>
         </div>
@@ -1581,6 +1585,14 @@ export function SmartInboxView({
                     >
                       {selectedThread.patientName}
                     </Link>
+                    {/* Thread tags — color-coded labels (follow-up, urgent…). */}
+                    <div className="mt-1">
+                      <EntityTagEditor
+                        scope="inbox-thread"
+                        entityId={selectedThread.threadId}
+                        compact
+                      />
+                    </div>
                   </div>
                   {selectedTriage && (
                     <div className="flex items-center gap-2">

--- a/src/app/(clinician)/clinic/patients/patient-list-client.tsx
+++ b/src/app/(clinician)/clinic/patients/patient-list-client.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { listStagger, listStaggerChild } from "@/lib/ui/motion";
 import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { PatientTagStrip } from "@/components/ui/patient-tag-strip";
 import { MetricTile } from "@/components/ui/metric-tile";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
@@ -819,6 +820,8 @@ export function PatientListClient({
                             Last visit {formatShortDate(p.lastVisit)}
                           </Badge>
                         )}
+                        {/* Tag strip — reads PatientTag selections from localStorage. */}
+                        <PatientTagStrip patientId={p.id} />
                       </div>
                     </div>
 

--- a/src/components/patient/ChartTaskList.tsx
+++ b/src/components/patient/ChartTaskList.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils/cn";
 import { Badge } from "@/components/ui/badge";
 import { formatRelative } from "@/lib/utils/format";
 import { SortableList, reorder } from "@/components/ui/sortable";
+import { EntityTagEditor, EntityTagStrip } from "@/components/ui/entity-tag-editor";
 
 // EMR-180 — Chart Task List / To-Do on Open
 //
@@ -273,6 +274,8 @@ export function ChartTaskList({
                   </span>
                   {item.severity === "danger" && <Badge tone="danger">Urgent</Badge>}
                   {item.severity === "warning" && <Badge tone="warning">Attention</Badge>}
+                  {/* Read-only tag strip (editor sits outside the Link). */}
+                  <EntityTagStrip scope="chart-task" entityId={item.id} />
                 </div>
                 <p className="text-sm text-text font-medium leading-snug">
                   {item.title}
@@ -287,6 +290,10 @@ export function ChartTaskList({
                 </span>
               )}
             </Link>
+            {/* Tag affordance outside the Link so the popover doesn't navigate. */}
+            <div className="self-center pr-2">
+              <EntityTagEditor scope="chart-task" entityId={item.id} compact />
+            </div>
           </div>
         )}
       />

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { Tooltip } from "@/components/ui/tooltip";
+
+// ---------------------------------------------------------------------------
+// ColorPicker — restricted-palette swatch picker (NOT a free RGB picker).
+//
+// Design intent: every color that ships across EMR (tags, calendar labels,
+// broadcast categories) must come from the same brand-safe palette so the
+// UI never gets a #FF00FF surprise. The picker enforces that by accepting
+// only `PaletteColor.name` values — there's no raw hex input on purpose.
+//
+// The 8 default colors match `TAG_COLOR_CLASSES` in `@/lib/domain/patient-tags`
+// so a tag picked here renders identically anywhere a PatientTagBadge or
+// TagPill shows up.
+// ---------------------------------------------------------------------------
+
+export interface PaletteColor {
+  /** Stable identifier persisted with the entity (e.g. `emerald`). */
+  name: string;
+  /** Human label shown in the tooltip. */
+  label: string;
+  /** Hex preview used to paint the swatch — not stored on the entity. */
+  hex: string;
+}
+
+/**
+ * Default 8-color brand palette. Names match the `PatientTag["color"]` union
+ * in `src/lib/domain/patient-tags.ts` so tags picked here are interchangeable
+ * with the existing PatientTag system.
+ *
+ * Order: accent → success → warning → danger → indigo (blue) → purple → pink → neutral.
+ */
+export const DEFAULT_PALETTE: readonly PaletteColor[] = [
+  { name: "emerald", label: "Accent · Emerald", hex: "#10B981" },
+  { name: "teal", label: "Success · Teal", hex: "#14B8A6" },
+  { name: "amber", label: "Warning · Amber", hex: "#F59E0B" },
+  { name: "red", label: "Danger · Red", hex: "#EF4444" },
+  { name: "blue", label: "Indigo · Blue", hex: "#3B82F6" },
+  { name: "purple", label: "Purple", hex: "#8B5CF6" },
+  { name: "rose", label: "Pink · Rose", hex: "#F43F5E" },
+  { name: "gray", label: "Neutral · Gray", hex: "#6B7280" },
+] as const;
+
+export interface ColorPickerProps {
+  /** Currently selected color `name` (must exist in `palette`). */
+  value: string;
+  /** Called with the new `name` when the user picks a swatch. */
+  onChange: (name: string) => void;
+  /** Override the swatch list. Defaults to `DEFAULT_PALETTE`. */
+  palette?: readonly PaletteColor[];
+  /** Optional aria-label for the swatch row container. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Restricted-palette color picker. Renders a single row of swatches with
+ * a hairline ring on the selected one. Keyboard: ←/→ to navigate, Enter /
+ * Space to commit. Hover/focus surfaces the color's human label via Tooltip.
+ */
+export function ColorPicker({
+  value,
+  onChange,
+  palette = DEFAULT_PALETTE,
+  ariaLabel = "Color",
+  className,
+}: ColorPickerProps) {
+  // Track focus so arrow-key nav doesn't fight the natural tab order on
+  // page load — we only intercept arrows once the swatch row has focus.
+  const [focusedIndex, setFocusedIndex] = React.useState<number>(() => {
+    const idx = palette.findIndex((c) => c.name === value);
+    return idx >= 0 ? idx : 0;
+  });
+  const swatchRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+
+  // Keep focus index in sync if `value` changes externally.
+  React.useEffect(() => {
+    const idx = palette.findIndex((c) => c.name === value);
+    if (idx >= 0) setFocusedIndex(idx);
+  }, [value, palette]);
+
+  function handleKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Enter" && e.key !== " ") {
+      return;
+    }
+    e.preventDefault();
+    if (e.key === "Enter" || e.key === " ") {
+      const c = palette[focusedIndex];
+      if (c) onChange(c.name);
+      return;
+    }
+    const delta = e.key === "ArrowLeft" ? -1 : 1;
+    const next = (focusedIndex + delta + palette.length) % palette.length;
+    setFocusedIndex(next);
+    swatchRefs.current[next]?.focus();
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      onKeyDown={handleKey}
+      className={cn("inline-flex items-center gap-1.5", className)}
+    >
+      {palette.map((c, i) => {
+        const selected = c.name === value;
+        return (
+          <Tooltip key={c.name} content={c.label} delay={300}>
+            <button
+              ref={(node) => {
+                swatchRefs.current[i] = node;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={c.label}
+              tabIndex={selected || (focusedIndex === i && !palette.some((p) => p.name === value)) ? 0 : -1}
+              onClick={() => onChange(c.name)}
+              onFocus={() => setFocusedIndex(i)}
+              className={cn(
+                "h-6 w-6 rounded-full border border-black/10 transition-transform duration-150",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                "hover:scale-110",
+                selected && "ring-2 ring-offset-2 ring-offset-surface ring-text/60",
+              )}
+              style={{ backgroundColor: c.hex }}
+            />
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/entity-tag-editor.tsx
+++ b/src/components/ui/entity-tag-editor.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { TagPill } from "@/components/ui/tag-pill";
+import { TagInput, type Tag } from "@/components/ui/tag-input";
+import {
+  readTags,
+  writeTags,
+  SUGGESTED_TAGS,
+  type EntityTagScope,
+} from "@/lib/domain/entity-tags";
+
+// ---------------------------------------------------------------------------
+// EntityTagEditor — reusable popover wrapper around TagInput that persists to
+// localStorage under a scope/entityId pair. Used by inbox threads, chart
+// tasks, and broadcast campaigns until a server-side Tag model lands.
+// ---------------------------------------------------------------------------
+
+interface EntityTagEditorProps {
+  scope: EntityTagScope;
+  entityId: string;
+  /** Compact = no leading "Tags" label, smaller affordance. */
+  compact?: boolean;
+  className?: string;
+}
+
+interface EntityTagStripProps {
+  scope: EntityTagScope;
+  entityId: string;
+  /** Truncate after this many pills; show "+N". Default 3. */
+  max?: number;
+  className?: string;
+}
+
+/**
+ * Read-only horizontal strip of an entity's tags. Pairs with EntityTagEditor
+ * for surfaces (inbox list, task rows) where the editor is too heavy.
+ */
+export function EntityTagStrip({
+  scope,
+  entityId,
+  max = 3,
+  className,
+}: EntityTagStripProps) {
+  const [tags, setTags] = React.useState<Tag[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    setTags(readTags(scope, entityId));
+    setHydrated(true);
+  }, [scope, entityId]);
+
+  if (!hydrated || tags.length === 0) return null;
+  const shown = tags.slice(0, max);
+  const overflow = tags.length - shown.length;
+
+  return (
+    <span className={cn("inline-flex items-center gap-1 flex-wrap", className)}>
+      {shown.map((t, i) => (
+        <TagPill key={`${t.label}-${i}`} label={t.label} color={t.color} size="sm" />
+      ))}
+      {overflow > 0 && (
+        <span className="text-[10px] text-text-subtle font-medium px-1">
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function EntityTagEditor({
+  scope,
+  entityId,
+  compact = false,
+  className,
+}: EntityTagEditorProps) {
+  const [tags, setTags] = React.useState<Tag[]>([]);
+  const [open, setOpen] = React.useState(false);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    setTags(readTags(scope, entityId));
+    setHydrated(true);
+  }, [scope, entityId]);
+
+  function persist(next: Tag[]) {
+    setTags(next);
+    writeTags(scope, entityId, next);
+  }
+
+  // SSR placeholder — render a stable-height shell so layout doesn't jump
+  // when the client hydrates and pulls tags from storage.
+  if (!hydrated) {
+    return <div className={cn("h-6", className)} aria-hidden="true" />;
+  }
+
+  return (
+    <div className={cn("inline-flex items-center gap-1.5 flex-wrap", className)}>
+      {!compact && tags.length > 0 && (
+        <span className="text-[10px] uppercase tracking-wider text-text-subtle font-medium">
+          Tags
+        </span>
+      )}
+      {tags.map((t, i) => (
+        <TagPill key={`${t.label}-${i}`} label={t.label} color={t.color} />
+      ))}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            setOpen((o) => !o);
+          }}
+          className={cn(
+            "inline-flex items-center gap-1 rounded-full border border-dashed border-border-strong",
+            "text-text-muted hover:bg-surface-muted",
+            compact
+              ? "px-1.5 py-0.5 text-[10px]"
+              : "px-2.5 py-0.5 text-[11px] font-medium",
+          )}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+        >
+          {tags.length === 0 ? "+ Tag" : "Edit"}
+        </button>
+
+        {open && (
+          <>
+            <button
+              type="button"
+              className="fixed inset-0 z-40"
+              aria-label="Close tag editor"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+              }}
+            />
+            <div
+              role="dialog"
+              aria-label="Edit tags"
+              onClick={(e) => e.stopPropagation()}
+              className="absolute z-50 top-full mt-2 left-0 w-72 rounded-xl border border-border bg-surface-raised shadow-lg p-3"
+            >
+              <p className="text-[10px] uppercase tracking-wider text-text-subtle font-medium mb-2">
+                Tags
+              </p>
+              <TagInput
+                value={tags}
+                onChange={persist}
+                suggestions={SUGGESTED_TAGS[scope]}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/patient-tag-strip.tsx
+++ b/src/components/ui/patient-tag-strip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { TagPill } from "@/components/ui/tag-pill";
+import { DEFAULT_TAGS, type PatientTag } from "@/lib/domain/patient-tags";
+
+// ---------------------------------------------------------------------------
+// PatientTagStrip — read-only horizontal strip of a patient's selected tags.
+//
+// Reads from the same localStorage keys (`patient-tags-${patientId}`) that
+// the TagManager writes to, so the roster row and the patient detail are
+// always in sync.
+//
+// TODO(EMR-684): swap reads to a server-side PatientTag table when it lands.
+// ---------------------------------------------------------------------------
+
+interface PatientTagStripProps {
+  patientId: string;
+  /** Truncate after this many; show "+N" overflow. Default 3. */
+  max?: number;
+  className?: string;
+}
+
+export function PatientTagStrip({
+  patientId,
+  max = 3,
+  className,
+}: PatientTagStripProps) {
+  const [tagIds, setTagIds] = React.useState<string[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(`patient-tags-${patientId}`);
+      if (raw) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) {
+          setTagIds(parsed.filter((x): x is string => typeof x === "string"));
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true);
+  }, [patientId]);
+
+  if (!hydrated || tagIds.length === 0) return null;
+
+  const tags: PatientTag[] = DEFAULT_TAGS.filter((t) => tagIds.includes(t.id));
+  const shown = tags.slice(0, max);
+  const overflow = tags.length - shown.length;
+
+  return (
+    <span className={cn("inline-flex items-center gap-1 flex-wrap", className)}>
+      {shown.map((t) => (
+        <TagPill key={t.id} label={t.label} color={t.color} size="sm" />
+      ))}
+      {overflow > 0 && (
+        <span className="text-[10px] text-text-subtle font-medium px-1">
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { TagPill, type TagColor } from "@/components/ui/tag-pill";
+import { ColorPicker, DEFAULT_PALETTE } from "@/components/ui/color-picker";
+
+// ---------------------------------------------------------------------------
+// TagInput — Notion-style multi-tag editor.
+//
+// Behavior:
+//   • Type to filter `suggestions`; ↑/↓ to navigate, Enter to commit the
+//     highlighted suggestion (or create a new tag with the typed label).
+//   • Backspace on an empty input removes the last selected tag.
+//   • A small ColorPicker sits inline below the input — assigns a color to
+//     the *next* tag being created. Defaults to the first palette color.
+//   • Tags appear as TagPills with × to remove.
+//
+// Storage shape is intentionally tiny and additive:
+//   { id?, label, color }
+//
+// The component is fully controlled — it does not own selection state.
+// ---------------------------------------------------------------------------
+
+export interface Tag {
+  /** Stable id when persisted (DB / localStorage); undefined for ad-hoc tags. */
+  id?: string;
+  /** Visible label, e.g. "follow-up". */
+  label: string;
+  /** Palette color name. */
+  color: TagColor;
+}
+
+export interface TagInputProps {
+  value: Tag[];
+  onChange: (next: Tag[]) => void;
+  /** Optional pool of tag suggestions. Filtered by typed query. */
+  suggestions?: Tag[];
+  /** Placeholder text shown when no tags are selected. */
+  placeholder?: string;
+  /** Disable input + remove buttons. */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Multi-tag input with inline color picker and suggestion dropdown.
+ *
+ * Implementation notes:
+ *   • Dedupe by lowercased label so picking the same suggestion twice or
+ *     hitting Enter on an existing tag is a no-op.
+ *   • Suggestions filter is case-insensitive substring match. Already-selected
+ *     tags are hidden from the suggestion list to avoid noise.
+ */
+export function TagInput({
+  value,
+  onChange,
+  suggestions = [],
+  placeholder = "Add a tag…",
+  disabled = false,
+  className,
+}: TagInputProps) {
+  const [query, setQuery] = React.useState("");
+  const [nextColor, setNextColor] = React.useState<TagColor>(
+    DEFAULT_PALETTE[0]?.name as TagColor,
+  );
+  const [highlight, setHighlight] = React.useState(0);
+  const [open, setOpen] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const selectedLabels = React.useMemo(
+    () => new Set(value.map((t) => t.label.trim().toLowerCase())),
+    [value],
+  );
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return suggestions
+      .filter((t) => !selectedLabels.has(t.label.trim().toLowerCase()))
+      .filter((t) => (q ? t.label.toLowerCase().includes(q) : true))
+      .slice(0, 8);
+  }, [suggestions, query, selectedLabels]);
+
+  // Keep highlight in bounds when the filtered list shrinks.
+  React.useEffect(() => {
+    if (highlight >= filtered.length) setHighlight(0);
+  }, [filtered.length, highlight]);
+
+  function commitTag(tag: Tag) {
+    const label = tag.label.trim();
+    if (!label) return;
+    if (selectedLabels.has(label.toLowerCase())) return;
+    onChange([...value, { ...tag, label }]);
+    setQuery("");
+    setHighlight(0);
+  }
+
+  function removeAt(index: number) {
+    onChange(value.filter((_, i) => i !== index));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Backspace" && query === "" && value.length > 0) {
+      e.preventDefault();
+      removeAt(value.length - 1);
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      if (filtered.length === 0) return;
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => (h + 1) % filtered.length);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      if (filtered.length === 0) return;
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => (h - 1 + filtered.length) % filtered.length);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const picked = filtered[highlight];
+      if (picked) {
+        commitTag(picked);
+      } else if (query.trim()) {
+        commitTag({ label: query.trim(), color: nextColor });
+      }
+      return;
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className={cn("w-full", className)}>
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1.5",
+          "focus-within:ring-2 focus-within:ring-accent/30 focus-within:border-accent/40",
+          disabled && "opacity-60 pointer-events-none",
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {value.map((t, i) => (
+          <TagPill
+            key={`${t.label}-${i}`}
+            label={t.label}
+            color={t.color}
+            onRemove={disabled ? undefined : () => removeAt(i)}
+          />
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          placeholder={value.length === 0 ? placeholder : ""}
+          disabled={disabled}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            // Delay close so a click on a suggestion still registers.
+            window.setTimeout(() => setOpen(false), 120);
+          }}
+          onKeyDown={handleKeyDown}
+          aria-label="Add tag"
+          className="flex-1 min-w-[100px] bg-transparent outline-none text-sm text-text placeholder:text-text-subtle py-0.5"
+        />
+      </div>
+
+      <div className="mt-2 flex items-center gap-3">
+        <span className="text-[10px] uppercase tracking-wider text-text-subtle">
+          Color
+        </span>
+        <ColorPicker
+          value={nextColor}
+          onChange={(name) => setNextColor(name as TagColor)}
+          ariaLabel="Color for next tag"
+        />
+        {query.trim() && (
+          <span className="text-[11px] text-text-subtle">
+            Enter to add &ldquo;{query.trim()}&rdquo;
+          </span>
+        )}
+      </div>
+
+      {open && filtered.length > 0 && (
+        <div
+          role="listbox"
+          className="relative mt-1"
+        >
+          <ul className="absolute z-30 left-0 right-0 max-h-56 overflow-y-auto rounded-lg border border-border bg-surface-raised shadow-lg py-1">
+            {filtered.map((s, i) => (
+              <li key={`${s.label}-${i}`}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={i === highlight}
+                  // Use mousedown so we fire before the input's onBlur close.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    commitTag(s);
+                  }}
+                  onMouseEnter={() => setHighlight(i)}
+                  className={cn(
+                    "w-full flex items-center gap-2 px-2 py-1.5 text-left text-sm",
+                    i === highlight ? "bg-surface-muted" : "hover:bg-surface-muted/60",
+                  )}
+                >
+                  <TagPill label={s.label} color={s.color} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/tag-pill.tsx
+++ b/src/components/ui/tag-pill.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import { TAG_COLOR_CLASSES, type PatientTag } from "@/lib/domain/patient-tags";
+
+// ---------------------------------------------------------------------------
+// TagPill — small rounded pill for a colored label.
+//
+// Shares its color tokens with the existing PatientTagBadge so a tag rendered
+// in the roster, the smart inbox, and a chart task all read as the same color.
+// Light + dark mode safe because `TAG_COLOR_CLASSES` uses Tailwind's
+// `bg-{color}-100 / text-{color}-700` shades that flip via Tailwind dark
+// variants where applied.
+// ---------------------------------------------------------------------------
+
+export type TagColor = PatientTag["color"];
+
+export interface TagPillProps {
+  /** Visible label. */
+  label: string;
+  /** Color name from the `PatientTag` palette. Defaults to neutral gray. */
+  color?: TagColor;
+  /** Pill size — `sm` for inline lists, `md` for headers / detail surfaces. */
+  size?: "sm" | "md";
+  /** Optional remove handler — renders a × button when provided. */
+  onRemove?: () => void;
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<NonNullable<TagPillProps["size"]>, string> = {
+  sm: "px-2 py-0.5 text-[10.5px]",
+  md: "px-2.5 py-1 text-xs",
+};
+
+/**
+ * Small colored pill. Use anywhere a tag is rendered (patient roster,
+ * inbox thread headers, chart tasks, broadcast cards).
+ */
+export function TagPill({
+  label,
+  color = "gray",
+  size = "sm",
+  onRemove,
+  className,
+}: TagPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-medium tracking-wide",
+        "max-w-[160px] whitespace-nowrap",
+        SIZE_CLASSES[size],
+        TAG_COLOR_CLASSES[color],
+        className,
+      )}
+    >
+      <span className="truncate">{label}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${label}`}
+          className="ml-0.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full text-current opacity-60 hover:opacity-100 hover:bg-black/10"
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/lib/domain/entity-tags.ts
+++ b/src/lib/domain/entity-tags.ts
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// entity-tags — lightweight localStorage tag store for non-Patient surfaces.
+//
+// Patient tags already have a typed model in `patient-tags.ts` (and will be
+// promoted to a Prisma table per EMR-684). This helper covers the rest of the
+// surfaces that the tag-system UX touches today — smart-inbox threads, chart
+// tasks, broadcast campaigns — without paying for new schema migrations.
+//
+// TODO(EMR-684 follow-up): when the PatientTag / EntityTag Prisma model lands,
+// replace these client-only reads/writes with server actions. Until then this
+// keeps the UX honest and discoverable across reloads of the same device.
+// ---------------------------------------------------------------------------
+
+import type { Tag } from "@/components/ui/tag-input";
+
+const STORAGE_VERSION = "v1";
+
+export type EntityTagScope =
+  | "inbox-thread"
+  | "chart-task"
+  | "broadcast-campaign";
+
+function storageKey(scope: EntityTagScope, entityId: string): string {
+  return `entity-tags:${STORAGE_VERSION}:${scope}:${entityId}`;
+}
+
+/** Read tags for one entity. Returns [] when SSR / storage unavailable. */
+export function readTags(scope: EntityTagScope, entityId: string): Tag[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(storageKey(scope, entityId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (t): t is Tag =>
+        !!t && typeof t === "object" && "label" in t && "color" in t,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Write tags for one entity. Silent on storage failure (private mode etc.). */
+export function writeTags(scope: EntityTagScope, entityId: string, tags: Tag[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(scope, entityId), JSON.stringify(tags));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Default suggestion pool per scope. Tuned to what clinicians actually call
+ * these things in the channel — short, lowercase, color-coded.
+ */
+export const SUGGESTED_TAGS: Record<EntityTagScope, Tag[]> = {
+  "inbox-thread": [
+    { label: "follow-up", color: "blue" },
+    { label: "urgent", color: "red" },
+    { label: "billing", color: "amber" },
+    { label: "refill", color: "teal" },
+    { label: "lab result", color: "purple" },
+    { label: "new patient", color: "emerald" },
+  ],
+  "chart-task": [
+    { label: "priority", color: "red" },
+    { label: "this week", color: "amber" },
+    { label: "delegated", color: "purple" },
+    { label: "blocked", color: "gray" },
+    { label: "research", color: "teal" },
+  ],
+  "broadcast-campaign": [
+    { label: "education", color: "blue" },
+    { label: "marketing", color: "rose" },
+    { label: "compliance", color: "purple" },
+    { label: "wellness", color: "emerald" },
+    { label: "operational", color: "gray" },
+  ],
+};


### PR DESCRIPTION
## Summary

Adds three Notion-tier UI primitives — `ColorPicker`, `TagPill`, `TagInput` — built on the **existing** `PatientTag` color palette so every tag across the EMR pulls from the same brand-safe set. Then adopts them in four surfaces (patient roster, smart inbox, chart tasks, broadcasts).

UI-only. No schema changes. Storage stays in `localStorage` until the server-side `Tag` / `EntityTag` model lands (tracked under EMR-684).

## Primitives

- **`src/components/ui/color-picker.tsx`** — 8-swatch restricted palette (NOT a free RGB picker). Keyboard ←/→ to navigate, Enter/Space to commit. Each swatch shows its name in a Tooltip on hover/focus. Default palette mirrors `PatientTag["color"]` so tags picked here are interchangeable with the existing PatientTag system.
- **`src/components/ui/tag-pill.tsx`** — small rounded pill with `bg-{color}-100 / text-{color}-700` semantic tokens (light + dark safe). `sm`/`md` sizes; optional remove (×) button.
- **`src/components/ui/tag-input.tsx`** — Notion-style multi-tag editor: type to filter `suggestions`, ↑/↓ to highlight, Enter to commit (existing suggestion or new tag), Backspace removes last, inline `ColorPicker` assigns color for the next tag. Tag shape: `{ id?, label, color }`.

Shared helpers:
- `src/lib/domain/entity-tags.ts` — localStorage read/write for non-Patient scopes (`inbox-thread`, `chart-task`, `broadcast-campaign`) + curated suggestion pools per scope.
- `src/components/ui/entity-tag-editor.tsx` — popover editor + read-only `EntityTagStrip` wrapping `TagInput`.
- `src/components/ui/patient-tag-strip.tsx` — read-only strip reading from the existing `patient-tags-${id}` localStorage keys.

## Surface adoptions

- **Patient roster** (`patient-list-client.tsx`) — `PatientTagStrip` rendered next to the status badges, reads from the same `patient-tags-${id}` keys the existing `TagManager` writes to.
- **Smart inbox** (`smart-inbox.tsx`) — read-only tag strip in each list row + full `EntityTagEditor` in the thread detail header (suggestions: follow-up, urgent, billing, refill, lab result, new patient).
- **Chart task list** (`ChartTaskList.tsx`) — read-only strip inside the Link + tag-edit affordance outside the Link so the popover doesn't navigate.
- **Broadcast campaigns** (`broadcasts/page.tsx`) — per-campaign tag editor in the recent-campaigns sidebar (suggestions: education, marketing, compliance, wellness, operational).

## Schema status

No schema changes. Storage is localStorage-keyed with a versioned prefix (`entity-tags:v1:{scope}:{id}` for non-patient surfaces, `patient-tags-{id}` for patients). TODOs reference EMR-684 for the eventual server-side promotion.

## Constraints honored

- No `prisma/schema.prisma`, `middleware.ts`, `.github/workflows`, `lib/auth/`, `CLAUDE.md`, or `manifests/` edits.
- No `/ops/supplies` touches.
- No new dependencies.
- Reuses existing `Tooltip` (PR #483) and `TAG_COLOR_CLASSES` from `lib/domain/patient-tags.ts`.

## Test plan

- [ ] `npx prisma generate && npm run typecheck && npm run lint` — clean
- [ ] Visit `/clinic/patients` — tags from any existing PatientTag selections show on roster rows
- [ ] Visit `/clinic/messages` — select a thread, edit tags in the detail header, confirm strip appears on the list row
- [ ] Visit a patient chart with open tasks — confirm per-task tag editor works and the popover does not trigger navigation
- [ ] Visit `/clinic/communications/broadcasts` — tag a campaign in the sidebar
- [ ] Keyboard test the ColorPicker (←/→/Enter) and TagInput (↑/↓/Enter/Backspace) on each surface
- [ ] Dark-mode pass — pills remain legible on `--surface` dark tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)