### PR TITLE
test: keep click crawler timeout at intended budget

### DIFF
--- a/e2e/click-handlers.spec.ts
+++ b/e2e/click-handlers.spec.ts
@@ -425,11 +425,6 @@ async function clickAndObserve(
 test.describe.configure({ timeout: 300_000 });
 
 test.describe("Click handlers — find-and-fix pass 8", () => {
-  // Each route fires up to MAX_CLICKS_PER_ROUTE per-click pages; with
-  // CLICK_OBSERVE_MS=2s plus nav+probe time this easily breaches the
-  // 30s default test timeout. Give each route its own generous budget.
-  test.setTimeout(180_000);
-
   for (const route of ROUTES) {
     test(`crawl ${route}`, async ({ page, context }) => {
       stats.routesScanned += 1;


### PR DESCRIPTION
## Summary
- Removes the stale per-test 180s timeout that overrode the click-handler crawler suite's intended 300s budget.
- Allows the Leafmart public click-crawler routes to use the same bounded headroom already documented in the spec.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- src/lib/navigation/app-route-map.test.ts src/components/ui/command-palette.test.tsx`
- [ ] GitHub staging Playwright pipeline rerun

## Notes
- Local Playwright browser launch is blocked in this sandbox by macOS Mach port permissions, so the staging GitHub runner is the authoritative browser verification.