### PR TITLE
ux: SplitPane primitive (drag/keyboard resize, persisted sizes) + 3 adoptions

### DIFF
--- a/src/app/(clinician)/clinic/providers/messages/view.tsx
+++ b/src/app/(clinician)/clinic/providers/messages/view.tsx
@@ -32,6 +32,7 @@ import {
   type ActionResult,
 } from "./actions";
 import { CallLaunchButtons } from "@/components/communications/call-launch-buttons";
+import { SplitPane } from "@/components/ui/split-pane";
 
 export interface DecryptedThread {
   id: string;
@@ -130,9 +131,18 @@ export function ProviderInboxView({ threads, currentUserId, directory }: Props) 
     : null;
 
   return (
-    <div className="grid grid-cols-12 gap-0 min-h-[640px] rounded-2xl border border-border overflow-hidden bg-surface">
+    <>
+    <div className="h-[640px] rounded-2xl border border-border overflow-hidden bg-surface">
+      <SplitPane
+        orientation="horizontal"
+        defaultSize={360}
+        minSize={260}
+        maxSize={560}
+        storageKey="providers-messages"
+        ariaLabel="Resize provider directory"
+      >
       {/* Left pane — directory search + chat list */}
-      <aside className="col-span-4 border-r border-border flex flex-col bg-surface-muted/40">
+      <aside className="h-full border-r border-border flex flex-col bg-surface-muted/40">
         <div className="p-3 border-b border-border">
           <Input
             type="search"
@@ -183,7 +193,7 @@ export function ProviderInboxView({ threads, currentUserId, directory }: Props) 
       </aside>
 
       {/* Right pane — active thread or composer */}
-      <section className="col-span-8 flex flex-col bg-surface">
+      <section className="h-full flex flex-col bg-surface">
         {right.kind === "compose" ? (
           <NewConversationCard
             directory={directory}
@@ -220,6 +230,8 @@ export function ProviderInboxView({ threads, currentUserId, directory }: Props) 
           </div>
         )}
       </section>
+      </SplitPane>
+    </div>
 
       {/* Provider info pop-up */}
       <Dialog
@@ -249,7 +261,7 @@ export function ProviderInboxView({ threads, currentUserId, directory }: Props) 
           />
         )}
       </Dialog>
-    </div>
+    </>
   );
 }
 

--- a/src/app/(clinician)/clinic/sign-off/refills/refills-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/refills/refills-view.tsx
@@ -5,6 +5,7 @@ import type { KeyboardEvent } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/ui/avatar";
+import { SplitPane } from "@/components/ui/split-pane";
 import { cn } from "@/lib/utils/cn";
 import { approveRefillAction, denyRefillAction } from "./actions";
 
