### PR TITLE
feat(notes): dictate the whole visit straight into the SOAP sections

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -21,6 +21,12 @@ import {
 } from "@/lib/domain/notes";
 import { LeafSprig } from "@/components/ui/ornament";
 import { DictateButton } from "@/components/ui/dictation";
+import { SoapDictation } from "@/components/clinical/SoapDictation";
+import {
+  ensureSoapBlocks,
+  mergeDictatedBody,
+  OBJECTIVE_DICTATION_PREF_KEY,
+} from "@/lib/clinical/dictation-routing";
 import { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { NoteTemplatePicker, type PickerBlock } from "@/components/clinical/note-template-picker";
 import { NOTE_BLOCK_LABELS as NB_LABELS } from "@/lib/domain/notes";
@@ -142,6 +148,62 @@ export function NoteEditor({
   }
 
   const isEditable = currentStatus === "draft" || currentStatus === "needs_review";
+
+  // Whole-visit dictation (SOAP routing). The Objective opt-in is a
+  // per-physician setting (default off — staff document vitals), stored in the
+  // same `emr.prefs.v1.*` localStorage namespace the Preferences page uses.
+  const [objectiveDictation, setObjectiveDictation] = useState(false);
+  useEffect(() => {
+    try {
+      setObjectiveDictation(
+        window.localStorage.getItem(OBJECTIVE_DICTATION_PREF_KEY) === "1",
+      );
+    } catch {
+      /* private mode — keep default off */
+    }
+  }, []);
+  const objectiveDictationRef = useRef(objectiveDictation);
+  useEffect(() => {
+    objectiveDictationRef.current = objectiveDictation;
+  }, [objectiveDictation]);
+  // Snapshot of each block's body when dictation starts, so streaming updates
+  // append to a stable base instead of compounding on every chunk.
+  const dictationBaseRef = useRef<Partial<Record<NoteBlockType, string>>>({});
+
+  function handleObjectiveToggle(next: boolean) {
+    setObjectiveDictation(next);
+    try {
+      window.localStorage.setItem(OBJECTIVE_DICTATION_PREF_KEY, next ? "1" : "0");
+    } catch {
+      /* private mode — toggle still applies for this session */
+    }
+  }
+
+  function handleDictationStart() {
+    setBlocks((prev) => {
+      const ensured = ensureSoapBlocks(prev, objectiveDictationRef.current) as NoteBlock[];
+      const base: Partial<Record<NoteBlockType, string>> = {};
+      for (const b of ensured) if (b.type) base[b.type] = b.body;
+      dictationBaseRef.current = base;
+      return ensured;
+    });
+  }
+
+  function handleDictationSections(
+    byType: Partial<Record<NoteBlockType, string>>,
+  ) {
+    setBlocks((prev) =>
+      prev.map((b) => {
+        if (b.type && byType[b.type] !== undefined) {
+          return {
+            ...b,
+            body: mergeDictatedBody(dictationBaseRef.current[b.type] ?? "", byType[b.type]!),
+          };
+        }
+        return b;
+      }),
+    );
+  }
 
   function updateBlock(index: number, field: "heading" | "body", value: string) {
     setBlocks((prev) => {
@@ -298,6 +360,17 @@ export function NoteEditor({
         />
       </div>
 
+      {/* Whole-visit dictation → SOAP. Speak the visit with section cues and
+          each block fills itself. Objective is a per-physician setting. */}
+      {isEditable && (
+        <SoapDictation
+          includeObjective={objectiveDictation}
+          onToggleObjective={handleObjectiveToggle}
+          onStart={handleDictationStart}
+          onSections={handleDictationSections}
+        />
+      )}
+
       {/* Emotional vitals — EMR-134: emoji demeanor scale persisted to encounter */}
       {isEditable && (
         <div className="flex items-center gap-3 flex-wrap">
@@ -369,9 +442,11 @@ export function NoteEditor({
                       omitForObjective={block.type === "findings"}
                       placeholder="Note content. Use the toolbar or type / for block commands."
                       aria-label={`${block.heading} body`}
-                      textareaClassName={block.type === "findings" ? "" : "pr-10"}
+                      textareaClassName={
+                        block.type !== "findings" || objectiveDictation ? "pr-10" : ""
+                      }
                     />
-                    {block.type !== "findings" && (
+                    {(block.type !== "findings" || objectiveDictation) && (
                       <DictateButton
                         onText={(text) => {
                           const sep = block.body && !/\s$/.test(block.body) ? " " : "";

--- a/src/app/(clinician)/settings/preferences/preferences-client.tsx
+++ b/src/app/(clinician)/settings/preferences/preferences-client.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/card";
 import { KeyboardHelpModal } from "@/components/ui/keyboard-help-modal";
 import { AvatarUpload } from "@/components/ui/avatar-upload";
+import { OBJECTIVE_DICTATION_PREF_KEY } from "@/lib/clinical/dictation-routing";
 import { cn } from "@/lib/utils/cn";
 
 // ----------------------------------------------------------------------
@@ -106,6 +107,7 @@ type SectionId =
   | "profile"
   | "appearance"
   | "defaults"
+  | "documentation"
   | "notifications"
   | "keyboard"
   | "privacy";
@@ -127,6 +129,11 @@ const NAV: NavItem[] = [
     id: "defaults",
     label: "Defaults",
     description: "Landing route and filters",
+  },
+  {
+    id: "documentation",
+    label: "Documentation",
+    description: "Dictation and note authoring",
   },
   {
     id: "notifications",
@@ -179,6 +186,7 @@ export function PreferencesClient() {
   const [bell, setBellState] = useState(true);
   const [digest, setDigestState] = useState(false);
   const [kbdEnabled, setKbdEnabledState] = useState(true);
+  const [dictateObjective, setDictateObjectiveState] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 
   useEffect(() => {
@@ -197,6 +205,7 @@ export function PreferencesClient() {
     setBellState(readLocalBool(nsKey("notif.bell"), true));
     setDigestState(readLocalBool(nsKey("notif.digest"), false));
     setKbdEnabledState(readLocalBool(nsKey("kbd.enabled"), true));
+    setDictateObjectiveState(readLocalBool(OBJECTIVE_DICTATION_PREF_KEY, false));
   }, []);
 
   // Apply runtime side-effects (data-attributes on <html>) whenever the
@@ -307,6 +316,12 @@ export function PreferencesClient() {
     () => setBool("kbd.enabled", setKbdEnabledState, "Keyboard shortcuts"),
     [setBool],
   );
+  // nsKey("dictate.objective") === OBJECTIVE_DICTATION_PREF_KEY — the note
+  // editor reads the same key, so this toggle governs in-visit dictation too.
+  const setDictateObjective = useMemo(
+    () => setBool("dictate.objective", setDictateObjectiveState, "Objective dictation"),
+    [setBool],
+  );
 
   const handleExport = useCallback(() => {
     toast({
@@ -341,6 +356,13 @@ export function PreferencesClient() {
               onLanding={setLanding}
               msgFilter={msgFilter}
               onMsgFilter={setMsgFilter}
+            />
+          )}
+
+          {active === "documentation" && (
+            <DocumentationSection
+              dictateObjective={dictateObjective}
+              onDictateObjective={setDictateObjective}
             />
           )}
 
@@ -791,6 +813,39 @@ function DefaultsSection({
           </code>{" "}
           from <code className="font-mono text-[11px]">localStorage</code>.
         </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DocumentationSection({
+  dictateObjective,
+  onDictateObjective,
+}: {
+  dictateObjective: boolean;
+  onDictateObjective: (b: boolean) => void;
+}) {
+  return (
+    <Card tone="raised">
+      <CardHeader>
+        <CardTitle>Documentation</CardTitle>
+        <CardDescription>
+          How voice dictation behaves in the note editor. Saved to this browser.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="divide-y divide-border/60">
+          <Row
+            title="Dictate the Objective section"
+            description="Off by default — many practices have staff document vitals/Objective. Turn on to dictate Objective yourself (e.g. reading vitals aloud). AI generation for Objective stays disabled either way."
+          >
+            <Toggle
+              ariaLabel="Dictate the Objective section"
+              checked={dictateObjective}
+              onChange={onDictateObjective}
+            />
+          </Row>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/clinical/SoapDictation.tsx
+++ b/src/components/clinical/SoapDictation.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * Whole-visit dictation for the note editor.
+ *
+ * The clinician starts one continuous dictation and speaks the visit, using
+ * spoken section cues ("Subjective… Assessment… Plan…"). Speech streams live
+ * into the matching SOAP blocks via the existing browser-speech hook
+ * (useDictation) and the deterministic section parser (splitIntoApsoSections).
+ *
+ * Objective is gated by a per-physician setting: practices often have staff
+ * document vitals, so by default Objective speech is captured-but-not-filed and
+ * surfaced as a hint. Toggle it on for the "reading the vitals out loud" case.
+ * (AI *generation* for Objective stays disabled elsewhere — this only governs
+ * the physician's own dictation.)
+ */
+
+import * as React from "react";
+import { useDictation } from "@/components/ui/dictation";
+import { splitIntoApsoSections } from "@/lib/clinical/voice-dictation";
+import {
+  routeDictationToBlocks,
+  type SoapRoutableBlock,
+} from "@/lib/clinical/dictation-routing";
+import type { NoteBlockType } from "@/lib/domain/notes";
+import { cn } from "@/lib/utils/cn";
+
+interface SoapDictationProps {
+  /** Whether the physician's dictation may write into the Objective section. */
+  includeObjective: boolean;
+  /** Persist + reflect a change to the Objective opt-in. */
+  onToggleObjective: (next: boolean) => void;
+  /** Fired when dictation starts — editor snapshots base bodies + ensures SOAP blocks. */
+  onStart: () => void;
+  /** Fired on each transcript update with routed section text keyed by block type. */
+  onSections: (byType: Partial<Record<NoteBlockType, string>>) => void;
+  /** Fired when dictation stops. */
+  onStop?: () => void;
+  disabled?: boolean;
+}
+
+export function SoapDictation({
+  includeObjective,
+  onToggleObjective,
+  onStart,
+  onSections,
+  onStop,
+  disabled,
+}: SoapDictationProps) {
+  const transcriptRef = React.useRef("");
+  const includeObjRef = React.useRef(includeObjective);
+  const [interim, setInterim] = React.useState("");
+  const [skipped, setSkipped] = React.useState("");
+
+  React.useEffect(() => {
+    includeObjRef.current = includeObjective;
+  }, [includeObjective]);
+
+  const route = React.useCallback(
+    (includeObj: boolean) => {
+      const sectioned = splitIntoApsoSections(transcriptRef.current);
+      const { byType, skippedObjective } = routeDictationToBlocks(sectioned, {
+        includeObjective: includeObj,
+      });
+      onSections(byType);
+      setSkipped(skippedObjective);
+    },
+    [onSections],
+  );
+
+  const handleFinal = React.useCallback(
+    (text: string) => {
+      const t = text.trim();
+      if (!t) return;
+      transcriptRef.current = transcriptRef.current
+        ? `${transcriptRef.current} ${t}`
+        : t;
+      setInterim("");
+      route(includeObjRef.current);
+    },
+    [route],
+  );
+
+  const { status, start, stop } = useDictation({
+    onFinal: handleFinal,
+    onInterim: setInterim,
+  });
+
+  const listening = status === "listening";
+  const unsupported = status === "unsupported";
+  const denied = status === "denied";
+
+  function toggleDictation() {
+    if (listening) {
+      stop();
+      setInterim("");
+      onStop?.();
+    } else {
+      transcriptRef.current = "";
+      setSkipped("");
+      setInterim("");
+      onStart();
+      start();
+    }
+  }
+
+  function toggleObjective() {
+    const next = !includeObjective;
+    onToggleObjective(next);
+    // Re-route the transcript so far against the new setting, so flipping it
+    // mid-visit immediately files (or unfiles the hint for) Objective.
+    if (transcriptRef.current) route(next);
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-raised/60 p-3 space-y-2.5">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2.5">
+          <button
+            type="button"
+            onClick={disabled || unsupported ? undefined : toggleDictation}
+            disabled={disabled || unsupported}
+            aria-pressed={listening}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-lg px-3 h-9 text-sm font-medium transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+              listening
+                ? "bg-danger/15 text-danger animate-pulse"
+                : "bg-accent text-accent-ink hover:opacity-90",
+              (disabled || unsupported) && "opacity-40 cursor-not-allowed",
+            )}
+          >
+            <MicIcon listening={listening} />
+            {listening ? "Stop dictating" : "Dictate visit"}
+          </button>
+          <span className="text-[11px] text-text-subtle">
+            {unsupported
+              ? "Dictation isn't supported in this browser."
+              : denied
+                ? "Microphone permission denied."
+                : listening
+                  ? "Listening — say “Subjective…”, “Assessment…”, “Plan…” to route sections."
+                  : "Speak the visit; cue words file each SOAP section automatically."}
+          </span>
+        </div>
+
+        {/* Objective opt-in (the per-physician setting) */}
+        <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+          <span className="text-[11px] text-text-muted">
+            Dictate Objective {includeObjective ? "(vitals)" : "(staff documents)"}
+          </span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={includeObjective}
+            aria-label="Dictate the Objective section"
+            onClick={toggleObjective}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+              includeObjective ? "bg-accent" : "bg-surface-muted border border-border",
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                "pointer-events-none inline-block size-4 transform rounded-full bg-white shadow transition",
+                includeObjective ? "translate-x-4" : "translate-x-0.5",
+                "mt-0.5",
+              )}
+            />
+          </button>
+        </label>
+      </div>
+
+      {/* Live interim ("hearing") preview */}
+      {listening && interim && (
+        <p className="text-xs text-text-subtle italic leading-relaxed">
+          …{interim}
+        </p>
+      )}
+
+      {/* Objective captured-but-not-filed notice */}
+      {skipped && !includeObjective && (
+        <div className="flex items-start gap-2 rounded-md border border-border/60 bg-surface px-2.5 py-1.5 text-[11px] text-text-muted">
+          <span aria-hidden="true" className="shrink-0">🩺</span>
+          <span className="leading-relaxed">
+            Heard Objective/vitals but didn’t file them — your staff documents
+            this section. Turn on <span className="font-medium">Dictate Objective</span> to
+            capture it here.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MicIcon({ listening }: { listening: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill={listening ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="3" width="6" height="11" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0" />
+      <path d="M12 18v3" />
+    </svg>
+  );
+}
+
+export type { SoapRoutableBlock };

--- a/src/lib/clinical/__tests__/dictation-routing.test.ts
+++ b/src/lib/clinical/__tests__/dictation-routing.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { splitIntoApsoSections } from "../voice-dictation";
+import {
+  ensureSoapBlocks,
+  mergeDictatedBody,
+  routeDictationToBlocks,
+  soapTargetTypes,
+} from "../dictation-routing";
+
+const empty = {
+  assessment: "",
+  plan: "",
+  subjective: "",
+  objective: "",
+  unfiled: "",
+};
+
+describe("routeDictationToBlocks", () => {
+  it("folds pre-cue (unfiled) and subjective speech into the summary block", () => {
+    const { byType } = routeDictationToBlocks(
+      { ...empty, unfiled: "Patient reports better sleep.", subjective: "Mood improved." },
+      { includeObjective: false },
+    );
+    expect(byType.summary).toBe("Patient reports better sleep. Mood improved.");
+  });
+
+  it("maps assessment and plan onto their blocks", () => {
+    const { byType } = routeDictationToBlocks(
+      { ...empty, assessment: "Chronic insomnia, improving.", plan: "Continue evening CBD." },
+      { includeObjective: false },
+    );
+    expect(byType.assessment).toBe("Chronic insomnia, improving.");
+    expect(byType.plan).toBe("Continue evening CBD.");
+  });
+
+  it("withholds Objective by default (staff documents vitals)", () => {
+    const result = routeDictationToBlocks(
+      { ...empty, objective: "BP 120/80, HR 72." },
+      { includeObjective: false },
+    );
+    expect(result.byType.findings).toBeUndefined();
+    expect(result.skippedObjective).toBe("BP 120/80, HR 72.");
+  });
+
+  it("routes Objective into findings when the physician opts in", () => {
+    const result = routeDictationToBlocks(
+      { ...empty, objective: "BP 120/80, HR 72." },
+      { includeObjective: true },
+    );
+    expect(result.byType.findings).toBe("BP 120/80, HR 72.");
+    expect(result.skippedObjective).toBe("");
+  });
+
+  it("end-to-end: parses a dictated stream and routes it by SOAP cue", () => {
+    const transcript =
+      "Subjective: patient reports improved sleep. " +
+      "Assessment: chronic insomnia improving. " +
+      "Plan: continue current regimen.";
+    const { byType } = routeDictationToBlocks(
+      splitIntoApsoSections(transcript),
+      { includeObjective: false },
+    );
+    expect(byType.summary).toContain("improved sleep");
+    expect(byType.assessment).toContain("chronic insomnia improving");
+    expect(byType.plan).toContain("continue current regimen");
+  });
+});
+
+describe("mergeDictatedBody", () => {
+  it("appends dictated text below existing content with a blank line", () => {
+    expect(mergeDictatedBody("Seeded by AI.", "Dictated addition.")).toBe(
+      "Seeded by AI.\n\nDictated addition.",
+    );
+  });
+
+  it("returns just the dictated text when the base is empty", () => {
+    expect(mergeDictatedBody("", "Dictated only.")).toBe("Dictated only.");
+  });
+
+  it("leaves the base untouched when there is no dictated text", () => {
+    expect(mergeDictatedBody("Existing.", "")).toBe("Existing.");
+  });
+
+  it("is idempotent across streaming updates against the same base", () => {
+    const base = "AI seed.";
+    const once = mergeDictatedBody(base, "BP rising");
+    const twice = mergeDictatedBody(base, "BP rising and HR up");
+    expect(once).toBe("AI seed.\n\nBP rising");
+    expect(twice).toBe("AI seed.\n\nBP rising and HR up");
+  });
+});
+
+describe("soapTargetTypes", () => {
+  it("excludes Objective by default and includes it on opt-in", () => {
+    expect(soapTargetTypes(false)).toEqual(["summary", "assessment", "plan"]);
+    expect(soapTargetTypes(true)).toEqual(["summary", "findings", "assessment", "plan"]);
+  });
+});
+
+describe("ensureSoapBlocks", () => {
+  it("creates empty APSO-labelled blocks for missing SOAP sections", () => {
+    const result = ensureSoapBlocks([], false);
+    const types = result.map((b) => b.type);
+    // APSO order: assessment, plan, summary, (findings), followUp
+    expect(types).toEqual(["assessment", "plan", "summary"]);
+    expect(result.every((b) => b.body === "")).toBe(true);
+    expect(result.find((b) => b.type === "summary")?.heading).toBe("Subjective");
+  });
+
+  it("adds the Objective block only when opted in, in APSO position", () => {
+    const result = ensureSoapBlocks([], true);
+    expect(result.map((b) => b.type)).toEqual([
+      "assessment",
+      "plan",
+      "summary",
+      "findings",
+    ]);
+  });
+
+  it("preserves existing blocks and their content, APSO-sorted", () => {
+    const existing = [
+      { type: "plan" as const, heading: "Plan", body: "Existing plan." },
+      { type: "assessment" as const, heading: "Assessment", body: "Existing assessment." },
+    ];
+    const result = ensureSoapBlocks(existing, false);
+    expect(result.map((b) => b.type)).toEqual(["assessment", "plan", "summary"]);
+    expect(result.find((b) => b.type === "assessment")?.body).toBe("Existing assessment.");
+    expect(result.find((b) => b.type === "plan")?.body).toBe("Existing plan.");
+    // Only the missing Subjective is added empty.
+    expect(result.find((b) => b.type === "summary")?.body).toBe("");
+  });
+});

--- a/src/lib/clinical/dictation-routing.ts
+++ b/src/lib/clinical/dictation-routing.ts
@@ -1,0 +1,129 @@
+/**
+ * Dictation → SOAP routing.
+ *
+ * Pure helpers that map a dictated, section-split transcript onto the note
+ * editor's blocks. The browser speech wiring (useDictation) and the
+ * section-cue parser (splitIntoApsoSections) already exist; this module is
+ * the deterministic glue between them and the editor's NoteBlock shape, kept
+ * pure so it's unit-testable.
+ *
+ * Section mapping (SOAP ⇄ NoteBlockType):
+ *   Subjective → "summary"     Objective  → "findings"
+ *   Assessment → "assessment"  Plan       → "plan"
+ *
+ * Objective is gated: physicians often have staff document vitals, so the
+ * Objective bucket only routes into the note when the physician has opted in
+ * (the "reading the vitals out loud" case). Otherwise it's returned as
+ * `skippedObjective` so the UI can tell them it was heard but not filed.
+ */
+
+import type { SectionedTranscript } from "./voice-dictation";
+import { APSO_ORDER, NOTE_BLOCK_LABELS, type NoteBlockType } from "@/lib/domain/notes";
+
+/** localStorage key (matches the app's `emr.prefs.v1.*` preference namespace). */
+export const OBJECTIVE_DICTATION_PREF_KEY = "emr.prefs.v1.dictate.objective";
+
+export interface SoapRoutableBlock {
+  type?: NoteBlockType;
+  heading: string;
+  body: string;
+}
+
+export interface DictationRouting {
+  /** Dictated text keyed by note block type (only sections that had speech). */
+  byType: Partial<Record<NoteBlockType, string>>;
+  /** Objective speech heard but not filed (when includeObjective is false). */
+  skippedObjective: string;
+}
+
+function clean(s: string): string {
+  return (s ?? "").trim();
+}
+
+/**
+ * Map a `SectionedTranscript` (from `splitIntoApsoSections`) onto note block
+ * types. Pre-cue "unfiled" speech and Subjective both land in the Subjective
+ * ("summary") block. Objective routes to "findings" only when
+ * `includeObjective` is true; otherwise it's returned as `skippedObjective`.
+ */
+export function routeDictationToBlocks(
+  sectioned: SectionedTranscript,
+  opts: { includeObjective: boolean },
+): DictationRouting {
+  const byType: Partial<Record<NoteBlockType, string>> = {};
+
+  // Anything spoken before a section cue is almost always the patient's
+  // narrative — fold it into Subjective ahead of the cued subjective text.
+  const subjective = [clean(sectioned.unfiled), clean(sectioned.subjective)]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  if (subjective) byType.summary = subjective;
+
+  const assessment = clean(sectioned.assessment);
+  if (assessment) byType.assessment = assessment;
+
+  const plan = clean(sectioned.plan);
+  if (plan) byType.plan = plan;
+
+  const objective = clean(sectioned.objective);
+  let skippedObjective = "";
+  if (objective) {
+    if (opts.includeObjective) byType.findings = objective;
+    else skippedObjective = objective;
+  }
+
+  return { byType, skippedObjective };
+}
+
+/**
+ * Combine a block's pre-dictation base body with the freshly dictated section
+ * text. Dictation is *additive*: it appends below whatever the AI seeded or
+ * the clinician already wrote, separated by a blank line. Idempotent across
+ * streaming updates because callers pass the full section text each time and
+ * always against the same captured base.
+ */
+export function mergeDictatedBody(base: string, dictated: string): string {
+  const b = clean(base);
+  const d = clean(dictated);
+  if (!d) return base ?? "";
+  if (!b) return d;
+  return `${b}\n\n${d}`;
+}
+
+/** The note block types dictation may write into, given the Objective opt-in. */
+export function soapTargetTypes(includeObjective: boolean): NoteBlockType[] {
+  return includeObjective
+    ? ["summary", "findings", "assessment", "plan"]
+    : ["summary", "assessment", "plan"];
+}
+
+function apsoIndex(type?: NoteBlockType): number {
+  const i = type ? APSO_ORDER.indexOf(type) : -1;
+  return i === -1 ? APSO_ORDER.length : i;
+}
+
+/**
+ * Ensure the block list has a slot for every SOAP target type before
+ * dictation starts, appending empty APSO-labelled blocks for any that are
+ * missing (e.g. a template-applied note without a Subjective block). Returns
+ * the list APSO-sorted so the cards don't reorder mid-dictation.
+ */
+export function ensureSoapBlocks<T extends SoapRoutableBlock>(
+  blocks: T[],
+  includeObjective: boolean,
+): (T | SoapRoutableBlock)[] {
+  const present = new Set<NoteBlockType>(
+    blocks
+      .map((b) => b.type)
+      .filter((t): t is NoteBlockType => Boolean(t)),
+  );
+  const additions: SoapRoutableBlock[] = [];
+  for (const type of soapTargetTypes(includeObjective)) {
+    if (!present.has(type)) {
+      additions.push({ type, heading: NOTE_BLOCK_LABELS[type], body: "" });
+    }
+  }
+  const combined: (T | SoapRoutableBlock)[] = [...blocks, ...additions];
+  return combined.sort((a, b) => apsoIndex(a.type) - apsoIndex(b.type));
+}


### PR DESCRIPTION
## Why
Physicians wanted to **dictate a whole visit at the note and have it land in the SOAP sections** — not dictate section-by-section. The editor already had per-section mics; this adds the missing "speak the visit → SOAP" workflow, built on the infrastructure that was already in the repo (`useDictation` + the tested `splitIntoApsoSections` parser).

## What you get
- A **"Dictate visit"** control at the top of the note. Start it, speak the visit using section cues — *"Subjective… Assessment… Plan…"* — and text **streams live into the matching blocks**: Subjective→summary, Assessment, Plan (and Objective when enabled). No model call, instant, private.
- **Additive & non-destructive:** dictation appends *below* existing AI-seeded/typed content; missing SOAP blocks are pre-created in APSO order so cards don't reorder mid-dictation.
- A live "hearing…" preview while you speak.

## Objective is a setting (per your direction)
Practices often have **staff document vitals/Objective**, so:
- New per-physician toggle **"Dictate the Objective section"**, default **OFF**, in both the dictation control *and* a new **Settings → Preferences → Documentation** section (same `emr.prefs.v1.*` localStorage pattern the app already uses).
- **OFF:** dictated Objective/vitals are *captured-but-not-filed* with a gentle hint, not silently dropped. The per-section Objective mic stays hidden.
- **ON** (the "reading vitals aloud" case): dictation routes into Objective and the per-section Objective mic appears.
- **AI *generation* for Objective stays disabled either way** — this only governs the physician's own voice input, so the Dr. Patel "human-authored Objective" rule holds.

## Design notes / follow-ups (not in this PR)
- Routing to a staff/MA "staffing workflow" for Objective documentation.
- Optional AI "structure my freeform dictation" cleanup pass (the deterministic cue-split is v1).

## Files
- `src/lib/clinical/dictation-routing.ts` — pure routing/merge/ensure helpers.
- `src/components/clinical/SoapDictation.tsx` — the control.
- `note-editor.tsx` — wiring + base-snapshot merge + Objective-aware per-section mic.
- `preferences-client.tsx` — Documentation settings section.

## Tests
- `dictation-routing.test.ts` — 13 tests (section routing, Objective gating, idempotent merge, block pre-creation).
- Full clinical lib suite green (269 tests); `tsc --noEmit` clean.

https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3

---
_Generated by [Claude Code](https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3)_