### PR TITLE
feat(coding): ground billing-code suggestions to the note (kill hardcoded codes + confidence loop)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
@@ -26,9 +26,9 @@ import {
 } from "@/lib/agents/guardrails/note-guardrails";
 import { ensureConsentDisclaimerBlock } from "@/lib/clinical/ai-consent-disclaimer";
 import {
-  applyGrounding,
   buildCodingPrompt,
   parseCodingResponse,
+  runConfidenceLoop,
 } from "@/lib/clinical/coding-confidence";
 import { logger } from "@/lib/observability/log";
 
@@ -481,13 +481,27 @@ export async function recommendCodes(
   const patientContext = note.encounter.patient.presentingConcerns ?? "Not documented";
 
   let parsed: ReturnType<typeof parseCodingResponse> = null;
+  let kept: Awaited<ReturnType<typeof runConfidenceLoop>>["kept"] = [];
+  let dropped: Awaited<ReturnType<typeof runConfidenceLoop>>["dropped"] = [];
   try {
     const model = resolveModelClient();
-    const resp = await model.complete(buildCodingPrompt(noteText, patientContext), {
+    const complete = (p: string, o?: { maxTokens?: number; temperature?: number }) =>
+      model.complete(p, o);
+    const resp = await complete(buildCodingPrompt(noteText, patientContext), {
       maxTokens: 1024,
       temperature: 0.2,
     });
     parsed = parseCodingResponse(resp);
+    if (parsed) {
+      // Aggressive confidence loop: ground → strict critic → iterate → floor.
+      const loop = await runConfidenceLoop({
+        noteText,
+        candidates: parsed.icd10,
+        complete,
+      });
+      kept = loop.kept;
+      dropped = loop.dropped;
+    }
   } catch (err) {
     logger.warn({ event: "clinic.voice_chart.recommend_codes_failed", err });
     return { ok: false, error: "Could not generate codes right now. Please retry." };
@@ -495,7 +509,6 @@ export async function recommendCodes(
 
   if (!parsed) return { ok: true, codes: [], droppedCount: 0 };
 
-  const { kept, dropped } = applyGrounding(parsed.icd10, noteText);
   const codes: RecommendedCode[] = kept.map((c) => ({
     code: c.code,
     type: "ICD-10" as const,

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
@@ -25,6 +25,11 @@ import {
   type NoteSnapshot,
 } from "@/lib/agents/guardrails/note-guardrails";
 import { ensureConsentDisclaimerBlock } from "@/lib/clinical/ai-consent-disclaimer";
+import {
+  applyGrounding,
+  buildCodingPrompt,
+  parseCodingResponse,
+} from "@/lib/clinical/coding-confidence";
 import { logger } from "@/lib/observability/log";
 
 // ── Result types ───────────────────────────────────────────────
@@ -414,6 +419,100 @@ ${summaryMd}
       error: err instanceof Error ? err.message : "Failed to process transcript.",
     };
   }
+}
+
+// ── Billing code recommendations (grounded) ────────────────────────────
+
+export interface RecommendedCode {
+  code: string;
+  type: "ICD-10" | "CPT";
+  label: string;
+  confidence: number;
+  grounded?: boolean;
+}
+
+const EM_LABELS: Record<string, string> = {
+  "99202": "Office visit, new patient (15-29 min)",
+  "99203": "Office visit, new patient (30-44 min)",
+  "99204": "Office visit, new patient (45-59 min)",
+  "99205": "Office visit, new patient (60-74 min)",
+  "99211": "Office visit, established (minimal)",
+  "99212": "Office visit, established (10-19 min)",
+  "99213": "Office visit, established (20-29 min)",
+  "99214": "Office visit, established (30-39 min)",
+  "99215": "Office visit, established (40-54 min)",
+};
+
+/**
+ * Generate billing-code recommendations for a note, GROUNDED against the
+ * documented text — diagnostic codes whose concept isn't in the note are
+ * dropped rather than shown. Replaces the previous hardcoded placeholder
+ * codes in the voice-chart UI.
+ */
+export async function recommendCodes(
+  noteId: string,
+): Promise<
+  | { ok: true; codes: RecommendedCode[]; droppedCount: number }
+  | { ok: false; error: string }
+> {
+  const user = await requireUser();
+
+  const note = await prisma.note.findUnique({
+    where: { id: noteId },
+    include: { encounter: { include: { patient: true } } },
+  });
+  if (!note) return { ok: false, error: "Note not found." };
+  if (note.encounter.organizationId !== user.organizationId) {
+    return { ok: false, error: "Unauthorized" };
+  }
+
+  const blocks = Array.isArray(note.blocks) ? (note.blocks as any[]) : [];
+  const noteText = blocks
+    .filter(
+      (b) =>
+        b &&
+        typeof b === "object" &&
+        typeof b.heading === "string" &&
+        !b.heading.startsWith("_"),
+    )
+    .map((b) => `${b.heading}: ${b.body ?? ""}`)
+    .join("\n\n");
+
+  const patientContext = note.encounter.patient.presentingConcerns ?? "Not documented";
+
+  let parsed: ReturnType<typeof parseCodingResponse> = null;
+  try {
+    const model = resolveModelClient();
+    const resp = await model.complete(buildCodingPrompt(noteText, patientContext), {
+      maxTokens: 1024,
+      temperature: 0.2,
+    });
+    parsed = parseCodingResponse(resp);
+  } catch (err) {
+    logger.warn({ event: "clinic.voice_chart.recommend_codes_failed", err });
+    return { ok: false, error: "Could not generate codes right now. Please retry." };
+  }
+
+  if (!parsed) return { ok: true, codes: [], droppedCount: 0 };
+
+  const { kept, dropped } = applyGrounding(parsed.icd10, noteText);
+  const codes: RecommendedCode[] = kept.map((c) => ({
+    code: c.code,
+    type: "ICD-10" as const,
+    label: c.label,
+    confidence: c.confidence,
+    grounded: c.grounded,
+  }));
+  if (parsed.emLevel) {
+    codes.unshift({
+      code: parsed.emLevel,
+      type: "CPT" as const,
+      label: EM_LABELS[parsed.emLevel] ?? "Evaluation & management",
+      confidence: parsed.overallConfidence ?? 0.7,
+    });
+  }
+
+  return { ok: true, codes, droppedCount: dropped.length };
 }
 
 /**

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
@@ -23,6 +23,8 @@ import {
   startVoiceEncounter,
   processTranscript,
   saveTranscriptToEncounter,
+  recommendCodes,
+  type RecommendedCode,
 } from "./actions";
 import { saveAndFinalizeNote } from "../notes/[noteId]/actions";
 
@@ -561,6 +563,8 @@ export function VoiceRecorder({
 
   // Billing & Sign-off States
   const [acceptedCodes, setAcceptedCodes] = useState<string[]>([]);
+  const [billingCodes, setBillingCodes] = useState<RecommendedCode[]>([]);
+  const [codesLoading, setCodesLoading] = useState(false);
   const [isSignOffModalOpen, setIsSignOffModalOpen] = useState(false);
   const [signOffPassword, setSignOffPassword] = useState("");
   const [signOffError, setSignOffError] = useState<string | null>(null);
@@ -762,6 +766,17 @@ export function VoiceRecorder({
         setDocumentHeader(result.documentHeader);
         setSectionOrder(result.sectionOrder);
         setState("complete");
+
+        // Generate grounded billing codes for this note (replaces the old
+        // hardcoded placeholder list). Fire-and-forget; the panel shows a
+        // loading state until it resolves.
+        setCodesLoading(true);
+        setBillingCodes([]);
+        void recommendCodes(result.noteId)
+          .then((res) => {
+            if (res.ok) setBillingCodes(res.codes);
+          })
+          .finally(() => setCodesLoading(false));
       } else {
         setError(result.error);
         setState("idle");
@@ -1452,30 +1467,23 @@ export function VoiceRecorder({
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-3">
-                    {[
-                      {
-                        code: "99214",
-                        type: "CPT",
-                        desc: "Outpatient visit, 30-39 min",
-                        conf: "95%",
-                      },
-                      {
-                        code: "G89.3",
-                        type: "ICD-10",
-                        desc: "Neoplasm related pain (chronic)",
-                        conf: "92%",
-                      },
-                      {
-                        code: "F51.01",
-                        type: "ICD-10",
-                        desc: "Primary insomnia",
-                        conf: "88%",
-                      },
-                    ].map((item) => {
+                    {codesLoading && (
+                      <p className="text-xs text-text-subtle py-2">
+                        Analyzing the note for supported codes…
+                      </p>
+                    )}
+                    {!codesLoading && billingCodes.length === 0 && (
+                      <p className="text-xs text-text-subtle py-2">
+                        No codes are clearly supported by the documentation yet.
+                        Add detail to the note and re-run, or code manually.
+                      </p>
+                    )}
+                    {billingCodes.map((item) => {
                       const isAccepted = acceptedCodes.includes(item.code);
+                      const pct = Math.round(item.confidence * 100);
                       return (
                         <div
-                          key={item.code}
+                          key={`${item.type}-${item.code}`}
                           className="flex items-center justify-between p-3 rounded-lg border border-border bg-surface-muted"
                         >
                           <div className="space-y-1">
@@ -1486,11 +1494,20 @@ export function VoiceRecorder({
                               <span className="font-mono font-bold text-sm text-text">
                                 {item.code}
                               </span>
-                              <span className="text-[10px] text-success font-semibold">
-                                ({item.conf} match)
+                              <span
+                                className={cn(
+                                  "text-[10px] font-semibold",
+                                  pct >= 80
+                                    ? "text-success"
+                                    : pct >= 60
+                                      ? "text-warning"
+                                      : "text-text-subtle",
+                                )}
+                              >
+                                ({pct}% supported)
                               </span>
                             </div>
-                            <p className="text-xs text-text-subtle">{item.desc}</p>
+                            <p className="text-xs text-text-subtle">{item.label}</p>
                           </div>
                           <button
                             onClick={() => {

--- a/src/lib/agents/coding-readiness-agent.ts
+++ b/src/lib/agents/coding-readiness-agent.ts
@@ -2,25 +2,35 @@ import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import type { Agent } from "@/lib/orchestration/types";
 import { writeAgentAudit } from "@/lib/orchestration/context";
+import {
+  applyGrounding,
+  buildCodingPrompt,
+  overallCodingConfidence,
+  parseCodingResponse,
+  type CandidateCode,
+} from "@/lib/clinical/coding-confidence";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Try to extract and parse JSON from a model response.
- * The model may wrap the JSON in markdown code fences.
- */
-function tryParseJSON(text: string): any | null {
-  const jsonMatch =
-    text.match(/```(?:json)?\s*([\s\S]*?)```/) ||
-    text.match(/(\{[\s\S]*\})/);
-  if (!jsonMatch) return null;
-  try {
-    return JSON.parse(jsonMatch[1] || jsonMatch[0]);
-  } catch {
-    return null;
+/** Keyword fallback used when the model returns unparseable output (e.g. the StubModelClient). */
+function keywordFallbackCodes(blocks: unknown): CandidateCode[] {
+  const narrative = JSON.stringify(blocks).toLowerCase();
+  const codes: CandidateCode[] = [];
+  if (/pain/.test(narrative)) {
+    codes.push({ code: "G89.29", label: "Other chronic pain", confidence: 0.55 });
   }
+  if (/sleep|insomnia/.test(narrative)) {
+    codes.push({ code: "G47.00", label: "Insomnia, unspecified", confidence: 0.5 });
+  }
+  if (/nausea/.test(narrative)) {
+    codes.push({ code: "R11.0", label: "Nausea", confidence: 0.5 });
+  }
+  if (/anxiety/.test(narrative)) {
+    codes.push({ code: "F41.1", label: "Generalized anxiety disorder", confidence: 0.5 });
+  }
+  return codes;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,31 +105,8 @@ export const codingReadinessAgent: Agent<
     // ------------------------------------------------------------------
     // 3. Build the coding prompt and call the model
     // ------------------------------------------------------------------
-    const prompt = `You are a medical coding assistant. Review this clinical note and suggest appropriate ICD-10 diagnostic codes and an E&M evaluation/management level.
-
-CLINICAL NOTE:
-${noteText}
-
-Patient context: ${patient.presentingConcerns ?? "Not documented"}
-
-Cannabis history:
-${cannabisHistory}
-
-Return ONLY valid JSON:
-{
-  "icd10": [
-    { "code": "G89.29", "label": "Other chronic pain", "confidence": 0.85, "rationale": "Patient presents with chronic neuropathic pain post-chemo" }
-  ],
-  "emLevel": "99214",
-  "emRationale": "Moderate complexity visit with established patient, detailed history, moderate decision-making",
-  "overallConfidence": 0.75
-}
-
-Guidelines:
-- Include all relevant diagnostic codes, not just one
-- E&M codes: 99211-99215 for established, 99201-99205 for new patients
-- Cannabis-related codes may include F12.x series if applicable
-- Provide clear rationale for each code`;
+    const patientContext = `${patient.presentingConcerns ?? "Not documented"}\nCannabis history: ${cannabisHistory}`;
+    const prompt = buildCodingPrompt(noteText, patientContext);
 
     ctx.log("info", "Sending coding prompt to model", {
       promptLength: prompt.length,
@@ -131,125 +118,63 @@ Guidelines:
     });
 
     // ------------------------------------------------------------------
-    // 4. Parse model response (structured JSON or keyword fallback)
+    // 4. Parse, then GROUND each code against the documented note. A
+    //    diagnostic code only survives if its clinical concept actually
+    //    appears in the note — this kills the "code for a condition the
+    //    note never mentions" failure mode, and reconciles each surviving
+    //    code's confidence by how well it's supported.
     // ------------------------------------------------------------------
-    const parsed = tryParseJSON(modelResponse);
+    const parsedCoding = parseCodingResponse(modelResponse);
+    const candidates: CandidateCode[] = parsedCoding
+      ? parsedCoding.icd10
+      : keywordFallbackCodes(note.blocks);
+    const emLevel = parsedCoding?.emLevel ?? null;
+    const emRationale = parsedCoding?.emRationale ?? "";
 
-    let codes: z.infer<typeof output>["icd10"];
-    let emLevel: string | null;
-    let rationale: string;
+    const { kept, dropped } = applyGrounding(candidates, noteText);
+    const overall = overallCodingConfidence(kept);
 
-    if (parsed && typeof parsed === "object" && Array.isArray(parsed.icd10)) {
-      // Successful structured parse
-      codes = parsed.icd10
-        .filter(
-          (c: any) =>
-            typeof c === "object" &&
-            typeof c.code === "string" &&
-            typeof c.label === "string"
-        )
-        .map((c: any) => ({
-          code: c.code,
-          label: c.label,
-          confidence:
-            typeof c.confidence === "number"
-              ? Math.max(0, Math.min(1, c.confidence))
-              : 0.5,
-        }));
+    const codes: z.infer<typeof output>["icd10"] = kept.map((c) => ({
+      code: c.code,
+      label: c.label,
+      confidence: c.confidence,
+    }));
 
-      emLevel =
-        typeof parsed.emLevel === "string" ? parsed.emLevel : null;
+    const rationale = [
+      emRationale,
+      `Overall confidence: ${overall.toFixed(2)}.`,
+      dropped.length > 0
+        ? `Dropped ${dropped.length} code(s) unsupported by the documentation: ${dropped
+            .map((d) => `${d.code} (${d.label})`)
+            .join(", ")}.`
+        : "",
+      kept.length === 0 ? "No documented findings support a code; manual review recommended." : "",
+      "Clinician review required before any submission.",
+    ]
+      .filter(Boolean)
+      .join(" ");
 
-      const emRationale =
-        typeof parsed.emRationale === "string"
-          ? parsed.emRationale
-          : "";
-
-      const overallConfidence =
-        typeof parsed.overallConfidence === "number"
-          ? parsed.overallConfidence.toFixed(2)
-          : "N/A";
-
-      rationale =
-        [
-          emRationale,
-          `Overall confidence: ${overallConfidence}.`,
-          "Clinician review required before any submission.",
-        ]
-          .filter(Boolean)
-          .join(" ");
-
-      ctx.log("info", "Parsed structured coding JSON from model", {
-        codeCount: codes.length,
-        emLevel,
-      });
-    } else {
-      // Fallback: keyword matching (preserves V1 behavior for StubModelClient)
-      const narrative = JSON.stringify(note.blocks).toLowerCase();
-      codes = [];
-
-      if (/pain/.test(narrative)) {
-        codes.push({
-          code: "G89.29",
-          label: "Other chronic pain",
-          confidence: 0.55,
-        });
-      }
-      if (/sleep|insomnia/.test(narrative)) {
-        codes.push({
-          code: "G47.00",
-          label: "Insomnia, unspecified",
-          confidence: 0.5,
-        });
-      }
-      if (/nausea/.test(narrative)) {
-        codes.push({
-          code: "R11.0",
-          label: "Nausea",
-          confidence: 0.5,
-        });
-      }
-      if (/anxiety/.test(narrative)) {
-        codes.push({
-          code: "F41.1",
-          label: "Generalized anxiety disorder",
-          confidence: 0.5,
-        });
-      }
-
-      emLevel = null;
-
-      rationale =
-        codes.length > 0
-          ? "Suggestions are based on narrative keywords. Clinician review required before any submission."
-          : "No clear code matches found in narrative. Manual review recommended.";
-
-      ctx.log("info", "Model returned plain text; using keyword fallback", {
-        codeCount: codes.length,
-      });
-    }
+    ctx.log("info", "Grounded coding suggestions", {
+      candidateCount: candidates.length,
+      keptCount: kept.length,
+      droppedCount: dropped.length,
+      emLevel,
+      structured: Boolean(parsedCoding),
+    });
 
     // ------------------------------------------------------------------
-    // 5. Persist the coding suggestion
+    // 5. Persist the coding suggestion (grounded codes only)
     // ------------------------------------------------------------------
     ctx.assertCan("write.coding");
 
-    // Build the full icd10 payload with rationale per code (for structured path)
-    const icd10Payload =
-      parsed && Array.isArray(parsed.icd10)
-        ? parsed.icd10
-            .filter(
-              (c: any) =>
-                typeof c === "object" && typeof c.code === "string"
-            )
-            .map((c: any) => ({
-              code: c.code,
-              label: c.label ?? "",
-              confidence:
-                typeof c.confidence === "number" ? c.confidence : 0.5,
-              rationale: c.rationale ?? undefined,
-            }))
-        : (codes as any);
+    const icd10Payload = kept.map((c) => ({
+      code: c.code,
+      label: c.label,
+      confidence: c.confidence,
+      rationale: c.rationale ?? undefined,
+      grounded: c.grounded,
+      matchedTerms: c.matchedTerms,
+    }));
 
     await prisma.codingSuggestion.upsert({
       where: { noteId },

--- a/src/lib/agents/coding-readiness-agent.ts
+++ b/src/lib/agents/coding-readiness-agent.ts
@@ -3,10 +3,9 @@ import { prisma } from "@/lib/db/prisma";
 import type { Agent } from "@/lib/orchestration/types";
 import { writeAgentAudit } from "@/lib/orchestration/context";
 import {
-  applyGrounding,
   buildCodingPrompt,
-  overallCodingConfidence,
   parseCodingResponse,
+  runConfidenceLoop,
   type CandidateCode,
 } from "@/lib/clinical/coding-confidence";
 
@@ -131,8 +130,13 @@ export const codingReadinessAgent: Agent<
     const emLevel = parsedCoding?.emLevel ?? null;
     const emRationale = parsedCoding?.emRationale ?? "";
 
-    const { kept, dropped } = applyGrounding(candidates, noteText);
-    const overall = overallCodingConfidence(kept);
+    // Aggressive confidence loop: ground → strict LLM critic (drops
+    // unsupported codes, pulls in clearly-missed ones) → iterate → floor.
+    const { kept, dropped, overall, rounds } = await runConfidenceLoop({
+      noteText,
+      candidates,
+      complete: (p, o) => ctx.model.complete(p, o),
+    });
 
     const codes: z.infer<typeof output>["icd10"] = kept.map((c) => ({
       code: c.code,
@@ -154,10 +158,11 @@ export const codingReadinessAgent: Agent<
       .filter(Boolean)
       .join(" ");
 
-    ctx.log("info", "Grounded coding suggestions", {
+    ctx.log("info", "Coding confidence loop complete", {
       candidateCount: candidates.length,
       keptCount: kept.length,
       droppedCount: dropped.length,
+      criticRounds: rounds,
       emLevel,
       structured: Boolean(parsedCoding),
     });

--- a/src/lib/clinical/__tests__/coding-confidence.test.ts
+++ b/src/lib/clinical/__tests__/coding-confidence.test.ts
@@ -5,7 +5,9 @@ import {
   groundCode,
   overallCodingConfidence,
   parseCodingResponse,
+  parseCriticResponse,
   reconcileConfidence,
+  runConfidenceLoop,
   type CandidateCode,
 } from "../coding-confidence";
 
@@ -73,6 +75,70 @@ describe("applyGrounding — the screenshot scenario", () => {
     expect(kept[0].code).toBe("G89.29");
     expect(kept[0].grounded).toBe(true);
     expect(kept[0].confidence).toBeCloseTo(0.8, 5); // 'pain' present → full grounding
+  });
+});
+
+describe("parseCriticResponse", () => {
+  it("parses verdicts and missed codes", () => {
+    const r = parseCriticResponse(
+      '{"verdicts":[{"code":"G89.29","supported":true,"confidence":0.9,"evidence":"low back pain"}],"missed":[{"code":"F41.1","label":"Generalized anxiety disorder","confidence":0.8}]}',
+    );
+    expect(r?.verdicts[0]).toMatchObject({ code: "G89.29", supported: true });
+    expect(r?.missed[0].code).toBe("F41.1");
+  });
+});
+
+describe("runConfidenceLoop (aggressive critic loop)", () => {
+  const note =
+    "Assessment: chronic low back pain. Patient also reports anxiety.";
+  const candidates: CandidateCode[] = [
+    { code: "G89.29", label: "Other chronic pain", confidence: 0.8 },
+    { code: "F51.01", label: "Primary insomnia", confidence: 0.88 },
+  ];
+
+  function scriptedComplete(responses: string[]) {
+    let i = 0;
+    return async () => responses[Math.min(i++, responses.length - 1)];
+  }
+
+  it("drops ungrounded codes, adds critic-surfaced missed codes, and stabilises", async () => {
+    const complete = scriptedComplete([
+      // round 1: pain supported, anxiety surfaced as missed
+      '{"verdicts":[{"code":"G89.29","supported":true,"confidence":0.9,"evidence":"low back pain"}],"missed":[{"code":"F41.1","label":"Generalized anxiety disorder","confidence":0.8,"rationale":"reports anxiety"}]}',
+      // round 2: both supported, nothing missed → stable
+      '{"verdicts":[{"code":"G89.29","supported":true,"confidence":0.9},{"code":"F41.1","supported":true,"confidence":0.8}],"missed":[]}',
+    ]);
+    const res = await runConfidenceLoop({ noteText: note, candidates, complete });
+    const codes = res.kept.map((c) => c.code).sort();
+    expect(codes).toEqual(["F41.1", "G89.29"]);
+    expect(res.dropped.some((d) => d.code === "F51.01")).toBe(true); // insomnia gone
+    expect(res.rounds).toBe(2);
+  });
+
+  it("drops a code the critic marks unsupported", async () => {
+    const complete = scriptedComplete([
+      '{"verdicts":[{"code":"G89.29","supported":false,"confidence":0.2}],"missed":[]}',
+    ]);
+    const res = await runConfidenceLoop({
+      noteText: note,
+      candidates: [{ code: "G89.29", label: "Other chronic pain", confidence: 0.8 }],
+      complete,
+    });
+    expect(res.kept).toHaveLength(0);
+  });
+
+  it("applies the aggressive confidence floor with the critic disabled", async () => {
+    const res = await runConfidenceLoop({
+      noteText: "Patient reports mild nausea.",
+      candidates: [{ code: "R11.0", label: "Nausea", confidence: 0.3 }],
+      complete: async () => {
+        throw new Error("critic should not be called");
+      },
+      options: { enableCritic: false, confidenceFloor: 0.5 },
+    });
+    expect(res.rounds).toBe(0);
+    expect(res.kept).toHaveLength(0); // 0.3 < floor
+    expect(res.dropped.some((d) => d.code === "R11.0")).toBe(true);
   });
 });
 

--- a/src/lib/clinical/__tests__/coding-confidence.test.ts
+++ b/src/lib/clinical/__tests__/coding-confidence.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyGrounding,
+  conceptTerms,
+  groundCode,
+  overallCodingConfidence,
+  parseCodingResponse,
+  reconcileConfidence,
+  type CandidateCode,
+} from "../coding-confidence";
+
+describe("conceptTerms", () => {
+  it("drops generic descriptors, keeps clinical concepts", () => {
+    expect(conceptTerms("Other chronic pain")).toEqual(["pain"]);
+    expect(conceptTerms("Neoplasm related pain (chronic)")).toEqual(["neoplasm", "pain"]);
+    expect(conceptTerms("Primary insomnia")).toEqual(["insomnia"]);
+  });
+});
+
+describe("groundCode", () => {
+  it("grounds a code whose concept (or synonym) is in the note", () => {
+    const note = "Patient reports trouble with sleep and frequent waking.";
+    const g = groundCode("Primary insomnia", note);
+    expect(g.grounded).toBe(true);
+    expect(g.matchedTerms).toContain("insomnia"); // matched via 'sleep' synonym
+  });
+
+  it("does NOT ground a code whose concept is absent", () => {
+    const note = "Complaints regarding the scrotal and anal areas. Further evaluation needed.";
+    expect(groundCode("Primary insomnia", note).grounded).toBe(false);
+    expect(groundCode("Neoplasm related pain (chronic)", note).grounded).toBe(false);
+  });
+
+  it("treats concept-less labels as neutral (not dropped)", () => {
+    const g = groundCode("Unspecified", "anything");
+    expect(g.grounded).toBe(true);
+    expect(g.score).toBe(0.5);
+  });
+});
+
+describe("reconcileConfidence", () => {
+  it("keeps ~model confidence when fully grounded and scales down partial support", () => {
+    expect(reconcileConfidence(0.9, 1)).toBeCloseTo(0.9, 5);
+    expect(reconcileConfidence(0.9, 0.5)).toBeCloseTo(0.63, 5);
+    expect(reconcileConfidence(0.9, 0)).toBeCloseTo(0.36, 5);
+  });
+});
+
+describe("applyGrounding — the screenshot scenario", () => {
+  // The note from the report: scrotal/anal complaint, no pain/sleep/neoplasm.
+  const note =
+    "### Objective\n\n### Assessment\nThe patient presents with complaints regarding the scrotal and anal areas. Further evaluation is needed.\n\n### Plan\nSchedule a follow-up appointment for a comprehensive physical exam.";
+
+  const candidates: CandidateCode[] = [
+    { code: "G89.3", label: "Neoplasm related pain (chronic)", confidence: 0.92 },
+    { code: "F51.01", label: "Primary insomnia", confidence: 0.88 },
+  ];
+
+  it("drops both mismatched codes that the note never supports", () => {
+    const { kept, dropped } = applyGrounding(candidates, note);
+    expect(kept).toHaveLength(0);
+    expect(dropped.map((c) => c.code).sort()).toEqual(["F51.01", "G89.3"]);
+    expect(overallCodingConfidence(kept)).toBe(0);
+  });
+
+  it("keeps a code that IS supported and reconciles its confidence", () => {
+    const supportedNote = note + " Patient also reports chronic low back pain.";
+    const { kept } = applyGrounding(
+      [{ code: "G89.29", label: "Other chronic pain", confidence: 0.8 }],
+      supportedNote,
+    );
+    expect(kept).toHaveLength(1);
+    expect(kept[0].code).toBe("G89.29");
+    expect(kept[0].grounded).toBe(true);
+    expect(kept[0].confidence).toBeCloseTo(0.8, 5); // 'pain' present → full grounding
+  });
+});
+
+describe("parseCodingResponse", () => {
+  it("parses fenced JSON into a normalized shape", () => {
+    const res = parseCodingResponse(
+      '```json\n{"icd10":[{"code":"G47.00","label":"Insomnia, unspecified","confidence":0.7}],"emLevel":"99214","emRationale":"moderate","overallConfidence":0.7}\n```',
+    );
+    expect(res?.icd10).toHaveLength(1);
+    expect(res?.icd10[0].code).toBe("G47.00");
+    expect(res?.emLevel).toBe("99214");
+    expect(res?.overallConfidence).toBe(0.7);
+  });
+
+  it("returns null on unusable output", () => {
+    expect(parseCodingResponse("no json here")).toBeNull();
+  });
+});

--- a/src/lib/clinical/coding-confidence.ts
+++ b/src/lib/clinical/coding-confidence.ts
@@ -1,0 +1,216 @@
+/**
+ * Coding domain logic — prompt, parse, and (the headline) deterministic
+ * grounding for ICD-10 suggestions.
+ *
+ * The problem this solves: the coding model emits ICD-10 codes with
+ * self-reported confidence and nothing checks them against the note, so a
+ * code for a concept the note never mentions (e.g. "Primary insomnia" on a
+ * visit that never discusses sleep) ships at 88% "confidence". Grounding is a
+ * cheap, deterministic gate: a diagnostic code only survives if its clinical
+ * concept actually appears in the documented note, and its confidence is
+ * reconciled down by how well it's supported.
+ *
+ * Pure + dependency-free so the grounding rules are unit-testable.
+ */
+
+export interface CandidateCode {
+  code: string;
+  label: string;
+  /** Model self-reported confidence, 0–1. */
+  confidence: number;
+  rationale?: string;
+}
+
+export interface GroundedCode extends CandidateCode {
+  /** True when the code's concept is supported by the note text. */
+  grounded: boolean;
+  /** 0–1 fraction of the label's concept terms found in the note. */
+  groundingScore: number;
+  /** The note terms that supported this code (for the rationale/UI). */
+  matchedTerms: string[];
+}
+
+export interface ParsedCoding {
+  icd10: CandidateCode[];
+  emLevel: string | null;
+  emRationale: string;
+  overallConfidence: number | null;
+}
+
+/* ── Prompt + parse (shared by the agent and the draft action) ─────────── */
+
+export function buildCodingPrompt(noteText: string, patientContext: string): string {
+  return `You are a medical coding assistant. Review this clinical note and suggest appropriate ICD-10 diagnostic codes and an E&M evaluation/management level.
+
+CLINICAL NOTE:
+${noteText}
+
+Patient context: ${patientContext || "Not documented"}
+
+Return ONLY valid JSON:
+{
+  "icd10": [
+    { "code": "G89.29", "label": "Other chronic pain", "confidence": 0.85, "rationale": "Patient presents with chronic neuropathic pain" }
+  ],
+  "emLevel": "99214",
+  "emRationale": "Moderate complexity visit with established patient",
+  "overallConfidence": 0.75
+}
+
+Guidelines:
+- Only suggest a code when the note documents findings that support it. Do not infer diagnoses that are not in the note.
+- E&M codes: 99211-99215 for established, 99201-99205 for new patients.
+- Cannabis-related codes may include F12.x series if applicable.
+- Provide a clear rationale for each code, citing the documented finding.`;
+}
+
+function tryParseJSON(text: string): any | null {
+  const jsonMatch =
+    text.match(/```(?:json)?\s*([\s\S]*?)```/) || text.match(/(\{[\s\S]*\})/);
+  if (!jsonMatch) return null;
+  try {
+    return JSON.parse(jsonMatch[1] || jsonMatch[0]);
+  } catch {
+    return null;
+  }
+}
+
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+
+/** Parse a model coding response into a normalized shape. Returns null when the response isn't usable JSON. */
+export function parseCodingResponse(text: string): ParsedCoding | null {
+  const parsed = tryParseJSON(text);
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.icd10)) {
+    return null;
+  }
+  const icd10: CandidateCode[] = parsed.icd10
+    .filter(
+      (c: any) =>
+        c && typeof c === "object" && typeof c.code === "string" && typeof c.label === "string",
+    )
+    .map((c: any) => ({
+      code: c.code,
+      label: c.label,
+      confidence: typeof c.confidence === "number" ? clamp01(c.confidence) : 0.5,
+      rationale: typeof c.rationale === "string" ? c.rationale : undefined,
+    }));
+  return {
+    icd10,
+    emLevel: typeof parsed.emLevel === "string" ? parsed.emLevel : null,
+    emRationale: typeof parsed.emRationale === "string" ? parsed.emRationale : "",
+    overallConfidence:
+      typeof parsed.overallConfidence === "number" ? clamp01(parsed.overallConfidence) : null,
+  };
+}
+
+/* ── Grounding ─────────────────────────────────────────────────────────── */
+
+// Generic descriptors carry no clinical concept, so they don't count toward
+// grounding (otherwise "Other chronic pain" would "match" on the word "other").
+const STOPWORDS = new Set([
+  "other", "unspecified", "primary", "secondary", "chronic", "acute", "related",
+  "disorder", "disorders", "disease", "diseases", "syndrome", "type", "with",
+  "without", "due", "the", "and", "nos", "not", "elsewhere", "classified",
+  "unspec", "site", "left", "right", "bilateral", "encounter", "status",
+]);
+
+// Concept synonym expansion: a label term grounds if it OR any synonym is in
+// the note. Conservative — only well-known clinical equivalences.
+const SYNONYMS: Record<string, string[]> = {
+  pain: ["pain", "painful", "ache", "aching", "discomfort", "sore", "soreness"],
+  insomnia: ["insomnia", "sleep", "sleeplessness", "sleepless", "wakeful"],
+  anxiety: ["anxiety", "anxious", "panic", "worried", "worry"],
+  depression: ["depression", "depressed", "depressive", "mood"],
+  nausea: ["nausea", "nauseated", "nauseous", "vomiting", "queasy"],
+  neoplasm: ["neoplasm", "cancer", "tumor", "tumour", "malignancy", "malignant", "carcinoma", "mass", "oncolog"],
+  seizure: ["seizure", "seizures", "epilepsy", "epileptic", "convulsion"],
+  migraine: ["migraine", "headache", "cephalgia"],
+  spasticity: ["spasticity", "spasm", "spastic", "cramp"],
+  fatigue: ["fatigue", "tired", "tiredness", "exhaustion", "lethargy"],
+  appetite: ["appetite", "anorexia", "cachexia", "weight loss"],
+  inflammation: ["inflammation", "inflammatory", "swelling", "swollen"],
+  neuropathy: ["neuropathy", "neuropathic", "numbness", "tingling", "paresthesia"],
+  arthritis: ["arthritis", "arthritic", "joint"],
+};
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Significant (concept-bearing) lowercase terms from a code label. */
+export function conceptTerms(label: string): string[] {
+  return Array.from(
+    new Set(
+      (label.toLowerCase().match(/[a-z]+/g) ?? []).filter(
+        (w) => w.length >= 3 && !STOPWORDS.has(w),
+      ),
+    ),
+  );
+}
+
+function termPresent(term: string, haystack: string): boolean {
+  const variants = SYNONYMS[term] ?? [term];
+  return variants.some((v) =>
+    // Prefix-tolerant word match: "oncolog" matches "oncology", "pain" matches
+    // "painful" only via the explicit synonym list above (not substring), so
+    // we anchor on a word boundary then allow a suffix.
+    new RegExp(`\\b${escapeRegExp(v)}`, "i").test(haystack),
+  );
+}
+
+/**
+ * Ground a single code's label against the note text. A code is grounded when
+ * at least one of its concept terms (or a synonym) appears in the note. Codes
+ * whose label carries no concept term (all stopwords) are treated as grounded
+ * with a neutral score — we don't drop what we can't evaluate.
+ */
+export function groundCode(label: string, noteText: string): {
+  grounded: boolean;
+  score: number;
+  matchedTerms: string[];
+} {
+  const terms = conceptTerms(label);
+  if (terms.length === 0) {
+    return { grounded: true, score: 0.5, matchedTerms: [] };
+  }
+  const matchedTerms = terms.filter((t) => termPresent(t, noteText));
+  const score = matchedTerms.length / terms.length;
+  return { grounded: matchedTerms.length > 0, score, matchedTerms };
+}
+
+/** Reconcile model confidence with how well the note supports the code. */
+export function reconcileConfidence(modelConfidence: number, groundingScore: number): number {
+  // A fully-supported code keeps ~its model confidence; a thinly-supported one
+  // is scaled down. Ungrounded codes are dropped upstream, not reconciled.
+  return clamp01(modelConfidence * (0.4 + 0.6 * groundingScore));
+}
+
+/**
+ * Partition candidate ICD-10 codes into grounded (kept, with reconciled
+ * confidence) and dropped (concept absent from the note).
+ */
+export function applyGrounding(
+  codes: CandidateCode[],
+  noteText: string,
+): { kept: GroundedCode[]; dropped: GroundedCode[] } {
+  const kept: GroundedCode[] = [];
+  const dropped: GroundedCode[] = [];
+  for (const c of codes) {
+    const g = groundCode(c.label, noteText);
+    const graded: GroundedCode = {
+      ...c,
+      grounded: g.grounded,
+      groundingScore: g.score,
+      matchedTerms: g.matchedTerms,
+      confidence: g.grounded ? reconcileConfidence(c.confidence, g.score) : c.confidence,
+    };
+    (g.grounded ? kept : dropped).push(graded);
+  }
+  return { kept, dropped };
+}
+
+/** Overall confidence across kept codes (mean), 0 when none survive. */
+export function overallCodingConfidence(kept: GroundedCode[]): number {
+  if (kept.length === 0) return 0;
+  return clamp01(kept.reduce((s, c) => s + c.confidence, 0) / kept.length);
+}

--- a/src/lib/clinical/coding-confidence.ts
+++ b/src/lib/clinical/coding-confidence.ts
@@ -214,3 +214,178 @@ export function overallCodingConfidence(kept: GroundedCode[]): number {
   if (kept.length === 0) return 0;
   return clamp01(kept.reduce((s, c) => s + c.confidence, 0) / kept.length);
 }
+
+/* ── Critic pass + iterative confidence loop ───────────────────────────── */
+
+export interface CodeVerdict {
+  code: string;
+  supported: boolean;
+  confidence: number;
+  evidence?: string;
+}
+
+export interface CriticResult {
+  verdicts: CodeVerdict[];
+  missed: CandidateCode[];
+}
+
+/** Minimal model-call shape the loop depends on (injected so this stays pure/testable). */
+export type CompleteFn = (
+  prompt: string,
+  opts?: { maxTokens?: number; temperature?: number },
+) => Promise<string>;
+
+/** Strict auditor prompt: re-checks each proposed code against the note. */
+export function buildCriticPrompt(noteText: string, codes: CandidateCode[]): string {
+  const list = codes.map((c) => `- ${c.code} (${c.label})`).join("\n") || "(none)";
+  return `You are a STRICT medical coding auditor. Given the clinical note and a list of proposed ICD-10 codes, decide for EACH proposed code whether the note documents findings that clearly support it. Be conservative: if the condition is not clearly documented, mark it unsupported. Also list any diagnosis that IS clearly documented in the note but is MISSING from the list.
+
+CLINICAL NOTE:
+${noteText}
+
+PROPOSED CODES:
+${list}
+
+Return ONLY valid JSON:
+{
+  "verdicts": [
+    { "code": "G89.29", "supported": true, "confidence": 0.9, "evidence": "exact phrase from the note" }
+  ],
+  "missed": [
+    { "code": "F41.1", "label": "Generalized anxiety disorder", "confidence": 0.8, "rationale": "note documents ..." }
+  ]
+}`;
+}
+
+/** Parse a critic response; returns null when unusable. */
+export function parseCriticResponse(text: string): CriticResult | null {
+  const parsed = tryParseJSON(text);
+  if (!parsed || typeof parsed !== "object") return null;
+  const verdicts: CodeVerdict[] = Array.isArray(parsed.verdicts)
+    ? parsed.verdicts
+        .filter((v: any) => v && typeof v.code === "string")
+        .map((v: any) => ({
+          code: v.code,
+          supported: Boolean(v.supported),
+          confidence: typeof v.confidence === "number" ? clamp01(v.confidence) : 0.5,
+          evidence: typeof v.evidence === "string" ? v.evidence : undefined,
+        }))
+    : [];
+  const missed: CandidateCode[] = Array.isArray(parsed.missed)
+    ? parsed.missed
+        .filter((m: any) => m && typeof m.code === "string" && typeof m.label === "string")
+        .map((m: any) => ({
+          code: m.code,
+          label: m.label,
+          confidence: typeof m.confidence === "number" ? clamp01(m.confidence) : 0.6,
+          rationale: typeof m.rationale === "string" ? m.rationale : undefined,
+        }))
+    : [];
+  return { verdicts, missed };
+}
+
+export interface CodingLoopOptions {
+  /** Max critic rounds (regenerate-with-feedback). Default 2 (aggressive). */
+  maxCriticRounds?: number;
+  /** Drop any surviving code below this confidence. Default 0.5 (aggressive). */
+  confidenceFloor?: number;
+  /** Turn the LLM critic off and run grounding-only. Default true. */
+  enableCritic?: boolean;
+}
+
+export interface CodingLoopResult {
+  kept: GroundedCode[];
+  dropped: GroundedCode[];
+  rounds: number;
+  overall: number;
+}
+
+const codeKey = (c: { code: string }) => c.code.toUpperCase();
+const sameCodeSet = (a: GroundedCode[], b: GroundedCode[]) => {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a.map(codeKey));
+  return b.every((c) => sa.has(codeKey(c)));
+};
+
+/**
+ * The aggressive confidence loop: ground candidates, then repeatedly run a
+ * strict LLM critic that drops unsupported codes and pulls in clearly-missed
+ * ones, re-grounding each round until the set stabilises (or maxCriticRounds).
+ * Finally apply a confidence floor. Pure aside from the injected `complete`.
+ */
+export async function runConfidenceLoop(args: {
+  noteText: string;
+  candidates: CandidateCode[];
+  complete: CompleteFn;
+  options?: CodingLoopOptions;
+}): Promise<CodingLoopResult> {
+  const {
+    maxCriticRounds = 2,
+    confidenceFloor = 0.5,
+    enableCritic = true,
+  } = args.options ?? {};
+
+  const dropped: GroundedCode[] = [];
+  let { kept, dropped: groundedOut } = applyGrounding(args.candidates, args.noteText);
+  dropped.push(...groundedOut);
+
+  let rounds = 0;
+  if (enableCritic) {
+    for (let i = 0; i < maxCriticRounds; i += 1) {
+      let critic: CriticResult | null = null;
+      try {
+        const resp = await args.complete(buildCriticPrompt(args.noteText, kept), {
+          maxTokens: 768,
+          temperature: 0.1,
+        });
+        critic = parseCriticResponse(resp);
+      } catch {
+        break; // critic unavailable — keep what grounding produced
+      }
+      if (!critic) break;
+      rounds += 1;
+
+      const verdict = new Map(critic.verdicts.map((v) => [codeKey(v), v]));
+      const supported: CandidateCode[] = kept
+        .filter((c) => {
+          const v = verdict.get(codeKey(c));
+          return v ? v.supported : true; // codes the critic ignored stay
+        })
+        .map((c) => {
+          const v = verdict.get(codeKey(c));
+          return {
+            code: c.code,
+            label: c.label,
+            confidence: v ? v.confidence : c.confidence,
+            rationale: v?.evidence ?? c.rationale,
+          };
+        });
+      const missed = critic.missed.filter(
+        (m) => !supported.some((s) => codeKey(s) === codeKey(m)),
+      );
+      const merged = [...supported, ...missed];
+
+      const grounded = applyGrounding(merged, args.noteText);
+      dropped.push(...grounded.dropped);
+
+      if (sameCodeSet(grounded.kept, kept) && missed.length === 0) {
+        kept = grounded.kept; // adopt corrected confidences, then stop
+        break;
+      }
+      kept = grounded.kept;
+    }
+  }
+
+  // Aggressive floor: anything we still aren't confident in is set aside.
+  const surviving: GroundedCode[] = [];
+  for (const c of kept) {
+    (c.confidence >= confidenceFloor ? surviving : dropped).push(c);
+  }
+
+  return {
+    kept: surviving,
+    dropped,
+    rounds,
+    overall: overallCodingConfidence(surviving),
+  };
+}


### PR DESCRIPTION
## Why
The "AI Billing Recommendations" codes didn't fit the note because **they were hardcoded** — `voice-recorder.tsx` rendered a static `99214 / G89.3 "Neoplasm related pain" / F51.01 "Primary insomnia"` list with fake "95%/92%/88% match", independent of the visit. And the *real* coding agent emitted ICD-10 codes with **model-self-reported confidence and no check against the documentation**.

## What changed — an aggressive, multi-stage confidence loop
New pure, unit-tested `coding-confidence.ts` with a shared coding prompt+parser and:

1. **Grounding gate** — a code only survives if its clinical concept (with a conservative synonym map: *insomnia↔sleep*, *neoplasm↔cancer/tumor*, *pain↔ache/discomfort*, …) actually appears in the note; confidence is reconciled down by support. Concept-less labels treated neutrally (never false-dropped).
2. **Strict LLM critic pass** — re-audits every surviving code against the note: drops the ones the note doesn't clearly document, corrects confidence, and **surfaces clearly-missed codes**.
3. **Iterates** — re-grounds and re-critiques until the code set stabilises (max 2 rounds).
4. **Aggressive confidence floor (0.5)** — anything still weakly supported is set aside.

All knobs (`maxCriticRounds`, `confidenceFloor`, `enableCritic`) are options; the loop takes an injected `complete` fn so the module stays dependency-free/testable.

**Wired through:** the `coding-readiness-agent` runs the full loop before persisting; a new `recommendCodes()` action runs it for the voice draft, and the voice-chart panel now renders **real grounded codes** with a true "% supported" (+ loading/empty states) instead of the hardcoded fiction.

> Scope note: started aggressive (grounding **+** critic **+** iterate **+** floor) per direction. The feedback-learning loop (Accept/Reject → `AgentFeedback`, already in the schema) is still a deliberate follow-up — Accept stays local for now.

## Verification
- `coding-confidence.test.ts` — 13 tests: the **exact screenshot case** (both bogus codes dropped), grounding, confidence reconciliation, and the critic loop (drops critic-unsupported, adds grounded missed codes, stabilises in 2 rounds, floor applies with critic disabled).
- Agent/clinical/voice-chart-security suites green; `tsc --noEmit` clean.

## Follow-ups
- Wire Accept/Reject → `AgentFeedback` and learn from it (accepted/rejected exemplars + accept-rate confidence nudging).
- Tune `confidenceFloor`/`maxCriticRounds` once we see real accept rates (started aggressive intentionally).

https://claude.ai/code/session_015HBfSU39aAWTLebKGvzQP3