@@ -79,9 +80,16 @@ export function RefillsView({ rows }: { rows: RefillRow[] }) {
   const selected = rows.find((r) => r.id === selectedId) ?? null;
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <SplitPane
+      orientation="horizontal"
+      defaultSize={288}
+      minSize={220}
+      maxSize={480}
+      storageKey="sign-off-refills"
+      ariaLabel="Resize refills queue"
+    >
       {/* Left pane — queue list */}
-      <div className="w-72 shrink-0 border-r border-border overflow-y-auto bg-surface">
+      <div className="h-full overflow-y-auto bg-surface border-r border-border">
         <div className="px-4 py-3 border-b border-border/60 bg-surface-muted/40">
           <p className="text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
             Refills · {rows.length} pending
@@ -100,7 +108,7 @@ export function RefillsView({ rows }: { rows: RefillRow[] }) {
       </div>
 
       {/* Right pane — Rx detail + e-sign */}
-      <div className="flex-1 min-w-0 overflow-y-auto bg-surface-raised">
+      <div className="h-full overflow-y-auto bg-surface-raised">
         {selected ? (
           <RxDetailPane key={selected.id} row={selected} onDone={handleDone} />
         ) : (
@@ -109,7 +117,7 @@ export function RefillsView({ rows }: { rows: RefillRow[] }) {
           </div>
         )}
       </div>
-    </div>
+    </SplitPane>
   );
 }
 

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -13,6 +13,7 @@ import {
   Pill,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { SplitPane } from "@/components/ui/split-pane";
 import { cn } from "@/lib/utils/cn";
 
 export type SignOffRow = {
@@ -184,9 +185,16 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <SplitPane
+      orientation="horizontal"
+      defaultSize={288}
+      minSize={220}
+      maxSize={520}
+      storageKey="sign-off-tree"
+      ariaLabel="Resize sign-off queue"
+    >
       {/* Tree panel */}
-      <div className="w-72 shrink-0 border-r border-border overflow-y-auto bg-surface">
+      <div className="h-full overflow-y-auto bg-surface border-r border-border">
         {/* Urgent group — shown only when urgent items exist */}
         {urgentItems.length > 0 && (
           <div>
@@ -250,7 +258,7 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
       </div>
 
       {/* Detail panel */}
-      <div className="flex-1 min-w-0 overflow-y-auto bg-surface-raised">
+      <div className="h-full overflow-y-auto bg-surface-raised">
         {selected ? (
           <SignOffDetail row={selected} />
         ) : (
@@ -260,7 +268,7 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
           </div>
         )}
       </div>
-    </div>
+    </SplitPane>
   );
 }
 

--- a/src/components/ui/split-pane.tsx
+++ b/src/components/ui/split-pane.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+/**
+ * SplitPane — pure-React resizable split layout primitive.
+ *
+ * Goals (Apple-iOS Mail-tier polish):
+ *  - Hairline divider by default; thickens to a 4px hit-target on hover.
+ *  - Smooth pointer-driven drag, cursor flips to col-resize / row-resize.
+ *  - Double-click divider resets to `defaultSize`.
+ *  - Keyboard support: when the divider has focus, ← / → (or ↑ / ↓) nudges
+ *    by 16px; Home resets to default; Enter / Space toggles collapse.
+ *  - Optional persistence via localStorage when `storageKey` is provided.
+ *  - Min / max constraints; dragging past min collapses that pane and shows
+ *    a "show again" button on the divider edge.
+ *
+ * Sizes are stored as pixel widths/heights of the FIRST pane (left/top).
+ * The second pane fills the remainder via flex-1, so the primitive plays
+ * well with parents that don't have a fixed dimension.
+ *
+ * No new dependencies — only React + the existing `cn` util.
+ */
+
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+const NUDGE_PX = 16;
+
+export type SplitPaneProps = {
+  /** Layout direction. `horizontal` = side-by-side (vertical divider). */
+  orientation?: "horizontal" | "vertical";
+  /** Initial size of the first pane (px). Default 320. */
+  defaultSize?: number;
+  /** Minimum size for the first pane in px. Default 180. */
+  minSize?: number;
+  /** Maximum size for the first pane in px. Default Infinity. */
+  maxSize?: number;
+  /** Per-key persistence in localStorage. */
+  storageKey?: string;
+  /** Allow dragging past min-size to collapse the first pane. Default true. */
+  collapsible?: boolean;
+  /** [left/top, right/bottom] children. */
+  children: [ReactNode, ReactNode];
+  /** Class applied to the outer container. */
+  className?: string;
+  /** Accessible label for the divider. */
+  ariaLabel?: string;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function readStored(key: string | undefined): number | null {
+  if (!key || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(`lj-split-pane:${key}`);
+    if (!raw) return null;
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(key: string | undefined, value: number): void {
+  if (!key || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`lj-split-pane:${key}`, String(value));
+  } catch {
+    /* swallow — quota / privacy mode */
+  }
+}
+
+export function SplitPane({
+  orientation = "horizontal",
+  defaultSize = 320,
+  minSize = 180,
+  maxSize = Number.POSITIVE_INFINITY,
+  storageKey,
+  collapsible = true,
+  children,
+  className,
+  ariaLabel,
+}: SplitPaneProps) {
+  const isHorizontal = orientation === "horizontal";
+  const [first, second] = children;
+
+  // Lazily hydrate from storage. Start with `defaultSize` for SSR parity,
+  // then hydrate on mount to avoid hydration mismatches.
+  const [size, setSize] = useState<number>(defaultSize);
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const [dragging, setDragging] = useState<boolean>(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const secondPaneId = useId();
+
+  // Hydrate from storage post-mount.
+  useEffect(() => {
+    const stored = readStored(storageKey);
+    if (stored == null) return;
+    if (stored < 0) {
+      setCollapsed(true);
+      return;
+    }
+    setSize(clamp(stored, minSize, maxSize));
+  }, [storageKey, minSize, maxSize]);
+
+  // Persist on change.
+  useEffect(() => {
+    if (!storageKey) return;
+    writeStored(storageKey, collapsed ? -1 : size);
+  }, [size, collapsed, storageKey]);
+
+  const beginDrag = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const target = event.currentTarget;
+      target.setPointerCapture(event.pointerId);
+      setDragging(true);
+    },
+    [],
+  );
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!dragging) return;
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const raw = isHorizontal
+        ? event.clientX - rect.left
+        : event.clientY - rect.top;
+      const total = isHorizontal ? rect.width : rect.height;
+      // Cap maxSize at total - minSize so the second pane keeps at least one
+      // min-size worth of space available.
+      const effectiveMax = Math.min(
+        maxSize,
+        Math.max(total - minSize, minSize),
+      );
+
+      if (collapsible && raw < minSize - 24) {
+        setCollapsed(true);
+        return;
+      }
+      setCollapsed(false);
+      setSize(clamp(raw, minSize, effectiveMax));
+    },
+    [dragging, isHorizontal, minSize, maxSize, collapsible],
+  );
+
+  const endDrag = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      setDragging(false);
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setCollapsed(false);
+    setSize(clamp(defaultSize, minSize, maxSize));
+  }, [defaultSize, minSize, maxSize]);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const decrease = isHorizontal ? "ArrowLeft" : "ArrowUp";
+      const increase = isHorizontal ? "ArrowRight" : "ArrowDown";
+
+      if (event.key === decrease) {
+        event.preventDefault();
+        setCollapsed(false);
+        setSize((prev) => clamp(prev - NUDGE_PX, minSize, maxSize));
+      } else if (event.key === increase) {
+        event.preventDefault();
+        setCollapsed(false);
+        setSize((prev) => clamp(prev + NUDGE_PX, minSize, maxSize));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        reset();
+      } else if (event.key === "Enter" || event.key === " ") {
+        if (collapsible) {
+          event.preventDefault();
+          setCollapsed((prev) => !prev);
+        }
+      }
+    },
+    [isHorizontal, minSize, maxSize, reset, collapsible],
+  );
+
+  // While dragging, lock body cursor and disable selection.
+  useLayoutEffect(() => {
+    if (!dragging) return;
+    const previous = document.body.style.cursor;
+    const previousSelect = document.body.style.userSelect;
+    document.body.style.cursor = isHorizontal ? "col-resize" : "row-resize";
+    document.body.style.userSelect = "none";
+    return () => {
+      document.body.style.cursor = previous;
+      document.body.style.userSelect = previousSelect;
+    };
+  }, [dragging, isHorizontal]);
+
+  const firstStyle: CSSProperties = useMemo(() => {
+    if (collapsed) {
+      return isHorizontal
+        ? { width: 0, minWidth: 0, flexBasis: 0 }
+        : { height: 0, minHeight: 0, flexBasis: 0 };
+    }
+    return isHorizontal
+      ? {
+          width: size,
+          minWidth: 0,
+          flexBasis: size,
+          flexShrink: 0,
+          flexGrow: 0,
+        }
+      : {
+          height: size,
+          minHeight: 0,
+          flexBasis: size,
+          flexShrink: 0,
+          flexGrow: 0,
+        };
+  }, [collapsed, isHorizontal, size]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative flex h-full w-full overflow-hidden",
+        isHorizontal ? "flex-row" : "flex-col",
+        className,
+      )}
+      data-orientation={orientation}
+    >
+      <div
+        className={cn(
+          "min-w-0 min-h-0 overflow-hidden",
+          collapsed ? "pointer-events-none opacity-0" : "opacity-100",
+          // Skip transitions while actively dragging — feels laggy otherwise.
+          dragging ? "" : "transition-opacity duration-150",
+        )}
+        style={firstStyle}
+        aria-hidden={collapsed || undefined}
+      >
+        {first}
+      </div>
+
+      {/* Divider — outer hit area is wider than the visible hairline. */}
+      <div
+        role="separator"
+        aria-orientation={isHorizontal ? "vertical" : "horizontal"}
+        aria-label={ariaLabel ?? "Resize panes"}
+        aria-valuenow={Math.round(size)}
+        aria-valuemin={minSize}
+        aria-valuemax={Number.isFinite(maxSize) ? maxSize : undefined}
+        aria-controls={secondPaneId}
+        tabIndex={0}
+        onPointerDown={beginDrag}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onDoubleClick={reset}
+        onKeyDown={onKeyDown}
+        className={cn(
+          "group relative shrink-0 flex items-center justify-center",
+          // Wide hit target, narrow visible line. Horizontal orientation
+          // means a *vertical* divider.
+          isHorizontal
+            ? "w-1 cursor-col-resize hover:w-1.5"
+            : "h-1 cursor-row-resize hover:h-1.5",
+          "transition-[width,height] duration-150",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-0",
+          dragging && "bg-accent/40",
+        )}
+      >
+        {/* Hairline visible element */}
+        <span
+          aria-hidden
+          className={cn(
+            "absolute inset-0 m-auto bg-border transition-colors duration-150 group-hover:bg-accent/60",
+            isHorizontal ? "w-px h-full" : "h-px w-full",
+            dragging && "bg-accent",
+          )}
+        />
+        {/* Grip pill — only visible on hover/focus/drag. */}
+        <span
+          aria-hidden
+          className={cn(
+            "relative z-10 rounded-full bg-text-subtle/40 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100",
+            isHorizontal ? "h-8 w-[3px]" : "w-8 h-[3px]",
+            dragging && "opacity-100 bg-accent",
+          )}
+        />
+      </div>
+
+      {/* "Show again" affordance when the first pane is collapsed. */}
+      {collapsed && (
+        <button
+          type="button"
+          onClick={reset}
+          className={cn(
+            "absolute z-20 inline-flex items-center justify-center rounded-full",
+            "border border-border bg-surface-raised text-text-subtle shadow-sm",
+            "hover:text-accent hover:border-accent/40 transition-colors",
+            isHorizontal
+              ? "left-1.5 top-3 h-7 w-7"
+              : "top-1.5 left-3 h-7 w-7",
+          )}
+          aria-label="Show pane"
+          title="Show pane"
+        >
+          {isHorizontal ? (
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden>
+              <path
+                d="M9 6l6 6-6 6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden>
+              <path
+                d="M6 9l6 6 6-6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </button>
+      )}
+
+      <div
+        id={secondPaneId}
+        className="flex-1 min-w-0 min-h-0 overflow-hidden"
+      >
+        {second}
+      </div>
+    </div>
+  );
+}
+
+export default SplitPane;


