### PR TITLE
fix(billing): use DTM*405 production date when 835 omits BPR16

### DIFF
--- a/src/lib/billing/era-parser.test.ts
+++ b/src/lib/billing/era-parser.test.ts
@@ -91,6 +91,22 @@ describe("parseEra835", () => {
     expect(era.claimPayments[0].totalPaidCents).toBeLessThan(0);
   });
 
+  it("uses the BPR16 effective date as the check date", () => {
+    const era = parseEra835(MINIMAL_835);
+    expect(era.checkDate).toEqual(new Date(Date.UTC(2006, 2, 10)));
+  });
+
+  it("falls back to the DTM*405 production date when BPR16 is omitted", () => {
+    // Drop the trailing BPR16 effective date (last element of the BPR
+    // segment) so the parser must fall back to DTM*405 (20060310).
+    const noBprDate = MINIMAL_835.replace(
+      "DA*98765*20060310~",
+      "DA*98765~",
+    );
+    const era = parseEra835(noBprDate);
+    expect(era.checkDate).toEqual(new Date(Date.UTC(2006, 2, 10)));
+  });
+
   it("throws Era835ParseError when TRN trace is missing", () => {
     const broken = MINIMAL_835.replace("TRN*1*EFT12345*1234567890~", "");
     expect(() => parseEra835(broken)).toThrow(Era835ParseError);

--- a/src/lib/billing/era-parser.ts
+++ b/src/lib/billing/era-parser.ts
@@ -163,7 +163,11 @@ export function parseEra835(payload: string): ParsedEra835 {
   let payeeName = "";
   let payeeNpi: string | null = null;
   let checkNumber = "";
-  let checkDate = new Date();
+  // Null until a date segment supplies one — BPR16 (effective date) is
+  // authoritative, DTM*405 (production date) is the fallback. We default
+  // to "now" only at return time if neither is present, so the DTM
+  // fallback below is actually reachable when BPR16 is omitted.
+  let checkDate: Date | null = null;
   let paymentMethod: ParsedEra835["paymentMethod"] = "ach";
   let totalPaymentCents = 0;
 
@@ -317,7 +321,7 @@ export function parseEra835(payload: string): ParsedEra835 {
     payeeName,
     payeeNpi,
     checkNumber,
-    checkDate,
+    checkDate: checkDate ?? new Date(),
     paymentMethod,
     totalPaymentCents,
     claimPayments,


### PR DESCRIPTION
## Context

Assigned Phase 12 Track 5 (Financial Operations & Lockbox). On investigation, **the entire Track 5 feature set is already implemented and merged to `main`** — every named deliverable (ERA/835 parser, lockbox matcher, RCM daily-close, and the `ops/revenue` / `ops/era` / `ops/lockbox` / `ops/daily-close` dashboards) exists, and all 15 tickets (EMR-068/076/105/106/114/115/127/172/221/224/225/226/227/228/230) map to existing lib files. Typecheck, lint, and 39/39 billing tests pass as-is.

Rather than re-implement existing code, this PR ships the one genuine defect surfaced while reviewing those deliverables.

## The bug

In `src/lib/billing/era-parser.ts`, `parseEra835` initialized `checkDate` to `new Date()`. That made the `!checkDate` guard on the `DTM*405` fallback **permanently false** — dead code. When a payer's 835 omitted the `BPR16` effective date, the check date silently defaulted to *"now"* instead of the `DTM*405` production date.

Downstream impact:
- **Lockbox matching (EMR-224)** uses `expectedDate` in a ±5-day window; a wrong check date pushes legitimate ERAs out of the window → false "unmatched" exceptions.
- **Daily-close reconciliation (EMR-230)** buckets by check date.

## The fix

- Initialize `checkDate` to `null`; let `BPR16` (authoritative) and `DTM*405` (fallback) populate it in segment order.
- Default to `new Date()` only at return time, when neither date segment is present.
- Regression tests for both the BPR16-present and BPR16-absent paths.

## Verification

- `tsc --noEmit` → exit 0
- `next lint` on changed files → clean
- `vitest run src/lib/billing/era-parser.test.ts` → 16/16 pass (was 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)