### PR TITLE
fix: harden authenticated navigation recovery

### DIFF
--- a/docs/superpowers/plans/2026-05-27-commercial-app-hardening.md
+++ b/docs/superpowers/plans/2026-05-27-commercial-app-hardening.md
@@ -1,0 +1,317 @@
+# Commercial App Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the authenticated commercial app so recovery actions and command navigation keep signed-in users inside the product.
+
+**Architecture:** Add focused route-integrity tests around authenticated navigation, correct known stale command routes, and replace authenticated `/` recovery exits with role-appropriate destinations. Keep route definitions inspectable without rendering server layouts.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, React Testing Library patterns already used in repo.
+
+---
+
+## File Structure
+
+- Modify `src/components/ui/command-palette.tsx`: export command arrays/helpers and correct stale authenticated hrefs.
+- Create `src/components/ui/command-palette.test.tsx`: validate authenticated command hrefs resolve to the app route tree.
+- Modify `src/app/(patient)/portal/error.tsx`: route recovery to `/portal` instead of `/`.
+- Modify `src/app/(clinician)/clinic/error.tsx`: route recovery to `/clinic` instead of `/`.
+- Modify `src/app/(patient)/layout.tsx`: use `primaryRole()` when redirecting non-patient users.
+- Modify `src/app/(operator)/layout.tsx`: use `primaryRole()` when redirecting non-operator users.
+- Create `src/lib/navigation/app-route-map.ts`: route-tree helper used by tests.
+- Create `src/lib/navigation/app-route-map.test.ts`: prove helper recognizes static, query, and dynamic routes.
+- Create `src/app/(patient)/portal/error.test.tsx` and `src/app/(clinician)/clinic/error.test.tsx`: verify authenticated recovery pages do not route to `/`.
+
+### Task 1: Route Map Helper
+
+**Files:**
+- Create: `src/lib/navigation/app-route-map.ts`
+- Test: `src/lib/navigation/app-route-map.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createAppRouteMatcher } from "./app-route-map";
+
+describe("createAppRouteMatcher", () => {
+  it("matches exact app routes and strips query strings", () => {
+    const matches = createAppRouteMatcher(["/clinic", "/ops/settings/ai-config"]);
+
+    expect(matches("/clinic")).toBe(true);
+    expect(matches("/ops/settings/ai-config?tab=models")).toBe(true);
+  });
+
+  it("matches dynamic route segments", () => {
+    const matches = createAppRouteMatcher(["/clinic/patients/:id", "/ops/cfo/reports/:id"]);
+
+    expect(matches("/clinic/patients/patient_123")).toBe(true);
+    expect(matches("/ops/cfo/reports/report_123")).toBe(true);
+  });
+
+  it("does not match missing sibling routes", () => {
+    const matches = createAppRouteMatcher(["/clinic", "/clinic/sign-off/labs"]);
+
+    expect(matches("/clinic/queue")).toBe(false);
+    expect(matches("/clinic/labs-review")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/navigation/app-route-map.test.ts`
+
+Expected: FAIL because `src/lib/navigation/app-route-map.ts` does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+```ts
+export function normalizeAppHref(href: string): string {
+  const path = href.split(/[?#]/)[0] || "/";
+  return path.length > 1 ? path.replace(/\/+$/, "") : "/";
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function routeToRegex(route: string): RegExp {
+  const normalized = normalizeAppHref(route);
+  const pattern = normalized
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) return "[^/]+";
+      if (segment === "*") return ".*";
+      return escapeRegex(segment);
+    })
+    .join("/");
+  return new RegExp(`^${pattern}$`);
+}
+
+export function createAppRouteMatcher(routes: string[]): (href: string) => boolean {
+  const exactRoutes = new Set(routes.map(normalizeAppHref));
+  const dynamicRoutes = routes
+    .filter((route) => route.includes(":") || route.includes("*"))
+    .map(routeToRegex);
+
+  return (href: string) => {
+    const normalized = normalizeAppHref(href);
+    if (exactRoutes.has(normalized)) return true;
+    return dynamicRoutes.some((route) => route.test(normalized));
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/lib/navigation/app-route-map.test.ts`
+
+Expected: PASS.
+
+### Task 2: Command Palette Route Integrity
+
+**Files:**
+- Modify: `src/components/ui/command-palette.tsx`
+- Test: `src/components/ui/command-palette.test.tsx`
+- Use: `src/lib/navigation/app-route-map.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { AUTHENTICATED_COMMANDS } from "./command-palette";
+import { createAppRouteMatcher } from "@/lib/navigation/app-route-map";
+
+const APP_ROUTES = [
+  "/clinic",
+  "/clinic/command",
+  "/clinic/messages",
+  "/clinic/morning-brief",
+  "/clinic/patients",
+  "/clinic/providers",
+  "/clinic/research",
+  "/clinic/library",
+  "/clinic/audit-trail",
+  "/clinic/schedule",
+  "/clinic/sign-off",
+  "/clinic/sign-off/labs",
+  "/clinic/sign-off/refills",
+  "/settings/preferences",
+  "/ops",
+  "/ops/mission-control",
+  "/ops/schedule",
+  "/ops/patients",
+  "/ops/queue",
+  "/ops/billing",
+  "/ops/scrub",
+  "/ops/denials",
+  "/ops/aging",
+  "/ops/billing-agents",
+  "/ops/revenue",
+  "/ops/eligibility",
+  "/ops/cfo",
+  "/ops/cfo/pnl",
+  "/ops/cfo/cash-flow",
+  "/ops/cfo/balance-sheet",
+  "/ops/cfo/expenses",
+  "/ops/cfo/cash",
+  "/ops/cfo/assets",
+  "/ops/cfo/liabilities",
+  "/ops/cfo/equity",
+  "/ops/cfo/goals",
+  "/ops/cfo/reports",
+  "/ops/staff-schedule",
+  "/ops/time-clock",
+  "/ops/training",
+  "/ops/policies",
+  "/ops/incidents",
+  "/ops/supplies",
+  "/ops/vendors",
+  "/ops/feedback",
+  "/ops/marketing",
+  "/ops/announcements",
+  "/ops/onboarding",
+  "/ops/launch",
+  "/ops/intake-builder",
+  "/ops/export",
+  "/ops/analytics",
+  "/ops/analytics-lab",
+  "/ops/population",
+  "/ops/settings/ai-config",
+  "/ops/webhooks",
+  "/ops/api-keys",
+  "/ops/performance",
+  "/ops/feature-flags",
+  "/ops/backups",
+  "/portal",
+  "/portal/log-dose",
+  "/portal/records",
+  "/portal/garden",
+  "/portal/community",
+  "/portal/schedule",
+  "/portal/messages",
+  "/portal/qa",
+  "/portal/profile",
+];
+
+describe("authenticated command palette routes", () => {
+  it("points every authenticated command href at an existing route", () => {
+    const matches = createAppRouteMatcher(APP_ROUTES);
+    const missing = AUTHENTICATED_COMMANDS
+      .filter((command) => command.href)
+      .filter((command) => !matches(command.href!))
+      .map((command) => `${command.id}: ${command.href}`);
+
+    expect(missing).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/ui/command-palette.test.tsx`
+
+Expected: FAIL showing the known missing hrefs.
+
+- [ ] **Step 3: Export command definitions and correct stale routes**
+
+Changes:
+
+- Export `CLINICIAN_COMMANDS`, `OPERATOR_COMMANDS`, `PATIENT_COMMANDS`, and `AUTHENTICATED_COMMANDS`.
+- Change `c-open-queue` href to `/clinic`.
+- Change `c-open-settings` href to `/settings/preferences`.
+- Change `c-go-labs` href to `/clinic/sign-off/labs`.
+- Change `c-go-refills` href to `/clinic/sign-off/refills`.
+- Change `o-compose-message` href to `/clinic/messages?action=compose`.
+- Change `o-open-settings` href to `/ops/settings/ai-config`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/components/ui/command-palette.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Authenticated Recovery Routes
+
+**Files:**
+- Modify: `src/app/(patient)/portal/error.tsx`
+- Modify: `src/app/(clinician)/clinic/error.tsx`
+- Test: `src/app/(patient)/portal/error.test.tsx`
+- Test: `src/app/(clinician)/clinic/error.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Patient test asserts clicking the secondary recovery button assigns `/portal`, not `/`.
+
+Clinician test asserts clicking the secondary recovery button assigns `/clinic`, not `/`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -- 'src/app/(patient)/portal/error.test.tsx' 'src/app/(clinician)/clinic/error.test.tsx'`
+
+Expected: FAIL because existing buttons assign `/`.
+
+- [ ] **Step 3: Implement route corrections**
+
+Change patient `window.location.href = "/"` to `window.location.href = "/portal"` and button text to `Back to dashboard`.
+
+Change clinician `window.location.href = "/"` to `window.location.href = "/clinic"` and button text to `Go to Today`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -- 'src/app/(patient)/portal/error.test.tsx' 'src/app/(clinician)/clinic/error.test.tsx'`
+
+Expected: PASS.
+
+### Task 4: Primary Role Redirects
+
+**Files:**
+- Modify: `src/app/(patient)/layout.tsx`
+- Modify: `src/app/(operator)/layout.tsx`
+
+- [ ] **Step 1: Inspect existing redirect behavior**
+
+Confirm `patient/layout.tsx` and `operator/layout.tsx` use `user.roles[0]` in rejection paths.
+
+- [ ] **Step 2: Implement minimal correction**
+
+Import `primaryRole` where missing and redirect via `ROLE_HOME[primaryRole(user.roles)] ?? "/"`.
+
+- [ ] **Step 3: Run typecheck or focused compile-adjacent checks**
+
+Run: `npm run typecheck`
+
+Expected: PASS, or document unrelated baseline blocker.
+
+### Task 5: Final Verification
+
+**Files:**
+- All files touched in Tasks 1-4.
+
+- [ ] **Step 1: Run focused test suite**
+
+Run: `npm run test -- src/lib/navigation/app-route-map.test.ts src/components/ui/command-palette.test.tsx 'src/app/(patient)/portal/error.test.tsx' 'src/app/(clinician)/clinic/error.test.tsx'`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: PASS, or capture exact unrelated failures.
+
+- [ ] **Step 3: Review diff**
+
+Run: `git diff --stat && git diff --check`
+
+Expected: no whitespace errors; diff limited to spec, plan, command palette, error pages, route helper/tests, and redirect layouts.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add src docs/superpowers/plans/2026-05-27-commercial-app-hardening.md
+git commit -m "fix: harden authenticated navigation recovery"
+```

