### PR TITLE
EMR-645: /clinic top-ribbon counts as links; Threads non-clickable

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -208,7 +208,11 @@ function StatusDot({
   }
 
   return (
-    <div className="flex items-center gap-2" title={label}>
+    <div
+      className="flex items-center gap-2"
+      title={`${label}: ${count}`}
+      aria-label={`${label}: ${count}`}
+    >
       {body}
     </div>
   );


### PR DESCRIPTION
Implements EMR-645.

## What changed
- The three active-count `StatusDot` indicators in the `/clinic` command strip already navigated correctly on `main` (Patients today → `/clinic/schedule`, Notes to sign → `/clinic/sign-off`, Approvals → `/clinic/approvals`; Threads carries no `href` and remains non-clickable) — the core ticket requirement was pre-implemented.
- This PR closes the one remaining gap: the non-interactive **Threads** dot had `title="Threads"` (count-less) while the linked dots expose `aria-label="Threads: N"`. The dot's `title` is now `"Threads: N"` and an `aria-label` is added, making it symmetric with its linked siblings for accessibility.

## How to verify
1. Visit `/clinic` — confirm **Patients today**, **Notes to sign**, and **Approvals** dots are clickable and navigate to their respective pages.
2. Confirm **Threads** dot is NOT a link (no cursor pointer, no hover ring).
3. Hover the Threads dot — tooltip should read "Threads: N" (e.g. "Threads: 3").
4. With a screen reader, the Threads dot announces "Threads: N" aloud.

## Notes
- All typecheck errors in the environment are pre-existing (missing `react`/`next`/`@prisma/client` type declarations — `node_modules` absent); no new logical errors introduced.
- Diff is 5 lines; well within the 300 LOC cap.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFwx5vRWz5HXSeTdLC6an2)_