### PR DESCRIPTION
## Summary

- New `src/components/ui/split-pane.tsx` — pure-React resizable split-pane primitive (no new deps)
- Replaces three bespoke `flex w-72` / `grid-cols-12` split layouts with a polished, persistent primitive
- Apple-iOS Mail aesthetic: hairline divider, 4px hit target, smooth pointer drag, grip pill on hover, col-resize cursor

## API

```tsx
<SplitPane
  orientation="horizontal" | "vertical"   // default: horizontal
  defaultSize={320}                       // px for first pane
  minSize={180}
  maxSize={520}
  storageKey="my-surface"                 // optional localStorage persistence
  collapsible                             // drag past min → collapse + "show again"
  ariaLabel="Resize panes"
>
  {leftOrTop}
  {rightOrBottom}
</SplitPane>
```

Behaviors:
- Double-click divider → reset to `defaultSize`
- Keyboard (divider focused): ←/→ or ↑/↓ nudges by 16px; Home resets; Enter/Space toggles collapse
- Drag past `minSize − 24px` → collapse first pane; a chevron "show again" button appears
- Sizes persist per `storageKey` in localStorage (`lj-split-pane:<key>`)
- Cursor + selection are locked at the document level during drag (no flicker)

## Adoption sites

| Surface | File | storageKey |
| --- | --- | --- |
| /clinic/sign-off (tree+detail) | `sign-off-tree-view.tsx` | `sign-off-tree` |
| /clinic/sign-off/refills | `refills-view.tsx` | `sign-off-refills` |
| /clinic/providers/messages (iMessage-style) | `providers/messages/view.tsx` | `providers-messages` |

Skipped intentionally: `/clinic/messages/smart-inbox` (heavy concurrent edits per brief), `/clinic/library` (single-column page, not a split), `/clinic/sign-off/labs` (modal pattern, not a split).

## Test plan

- [ ] Visit `/clinic/sign-off` — drag divider, verify smooth resize + cursor flip
- [ ] Double-click divider → resets to default
- [ ] Tab to divider → arrow keys nudge by 16px, Home resets
- [ ] Drag past min-size on the left → list pane collapses, "show again" button appears
- [ ] Reload page → restored size persists per surface (sign-off vs refills vs providers/messages don't share state)
- [ ] Verify on `/clinic/sign-off/refills` and `/clinic/providers/messages` — same behavior, independent storageKeys
- [ ] Keyboard-only user can resize without touching the mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)