### PR TITLE
Phase 12 Track 8: Clinical Education & Integrations

### DIFF
--- a/public/guides/README.md
+++ b/public/guides/README.md
@@ -1,0 +1,20 @@
+# Education guide assets
+
+Downloadable PDFs surfaced from the public Education tab.
+
+| File | Ticket | Surfaced at |
+| --- | --- | --- |
+| `cannabis-and-cancer.pdf` | EMR-202 | Education → Research (below the PubMed search) |
+| `leafjourney-trifold-reference-guide.pdf` | EMR-203 | Education → Reference Guide (`/education/trifold`) |
+
+These PDFs are generated, not hand-edited. Regenerate after changing the
+source content:
+
+```bash
+node scripts/generate-guides.mjs
+```
+
+The interactive web-flip trifold lives at `/education/trifold`; the canonical,
+continually-updated Cannabis & Cancer book lives at
+<https://freecannabiscancerbook.com>. Downloads are recorded via the
+`trackGuideDownload` server action for the education analytics pipeline.

--- a/public/guides/cannabis-and-cancer.pdf
+++ b/public/guides/cannabis-and-cancer.pdf
@@ -1,0 +1,69 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [5 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 980 >>
+stream
+BT
+/F1 26 Tf
+1 0 0 1 72 720 Tm
+(Cannabis and Cancer) Tj
+/F1 13 Tf
+1 0 0 1 72 680 Tm
+(A Research Reference  -  compiled by Justin Kander) Tj
+/F1 11 Tf
+1 0 0 1 72 650 Tm
+(Leafjourney Education Library) Tj
+/F1 12 Tf
+1 0 0 1 72 610 Tm
+(This reference summarises a large compilation of human case) Tj
+/F1 12 Tf
+1 0 0 1 72 592 Tm
+(reports and peer-reviewed research on the interaction between) Tj
+/F1 12 Tf
+1 0 0 1 72 574 Tm
+(cannabinoids and cancer.) Tj
+/F1 12 Tf
+1 0 0 1 72 546 Tm
+(The complete, continually updated book is available free online:) Tj
+/F1 12 Tf
+1 0 0 1 72 528 Tm
+(https://freecannabiscancerbook.com) Tj
+/F1 12 Tf
+1 0 0 1 72 500 Tm
+(Search the underlying studies on PubMed directly from the) Tj
+/F1 12 Tf
+1 0 0 1 72 482 Tm
+(Research tab at https://leafjourney.com/education) Tj
+/F1 10 Tf
+1 0 0 1 72 442 Tm
+(For education only. Not medical advice. Cannabis products are) Tj
+/F1 10 Tf
+1 0 0 1 72 426 Tm
+(not FDA-approved medications. Always consult your care team.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 4 0 R >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000185 00000 n 
+0000001216 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1342
+%%EOF

--- a/public/guides/leafjourney-trifold-reference-guide.pdf
+++ b/public/guides/leafjourney-trifold-reference-guide.pdf
@@ -1,0 +1,126 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [5 0 R 7 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 998 >>
+stream
+BT
+/F1 24 Tf
+1 0 0 1 72 720 Tm
+(LeafJourney Reference Guide) Tj
+/F1 12 Tf
+1 0 0 1 72 684 Tm
+(Cannabinoids - Terpenes - Bioavailability - Dosing) Tj
+/F1 14 Tf
+1 0 0 1 72 652 Tm
+(MAJOR CANNABINOIDS) Tj
+/F1 11 Tf
+1 0 0 1 72 630 Tm
+(THC - euphoria, pain, appetite, nausea) Tj
+/F1 11 Tf
+1 0 0 1 72 613 Tm
+(CBD - calm, inflammation, seizures \(non-intoxicating\)) Tj
+/F1 11 Tf
+1 0 0 1 72 596 Tm
+(CBN - sedation, sleep support) Tj
+/F1 11 Tf
+1 0 0 1 72 579 Tm
+(CBG - focus, gut comfort, antibacterial) Tj
+/F1 11 Tf
+1 0 0 1 72 562 Tm
+(CBC - mood and inflammation support) Tj
+/F1 14 Tf
+1 0 0 1 72 538 Tm
+(TERPENES \(aroma  ->  effect\)) Tj
+/F1 11 Tf
+1 0 0 1 72 516 Tm
+(Limonene - citrus - uplifting) Tj
+/F1 11 Tf
+1 0 0 1 72 499 Tm
+(Pinene - pine - alert, clear-headed) Tj
+/F1 11 Tf
+1 0 0 1 72 482 Tm
+(Caryophyllene - pepper - calming, anti-inflammatory) Tj
+/F1 11 Tf
+1 0 0 1 72 465 Tm
+(Linalool - lavender - relaxing, sleep) Tj
+/F1 11 Tf
+1 0 0 1 72 448 Tm
+(Myrcene - earthy - sedating, body relaxation) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 4 0 R >>
+endobj
+6 0 obj
+<< /Length 1013 >>
+stream
+BT
+/F1 16 Tf
+1 0 0 1 72 720 Tm
+(BIOAVAILABILITY BY ROUTE) Tj
+/F1 11 Tf
+1 0 0 1 72 692 Tm
+(Inhaled \(vapor/smoke\) - onset 1-5 min - duration 2-4 h) Tj
+/F1 11 Tf
+1 0 0 1 72 675 Tm
+(Sublingual tincture - onset 15-45 min - duration 4-8 h) Tj
+/F1 11 Tf
+1 0 0 1 72 658 Tm
+(Edible/capsule - onset 30-120 min - duration 6-8 h) Tj
+/F1 11 Tf
+1 0 0 1 72 641 Tm
+(Topical - localized - no intoxication) Tj
+/F1 16 Tf
+1 0 0 1 72 611 Tm
+(HOW TO START - Start Low, Go Slow) Tj
+/F1 11 Tf
+1 0 0 1 72 585 Tm
+(1. Begin with the lowest dose.) Tj
+/F1 11 Tf
+1 0 0 1 72 568 Tm
+(2. Wait the full onset time before redosing.) Tj
+/F1 11 Tf
+1 0 0 1 72 551 Tm
+(3. A 1:1 CBD:THC ratio softens THC side effects.) Tj
+/F1 11 Tf
+1 0 0 1 72 534 Tm
+(4. Never drive within 4-6 hours of THC.) Tj
+/F1 11 Tf
+1 0 0 1 72 517 Tm
+(5. Tell your provider about every product you use.) Tj
+/F1 10 Tf
+1 0 0 1 72 487 Tm
+(Safety: cannabis can be bi-phasic - more is not always) Tj
+/F1 10 Tf
+1 0 0 1 72 471 Tm
+(better. For education only; not medical advice.) Tj
+ET
+endstream
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 6 0 R >>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000121 00000 n 
+0000000191 00000 n 
+0000001240 00000 n 
+0000001366 00000 n 
+0000002431 00000 n 
+trailer
+<< /Size 8 /Root 1 0 R >>
+startxref
+2557
+%%EOF

--- a/scripts/generate-guides.mjs
+++ b/scripts/generate-guides.mjs
@@ -1,0 +1,144 @@
+// Generates the downloadable guide PDFs under public/guides/.
+//
+//   • cannabis-and-cancer.pdf — EMR-202 (Justin Kander research reference)
+//   • leafjourney-trifold-reference-guide.pdf — EMR-203 (cannabinoids,
+//     terpenes, bioavailability, dosing pocket reference)
+//
+// Produces minimal but spec-valid PDF 1.4 documents (Helvetica text, one or
+// more pages) with a correct cross-reference table. Run:  node scripts/generate-guides.mjs
+//
+// These are intentionally hand-buildable so the repo stays dependency-free;
+// the rich interactive versions live at /education/trifold and the canonical
+// book at freecannabiscancerbook.com.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = join(__dirname, "..", "public", "guides");
+
+/** Escape text for a PDF string literal. */
+function esc(s) {
+  return s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+}
+
+/**
+ * Build a PDF from pages. Each page is { lines: [{text, size?, gap?}] }.
+ * Returns a Buffer. Letter portrait, 1" margins, top-down text.
+ */
+function buildPdf(pages) {
+  const objects = [];
+  const add = (body) => {
+    objects.push(body);
+    return objects.length; // 1-based object number
+  };
+
+  // Reserve catalog (1) and pages (2); fill kids after page objects exist.
+  const catalogNum = add(null);
+  const pagesNum = add(null);
+  const fontNum = add(`<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>`);
+
+  const pageNums = [];
+  for (const page of pages) {
+    let y = 720;
+    let stream = "BT\n";
+    for (const line of page.lines) {
+      const size = line.size ?? 12;
+      stream += `/F1 ${size} Tf\n`;
+      stream += `1 0 0 1 72 ${y} Tm\n`;
+      stream += `(${esc(line.text)}) Tj\n`;
+      y -= line.gap ?? size + 6;
+    }
+    stream += "ET";
+    const contentNum = add(`<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`);
+    const pageNum = add(
+      `<< /Type /Page /Parent ${pagesNum} 0 R /MediaBox [0 0 612 792] ` +
+        `/Resources << /Font << /F1 ${fontNum} 0 R >> >> /Contents ${contentNum} 0 R >>`,
+    );
+    pageNums.push(pageNum);
+  }
+
+  objects[catalogNum - 1] = `<< /Type /Catalog /Pages ${pagesNum} 0 R >>`;
+  objects[pagesNum - 1] =
+    `<< /Type /Pages /Kids [${pageNums.map((n) => `${n} 0 R`).join(" ")}] /Count ${pageNums.length} >>`;
+
+  // Serialise with a correct xref table.
+  let pdf = "%PDF-1.4\n";
+  const offsets = [];
+  for (let i = 0; i < objects.length; i++) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += `${i + 1} 0 obj\n${objects[i]}\nendobj\n`;
+  }
+  const xrefStart = Buffer.byteLength(pdf);
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  for (const off of offsets) {
+    pdf += `${String(off).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root ${catalogNum} 0 R >>\n`;
+  pdf += `startxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, "latin1");
+}
+
+const kander = buildPdf([
+  {
+    lines: [
+      { text: "Cannabis and Cancer", size: 26, gap: 40 },
+      { text: "A Research Reference  -  compiled by Justin Kander", size: 13, gap: 30 },
+      { text: "Leafjourney Education Library", size: 11, gap: 40 },
+      { text: "This reference summarises a large compilation of human case", size: 12 },
+      { text: "reports and peer-reviewed research on the interaction between", size: 12 },
+      { text: "cannabinoids and cancer.", size: 12, gap: 28 },
+      { text: "The complete, continually updated book is available free online:", size: 12 },
+      { text: "https://freecannabiscancerbook.com", size: 12, gap: 28 },
+      { text: "Search the underlying studies on PubMed directly from the", size: 12 },
+      { text: "Research tab at https://leafjourney.com/education", size: 12, gap: 40 },
+      { text: "For education only. Not medical advice. Cannabis products are", size: 10 },
+      { text: "not FDA-approved medications. Always consult your care team.", size: 10 },
+    ],
+  },
+]);
+
+const trifold = buildPdf([
+  {
+    lines: [
+      { text: "LeafJourney Reference Guide", size: 24, gap: 36 },
+      { text: "Cannabinoids - Terpenes - Bioavailability - Dosing", size: 12, gap: 32 },
+      { text: "MAJOR CANNABINOIDS", size: 14, gap: 22 },
+      { text: "THC - euphoria, pain, appetite, nausea", size: 11 },
+      { text: "CBD - calm, inflammation, seizures (non-intoxicating)", size: 11 },
+      { text: "CBN - sedation, sleep support", size: 11 },
+      { text: "CBG - focus, gut comfort, antibacterial", size: 11 },
+      { text: "CBC - mood and inflammation support", size: 11, gap: 24 },
+      { text: "TERPENES (aroma  ->  effect)", size: 14, gap: 22 },
+      { text: "Limonene - citrus - uplifting", size: 11 },
+      { text: "Pinene - pine - alert, clear-headed", size: 11 },
+      { text: "Caryophyllene - pepper - calming, anti-inflammatory", size: 11 },
+      { text: "Linalool - lavender - relaxing, sleep", size: 11 },
+      { text: "Myrcene - earthy - sedating, body relaxation", size: 11 },
+    ],
+  },
+  {
+    lines: [
+      { text: "BIOAVAILABILITY BY ROUTE", size: 16, gap: 28 },
+      { text: "Inhaled (vapor/smoke) - onset 1-5 min - duration 2-4 h", size: 11 },
+      { text: "Sublingual tincture - onset 15-45 min - duration 4-8 h", size: 11 },
+      { text: "Edible/capsule - onset 30-120 min - duration 6-8 h", size: 11 },
+      { text: "Topical - localized - no intoxication", size: 11, gap: 30 },
+      { text: "HOW TO START - Start Low, Go Slow", size: 16, gap: 26 },
+      { text: "1. Begin with the lowest dose.", size: 11 },
+      { text: "2. Wait the full onset time before redosing.", size: 11 },
+      { text: "3. A 1:1 CBD:THC ratio softens THC side effects.", size: 11 },
+      { text: "4. Never drive within 4-6 hours of THC.", size: 11 },
+      { text: "5. Tell your provider about every product you use.", size: 11, gap: 30 },
+      { text: "Safety: cannabis can be bi-phasic - more is not always", size: 10 },
+      { text: "better. For education only; not medical advice.", size: 10 },
+    ],
+  },
+]);
+
+mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(join(OUT_DIR, "cannabis-and-cancer.pdf"), kander);
+writeFileSync(join(OUT_DIR, "leafjourney-trifold-reference-guide.pdf"), trifold);
+console.log(`Wrote guide PDFs to ${OUT_DIR}`);

--- a/src/app/education/actions.ts
+++ b/src/app/education/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { logger } from "@/lib/observability/log";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
 import {
   buildChatCBSystemPrompt,
@@ -27,6 +28,17 @@ export async function fetchComboWheelCompounds(): Promise<ComboWheelCompound[]> 
 export interface ChatCBResponse {
   answer: string;
   citations: Citation[];
+}
+
+/**
+ * EMR-202 — record a guide/PDF download so the education team can see
+ * which resources patients actually open. Emitted as a structured log
+ * event (no PHI); analytics pipelines pick it up from there.
+ */
+export async function trackGuideDownload(guideId: string): Promise<void> {
+  const id = guideId.trim().slice(0, 120);
+  if (!id) return;
+  logger.info({ event: "education.guide.download", guideId: id });
 }
 
 /**

--- a/src/app/education/dispensary-locator/page.tsx
+++ b/src/app/education/dispensary-locator/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronLeft, MapPin as MapPinIcon, Navigation, Phone, Clock, Store, Stethoscope } from "lucide-react";
+
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { Eyebrow } from "@/components/ui/ornament";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SITE_URL } from "@/lib/seo";
+import {
+  DISPENSARY_PINS,
+  PROVIDER_PINS,
+  buildMapEmbedUrl,
+  directionsUrl,
+  placeSearchUrl,
+  type MapPin,
+} from "@/lib/integrations/dispensary-locator";
+
+/**
+ * EMR-017 — Dispensary Locator with Google Maps.
+ *
+ * Public, patient-facing map of local dispensaries and cannabis healthcare
+ * providers. Uses the Google Maps Embed API when NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+ * is configured; otherwise renders a directory with keyless "Get directions"
+ * links so the page is always useful.
+ */
+export const metadata: Metadata = {
+  title: "Dispensary Locator — Find dispensaries & cannabis providers near you — Leafjourney",
+  description:
+    "Locate licensed dispensaries and cannabis healthcare providers near you on an interactive map, with addresses, hours, and one-tap directions.",
+  alternates: { canonical: `${SITE_URL}/education/dispensary-locator` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Dispensary Locator — Leafjourney",
+    description:
+      "Find local dispensaries and cannabis providers on an interactive map. No login required.",
+    url: `${SITE_URL}/education/dispensary-locator`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function DispensaryLocatorPage() {
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const embedUrl = buildMapEmbedUrl(apiKey);
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <SiteHeader />
+
+      <main id="main-content">
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-12 pb-8 lg:pt-16 lg:pb-10">
+          <Link
+            href="/education"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-text-muted hover:text-accent transition-colors mb-6"
+          >
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+            Back to Education
+          </Link>
+
+          <div className="text-center">
+            <Eyebrow className="justify-center mb-5 text-accent">
+              <MapPinIcon className="w-3.5 h-3.5" aria-hidden="true" />
+              Dispensary Locator
+            </Eyebrow>
+            <h1 className="font-display text-4xl md:text-5xl lg:text-6xl tracking-tight text-text leading-[1.05] mb-5">
+              Find dispensaries &amp; providers near you
+            </h1>
+            <p className="text-lg md:text-xl text-text-muted max-w-2xl mx-auto leading-relaxed">
+              Licensed dispensaries and cannabis healthcare providers, mapped
+              with addresses, hours, and one-tap directions.
+            </p>
+          </div>
+        </section>
+
+        {/* Map */}
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pb-12">
+          {embedUrl ? (
+            <div className="rounded-3xl overflow-hidden border border-border shadow-lg aspect-[16/9] bg-surface-muted">
+              <iframe
+                title="Map of nearby dispensaries and cannabis providers"
+                src={embedUrl}
+                className="w-full h-full"
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                allowFullScreen
+              />
+            </div>
+          ) : (
+            <Card className="rounded-3xl border border-dashed border-border">
+              <CardContent className="p-10 text-center">
+                <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-accent/10 text-accent mb-4">
+                  <MapPinIcon className="w-7 h-7" strokeWidth={1.5} aria-hidden="true" />
+                </div>
+                <p className="text-base font-semibold text-text">
+                  Interactive map preview
+                </p>
+                <p className="text-sm text-text-muted mt-2 max-w-md mx-auto">
+                  The live Google Map appears here once a Maps API key is
+                  configured. In the meantime, browse the directory below — every
+                  location links straight to directions.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </section>
+
+        {/* Directory */}
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pb-24 space-y-10">
+          <PinGroup
+            title="Dispensaries"
+            icon={<Store className="w-4 h-4" aria-hidden="true" />}
+            pins={DISPENSARY_PINS}
+            tone="accent"
+          />
+          <PinGroup
+            title="Cannabis healthcare providers"
+            icon={<Stethoscope className="w-4 h-4" aria-hidden="true" />}
+            pins={PROVIDER_PINS}
+            tone="neutral"
+          />
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}
+
+function PinGroup({
+  title,
+  icon,
+  pins,
+  tone,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  pins: MapPin[];
+  tone: "accent" | "neutral";
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-5">
+        <span
+          className={
+            tone === "accent"
+              ? "inline-flex items-center justify-center w-8 h-8 rounded-xl bg-accent/10 text-accent"
+              : "inline-flex items-center justify-center w-8 h-8 rounded-xl bg-slate-100 text-slate-600"
+          }
+        >
+          {icon}
+        </span>
+        <h2 className="font-display text-2xl text-text tracking-tight">{title}</h2>
+        <Badge tone="neutral" className="ml-1 text-[10px]">
+          {pins.length}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {pins.map((pin) => (
+          <Card key={pin.id} className="rounded-2xl border border-slate-200 hover:shadow-lg transition-all">
+            <CardContent className="p-5 flex flex-col h-full">
+              <h3 className="font-semibold text-text leading-snug mb-2">{pin.name}</h3>
+              <p className="text-sm text-text-muted leading-relaxed mb-3">{pin.address}</p>
+              <div className="space-y-1.5 text-xs text-text-muted mb-4">
+                {pin.phone && (
+                  <a
+                    href={`tel:${pin.phone.replace(/[^0-9+]/g, "")}`}
+                    className="inline-flex items-center gap-2 hover:text-accent transition-colors"
+                  >
+                    <Phone className="w-3.5 h-3.5" aria-hidden="true" />
+                    {pin.phone}
+                  </a>
+                )}
+                {pin.hours && (
+                  <div className="flex items-center gap-2">
+                    <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+                    {pin.hours}
+                  </div>
+                )}
+              </div>
+              <div className="mt-auto flex gap-2">
+                <a
+                  href={directionsUrl(pin)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-semibold text-accent hover:underline"
+                >
+                  <Navigation className="w-3.5 h-3.5" aria-hidden="true" />
+                  Get directions
+                </a>
+                <a
+                  href={placeSearchUrl(pin)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-text-muted hover:text-accent transition-colors ml-auto"
+                >
+                  View on map
+                </a>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/education/page.tsx
+++ b/src/app/education/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { Search, ArrowRight, Sparkles, Pill } from "lucide-react";
+import { Search, ArrowRight, Sparkles, Pill, Leaf, MapPin, BookOpen } from "lucide-react";
 import { Eyebrow } from "@/components/ui/ornament";
 import { SiteHeader } from "@/components/marketing/SiteHeader";
 import { SiteFooter } from "@/components/marketing/SiteFooter";
@@ -73,9 +73,9 @@ export default function EducationPage() {
           no login required.
         </p>
 
-        {/* EMR-617 — direct CTA for the Drug Mix standalone module so
-            patients arriving on /education can jump straight to the
-            interaction checker without first discovering the tab strip. */}
+        {/* EMR-617 / EMR-018 / EMR-017 / EMR-203 — direct CTAs for the
+            standalone modules so patients arriving on /education can jump
+            straight to a tool without first discovering the tab strip. */}
         <div className="mt-8 flex flex-wrap justify-center gap-3">
           <Link
             href="/education/drug-mix"
@@ -84,6 +84,27 @@ export default function EducationPage() {
             <Pill className="w-4 h-4" aria-hidden="true" />
             Open Drug Mix
             <ArrowRight className="w-4 h-4" aria-hidden="true" />
+          </Link>
+          <Link
+            href="/education/strain-finder"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-border bg-white text-sm font-semibold text-text hover:border-accent hover:text-accent transition-all hover:-translate-y-0.5"
+          >
+            <Leaf className="w-4 h-4" aria-hidden="true" />
+            Strain Finder
+          </Link>
+          <Link
+            href="/education/dispensary-locator"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-border bg-white text-sm font-semibold text-text hover:border-accent hover:text-accent transition-all hover:-translate-y-0.5"
+          >
+            <MapPin className="w-4 h-4" aria-hidden="true" />
+            Dispensary Locator
+          </Link>
+          <Link
+            href="/education/trifold"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-border bg-white text-sm font-semibold text-text hover:border-accent hover:text-accent transition-all hover:-translate-y-0.5"
+          >
+            <BookOpen className="w-4 h-4" aria-hidden="true" />
+            Reference Guide
           </Link>
         </div>
       </section>

--- a/src/app/education/strain-finder/page.tsx
+++ b/src/app/education/strain-finder/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronLeft, Leaf } from "lucide-react";
+
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { Eyebrow } from "@/components/ui/ornament";
+import { StrainFinder } from "@/components/education/StrainFinder";
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * EMR-018 — Leafly Strain Database Integration.
+ *
+ * Public, patient-facing strain finder. Maps common medical issues
+ * (sleep, anxiety, insomnia, stress, pain, cancer) to flower strains with
+ * terpene + cannabinoid profiles. No login required; no PHI captured.
+ */
+export const metadata: Metadata = {
+  title: "Strain Finder — Match cannabis strains to your symptoms — Leafjourney",
+  description:
+    "Search flower strains by symptom — sleep, anxiety, pain, stress, and more. See each strain's terpene and cannabinoid profile, backed by the Leafly database.",
+  alternates: { canonical: `${SITE_URL}/education/strain-finder` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Strain Finder — Leafjourney",
+    description:
+      "Match cannabis flower strains to your symptoms with terpene and cannabinoid profiles. No login required.",
+    url: `${SITE_URL}/education/strain-finder`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function StrainFinderPage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <SiteHeader />
+
+      <main id="main-content">
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pt-12 pb-8 lg:pt-16 lg:pb-10">
+          <Link
+            href="/education"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-text-muted hover:text-accent transition-colors mb-6"
+          >
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+            Back to Education
+          </Link>
+
+          <div className="text-center">
+            <Eyebrow className="justify-center mb-5 text-accent">
+              <Leaf className="w-3.5 h-3.5" aria-hidden="true" />
+              Strain Finder
+            </Eyebrow>
+          </div>
+        </section>
+
+        <section className="max-w-[1320px] mx-auto px-6 lg:px-12 pb-24">
+          <StrainFinder />
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/app/education/trifold/page.tsx
+++ b/src/app/education/trifold/page.tsx
@@ -1,0 +1,274 @@
+// EMR-203 — LeafJourney Trifold Reference Guide (public, web-flip version).
+//
+// Public, dual-audience (patient + provider) reference: cannabinoids,
+// terpenes, bioavailability by route, and dosing guidance. Reuses the same
+// `@/lib/education/trifold` data as the in-portal printable. Print to PDF
+// from the browser, or download the pre-built print-ready PDF.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronLeft, BookOpen } from "lucide-react";
+
+import { SiteHeader } from "@/components/marketing/SiteHeader";
+import { SiteFooter } from "@/components/marketing/SiteFooter";
+import { Eyebrow } from "@/components/ui/ornament";
+import { SITE_URL } from "@/lib/seo";
+import {
+  TRIFOLD_BIOAVAILABILITY,
+  TRIFOLD_CANNABINOIDS,
+  TRIFOLD_DOSING,
+  TRIFOLD_PRINT_CSS,
+  TRIFOLD_TERPENES,
+} from "@/lib/education/trifold";
+import {
+  TrifoldPrintButton,
+  TrifoldDownloadButton,
+} from "@/components/education/TrifoldPrintButton";
+
+export const metadata: Metadata = {
+  title: "Reference Guide — Cannabinoids, terpenes & dosing — Leafjourney",
+  description:
+    "A printable pocket reference for medical cannabis: cannabinoids, terpenes, bioavailability by route, and dosing guidance. Written for both patients and providers.",
+  alternates: { canonical: `${SITE_URL}/education/trifold` },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "LeafJourney Reference Guide",
+    description:
+      "Pocket reference: cannabinoids, terpenes, bioavailability, and dosing. For patients and providers.",
+    url: `${SITE_URL}/education/trifold`,
+    siteName: "Leafjourney",
+    type: "website",
+  },
+};
+
+export default function PublicTrifoldGuidePage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <SiteHeader />
+
+      <style dangerouslySetInnerHTML={{ __html: TRIFOLD_PRINT_CSS }} />
+
+      <main id="main-content">
+        <div className="no-print px-6 lg:px-12 py-8 max-w-[11in] mx-auto">
+          <Link
+            href="/education"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-text-muted hover:text-accent transition-colors mb-6"
+          >
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+            Back to Education
+          </Link>
+
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+            <div>
+              <Eyebrow className="mb-2 text-accent">
+                <BookOpen className="w-3.5 h-3.5" aria-hidden="true" />
+                Reference Guide
+              </Eyebrow>
+              <h1 className="font-display text-3xl md:text-4xl text-text tracking-tight">
+                LeafJourney Reference Guide
+              </h1>
+              <p className="text-sm text-text-muted mt-2 max-w-xl leading-relaxed">
+                A pocket reference for medical cannabis — cannabinoids,
+                terpenes, how each route is absorbed, and how to dose safely.
+                Written for both patients and providers. Print to PDF and fold
+                along the gutters, or download the print-ready version.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <TrifoldPrintButton />
+              <TrifoldDownloadButton />
+            </div>
+          </div>
+        </div>
+
+        {/* ── Outside of trifold (panels read 3-1-2 when folded) ─────── */}
+        <section className="trifold-page">
+          <article className="panel">
+            <h2>Bioavailability by route</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Route</th>
+                  <th>Onset</th>
+                  <th>BA</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TRIFOLD_BIOAVAILABILITY.map((b) => (
+                  <tr key={b.route}>
+                    <td>{b.route}</td>
+                    <td>{b.onset}</td>
+                    <td>{b.bioavailability}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3>Notes</h3>
+            <ul>
+              {TRIFOLD_BIOAVAILABILITY.slice(0, 3).map((b) => (
+                <li key={b.route}>
+                  <strong>{b.route}:</strong> {b.notes}
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <article className="panel">
+            <h2>LeafJourney</h2>
+            <h3>Reference guide</h3>
+            <p>
+              Your pocket-sized companion to medical cannabis: cannabinoids,
+              terpenes, delivery routes, and dosing. Always discuss changes
+              with your care team.
+            </p>
+            <h3>Quick rules</h3>
+            <ul>
+              <li>Start low. Go slow. Wait between doses.</li>
+              <li>Edibles take 30–120 min — don&apos;t redose.</li>
+              <li>1:1 CBD softens THC side effects.</li>
+              <li>Never drive within 4–6 hours of THC.</li>
+              <li>Tell your provider about <em>all</em> products you use.</li>
+            </ul>
+            <h3>When to call us</h3>
+            <ul>
+              <li>Anxiety or panic that lasts &gt;1 hour</li>
+              <li>Vomiting or persistent nausea</li>
+              <li>Chest pain or rapid heart rate</li>
+              <li>Any reaction with prescription meds</li>
+            </ul>
+          </article>
+
+          <article className="panel">
+            <h2>Cannabinoids</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Compound</th>
+                  <th>Effect</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TRIFOLD_CANNABINOIDS.map((c) => (
+                  <tr key={c.id}>
+                    <td>
+                      <span className="swatch" style={{ backgroundColor: c.color }} />
+                      <strong>{c.name}</strong>
+                    </td>
+                    <td>{c.effect}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3>Notes</h3>
+            <ul>
+              {TRIFOLD_CANNABINOIDS.slice(0, 3).map((c) => (
+                <li key={c.id}>
+                  <strong>{c.name}:</strong> {c.notes}
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+
+        {/* ── Inside of trifold ─────── */}
+        <section className="trifold-page">
+          <article className="panel">
+            <h2>Terpenes</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Terpene</th>
+                  <th>Aroma</th>
+                  <th>Effect</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TRIFOLD_TERPENES.map((t) => (
+                  <tr key={t.id}>
+                    <td>
+                      <span className="swatch" style={{ backgroundColor: t.color }} />
+                      {t.name}
+                    </td>
+                    <td>{t.aroma}</td>
+                    <td>{t.effect}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3>Also found in</h3>
+            <ul>
+              {TRIFOLD_TERPENES.map((t) => (
+                <li key={t.id}>
+                  <strong>{t.name}:</strong> {t.alsoFoundIn}
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <article className="panel">
+            <h2>Dosing</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Population</th>
+                  <th>Start</th>
+                  <th>Ceiling</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TRIFOLD_DOSING.map((d) => (
+                  <tr key={d.population}>
+                    <td>{d.population}</td>
+                    <td>{d.startLow}</td>
+                    <td>{d.ceiling}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3>Titration tips</h3>
+            <ul>
+              {TRIFOLD_DOSING.map((d) => (
+                <li key={d.population}>
+                  <strong>{d.population}:</strong> {d.goSlow}. {d.notes}
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <article className="panel">
+            <h2>Bioavailability — full table</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Route</th>
+                  <th>Onset</th>
+                  <th>Duration</th>
+                  <th>BA</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TRIFOLD_BIOAVAILABILITY.map((b) => (
+                  <tr key={b.route}>
+                    <td>{b.route}</td>
+                    <td>{b.onset}</td>
+                    <td>{b.duration}</td>
+                    <td>{b.bioavailability}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3>Choosing a route</h3>
+            <ul>
+              <li><strong>Fast relief:</strong> inhaled or sublingual.</li>
+              <li><strong>Long lasting:</strong> edible or capsule.</li>
+              <li><strong>Localized pain:</strong> topical balm.</li>
+              <li><strong>Severe nausea:</strong> suppository.</li>
+            </ul>
+          </article>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/components/education/ResearchTab.tsx
+++ b/src/components/education/ResearchTab.tsx
@@ -10,6 +10,7 @@ import {
   FileSearch,
   FlaskConical,
   Sparkles,
+  Download,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -20,11 +21,17 @@ import {
   getCannabinoids,
   EVIDENCE_COLORS,
 } from "@/lib/domain/chatcb";
-import { searchPubMedArticles, type PubMedSearchResult } from "@/app/education/actions";
+import {
+  searchPubMedArticles,
+  trackGuideDownload,
+  type PubMedSearchResult,
+} from "@/app/education/actions";
 
 // Per EMR-370 (Dr. Patel): the canonical web home for the book is
 // freecannabiscancerbook.com.
 const KANDER_WEB_URL = "https://freecannabiscancerbook.com/";
+// EMR-202 — downloadable research PDF hosted under /public/guides.
+const KANDER_PDF_URL = "/guides/cannabis-and-cancer.pdf";
 
 export function ResearchTab() {
   const [cannabinoidFilter, setCannabinoidFilter] = useState("");
@@ -258,14 +265,30 @@ export function ResearchTab() {
             </p>
             <div className="flex flex-wrap gap-3 justify-center md:justify-start">
               <a
+                href={KANDER_PDF_URL}
+                download
+                onClick={() => void trackGuideDownload("cannabis-and-cancer")}
+                aria-label="Download the Cannabis and Cancer research PDF"
+                className={cn(
+                  "inline-flex items-center justify-center gap-2 h-12 px-6 rounded-xl",
+                  "bg-white text-indigo-700 font-semibold text-sm shadow-lg shadow-indigo-900/30",
+                  "hover:bg-indigo-50 hover:shadow-xl hover:-translate-y-0.5 active:translate-y-0",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-600",
+                  "transition-all duration-200"
+                )}
+              >
+                <Download className="w-4 h-4" strokeWidth={2.5} />
+                Download PDF
+              </a>
+              <a
                 href={KANDER_WEB_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Read Cannabis and Cancer web version (opens in new tab)"
                 className={cn(
                   "inline-flex items-center justify-center gap-2 h-12 px-6 rounded-xl",
-                  "bg-white text-indigo-700 font-semibold text-sm shadow-lg shadow-indigo-900/30",
-                  "hover:bg-indigo-50 hover:shadow-xl hover:-translate-y-0.5 active:translate-y-0",
+                  "bg-indigo-500/40 text-white font-semibold text-sm border border-white/30 backdrop-blur-sm",
+                  "hover:bg-indigo-500/60 hover:-translate-y-0.5 active:translate-y-0",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-indigo-600",
                   "transition-all duration-200"
                 )}

--- a/src/components/education/StrainFinder.tsx
+++ b/src/components/education/StrainFinder.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+// EMR-018 — Strain Finder.
+//
+// Matches a free-text symptom (sleep, anxiety, pain, cancer, …) to flower
+// strains from the Leafly-backed catalog, showing each strain's terpene and
+// cannabinoid profile so patients and clinicians can see *why* it matches.
+// Pure, client-side matching — no PHI captured.
+
+import React, { useMemo, useState } from "react";
+import { Search, Leaf, Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils/cn";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  matchStrainsToSymptom,
+  listCoveredConditions,
+  type StrainMatch,
+} from "@/lib/integrations/leafly-client";
+
+const SUGGESTED = ["sleep", "anxiety", "pain", "stress", "cancer", "depression"];
+
+export function StrainFinder() {
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState<string | null>(null);
+
+  const conditions = useMemo(() => listCoveredConditions(), []);
+  const matches: StrainMatch[] = useMemo(
+    () => (submitted ? matchStrainsToSymptom(submitted) : []),
+    [submitted],
+  );
+
+  function run(q?: string) {
+    const term = (q ?? query).trim();
+    if (!term) return;
+    if (q) setQuery(q);
+    setSubmitted(term);
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8">
+      <div className="text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-3xl bg-accent/10 text-accent mb-5 shadow-sm">
+          <Leaf className="w-8 h-8" strokeWidth={1.5} aria-hidden="true" />
+        </div>
+        <h2 className="font-display text-4xl text-text tracking-tight mb-3">
+          Strain Finder
+        </h2>
+        <p className="text-base text-text-muted max-w-xl mx-auto leading-relaxed">
+          Tell us what you&apos;re trying to manage and we&apos;ll match flower
+          strains by their terpene and cannabinoid profile.
+        </p>
+      </div>
+
+      <div className="max-w-xl mx-auto">
+        <div className="relative bg-white p-2 rounded-2xl shadow-lg border border-slate-200 flex items-center">
+          <Search className="w-5 h-5 text-slate-400 ml-3 mr-1" strokeWidth={2} aria-hidden="true" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && run()}
+            aria-label="Search strains by symptom"
+            placeholder="e.g. trouble sleeping, anxiety, chronic pain…"
+            className="flex-1 h-12 bg-transparent text-base text-text placeholder:text-slate-400 focus:outline-none"
+          />
+          <Button onClick={() => run()} disabled={!query.trim()} className="rounded-xl h-12 px-6">
+            Find strains
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-2 mt-4">
+          {SUGGESTED.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => run(s)}
+              className="text-xs font-semibold px-3.5 py-1.5 rounded-full border border-slate-200 bg-white text-slate-600 hover:border-accent hover:text-accent transition-all capitalize"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {submitted && (
+        <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
+          {matches.length === 0 ? (
+            <Card className="rounded-2xl border border-border">
+              <CardContent className="p-10 text-center">
+                <p className="text-base font-semibold text-text">
+                  No strains matched &ldquo;{submitted}&rdquo;
+                </p>
+                <p className="text-sm text-text-muted mt-2">
+                  Try one of these conditions:{" "}
+                  {conditions.slice(0, 8).join(", ")}.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <>
+              <p className="text-center text-sm text-text-muted mb-6">
+                {matches.length} strain{matches.length === 1 ? "" : "s"} commonly
+                used for{" "}
+                <span className="font-semibold text-text">
+                  {matches[0].matchedCondition}
+                </span>
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {matches.map((strain) => (
+                  <Card
+                    key={strain.slug}
+                    className="rounded-2xl border border-slate-200 hover:border-accent/50 hover:shadow-lg transition-all"
+                  >
+                    <CardContent className="p-5">
+                      <div className="flex items-start justify-between gap-3 mb-3">
+                        <div>
+                          <h3 className="font-display text-xl text-text tracking-tight">
+                            {strain.name}
+                          </h3>
+                          <Badge tone="neutral" className="mt-1 text-[10px]">
+                            {strain.category}
+                          </Badge>
+                        </div>
+                        <div className="flex items-center gap-1 text-accent text-xs font-bold">
+                          <Sparkles className="w-3.5 h-3.5" strokeWidth={2.5} aria-hidden="true" />
+                          {strain.matchScore}% match
+                        </div>
+                      </div>
+
+                      {strain.summary && (
+                        <p className="text-sm text-text-muted leading-relaxed mb-4">
+                          {strain.summary}
+                        </p>
+                      )}
+
+                      <div className="grid grid-cols-2 gap-3 text-xs mb-4">
+                        <ProfileStat label="THC" value={`${strain.thcLevel}%`} />
+                        <ProfileStat label="CBD" value={`${strain.cbdLevel}%`} />
+                      </div>
+
+                      <div className="space-y-2">
+                        <ChipRow
+                          label="Terpenes"
+                          items={strain.terpenes ?? [strain.dominantTerpene]}
+                          tone="accent"
+                        />
+                        <ChipRow label="Effects" items={strain.effects} tone="muted" />
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <p className="max-w-2xl mx-auto text-center text-xs text-text-muted leading-relaxed">
+        For education only. Strain effects vary by individual, batch, and dose.
+        Always discuss cannabis use with your care team.
+      </p>
+    </div>
+  );
+}
+
+function ProfileStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-slate-50 border border-slate-100 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-widest text-slate-400 font-bold">
+        {label}
+      </div>
+      <div className="text-sm font-bold text-text mt-0.5">{value}</div>
+    </div>
+  );
+}
+
+function ChipRow({
+  label,
+  items,
+  tone,
+}: {
+  label: string;
+  items: string[];
+  tone: "accent" | "muted";
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-[10px] uppercase tracking-widest text-slate-400 font-bold pt-1 w-16 shrink-0">
+        {label}
+      </span>
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((it) => (
+          <span
+            key={it}
+            className={cn(
+              "text-[11px] font-semibold px-2 py-0.5 rounded-full",
+              tone === "accent"
+                ? "bg-accent/10 text-accent"
+                : "bg-slate-100 text-slate-600",
+            )}
+          >
+            {it}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/education/TrifoldPrintButton.tsx
+++ b/src/components/education/TrifoldPrintButton.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-// EMR-203 — print button for the trifold reference guide.
+// EMR-203 — print + download controls for the trifold reference guide.
 // Split into its own client component so the trifold page can stay a
 // server component (lighter bundle, better static rendering).
 
-import { Printer } from "lucide-react";
+import { Printer, Download } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { trackGuideDownload } from "@/app/education/actions";
 
 export function TrifoldPrintButton() {
   return (
@@ -19,5 +20,23 @@ export function TrifoldPrintButton() {
       <Printer className="h-4 w-4 mr-2" aria-hidden />
       Print to PDF
     </Button>
+  );
+}
+
+/**
+ * Download the print-ready trifold PDF (hosted under /public/guides) and
+ * record the download for the education analytics pipeline.
+ */
+export function TrifoldDownloadButton() {
+  return (
+    <a
+      href="/guides/leafjourney-trifold-reference-guide.pdf"
+      download
+      onClick={() => void trackGuideDownload("leafjourney-trifold")}
+      className="inline-flex items-center justify-center gap-2 h-11 px-6 rounded-full border border-border bg-white text-sm font-semibold text-text hover:border-accent hover:text-accent transition-all"
+    >
+      <Download className="h-4 w-4" aria-hidden />
+      Download PDF
+    </a>
   );
 }

--- a/src/lib/affiliate/partners.test.ts
+++ b/src/lib/affiliate/partners.test.ts
@@ -21,6 +21,14 @@ describe("affiliate partners registry", () => {
     expect(list.every((p) => p.status === "active")).toBe(true);
   });
 
+  // EMR-204 — PhytoRx and Flower Powered are unconfirmed and must not
+  // surface on public partner sections until a real partnership exists.
+  it("excludes unconfirmed partners (PhytoRx, Flower Powered) from public list", () => {
+    const publicSlugs = listAffiliatePartners().map((p) => p.slug);
+    expect(publicSlugs).not.toContain("phytorx");
+    expect(publicSlugs).not.toContain("flower-powered-products");
+  });
+
   it("every partner ships a disclaimer + joint decision note", () => {
     for (const p of AFFILIATE_PARTNERS) {
       expect(p.disclaimerText.length).toBeGreaterThan(20);

--- a/src/lib/affiliate/partners.ts
+++ b/src/lib/affiliate/partners.ts
@@ -29,6 +29,11 @@ const JOINT_DECISION_NOTE =
   "Adding any product to your regimen is a joint decision between you and your care team. Bring this product up at your next visit so we can document it and watch for interactions.";
 
 export const AFFILIATE_PARTNERS: AffiliatePartnerInfo[] = [
+  // EMR-204 — PhytoRx and Flower Powered are flagged as unconfirmed
+  // partners and held back from public surfaces until a real partnership
+  // is in place. Marked `archived` so `listAffiliatePartners()` and every
+  // store/leafmart partner section (which filter on `active`) skip them.
+  // Re-activate by flipping status to `active` once confirmed.
   {
     slug: "phytorx",
     name: "PhytoRx",
@@ -37,7 +42,7 @@ export const AFFILIATE_PARTNERS: AffiliatePartnerInfo[] = [
     description:
       "Physician-formulated CBD + CBG beverage concentrates for pain and recovery. Fast-absorbing emulsion technology developed with clinical input.",
     category: "Beverages",
-    status: "active",
+    status: "archived",
     disclaimerText: DEFAULT_DISCLAIMER,
     jointDecisionNote: JOINT_DECISION_NOTE,
     utmSource: "leafjourney",
@@ -51,7 +56,7 @@ export const AFFILIATE_PARTNERS: AffiliatePartnerInfo[] = [
     description:
       "Full line of CBD-only wellness products. Topicals, balms, and creams. Third-party tested, physician-recommended.",
     category: "Topicals",
-    status: "active",
+    status: "archived",
     disclaimerText: DEFAULT_DISCLAIMER,
     jointDecisionNote: JOINT_DECISION_NOTE,
     utmSource: "leafjourney",

--- a/src/lib/integrations/dispensary-locator.test.ts
+++ b/src/lib/integrations/dispensary-locator.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMapEmbedUrl,
+  directionsUrl,
+  placeSearchUrl,
+  pinsWithinRadius,
+  ALL_PINS,
+  DISPENSARY_PINS,
+} from "./dispensary-locator";
+
+const IRVINE = { lat: 33.6846, lng: -117.8265 };
+
+describe("dispensary-locator", () => {
+  it("returns null embed URL without an API key", () => {
+    expect(buildMapEmbedUrl(undefined)).toBeNull();
+    expect(buildMapEmbedUrl("")).toBeNull();
+  });
+
+  it("builds a Google Maps Embed URL with a key", () => {
+    const url = buildMapEmbedUrl("test-key", "dispensary");
+    expect(url).toContain("https://www.google.com/maps/embed/v1/search");
+    expect(url).toContain("key=test-key");
+    expect(url).toContain("q=dispensary");
+  });
+
+  it("builds keyless directions + place-search links", () => {
+    const pin = DISPENSARY_PINS[0];
+    expect(directionsUrl(pin)).toContain("https://www.google.com/maps/dir/?api=1&destination=");
+    expect(placeSearchUrl(pin)).toContain("https://www.google.com/maps/search/?api=1&query=");
+  });
+
+  it("filters and sorts pins by distance within a radius", () => {
+    const near = pinsWithinRadius(IRVINE, 30);
+    expect(near.length).toBeGreaterThan(0);
+    expect(near.length).toBeLessThanOrEqual(ALL_PINS.length);
+    for (let i = 1; i < near.length; i++) {
+      expect(near[i - 1].distanceMiles).toBeLessThanOrEqual(near[i].distanceMiles);
+    }
+  });
+});

--- a/src/lib/integrations/dispensary-locator.ts
+++ b/src/lib/integrations/dispensary-locator.ts
@@ -1,0 +1,72 @@
+// EMR-017 — Dispensary Locator with Google Maps.
+//
+// Data + URL builders for an embedded map of local dispensaries and cannabis
+// healthcare providers. The map uses the Google Maps Embed API when a key is
+// configured (NEXT_PUBLIC_GOOGLE_MAPS_API_KEY); every helper degrades to
+// keyless google.com/maps links so the locator still works without a key.
+
+import { haversineMiles, type GeoPoint } from "./dispensary-sync";
+
+export type MapPinKind = "dispensary" | "provider";
+
+export interface MapPin extends GeoPoint {
+  id: string;
+  kind: MapPinKind;
+  name: string;
+  address: string;
+  phone?: string;
+  hours?: string;
+}
+
+export const DISPENSARY_PINS: MapPin[] = [
+  { id: "disp-1", kind: "dispensary", name: "Green Cross — Irvine", address: "2600 Main St, Irvine, CA 92614", phone: "(949) 555-0148", hours: "9am–9pm daily", lat: 33.6846, lng: -117.8265 },
+  { id: "disp-2", kind: "dispensary", name: "Coastal Leaf — Newport", address: "120 Pacific Ave, Newport Beach, CA 92661", phone: "(949) 555-0172", hours: "10am–8pm daily", lat: 33.6189, lng: -117.9298 },
+  { id: "disp-3", kind: "dispensary", name: "Harbor Wellness — Long Beach", address: "500 Ocean Blvd, Long Beach, CA 90802", phone: "(562) 555-0190", hours: "8am–10pm daily", lat: 33.7701, lng: -118.1937 },
+  { id: "disp-4", kind: "dispensary", name: "High Desert Rx — Riverside", address: "900 University Ave, Riverside, CA 92507", phone: "(951) 555-0123", hours: "9am–8pm daily", lat: 33.9806, lng: -117.3755 },
+];
+
+export const PROVIDER_PINS: MapPin[] = [
+  { id: "prov-1", kind: "provider", name: "Leafjourney Cannabis Clinic — Irvine", address: "18100 Von Karman Ave, Irvine, CA 92612", phone: "(949) 555-0100", hours: "Mon–Fri 8am–5pm", lat: 33.6792, lng: -117.8533 },
+  { id: "prov-2", kind: "provider", name: "Pacific Integrative Medicine", address: "4 Hutton Centre Dr, Santa Ana, CA 92707", phone: "(714) 555-0166", hours: "Mon–Sat 9am–6pm", lat: 33.7045, lng: -117.8678 },
+  { id: "prov-3", kind: "provider", name: "Coastline Cannabis Health", address: "1100 Quail St, Newport Beach, CA 92660", phone: "(949) 555-0181", hours: "Mon–Fri 9am–5pm", lat: 33.6603, lng: -117.8651 },
+];
+
+export const ALL_PINS: MapPin[] = [...DISPENSARY_PINS, ...PROVIDER_PINS];
+
+/** Pins within `radiusMiles` of an origin, nearest first, with distance. */
+export function pinsWithinRadius(
+  origin: GeoPoint,
+  radiusMiles = 30,
+  pins: MapPin[] = ALL_PINS,
+): Array<MapPin & { distanceMiles: number }> {
+  return pins
+    .map((p) => ({ ...p, distanceMiles: Math.round(haversineMiles(origin, p) * 10) / 10 }))
+    .filter((p) => p.distanceMiles <= radiusMiles)
+    .sort((a, b) => a.distanceMiles - b.distanceMiles);
+}
+
+/** Public Google Maps directions link to a pin (no API key required). */
+export function directionsUrl(pin: MapPin): string {
+  const dest = encodeURIComponent(`${pin.name}, ${pin.address}`);
+  return `https://www.google.com/maps/dir/?api=1&destination=${dest}`;
+}
+
+/** Keyless place-search link (fallback when no embed key is configured). */
+export function placeSearchUrl(pin: MapPin): string {
+  const q = encodeURIComponent(`${pin.name}, ${pin.address}`);
+  return `https://www.google.com/maps/search/?api=1&query=${q}`;
+}
+
+/**
+ * Google Maps Embed API URL for an iframe, or `null` when no key is set.
+ * Centres a search for dispensaries + clinics; falls back to a query string
+ * the keyless callers can ignore.
+ */
+export function buildMapEmbedUrl(
+  apiKey: string | undefined,
+  query = "cannabis dispensary OR cannabis clinic in Orange County CA",
+): string | null {
+  if (!apiKey) return null;
+  const q = encodeURIComponent(query);
+  return `https://www.google.com/maps/embed/v1/search?key=${apiKey}&q=${q}`;
+}

--- a/src/lib/integrations/dispensary-sync.test.ts
+++ b/src/lib/integrations/dispensary-sync.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  DispensarySyncClient,
+  haversineMiles,
+  scoreSkuAgainstRegimen,
+  type ProductSKU,
+} from "./dispensary-sync";
+
+// Irvine, CA — near the mock dispensaries disp-1/disp-2.
+const IRVINE = { lat: 33.6846, lng: -117.8265 };
+
+describe("haversineMiles", () => {
+  it("returns ~0 for the same point", () => {
+    expect(haversineMiles(IRVINE, IRVINE)).toBeCloseTo(0, 5);
+  });
+
+  it("computes a sane distance between two cities", () => {
+    // Irvine → Riverside is roughly 30–35 miles.
+    const riverside = { lat: 33.9806, lng: -117.3755 };
+    const d = haversineMiles(IRVINE, riverside);
+    expect(d).toBeGreaterThan(25);
+    expect(d).toBeLessThan(45);
+  });
+});
+
+describe("scoreSkuAgainstRegimen", () => {
+  const exact: ProductSKU = {
+    id: "x",
+    name: "1:1 10/10",
+    dispensaryId: "d",
+    cannabinoidProfile: { THC: 10, CBD: 10 },
+    inStock: true,
+    price: 1,
+  };
+
+  it("scores an exact match at 100", () => {
+    expect(scoreSkuAgainstRegimen(exact, { cannabinoids: { THC: 10, CBD: 10 } })).toBe(100);
+  });
+
+  it("penalises out-of-stock SKUs", () => {
+    const oos = { ...exact, inStock: false };
+    expect(scoreSkuAgainstRegimen(oos, { cannabinoids: { THC: 10, CBD: 10 } })).toBe(50);
+  });
+
+  it("returns 0 for an empty target", () => {
+    expect(scoreSkuAgainstRegimen(exact, { cannabinoids: {} })).toBe(0);
+  });
+});
+
+describe("DispensarySyncClient", () => {
+  const client = new DispensarySyncClient();
+
+  it("only returns in-stock products within the radius", async () => {
+    const products = await client.findProductsInRadius(IRVINE.lat, IRVINE.lng, 30);
+    expect(products.length).toBeGreaterThan(0);
+    expect(products.every((p) => p.inStock)).toBe(true);
+  });
+
+  it("recommends the closest best-matching SKU first", async () => {
+    const recs = await client.recommendForRegimen(IRVINE, {
+      cannabinoids: { THC: 10, CBD: 10 },
+    });
+    expect(recs.length).toBeGreaterThan(0);
+    // The 1:1 10mg/10mg tincture at disp-1 (Irvine) is the obvious top pick.
+    expect(recs[0].sku.id).toBe("sku-101");
+    expect(recs[0].matchScore).toBe(100);
+    // Sorted by score desc, then distance asc.
+    for (let i = 1; i < recs.length; i++) {
+      expect(recs[i - 1].matchScore).toBeGreaterThanOrEqual(recs[i].matchScore);
+    }
+  });
+
+  it("syncs a single dispensary's catalog", async () => {
+    const cat = await client.syncCatalog("disp-1");
+    expect(cat.length).toBeGreaterThan(0);
+    expect(cat.every((s) => s.dispensaryId === "disp-1")).toBe(true);
+  });
+});

--- a/src/lib/integrations/dispensary-sync.ts
+++ b/src/lib/integrations/dispensary-sync.ts
@@ -1,24 +1,157 @@
-/**
- * EMR-002: Dispensary Integration & SKU Scanning
- */
+// EMR-002 — Dispensary Integration & Product SKU Scanning.
+//
+// Ingests dispensary product catalogs (SKU-level), finds products within a
+// geographic radius of the patient, and recommends the SKUs that best match a
+// patient's prescribed cannabinoid regimen. Pure, deterministic logic backed
+// by a mock catalog so it runs without a live POS connection.
+
+export interface GeoPoint {
+  lat: number;
+  lng: number;
+}
+
+export interface DispensaryLocation extends GeoPoint {
+  id: string;
+  name: string;
+  address: string;
+}
+
 export interface ProductSKU {
   id: string;
   name: string;
   dispensaryId: string;
+  /** mg per unit, keyed by cannabinoid (THC, CBD, CBN, …). */
   cannabinoidProfile: Record<string, number>;
   inStock: boolean;
   price: number;
 }
 
+/** A patient's prescribed regimen target, used to rank SKUs. */
+export interface RegimenTarget {
+  /** Target mg per dose, keyed by cannabinoid. */
+  cannabinoids: Record<string, number>;
+}
+
+export interface SkuRecommendation {
+  sku: ProductSKU;
+  dispensary: DispensaryLocation;
+  distanceMiles: number;
+  /** 0–100 fit score against the regimen target. */
+  matchScore: number;
+}
+
+// ── Geo ──────────────────────────────────────────────────────────────────
+
+const EARTH_RADIUS_MILES = 3958.8;
+
+/** Great-circle distance between two points, in miles. */
+export function haversineMiles(a: GeoPoint, b: GeoPoint): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_MILES * Math.asin(Math.sqrt(h));
+}
+
+// ── Mock data ──────────────────────────────────────────────────────────────
+
+const MOCK_DISPENSARIES: DispensaryLocation[] = [
+  { id: "disp-1", name: "Green Cross — Irvine", address: "2600 Main St, Irvine, CA", lat: 33.6846, lng: -117.8265 },
+  { id: "disp-2", name: "Coastal Leaf — Newport", address: "120 Pacific Ave, Newport Beach, CA", lat: 33.6189, lng: -117.9298 },
+  { id: "disp-3", name: "Harbor Wellness — Long Beach", address: "500 Ocean Blvd, Long Beach, CA", lat: 33.7701, lng: -118.1937 },
+  { id: "disp-4", name: "High Desert Rx — Riverside", address: "900 University Ave, Riverside, CA", lat: 33.9806, lng: -117.3755 },
+];
+
+const MOCK_CATALOG: ProductSKU[] = [
+  { id: "sku-101", name: "Balanced 1:1 Tincture 10mg/10mg", dispensaryId: "disp-1", cannabinoidProfile: { THC: 10, CBD: 10 }, inStock: true, price: 45 },
+  { id: "sku-102", name: "CBD Softgel 25mg", dispensaryId: "disp-1", cannabinoidProfile: { CBD: 25 }, inStock: true, price: 38 },
+  { id: "sku-103", name: "Indica Gummy 5mg THC", dispensaryId: "disp-2", cannabinoidProfile: { THC: 5 }, inStock: true, price: 22 },
+  { id: "sku-104", name: "CBN Sleep Drops 5mg", dispensaryId: "disp-2", cannabinoidProfile: { CBN: 5, CBD: 5 }, inStock: false, price: 40 },
+  { id: "sku-105", name: "20:1 CBD:THC Capsule", dispensaryId: "disp-3", cannabinoidProfile: { CBD: 20, THC: 1 }, inStock: true, price: 50 },
+  { id: "sku-106", name: "High-THC Distillate Cart 2.5mg/puff", dispensaryId: "disp-4", cannabinoidProfile: { THC: 2.5 }, inStock: true, price: 35 },
+];
+
+// ── Matching ─────────────────────────────────────────────────────────────
+
+/**
+ * Score how well a SKU matches a regimen target (0–100). Closer per-cannabinoid
+ * mg means a higher score; out-of-stock SKUs are penalised but not excluded.
+ */
+export function scoreSkuAgainstRegimen(
+  sku: ProductSKU,
+  target: RegimenTarget,
+): number {
+  const keys = Object.keys(target.cannabinoids);
+  if (keys.length === 0) return 0;
+
+  let total = 0;
+  for (const key of keys) {
+    const want = target.cannabinoids[key];
+    const have = sku.cannabinoidProfile[key] ?? 0;
+    if (want <= 0) continue;
+    // Relative error → similarity in [0,1].
+    const err = Math.min(Math.abs(have - want) / want, 1);
+    total += 1 - err;
+  }
+  let score = (total / keys.length) * 100;
+  if (!sku.inStock) score *= 0.5;
+  return Math.round(score);
+}
+
 export class DispensarySyncClient {
+  constructor(
+    private catalog: ProductSKU[] = MOCK_CATALOG,
+    private dispensaries: DispensaryLocation[] = MOCK_DISPENSARIES,
+  ) {}
+
+  /** Sync (ingest) a dispensary's SKU catalog from its POS system. */
   async syncCatalog(dispensaryId: string): Promise<ProductSKU[]> {
-    // Mock API call to dispensary POS system
-    console.log(`[DispensarySync] Syncing catalog for ${dispensaryId}`);
-    return [];
+    return this.catalog.filter((s) => s.dispensaryId === dispensaryId);
   }
 
-  async findProductsInRadius(lat: number, lng: number, radiusMiles: number = 30): Promise<ProductSKU[]> {
-    // Mock geolocation lookup
-    return [];
+  /** Find in-stock SKUs at dispensaries within `radiusMiles` of a point. */
+  async findProductsInRadius(
+    lat: number,
+    lng: number,
+    radiusMiles = 30,
+  ): Promise<ProductSKU[]> {
+    const origin: GeoPoint = { lat, lng };
+    const nearbyIds = new Set(
+      this.dispensaries
+        .filter((d) => haversineMiles(origin, d) <= radiusMiles)
+        .map((d) => d.id),
+    );
+    return this.catalog.filter((s) => nearbyIds.has(s.dispensaryId) && s.inStock);
+  }
+
+  /**
+   * Recommend SKUs near a patient that best match their prescribed regimen,
+   * ranked by match score then distance. Powers the in-app purchasing flow.
+   */
+  async recommendForRegimen(
+    origin: GeoPoint,
+    target: RegimenTarget,
+    radiusMiles = 30,
+  ): Promise<SkuRecommendation[]> {
+    const dispById = new Map(this.dispensaries.map((d) => [d.id, d]));
+    const recs: SkuRecommendation[] = [];
+
+    for (const sku of this.catalog) {
+      const dispensary = dispById.get(sku.dispensaryId);
+      if (!dispensary) continue;
+      const distanceMiles = haversineMiles(origin, dispensary);
+      if (distanceMiles > radiusMiles) continue;
+      const matchScore = scoreSkuAgainstRegimen(sku, target);
+      if (matchScore <= 0) continue;
+      recs.push({ sku, dispensary, distanceMiles: Math.round(distanceMiles * 10) / 10, matchScore });
+    }
+
+    return recs.sort(
+      (a, b) => b.matchScore - a.matchScore || a.distanceMiles - b.distanceMiles,
+    );
   }
 }

--- a/src/lib/integrations/fhir-adapter.test.ts
+++ b/src/lib/integrations/fhir-adapter.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  chartToFhirBundle,
+  medicationsFromBundle,
+  reconcileMedications,
+  FhirAdapter,
+  type PatientChart,
+} from "./fhir-adapter";
+
+const chart: PatientChart = {
+  id: "p1",
+  firstName: "Jane",
+  lastName: "Doe",
+  birthDate: "1980-05-01",
+  conditions: [{ name: "Chronic pain", code: "G89.4" }],
+  medications: [
+    { name: "Lisinopril", dose: "10 mg", code: "29046" },
+    { name: "CBD tincture", dose: "20 mg", isCannabis: true },
+  ],
+};
+
+describe("chartToFhirBundle", () => {
+  it("emits a Patient + Condition + MedicationStatement bundle", () => {
+    const bundle = chartToFhirBundle(chart);
+    expect(bundle.resourceType).toBe("Bundle");
+    const types = bundle.entry.map((e) => e.resource.resourceType);
+    expect(types).toContain("Patient");
+    expect(types).toContain("Condition");
+    expect(types.filter((t) => t === "MedicationStatement")).toHaveLength(2);
+  });
+
+  it("round-trips medications back out of the bundle", () => {
+    const meds = medicationsFromBundle(chartToFhirBundle(chart));
+    expect(meds.map((m) => m.name)).toEqual(["Lisinopril", "CBD tincture"]);
+    expect(meds[0].dose).toBe("10 mg");
+  });
+});
+
+describe("reconcileMedications", () => {
+  it("adds new meds, flags dose conflicts, and de-dupes", () => {
+    const existing = chart.medications;
+    const incoming = [
+      { name: "lisinopril", dose: "20 mg" }, // dose conflict (case-insensitive)
+      { name: "Metformin", dose: "500 mg" }, // new
+      { name: "CBD tincture", dose: "20 mg", isCannabis: true }, // same
+    ];
+    const { merged, added, conflicts } = reconcileMedications(existing, incoming);
+    expect(added.map((m) => m.name)).toEqual(["Metformin"]);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ existingDose: "10 mg", incomingDose: "20 mg" });
+    // 3 unique drugs after merge.
+    expect(merged).toHaveLength(3);
+  });
+});
+
+describe("FhirAdapter", () => {
+  it("imports a bundle JSON and reconciles", async () => {
+    const adapter = new FhirAdapter("https://emr.example/fhir", "/certs/x.pem");
+    const bundleJson = JSON.stringify(chartToFhirBundle(chart));
+    const result = await adapter.importAndReconcile(bundleJson, [
+      { name: "Aspirin", dose: "81 mg" },
+    ]);
+    // Both chart meds are new relative to the local [Aspirin] list.
+    expect(result.added).toHaveLength(2);
+    expect(result.merged).toHaveLength(3);
+  });
+});

--- a/src/lib/integrations/fhir-adapter.ts
+++ b/src/lib/integrations/fhir-adapter.ts
@@ -1,23 +1,208 @@
-/**
- * EMR-013: Conventional EMR Integration
- * HL7 FHIR Adapter for bidirectional data exchange
- */
-export class FhirAdapter {
-  constructor(private endpoint: string, private certPath: string) {}
+// EMR-013 — Conventional EMR Integration (HL7 FHIR R4 adapter).
+//
+// Bidirectional data exchange with conventional EMRs (Epic, Cerner, …):
+//   • Export a patient as a FHIR R4 document Bundle (Patient + conditions +
+//     medications) so an outside system can ingest the Leafjourney chart.
+//   • Import a FHIR Bundle and reconcile medications (cannabis + conventional)
+//     into a single de-duplicated list, flagging conflicts for the clinician.
+//
+// The mapping helpers are pure and unit-tested; the network plumbing is a thin
+// shell around them.
 
-  async exportPatientBundle(patientId: string) {
-    console.log(`[FHIR] Exporting bundle for ${patientId}`);
-    // Scaffold FHIR R4 Bundle mapping
-    return {
-      resourceType: "Bundle",
-      type: "document",
-      entry: []
-    };
+export interface SimpleMedication {
+  name: string;
+  /** e.g. "10 mg", "0.5 mL" */
+  dose?: string;
+  /** Whether this is a cannabis product vs. a conventional pharmaceutical. */
+  isCannabis?: boolean;
+  /** RxNorm / source code, when known. */
+  code?: string;
+}
+
+export interface SimpleCondition {
+  name: string;
+  /** ICD-10 code, when known. */
+  code?: string;
+}
+
+export interface PatientChart {
+  id: string;
+  firstName: string;
+  lastName: string;
+  birthDate?: string;
+  conditions: SimpleCondition[];
+  medications: SimpleMedication[];
+}
+
+// ── FHIR resource shapes (minimal R4 subset) ───────────────────────────────
+
+export interface FhirBundle {
+  resourceType: "Bundle";
+  type: "document";
+  entry: Array<{ resource: FhirResource }>;
+}
+
+export type FhirResource =
+  | FhirPatient
+  | FhirCondition
+  | FhirMedicationStatement;
+
+interface FhirPatient {
+  resourceType: "Patient";
+  id: string;
+  name: Array<{ family: string; given: string[] }>;
+  birthDate?: string;
+}
+
+interface FhirCondition {
+  resourceType: "Condition";
+  code: { text: string; coding?: Array<{ system: string; code: string }> };
+  subject: { reference: string };
+}
+
+interface FhirMedicationStatement {
+  resourceType: "MedicationStatement";
+  status: "active";
+  medicationCodeableConcept: {
+    text: string;
+    coding?: Array<{ system: string; code: string }>;
+  };
+  dosage?: Array<{ text: string }>;
+  subject: { reference: string };
+}
+
+const ICD10_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm";
+const RXNORM_SYSTEM = "http://www.nlm.nih.gov/research/umls/rxnorm";
+
+// ── Pure mapping ────────────────────────────────────────────────────────────
+
+/** Map an internal patient chart to a FHIR R4 document Bundle. */
+export function chartToFhirBundle(chart: PatientChart): FhirBundle {
+  const ref = `Patient/${chart.id}`;
+  const entries: Array<{ resource: FhirResource }> = [
+    {
+      resource: {
+        resourceType: "Patient",
+        id: chart.id,
+        name: [{ family: chart.lastName, given: [chart.firstName] }],
+        ...(chart.birthDate ? { birthDate: chart.birthDate } : {}),
+      },
+    },
+    ...chart.conditions.map((c) => ({
+      resource: {
+        resourceType: "Condition" as const,
+        code: {
+          text: c.name,
+          ...(c.code ? { coding: [{ system: ICD10_SYSTEM, code: c.code }] } : {}),
+        },
+        subject: { reference: ref },
+      },
+    })),
+    ...chart.medications.map((m) => ({
+      resource: {
+        resourceType: "MedicationStatement" as const,
+        status: "active" as const,
+        medicationCodeableConcept: {
+          text: m.name,
+          ...(m.code ? { coding: [{ system: RXNORM_SYSTEM, code: m.code }] } : {}),
+        },
+        ...(m.dose ? { dosage: [{ text: m.dose }] } : {}),
+        subject: { reference: ref },
+      },
+    })),
+  ];
+
+  return { resourceType: "Bundle", type: "document", entry: entries };
+}
+
+/** Extract medications from an inbound FHIR Bundle. */
+export function medicationsFromBundle(bundle: FhirBundle): SimpleMedication[] {
+  return bundle.entry
+    .map((e) => e.resource)
+    .filter(
+      (r): r is FhirMedicationStatement =>
+        r.resourceType === "MedicationStatement",
+    )
+    .map((r) => ({
+      name: r.medicationCodeableConcept.text,
+      dose: r.dosage?.[0]?.text,
+      code: r.medicationCodeableConcept.coding?.[0]?.code,
+    }));
+}
+
+export interface ReconciliationResult {
+  /** De-duplicated union of both medication lists. */
+  merged: SimpleMedication[];
+  /** Medications present only in the incoming (external) list. */
+  added: SimpleMedication[];
+  /** Same drug name with a differing dose between the two lists. */
+  conflicts: Array<{ name: string; existingDose?: string; incomingDose?: string }>;
+}
+
+const normName = (s: string) => s.trim().toLowerCase();
+
+/**
+ * Medication reconciliation between the local chart and an external EMR's
+ * list. De-duplicates by name, surfaces new meds, and flags dose conflicts so
+ * the clinician can resolve them. Cannabis flags are preserved from whichever
+ * side asserts them.
+ */
+export function reconcileMedications(
+  existing: SimpleMedication[],
+  incoming: SimpleMedication[],
+): ReconciliationResult {
+  const byName = new Map<string, SimpleMedication>();
+  for (const m of existing) byName.set(normName(m.name), { ...m });
+
+  const added: SimpleMedication[] = [];
+  const conflicts: ReconciliationResult["conflicts"] = [];
+
+  for (const m of incoming) {
+    const key = normName(m.name);
+    const prior = byName.get(key);
+    if (!prior) {
+      byName.set(key, { ...m });
+      added.push(m);
+      continue;
+    }
+    if (m.dose && prior.dose && m.dose !== prior.dose) {
+      conflicts.push({ name: prior.name, existingDose: prior.dose, incomingDose: m.dose });
+    }
+    // Preserve a cannabis flag from either source; fill in a missing dose.
+    byName.set(key, {
+      ...prior,
+      dose: prior.dose ?? m.dose,
+      isCannabis: prior.isCannabis || m.isCannabis,
+      code: prior.code ?? m.code,
+    });
   }
 
-  async importCcdDocument(ccdXml: string) {
-    console.log(`[FHIR] Importing CCD...`);
-    // Scaffold parsing logic
-    return { success: true };
+  return { merged: Array.from(byName.values()), added, conflicts };
+}
+
+// ── Network shell ────────────────────────────────────────────────────────────
+
+export class FhirAdapter {
+  constructor(
+    private endpoint: string,
+    private certPath: string,
+  ) {}
+
+  /** Export a patient chart as a FHIR R4 document Bundle. */
+  async exportPatientBundle(chart: PatientChart): Promise<FhirBundle> {
+    return chartToFhirBundle(chart);
+  }
+
+  /**
+   * Import a FHIR Bundle (JSON) and reconcile its medications against the
+   * local chart's current medication list.
+   */
+  async importAndReconcile(
+    bundleJson: string,
+    existing: SimpleMedication[],
+  ): Promise<ReconciliationResult> {
+    const bundle = JSON.parse(bundleJson) as FhirBundle;
+    const incoming = medicationsFromBundle(bundle);
+    return reconcileMedications(existing, incoming);
   }
 }

--- a/src/lib/integrations/leafly-client.test.ts
+++ b/src/lib/integrations/leafly-client.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { fetchLeaflyStrains } from "./leafly-client";
+import {
+  fetchLeaflyStrains,
+  matchStrainsToSymptom,
+  normalizeSymptom,
+  listCoveredConditions,
+  STRAIN_CATALOG,
+} from "./leafly-client";
 
 global.fetch = vi.fn();
 
@@ -17,5 +23,45 @@ describe("Leafly API Client", () => {
     const strains = await fetchLeaflyStrains();
     expect(strains).toHaveLength(1);
     expect(strains[0].name).toBe("Blue Dream");
+  });
+
+  it("falls back to the curated catalog when the API fails", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("offline"));
+    const strains = await fetchLeaflyStrains();
+    expect(strains.length).toBeGreaterThan(0);
+    expect(strains).toBe(STRAIN_CATALOG);
+  });
+});
+
+describe("Symptom → strain matcher (EMR-018)", () => {
+  it("normalizes natural-language symptoms to canonical conditions", () => {
+    expect(normalizeSymptom("can't sleep")).toBe("insomnia");
+    expect(normalizeSymptom("Anxious")).toBe("anxiety");
+    expect(normalizeSymptom("  ")).toBeNull();
+  });
+
+  it("ranks sleep strains highest for insomnia", () => {
+    const matches = matchStrainsToSymptom("insomnia");
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0].helpsWith).toContain("insomnia");
+    // Scores are sorted descending.
+    for (let i = 1; i < matches.length; i++) {
+      expect(matches[i - 1].matchScore).toBeGreaterThanOrEqual(matches[i].matchScore);
+    }
+  });
+
+  it("returns high-CBD cultivars for seizures", () => {
+    const matches = matchStrainsToSymptom("seizures");
+    expect(matches.some((m) => m.slug === "charlottes-web")).toBe(true);
+  });
+
+  it("returns nothing for an unknown symptom with no synonym/effect overlap", () => {
+    expect(matchStrainsToSymptom("teleportation")).toEqual([]);
+  });
+
+  it("exposes the covered conditions for UI chips", () => {
+    const conditions = listCoveredConditions();
+    expect(conditions).toContain("pain");
+    expect(conditions).toContain("anxiety");
   });
 });

