### PR TITLE
test: cover go-live scheduling recommendations

### DIFF
--- a/src/lib/scheduling/cadence-engine.test.ts
+++ b/src/lib/scheduling/cadence-engine.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { nextDueDate, recommendCadence, type CadenceRecommendation } from "./cadence-engine";
+
+describe("recommendCadence", () => {
+  it("uses the chronic-pain maintenance standard cadence for routine physician follow-up", () => {
+    const rec = recommendCadence({
+      condition: "chronic_pain",
+      phase: "maintenance",
+      patientState: "CA",
+      daysSinceCertIssued: 100,
+    });
+
+    expect(rec).toMatchObject({
+      intervalDays: 90,
+      modality: "video",
+      inPersonRequired: false,
+      overdueGraceDays: 30,
+    });
+    expect(rec.rationale).toContain("Chronic Pain");
+    expect(rec.rationale).toContain("maintenance");
+  });
+
+  it("pulls required-renewal states into an in-person visit before certification expiry", () => {
+    const rec = recommendCadence({
+      condition: "chronic_pain",
+      phase: "maintenance",
+      patientState: "FL",
+      daysSinceCertIssued: 350,
+    });
+
+    expect(rec.intervalDays).toBe(15);
+    expect(rec.modality).toBe("in_person");
+    expect(rec.inPersonRequired).toBe(true);
+    expect(rec.rationale).toContain("Pulled in for cert renewal in FL");
+  });
+
+  it("never schedules renewal squeeze visits less than seven days out", () => {
+    const rec = recommendCadence({
+      condition: "epilepsy",
+      phase: "maintenance",
+      patientState: "PA",
+      daysSinceCertIssued: 364,
+    });
+
+    expect(rec.intervalDays).toBe(7);
+    expect(rec.modality).toBe("in_person");
+    expect(rec.inPersonRequired).toBe(true);
+  });
+
+  it("respects positive clinician override days without dropping table grace-window policy", () => {
+    const rec = recommendCadence({
+      condition: "anxiety",
+      phase: "titration",
+      patientState: "CA",
+      daysSinceCertIssued: 30,
+      clinicianOverrideDays: 21,
+    });
+
+    expect(rec.intervalDays).toBe(21);
+    expect(rec.modality).toBe("video");
+    expect(rec.overdueGraceDays).toBe(5);
+    expect(rec.rationale).toContain("Clinician override: 21 days");
+  });
+});
+
+describe("nextDueDate", () => {
+  const rec: CadenceRecommendation = {
+    intervalDays: 14,
+    modality: "video",
+    inPersonRequired: false,
+    rationale: "test cadence",
+    overdueGraceDays: 3,
+  };
+
+  it("computes the next due date and stays inside the grace window", () => {
+    const result = nextDueDate(
+      new Date("2026-05-01T12:00:00.000Z"),
+      rec,
+      new Date("2026-05-17T12:00:00.000Z"),
+    );
+
+    expect(result.dueAt.toISOString()).toBe("2026-05-15T12:00:00.000Z");
+    expect(result.overdue).toBe(false);
+    expect(result.daysOverdue).toBe(2);
+  });
+
+  it("marks patients overdue only after the grace window has elapsed", () => {
+    const result = nextDueDate(
+      new Date("2026-05-01T12:00:00.000Z"),
+      rec,
+      new Date("2026-05-19T12:00:00.000Z"),
+    );
+
+    expect(result.overdue).toBe(true);
+    expect(result.daysOverdue).toBe(4);
+  });
+});

