### PR TITLE
fix(onboarding): resolve clinician tour modal overlap and path-change block

### DIFF
--- a/src/components/onboarding/clinician-tour.tsx
+++ b/src/components/onboarding/clinician-tour.tsx
@@ -149,7 +149,10 @@ export function ClinicianTour() {
   // mission control home), only when the flag is absent. Subsequent renders
   // are no-ops because the flag is set on completion/skip.
   useEffect(() => {
-    if (pathname !== "/clinic") return;
+    if (pathname !== "/clinic") {
+      setOpen(false);
+      return;
+    }
     if (readStored()) return;
 
     // Check if the Quote Welcome Modal is active in the current session.
@@ -157,7 +160,7 @@ export function ClinicianTour() {
     // we wait for the dismissal event.
     const isQuoteShowing =
       typeof window !== "undefined" &&
-      !window.sessionStorage.getItem("emr-quote-welcome-shown");
+      ((window as any).__emr_quote_showing || !window.sessionStorage.getItem("emr-quote-welcome-shown"));
 
     if (isQuoteShowing) {
       const handleWelcomeDismissed = () => {

--- a/src/components/ui/quote-of-the-day.tsx
+++ b/src/components/ui/quote-of-the-day.tsx
@@ -20,11 +20,15 @@ export function QuoteWelcomeModal({ userName }: { userName?: string }) {
     const shown = sessionStorage.getItem(key);
     if (shown) return;
 
+    (window as any).__emr_quote_showing = true;
     sessionStorage.setItem(key, "1");
     setQuote(QUOTES[Math.floor(Math.random() * QUOTES.length)]);
     // Slight delay for smooth entrance
     const t = setTimeout(() => setVisible(true), 300);
-    return () => clearTimeout(t);
+    return () => {
+      clearTimeout(t);
+      (window as any).__emr_quote_showing = false;
+    };
   }, []);
 
   if (!quote || !visible) return null;
@@ -32,6 +36,7 @@ export function QuoteWelcomeModal({ userName }: { userName?: string }) {
   const dismissModal = () => {
     setVisible(false);
     if (typeof window !== "undefined") {
+      (window as any).__emr_quote_showing = false;
       window.dispatchEvent(new CustomEvent("emr:welcome:dismissed"));
     }
   };


### PR DESCRIPTION
This PR resolves: 1. A layout collision where QuoteWelcomeModal and ClinicianTour overlapped. 2. A bug where navigating away from /clinic did not close ClinicianTour, blocking UI interaction on other pages.