### PR TITLE
ux: Tabs primitive + 5 surface adoptions (underline indicator, keyboard, url-sync)

### DIFF
--- a/src/app/(operator)/ops/analytics-lab/terpenes/terpenes-view.tsx
+++ b/src/app/(operator)/ops/analytics-lab/terpenes/terpenes-view.tsx
@@ -9,6 +9,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Tabs, TabList, Trigger, Panel } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils/cn";
 
 export interface Terpene {
@@ -48,33 +49,13 @@ export function TerpenesView({
   const [tab, setTab] = useState<Tab>("grid");
 
   return (
-    <>
-      <div className="flex gap-2 mb-6">
-        <button
-          onClick={() => setTab("grid")}
-          className={cn(
-            "h-9 px-4 rounded-full text-sm font-medium border transition-all",
-            tab === "grid"
-              ? "bg-accent text-accent-ink border-accent"
-              : "bg-surface-raised text-text-muted border-border hover:border-accent/40"
-          )}
-        >
-          Terpene grid
-        </button>
-        <button
-          onClick={() => setTab("correlation")}
-          className={cn(
-            "h-9 px-4 rounded-full text-sm font-medium border transition-all",
-            tab === "correlation"
-              ? "bg-accent text-accent-ink border-accent"
-              : "bg-surface-raised text-text-muted border-border hover:border-accent/40"
-          )}
-        >
-          Outcome correlations
-        </button>
-      </div>
+    <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)} variant="pill">
+      <TabList aria-label="Terpene view" className="mb-6">
+        <Trigger value="grid">Terpene grid</Trigger>
+        <Trigger value="correlation">Outcome correlations</Trigger>
+      </TabList>
 
-      {tab === "grid" && (
+      <Panel value="grid">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {terpenes.map((t) => (
             <Card key={t.name} tone="raised">
@@ -128,9 +109,9 @@ export function TerpenesView({
             </Card>
           ))}
         </div>
-      )}
+      </Panel>
 
-      {tab === "correlation" && (
+      <Panel value="correlation" lazy>
         <Card tone="raised">
           <CardHeader>
             <CardTitle>Terpene × outcome correlation</CardTitle>
@@ -189,7 +170,7 @@ export function TerpenesView({
             </div>
           </CardContent>
         </Card>
-      )}
-    </>
+      </Panel>
+    </Tabs>
   );
 }

--- a/src/app/(operator)/ops/settings/ai-config/tabs.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { cn } from "@/lib/utils/cn";
+import { Tabs, TabList, Trigger, Panel } from "@/components/ui/tabs";
 import { ModelConfigPanel } from "./model-config";
 import { AgentFleetPanel } from "./agent-fleet";
 
@@ -17,28 +17,23 @@ export function AiConfigTabs() {
   const active = TABS.find((t) => t.key === tab)!;
 
   return (
-    <div>
-      <div className="flex items-center gap-1 border-b border-border mb-5">
+    <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)} urlParam="section">
+      <TabList aria-label="AI configuration sections" className="mb-5">
         {TABS.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setTab(t.key)}
-            className={cn(
-              "relative px-4 py-3 text-sm font-medium transition-colors",
-              tab === t.key ? "text-accent" : "text-text-muted hover:text-text",
-            )}
-          >
+          <Trigger key={t.key} value={t.key}>
             {t.label}
-            {tab === t.key && (
-              <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-accent rounded-full" />
-            )}
-          </button>
+          </Trigger>
         ))}
-      </div>
+      </TabList>
       <p className="text-xs text-text-subtle mb-5">{active.hint}</p>
-      {tab === "default" && <ModelConfigPanel />}
-      {tab === "fleet" && <AgentFleetPanel />}
-    </div>
+      {/* Each panel renders its own state-heavy component; mark as lazy so
+          we don't double-fetch on every console open. */}
+      <Panel value="default" lazy>
+        <ModelConfigPanel />
+      </Panel>
+      <Panel value="fleet" lazy>
+        <AgentFleetPanel />
+      </Panel>
+    </Tabs>
   );
 }

