### PR TITLE
feat(notes): staff Objective/vitals documentation workflow

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -6,9 +6,15 @@ import { requireUser } from "@/lib/auth/session";
 import {
   ForbiddenError,
   assertChartAccess,
+  canDocumentObjective,
   hasPermission,
   requiresCosignature,
 } from "@/lib/rbac/permissions";
+import { primaryRole } from "@/lib/rbac/roles";
+import {
+  composeObjectiveBody,
+  type Vitals,
+} from "@/lib/clinical/objective-vitals";
 import { dispatch } from "@/lib/orchestration/dispatch";
 import { runTick } from "@/lib/orchestration/runner";
 import {
@@ -422,6 +428,126 @@ export async function saveEmotionalVital(
 
   revalidatePath(`/clinic/patients/${encounter.patientId}`);
   return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Objective / vitals staffing workflow
+// ---------------------------------------------------------------------------
+// Rooming staff (MAs) document the Objective section before the physician
+// sees the patient. This action is scoped to the "findings" block ONLY —
+// it never touches Assessment/Plan/Subjective and never finalizes — gated by
+// the `notes.objective.document` capability (canDocumentObjective).
+
+const vitalsSchema = z.object({
+  systolic: z.number().min(0).max(400).nullable().optional(),
+  diastolic: z.number().min(0).max(300).nullable().optional(),
+  heartRate: z.number().min(0).max(400).nullable().optional(),
+  temperature: z.number().min(50).max(115).nullable().optional(),
+  tempUnit: z.enum(["F", "C"]).optional(),
+  respiratoryRate: z.number().min(0).max(120).nullable().optional(),
+  spo2: z.number().min(0).max(100).nullable().optional(),
+  weight: z.number().min(0).max(2000).nullable().optional(),
+  weightUnit: z.enum(["lb", "kg"]).optional(),
+  pain: z.number().min(0).max(10).nullable().optional(),
+});
+
+const objectiveDocSchema = z.object({
+  vitals: vitalsSchema,
+  exam: z.string().max(8000),
+});
+
+export async function saveObjectiveDocumentation(
+  noteId: string,
+  input: { vitals: Vitals; exam: string },
+): Promise<SaveNoteResult> {
+  const user = await requireUser();
+
+  // Scoped capability — MAs carry this without full `notes.edit`.
+  if (!canDocumentObjective(user)) {
+    return { ok: false, error: "Forbidden: cannot document the Objective section" };
+  }
+
+  const parsed = objectiveDocSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid vitals or exam input" };
+  }
+
+  const note = await prisma.note.findUnique({
+    where: { id: noteId },
+    include: { encounter: true },
+  });
+  if (!note) return { ok: false, error: "Note not found" };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: { id: note.encounterId, organizationId: user.organizationId! },
+  });
+  if (!encounter) return { ok: false, error: "Unauthorized" };
+
+  try {
+    await assertChartAccess(user, encounter.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Forbidden: chart is restricted" };
+    }
+    throw err;
+  }
+
+  if (note.status === "finalized") {
+    return { ok: false, error: "This note is signed and can no longer be edited." };
+  }
+
+  const body = composeObjectiveBody(parsed.data);
+  const attribution = {
+    objectiveVitals: parsed.data.vitals,
+    objectiveExam: parsed.data.exam,
+    documentedByUserId: user.id,
+    documentedByName: `${user.firstName} ${user.lastName}`.trim(),
+    documentedByRole: primaryRole(user.roles),
+    documentedAt: new Date().toISOString(),
+  };
+
+  // Merge into ONLY the findings block; every other block is preserved
+  // byte-for-byte (including the internal _scribe / _guardrails blocks).
+  const existing: any[] = Array.isArray(note.blocks) ? (note.blocks as any[]) : [];
+  let found = false;
+  const nextBlocks = existing.map((b) => {
+    if (b && typeof b === "object" && (b as any).type === "findings") {
+      found = true;
+      return {
+        ...b,
+        heading: (b as any).heading ?? "Objective",
+        body,
+        metadata: { ...((b as any).metadata ?? {}), ...attribution },
+      };
+    }
+    return b;
+  });
+  if (!found) {
+    nextBlocks.push({ type: "findings", heading: "Objective", body, metadata: attribution });
+  }
+
+  await prisma.note.update({
+    where: { id: noteId },
+    data: { blocks: nextBlocks as any },
+  });
+
+  // Audit the staff PHI write (non-physician documenting on the chart).
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: "note.objective.documented",
+      subjectType: "Note",
+      subjectId: noteId,
+      metadata: {
+        documentedByRole: attribution.documentedByRole,
+        vitals: parsed.data.vitals as any,
+      },
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${encounter.patientId}`);
+  return { ok: true, status: note.status };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -4,9 +4,13 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { formatDate } from "@/lib/utils/format";
 import { NoteEditor } from "./note-editor";
+import { StaffObjectiveEditor } from "./staff-objective-editor";
 import { NoteCommentsPanel } from "@/components/collaboration/note-comments-panel";
+import { hasPermission, canDocumentObjective } from "@/lib/rbac/permissions";
+import { coerceVitals } from "@/lib/clinical/objective-vitals";
 
 interface PageProps {
   params: { id: string; noteId: string };
@@ -52,6 +56,39 @@ export default async function NoteDetailPage({ params }: PageProps) {
       (b as { heading: string }).heading !== "_guardrails",
   );
 
+  // Role-aware authoring surface. Physicians/mid-levels get the full editor;
+  // rooming staff (MAs) with only the scoped Objective capability get the
+  // vitals/exam editor; read-only viewers see a static render; anyone with no
+  // note access at all is bounced to notFound (front-office has no clinical
+  // grant and should never see chart content).
+  const canEditNotes = hasPermission(user, "notes.edit");
+  const canDocObjective = canDocumentObjective(user);
+  const canReadNotes = hasPermission(user, "notes.read");
+  if (!canEditNotes && !canDocObjective && !canReadNotes) notFound();
+
+  // Pull the Objective ("findings") block (+ any prior staff attribution) for
+  // the staff editor's initial state.
+  const findingsBlock = rawBlocks.find(
+    (b): b is Record<string, unknown> =>
+      !!b && typeof b === "object" && (b as { type?: unknown }).type === "findings",
+  ) as Record<string, unknown> | undefined;
+  const fMeta = (findingsBlock?.metadata ?? {}) as Record<string, unknown>;
+  const initialVitals = coerceVitals(fMeta.objectiveVitals);
+  const initialExam =
+    typeof fMeta.objectiveExam === "string"
+      ? fMeta.objectiveExam
+      : typeof findingsBlock?.body === "string"
+        ? (findingsBlock.body as string)
+        : "";
+  const initialAttribution =
+    fMeta.documentedByName || fMeta.documentedAt
+      ? {
+          name: typeof fMeta.documentedByName === "string" ? fMeta.documentedByName : undefined,
+          role: typeof fMeta.documentedByRole === "string" ? fMeta.documentedByRole : undefined,
+          at: typeof fMeta.documentedAt === "string" ? fMeta.documentedAt : undefined,
+        }
+      : null;
+
   // Parse coding suggestion. `icd10` is a JSON column — runtime-validate
   // that it's actually an array before handing it to the client, otherwise
   // a legacy/malformed row will crash the editor on render.
@@ -88,28 +125,66 @@ export default async function NoteDetailPage({ params }: PageProps) {
         }
       />
 
-      <NoteEditor
-        noteId={note.id}
-        patientId={params.id}
-        encounterId={note.encounterId}
-        initialBlocks={blocks}
-        status={note.status}
-        aiDrafted={note.aiDrafted}
-        aiConfidence={note.aiConfidence}
-        codingSuggestion={codingSuggestion}
-        initialDemeanor={
-          note.encounter.briefingContext &&
-          typeof note.encounter.briefingContext === "object" &&
-          "patientDemeanor" in (note.encounter.briefingContext as Record<string, unknown>)
-            ? ((note.encounter.briefingContext as Record<string, unknown>).patientDemeanor as any)
-            : null
-        }
-      />
+      {canEditNotes ? (
+        <NoteEditor
+          noteId={note.id}
+          patientId={params.id}
+          encounterId={note.encounterId}
+          initialBlocks={blocks}
+          status={note.status}
+          aiDrafted={note.aiDrafted}
+          aiConfidence={note.aiConfidence}
+          codingSuggestion={codingSuggestion}
+          initialDemeanor={
+            note.encounter.briefingContext &&
+            typeof note.encounter.briefingContext === "object" &&
+            "patientDemeanor" in (note.encounter.briefingContext as Record<string, unknown>)
+              ? ((note.encounter.briefingContext as Record<string, unknown>).patientDemeanor as any)
+              : null
+          }
+        />
+      ) : canDocObjective ? (
+        <StaffObjectiveEditor
+          noteId={note.id}
+          patientName={`${patient.firstName} ${patient.lastName}`}
+          modality={note.encounter.modality}
+          status={note.status}
+          initialVitals={initialVitals}
+          initialExam={initialExam}
+          initialAttribution={initialAttribution}
+        />
+      ) : (
+        <ReadOnlyNote blocks={blocks} />
+      )}
 
       {/* ux/comments-mentions-collab — inline collaboration on chart notes */}
       <div className="mt-8">
         <NoteCommentsPanel noteId={note.id} patientId={params.id} />
       </div>
     </PageShell>
+  );
+}
+
+/** Static, read-only note render for users with `notes.read` but no edit. */
+function ReadOnlyNote({
+  blocks,
+}: {
+  blocks: { heading: string; body: string }[];
+}) {
+  return (
+    <div className="space-y-3">
+      {blocks.map((block, i) => (
+        <Card key={i}>
+          <CardContent className="pt-5 pb-5 space-y-2">
+            <h3 className="font-display text-lg font-medium text-text tracking-tight">
+              {block.heading}
+            </h3>
+            <p className="text-sm text-text-muted leading-relaxed whitespace-pre-wrap">
+              {block.body}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/staff-objective-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/staff-objective-editor.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+/**
+ * Staff (MA) Objective / vitals documentation surface.
+ *
+ * Rendered instead of the full NoteEditor when the signed-in user can document
+ * the Objective section but cannot edit the rest of the note (rooming staff).
+ * They capture structured vitals + a free-text exam; on save it writes ONLY
+ * the note's findings block via the scoped `saveObjectiveDocumentation` action.
+ * The physician later opens the note to a staff-authored Objective already in
+ * place and dictates the rest.
+ */
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { FieldGroup, Input } from "@/components/ui/input";
+import { DictateButton } from "@/components/ui/dictation";
+import { cn } from "@/lib/utils/cn";
+import {
+  composeObjectiveBody,
+  formatVitalsLine,
+  type Vitals,
+} from "@/lib/clinical/objective-vitals";
+import { saveObjectiveDocumentation } from "./actions";
+
+interface Attribution {
+  name?: string;
+  role?: string;
+  at?: string;
+}
+
+interface StaffObjectiveEditorProps {
+  noteId: string;
+  patientName: string;
+  modality: string;
+  status: string;
+  initialVitals: Vitals;
+  initialExam: string;
+  initialAttribution?: Attribution | null;
+}
+
+const parseNum = (s: string): number | null => {
+  const t = s.trim();
+  if (t === "") return null;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
+};
+
+export function StaffObjectiveEditor({
+  noteId,
+  patientName,
+  modality,
+  status,
+  initialVitals,
+  initialExam,
+  initialAttribution,
+}: StaffObjectiveEditorProps) {
+  const router = useRouter();
+  const [vitals, setVitals] = React.useState<Vitals>(initialVitals);
+  const [exam, setExam] = React.useState(initialExam);
+  const [saving, setSaving] = React.useState(false);
+  const [message, setMessage] = React.useState<string | null>(null);
+  const [savedAttribution, setSavedAttribution] = React.useState<Attribution | null>(
+    initialAttribution ?? null,
+  );
+
+  const finalized = status === "finalized";
+  const editable = !finalized;
+
+  function setV<K extends keyof Vitals>(key: K, value: Vitals[K]) {
+    setVitals((prev) => ({ ...prev, [key]: value }));
+  }
+
+  const previewBody = composeObjectiveBody({ vitals, exam });
+  const vitalsLine = formatVitalsLine(vitals);
+
+  function handleSave() {
+    setSaving(true);
+    setMessage(null);
+    void saveObjectiveDocumentation(noteId, { vitals, exam })
+      .then((res) => {
+        if (res.ok) {
+          setMessage("Objective saved");
+          setSavedAttribution({
+            name: "You",
+            role: "back office",
+            at: new Date().toISOString(),
+          });
+          router.refresh();
+          setTimeout(() => setMessage(null), 2500);
+        } else {
+          setMessage(res.error);
+        }
+      })
+      .finally(() => setSaving(false));
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="border-l-4 border-l-accent bg-accent/[0.03]">
+        <CardContent className="py-3">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-accent font-medium mb-1">
+            Rooming · Objective
+          </p>
+          <p className="text-xs text-text-muted leading-relaxed">
+            Document vitals and exam findings for {patientName}&apos;s {modality} visit.
+            This fills the <span className="font-medium">Objective</span> section
+            only — the provider completes Assessment &amp; Plan and signs the note.
+          </p>
+        </CardContent>
+      </Card>
+
+      {savedAttribution?.at && (
+        <div className="flex items-center gap-2 text-[11px] text-text-subtle">
+          <Badge tone="neutral">Documented</Badge>
+          <span>
+            Last saved
+            {savedAttribution.name ? ` by ${savedAttribution.name}` : ""} ·{" "}
+            {new Date(savedAttribution.at).toLocaleString()}
+          </span>
+        </div>
+      )}
+
+      <Card tone="raised">
+        <CardHeader>
+          <CardTitle>Vitals</CardTitle>
+          <CardDescription>
+            Leave any field blank if not measured.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <fieldset disabled={!editable} className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <FieldGroup label="BP systolic" htmlFor="v-sys">
+              <Input
+                id="v-sys"
+                inputMode="numeric"
+                placeholder="120"
+                value={vitals.systolic ?? ""}
+                onChange={(e) => setV("systolic", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label="BP diastolic" htmlFor="v-dia">
+              <Input
+                id="v-dia"
+                inputMode="numeric"
+                placeholder="80"
+                value={vitals.diastolic ?? ""}
+                onChange={(e) => setV("diastolic", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label="Heart rate (bpm)" htmlFor="v-hr">
+              <Input
+                id="v-hr"
+                inputMode="numeric"
+                placeholder="72"
+                value={vitals.heartRate ?? ""}
+                onChange={(e) => setV("heartRate", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label={`Temp (°${vitals.tempUnit ?? "F"})`} htmlFor="v-temp">
+              <Input
+                id="v-temp"
+                inputMode="decimal"
+                placeholder="98.6"
+                value={vitals.temperature ?? ""}
+                onChange={(e) => setV("temperature", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label="Resp rate" htmlFor="v-rr">
+              <Input
+                id="v-rr"
+                inputMode="numeric"
+                placeholder="16"
+                value={vitals.respiratoryRate ?? ""}
+                onChange={(e) => setV("respiratoryRate", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label="SpO2 (%)" htmlFor="v-spo2">
+              <Input
+                id="v-spo2"
+                inputMode="numeric"
+                placeholder="98"
+                value={vitals.spo2 ?? ""}
+                onChange={(e) => setV("spo2", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label={`Weight (${vitals.weightUnit ?? "lb"})`} htmlFor="v-wt">
+              <Input
+                id="v-wt"
+                inputMode="decimal"
+                placeholder="180"
+                value={vitals.weight ?? ""}
+                onChange={(e) => setV("weight", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+            <FieldGroup label="Pain (0–10)" htmlFor="v-pain">
+              <Input
+                id="v-pain"
+                inputMode="numeric"
+                placeholder="3"
+                value={vitals.pain ?? ""}
+                onChange={(e) => setV("pain", parseNum(e.target.value))}
+              />
+            </FieldGroup>
+          </fieldset>
+          {vitalsLine && (
+            <p className="mt-3 text-xs text-text-muted">
+              <span className="font-medium text-text">Preview:</span> {vitalsLine}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card tone="raised">
+        <CardHeader>
+          <CardTitle>Exam / observations</CardTitle>
+          <CardDescription>
+            Free text. Use the mic to dictate.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="relative">
+            <textarea
+              value={exam}
+              disabled={!editable}
+              onChange={(e) => setExam(e.target.value)}
+              rows={Math.max(4, exam.split("\n").length + 1)}
+              placeholder="General appearance, focused exam findings…"
+              aria-label="Objective exam"
+              className={cn(
+                "w-full rounded-md border border-border-strong/70 bg-surface px-3 py-2 pr-10 text-sm text-text",
+                "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20",
+                "disabled:opacity-60",
+              )}
+            />
+            {editable && (
+              <DictateButton
+                onText={(text) => {
+                  setExam((prev) => {
+                    const sep = prev && !/\s$/.test(prev) ? " " : "";
+                    return `${prev}${sep}${text.trim()}`;
+                  });
+                }}
+                className="absolute top-2 right-2"
+              />
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {previewBody && (
+        <Card tone="ambient">
+          <CardContent className="py-3">
+            <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle mb-1">
+              Objective section preview
+            </p>
+            <p className="text-sm text-text-muted leading-relaxed whitespace-pre-wrap">
+              {previewBody}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {editable ? (
+        <div className="flex items-center gap-3 pt-1">
+          <Button variant="primary" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save Objective"}
+          </Button>
+          {message && <span className="text-sm text-text-muted">{message}</span>}
+        </div>
+      ) : (
+        <p className="text-sm text-text-subtle">
+          This note is signed — the Objective can no longer be edited.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/clinical/__tests__/objective-vitals.test.ts
+++ b/src/lib/clinical/__tests__/objective-vitals.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceVitals,
+  composeObjectiveBody,
+  formatVitalsLine,
+  isObjectiveEmpty,
+  type Vitals,
+} from "../objective-vitals";
+
+const full: Vitals = {
+  systolic: 120,
+  diastolic: 80,
+  heartRate: 72,
+  temperature: 98.6,
+  tempUnit: "F",
+  respiratoryRate: 16,
+  spo2: 98,
+  weight: 180,
+  weightUnit: "lb",
+  pain: 3,
+};
+
+describe("formatVitalsLine", () => {
+  it("formats a complete set of vitals", () => {
+    expect(formatVitalsLine(full)).toBe(
+      "BP 120/80 · HR 72 · Temp 98.6°F · RR 16 · SpO2 98% · Wt 180 lb · Pain 3/10",
+    );
+  });
+
+  it("omits blank fields", () => {
+    expect(formatVitalsLine({ heartRate: 72, spo2: 98 })).toBe("HR 72 · SpO2 98%");
+  });
+
+  it("renders a one-sided BP when only systolic is present", () => {
+    expect(formatVitalsLine({ systolic: 120 })).toBe("BP 120/–");
+  });
+
+  it("honors metric units", () => {
+    expect(formatVitalsLine({ temperature: 37, tempUnit: "C", weight: 80, weightUnit: "kg" })).toBe(
+      "Temp 37°C · Wt 80 kg",
+    );
+  });
+
+  it("returns empty string when nothing is recorded", () => {
+    expect(formatVitalsLine({})).toBe("");
+  });
+});
+
+describe("composeObjectiveBody", () => {
+  it("leads with a bold vitals line, then the exam", () => {
+    expect(composeObjectiveBody({ vitals: { heartRate: 72 }, exam: "Alert, NAD." })).toBe(
+      "**Vitals:** HR 72\n\nAlert, NAD.",
+    );
+  });
+
+  it("renders exam alone when no vitals were taken", () => {
+    expect(composeObjectiveBody({ vitals: {}, exam: "Lungs clear." })).toBe("Lungs clear.");
+  });
+
+  it("renders vitals alone when there's no exam text", () => {
+    expect(composeObjectiveBody({ vitals: { spo2: 99 }, exam: "  " })).toBe("**Vitals:** SpO2 99%");
+  });
+
+  it("is empty when nothing is provided", () => {
+    expect(composeObjectiveBody({ vitals: {}, exam: "" })).toBe("");
+  });
+});
+
+describe("isObjectiveEmpty", () => {
+  it("is true only when both vitals and exam are blank", () => {
+    expect(isObjectiveEmpty({ vitals: {}, exam: "" })).toBe(true);
+    expect(isObjectiveEmpty({ vitals: { heartRate: 72 }, exam: "" })).toBe(false);
+    expect(isObjectiveEmpty({ vitals: {}, exam: "note" })).toBe(false);
+  });
+});
+
+describe("coerceVitals", () => {
+  it("narrows a metadata-shaped object and defaults units", () => {
+    const v = coerceVitals({ systolic: 118, diastolic: 76, spo2: 97 });
+    expect(v.systolic).toBe(118);
+    expect(v.diastolic).toBe(76);
+    expect(v.spo2).toBe(97);
+    expect(v.tempUnit).toBe("F");
+    expect(v.weightUnit).toBe("lb");
+    expect(v.heartRate).toBeNull();
+  });
+
+  it("drops non-finite/garbage values to null", () => {
+    const v = coerceVitals({ heartRate: "fast", systolic: NaN, pain: 4 });
+    expect(v.heartRate).toBeNull();
+    expect(v.systolic).toBeNull();
+    expect(v.pain).toBe(4);
+  });
+
+  it("returns empties for non-object input", () => {
+    expect(coerceVitals(null).systolic).toBeNull();
+    expect(coerceVitals("nope").heartRate).toBeNull();
+  });
+});

--- a/src/lib/clinical/objective-vitals.ts
+++ b/src/lib/clinical/objective-vitals.ts
@@ -1,0 +1,104 @@
+/**
+ * Objective / vitals documentation helpers.
+ *
+ * The Objective ("findings") section is often documented by rooming staff
+ * (MAs) rather than the physician. Staff capture structured vitals + a
+ * free-text exam; this module composes them into the note's Objective block
+ * body (markdown) and keeps the raw values in block metadata so they stay
+ * queryable later (a dedicated Vitals table is a future migration).
+ *
+ * Pure + framework-free so the formatting is unit-testable.
+ */
+
+export interface Vitals {
+  /** Systolic / diastolic blood pressure (mmHg). */
+  systolic?: number | null;
+  diastolic?: number | null;
+  /** Heart rate (bpm). */
+  heartRate?: number | null;
+  /** Temperature, in `tempUnit`. */
+  temperature?: number | null;
+  tempUnit?: "F" | "C";
+  /** Respiratory rate (breaths/min). */
+  respiratoryRate?: number | null;
+  /** Oxygen saturation (%). */
+  spo2?: number | null;
+  /** Weight, in `weightUnit`. */
+  weight?: number | null;
+  weightUnit?: "lb" | "kg";
+  /** Patient-reported pain, 0–10. */
+  pain?: number | null;
+}
+
+export interface ObjectiveDocumentation {
+  vitals: Vitals;
+  /** Free-text exam / observations the staff member adds. */
+  exam: string;
+}
+
+const num = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+/** Format the vitals object into a single compact line, omitting blanks. */
+export function formatVitalsLine(vitals: Vitals): string {
+  const parts: string[] = [];
+  const sys = num(vitals.systolic);
+  const dia = num(vitals.diastolic);
+  if (sys != null && dia != null) parts.push(`BP ${sys}/${dia}`);
+  else if (sys != null) parts.push(`BP ${sys}/–`);
+
+  const hr = num(vitals.heartRate);
+  if (hr != null) parts.push(`HR ${hr}`);
+
+  const temp = num(vitals.temperature);
+  if (temp != null) parts.push(`Temp ${temp}°${vitals.tempUnit ?? "F"}`);
+
+  const rr = num(vitals.respiratoryRate);
+  if (rr != null) parts.push(`RR ${rr}`);
+
+  const spo2 = num(vitals.spo2);
+  if (spo2 != null) parts.push(`SpO2 ${spo2}%`);
+
+  const wt = num(vitals.weight);
+  if (wt != null) parts.push(`Wt ${wt} ${vitals.weightUnit ?? "lb"}`);
+
+  const pain = num(vitals.pain);
+  if (pain != null) parts.push(`Pain ${pain}/10`);
+
+  return parts.join(" · ");
+}
+
+/** True when no vitals field and no exam text were provided. */
+export function isObjectiveEmpty(doc: ObjectiveDocumentation): boolean {
+  return formatVitalsLine(doc.vitals) === "" && doc.exam.trim() === "";
+}
+
+/**
+ * Compose the Objective block body (markdown) from structured vitals + exam.
+ * Vitals render as a bold-led line; the exam follows as free text.
+ */
+export function composeObjectiveBody(doc: ObjectiveDocumentation): string {
+  const vitalsLine = formatVitalsLine(doc.vitals);
+  const exam = doc.exam.trim();
+  const sections: string[] = [];
+  if (vitalsLine) sections.push(`**Vitals:** ${vitalsLine}`);
+  if (exam) sections.push(exam);
+  return sections.join("\n\n");
+}
+
+/** Narrow an unknown (e.g. block metadata) into a normalized Vitals object. */
+export function coerceVitals(raw: unknown): Vitals {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    systolic: num(r.systolic),
+    diastolic: num(r.diastolic),
+    heartRate: num(r.heartRate),
+    temperature: num(r.temperature),
+    tempUnit: r.tempUnit === "C" ? "C" : "F",
+    respiratoryRate: num(r.respiratoryRate),
+    spo2: num(r.spo2),
+    weight: num(r.weight),
+    weightUnit: r.weightUnit === "kg" ? "kg" : "lb",
+    pain: num(r.pain),
+  };
+}

--- a/src/lib/rbac/permissions.test.ts
+++ b/src/lib/rbac/permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Role } from "@prisma/client";
 import {
+  canDocumentObjective,
   canEditSection,
   canViewSection,
   ForbiddenError,
@@ -73,6 +74,26 @@ describe("hasPermission — clinician", () => {
 
   it("can manage chart privacy", () => {
     expect(hasPermission(user("clinician"), "chart.privacy.manage")).toBe(true);
+  });
+});
+
+describe("canDocumentObjective — staffing workflow", () => {
+  it("back_office (MAs) can document Objective but still cannot edit the note", () => {
+    const u = user("back_office");
+    expect(hasPermission(u, "notes.objective.document")).toBe(true);
+    expect(canDocumentObjective(u)).toBe(true);
+    // Scoped: must NOT grant full note editing.
+    expect(hasPermission(u, "notes.edit")).toBe(false);
+  });
+
+  it("front_office cannot document the Objective", () => {
+    expect(canDocumentObjective(user("front_office"))).toBe(false);
+    expect(hasPermission(user("front_office"), "notes.objective.document")).toBe(false);
+  });
+
+  it("clinicians and mid-levels can document Objective via notes.edit", () => {
+    expect(canDocumentObjective(user("clinician"))).toBe(true);
+    expect(canDocumentObjective(user("midlevel"))).toBe(true);
   });
 });
 

--- a/src/lib/rbac/permissions.ts
+++ b/src/lib/rbac/permissions.ts
@@ -46,6 +46,11 @@ export type Permission =
   // Clinical notes (SOAP, progress, telehealth, etc.).
   | "notes.read"
   | "notes.edit"
+  // Scoped Objective/vitals documentation. Narrower than `notes.edit`:
+  // lets rooming staff (MAs) document ONLY the Objective ("findings")
+  // section of a note — never the rest, never finalize. Clinicians and
+  // mid-levels carry it implicitly via `notes.edit`.
+  | "notes.objective.document"
   // Clinical history: problems list, encounter history, prior diagnoses.
   | "clinical_history.read"
   // Sensitive diagnoses (behavioral health, substance use, HIV, etc.).
@@ -94,6 +99,9 @@ const PERMISSIONS: Record<Role, ReadonlySet<Permission>> = {
     "billing.read",
     "billing.edit",
     "notes.read",
+    // MAs room patients and record vitals/exam. Scoped to the Objective
+    // section only — they still cannot author or edit the rest of the note.
+    "notes.objective.document",
     "clinical_history.read",
   ]),
 
@@ -213,6 +221,19 @@ export function requirePermission(
   if (!hasPermission(user, permission)) {
     throw new ForbiddenError({ permission, reason: "role" });
   }
+}
+
+/**
+ * Can this user document the Objective / vitals section of a note? True for
+ * full note editors (clinician, mid-level, owner — via `notes.edit`) and for
+ * rooming staff (MAs) who carry only the scoped `notes.objective.document`
+ * grant. Use this to gate the staff Objective workflow.
+ */
+export function canDocumentObjective(user: Pick<AuthedUser, "roles">): boolean {
+  return (
+    hasPermission(user, "notes.edit") ||
+    hasPermission(user, "notes.objective.document")
+  );
 }
 
 /**


### PR DESCRIPTION
## Why
This is the **staffing workflow** follow-up to the dictation work (#528). Practices have **MAs document the Objective/vitals** during rooming — which is exactly why physician Objective-dictation defaults off. Today the permission model blocks this: `front_office` has no note access and `back_office` (where MAs live) is read-only, with no Vitals model. This adds a *scoped* path so an MA can fill the Objective — and only the Objective — before the physician opens the note.

## What it does
- **New scoped permission `notes.objective.document`** (+ `canDocumentObjective` helper). Granted to **back_office (MAs)**; clinicians/mid-levels get it implicitly via `notes.edit`. It is **strictly narrower** than `notes.edit` — staff still can't author/edit the rest of the note or finalize (locked in by permission tests).
- **`saveObjectiveDocumentation` server action** — writes **only** the `findings` block (all other blocks, including internal `_scribe`/`_guardrails`, preserved byte-for-byte), stamps attribution (who/role/when) into block metadata, writes an **audit-log** row, refuses finalized notes, and is org- + chart-privacy-gated.
- **Structured vitals capture** — BP, HR, Temp, RR, SpO2, Weight, Pain + a dictatable free-text exam, composed into the Objective body by a pure, unit-tested module (`objective-vitals.ts`). Raw values are kept in metadata so they stay queryable.
- **Role-aware note route** — physicians/mid-levels → full `NoteEditor`; MAs → new `StaffObjectiveEditor`; `notes.read`-only → static render; no-access → `notFound()` (this also closes a latent gap where *any* `/clinic` visitor reached the editor).

The physician then opens the note to a staff-filled Objective already in place (the `**Vitals:** …` line), and dictates the rest.

## Decisions (per product owner)
- **Who:** back-office MAs get the capability; front office excluded; mid-levels already covered.
- **Capture:** structured vitals + exam (not free-text-only).

## Follow-ups (noted, not in this PR)
- A physician-facing "Documented by [MA] · [time]" badge in the note editor (attribution is already stored; left out here to avoid churn with the open #528 dictation PR on the same file).
- A dedicated `Vitals` table for first-class querying (today they live in note metadata).
- A rooming queue/task to route patients to staff for vitals.

## Tests
- `objective-vitals.test.ts` — 13 tests (formatting, composition, coercion).
- `permissions.test.ts` — added: back_office can document Objective but **not** edit; front_office cannot; clinician/midlevel via `notes.edit`.
- `tsc --noEmit` clean.

> Note: touches `permissions.ts` and the note route but **not** `note-editor.tsx`, so it does not conflict with #528.

https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3

---
_Generated by [Claude Code](https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3)_