--- a/docs/superpowers/specs/2026-05-27-commercial-app-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-27-commercial-app-hardening-design.md
@@ -1,0 +1,94 @@
+# Commercial App Hardening Design
+
+Date: 2026-05-27
+
+## Context
+
+The signed-in Leafjourney experience currently feels unstable in two visible ways:
+
+- Some recovery actions send authenticated users to `/`, which is the public marketing landing page. For a patient, clinician, or operator, that reads like being kicked out of the product.
+- Some command-palette actions point to routes that are not present in `src/app`, producing dead ends instead of reliable work surfaces.
+
+The main workspace also contains many unrelated in-progress edits, so this work is done in an isolated worktree on `hardening/commercial-app-stability`.
+
+## Goal
+
+Make the authenticated commercial app feel dependable by hardening signed-in navigation, error recovery, and route integrity for the patient portal, clinician clinic, and operator ops surfaces.
+
+## Scope
+
+In scope:
+
+- Patient portal, clinician clinic, and operator ops route groups.
+- Error and not-found recovery links that appear inside authenticated contexts.
+- Command palette routes for authenticated roles.
+- Role redirect logic that chooses a user's signed-in home.
+- Automated tests that catch missing authenticated navigation targets before they ship.
+
+Out of scope:
+
+- Public marketing pages.
+- Leafmart storefront and marketplace polish.
+- Full click-crawler coverage of every authenticated interactive element.
+- New product features or broad UI redesign.
+
+## Approach
+
+Use a stability rail rather than a one-off patch:
+
+1. Route recovery actions inside authenticated contexts to role-appropriate homes:
+   - patient: `/portal`
+   - clinician and clinic-floor roles: `/clinic`
+   - operator, practice owner, practice admin, and system roles: `/ops`
+2. Replace missing command-palette routes with existing surfaces or remove commands where no equivalent exists.
+3. Export authenticated navigation definitions from the layouts into small route modules so tests can inspect them without rendering server components.
+4. Add a route-integrity test that compares signed-in nav and command-palette hrefs against actual `src/app/**/page.tsx` routes, including dynamic segments.
+5. Keep changes tightly scoped and avoid touching unrelated dirty files from the main workspace.
+
+## Expected Route Corrections
+
+Known command-palette misses from the initial scan:
+
+- `/clinic/queue` -> `/clinic`
+- `/clinic/settings` -> `/settings/preferences`
+- `/clinic/labs-review` -> `/clinic/sign-off/labs`
+- `/clinic/refills` -> `/clinic/sign-off/refills`
+- `/ops/messages?action=compose` -> `/clinic/messages?action=compose`
+- `/ops/settings` -> `/ops/settings/ai-config`
+
+Known authenticated recovery misses:
+
+- `src/app/(patient)/portal/error.tsx` uses `window.location.href = "/"`; route it to `/portal`.
+- `src/app/(clinician)/clinic/error.tsx` uses `window.location.href = "/"`; route it to `/clinic`.
+- Root and global error screens should avoid claiming "Go home" when the destination is public marketing; label the public fallback clearly or route through `/post-sign-in` when safe.
+
+## Testing
+
+Add focused tests before implementation changes:
+
+- A command-palette route test that fails on the six known missing hrefs.
+- A signed-in recovery route test that fails if authenticated error pages link or assign to `/`.
+- A navigation route-integrity test that validates exported patient, clinician, and operator nav hrefs against actual app routes.
+- A role redirect test for primary-role fallback in patient/operator layouts where arbitrary `user.roles[0]` is still used.
+
+Verification commands:
+
+- `npm run test -- src/components/ui/command-palette.test.tsx src/components/shell/authenticated-route-integrity.test.ts src/lib/rbac/roles.test.ts`
+- `npm run typecheck`
+
+If the full typecheck is blocked by unrelated baseline issues, capture the failure and run the focused tests as the completion gate for this slice.
+
+## Success Criteria
+
+- No authenticated recovery action sends the user to public `/` as a "home" action.
+- All authenticated command-palette hrefs resolve to actual app routes.
+- Authenticated nav definitions can be validated by automated tests.
+- Multi-role redirects use `primaryRole()` instead of role array order in the touched layouts.
+- Focused tests pass and typecheck is run or its unrelated blocker is documented.
+
+## Self-Review
+
+- Placeholder scan: no TBD/TODO placeholders remain.
+- Scope check: the design is limited to signed-in commercial stability and does not include public or storefront polish.
+- Consistency check: route corrections match the existing app route tree.
+- Ambiguity check: `/` is allowed only as a clearly public fallback, not as authenticated "home".