--- a/src/lib/scheduling/slot-recommender.test.ts
+++ b/src/lib/scheduling/slot-recommender.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { rankSlots, type CandidateSlot, type PatientContext } from "./slot-recommender";
+
+const basePatient: PatientContext = {
+  patientId: "patient-1",
+  preferredProviderId: null,
+  lastVisitProviderId: null,
+  riskTier: "low",
+  preferredDaysOfWeek: [],
+  preferredHours: null,
+  preferredModality: null,
+  dueAt: null,
+  overdueGraceDays: 0,
+  providerLockedTo: null,
+};
+
+const slot = (
+  slotId: string,
+  overrides: Partial<CandidateSlot> = {},
+): CandidateSlot => ({
+  slotId,
+  providerId: "provider-a",
+  startAt: new Date("2026-05-18T15:00:00.000Z"),
+  endAt: new Date("2026-05-18T15:30:00.000Z"),
+  modality: "video",
+  slotValue: 0.5,
+  ...overrides,
+});
+
+describe("rankSlots", () => {
+  it("prioritizes same-clinician continuity for physician follow-up", () => {
+    const results = rankSlots(
+      [
+        slot("other-provider-prime", { providerId: "provider-b", slotValue: 1 }),
+        slot("last-provider", { providerId: "provider-a", slotValue: 0.4 }),
+      ],
+      { ...basePatient, lastVisitProviderId: "provider-a", riskTier: "medium" },
+    );
+
+    expect(results[0].slotId).toBe("last-provider");
+    expect(results[0].reasons).toContain("Same provider as last visit");
+  });
+
+  it("filters out slots that violate provider lock or required modality hard constraints", () => {
+    const results = rankSlots(
+      [
+        slot("wrong-provider", { providerId: "provider-a", modality: "in_person" }),
+        slot("wrong-modality", { providerId: "provider-locked", modality: "phone" }),
+        slot("eligible", { providerId: "provider-locked", modality: "in_person" }),
+      ],
+      { ...basePatient, providerLockedTo: "provider-locked" },
+      { requiredModality: "in_person" },
+    );
+
+    expect(results.map((s) => s.slotId)).toEqual(["eligible"]);
+  });
+
+  it("steers high no-show-risk patients toward lower-value slots", () => {
+    const results = rankSlots(
+      [
+        slot("prime-slot", { slotValue: 1 }),
+        slot("cheap-slot", { slotValue: 0.05 }),
+      ],
+      { ...basePatient, riskTier: "high" },
+    );
+
+    expect(results[0].slotId).toBe("cheap-slot");
+    expect(results[0].reasons).toContain("Slot value matches risk tier");
+  });
+
+  it("rewards patient stated preferences and cadence-fit reasons", () => {
+    const results = rankSlots(
+      [
+        slot("generic", {
+          providerId: "provider-b",
+          startAt: new Date("2026-05-22T18:00:00.000Z"),
+          endAt: new Date("2026-05-22T18:30:00.000Z"),
+          modality: "phone",
+          slotValue: 0.5,
+        }),
+        slot("preferred", {
+          providerId: "provider-a",
+          startAt: new Date("2026-05-20T14:00:00.000Z"),
+          endAt: new Date("2026-05-20T14:30:00.000Z"),
+          modality: "video",
+          slotValue: 0.5,
+        }),
+      ],
+      {
+        ...basePatient,
+        preferredProviderId: "provider-a",
+        preferredDaysOfWeek: [3],
+        // Broad enough to avoid making this regression test depend on the
+        // machine timezone used by Date#getHours().
+        preferredHours: { earliestHour: 0, latestHour: 24 },
+        preferredModality: "video",
+        dueAt: new Date("2026-05-20T14:00:00.000Z"),
+        overdueGraceDays: 2,
+        riskTier: "medium",
+      },
+    );
+
+    expect(results[0].slotId).toBe("preferred");
+    expect(results[0].reasons).toEqual(
+      expect.arrayContaining([
+        "Preferred provider",
+        "Matches modality preference (video)",
+        "Within preferred hours",
+        "Preferred day of week",
+        "Lands on cadence due date",
+      ]),
+    );
+  });
+
+  it("honors return limits after ranking", () => {
+    const results = rankSlots(
+      [slot("one", { slotValue: 1 }), slot("two", { slotValue: 0.8 }), slot("three", { slotValue: 0.6 })],
+      basePatient,
+      { limit: 2 },
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results.map((s) => s.slotId)).toEqual(["one", "two"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds go-live-focused regression coverage for follow-up cadence recommendations.
- Adds smart slot ranking coverage for clinician continuity, provider/modality hard constraints, no-show risk fit, cadence fit, patient preferences, and return limits.
- No Prisma schema/migration/data writes.

## Verification
- `npm test -- src/lib/scheduling/cadence-engine.test.ts src/lib/scheduling/slot-recommender.test.ts --reporter=verbose`
- `npm run typecheck`
- `npm test -- --reporter=dot` → 216 files / 2114 tests passed
- `npm run build` → exits 0, but logs static-generation Prisma/Clerk warnings captured in Linear EMR-911

## Go-live risk noted
- Created EMR-911 for noisy successful production build logs: Prisma ENOTFOUND `base`, Clerk auth middleware detection, and dynamic server usage warnings during static generation.