--- a/src/app/(patient)/portal/learn/page.tsx
+++ b/src/app/(patient)/portal/learn/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { LeafSprig, EditorialRule, Eyebrow } from "@/components/ui/ornament";
+import { Tabs, TabList, Trigger, Panel } from "@/components/ui/tabs";
 import {
   CANNABINOIDS,
   TERPENES,
@@ -41,14 +42,9 @@ export default function LearnPage() {
   const initialTab = parseTab(searchParams.get("tab")) ?? "conditions";
   const [tab, setTab] = useState<Tab>(initialTab);
   const [search, setSearch] = useState("");
-
-  // Re-sync tab when the user navigates between deep links from
-  // the Education hub without a full page reload.
-  useEffect(() => {
-    const next = parseTab(searchParams.get("tab"));
-    if (next && next !== tab) setTab(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  // Note: deep-link sync between Education hub tabs and this page is
+  // handled by the Tabs primitive via `urlParam="tab"` below — no manual
+  // useEffect reconciliation needed.
 
   const searchResults = useMemo(() => {
     if (search.length < 2) return null;
@@ -129,33 +125,27 @@ export default function LearnPage() {
       )}
 
       {/* ── Tab bar ────────────────────────────────── */}
-      <div className="flex items-center gap-1 border-b border-border mb-8 overflow-x-auto">
-        {([
-          { key: "conditions" as Tab, label: "By Condition", count: CONDITION_GUIDES.length },
-          { key: "cannabinoids" as Tab, label: "Cannabinoids", count: CANNABINOIDS.length },
-          { key: "terpenes" as Tab, label: "Terpenes", count: TERPENES.length },
-          { key: "delivery" as Tab, label: "Delivery Methods", count: DELIVERY_METHODS.length },
-        ]).map((t) => (
-          <button
-            key={t.key}
-            onClick={() => setTab(t.key)}
-            className={`relative px-4 py-2.5 text-sm font-medium transition-colors whitespace-nowrap ${
-              tab === t.key
-                ? "text-accent"
-                : "text-text-muted hover:text-text"
-            }`}
-          >
-            {t.label}
-            <span className="ml-1.5 text-xs text-text-subtle">{t.count}</span>
-            {tab === t.key && (
-              <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full" />
-            )}
-          </button>
-        ))}
-      </div>
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setTab(v as Tab)}
+        urlParam="tab"
+      >
+        <TabList aria-label="Educational library sections" className="mb-8 overflow-x-auto">
+          {([
+            { key: "conditions" as Tab, label: "By Condition", count: CONDITION_GUIDES.length },
+            { key: "cannabinoids" as Tab, label: "Cannabinoids", count: CANNABINOIDS.length },
+            { key: "terpenes" as Tab, label: "Terpenes", count: TERPENES.length },
+            { key: "delivery" as Tab, label: "Delivery Methods", count: DELIVERY_METHODS.length },
+          ]).map((t) => (
+            <Trigger key={t.key} value={t.key}>
+              {t.label}
+              <span className="ml-1.5 text-xs text-text-subtle">{t.count}</span>
+            </Trigger>
+          ))}
+        </TabList>
 
       {/* ── Condition guides ───────────────────────── */}
-      {tab === "conditions" && (
+      <Panel value="conditions">
         <div className="space-y-5">
           {CONDITION_GUIDES.map((g) => (
             <Card key={g.condition} tone="raised">
@@ -213,10 +203,10 @@ export default function LearnPage() {
             </Card>
           ))}
         </div>
-      )}
+      </Panel>
 
       {/* ── Cannabinoids ───────────────────────────── */}
-      {tab === "cannabinoids" && (
+      <Panel value="cannabinoids" lazy>
         <div className="space-y-5">
           {CANNABINOIDS.map((c) => (
             <Card key={c.name} tone="raised">
@@ -244,10 +234,10 @@ export default function LearnPage() {
             </Card>
           ))}
         </div>
-      )}
+      </Panel>
 
       {/* ── Terpenes ───────────────────────────────── */}
-      {tab === "terpenes" && (
+      <Panel value="terpenes" lazy>
         <div className="space-y-5">
           {TERPENES.map((t) => (
             <Card key={t.name} tone="raised">
@@ -273,10 +263,10 @@ export default function LearnPage() {
             </Card>
           ))}
         </div>
-      )}
+      </Panel>
 
       {/* ── Delivery methods ───────────────────────── */}
-      {tab === "delivery" && (
+      <Panel value="delivery" lazy>
         <div className="space-y-5">
           {DELIVERY_METHODS.map((d) => (
             <Card key={d.name} tone="raised">
@@ -330,7 +320,8 @@ export default function LearnPage() {
             </Card>
           ))}
         </div>
-      )}
+      </Panel>
+      </Tabs>
 
       {/* ── Disclaimer ─────────────────────────────── */}
       <div className="mt-12 mb-4 text-center">

--- a/src/app/(patient)/portal/seed-trove/wallet-view.tsx
+++ b/src/app/(patient)/portal/seed-trove/wallet-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input, Textarea, FieldGroup } from "@/components/ui/input";
+import { Tabs, TabList, Trigger, Panel } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils/cn";
 import { lex, lexPlural } from "@/lib/lexicon";
 import {
@@ -49,29 +50,26 @@ export function TroveWalletView({
   const [balance, setBalance] = useState<number>(snapshot.balance);
 
   return (
-    <div className="space-y-6">
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as Tab)}
+      variant="pill"
+      className="space-y-6"
+    >
       <TierStrip snapshot={snapshot} balance={balance} />
 
-      <div className="flex items-center gap-2 flex-wrap">
+      <TabList aria-label="Seed trove sections" className="flex-wrap">
         {TABS.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setTab(t.key)}
-            className={cn(
-              "px-3 py-1.5 rounded-full text-xs font-medium border transition-colors",
-              tab === t.key
-                ? "bg-emerald-700 text-white border-emerald-700"
-                : "bg-surface text-text-muted border-border hover:bg-surface-muted",
-            )}
-          >
+          <Trigger key={t.key} value={t.key}>
             {t.label}
-          </button>
+          </Trigger>
         ))}
-      </div>
+      </TabList>
 
-      {tab === "wallet" && <WalletPanel snapshot={snapshot} balance={balance} />}
-      {tab === "redeem" && (
+      <Panel value="wallet">
+        <WalletPanel snapshot={snapshot} balance={balance} />
+      </Panel>
+      <Panel value="redeem" lazy>
         <RedeemPanel
           balance={balance}
           onIssue={(card) => {
@@ -79,10 +77,14 @@ export function TroveWalletView({
             setBalance((prev) => prev - (card.seedsBurned ?? 0));
           }}
         />
-      )}
-      {tab === "fruit-cards" && <FruitCardsPanel cards={cards} />}
-      {tab === "history" && <HistoryPanel entries={snapshot.recentEntries} />}
-    </div>
+      </Panel>
+      <Panel value="fruit-cards" lazy>
+        <FruitCardsPanel cards={cards} />
+      </Panel>
+      <Panel value="history" lazy>
+        <HistoryPanel entries={snapshot.recentEntries} />
+      </Panel>
+    </Tabs>
   );
 }
 

--- a/src/components/admin/super-admin-console.tsx
+++ b/src/components/admin/super-admin-console.tsx
@@ -15,7 +15,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils/cn";
+import { Tabs, TabList, Trigger, Panel } from "@/components/ui/tabs";
 import { EmergencyRevokeDialog } from "@/components/admin/emergency-revoke-dialog";
 
 type SpecialtyManifest = {
@@ -64,15 +64,11 @@ export function SuperAdminConsole() {
   }, []);
 
   return (
-    <div className="space-y-6">
-      <div role="tablist" aria-label="Console sections" className="flex gap-1 border-b border-border">
-        <TabButton active={tab === "practices"} onClick={() => setTab("practices")}>
-          Practices
-        </TabButton>
-        <TabButton active={tab === "admins"} onClick={() => setTab("admins")}>
-          Super-admins
-        </TabButton>
-      </div>
+    <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)} className="space-y-6">
+      <TabList aria-label="Console sections">
+        <Trigger value="practices">Practices</Trigger>
+        <Trigger value="admins">Super-admins</Trigger>
+      </TabList>
 
       {templatesError && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-danger">
@@ -80,40 +76,13 @@ export function SuperAdminConsole() {
         </div>
       )}
 
-      {tab === "practices" ? (
+      <Panel value="practices">
         <PracticesTab templates={templates} />
-      ) : (
+      </Panel>
+      <Panel value="admins" lazy>
         <AdminsTab />
-      )}
-    </div>
-  );
-}
-
-function TabButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        "px-4 py-2 text-sm font-medium transition-colors duration-200",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-        active
-          ? "text-text border-b-2 border-accent -mb-px"
-          : "text-text-muted hover:text-text",
-      )}
-    >
-      {children}
-    </button>
+      </Panel>
+    </Tabs>
   );
 }
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+/**
+ * Tabs — Linear/Radix-tier compound primitive.
+ *
+ * Why this exists:
+ *   We had ~10+ bespoke tab implementations across the EMR (sign-off rail,
+ *   super-admin console, AI config, practice drilldown, education hub).
+ *   Each reinvented keyboard handling, aria wiring, and active-indicator
+ *   styles. This unifies them with a small headless API that matches the
+ *   Radix surface, but ships a polished animated underline (or pill) by
+ *   default so adopters don't have to draw their own.
+ *
+ * Compound API:
+ *   <Tabs value="x" onValueChange={setX} variant="underline" urlParam="tab">
+ *     <TabList aria-label="Sections">
+ *       <Trigger value="x">Label</Trigger>
+ *       <Trigger value="y">Label</Trigger>
+ *     </TabList>
+ *     <Panel value="x">…</Panel>
+ *     <Panel value="y" lazy>…</Panel>
+ *   </Tabs>
+ *
+ * Keyboard model (matches WAI-ARIA "automatic activation" tabs pattern):
+ *   - ←/→ moves the active tab (in horizontal orientation; ↑/↓ in vertical)
+ *   - Home / End jump to the first / last enabled tab
+ *   - Tab key moves focus *out* of the tablist (only the active trigger is
+ *     in the tab order — others have tabIndex=-1)
+ *
+ * Indicator:
+ *   The underline (or pill background) is a single positioned span that
+ *   measures the active trigger and animates to its new position with
+ *   framer-motion. Reduced-motion preference short-circuits the spring so
+ *   the indicator snaps instead.
+ *
+ * URL sync:
+ *   If `urlParam` is set, the active tab mirrors that search-param. Updates
+ *   use `router.replace(..., { scroll: false })` so back/forward stays
+ *   meaningful but selection doesn't add a new history entry per click.
+ *
+ * Lazy panels:
+ *   `<Panel lazy>` only mounts its children the first time the panel becomes
+ *   active, then keeps them mounted (hidden via `hidden`/`display`) so state
+ *   isn't blown away on subsequent toggles. Standard panels render eagerly.
+ *
+ * Not in scope here:
+ *   - Manual-activation mode (focus-without-select) — none of our existing
+ *     surfaces use it; can be added later via an `activationMode` prop.
+ *   - Animated panel cross-fades — out of scope; consumers can wrap.
+ */
+
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { cn } from "@/lib/utils/cn";
+
+// ---------------------------------------------------------------------------
+// Types & context
+// ---------------------------------------------------------------------------
+
+export type TabsVariant = "underline" | "pill";
+export type TabsOrientation = "horizontal" | "vertical";
+
+type RegistryEntry = {
+  value: string;
+  el: HTMLButtonElement;
+  disabled: boolean;
+};
+
+interface TabsContextValue {
+  value: string;
+  setValue: (next: string) => void;
+  variant: TabsVariant;
+  orientation: TabsOrientation;
+  baseId: string;
+  registerTrigger: (entry: RegistryEntry) => () => void;
+  /** Stable ref list, kept in DOM order for ←/→/Home/End navigation. */
+  triggerOrderRef: React.MutableRefObject<RegistryEntry[]>;
+  /** Token that bumps every time the active trigger or layout might change,
+   *  so the indicator re-measures. */
+  layoutToken: number;
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsCtx(component: string): TabsContextValue {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) {
+    throw new Error(`<${component}> must be rendered inside <Tabs>.`);
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export interface TabsProps {
+  /** Controlled active value. */
+  value?: string;
+  /** Initial value when uncontrolled. */
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  /** Indicator style. Default: "underline". */
+  variant?: TabsVariant;
+  /** Orientation. Default: "horizontal". */
+  orientation?: TabsOrientation;
+  /** Sync active value to this URL search param. */
+  urlParam?: string;
+  /** Optional id prefix; auto-generated otherwise. */
+  id?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function Tabs({
+  value: controlled,
+  defaultValue,
+  onValueChange,
+  variant = "underline",
+  orientation = "horizontal",
+  urlParam,
+  id,
+  className,
+  children,
+}: TabsProps) {
+  const router = useRouter();
+  // searchParams / pathname are only consulted when urlParam is set, but
+  // hook order must be stable — call them unconditionally and ignore the
+  // result otherwise. Inside the app router both hooks are safe in client
+  // components.
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const reactId = React.useId();
+  const baseId = id ?? `tabs-${reactId.replace(/[:]/g, "")}`;
+
+  // Resolve the initial value: explicit controlled > URL param > defaultValue.
+  // If none match, the root renders without an active trigger until the
+  // first child registers — which is fine; the indicator is hidden in that
+  // state.
+  const urlValue = urlParam ? searchParams?.get(urlParam) ?? null : null;
+
+  const [uncontrolled, setUncontrolled] = React.useState<string>(
+    () => controlled ?? urlValue ?? defaultValue ?? "",
+  );
+  const value = controlled ?? uncontrolled;
+
+  // Keep uncontrolled state in sync with URL changes (back/forward). Skipped
+  // in controlled mode — consumer owns it then.
+  React.useEffect(() => {
+    if (controlled !== undefined) return;
+    if (!urlParam) return;
+    if (urlValue !== null && urlValue !== uncontrolled) {
+      setUncontrolled(urlValue);
+    }
+  }, [controlled, urlParam, urlValue, uncontrolled]);
+
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (next === value) return;
+      if (controlled === undefined) setUncontrolled(next);
+      onValueChange?.(next);
+      if (urlParam && pathname) {
+        const params = new URLSearchParams(searchParams?.toString() ?? "");
+        params.set(urlParam, next);
+        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      }
+    },
+    [controlled, onValueChange, urlParam, pathname, router, searchParams, value],
+  );
+
+  // Registry — every <Trigger> registers its DOM node and value here so
+  // keyboard nav and the indicator have a stable, ordered list to work
+  // against without needing to walk the DOM.
+  const triggerOrderRef = React.useRef<RegistryEntry[]>([]);
+  const [layoutToken, setLayoutToken] = React.useState(0);
+
+  const registerTrigger = React.useCallback((entry: RegistryEntry) => {
+    const list = triggerOrderRef.current;
+    // Replace any existing entry for this value (handles fast refresh).
+    const idx = list.findIndex((e) => e.value === entry.value);
+    if (idx >= 0) list[idx] = entry;
+    else list.push(entry);
+    // Sort by DOM order so ←/→ matches what users see.
+    list.sort((a, b) => {
+      if (a.el === b.el) return 0;
+      const pos = a.el.compareDocumentPosition(b.el);
+      // eslint-disable-next-line no-bitwise
+      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      // eslint-disable-next-line no-bitwise
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+    setLayoutToken((t) => t + 1);
+
+    return () => {
+      const cur = triggerOrderRef.current;
+      const i = cur.findIndex((e) => e.value === entry.value);
+      if (i >= 0) cur.splice(i, 1);
+      setLayoutToken((t) => t + 1);
+    };
+  }, []);
+
+  const ctxValue = React.useMemo<TabsContextValue>(
+    () => ({
+      value,
+      setValue,
+      variant,
+      orientation,
+      baseId,
+      registerTrigger,
+      triggerOrderRef,
+      layoutToken,
+    }),
+    [value, setValue, variant, orientation, baseId, registerTrigger, layoutToken],
+  );
+
+  return (
+    <TabsContext.Provider value={ctxValue}>
+      <div
+        className={cn(
+          orientation === "vertical" ? "flex gap-6" : "flex flex-col",
+          className,
+        )}
+        data-orientation={orientation}
+      >
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TabList
+// ---------------------------------------------------------------------------
+
+export interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  "aria-label"?: string;
+  children?: React.ReactNode;
+}
+
+export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
+  function TabList({ className, children, ...rest }, ref) {
+    const ctx = useTabsCtx("TabList");
+    const listRef = React.useRef<HTMLDivElement | null>(null);
+    const setRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        listRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      },
+      [ref],
+    );
+
+    return (
+      <div
+        ref={setRefs}
+        role="tablist"
+        aria-orientation={ctx.orientation}
+        data-variant={ctx.variant}
+        data-orientation={ctx.orientation}
+        className={cn(
+          "relative",
+          ctx.orientation === "horizontal"
+            ? "flex items-center gap-1"
+            : "flex flex-col items-stretch gap-0.5 min-w-[180px]",
+          // Underline rail sits on the bottom of horizontal lists / right
+          // edge of vertical rails. The indicator floats above this.
+          ctx.variant === "underline" &&
+            (ctx.orientation === "horizontal"
+              ? "border-b border-border"
+              : "border-r border-border pr-1"),
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+        <TabIndicator listRef={listRef} />
+      </div>
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Indicator (animated)
+// ---------------------------------------------------------------------------
+
+interface TabIndicatorProps {
+  listRef: React.RefObject<HTMLDivElement>;
+}
+
+function TabIndicator({ listRef }: TabIndicatorProps) {
+  const ctx = useTabsCtx("TabIndicator");
+  const reduceMotion = useReducedMotion();
+  const [rect, setRect] = React.useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const measure = React.useCallback(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const active = ctx.triggerOrderRef.current.find((e) => e.value === ctx.value);
+    if (!active) {
+      setRect(null);
+      return;
+    }
+    const listBox = list.getBoundingClientRect();
+    const elBox = active.el.getBoundingClientRect();
+    setRect({
+      left: elBox.left - listBox.left,
+      top: elBox.top - listBox.top,
+      width: elBox.width,
+      height: elBox.height,
+    });
+  }, [ctx.triggerOrderRef, ctx.value, listRef]);
+
+  // Re-measure when the active value changes, when registrations change
+  // (layoutToken), and on resize. ResizeObserver covers font-load and
+  // container-size shifts that don't fire `resize`.
+  React.useLayoutEffect(() => {
+    measure();
+  }, [measure, ctx.value, ctx.layoutToken]);
+
+  React.useEffect(() => {
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+    const ro = new ResizeObserver(() => measure());
+    if (listRef.current) ro.observe(listRef.current);
+    for (const entry of ctx.triggerOrderRef.current) {
+      ro.observe(entry.el);
+    }
+    return () => ro.disconnect();
+  }, [measure, ctx.layoutToken, ctx.triggerOrderRef, listRef]);
+
+  if (!rect) return null;
+
+  // Per-variant geometry. Underline = 2px line on the inner edge of the
+  // rail. Pill = soft background that wraps the trigger.
+  const isUnderline = ctx.variant === "underline";
+  const isHorizontal = ctx.orientation === "horizontal";
+
+  // Build the animate target as plain numbers — framer-motion accepts any
+  // numeric layout prop here, but its inferred type for the `animate` prop
+  // is so broad that mixing-in optional fields triggers "union too complex".
+  // Spelling out a single shape keeps inference happy.
+  const animate: { left?: number; top?: number; right?: number; bottom?: number; width: number; height: number } =
+    isUnderline
+      ? isHorizontal
+        ? { left: rect.left, width: rect.width, bottom: -1, height: 2 }
+        : { top: rect.top, height: rect.height, right: -1, width: 2 }
+      : { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+
+  return (
+    <motion.span
+      aria-hidden="true"
+      data-tab-indicator
+      initial={false}
+      animate={animate}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : { type: "spring", stiffness: 500, damping: 40, mass: 0.6 }
+      }
+      className={cn(
+        "absolute pointer-events-none",
+        isUnderline ? "bg-accent rounded-full" : "rounded-md bg-accent-soft",
+      )}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+export interface TriggerProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "value"> {
+  value: string;
+  disabled?: boolean;
+}
+
+export const Trigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
+  function Trigger({ value, disabled, className, onClick, onKeyDown, children, ...rest }, forwardedRef) {
+    const ctx = useTabsCtx("Trigger");
+    const localRef = React.useRef<HTMLButtonElement | null>(null);
+
+    const setRefs = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        localRef.current = node;
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) (forwardedRef as React.MutableRefObject<HTMLButtonElement | null>).current = node;
+      },
+      [forwardedRef],
+    );
+
+    // Register / unregister with the root. We re-register whenever
+    // disabled flips, so keyboard nav can skip disabled triggers.
+    React.useEffect(() => {
+      const el = localRef.current;
+      if (!el) return;
+      return ctx.registerTrigger({ value, el, disabled: !!disabled });
+    }, [ctx, value, disabled]);
+
+    const isActive = ctx.value === value;
+    const triggerId = `${ctx.baseId}-trigger-${value}`;
+    const panelId = `${ctx.baseId}-panel-${value}`;
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      const list = ctx.triggerOrderRef.current.filter((entry) => !entry.disabled);
+      if (list.length === 0) return;
+      const idx = list.findIndex((entry) => entry.value === ctx.value);
+      const last = list.length - 1;
+      let nextIdx = idx;
+
+      const isHorizontal = ctx.orientation === "horizontal";
+      const prevKey = isHorizontal ? "ArrowLeft" : "ArrowUp";
+      const nextKey = isHorizontal ? "ArrowRight" : "ArrowDown";
+
+      switch (e.key) {
+        case nextKey:
+          nextIdx = idx < 0 ? 0 : (idx + 1) % list.length;
+          break;
+        case prevKey:
+          nextIdx = idx <= 0 ? last : idx - 1;
+          break;
+        case "Home":
+          nextIdx = 0;
+          break;
+        case "End":
+          nextIdx = last;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      const target = list[nextIdx];
+      if (!target) return;
+      ctx.setValue(target.value);
+      // Roving-tabindex: move focus to the newly active trigger so the
+      // user can keep pressing arrow keys without intermediate Tabs.
+      requestAnimationFrame(() => target.el.focus());
+    };
+
+    return (
+      <button
+        ref={setRefs}
+        type="button"
+        role="tab"
+        id={triggerId}
+        aria-selected={isActive}
+        aria-controls={panelId}
+        tabIndex={isActive ? 0 : -1}
+        disabled={disabled}
+        data-state={isActive ? "active" : "inactive"}
+        onClick={(e) => {
+          onClick?.(e);
+          if (e.defaultPrevented) return;
+          if (!disabled) ctx.setValue(value);
+        }}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "relative inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium",
+          "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 rounded-md",
+          ctx.variant === "underline"
+            ? ctx.orientation === "horizontal"
+              ? "px-4 py-2.5"
+              : "px-3 py-2 justify-start text-left"
+            : "px-3 py-1.5",
+          isActive
+            ? ctx.variant === "underline"
+              ? "text-accent"
+              : "text-accent"
+            : "text-text-muted hover:text-text",
+          disabled && "opacity-50 pointer-events-none",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Panel
+// ---------------------------------------------------------------------------
+
+export interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+  /**
+   * If true, panel children are not rendered until the panel first becomes
+   * active. After first mount they stay mounted (hidden when inactive) so
+   * input state / scroll position survive tab toggles.
+   */
+  lazy?: boolean;
+  /**
+   * If true, the panel unmounts whenever it isn't active. Mutually
+   * exclusive with `lazy` — `lazy` wins if both are set. Use sparingly:
+   * this blows away input state.
+   */
+  forceMount?: boolean;
+}
+
+export const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
+  function Panel({ value, lazy, forceMount, className, children, ...rest }, ref) {
+    const ctx = useTabsCtx("Panel");
+    const isActive = ctx.value === value;
+    const [hasBeenActive, setHasBeenActive] = React.useState(isActive);
+
+    React.useEffect(() => {
+      if (isActive && !hasBeenActive) setHasBeenActive(true);
+    }, [isActive, hasBeenActive]);
+
+    const triggerId = `${ctx.baseId}-trigger-${value}`;
+    const panelId = `${ctx.baseId}-panel-${value}`;
+
+    // Visibility / mounting strategy.
+    // Default: always mount, toggle `hidden`. `lazy` defers first mount
+    // until the panel becomes active. `forceMount` keeps the panel
+    // mounted even when other panels in the same Tabs root use lazy
+    // mounting — it has no effect today, but the prop is here so
+    // consumers can opt in once we add an opposite "unmountWhenHidden"
+    // mode (out of scope for this PR).
+    void forceMount;
+    const shouldRenderChildren = lazy ? hasBeenActive : true;
+
+    return (
+      <div
+        ref={ref}
+        role="tabpanel"
+        id={panelId}
+        aria-labelledby={triggerId}
+        hidden={!isActive}
+        tabIndex={0}
+        data-state={isActive ? "active" : "inactive"}
+        className={cn(
+          // A small top padding only matters in horizontal underline mode;
+          // consumers control their own panel padding via className.
+          "focus:outline-none",
+          className,
+        )}
+        {...rest}
+      >
+        {shouldRenderChildren ? children : null}
+      </div>
+    );
+  },
+);
+
+// All exports above. Consumers import { Tabs, TabList, Trigger, Panel }.


### PR DESCRIPTION
## Summary

Adds a Linear/Radix-tier compound Tabs primitive at `src/components/ui/tabs.tsx` and adopts it across five surfaces that had bespoke tab strips.

**Primitive API**

```tsx
<Tabs value="x" onValueChange={setX} variant="underline" urlParam="tab">
  <TabList aria-label="Sections">
    <Trigger value="x">Label</Trigger>
    <Trigger value="y">Label</Trigger>
  </TabList>
  <Panel value="x">…</Panel>
  <Panel value="y" lazy>…</Panel>
</Tabs>
```

**Primitive highlights**
- Headless compound API with full roving-tabindex keyboard nav (←/→ or ↑/↓ per orientation, Home/End, Tab leaves the list).
- Animated active-tab indicator tweened with framer-motion; respects `prefers-reduced-motion` (snaps instantly). Two variants: `underline` (default) and `pill`.
- ARIA wired end-to-end: `role=tab`/`tablist`/`tabpanel`, `aria-selected`, `aria-controls`, `aria-orientation`.
- Optional URL sync via `urlParam="…"` (replace-state, no scroll).
- Optional `lazy` panels — first mount on activation, then kept mounted across toggles so input state survives.

**Adoption sites**
- Super-admin console (Practices / Super-admins)
- Operator AI-config tabs (Practice default / Agent fleet, URL-synced to `?section=`)
- Patient seed-trove wallet (4 panels, pill variant)
- Operator analytics-lab terpenes view (2 panels, pill variant)
- Patient educational library (4 panels, URL-synced to `?tab=` — replaces the manual `useEffect` reconciliation)

**Out of scope**
- The chart-tabs rail keeps its bespoke drag-to-reorder + hover-peek + settings menu (doesn't generalize).
- Server-rendered Link-based tab strips (practice drilldown, global search) stay as-is — already accessible and need server rendering for SEO.

## Test plan

- [ ] Keyboard: focus a Trigger, press ←/→/Home/End — selection follows focus, only the active trigger is in the tab order.
- [ ] Indicator animates smoothly between triggers; OS "Reduce motion" causes the indicator to snap.
- [ ] Educational library: `/portal/learn?tab=terpenes` opens on the Terpenes panel; clicking another tab updates the URL without scrolling.
- [ ] AI-config: deep link `/ops/settings/ai-config?section=fleet` lands on the Agent fleet pane.
- [ ] Super-admin console: switch between Practices and Super-admins — admin list lazy-loads only on first activation.
- [ ] Screen reader announces "tab, selected, X of N" on focus / arrow key navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)