--- a/src/lib/integrations/leafly-client.ts
+++ b/src/lib/integrations/leafly-client.ts
@@ -1,34 +1,293 @@
+// EMR-018 — Leafly Strain Database Integration.
+//
+// Maps the most common medical issues cannabis is used for (sleep,
+// anxiety, insomnia, stress, pain, cancer, etc.) to flower strains,
+// each with its terpene and cannabinoid profile, and exposes a
+// symptom → strain matcher that powers the public Strain Finder on the
+// Education tab.
+//
+// In production `fetchLeaflyStrains` hits the Leafly B2B API; without a
+// key (or network) it falls back to the curated catalog below so the
+// finder always renders real, clinically-coherent results.
+
 export interface LeaflyStrainData {
   slug: string;
   name: string;
-  category: string;
+  category: "Indica" | "Sativa" | "Hybrid" | "CBD" | string;
+  /** Approximate THC potency, percent of dry weight. */
   thcLevel: number;
+  /** Approximate CBD potency, percent of dry weight. */
   cbdLevel: number;
   dominantTerpene: string;
+  /** Secondary terpenes that round out the entourage effect. */
+  terpenes?: string[];
   effects: string[];
+  /** Plain-language conditions this strain is commonly used for. */
+  helpsWith?: string[];
+  /** One-line clinician-readable summary. */
+  summary?: string;
+}
+
+/** Curated medical strain catalog. Kept clinically coherent rather than
+ *  exhaustive — every entry carries a terpene + cannabinoid profile so the
+ *  finder can explain *why* a strain matches a symptom. */
+export const STRAIN_CATALOG: LeaflyStrainData[] = [
+  {
+    slug: "blue-dream",
+    name: "Blue Dream",
+    category: "Hybrid",
+    thcLevel: 18,
+    cbdLevel: 0.1,
+    dominantTerpene: "Myrcene",
+    terpenes: ["Myrcene", "Pinene", "Caryophyllene"],
+    effects: ["Happy", "Relaxed", "Uplifted"],
+    helpsWith: ["stress", "pain", "depression", "anxiety"],
+    summary:
+      "Balanced daytime hybrid; gentle body relaxation without heavy sedation.",
+  },
+  {
+    slug: "granddaddy-purple",
+    name: "Granddaddy Purple",
+    category: "Indica",
+    thcLevel: 20,
+    cbdLevel: 0.1,
+    dominantTerpene: "Linalool",
+    terpenes: ["Linalool", "Myrcene", "Caryophyllene"],
+    effects: ["Sleepy", "Relaxed", "Calm"],
+    helpsWith: ["insomnia", "sleep", "pain", "stress"],
+    summary:
+      "Heavy indica rich in linalool and myrcene; a classic before-bed choice.",
+  },
+  {
+    slug: "sour-diesel",
+    name: "Sour Diesel",
+    category: "Sativa",
+    thcLevel: 22,
+    cbdLevel: 0.1,
+    dominantTerpene: "Caryophyllene",
+    terpenes: ["Caryophyllene", "Limonene", "Myrcene"],
+    effects: ["Energetic", "Focused", "Uplifted"],
+    helpsWith: ["depression", "stress", "fatigue", "anxiety"],
+    summary:
+      "Fast-acting sativa for daytime energy and mood; favour low doses for anxiety.",
+  },
+  {
+    slug: "charlottes-web",
+    name: "Charlotte's Web",
+    category: "CBD",
+    thcLevel: 0.3,
+    cbdLevel: 17,
+    dominantTerpene: "Pinene",
+    terpenes: ["Pinene", "Myrcene", "Caryophyllene"],
+    effects: ["Focused", "Relaxed", "Clear-headed"],
+    helpsWith: ["epilepsy", "anxiety", "seizures", "inflammation"],
+    summary:
+      "High-CBD, minimal-THC cultivar; non-intoxicating, well known for seizure support.",
+  },
+  {
+    slug: "acdc",
+    name: "ACDC",
+    category: "CBD",
+    thcLevel: 1,
+    cbdLevel: 20,
+    dominantTerpene: "Myrcene",
+    terpenes: ["Myrcene", "Pinene", "Caryophyllene"],
+    effects: ["Relaxed", "Clear-headed", "Focused"],
+    helpsWith: ["pain", "anxiety", "inflammation", "cancer"],
+    summary:
+      "~20:1 CBD:THC; daytime relief with little to no intoxication. Common adjunct in oncology supportive care.",
+  },
+  {
+    slug: "harlequin",
+    name: "Harlequin",
+    category: "Hybrid",
+    thcLevel: 7,
+    cbdLevel: 10,
+    dominantTerpene: "Myrcene",
+    terpenes: ["Myrcene", "Pinene", "Caryophyllene"],
+    effects: ["Clear-headed", "Relaxed", "Alert"],
+    helpsWith: ["pain", "anxiety", "stress", "inflammation"],
+    summary:
+      "Reliable ~5:2 CBD:THC hybrid; functional daytime relief that stays clear-headed.",
+  },
+  {
+    slug: "northern-lights",
+    name: "Northern Lights",
+    category: "Indica",
+    thcLevel: 18,
+    cbdLevel: 0.1,
+    dominantTerpene: "Myrcene",
+    terpenes: ["Myrcene", "Caryophyllene", "Pinene"],
+    effects: ["Sleepy", "Relaxed", "Euphoric"],
+    helpsWith: ["insomnia", "sleep", "pain", "stress"],
+    summary: "Deeply sedating indica; pain and sleep support in the evening.",
+  },
+  {
+    slug: "girl-scout-cookies",
+    name: "Girl Scout Cookies",
+    category: "Hybrid",
+    thcLevel: 25,
+    cbdLevel: 0.2,
+    dominantTerpene: "Caryophyllene",
+    terpenes: ["Caryophyllene", "Limonene", "Humulene"],
+    effects: ["Euphoric", "Relaxed", "Happy"],
+    helpsWith: ["pain", "nausea", "appetite", "cancer", "stress"],
+    summary:
+      "Potent hybrid; strong euphoria with appetite and nausea support — useful in chemo-related symptoms.",
+  },
+  {
+    slug: "jack-herer",
+    name: "Jack Herer",
+    category: "Sativa",
+    thcLevel: 19,
+    cbdLevel: 0.1,
+    dominantTerpene: "Terpinolene",
+    terpenes: ["Terpinolene", "Pinene", "Caryophyllene"],
+    effects: ["Focused", "Energetic", "Creative"],
+    helpsWith: ["depression", "fatigue", "stress", "focus"],
+    summary:
+      "Bright terpinolene-forward sativa; clear focus and mood lift for daytime use.",
+  },
+  {
+    slug: "white-widow",
+    name: "White Widow",
+    category: "Hybrid",
+    thcLevel: 19,
+    cbdLevel: 0.2,
+    dominantTerpene: "Myrcene",
+    terpenes: ["Myrcene", "Caryophyllene", "Pinene"],
+    effects: ["Euphoric", "Energetic", "Relaxed"],
+    helpsWith: ["stress", "depression", "pain", "fatigue"],
+    summary: "Even hybrid; balanced lift and relaxation, a versatile staple.",
+  },
+];
+
+/**
+ * Symptom synonyms → canonical condition keys used in `helpsWith`.
+ * Lets the finder accept natural language ("can't sleep", "nervous")
+ * and still match strain metadata.
+ */
+const SYMPTOM_SYNONYMS: Record<string, string> = {
+  "cant sleep": "insomnia",
+  "trouble sleeping": "insomnia",
+  sleepless: "insomnia",
+  insomnia: "insomnia",
+  sleep: "sleep",
+  nervous: "anxiety",
+  anxious: "anxiety",
+  anxiety: "anxiety",
+  panic: "anxiety",
+  stress: "stress",
+  stressed: "stress",
+  tension: "stress",
+  pain: "pain",
+  ache: "pain",
+  sore: "pain",
+  "chronic pain": "pain",
+  inflammation: "inflammation",
+  cancer: "cancer",
+  chemo: "cancer",
+  nausea: "nausea",
+  appetite: "appetite",
+  depression: "depression",
+  depressed: "depression",
+  "low mood": "depression",
+  fatigue: "fatigue",
+  tired: "fatigue",
+  focus: "focus",
+  seizure: "seizures",
+  seizures: "seizures",
+  epilepsy: "epilepsy",
+};
+
+export interface StrainMatch extends LeaflyStrainData {
+  /** 0–100 relevance score for the queried symptom. */
+  matchScore: number;
+  /** The canonical condition the query resolved to. */
+  matchedCondition: string;
+}
+
+/** Resolve a free-text symptom query to a canonical condition key. */
+export function normalizeSymptom(query: string): string | null {
+  // Lowercase, drop apostrophes ("can't" → "cant"), and collapse runs of
+  // non-alphanumerics to single spaces so punctuation never blocks a match.
+  const q = query
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+  if (!q) return null;
+  if (SYMPTOM_SYNONYMS[q]) return SYMPTOM_SYNONYMS[q];
+  // Substring fallback: longest matching synonym wins.
+  const hit = Object.keys(SYMPTOM_SYNONYMS)
+    .filter((syn) => q.includes(syn))
+    .sort((a, b) => b.length - a.length)[0];
+  return hit ? SYMPTOM_SYNONYMS[hit] : q;
+}
+
+/**
+ * Match strains to a free-text symptom query, ranked by relevance.
+ * Pure function — safe to unit test and call from client or server.
+ */
+export function matchStrainsToSymptom(
+  query: string,
+  catalog: LeaflyStrainData[] = STRAIN_CATALOG,
+): StrainMatch[] {
+  const condition = normalizeSymptom(query);
+  if (!condition) return [];
+
+  return catalog
+    .map((strain) => {
+      const helps = (strain.helpsWith ?? []).map((h) => h.toLowerCase());
+      let score = 0;
+      if (helps.includes(condition)) score += 70;
+      // Primary listed condition (first entry) gets a relevance bump.
+      if (helps[0] === condition) score += 15;
+      // Soft match on related effect terms.
+      const effectText = strain.effects.join(" ").toLowerCase();
+      if (
+        (condition === "insomnia" || condition === "sleep") &&
+        /sleep|relax|calm/.test(effectText)
+      )
+        score += 10;
+      if (
+        (condition === "anxiety" || condition === "stress") &&
+        /relax|calm|clear/.test(effectText)
+      )
+        score += 10;
+      if (
+        (condition === "depression" || condition === "fatigue") &&
+        /energ|uplift|happy|focus|creative/.test(effectText)
+      )
+        score += 10;
+      return { ...strain, matchScore: Math.min(score, 100), matchedCondition: condition };
+    })
+    .filter((s) => s.matchScore > 0)
+    .sort((a, b) => b.matchScore - a.matchScore);
+}
+
+/** Distinct conditions covered by the catalog, for UI suggestion chips. */
+export function listCoveredConditions(
+  catalog: LeaflyStrainData[] = STRAIN_CATALOG,
+): string[] {
+  const set = new Set<string>();
+  for (const s of catalog) for (const c of s.helpsWith ?? []) set.add(c);
+  return Array.from(set).sort();
 }
 
 export async function fetchLeaflyStrains(): Promise<LeaflyStrainData[]> {
   // In a real app, this hits the Leafly B2B API.
-  // For this integration, we will simulate fetching a batch of strains.
-  
   try {
     const res = await fetch("https://api.leafly.com/v1/strains");
     if (res.ok) {
       const json = await res.json();
       if (json.data && Array.isArray(json.data)) {
-         return json.data;
+        return json.data;
       }
     }
-  } catch (err) {
-    // Fallthrough to mock data if fetch fails (e.g. CORS, no network, or endpoint doesn't exist)
+  } catch {
+    // Fallthrough to the curated catalog if fetch fails (no key, CORS, offline).
   }
-  
-  // Mock data fallback
-  return [
-    { slug: "blue-dream", name: "Blue Dream", category: "Hybrid", thcLevel: 18, cbdLevel: 0.1, dominantTerpene: "Myrcene", effects: ["Happy", "Relaxed"] },
-    { slug: "charlottes-web", name: "Charlotte's Web", category: "CBD", thcLevel: 0.3, cbdLevel: 17, dominantTerpene: "Pinene", effects: ["Focused", "Relaxed"] },
-    { slug: "granddaddy-purple", name: "Granddaddy Purple", category: "Indica", thcLevel: 20, cbdLevel: 0.1, dominantTerpene: "Linalool", effects: ["Sleepy", "Relaxed"] },
-    { slug: "sour-diesel", name: "Sour Diesel", category: "Sativa", thcLevel: 22, cbdLevel: 0.1, dominantTerpene: "Caryophyllene", effects: ["Energetic", "Focused"] }
-  ];
+
+  return STRAIN_CATALOG;
 }


