### PR TITLE
fix(auth): stop the bootstrap allowlist from silently escalating clinician accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "audit:export": "tsx --conditions=react-server scripts/export-audit-log.ts",
     "lint:modality": "tsx --conditions=react-server scripts/lint-modality-bleed.ts",
     "lint:audit": "tsx --conditions=react-server scripts/lint-audit-log-coverage.ts",
-    "load:synthetic": "tsx scripts/load-synthetic.ts"
+    "load:synthetic": "tsx scripts/load-synthetic.ts",
+    "revoke:super-admin": "tsx --conditions=react-server scripts/revoke-super-admin.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.1",

--- a/scripts/revoke-super-admin.ts
+++ b/scripts/revoke-super-admin.ts
@@ -1,0 +1,99 @@
+/**
+ * Revoke a stray super_admin grant from an account.
+ *
+ * Background: the bootstrap allowlist (SUPER_ADMIN_BOOTSTRAP_EMAILS) can
+ * silently grant super_admin to any listed email on first admin-surface hit.
+ * A clinician demo login picked one up, which routed it into Practice
+ * Onboarding instead of /clinic. The code is now hardened to never escalate
+ * clinical/end-user accounts, but any *existing* stray grant must be cleaned
+ * up explicitly — that's what this script does.
+ *
+ * Usage:
+ *   # Preview (no writes):
+ *   tsx --conditions=react-server scripts/revoke-super-admin.ts clinician@demo.health
+ *
+ *   # Actually revoke:
+ *   tsx --conditions=react-server scripts/revoke-super-admin.ts clinician@demo.health --apply
+ *
+ * Safe by default: prints what it would do and exits unless --apply is passed.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { config } from "dotenv";
+
+async function main() {
+  config({ path: ".env.local" });
+  config({ path: ".env" });
+
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const email = args.find((a) => !a.startsWith("--"))?.trim().toLowerCase();
+
+  if (!email) {
+    console.error(
+      "Usage: tsx scripts/revoke-super-admin.ts <email> [--apply]",
+    );
+    process.exit(1);
+  }
+
+  const prisma = new PrismaClient();
+  try {
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        email: true,
+        memberships: {
+          select: { id: true, role: true, organizationId: true },
+        },
+      },
+    });
+
+    if (!user) {
+      console.error(`✗ No user found with email "${email}".`);
+      process.exit(1);
+    }
+
+    const superAdminMemberships = user.memberships.filter(
+      (m) => m.role === "super_admin",
+    );
+
+    console.log(`User: ${user.email} (${user.id})`);
+    console.log(
+      `Roles: ${user.memberships.map((m) => m.role).join(", ") || "(none)"}`,
+    );
+
+    if (superAdminMemberships.length === 0) {
+      console.log("✓ No super_admin membership to revoke. Nothing to do.");
+      return;
+    }
+
+    console.log(
+      `Found ${superAdminMemberships.length} super_admin membership(s): ` +
+        superAdminMemberships.map((m) => m.organizationId).join(", "),
+    );
+
+    if (!apply) {
+      console.log(
+        "\nDRY RUN — no changes made. Re-run with --apply to revoke.",
+      );
+      return;
+    }
+
+    const result = await prisma.membership.deleteMany({
+      where: { userId: user.id, role: "super_admin" },
+    });
+    console.log(`✓ Revoked ${result.count} super_admin membership(s).`);
+    console.log(
+      "Reminder: also remove this email from SUPER_ADMIN_BOOTSTRAP_EMAILS " +
+        "(and set SUPER_ADMIN_BOOTSTRAP_ENABLED=0) so it is not re-granted.",
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/auth/super-admin-bootstrap.test.ts
+++ b/src/lib/auth/super-admin-bootstrap.test.ts
@@ -28,12 +28,14 @@ const mockedPrisma = vi.mocked(prisma, true) as unknown as {
   membership: { upsert: ReturnType<typeof vi.fn> };
 };
 
+// A break-glass platform operator: allowlisted, no clinical/end-user role.
+// This is the ONLY shape that should ever be auto-promoted.
 const allowlistedUser: AuthedUser = {
   id: "user_seed",
   email: "scott@leafjourney.com",
   firstName: "Scott",
   lastName: "Wayman",
-  roles: ["clinician"],
+  roles: [],
   organizationId: "org_clinic",
   organizationName: "Test Clinic",
 };
@@ -81,5 +83,28 @@ describe("bootstrapSuperAdminIfAllowlisted", () => {
 
     expect(result).toBe(false);
     expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses to escalate an allowlisted CLINICIAN account", async () => {
+    // Regression: a clinician demo login on the allowlist was being silently
+    // promoted to super_admin and routed into the admin shell. Allowlist
+    // membership must not override the protected-role guard.
+    const user = { ...allowlistedUser, roles: ["clinician" as const] };
+    const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+    expect(result).toBe(false);
+    expect(user.roles).not.toContain("super_admin");
+    expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses to escalate other end-user roles (patient / office)", async () => {
+    for (const role of ["patient", "midlevel", "back_office", "front_office"] as const) {
+      mockedPrisma.membership.upsert.mockClear();
+      const user = { ...allowlistedUser, roles: [role] };
+      const result = await bootstrapSuperAdminIfAllowlisted(user);
+
+      expect(result).toBe(false);
+      expect(mockedPrisma.membership.upsert).not.toHaveBeenCalled();
+    }
   });
 });

--- a/src/lib/auth/super-admin-bootstrap.ts
+++ b/src/lib/auth/super-admin-bootstrap.ts
@@ -23,10 +23,27 @@ import "server-only";
 
 import { prisma } from "@/lib/db/prisma";
 import { logger } from "@/lib/observability/log";
+import type { Role } from "@prisma/client";
 import type { AuthedUser } from "./session";
 
 export const LEAFJOURNEY_HQ_SLUG = "leafjourney-hq";
 const LEAFJOURNEY_HQ_NAME = "LeafJourney HQ";
+
+/**
+ * Roles that must NEVER be silently escalated to platform super_admin via the
+ * bootstrap allowlist. Bootstrap is a break-glass recovery path for platform
+ * operators; a clinician / patient / office login that happens to be on the
+ * allowlist must not acquire owner-level rights (and get routed into the admin
+ * shell). Accounts holding these roles can still be granted admin explicitly
+ * through the /admin console by an existing super_admin.
+ */
+const PROTECTED_NON_ADMIN_ROLES: Role[] = [
+  "patient",
+  "clinician",
+  "midlevel",
+  "back_office",
+  "front_office",
+];
 
 /**
  * Returns the bootstrap email allowlist when bootstrap is *explicitly
@@ -94,6 +111,28 @@ export async function bootstrapSuperAdminIfAllowlisted(
   const allowlist = bootstrapAllowlist();
   if (allowlist.size === 0) return false;
   if (!allowlist.has(user.email.toLowerCase())) return false;
+
+  // Defense-in-depth: never auto-promote an account that already holds a
+  // clinical / end-user role. A clinician demo login was being silently
+  // escalated to super_admin (and routed into Practice Onboarding instead of
+  // /clinic) because its email was on the allowlist. Allowlist membership is
+  // not sufficient — the account must not be a clinician/patient/office user.
+  const protectedRole = user.roles.find((r) =>
+    PROTECTED_NON_ADMIN_ROLES.includes(r),
+  );
+  if (protectedRole) {
+    logger.warn({
+      event: "auth.bootstrap.refused_non_admin_account",
+      userId: user.id,
+      email: user.email,
+      roles: user.roles,
+      blockedBy: protectedRole,
+      message:
+        "Refused super_admin bootstrap: account holds a clinical/end-user role. " +
+        "Grant admin explicitly via /admin if this is intended.",
+    });
+    return false;
+  }
 
   const hqOrgId = await ensureLeafjourneyHq();
   await prisma.membership.upsert({


### PR DESCRIPTION
## Why
Follow-up to #526. The clinician login was landing in the admin shell because the **super_admin bootstrap allowlist** (`SUPER_ADMIN_BOOTSTRAP_EMAILS`) silently grants `super_admin` to *any* listed email the first time it hits an admin surface — and a clinician demo account picked one up. With the extra role, routing sent the clinician into Practice Onboarding instead of `/clinic`.

#526 fixed the *routing* (a clinician+admin now lands on `/clinic`). This PR fixes the *root cause* so a clinician can never be silently escalated in the first place.

The old behavior was even baked into the test — its fixture promoted a `roles: ["clinician"]` account. That was the footgun.

## What changed
- **`src/lib/auth/super-admin-bootstrap.ts`** — the bootstrap now refuses to escalate any account that already holds a clinical / end-user role (`patient`, `clinician`, `midlevel`, `back_office`, `front_office`). Bootstrap stays a break-glass recovery path for platform operators; clinical accounts must be granted admin explicitly via `/admin`. The refusal is logged (`auth.bootstrap.refused_non_admin_account`).
- **`scripts/revoke-super-admin.ts`** (+ `npm run revoke:super-admin`) — cleans up an *existing* stray grant. Dry-run by default; `--apply` to execute:
  ```
  npm run revoke:super-admin -- clinician@demo.health --apply
  ```
- **Tests** — the "promotes" fixture is now a role-less break-glass operator; added regression tests that an allowlisted clinician / patient / office account is refused.

## Operational follow-up (prod, needs your access)
1. Remove the clinician email from `SUPER_ADMIN_BOOTSTRAP_EMAILS` and set `SUPER_ADMIN_BOOTSTRAP_ENABLED=0` in Render once real admins are set.
2. Run the revoke script against prod to drop the stray `super_admin` membership on the clinician account.

## Tests
- `super-admin-bootstrap.test.ts` — 6 pass (incl. new clinician/patient/office refusal cases).
- `tsc --noEmit` clean.

https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3

---
_Generated by [Claude Code](https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3)_