### PR TITLE
ux(onboarding): defer clinician tour until welcome quote modal is dismissed

### DIFF
--- a/src/components/onboarding/clinician-tour.tsx
+++ b/src/components/onboarding/clinician-tour.tsx
@@ -151,10 +151,28 @@ export function ClinicianTour() {
   useEffect(() => {
     if (pathname !== "/clinic") return;
     if (readStored()) return;
-    // Defer to next frame so the destination DOM is mounted before we
-    // measure the first anchor.
-    const id = requestAnimationFrame(() => setOpen(true));
-    return () => cancelAnimationFrame(id);
+
+    // Check if the Quote Welcome Modal is active in the current session.
+    // If emr-quote-welcome-shown is not set, the modal will display, so
+    // we wait for the dismissal event.
+    const isQuoteShowing =
+      typeof window !== "undefined" &&
+      !window.sessionStorage.getItem("emr-quote-welcome-shown");
+
+    if (isQuoteShowing) {
+      const handleWelcomeDismissed = () => {
+        requestAnimationFrame(() => setOpen(true));
+      };
+      window.addEventListener("emr:welcome:dismissed", handleWelcomeDismissed);
+      return () => {
+        window.removeEventListener("emr:welcome:dismissed", handleWelcomeDismissed);
+      };
+    } else {
+      // Defer to next frame so the destination DOM is mounted before we
+      // measure the first anchor.
+      const id = requestAnimationFrame(() => setOpen(true));
+      return () => cancelAnimationFrame(id);
+    }
   }, [pathname]);
 
   // Listen for replay events fired by the keyboard help modal.

--- a/src/components/ui/quote-of-the-day.tsx
+++ b/src/components/ui/quote-of-the-day.tsx
@@ -29,10 +29,17 @@ export function QuoteWelcomeModal({ userName }: { userName?: string }) {
 
   if (!quote || !visible) return null;
 
+  const dismissModal = () => {
+    setVisible(false);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("emr:welcome:dismissed"));
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity duration-500 opacity-100"
-      onClick={() => setVisible(false)}
+      onClick={dismissModal}
     >
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" />
@@ -44,6 +51,7 @@ export function QuoteWelcomeModal({ userName }: { userName?: string }) {
           background:
             "linear-gradient(135deg, var(--surface-raised), var(--surface))",
         }}
+        onClick={(e) => e.stopPropagation()}
       >
         <div
           aria-hidden="true"
@@ -63,7 +71,7 @@ export function QuoteWelcomeModal({ userName }: { userName?: string }) {
           </blockquote>
           <p className="text-sm text-text-muted mt-5">— {quote.author}</p>
           <button
-            onClick={() => setVisible(false)}
+            onClick={dismissModal}
             className="mt-8 text-xs text-text-subtle hover:text-text transition-colors uppercase tracking-wider"
           >
             Continue &rarr;


### PR DESCRIPTION
This PR fixes the overlap/crowded UI issue by deferring the onboarding tour until after the welcome quote modal is dismissed.