### PR DESCRIPTION
## Phase 12 — Track 8: Clinical Education & Integrations

Work scoped to `src/lib/integrations/` and `src/app/education/`. All TypeScript checks and lint pass; new + affected test suites pass (157 tests).

### Tickets

| Ticket | Summary |
| --- | --- |
| **EMR-018** Leafly Strain Database | `leafly-client` becomes a real symptom→strain matcher (terpene + cannabinoid profiles, synonym normalization, ranked scoring). New public **`/education/strain-finder`**. |
| **EMR-002** Dispensary SKU Scanning | `dispensary-sync` gains a catalog, haversine radius filter, and a regimen→SKU recommendation engine. |
| **EMR-017** Dispensary Locator | New `dispensary-locator` integration (dispensary + provider pins, distance, keyless Maps links) and public **`/education/dispensary-locator`** with a Google Maps embed + graceful directory fallback. |
| **EMR-013** Conventional EMR Integration | FHIR R4 adapter: chart→Bundle mapping + cannabis/conventional **medication reconciliation** (adds, dose conflicts, de-dupe). |
| **EMR-202** Kander research PDF | Downloadable PDF under `/public/guides`, surfaced **below the PubMed search** in the Research tab, with a `trackGuideDownload` analytics action. |
| **EMR-203** Trifold Reference Guide | Public **`/education/trifold`** web-flip version (dual-audience), reusing the trifold data, plus a print-ready PDF download. |
| **EMR-204** Landing polish | Archived unconfirmed **PhytoRx** + **Flower Powered** partner brands so they drop from all public partner sections; regression test added. "POTENCY 710" category label already reads "CBD SKINCARE". |

### Already shipped — verified in place
- **EMR-179** — research/citation links open in a new tab (`target="_blank"`).
- **EMR-071 / EMR-080 / EMR-111** — ChatCB + cannabis education library/database.
- **EMR-003** — mg-based dosing display (existing dosing calculator).
- **EMR-173** — 15-day launch-readiness meta ticket (no code surface).

### Notes
- Guide PDFs are generated by `scripts/generate-guides.mjs` — reproducible, no new dependencies.
- The Maps embed activates when `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is set; without it the locator still works via keyless `google.com/maps` directions links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)