--- a/src/app/(clinician)/clinic/error.test.tsx
+++ b/src/app/(clinician)/clinic/error.test.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { isValidElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import ClinicError from "./error";
+
+function textOf(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) return textOf((node as any).props.children);
+  return "";
+}
+
+function findByText(node: ReactNode, text: string): any {
+  if (isValidElement(node) && textOf(node).trim() === text) return node;
+  if (isValidElement(node)) {
+    const children = (node as any).props.children;
+    const childList = Array.isArray(children) ? children : [children];
+    for (const child of childList) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+describe("Clinic error recovery", () => {
+  it("keeps clinic users inside the clinic when leaving the error screen", () => {
+    const previousWindow = globalThis.window;
+    const previousReact = (globalThis as any).React;
+    const location = { href: "" };
+    (globalThis as any).window = { location };
+    (globalThis as any).React = React;
+
+    try {
+      const tree = ClinicError({
+        error: new Error("boom"),
+        reset: () => undefined,
+      });
+
+      const button = findByText(tree, "Go to Today");
+      expect(button).toBeTruthy();
+      button.props.onClick();
+
+      expect(location.href).toBe("/clinic");
+    } finally {
+      (globalThis as any).window = previousWindow;
+      (globalThis as any).React = previousReact;
+    }
+  });
+});

--- a/src/app/(clinician)/clinic/error.tsx
+++ b/src/app/(clinician)/clinic/error.tsx
@@ -19,14 +19,14 @@ export default function Error({
         </h1>
         <p className="text-sm text-text-muted mt-2 max-w-md leading-relaxed">
           We ran into an unexpected issue loading the clinic view. This has been
-          logged. Try refreshing, or go back to the home page.
+          logged. Try refreshing, or go back to Today.
         </p>
         <div className="mt-6 flex items-center gap-3">
           <Button onClick={() => reset()} variant="secondary">
             Try again
           </Button>
-          <Button onClick={() => (window.location.href = "/")} variant="ghost">
-            Go home
+          <Button onClick={() => (window.location.href = "/clinic")} variant="ghost">
+            Go to Today
           </Button>
         </div>
       </div>

--- a/src/app/(clinician)/error.tsx
+++ b/src/app/(clinician)/error.tsx
@@ -7,8 +7,8 @@ import { useReportError } from "@/components/error-pages/use-report-error";
 
 /**
  * Clinician route-group error boundary. Catches anything thrown inside
- * /clinic/* that isn't handled by a more specific boundary. "Go home"
- * routes to the clinician's Today screen.
+ * /clinic/* that isn't handled by a more specific boundary. The
+ * secondary recovery action routes to the clinician's Today screen.
  */
 export default function ClinicianError({
   error,

--- a/src/app/(operator)/error.tsx
+++ b/src/app/(operator)/error.tsx
@@ -7,8 +7,8 @@ import { useReportError } from "@/components/error-pages/use-report-error";
 
 /**
  * Operator route-group error boundary. Catches anything thrown inside
- * /ops/* that isn't handled by a more specific boundary. "Go home"
- * routes back to the operator queue.
+ * /ops/* that isn't handled by a more specific boundary. The
+ * secondary recovery action routes back to the operator queue.
  */
 export default function OperatorError({
   error,

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -3,7 +3,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { SystemBannerRail } from "@/components/ui/system-banner";
-import { ROLE_HOME, primaryRole } from "@/lib/rbac/roles";
+import { homeForRoles } from "@/lib/rbac/roles";
 import { prisma } from "@/lib/db/prisma";
 import {
   computeAgingBadge,
@@ -30,8 +30,7 @@ export default async function OperatorLayout({
     (r) => r === "operator" || r === "practice_owner" || r === "system"
   );
   if (!allowed) {
-    const primary = user.roles[0];
-    redirect(ROLE_HOME[primary] ?? "/");
+    redirect(homeForRoles(user.roles));
   }
 
   if (!user.organizationId) {

--- a/src/app/(operator)/ops/error.test.tsx
+++ b/src/app/(operator)/ops/error.test.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { isValidElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import OpsError from "./error";
+
+function textOf(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) return textOf((node as any).props.children);
+  return "";
+}
+
+function findByText(node: ReactNode, text: string): any {
+  if (isValidElement(node) && textOf(node).trim() === text) return node;
+  if (isValidElement(node)) {
+    const children = (node as any).props.children;
+    const childList = Array.isArray(children) ? children : [children];
+    for (const child of childList) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+describe("Ops error recovery", () => {
+  it("keeps operators inside ops when leaving the error screen", () => {
+    const previousWindow = globalThis.window;
+    const previousReact = (globalThis as any).React;
+    const location = { href: "" };
+    (globalThis as any).window = { location };
+    (globalThis as any).React = React;
+
+    try {
+      const tree = OpsError({
+        error: new Error("boom"),
+        reset: () => undefined,
+      });
+
+      const button = findByText(tree, "Back to ops");
+      expect(button).toBeTruthy();
+      button.props.onClick();
+
+      expect(location.href).toBe("/ops");
+    } finally {
+      (globalThis as any).window = previousWindow;
+      (globalThis as any).React = previousReact;
+    }
+  });
+});

--- a/src/app/(operator)/ops/error.tsx
+++ b/src/app/(operator)/ops/error.tsx
@@ -19,14 +19,14 @@ export default function Error({
         </h1>
         <p className="text-sm text-text-muted mt-2 max-w-md leading-relaxed">
           We ran into an unexpected issue loading the operations dashboard. This
-          has been logged. Try refreshing, or go back to the home page.
+          has been logged. Try refreshing, or go back to ops.
         </p>
         <div className="mt-6 flex items-center gap-3">
           <Button onClick={() => reset()} variant="secondary">
             Try again
           </Button>
-          <Button onClick={() => (window.location.href = "/")} variant="ghost">
-            Go home
+          <Button onClick={() => (window.location.href = "/ops")} variant="ghost">
+            Back to ops
           </Button>
         </div>
       </div>

--- a/src/app/(patient)/error.tsx
+++ b/src/app/(patient)/error.tsx
@@ -7,8 +7,8 @@ import { useReportError } from "@/components/error-pages/use-report-error";
 
 /**
  * Patient route-group error boundary. Catches anything thrown inside
- * /portal/* that isn't handled by a more specific boundary. "Go home"
- * routes back to the patient portal dashboard.
+ * /portal/* that isn't handled by a more specific boundary. The
+ * secondary recovery action routes back to the patient portal dashboard.
  */
 export default function PatientError({
   error,

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth/session";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
-import { ROLE_HOME } from "@/lib/rbac/roles";
+import { homeForRoles } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { CommandPalette } from "@/components/ui/command-palette";
 import { ChatCBInterface } from "@/components/ask-cindy/ChatCBInterface";
@@ -116,8 +116,7 @@ export default async function PatientLayout({
   const user = await getCurrentUser();
   if (!user) redirect("/sign-in");
   if (!user.roles.includes("patient")) {
-    const primary = user.roles[0];
-    redirect(ROLE_HOME[primary] ?? "/");
+    redirect(homeForRoles(user.roles));
   }
 
   return (

--- a/src/app/(patient)/portal/error.test.tsx
+++ b/src/app/(patient)/portal/error.test.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { isValidElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import PatientPortalError from "./error";
+
+function textOf(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) return textOf((node as any).props.children);
+  return "";
+}
+
+function findByText(node: ReactNode, text: string): any {
+  if (isValidElement(node) && textOf(node).trim() === text) return node;
+  if (isValidElement(node)) {
+    const children = (node as any).props.children;
+    const childList = Array.isArray(children) ? children : [children];
+    for (const child of childList) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findByText(child, text);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+describe("Patient portal error recovery", () => {
+  it("keeps patients inside the portal when leaving the error screen", () => {
+    const previousWindow = globalThis.window;
+    const previousReact = (globalThis as any).React;
+    const location = { href: "" };
+    (globalThis as any).window = { location };
+    (globalThis as any).React = React;
+
+    try {
+      const tree = PatientPortalError({
+        error: new Error("boom"),
+        reset: () => undefined,
+      });
+
+      const button = findByText(tree, "Back to dashboard");
+      expect(button).toBeTruthy();
+      button.props.onClick();
+
+      expect(location.href).toBe("/portal");
+    } finally {
+      (globalThis as any).window = previousWindow;
+      (globalThis as any).React = previousReact;
+    }
+  });
+});

--- a/src/app/(patient)/portal/error.tsx
+++ b/src/app/(patient)/portal/error.tsx
@@ -19,14 +19,14 @@ export default function Error({
         </h1>
         <p className="text-sm text-text-muted mt-2 max-w-md leading-relaxed">
           We ran into an unexpected issue loading your portal. This has been
-          logged. Try refreshing, or head back to the home page.
+          logged. Try refreshing, or head back to your dashboard.
         </p>
         <div className="mt-6 flex items-center gap-3">
           <Button onClick={() => reset()} variant="secondary">
             Try again
           </Button>
-          <Button onClick={() => (window.location.href = "/")} variant="ghost">
-            Go home
+          <Button onClick={() => (window.location.href = "/portal")} variant="ghost">
+            Back to dashboard
           </Button>
         </div>
       </div>

--- a/src/components/ui/command-palette.test.tsx
+++ b/src/components/ui/command-palette.test.tsx
@@ -1,0 +1,51 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { createAppRouteMatcher } from "@/lib/navigation/app-route-map";
+import { AUTHENTICATED_COMMANDS } from "./command-palette";
+
+function walkPages(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const filePath = path.join(dir, name);
+    const stat = statSync(filePath);
+    if (stat.isDirectory()) {
+      walkPages(filePath, out);
+      continue;
+    }
+    if (name === "page.tsx") out.push(filePath);
+  }
+  return out;
+}
+
+function routeFromPage(filePath: string): string {
+  const appRoot = path.join(process.cwd(), "src", "app");
+  const relative = path.relative(appRoot, filePath).replace(/\/page\.tsx$/, "");
+  const parts = relative
+    .split(path.sep)
+    .filter(Boolean)
+    .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")))
+    .map((segment) => {
+      if (/^\[\[\.\.\..+\]\]$/.test(segment)) return "*";
+      if (/^\[\.\.\..+\]$/.test(segment)) return "*";
+      const dynamic = segment.match(/^\[(.+)\]$/);
+      return dynamic ? `:${dynamic[1]}` : segment;
+    });
+  return `/${parts.join("/")}`;
+}
+
+describe("authenticated command palette routes", () => {
+  it("points every authenticated command href at an existing app route", () => {
+    const appRoot = path.join(process.cwd(), "src", "app");
+    const routes = new Set(walkPages(appRoot).map(routeFromPage));
+    routes.add("/");
+    const matches = createAppRouteMatcher([...routes]);
+
+    const missing = AUTHENTICATED_COMMANDS
+      .filter((command) => command.href)
+      .filter((command) => !matches(command.href!))
+      .map((command) => `${command.id}: ${command.href}`);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -66,7 +66,7 @@ interface CommandDef {
 }
 
 // ───────────────────────────────────────── Clinician
-const CLINICIAN_COMMANDS: CommandDef[] = [
+export const CLINICIAN_COMMANDS: CommandDef[] = [
   // Default actions (verbs) — surfaced first per the Linear pattern.
   {
     id: "c-new-patient",
@@ -93,7 +93,7 @@ const CLINICIAN_COMMANDS: CommandDef[] = [
     label: "Open queue",
     hint: "Today's patient queue",
     icon: "⋮",
-    href: "/clinic/queue",
+    href: "/clinic",
     group: "Actions",
     roles: ["clinician"],
     keywords: ["queue", "today", "list", "next"],
@@ -123,7 +123,7 @@ const CLINICIAN_COMMANDS: CommandDef[] = [
     label: "Open settings",
     hint: "Account & preferences",
     icon: "⚙",
-    href: "/clinic/settings",
+    href: "/settings/preferences",
     group: "Actions",
     roles: ["clinician"],
     keywords: ["settings", "preferences", "account", "profile"],
@@ -136,8 +136,8 @@ const CLINICIAN_COMMANDS: CommandDef[] = [
   { id: "c-go-messages", label: "Open Inbox", icon: "✉", href: "/clinic/messages", group: "Navigate", roles: ["clinician"], keywords: ["inbox", "threads", "messages"] },
   { id: "c-go-morning-brief", label: "Open morning brief", icon: "☀", href: "/clinic/morning-brief", group: "Navigate", roles: ["clinician"], keywords: ["agenda", "today", "brief"] },
   { id: "c-go-approvals", label: "Open approvals", icon: "✓", href: "/clinic/approvals", group: "Navigate", roles: ["clinician"], keywords: ["drafts", "review", "approve"] },
-  { id: "c-go-labs", label: "Review labs", icon: "⚗", href: "/clinic/labs-review", group: "Navigate", roles: ["clinician"], keywords: ["labs", "results"] },
-  { id: "c-go-refills", label: "Review refills", icon: "℞", href: "/clinic/refills", group: "Navigate", roles: ["clinician"], keywords: ["refill", "rx", "prescription"] },
+  { id: "c-go-labs", label: "Review labs", icon: "⚗", href: "/clinic/sign-off/labs", group: "Navigate", roles: ["clinician"], keywords: ["labs", "results"] },
+  { id: "c-go-refills", label: "Review refills", icon: "℞", href: "/clinic/sign-off/refills", group: "Navigate", roles: ["clinician"], keywords: ["refill", "rx", "prescription"] },
   { id: "c-go-providers", label: "Providers directory", icon: "☷", href: "/clinic/providers", group: "Navigate", roles: ["clinician"], keywords: ["directory", "colleagues"] },
   { id: "c-go-research", label: "Research feed", icon: "✦", href: "/clinic/research", group: "Navigate", roles: ["clinician"], keywords: ["pubmed", "papers"] },
   { id: "c-go-library", label: "Education library", icon: "❦", href: "/clinic/library", group: "Navigate", roles: ["clinician"], keywords: ["leaflet", "library", "handouts"] },
@@ -155,13 +155,12 @@ const CLINICIAN_COMMANDS: CommandDef[] = [
 ];
 
 // ───────────────────────────────────────── Operator
-const OPERATOR_COMMANDS: CommandDef[] = [
+export const OPERATOR_COMMANDS: CommandDef[] = [
   // Default actions
   { id: "o-new-patient", label: "New patient", hint: "Create a new chart", icon: "+", href: "/ops/patients?action=new", group: "Actions", roles: ["operator"], keywords: ["create", "add", "patient", "new"] },
-  { id: "o-compose-message", label: "Compose message", hint: "Start a new patient thread", icon: "✎", href: "/ops/messages?action=compose", group: "Actions", roles: ["operator"], keywords: ["message", "compose", "thread"] },
   { id: "o-open-queue", label: "Open queue", icon: "⋮", href: "/ops/queue", group: "Actions", roles: ["operator"], keywords: ["queue", "today", "list"] },
   { id: "o-schedule-visit", label: "Schedule visit", icon: "◷", href: "/ops/schedule?action=new", group: "Actions", roles: ["operator"], keywords: ["schedule", "appointment", "book"] },
-  { id: "o-open-settings", label: "Open settings", icon: "⚙", href: "/ops/settings", group: "Actions", roles: ["operator"], keywords: ["settings", "preferences", "account"] },
+  { id: "o-open-settings", label: "Open settings", icon: "⚙", href: "/ops/settings/ai-config", group: "Actions", roles: ["operator"], keywords: ["settings", "preferences", "account"] },
 
   // Navigation
   { id: "o-overview", label: "Overview", icon: "○", href: "/ops", group: "Navigate", roles: ["operator"], keywords: ["home", "dashboard"] },
@@ -219,7 +218,7 @@ const OPERATOR_COMMANDS: CommandDef[] = [
 ];
 
 // ───────────────────────────────────────── Patient
-const PATIENT_COMMANDS: CommandDef[] = [
+export const PATIENT_COMMANDS: CommandDef[] = [
   { id: "p-home", label: "Home", icon: "○", href: "/portal", group: "Navigate", roles: ["patient"], keywords: ["home", "dashboard"] },
   { id: "p-log-dose", label: "Log Dose", icon: "+", href: "/portal/log-dose", group: "Navigate", roles: ["patient"], keywords: ["dose", "log", "intake"] },
   { id: "p-health", label: "My Records", icon: "❒", href: "/portal/records", group: "Navigate", roles: ["patient"], keywords: ["records", "health", "results"] },
@@ -236,6 +235,8 @@ const ALL_COMMANDS: CommandDef[] = [
   ...OPERATOR_COMMANDS,
   ...PATIENT_COMMANDS,
 ];
+
+export const AUTHENTICATED_COMMANDS: CommandDef[] = ALL_COMMANDS;
 
 // ───────────────────────────────────────── Ranker
 //

--- a/src/lib/navigation/app-route-map.test.ts
+++ b/src/lib/navigation/app-route-map.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { createAppRouteMatcher } from "./app-route-map";
+
+describe("createAppRouteMatcher", () => {
+  it("matches exact app routes and strips query strings", () => {
+    const matches = createAppRouteMatcher(["/clinic", "/ops/settings/ai-config"]);
+
+    expect(matches("/clinic")).toBe(true);
+    expect(matches("/ops/settings/ai-config?tab=models")).toBe(true);
+  });
+
+  it("matches dynamic route segments", () => {
+    const matches = createAppRouteMatcher([
+      "/clinic/patients/:id",
+      "/ops/cfo/reports/:id",
+    ]);
+
+    expect(matches("/clinic/patients/patient_123")).toBe(true);
+    expect(matches("/ops/cfo/reports/report_123")).toBe(true);
+  });
+
+  it("does not match missing sibling routes", () => {
+    const matches = createAppRouteMatcher(["/clinic", "/clinic/sign-off/labs"]);
+
+    expect(matches("/clinic/queue")).toBe(false);
+    expect(matches("/clinic/labs-review")).toBe(false);
+  });
+});

--- a/src/lib/navigation/app-route-map.ts
+++ b/src/lib/navigation/app-route-map.ts
@@ -1,0 +1,36 @@
+export function normalizeAppHref(href: string): string {
+  const path = href.split(/[?#]/)[0] || "/";
+  return path.length > 1 ? path.replace(/\/+$/, "") : "/";
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function routeToRegex(route: string): RegExp {
+  const normalized = normalizeAppHref(route);
+  const pattern = normalized
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) return "[^/]+";
+      if (segment === "*") return ".*";
+      return escapeRegex(segment);
+    })
+    .join("/");
+  return new RegExp(`^${pattern}$`);
+}
+
+export function createAppRouteMatcher(
+  routes: string[],
+): (href: string) => boolean {
+  const exactRoutes = new Set(routes.map(normalizeAppHref));
+  const dynamicRoutes = routes
+    .filter((route) => route.includes(":") || route.includes("*"))
+    .map(routeToRegex);
+
+  return (href: string) => {
+    const normalized = normalizeAppHref(href);
+    if (exactRoutes.has(normalized)) return true;
+    return dynamicRoutes.some((route) => route.test(normalized));
+  };
+}

--- a/src/lib/rbac/roles.test.ts
+++ b/src/lib/rbac/roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { primaryRole, ROLE_HOME } from "./roles";
+import { homeForRoles, primaryRole, ROLE_HOME } from "./roles";
 
 // primaryRole picks the highest-privilege role from a user's membership set
 // and is load-bearing for post-sign-in routing — Clerk lands every user on
@@ -61,5 +61,16 @@ describe("primaryRole", () => {
     ] as const) {
       expect(ROLE_HOME[role]).toBeTruthy();
     }
+  });
+});
+
+describe("homeForRoles", () => {
+  it("routes by highest privilege rather than role array order", () => {
+    expect(homeForRoles(["patient", "practice_owner"])).toBe("/ops");
+    expect(homeForRoles(["practice_owner", "patient"])).toBe("/ops");
+  });
+
+  it("uses the primary-role fallback for empty role lists", () => {
+    expect(homeForRoles([], "/sign-in")).toBe("/portal");
   });
 });

--- a/src/lib/rbac/roles.ts
+++ b/src/lib/rbac/roles.ts
@@ -90,3 +90,7 @@ export function primaryRole(roles: Role[]): Role {
   for (const r of order) if (roles.includes(r)) return r;
   return "patient";
 }
+
+export function homeForRoles(roles: Role[], fallback = "/"): string {
+  return ROLE_HOME[primaryRole(roles)] ?? fallback;
+}


### PR DESCRIPTION
## Summary
- Keeps authenticated error recovery inside `/portal`, `/clinic`, and `/ops`.
- Fixes stale authenticated command-palette routes.
- Uses primary-role home resolution for touched redirect fallbacks.
- Adds route-integrity and recovery regression tests.

## Test Plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`