### PR TITLE
Phase 12 Track 3: AI Scheduling Engine & Automation

### DIFF
--- a/src/app/(operator)/ops/schedule/analytics/page.tsx
+++ b/src/app/(operator)/ops/schedule/analytics/page.tsx
@@ -6,6 +6,14 @@ import { MetricTile } from "@/components/ui/metric-tile";
 import { Sparkline } from "@/components/ui/sparkline";
 import { Eyebrow } from "@/components/ui/ornament";
 import { Badge } from "@/components/ui/badge";
+import {
+  computeMetrics,
+  forecastWindows,
+  detectBottlenecks,
+  actionTriggers,
+  type AppointmentRecord,
+  type AppointmentStatus,
+} from "@/lib/scheduling";
 import { ExportCsvButton } from "./export-csv";
 
 export const metadata = { title: "Scheduling Analytics" };
@@ -13,13 +21,14 @@ export const metadata = { title: "Scheduling Analytics" };
 /**
  * EMR-215 — Scheduling analytics cockpit.
  *
- * The operator view of the supply side of scheduling. Surfaces:
- *   - Fill rate by week (last 12 weeks)
- *   - No-show / cancellation rate
- *   - Per-provider utilization with a 14-day forecast based on current
- *     booking velocity vs. capacity
- *   - CSV export of the underlying appointment-level data so the ops
- *     team can pivot it however they want
+ * The operator view of the supply side of scheduling. All KPIs are computed
+ * by the pure analytics engine (src/lib/scheduling/analytics.ts) so the page
+ * stays a thin rendering layer:
+ *   - Fill / no-show / cancellation rates + lead-time percentiles
+ *   - 30 / 60 / 90-day demand forecast from booking velocity
+ *   - Per-provider utilization with bottleneck callouts
+ *   - Action triggers (e.g. fill rate < 70% for 2 weeks → open a ticket)
+ *   - CSV export of the underlying appointment-level data
  */
 export default async function ScheduleAnalyticsPage() {
   const user = await requireUser();
@@ -55,49 +64,62 @@ export default async function ScheduleAnalyticsPage() {
     }),
   ]);
 
-  const past = appointments.filter((a) => a.startAt < now);
-  const future = appointments.filter((a) => a.startAt >= now);
+  // Map Prisma rows into the engine's flat record shape.
+  const records: AppointmentRecord[] = appointments.map((a) => ({
+    id: a.id,
+    providerId: a.providerId,
+    startAt: a.startAt,
+    endAt: a.endAt,
+    status: a.status as AppointmentStatus,
+    modality: a.modality,
+    createdAt: a.createdAt,
+  }));
 
-  const completed = past.filter((a) => a.status === "completed").length;
-  const noShow = past.filter((a) => a.status === "no_show").length;
-  const cancelled = past.filter((a) => a.status === "cancelled").length;
-  const filledPast = past.filter(
-    (a) => a.status === "completed" || a.status === "confirmed",
-  ).length;
+  const future = records.filter((a) => a.startAt >= now);
 
-  const fillRate = past.length === 0 ? 0 : filledPast / past.length;
-  const noShowRate = past.length === 0 ? 0 : noShow / past.length;
-  const cancelRate = past.length === 0 ? 0 : cancelled / past.length;
+  // Headline KPIs over the full 90d-past + 14d-future window.
+  const metrics = computeMetrics(records, now);
 
-  // Weekly fill rate sparkline — group last 12 weeks.
-  const weeklyFill = computeWeeklyFill(past, 12);
+  // Forward-looking utilization (next 14 days only). Capacity ≈ 80h / provider
+  // over the window. We re-run the engine on just the future set so rates
+  // reflect booked capacity ahead rather than historical attendance.
+  const forward = computeMetrics(future, now, { capacityHours: 80 });
+  const bottlenecks = detectBottlenecks(forward, { utilThreshold: 0.85 });
+  const bottleneckIds = new Set(bottlenecks.map((b) => b.providerId));
 
-  // Per-provider utilization (booked hours / capacity hours) over the
-  // next 14 days. Capacity = 5 work-days × 8 hours = 40h baseline.
-  const providerStats = providers.map((p) => {
-    const slots = future.filter((a) => a.providerId === p.id);
-    const bookedHours =
-      slots.reduce((s, a) => s + (a.endAt.getTime() - a.startAt.getTime()) / 3_600_000, 0) || 0;
-    const capacityHours = 80; // 14d × 8h × ~0.71 work day mix
-    const util = Math.min(1, bookedHours / capacityHours);
+  const forecast = forecastWindows(records, now);
 
-    // Booking velocity — appointments created in the last 14 days that are
-    // for this provider. Used to forecast 30-day demand.
-    const fourteenAgo = new Date(now);
-    fourteenAgo.setDate(fourteenAgo.getDate() - 14);
-    const recentlyBooked = appointments.filter(
-      (a) => a.providerId === p.id && a.createdAt >= fourteenAgo,
+  // Weekly fill rate (last 12 weeks) feeds both the sparkline and the
+  // low-fill-rate action trigger.
+  const weeklyFill = computeWeeklyFill(
+    records.filter((a) => a.startAt < now),
+    12,
+  );
+  const triggers = actionTriggers(weeklyFill.map((w) => w.rate));
+  const firedTriggers = triggers.filter((t) => t.fired);
+
+  const providerName = new Map(
+    providers.map((p) => [p.id, `${p.user.firstName} ${p.user.lastName}`.trim()]),
+  );
+  const providerTitle = new Map(providers.map((p) => [p.id, p.title ?? "Provider"]));
+
+  // Per-provider forward view: utilization from the engine + a simple 30-day
+  // booking-velocity forecast per provider.
+  const fourteenAgo = new Date(now);
+  fourteenAgo.setDate(fourteenAgo.getDate() - 14);
+  const providerStats = forward.providerUtilization.map((u) => {
+    const recentlyBooked = records.filter(
+      (a) => a.providerId === u.providerId && a.createdAt >= fourteenAgo,
     ).length;
-    const forecast30d = Math.round((recentlyBooked / 14) * 30);
-
     return {
-      id: p.id,
-      name: `${p.user.firstName} ${p.user.lastName}`.trim(),
-      title: p.title ?? "Provider",
-      bookedHours: Math.round(bookedHours * 10) / 10,
-      capacityHours,
-      util,
-      forecast30d,
+      id: u.providerId,
+      name: providerName.get(u.providerId) ?? "Unassigned",
+      title: providerTitle.get(u.providerId) ?? "Provider",
+      bookedHours: Math.round(u.bookedHours * 10) / 10,
+      capacityHours: 80,
+      util: u.util,
+      forecast30d: Math.round((recentlyBooked / 14) * 30),
+      bottleneck: bottleneckIds.has(u.providerId),
     };
   });
 
@@ -106,34 +128,57 @@ export default async function ScheduleAnalyticsPage() {
       <PageHeader
         eyebrow="Practice management"
         title="Scheduling analytics"
-        description="Fill rates, no-show trends, per-provider utilization, and a 30-day demand forecast. Export the appointment-level data anywhere."
+        description="Fill rates, no-show trends, lead time, per-provider utilization, and a 30/60/90-day demand forecast. Export the appointment-level data anywhere."
         actions={<ExportCsvButton orgScopedRows={appointments.length} />}
       />
+
+      {firedTriggers.length > 0 && (
+        <div className="mb-8 rounded-xl border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-5 py-4">
+          <p className="text-xs font-medium uppercase tracking-wider text-[color:var(--warning)] mb-1">
+            Action required
+          </p>
+          {firedTriggers.map((t) => (
+            <p key={t.rule} className="text-sm text-text">
+              {t.detail}
+            </p>
+          ))}
+        </div>
+      )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
         <MetricTile
           label="Fill rate (90d)"
-          value={`${Math.round(fillRate * 100)}%`}
-          hint={`${filledPast} of ${past.length}`}
+          value={`${Math.round(metrics.fillRate * 100)}%`}
+          hint={`${metrics.counts.completed} completed of ${metrics.counts.completed + metrics.counts.noShow} attended`}
           accent="forest"
         />
         <MetricTile
           label="No-show rate"
-          value={`${Math.round(noShowRate * 100)}%`}
-          hint={`${noShow} no-shows`}
+          value={`${Math.round(metrics.noShowRate * 100)}%`}
+          hint={`${metrics.counts.noShow} no-shows`}
           accent="amber"
         />
         <MetricTile
           label="Cancellation rate"
-          value={`${Math.round(cancelRate * 100)}%`}
-          hint={`${cancelled} cancellations`}
+          value={`${Math.round(metrics.cancelRate * 100)}%`}
+          hint={`${metrics.counts.cancelled} cancellations`}
         />
         <MetricTile
-          label="Booked next 14d"
-          value={future.length}
-          hint="visits ahead"
+          label="Lead time (P50)"
+          value={`${Math.round(metrics.leadTimeDaysP50)}d`}
+          hint={`P90 ${Math.round(metrics.leadTimeDaysP90)}d`}
           accent="forest"
         />
+      </div>
+
+      {/* Demand forecast */}
+      <div className="mb-3">
+        <Eyebrow>Demand forecast — booking velocity</Eyebrow>
+      </div>
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        <ForecastTile label="Next 30 days" value={Math.round(forecast.d30.projected)} />
+        <ForecastTile label="Next 60 days" value={Math.round(forecast.d60.projected)} />
+        <ForecastTile label="Next 90 days" value={Math.round(forecast.d90.projected)} />
       </div>
 
       <Card tone="raised" className="mb-8">
@@ -155,8 +200,13 @@ export default async function ScheduleAnalyticsPage() {
         </CardContent>
       </Card>
 
-      <div className="mb-3">
+      <div className="mb-3 flex items-baseline justify-between">
         <Eyebrow>Per-provider — next 14 days</Eyebrow>
+        {bottlenecks.length > 0 && (
+          <p className="text-xs text-[color:var(--warning)]">
+            {bottlenecks.length} provider{bottlenecks.length === 1 ? "" : "s"} running hot
+          </p>
+        )}
       </div>
       <div className="grid md:grid-cols-2 gap-4">
         {providerStats.map((p) => (
@@ -167,14 +217,14 @@ export default async function ScheduleAnalyticsPage() {
                   <p className="text-sm font-medium text-text">{p.name}</p>
                   <p className="text-[11px] text-text-subtle uppercase tracking-wider">{p.title}</p>
                 </div>
-                <Badge tone={p.util > 0.85 ? "warning" : p.util > 0.5 ? "success" : "neutral"}>
+                <Badge tone={p.bottleneck ? "danger" : p.util > 0.5 ? "success" : "neutral"}>
                   {Math.round(p.util * 100)}% utilized
                 </Badge>
               </div>
               <div className="h-2 rounded-full bg-surface-muted overflow-hidden mt-3 mb-2">
                 <div
                   className="h-full bg-gradient-to-r from-accent to-accent-strong"
-                  style={{ width: `${Math.round(p.util * 100)}%` }}
+                  style={{ width: `${Math.min(100, Math.round(p.util * 100))}%` }}
                 />
               </div>
               <div className="flex items-baseline justify-between text-[11px] text-text-subtle tabular-nums">
@@ -188,6 +238,18 @@ export default async function ScheduleAnalyticsPage() {
         ))}
       </div>
     </PageShell>
+  );
+}
+
+function ForecastTile({ label, value }: { label: string; value: number }) {
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-5 pb-5">
+        <p className="font-display text-3xl tabular-nums text-accent">{value}</p>
+        <p className="text-xs text-text-muted mt-1">{label}</p>
+        <p className="text-[10px] text-text-subtle mt-0.5">projected new bookings</p>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/lib/scheduling/analytics.test.ts
+++ b/src/lib/scheduling/analytics.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  actionTriggers,
+  computeMetrics,
+  detectBottlenecks,
+  forecastDemand,
+  forecastWindows,
+  percentile,
+  sliceBy,
+  type AppointmentRecord,
+} from "./analytics";
+
+const NOW = new Date("2026-05-28T12:00:00.000Z");
+
+function appt(overrides: Partial<AppointmentRecord> & Pick<AppointmentRecord, "id">): AppointmentRecord {
+  return {
+    providerId: "p1",
+    startAt: new Date("2026-05-20T15:00:00.000Z"),
+    endAt: new Date("2026-05-20T16:00:00.000Z"),
+    status: "completed",
+    modality: "video",
+    createdAt: new Date("2026-05-13T15:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("computeMetrics", () => {
+  const fixture: AppointmentRecord[] = [
+    // Past: completed (new patient, billed), no_show, cancelled.
+    appt({
+      id: "a-completed",
+      status: "completed",
+      cohort: "new",
+      revenue: 200,
+      visitType: "intake",
+      payer: "aetna",
+      startAt: new Date("2026-05-20T15:00:00.000Z"),
+      endAt: new Date("2026-05-20T16:00:00.000Z"),
+      createdAt: new Date("2026-05-18T15:00:00.000Z"), // 2 day lead
+    }),
+    appt({
+      id: "a-noshow",
+      status: "no_show",
+      cohort: "recurring",
+      revenue: null,
+      startAt: new Date("2026-05-21T15:00:00.000Z"),
+      endAt: new Date("2026-05-21T16:00:00.000Z"),
+      createdAt: new Date("2026-05-17T15:00:00.000Z"), // 4 day lead
+    }),
+    appt({
+      id: "a-cancelled",
+      status: "cancelled",
+      cohort: "recurring",
+      startAt: new Date("2026-05-22T15:00:00.000Z"),
+      endAt: new Date("2026-05-22T16:00:00.000Z"),
+      createdAt: new Date("2026-05-12T15:00:00.000Z"),
+    }),
+    // Future: confirmed (booked) + requested (not booked).
+    appt({
+      id: "a-future-confirmed",
+      status: "confirmed",
+      cohort: "recurring",
+      startAt: new Date("2026-06-10T15:00:00.000Z"),
+      endAt: new Date("2026-06-10T16:30:00.000Z"), // 1.5h
+      createdAt: new Date("2026-05-27T15:00:00.000Z"),
+    }),
+    appt({
+      id: "a-future-requested",
+      status: "requested",
+      startAt: new Date("2026-06-12T15:00:00.000Z"),
+      endAt: new Date("2026-06-12T16:00:00.000Z"),
+      createdAt: new Date("2026-05-27T15:00:00.000Z"),
+    }),
+  ];
+
+  it("computes rates over past appointments only and guards division", () => {
+    const m = computeMetrics(fixture, NOW);
+
+    // attended denom = completed(1) + no_show(1) = 2
+    expect(m.fillRate).toBe(0.5);
+    expect(m.noShowRate).toBe(0.5);
+    // cancelled(1) / past(3)
+    expect(m.cancelRate).toBeCloseTo(1 / 3, 6);
+
+    expect(m.counts.past).toBe(3);
+    expect(m.counts.future).toBe(2);
+    expect(m.counts.booked).toBe(3); // completed + no_show + confirmed
+    expect(m.counts.requested).toBe(1);
+  });
+
+  it("computes new-patient conversion and mean revenue over completed slots", () => {
+    const m = computeMetrics(fixture, NOW);
+    // 1 booked-new, 1 completed-new
+    expect(m.newPatientConversion).toBe(1);
+    // only one completed appt has numeric revenue (200)
+    expect(m.revenuePerSlot).toBe(200);
+  });
+
+  it("computes provider utilization against the capacity option", () => {
+    const m = computeMetrics(fixture, NOW, { capacityHours: 10 });
+    const p1 = m.providerUtilization.find((p) => p.providerId === "p1");
+    // booked durations: completed 1h + no_show 1h + confirmed 1.5h = 3.5h
+    expect(p1?.bookedHours).toBe(3.5);
+    expect(p1?.util).toBeCloseTo(0.35, 6);
+  });
+
+  it("returns zeroed rates instead of NaN for an empty input", () => {
+    const m = computeMetrics([], NOW);
+    expect(m.fillRate).toBe(0);
+    expect(m.noShowRate).toBe(0);
+    expect(m.cancelRate).toBe(0);
+    expect(m.newPatientConversion).toBe(0);
+    expect(m.revenuePerSlot).toBe(0);
+    expect(m.leadTimeDaysP50).toBe(0);
+    expect(m.providerUtilization).toEqual([]);
+  });
+});
+
+describe("percentile", () => {
+  it("interpolates p50 and p90 over lead times", () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(values, 0.5)).toBeCloseTo(5.5, 6);
+    expect(percentile(values, 0.9)).toBeCloseTo(9.1, 6);
+  });
+
+  it("handles single-element and empty inputs", () => {
+    expect(percentile([42], 0.9)).toBe(42);
+    expect(percentile([], 0.5)).toBe(0);
+  });
+});
+
+describe("sliceBy", () => {
+  const appts: AppointmentRecord[] = [
+    appt({ id: "s1", providerId: "dr-a", status: "completed", startAt: new Date("2026-05-20T15:00:00.000Z"), endAt: new Date("2026-05-20T16:00:00.000Z") }),
+    appt({ id: "s2", providerId: "dr-a", status: "no_show", startAt: new Date("2026-05-21T15:00:00.000Z"), endAt: new Date("2026-05-21T16:00:00.000Z") }),
+    appt({ id: "s3", providerId: "dr-b", status: "completed", startAt: new Date("2026-05-22T15:00:00.000Z"), endAt: new Date("2026-05-22T16:00:00.000Z") }),
+  ];
+
+  it("groups metrics by provider with deterministic key ordering", () => {
+    const slices = sliceBy(appts, "provider", NOW);
+    expect(slices.map((s) => s.key)).toEqual(["dr-a", "dr-b"]);
+
+    const drA = slices.find((s) => s.key === "dr-a");
+    expect(drA?.metrics.fillRate).toBe(0.5); // 1 completed, 1 no_show
+    const drB = slices.find((s) => s.key === "dr-b");
+    expect(drB?.metrics.fillRate).toBe(1);
+  });
+});
+
+describe("forecastDemand", () => {
+  const appts: AppointmentRecord[] = [
+    // 7 bookings inside the trailing 14d window ending at NOW.
+    ...Array.from({ length: 7 }, (_, i) =>
+      appt({
+        id: `recent-${i}`,
+        createdAt: new Date(`2026-05-2${i % 7}T09:00:00.000Z`),
+      }),
+    ),
+    // Old booking outside the window — should not count.
+    appt({ id: "old", createdAt: new Date("2026-01-01T09:00:00.000Z") }),
+  ];
+
+  it("scales projected demand linearly with horizon", () => {
+    const f30 = forecastDemand(appts, NOW, 30);
+    const f60 = forecastDemand(appts, NOW, 60);
+    // 7 bookings / 14 days = 0.5 / day
+    expect(f30.perDay).toBeCloseTo(0.5, 6);
+    expect(f30.projected).toBeCloseTo(15, 6);
+    expect(f60.projected).toBeCloseTo(30, 6);
+  });
+
+  it("exposes the three standard windows", () => {
+    const w = forecastWindows(appts, NOW);
+    expect(w.d30.projected).toBeCloseTo(15, 6);
+    expect(w.d90.projected).toBeCloseTo(45, 6);
+  });
+});
+
+describe("detectBottlenecks", () => {
+  it("flags providers over the utilization threshold, hottest first", () => {
+    const m = computeMetrics(
+      [
+        appt({ id: "b1", providerId: "hot", status: "completed", startAt: new Date("2026-05-20T08:00:00.000Z"), endAt: new Date("2026-05-20T18:00:00.000Z") }),
+        appt({ id: "b2", providerId: "cool", status: "completed", startAt: new Date("2026-05-21T08:00:00.000Z"), endAt: new Date("2026-05-21T09:00:00.000Z") }),
+      ],
+      NOW,
+      { capacityHours: 10 },
+    );
+    const flagged = detectBottlenecks(m); // hot util = 1.0, cool = 0.1
+    expect(flagged.map((b) => b.providerId)).toEqual(["hot"]);
+    expect(flagged[0].severity).toBe("critical");
+  });
+});
+
+describe("actionTriggers", () => {
+  it("fires when fill rate is below 0.70 for two consecutive weeks", () => {
+    const triggers = actionTriggers([0.9, 0.65, 0.6, 0.8]);
+    const rule = triggers[0];
+    expect(rule.fired).toBe(true);
+    expect(rule.rule).toContain("0.7");
+  });
+
+  it("does not fire on a single sub-floor week", () => {
+    const triggers = actionTriggers([0.9, 0.65, 0.8, 0.62]);
+    expect(triggers[0].fired).toBe(false);
+  });
+});

--- a/src/lib/scheduling/analytics.ts
+++ b/src/lib/scheduling/analytics.ts
@@ -1,0 +1,408 @@
+/**
+ * EMR-215 — Scheduling Analytics Cockpit (metrics + forecast engine).
+ *
+ * Pure-function analytics layer over a flat list of appointment records.
+ * Computes the operational KPIs the scheduling cockpit surfaces (fill rate,
+ * no-show / cancel rates, lead-time percentiles, new-patient conversion,
+ * revenue-per-slot, provider utilization), slices those metrics by an
+ * arbitrary dimension, projects near-term demand from booking velocity, and
+ * raises bottleneck / action-trigger alerts. The page (EMR-216) consumes
+ * this; everything here is deterministic and takes the reference time as an
+ * explicit `now` so it stays testable and never touches the wall clock.
+ */
+import { z } from "zod";
+
+export const AppointmentStatusSchema = z.enum([
+  "requested",
+  "confirmed",
+  "cancelled",
+  "completed",
+  "no_show",
+]);
+export type AppointmentStatus = z.infer<typeof AppointmentStatusSchema>;
+
+export const AppointmentCohortSchema = z.enum(["new", "recurring", "urgent"]);
+export type AppointmentCohort = z.infer<typeof AppointmentCohortSchema>;
+
+export const AppointmentRecordSchema = z.object({
+  id: z.string(),
+  /** Provider the appointment is assigned to. null = unassigned / pool. */
+  providerId: z.string().nullable(),
+  startAt: z.date(),
+  endAt: z.date(),
+  status: AppointmentStatusSchema,
+  /** Free-form modality string ("video", "in_person", ...). */
+  modality: z.string(),
+  /** When the appointment was booked — drives lead time + booking velocity. */
+  createdAt: z.date(),
+  visitType: z.string().optional(),
+  payer: z.string().nullable().optional(),
+  /** Captured revenue for completed visits. null/absent = not yet billed. */
+  revenue: z.number().nullable().optional(),
+  cohort: AppointmentCohortSchema.optional(),
+});
+export type AppointmentRecord = z.infer<typeof AppointmentRecordSchema>;
+
+export interface ProviderUtilization {
+  providerId: string;
+  bookedHours: number;
+  util: number; // bookedHours / capacityHours, 0..(unbounded if overbooked)
+}
+
+export interface SchedulingMetrics {
+  /** Completed / (completed + no_show) over past appts. 0 if no past appts. */
+  fillRate: number;
+  /** no_show / (completed + no_show) over past appts. */
+  noShowRate: number;
+  /** cancelled / (all past appts) over past appts. */
+  cancelRate: number;
+  /** Lead-time (days) percentiles over booked appts. */
+  leadTimeDaysP50: number;
+  leadTimeDaysP90: number;
+  /** completed-new / booked-new. 0 if no new patients booked. */
+  newPatientConversion: number;
+  /** Mean revenue across completed appts with a numeric revenue. */
+  revenuePerSlot: number;
+  providerUtilization: ProviderUtilization[];
+  counts: MetricCounts;
+}
+
+export interface MetricCounts {
+  total: number;
+  past: number;
+  future: number;
+  booked: number;
+  completed: number;
+  noShow: number;
+  cancelled: number;
+  requested: number;
+  confirmed: number;
+}
+
+export interface MetricsOptions {
+  /**
+   * Capacity hours per provider over the window the metrics cover. Used as
+   * the denominator for utilization. Default 80 (~two work weeks).
+   */
+  capacityHours?: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+
+/** "Booked" = a visit that consumed a slot (not just a pending request). */
+const BOOKED_STATUSES: ReadonlySet<AppointmentStatus> = new Set([
+  "confirmed",
+  "completed",
+  "no_show",
+]);
+
+function safeDiv(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+function isPast(appt: AppointmentRecord, now: Date): boolean {
+  return appt.startAt.getTime() < now.getTime();
+}
+
+function leadTimeDays(appt: AppointmentRecord): number {
+  return Math.max(0, (appt.startAt.getTime() - appt.createdAt.getTime()) / MS_PER_DAY);
+}
+
+function durationHours(appt: AppointmentRecord): number {
+  return Math.max(0, (appt.endAt.getTime() - appt.startAt.getTime()) / MS_PER_HOUR);
+}
+
+/**
+ * Linear-interpolated percentile (same convention as numpy's default). `p`
+ * is a fraction 0..1. Returns 0 for an empty input rather than NaN.
+ */
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return sorted[0];
+  const rank = p * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * frac;
+}
+
+/**
+ * Compute the full KPI bundle. Rates are computed over PAST appointments
+ * (startAt < now); lead time + booking-derived metrics use the booked set.
+ * Every ratio is divide-by-zero guarded and returns 0 when undefined.
+ */
+export function computeMetrics(
+  appts: AppointmentRecord[],
+  now: Date,
+  options: MetricsOptions = {},
+): SchedulingMetrics {
+  const capacityHours = options.capacityHours ?? 80;
+
+  const past = appts.filter((a) => isPast(a, now));
+  const future = appts.filter((a) => !isPast(a, now));
+
+  const completed = past.filter((a) => a.status === "completed");
+  const noShow = past.filter((a) => a.status === "no_show");
+  const cancelled = past.filter((a) => a.status === "cancelled");
+  const requested = appts.filter((a) => a.status === "requested");
+  const confirmed = appts.filter((a) => a.status === "confirmed");
+
+  // Attended denominator: visits that actually came due (completed + no_show).
+  const attendedDenom = completed.length + noShow.length;
+  const fillRate = safeDiv(completed.length, attendedDenom);
+  const noShowRate = safeDiv(noShow.length, attendedDenom);
+  const cancelRate = safeDiv(cancelled.length, past.length);
+
+  const booked = appts.filter((a) => BOOKED_STATUSES.has(a.status));
+  const leadTimes = booked.map(leadTimeDays);
+  const leadTimeDaysP50 = percentile(leadTimes, 0.5);
+  const leadTimeDaysP90 = percentile(leadTimes, 0.9);
+
+  const bookedNew = booked.filter((a) => a.cohort === "new");
+  const completedNew = bookedNew.filter((a) => a.status === "completed");
+  const newPatientConversion = safeDiv(completedNew.length, bookedNew.length);
+
+  const revenues = completed
+    .map((a) => a.revenue)
+    .filter((r): r is number => typeof r === "number");
+  const revenuePerSlot = safeDiv(
+    revenues.reduce((sum, r) => sum + r, 0),
+    revenues.length,
+  );
+
+  const providerUtilization = computeProviderUtilization(booked, capacityHours);
+
+  const counts: MetricCounts = {
+    total: appts.length,
+    past: past.length,
+    future: future.length,
+    booked: booked.length,
+    completed: completed.length,
+    noShow: noShow.length,
+    cancelled: cancelled.length,
+    requested: requested.length,
+    confirmed: confirmed.length,
+  };
+
+  return {
+    fillRate,
+    noShowRate,
+    cancelRate,
+    leadTimeDaysP50,
+    leadTimeDaysP90,
+    newPatientConversion,
+    revenuePerSlot,
+    providerUtilization,
+    counts,
+  };
+}
+
+function computeProviderUtilization(
+  booked: AppointmentRecord[],
+  capacityHours: number,
+): ProviderUtilization[] {
+  const byProvider = new Map<string, number>();
+  for (const appt of booked) {
+    if (appt.providerId === null) continue;
+    const prev = byProvider.get(appt.providerId) ?? 0;
+    byProvider.set(appt.providerId, prev + durationHours(appt));
+  }
+  return [...byProvider.entries()]
+    .map(([providerId, bookedHours]) => ({
+      providerId,
+      bookedHours,
+      util: safeDiv(bookedHours, capacityHours),
+    }))
+    .sort((a, b) => b.util - a.util);
+}
+
+export type SliceDimension =
+  | "provider"
+  | "visitType"
+  | "payer"
+  | "dayOfWeek"
+  | "hourOfDay"
+  | "cohort";
+
+export interface MetricsSlice {
+  key: string;
+  metrics: SchedulingMetrics;
+}
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function sliceKey(appt: AppointmentRecord, dimension: SliceDimension): string {
+  switch (dimension) {
+    case "provider":
+      return appt.providerId ?? "unassigned";
+    case "visitType":
+      return appt.visitType ?? "unknown";
+    case "payer":
+      return appt.payer ?? "unknown";
+    case "dayOfWeek":
+      return DAY_NAMES[appt.startAt.getDay()];
+    case "hourOfDay":
+      return String(appt.startAt.getHours());
+    case "cohort":
+      return appt.cohort ?? "unknown";
+  }
+}
+
+/**
+ * Group appointments by `dimension` and compute the full metric bundle per
+ * group. Keys are sorted ascending so output is deterministic.
+ */
+export function sliceBy(
+  appts: AppointmentRecord[],
+  dimension: SliceDimension,
+  now: Date,
+  options: MetricsOptions = {},
+): MetricsSlice[] {
+  const groups = new Map<string, AppointmentRecord[]>();
+  for (const appt of appts) {
+    const key = sliceKey(appt, dimension);
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(appt);
+    else groups.set(key, [appt]);
+  }
+  return [...groups.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, group]) => ({ key, metrics: computeMetrics(group, now, options) }));
+}
+
+export interface DemandForecast {
+  /** Booking velocity — appointments booked per day over the trailing window. */
+  perDay: number;
+  /** Projected new bookings over `horizonDays`. */
+  projected: number;
+}
+
+/** Trailing window (days) used to estimate booking velocity. */
+const VELOCITY_WINDOW_DAYS = 14;
+
+/**
+ * Forecast new-booking demand by extrapolating recent booking velocity.
+ * Counts appointments whose `createdAt` falls within the trailing 14 days
+ * ending at `now`, divides by 14 to get a per-day rate, then scales out to
+ * `horizonDays`. Deterministic — `now` is supplied by the caller.
+ */
+export function forecastDemand(
+  appts: AppointmentRecord[],
+  now: Date,
+  horizonDays: number,
+): DemandForecast {
+  const horizon = Math.max(0, horizonDays);
+  const windowStart = now.getTime() - VELOCITY_WINDOW_DAYS * MS_PER_DAY;
+  const recentBookings = appts.filter((a) => {
+    const t = a.createdAt.getTime();
+    return t >= windowStart && t <= now.getTime();
+  }).length;
+  const perDay = recentBookings / VELOCITY_WINDOW_DAYS;
+  return { perDay, projected: perDay * horizon };
+}
+
+export interface ForecastWindows {
+  d30: DemandForecast;
+  d60: DemandForecast;
+  d90: DemandForecast;
+}
+
+/** Convenience: the three standard planning horizons in one call. */
+export function forecastWindows(appts: AppointmentRecord[], now: Date): ForecastWindows {
+  return {
+    d30: forecastDemand(appts, now, 30),
+    d60: forecastDemand(appts, now, 60),
+    d90: forecastDemand(appts, now, 90),
+  };
+}
+
+export type BottleneckSeverity = "watch" | "warn" | "critical";
+
+export interface Bottleneck {
+  providerId: string;
+  util: number;
+  severity: BottleneckSeverity;
+}
+
+export interface BottleneckOptions {
+  /** Utilization above which a provider is flagged. Default 0.85. */
+  utilThreshold?: number;
+}
+
+function bottleneckSeverity(util: number): BottleneckSeverity {
+  if (util >= 1) return "critical";
+  if (util >= 0.95) return "warn";
+  return "watch";
+}
+
+/**
+ * Surface providers running hot. Returns every provider whose utilization
+ * exceeds the threshold (default 0.85), sorted hottest-first, tagged with a
+ * coarse severity the cockpit colors on.
+ */
+export function detectBottlenecks(
+  metrics: SchedulingMetrics,
+  opts: BottleneckOptions = {},
+): Bottleneck[] {
+  const threshold = opts.utilThreshold ?? 0.85;
+  return metrics.providerUtilization
+    .filter((p) => p.util > threshold)
+    .map((p) => ({
+      providerId: p.providerId,
+      util: p.util,
+      severity: bottleneckSeverity(p.util),
+    }))
+    .sort((a, b) => b.util - a.util);
+}
+
+export interface ActionTrigger {
+  rule: string;
+  fired: boolean;
+  detail: string;
+}
+
+export interface ActionTriggerOptions {
+  /** Fill-rate floor for the low-fill-rate streak rule. Default 0.70. */
+  fillRateFloor?: number;
+  /** Consecutive weeks below the floor before firing. Default 2. */
+  consecutiveWeeks?: number;
+}
+
+/**
+ * Evaluate operational alert rules against a series of weekly fill rates
+ * (oldest first). Currently implements the "fill rate below floor for N
+ * consecutive weeks" rule; the array shape keeps it extensible for future
+ * rules without changing the call site.
+ */
+export function actionTriggers(
+  weeklyFillRates: number[],
+  opts: ActionTriggerOptions = {},
+): ActionTrigger[] {
+  const floor = opts.fillRateFloor ?? 0.7;
+  const needed = opts.consecutiveWeeks ?? 2;
+
+  let longestStreak = 0;
+  let currentStreak = 0;
+  for (const rate of weeklyFillRates) {
+    if (rate < floor) {
+      currentStreak += 1;
+      longestStreak = Math.max(longestStreak, currentStreak);
+    } else {
+      currentStreak = 0;
+    }
+  }
+
+  const fired = longestStreak >= needed;
+  const lowFillRule: ActionTrigger = {
+    rule: `fill_rate_below_${floor}_for_${needed}_weeks`,
+    fired,
+    detail: fired
+      ? `Fill rate stayed below ${floor} for ${longestStreak} consecutive week(s).`
+      : `Longest sub-${floor} streak was ${longestStreak} week(s); needs ${needed}.`,
+  };
+
+  return [lowFillRule];
+}

--- a/src/lib/scheduling/index.ts
+++ b/src/lib/scheduling/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Public surface of the scheduling engine (Phase 12 Track 3).
+ *
+ * Re-exports the pure, dependency-free algorithm modules so callers can
+ * `import { rankSlots, rankWaitlist, computeMetrics } from "@/lib/scheduling"`
+ * instead of reaching into individual files. Only deterministic, DB-free
+ * modules are surfaced here — the server-side dispatch worker
+ * (`send-reminders.ts`, which talks to Prisma + the SMS adapter) is
+ * intentionally excluded so this barrel stays safe to import from any layer.
+ *
+ * Note: `analytics.ts` and `workflow-efficiency.ts` each export a local
+ * `percentile` helper with different conventions (linear-interpolated vs.
+ * nearest-rank). Per ES module semantics that name is ambiguous through the
+ * barrel and is omitted — import it from the specific module if you need it.
+ */
+export * from "./cadence-engine";
+export * from "./no-show-model";
+export * from "./slot-recommender";
+export * from "./intake-gate";
+export * from "./provider-prefs";
+export * from "./reminders";
+export * from "./ics-export";
+export * from "./waitlist";
+export * from "./recurring";
+export * from "./analytics";
+// workflow-efficiency re-exported explicitly: its `percentile` helper collides
+// with analytics' (different convention), so we omit it from the barrel.
+export {
+  WorkflowRoleSchema,
+  ClickEventSchema,
+  TASK_CLICK_TARGETS,
+  aggregateByTask,
+  aggregateByUser,
+  aggregateByRole,
+  flagRegressions,
+} from "./workflow-efficiency";
+export type {
+  WorkflowRole,
+  ClickEvent,
+  TaskAggregate,
+  UserAggregate,
+  RoleAggregate,
+  RegressionFlag,
+} from "./workflow-efficiency";

--- a/src/lib/scheduling/recurring.test.ts
+++ b/src/lib/scheduling/recurring.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  addToRoster,
+  backfillMissedWeeks,
+  detectConflicts,
+  expandBlock,
+  expandSeries,
+  seatsRemaining,
+  type BlockReservation,
+  type GroupVisit,
+  type RecurringSeries,
+} from "./recurring";
+
+describe("expandSeries", () => {
+  it("spaces weekly occurrences seven days apart", () => {
+    const series: RecurringSeries = {
+      startAt: new Date("2026-01-05T15:00:00.000Z"),
+      durationMinutes: 30,
+      frequency: "weekly",
+      count: 3,
+      providerId: "prov-1",
+      visitType: "group_titration",
+    };
+
+    const occ = expandSeries(series);
+    expect(occ).toHaveLength(3);
+    expect(occ[0].startAt.toISOString()).toBe("2026-01-05T15:00:00.000Z");
+    expect(occ[1].startAt.toISOString()).toBe("2026-01-12T15:00:00.000Z");
+    expect(occ[2].startAt.toISOString()).toBe("2026-01-19T15:00:00.000Z");
+    expect(occ[0].endAt.toISOString()).toBe("2026-01-05T15:30:00.000Z");
+    expect(occ.map((o) => o.index)).toEqual([0, 1, 2]);
+  });
+
+  it("spaces biweekly occurrences fourteen days apart", () => {
+    const series: RecurringSeries = {
+      startAt: new Date("2026-03-02T09:00:00.000Z"),
+      durationMinutes: 60,
+      frequency: "biweekly",
+      count: 3,
+      providerId: "prov-2",
+      visitType: "support_group",
+    };
+
+    const occ = expandSeries(series);
+    expect(occ[1].startAt.toISOString()).toBe("2026-03-16T09:00:00.000Z");
+    expect(occ[2].startAt.toISOString()).toBe("2026-03-30T09:00:00.000Z");
+  });
+
+  it("steps monthly by calendar month, clamping Jan 31 to Feb 28 in a non-leap year", () => {
+    const series: RecurringSeries = {
+      startAt: new Date("2026-01-31T13:00:00.000Z"),
+      durationMinutes: 45,
+      frequency: "monthly",
+      count: 4,
+      providerId: "prov-3",
+      visitType: "monthly_checkin",
+    };
+
+    const occ = expandSeries(series);
+    // 2026 is not a leap year -> Feb has 28 days.
+    expect(occ[1].startAt.toISOString()).toBe("2026-02-28T13:00:00.000Z");
+    // March has 31 days -> original day-of-month is restored.
+    expect(occ[2].startAt.toISOString()).toBe("2026-03-31T13:00:00.000Z");
+    // April has 30 days -> clamps to the 30th.
+    expect(occ[3].startAt.toISOString()).toBe("2026-04-30T13:00:00.000Z");
+  });
+
+  it("clamps Jan 31 to Feb 29 in a leap year", () => {
+    const series: RecurringSeries = {
+      startAt: new Date("2028-01-31T08:00:00.000Z"),
+      durationMinutes: 30,
+      frequency: "monthly",
+      count: 2,
+      providerId: "prov-3",
+      visitType: "monthly_checkin",
+    };
+
+    const occ = expandSeries(series);
+    // 2028 is a leap year -> Feb has 29 days.
+    expect(occ[1].startAt.toISOString()).toBe("2028-02-29T08:00:00.000Z");
+  });
+});
+
+describe("expandBlock", () => {
+  it("expands the next N weekly windows starting on/after fromDate", () => {
+    const block: BlockReservation = {
+      dayOfWeek: 1, // Monday
+      startHour: 9,
+      endHour: 12,
+      label: "New-patient block",
+      weeks: 3,
+    };
+
+    // 2026-05-28 is a Thursday; the next Monday is 2026-06-01.
+    const windows = expandBlock(block, new Date("2026-05-28T00:00:00.000Z"));
+    expect(windows).toHaveLength(3);
+    expect(windows[0].start.toISOString()).toBe("2026-06-01T09:00:00.000Z");
+    expect(windows[0].end.toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    expect(windows[1].start.toISOString()).toBe("2026-06-08T09:00:00.000Z");
+    expect(windows[2].start.toISOString()).toBe("2026-06-15T09:00:00.000Z");
+    expect(windows[0].label).toBe("New-patient block");
+  });
+
+  it("includes fromDate itself when it already lands on the block's day-of-week", () => {
+    const block: BlockReservation = {
+      dayOfWeek: 4, // Thursday
+      startHour: 13,
+      endHour: 17,
+      label: "Group day",
+      weeks: 1,
+    };
+
+    const windows = expandBlock(block, new Date("2026-05-28T06:00:00.000Z"));
+    expect(windows[0].start.toISOString()).toBe("2026-05-28T13:00:00.000Z");
+  });
+});
+
+describe("group visit roster", () => {
+  const base: GroupVisit = {
+    startAt: new Date("2026-06-01T17:00:00.000Z"),
+    durationMinutes: 90,
+    maxSeats: 2,
+    providerId: "prov-1",
+    topic: "Titration support",
+    roster: [],
+  };
+
+  it("adds patients until the visit is full, then rejects", () => {
+    const a = addToRoster(base, "pt-1");
+    expect(a.ok).toBe(true);
+    expect(seatsRemaining(a.visit)).toBe(1);
+
+    const b = addToRoster(a.visit, "pt-2");
+    expect(b.ok).toBe(true);
+    expect(seatsRemaining(b.visit)).toBe(0);
+
+    const c = addToRoster(b.visit, "pt-3");
+    expect(c.ok).toBe(false);
+    expect(c.reason).toBe("Group visit is full");
+    // Original roster is unchanged on rejection.
+    expect(c.visit.roster).toEqual(["pt-1", "pt-2"]);
+  });
+
+  it("rejects duplicate enrollment without mutating the roster", () => {
+    const a = addToRoster(base, "pt-1");
+    const dup = addToRoster(a.visit, "pt-1");
+    expect(dup.ok).toBe(false);
+    expect(dup.reason).toBe("Patient already on roster");
+    expect(dup.visit.roster).toEqual(["pt-1"]);
+    // Source visit was not mutated.
+    expect(base.roster).toEqual([]);
+  });
+});
+
+describe("detectConflicts", () => {
+  it("flags overlapping intervals and ignores non-overlapping ones", () => {
+    const occurrences = [
+      { start: new Date("2026-06-01T09:00:00.000Z"), end: new Date("2026-06-01T10:00:00.000Z") },
+      { start: new Date("2026-06-01T11:00:00.000Z"), end: new Date("2026-06-01T12:00:00.000Z") },
+    ];
+    const busy = [
+      { start: new Date("2026-06-01T09:30:00.000Z"), end: new Date("2026-06-01T10:30:00.000Z") },
+    ];
+
+    const conflicts = detectConflicts(occurrences, busy);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].occurrence).toBe(occurrences[0]);
+    expect(conflicts[0].conflictsWith).toBe(busy[0]);
+  });
+
+  it("treats touching endpoints as non-conflicting", () => {
+    const occurrences = [
+      { start: new Date("2026-06-01T09:00:00.000Z"), end: new Date("2026-06-01T10:00:00.000Z") },
+    ];
+    const busy = [
+      { start: new Date("2026-06-01T10:00:00.000Z"), end: new Date("2026-06-01T11:00:00.000Z") },
+    ];
+
+    expect(detectConflicts(occurrences, busy)).toHaveLength(0);
+  });
+});
+
+describe("backfillMissedWeeks", () => {
+  const series: RecurringSeries = {
+    startAt: new Date("2026-01-05T15:00:00.000Z"),
+    durationMinutes: 30,
+    frequency: "weekly",
+    count: 5,
+    providerId: "prov-1",
+    visitType: "group_titration",
+  };
+
+  it("returns the occurrence indexes the patient did not attend", () => {
+    expect(backfillMissedWeeks(series, [0, 2, 4])).toEqual([1, 3]);
+  });
+
+  it("returns all indexes when nothing was attended", () => {
+    expect(backfillMissedWeeks(series, [])).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("returns nothing when every occurrence was attended", () => {
+    expect(backfillMissedWeeks(series, [0, 1, 2, 3, 4])).toEqual([]);
+  });
+});

--- a/src/lib/scheduling/recurring.ts
+++ b/src/lib/scheduling/recurring.ts
@@ -1,0 +1,238 @@
+/**
+ * EMR-213 — Group visit, block, and recurring scheduling.
+ *
+ * Pure expansion + bookkeeping helpers for the three "many-at-once" booking
+ * shapes the scheduler supports: recurring series (a single visit repeated on
+ * a weekly/biweekly/monthly cadence), provider blocks (recurring time windows
+ * held open for a visit type), and group visits (one slot, many patients).
+ *
+ * Everything here is deterministic and clock-free: callers pass the reference
+ * date in explicitly (mirroring cadence-engine's nextDueDate) so the same
+ * inputs always expand to the same occurrences and tests never flake.
+ */
+import { z } from "zod";
+
+export const RecurrenceFrequencySchema = z.enum(["weekly", "biweekly", "monthly"]);
+export type RecurrenceFrequency = z.infer<typeof RecurrenceFrequencySchema>;
+
+export const RecurringSeriesSchema = z.object({
+  /** First occurrence start. Subsequent occurrences derive from this. */
+  startAt: z.date(),
+  /** Length of each occurrence in minutes. */
+  durationMinutes: z.number().int().positive(),
+  frequency: RecurrenceFrequencySchema,
+  /** Number of occurrences to generate (inclusive of the first). */
+  count: z.number().int().min(1).max(52),
+  providerId: z.string(),
+  visitType: z.string(),
+});
+export type RecurringSeries = z.infer<typeof RecurringSeriesSchema>;
+
+export interface Occurrence {
+  /** Zero-based position in the series. */
+  index: number;
+  startAt: Date;
+  endAt: Date;
+}
+
+export const BlockReservationSchema = z.object({
+  /** 0=Sun .. 6=Sat. */
+  dayOfWeek: z.number().int().min(0).max(6),
+  startHour: z.number().int().min(0).max(23),
+  endHour: z.number().int().min(0).max(23),
+  label: z.string(),
+  /** Number of weekly repetitions to expand. */
+  weeks: z.number().int().positive(),
+});
+export type BlockReservation = z.infer<typeof BlockReservationSchema>;
+
+export const GroupVisitSchema = z.object({
+  startAt: z.date(),
+  durationMinutes: z.number().int().positive(),
+  /** Hard cap on enrolled patients. */
+  maxSeats: z.number().int().positive(),
+  providerId: z.string(),
+  topic: z.string(),
+  /** Enrolled patient IDs, in enrollment order. */
+  roster: z.array(z.string()),
+});
+export type GroupVisit = z.infer<typeof GroupVisitSchema>;
+
+const MINUTE_MS = 60_000;
+
+/**
+ * Add one calendar month to a date, preserving the day-of-month where
+ * possible and clamping to the last day of the target month when the source
+ * day doesn't exist there (e.g. Jan 31 + 1mo -> Feb 28, or Feb 29 in a leap
+ * year). Operates in UTC so expansion is timezone-stable.
+ */
+function addCalendarMonths(base: Date, months: number): Date {
+  const year = base.getUTCFullYear();
+  const month = base.getUTCMonth();
+  const day = base.getUTCDate();
+
+  const targetMonthIndex = month + months;
+  const targetYear = year + Math.floor(targetMonthIndex / 12);
+  const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+
+  // Last day of the target month: day 0 of the following month.
+  const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+  const clampedDay = Math.min(day, lastDayOfTargetMonth);
+
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      clampedDay,
+      base.getUTCHours(),
+      base.getUTCMinutes(),
+      base.getUTCSeconds(),
+      base.getUTCMilliseconds(),
+    ),
+  );
+}
+
+function occurrenceStart(series: RecurringSeries, index: number): Date {
+  switch (series.frequency) {
+    case "weekly":
+      return new Date(series.startAt.getTime() + index * 7 * 24 * 60 * MINUTE_MS);
+    case "biweekly":
+      return new Date(series.startAt.getTime() + index * 14 * 24 * 60 * MINUTE_MS);
+    case "monthly":
+      return addCalendarMonths(series.startAt, index);
+  }
+}
+
+/**
+ * Expand a recurring series into its concrete occurrences. Weekly steps by
+ * 7 days, biweekly by 14 days, monthly by one calendar month (with end-of-month
+ * clamping). Every occurrence is `durationMinutes` long.
+ */
+export function expandSeries(series: RecurringSeries): Occurrence[] {
+  const parsed = RecurringSeriesSchema.parse(series);
+  const occurrences: Occurrence[] = [];
+
+  for (let index = 0; index < parsed.count; index += 1) {
+    const startAt = occurrenceStart(parsed, index);
+    const endAt = new Date(startAt.getTime() + parsed.durationMinutes * MINUTE_MS);
+    occurrences.push({ index, startAt, endAt });
+  }
+
+  return occurrences;
+}
+
+/**
+ * Expand a weekly provider block into the next `weeks` occurrences whose date
+ * falls on/after `fromDate`. The first occurrence is the first matching
+ * day-of-week on/after `fromDate`; each subsequent one is +7 days.
+ */
+export function expandBlock(
+  block: BlockReservation,
+  fromDate: Date,
+): Array<{ start: Date; end: Date; label: string }> {
+  const parsed = BlockReservationSchema.parse(block);
+
+  // Anchor on the calendar date of fromDate (UTC), then advance to the
+  // first matching day-of-week on/after that date.
+  const anchor = new Date(
+    Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth(), fromDate.getUTCDate()),
+  );
+  const dayDelta = ((parsed.dayOfWeek - anchor.getUTCDay()) % 7 + 7) % 7;
+  const firstDate = new Date(anchor.getTime() + dayDelta * 24 * 60 * MINUTE_MS);
+
+  const results: Array<{ start: Date; end: Date; label: string }> = [];
+  for (let week = 0; week < parsed.weeks; week += 1) {
+    const dayStart = new Date(firstDate.getTime() + week * 7 * 24 * 60 * MINUTE_MS);
+    const start = new Date(
+      Date.UTC(
+        dayStart.getUTCFullYear(),
+        dayStart.getUTCMonth(),
+        dayStart.getUTCDate(),
+        parsed.startHour,
+      ),
+    );
+    const end = new Date(
+      Date.UTC(
+        dayStart.getUTCFullYear(),
+        dayStart.getUTCMonth(),
+        dayStart.getUTCDate(),
+        parsed.endHour,
+      ),
+    );
+    results.push({ start, end, label: parsed.label });
+  }
+
+  return results;
+}
+
+/** Seats still open on a group visit (never negative). */
+export function seatsRemaining(visit: GroupVisit): number {
+  return Math.max(0, visit.maxSeats - visit.roster.length);
+}
+
+/**
+ * Add a patient to a group visit's roster. Rejects (without mutating) when the
+ * visit is full or the patient is already enrolled; otherwise returns a new
+ * visit with the patient appended. The input visit is never mutated.
+ */
+export function addToRoster(
+  visit: GroupVisit,
+  patientId: string,
+): { ok: boolean; visit: GroupVisit; reason?: string } {
+  if (visit.roster.includes(patientId)) {
+    return { ok: false, visit, reason: "Patient already on roster" };
+  }
+  if (seatsRemaining(visit) <= 0) {
+    return { ok: false, visit, reason: "Group visit is full" };
+  }
+  const updated: GroupVisit = { ...visit, roster: [...visit.roster, patientId] };
+  return { ok: true, visit: updated };
+}
+
+/**
+ * Detect overlaps between scheduled occurrences and known-busy intervals.
+ * Two intervals overlap iff `a.start < b.end && b.start < a.end` (touching
+ * endpoints are not a conflict). Returns one entry per (occurrence, busy) pair
+ * that overlaps so the caller can surface every collision.
+ */
+export function detectConflicts(
+  occurrences: Array<{ start: Date; end: Date }>,
+  busy: Array<{ start: Date; end: Date }>,
+): Array<{ occurrence: { start: Date; end: Date }; conflictsWith: { start: Date; end: Date } }> {
+  const conflicts: Array<{
+    occurrence: { start: Date; end: Date };
+    conflictsWith: { start: Date; end: Date };
+  }> = [];
+
+  for (const occurrence of occurrences) {
+    for (const slot of busy) {
+      if (
+        occurrence.start.getTime() < slot.end.getTime() &&
+        slot.start.getTime() < occurrence.end.getTime()
+      ) {
+        conflicts.push({ occurrence, conflictsWith: slot });
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * Given a series and the set of occurrence indexes the patient actually
+ * attended, return the indexes they missed (in ascending order). Feeds the
+ * auto-rebooking flow so missed sessions can be re-offered.
+ */
+export function backfillMissedWeeks(series: RecurringSeries, attended: number[]): number[] {
+  const parsed = RecurringSeriesSchema.parse(series);
+  const attendedSet = new Set(attended);
+  const missed: number[] = [];
+
+  for (let index = 0; index < parsed.count; index += 1) {
+    if (!attendedSet.has(index)) {
+      missed.push(index);
+    }
+  }
+
+  return missed;
+}

--- a/src/lib/scheduling/waitlist.test.ts
+++ b/src/lib/scheduling/waitlist.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  fillMetrics,
+  offerWaves,
+  rankWaitlist,
+  type OpenSlot,
+  type ScoredWaitlistEntry,
+  type WaitlistEntry,
+} from "./waitlist";
+
+// A Friday 10:00 local slot. (2026-05-29 is a Friday.)
+const slot: OpenSlot = {
+  slotId: "slot-1",
+  providerId: "prov-1",
+  startAt: new Date("2026-05-29T10:00:00.000"),
+  endAt: new Date("2026-05-29T10:30:00.000"),
+  modality: "video",
+  visitType: "follow_up",
+};
+
+function entry(overrides: Partial<WaitlistEntry> = {}): WaitlistEntry {
+  return {
+    patientId: "p-base",
+    displayName: "Base Patient",
+    addedAt: new Date("2026-05-28T10:00:00.000"),
+    visitType: "follow_up",
+    preferredProviderId: null,
+    acceptableWeekdays: [],
+    acceptableHourRange: null,
+    urgency: "routine",
+    overdueDays: 0,
+    riskTier: "low",
+    flexibilityScore: 0.5,
+    vip: false,
+    contactChannel: "sms",
+    ...overrides,
+  };
+}
+
+describe("rankWaitlist filtering", () => {
+  it("filters out a visit-type mismatch", () => {
+    const ranked = rankWaitlist([entry({ visitType: "intake" })], slot);
+    expect(ranked).toHaveLength(0);
+  });
+
+  it("filters out a patient whose acceptable weekdays exclude the slot day", () => {
+    // Slot is a Friday (day 5); patient only takes Mon/Tue.
+    const ranked = rankWaitlist([entry({ acceptableWeekdays: [1, 2] })], slot);
+    expect(ranked).toHaveLength(0);
+  });
+
+  it("keeps a patient whose acceptable weekdays include the slot day", () => {
+    const ranked = rankWaitlist([entry({ acceptableWeekdays: [5] })], slot);
+    expect(ranked).toHaveLength(1);
+  });
+
+  it("filters out a slot hour outside the acceptable hour range", () => {
+    const ranked = rankWaitlist(
+      [entry({ acceptableHourRange: { earliestHour: 13, latestHour: 17 } })],
+      slot,
+    );
+    expect(ranked).toHaveLength(0);
+  });
+
+  it("hard-filters a provider preference mismatch by default", () => {
+    const ranked = rankWaitlist([entry({ preferredProviderId: "prov-9" })], slot);
+    expect(ranked).toHaveLength(0);
+  });
+
+  it("allows a provider mismatch when honorProviderPreferenceAsHard is false", () => {
+    const ranked = rankWaitlist([entry({ preferredProviderId: "prov-9" })], slot, {
+      honorProviderPreferenceAsHard: false,
+    });
+    expect(ranked).toHaveLength(1);
+  });
+});
+
+describe("rankWaitlist ordering", () => {
+  it("ranks an urgent overdue patient above a routine on-time patient", () => {
+    const urgent = entry({
+      patientId: "urgent",
+      urgency: "urgent",
+      overdueDays: 20,
+    });
+    const routine = entry({ patientId: "routine", urgency: "routine", overdueDays: 0 });
+
+    const ranked = rankWaitlist([routine, urgent], slot);
+    expect(ranked.map((r) => r.entry.patientId)).toEqual(["urgent", "routine"]);
+    expect(ranked[0].reasons).toContain("Urgent clinical need");
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it("prefers a low-risk patient over an otherwise-identical high-risk one", () => {
+    const lowRisk = entry({ patientId: "low", riskTier: "low" });
+    const highRisk = entry({ patientId: "high", riskTier: "high" });
+
+    const ranked = rankWaitlist([highRisk, lowRisk], slot);
+    expect(ranked[0].entry.patientId).toBe("low");
+  });
+
+  it("rewards a longer wait time", () => {
+    const longWait = entry({
+      patientId: "long",
+      addedAt: new Date("2026-05-01T10:00:00.000"),
+    });
+    const shortWait = entry({
+      patientId: "short",
+      addedAt: new Date("2026-05-28T10:00:00.000"),
+    });
+
+    const ranked = rankWaitlist([shortWait, longWait], slot);
+    expect(ranked[0].entry.patientId).toBe("long");
+    expect(ranked[0].reasons.some((r) => r.startsWith("Waiting"))).toBe(true);
+  });
+
+  it("respects the limit option", () => {
+    const ranked = rankWaitlist(
+      [entry({ patientId: "a" }), entry({ patientId: "b" }), entry({ patientId: "c" })],
+      slot,
+      { limit: 2 },
+    );
+    expect(ranked).toHaveLength(2);
+  });
+});
+
+describe("offerWaves", () => {
+  function scored(id: string): ScoredWaitlistEntry {
+    return { entry: entry({ patientId: id }), score: 0.5, reasons: [] };
+  }
+
+  it("buckets ranked entries into 3/5/blast waves with staggered offsets", () => {
+    const ranked = Array.from({ length: 11 }, (_, i) => scored(`p-${i}`));
+    const waves = offerWaves(ranked);
+
+    expect(waves).toHaveLength(3);
+    expect(waves[0]).toMatchObject({ wave: 1, offsetMinutes: 0 });
+    expect(waves[0].entries).toHaveLength(3);
+    expect(waves[1]).toMatchObject({ wave: 2, offsetMinutes: 15 });
+    expect(waves[1].entries).toHaveLength(5);
+    expect(waves[2]).toMatchObject({ wave: 3, offsetMinutes: 45 });
+    expect(waves[2].entries).toHaveLength(3);
+  });
+
+  it("omits empty trailing waves", () => {
+    const waves = offerWaves([scored("a"), scored("b")]);
+    expect(waves).toHaveLength(1);
+    expect(waves[0].entries).toHaveLength(2);
+  });
+
+  it("returns no waves for an empty ranking", () => {
+    expect(offerWaves([])).toEqual([]);
+  });
+});
+
+describe("fillMetrics", () => {
+  it("computes fill rate and median fill time over filled events only", () => {
+    const metrics = fillMetrics([
+      {
+        cancelledAt: new Date("2026-05-28T10:00:00.000Z"),
+        filledAt: new Date("2026-05-28T10:10:00.000Z"), // 10 min
+      },
+      {
+        cancelledAt: new Date("2026-05-28T11:00:00.000Z"),
+        filledAt: new Date("2026-05-28T11:30:00.000Z"), // 30 min
+      },
+      {
+        cancelledAt: new Date("2026-05-28T12:00:00.000Z"),
+        filledAt: null, // unfilled
+      },
+    ]);
+
+    expect(metrics.total).toBe(3);
+    expect(metrics.filled).toBe(2);
+    expect(metrics.fillRate).toBeCloseTo(0.667, 3);
+    expect(metrics.medianFillMinutes).toBe(20); // mean of 10 and 30
+  });
+
+  it("returns zeros for an empty event list", () => {
+    expect(fillMetrics([])).toEqual({
+      fillRate: 0,
+      medianFillMinutes: 0,
+      filled: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/lib/scheduling/waitlist.ts
+++ b/src/lib/scheduling/waitlist.ts
@@ -1,0 +1,301 @@
+/**
+ * EMR-210 — Intelligent waitlist + cancellation fill.
+ *
+ * When a slot opens up (a cancellation, a no-show backfill, an added-capacity
+ * block), this engine decides who to offer it to and in what order. Entries
+ * that physically cannot take the slot (wrong visit type, wrong day, outside
+ * their stated hours, wrong provider) are hard-filtered out; the rest are
+ * scored by a weighted blend of clinical urgency, cadence overdue-ness,
+ * no-show risk fit, flexibility, VIP status, and how long they have waited.
+ *
+ * The ranker is pure and read-only — callers pass in the pre-fetched waitlist
+ * and the open slot, and we never read the wall clock (the slot's startAt is
+ * the reference time). Offer waves stagger outreach so we don't blast every
+ * patient at once and end up double-booked.
+ */
+import { z } from "zod";
+import type { RiskTier } from "./no-show-model";
+
+export const UrgencySchema = z.enum(["routine", "soon", "urgent"]);
+export type Urgency = z.infer<typeof UrgencySchema>;
+
+export const ContactChannelSchema = z.enum(["sms", "email", "voice", "portal"]);
+export type ContactChannel = z.infer<typeof ContactChannelSchema>;
+
+export const HourRangeSchema = z.object({
+  /** 0–23, inclusive lower bound on slot start hour. */
+  earliestHour: z.number().int().min(0).max(23),
+  /** 0–23, exclusive upper bound on slot start hour. */
+  latestHour: z.number().int().min(0).max(24),
+});
+export type HourRange = z.infer<typeof HourRangeSchema>;
+
+export const WaitlistEntrySchema = z.object({
+  patientId: z.string(),
+  displayName: z.string(),
+  /** When the patient joined the waitlist — older waits rank higher. */
+  addedAt: z.date(),
+  /** Visit type the patient is waiting for; must match the slot's visitType. */
+  visitType: z.string(),
+  /** Preferred provider — honored as a hard filter by default (see opts). */
+  preferredProviderId: z.string().nullable(),
+  /** Weekdays the patient can take (0=Sun..6=Sat). [] = any day works. */
+  acceptableWeekdays: z.array(z.number().int().min(0).max(6)),
+  /** Acceptable start-hour window, or null = any hour works. */
+  acceptableHourRange: HourRangeSchema.nullable(),
+  urgency: UrgencySchema,
+  /** Days overdue from the cadence engine (EMR-208); 0 if not overdue. */
+  overdueDays: z.number().min(0),
+  /** No-show risk tier from EMR-207. */
+  riskTier: z.custom<RiskTier>((v) => v === "low" || v === "medium" || v === "high"),
+  /** 0..1 — how flexible the patient is (short-notice, any-modality, etc.). */
+  flexibilityScore: z.number().min(0).max(1),
+  vip: z.boolean(),
+  contactChannel: ContactChannelSchema,
+});
+export type WaitlistEntry = z.infer<typeof WaitlistEntrySchema>;
+
+export interface OpenSlot {
+  slotId: string;
+  providerId: string;
+  startAt: Date;
+  endAt: Date;
+  modality: string;
+  visitType: string;
+}
+
+export interface ScoredWaitlistEntry {
+  entry: WaitlistEntry;
+  score: number;
+  reasons: string[];
+}
+
+export interface RankWaitlistOptions {
+  /**
+   * When true (default), a patient's preferredProviderId — if set — must
+   * match the slot's provider or they are filtered out entirely. When false,
+   * a provider mismatch is allowed (the preference still influences scoring
+   * via the soft provider-match bonus).
+   */
+  honorProviderPreferenceAsHard?: boolean;
+  /** Hard cap on the number of ranked entries returned. */
+  limit?: number;
+}
+
+const WEIGHTS = {
+  urgency: 0.3,
+  overdue: 0.22,
+  riskFit: 0.12,
+  flexibility: 0.1,
+  vip: 0.1,
+  waitTime: 0.16,
+} as const;
+
+/** Days of overdue-ness at which the cadence factor saturates to its full weight. */
+const OVERDUE_SATURATION_DAYS = 30;
+/** Days on the waitlist at which the wait-time factor saturates. */
+const WAIT_SATURATION_DAYS = 30;
+
+const URGENCY_WEIGHT: Record<Urgency, number> = {
+  routine: 0,
+  soon: 0.5,
+  urgent: 1,
+};
+
+/**
+ * Rank a waitlist against a single open slot. Entries that cannot physically
+ * take the slot are removed (not down-ranked) so the UI never offers them.
+ * The remaining entries are scored and returned highest-first.
+ */
+export function rankWaitlist(
+  entries: WaitlistEntry[],
+  slot: OpenSlot,
+  opts: RankWaitlistOptions = {},
+): ScoredWaitlistEntry[] {
+  const honorProvider = opts.honorProviderPreferenceAsHard ?? true;
+  const slotDay = slot.startAt.getDay();
+  const slotHour = slot.startAt.getHours();
+
+  const eligible = entries.filter((entry) => {
+    if (entry.visitType !== slot.visitType) return false;
+    if (
+      entry.acceptableWeekdays.length > 0 &&
+      !entry.acceptableWeekdays.includes(slotDay)
+    ) {
+      return false;
+    }
+    if (entry.acceptableHourRange) {
+      const { earliestHour, latestHour } = entry.acceptableHourRange;
+      if (slotHour < earliestHour || slotHour >= latestHour) return false;
+    }
+    if (
+      honorProvider &&
+      entry.preferredProviderId !== null &&
+      entry.preferredProviderId !== slot.providerId
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const scored = eligible.map((entry) => scoreEntry(entry, slot));
+  scored.sort((a, b) => b.score - a.score);
+
+  return typeof opts.limit === "number" ? scored.slice(0, opts.limit) : scored;
+}
+
+function scoreEntry(entry: WaitlistEntry, slot: OpenSlot): ScoredWaitlistEntry {
+  const reasons: string[] = [];
+  let score = 0;
+
+  // 1. Clinical urgency.
+  const urgencyContribution = WEIGHTS.urgency * URGENCY_WEIGHT[entry.urgency];
+  if (urgencyContribution > 0) {
+    score += urgencyContribution;
+    reasons.push(
+      entry.urgency === "urgent" ? "Urgent clinical need" : "Needs to be seen soon",
+    );
+  }
+
+  // 2. Cadence overdue-ness — the longer they're past due, the higher they rank.
+  if (entry.overdueDays > 0) {
+    const overdueFraction = Math.min(1, entry.overdueDays / OVERDUE_SATURATION_DAYS);
+    const overdueContribution = WEIGHTS.overdue * overdueFraction;
+    score += overdueContribution;
+    reasons.push(`Overdue by ${Math.floor(entry.overdueDays)}d`);
+  }
+
+  // 3. No-show risk fit — prefer not to burn a recovered slot on a high-risk
+  //    patient (modest weight; clinical need still dominates).
+  const riskFit = riskFitWeight(entry.riskTier);
+  const riskContribution = WEIGHTS.riskFit * riskFit;
+  score += riskContribution;
+  if (entry.riskTier === "low") {
+    reasons.push("Low no-show risk");
+  } else if (entry.riskTier === "high") {
+    reasons.push("High no-show risk (de-prioritized)");
+  }
+
+  // 4. Flexibility — flexible patients are cheaper to fill and less likely to
+  //    decline a short-notice offer.
+  const flexContribution = WEIGHTS.flexibility * entry.flexibilityScore;
+  score += flexContribution;
+  if (entry.flexibilityScore >= 0.7) reasons.push("Highly flexible");
+
+  // 5. VIP boost.
+  if (entry.vip) {
+    score += WEIGHTS.vip;
+    reasons.push("VIP patient");
+  }
+
+  // 6. Wait time — older entries (relative to the slot start) rank higher.
+  const waitDays = Math.max(
+    0,
+    (slot.startAt.getTime() - entry.addedAt.getTime()) / 86_400_000,
+  );
+  const waitFraction = Math.min(1, waitDays / WAIT_SATURATION_DAYS);
+  const waitContribution = WEIGHTS.waitTime * waitFraction;
+  score += waitContribution;
+  if (waitDays >= 7) reasons.push(`Waiting ${Math.floor(waitDays)}d`);
+
+  return { entry, score: round3(score), reasons };
+}
+
+/**
+ * Higher = more preferred for a recovered slot. Low-risk patients are the
+ * safest fill; high-risk patients are modestly de-prioritized so we don't
+ * hand a freshly opened prime slot to a likely no-show.
+ */
+function riskFitWeight(tier: RiskTier): number {
+  switch (tier) {
+    case "low":
+      return 1;
+    case "medium":
+      return 0.6;
+    case "high":
+      return 0.2;
+  }
+}
+
+export interface OfferWave {
+  wave: number;
+  offsetMinutes: number;
+  entries: ScoredWaitlistEntry[];
+}
+
+const WAVE_PLAN = [
+  { wave: 1, size: 3, offsetMinutes: 0 },
+  { wave: 2, size: 5, offsetMinutes: 15 },
+  { wave: 3, size: Infinity, offsetMinutes: 45 },
+] as const;
+
+/**
+ * Split a ranked waitlist into staggered offer waves. Wave 1 (top 3) goes out
+ * immediately in parallel; wave 2 (next 5) fires after a short delay if no one
+ * in wave 1 has claimed the slot; wave 3 is a final blast to everyone else.
+ * Empty waves are omitted.
+ */
+export function offerWaves(ranked: ScoredWaitlistEntry[]): OfferWave[] {
+  const waves: OfferWave[] = [];
+  let cursor = 0;
+
+  for (const plan of WAVE_PLAN) {
+    if (cursor >= ranked.length) break;
+    const end = plan.size === Infinity ? ranked.length : cursor + plan.size;
+    const entries = ranked.slice(cursor, end);
+    if (entries.length > 0) {
+      waves.push({ wave: plan.wave, offsetMinutes: plan.offsetMinutes, entries });
+    }
+    cursor = end;
+  }
+
+  return waves;
+}
+
+export interface FillEvent {
+  cancelledAt: Date;
+  /** When the slot was filled from the waitlist; null = never filled. */
+  filledAt: Date | null;
+}
+
+export interface FillMetrics {
+  /** Fraction of cancellations that were re-filled (0..1). */
+  fillRate: number;
+  /** Median minutes from cancellation to fill, across filled events only. */
+  medianFillMinutes: number;
+  filled: number;
+  total: number;
+}
+
+/**
+ * Aggregate cancellation-fill performance. fillRate is filled/total; the
+ * median fill time is computed only over events that actually filled (an
+ * unfilled slot has no fill latency). Returns zeros for an empty input.
+ */
+export function fillMetrics(events: FillEvent[]): FillMetrics {
+  const total = events.length;
+  const filledEvents = events.filter((e) => e.filledAt !== null);
+  const filled = filledEvents.length;
+
+  const durations = filledEvents
+    .map((e) => (e.filledAt as Date).getTime() - e.cancelledAt.getTime())
+    .map((ms) => Math.max(0, ms / 60_000))
+    .sort((a, b) => a - b);
+
+  return {
+    fillRate: total === 0 ? 0 : round3(filled / total),
+    medianFillMinutes: round3(median(durations)),
+    filled,
+    total,
+  };
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/src/lib/scheduling/workflow-efficiency.test.ts
+++ b/src/lib/scheduling/workflow-efficiency.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateByRole,
+  aggregateByTask,
+  aggregateByUser,
+  flagRegressions,
+  percentile,
+  TASK_CLICK_TARGETS,
+  type ClickEvent,
+} from "./workflow-efficiency";
+
+function event(overrides: Partial<ClickEvent> = {}): ClickEvent {
+  return {
+    userId: "u1",
+    role: "provider",
+    taskType: "finalize_note",
+    clicks: 5,
+    durationMs: 1000,
+    completedAt: new Date("2026-05-01T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("percentile", () => {
+  it("returns the median via nearest-rank on an odd-length array", () => {
+    // sorted: [1, 2, 3, 4, 5]; rank = ceil(0.5 * 5) = 3 -> value 3
+    expect(percentile([3, 1, 5, 2, 4], 0.5)).toBe(3);
+  });
+
+  it("returns the nearest-rank median on an even-length array (not interpolated)", () => {
+    // sorted: [2, 4, 6, 8]; rank = ceil(0.5 * 4) = 2 -> value 4
+    expect(percentile([8, 2, 6, 4], 0.5)).toBe(4);
+  });
+
+  it("computes p90 via nearest-rank", () => {
+    // sorted 1..10; rank = ceil(0.9 * 10) = 9 -> value 9
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(values, 0.9)).toBe(9);
+  });
+
+  it("clamps p to the first element at p=0 and the last at p=1", () => {
+    expect(percentile([10, 30, 20], 0)).toBe(10);
+    expect(percentile([10, 30, 20], 1)).toBe(30);
+  });
+
+  it("returns 0 for an empty array", () => {
+    expect(percentile([], 0.5)).toBe(0);
+  });
+});
+
+describe("aggregateByTask", () => {
+  it("groups by task and computes mean/median/p90 clicks and mean duration", () => {
+    const events: ClickEvent[] = [
+      event({ taskType: "finalize_note", clicks: 4, durationMs: 1000 }),
+      event({ taskType: "finalize_note", clicks: 6, durationMs: 3000 }),
+      event({ taskType: "finalize_note", clicks: 8, durationMs: 2000 }),
+      event({ taskType: "start_visit", clicks: 2, durationMs: 500 }),
+    ];
+
+    const rows = aggregateByTask(events);
+
+    // Sorted by count desc: finalize_note (3) before start_visit (1).
+    expect(rows.map((r) => r.taskType)).toEqual(["finalize_note", "start_visit"]);
+
+    const note = rows[0];
+    expect(note.count).toBe(3);
+    expect(note.avgClicks).toBe(6); // (4+6+8)/3
+    expect(note.medianClicks).toBe(6); // sorted [4,6,8], rank 2
+    expect(note.p90Clicks).toBe(8); // rank = ceil(0.9*3) = 3
+    expect(note.avgDurationMs).toBe(2000); // (1000+3000+2000)/3
+
+    const visit = rows[1];
+    expect(visit.count).toBe(1);
+    expect(visit.avgClicks).toBe(2);
+  });
+
+  it("returns an empty array when there are no events", () => {
+    expect(aggregateByTask([])).toEqual([]);
+  });
+});
+
+describe("aggregateByUser", () => {
+  it("rolls clicks and durations up per user, sorted by total clicks desc", () => {
+    const events: ClickEvent[] = [
+      event({ userId: "u1", clicks: 3, durationMs: 1000 }),
+      event({ userId: "u1", clicks: 5, durationMs: 2000 }),
+      event({ userId: "u2", clicks: 10, durationMs: 4000 }),
+    ];
+
+    const rows = aggregateByUser(events);
+
+    expect(rows.map((r) => r.userId)).toEqual(["u2", "u1"]);
+
+    const u1 = rows.find((r) => r.userId === "u1")!;
+    expect(u1.sessions).toBe(2);
+    expect(u1.totalClicks).toBe(8);
+    expect(u1.avgClicksPerTask).toBe(4);
+    expect(u1.avgDurationMs).toBe(1500);
+  });
+});
+
+describe("aggregateByRole", () => {
+  it("rolls clicks up per role", () => {
+    const events: ClickEvent[] = [
+      event({ role: "provider", clicks: 4 }),
+      event({ role: "provider", clicks: 6 }),
+      event({ role: "office_manager", clicks: 2 }),
+    ];
+
+    const rows = aggregateByRole(events);
+
+    const provider = rows.find((r) => r.role === "provider")!;
+    expect(provider.sessions).toBe(2);
+    expect(provider.totalClicks).toBe(10);
+    expect(provider.avgClicksPerTask).toBe(5);
+
+    const office = rows.find((r) => r.role === "office_manager")!;
+    expect(office.totalClicks).toBe(2);
+  });
+});
+
+describe("flagRegressions", () => {
+  it("flags only tasks whose average clicks exceed the target, worst-first", () => {
+    const events: ClickEvent[] = [
+      // finalize_note averages 7 vs target 5 -> over by 2.
+      event({ taskType: "finalize_note", clicks: 6 }),
+      event({ taskType: "finalize_note", clicks: 8 }),
+      // send_rx averages 5 vs target 4 -> over by 1.
+      event({ taskType: "send_rx", clicks: 5 }),
+      // start_visit averages 3 vs target 3 -> NOT over (strictly greater required).
+      event({ taskType: "start_visit", clicks: 3 }),
+    ];
+
+    const flags = flagRegressions(events);
+
+    expect(flags.map((f) => f.taskType)).toEqual(["finalize_note", "send_rx"]);
+
+    const note = flags[0];
+    expect(note.avgClicks).toBe(7);
+    expect(note.target).toBe(TASK_CLICK_TARGETS.finalize_note);
+    expect(note.overBy).toBe(2);
+
+    const rx = flags[1];
+    expect(rx.overBy).toBe(1);
+  });
+
+  it("ignores tasks with no defined target", () => {
+    const events: ClickEvent[] = [
+      event({ taskType: "mystery_task", clicks: 99 }),
+    ];
+
+    expect(flagRegressions(events)).toEqual([]);
+  });
+
+  it("respects a custom targets map", () => {
+    const events: ClickEvent[] = [
+      event({ taskType: "start_visit", clicks: 4 }),
+    ];
+
+    // Default target for start_visit is 3, so 4 would normally flag;
+    // raise it to 10 and nothing should flag.
+    expect(flagRegressions(events, { start_visit: 10 })).toEqual([]);
+  });
+});

--- a/src/lib/scheduling/workflow-efficiency.ts
+++ b/src/lib/scheduling/workflow-efficiency.ts
@@ -1,0 +1,232 @@
+/**
+ * EMR-104 — Click counter / workflow efficiency tracking.
+ *
+ * Pure aggregation engine over UI click telemetry. Each recorded event
+ * captures how many clicks and how long a given task ("start_visit",
+ * "finalize_note", …) took a given user. These functions roll those events
+ * up by task, by user, and by role so the practice can see where the EMR is
+ * costing clinicians clicks — and flag any task whose average click count
+ * has crept above its target ("average clicks to finalize a note: 7,
+ * target 5"). No database, no clock reads — callers pass pre-fetched events.
+ */
+import { z } from "zod";
+
+export const WorkflowRoleSchema = z.enum([
+  "patient",
+  "provider",
+  "office_manager",
+  "researcher",
+  "system",
+]);
+export type WorkflowRole = z.infer<typeof WorkflowRoleSchema>;
+
+export const ClickEventSchema = z.object({
+  /** Stable identifier of the user who performed the task. */
+  userId: z.string(),
+  /** Role the user was acting as when the task was performed. */
+  role: WorkflowRoleSchema,
+  /** Task being measured, e.g. "start_visit" | "finalize_note" | "send_rx" | "check_labs". */
+  taskType: z.string(),
+  /** Number of clicks the user spent completing the task. */
+  clicks: z.number().int().min(0),
+  /** Wall-clock duration of the task in milliseconds. */
+  durationMs: z.number().int().min(0),
+  /** When the task was completed. */
+  completedAt: z.date(),
+});
+
+export type ClickEvent = z.infer<typeof ClickEventSchema>;
+
+export interface TaskAggregate {
+  taskType: string;
+  count: number;
+  avgClicks: number;
+  medianClicks: number;
+  p90Clicks: number;
+  avgDurationMs: number;
+}
+
+export interface UserAggregate {
+  userId: string;
+  sessions: number;
+  totalClicks: number;
+  avgClicksPerTask: number;
+  avgDurationMs: number;
+}
+
+export interface RoleAggregate {
+  role: WorkflowRole;
+  sessions: number;
+  totalClicks: number;
+  avgClicksPerTask: number;
+  avgDurationMs: number;
+}
+
+export interface RegressionFlag {
+  taskType: string;
+  avgClicks: number;
+  target: number;
+  overBy: number;
+}
+
+/**
+ * Default per-task click budgets. These are the "this task should take no
+ * more than N clicks" targets the workflow team agreed on; tasks whose
+ * measured average exceeds the target are surfaced by flagRegressions.
+ */
+export const TASK_CLICK_TARGETS: Record<string, number> = {
+  start_visit: 3,
+  finalize_note: 5,
+  send_rx: 4,
+  check_labs: 3,
+};
+
+/**
+ * Nearest-rank percentile over a list of numbers. `p` is a fraction in
+ * [0, 1] (e.g. 0.5 for median, 0.9 for p90). Returns 0 for an empty list.
+ * The input is not assumed to be sorted.
+ */
+export function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const clamped = Math.min(1, Math.max(0, p));
+  // Nearest-rank: rank = ceil(p * N), 1-indexed; p=0 maps to the first element.
+  const rank = Math.max(1, Math.ceil(clamped * sorted.length));
+  return sorted[rank - 1];
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Roll events up by taskType. Each row reports how many events were seen,
+ * the mean/median/p90 click counts, and the mean duration. Sorted by event
+ * count descending (the tasks we have the most signal on come first).
+ */
+export function aggregateByTask(events: ClickEvent[]): TaskAggregate[] {
+  const groups = new Map<string, ClickEvent[]>();
+  for (const event of events) {
+    const bucket = groups.get(event.taskType);
+    if (bucket) {
+      bucket.push(event);
+    } else {
+      groups.set(event.taskType, [event]);
+    }
+  }
+
+  const rows: TaskAggregate[] = [];
+  for (const [taskType, bucket] of groups) {
+    const clicks = bucket.map((e) => e.clicks);
+    const durations = bucket.map((e) => e.durationMs);
+    rows.push({
+      taskType,
+      count: bucket.length,
+      avgClicks: round2(mean(clicks)),
+      medianClicks: percentile(clicks, 0.5),
+      p90Clicks: percentile(clicks, 0.9),
+      avgDurationMs: round2(mean(durations)),
+    });
+  }
+
+  rows.sort((a, b) => b.count - a.count);
+  return rows;
+}
+
+/**
+ * Roll events up by userId. `sessions` is the number of recorded events
+ * (task completions) for that user; `avgClicksPerTask` is total clicks
+ * divided by that count. Sorted by total clicks descending.
+ */
+export function aggregateByUser(events: ClickEvent[]): UserAggregate[] {
+  const groups = new Map<string, ClickEvent[]>();
+  for (const event of events) {
+    const bucket = groups.get(event.userId);
+    if (bucket) {
+      bucket.push(event);
+    } else {
+      groups.set(event.userId, [event]);
+    }
+  }
+
+  const rows: UserAggregate[] = [];
+  for (const [userId, bucket] of groups) {
+    const totalClicks = bucket.reduce((sum, e) => sum + e.clicks, 0);
+    rows.push({
+      userId,
+      sessions: bucket.length,
+      totalClicks,
+      avgClicksPerTask: round2(totalClicks / bucket.length),
+      avgDurationMs: round2(mean(bucket.map((e) => e.durationMs))),
+    });
+  }
+
+  rows.sort((a, b) => b.totalClicks - a.totalClicks);
+  return rows;
+}
+
+/**
+ * Roll events up by role — same shape as aggregateByUser but keyed by the
+ * acting role, so we can compare e.g. provider vs. office_manager workload.
+ * Sorted by total clicks descending.
+ */
+export function aggregateByRole(events: ClickEvent[]): RoleAggregate[] {
+  const groups = new Map<WorkflowRole, ClickEvent[]>();
+  for (const event of events) {
+    const bucket = groups.get(event.role);
+    if (bucket) {
+      bucket.push(event);
+    } else {
+      groups.set(event.role, [event]);
+    }
+  }
+
+  const rows: RoleAggregate[] = [];
+  for (const [role, bucket] of groups) {
+    const totalClicks = bucket.reduce((sum, e) => sum + e.clicks, 0);
+    rows.push({
+      role,
+      sessions: bucket.length,
+      totalClicks,
+      avgClicksPerTask: round2(totalClicks / bucket.length),
+      avgDurationMs: round2(mean(bucket.map((e) => e.durationMs))),
+    });
+  }
+
+  rows.sort((a, b) => b.totalClicks - a.totalClicks);
+  return rows;
+}
+
+/**
+ * Flag tasks whose average click count exceeds its target. Only tasks that
+ * (a) have a target defined in `targets` and (b) are actually over that
+ * target are returned. Sorted worst-first (largest `overBy` first).
+ */
+export function flagRegressions(
+  events: ClickEvent[],
+  targets: Record<string, number> = TASK_CLICK_TARGETS,
+): RegressionFlag[] {
+  const byTask = aggregateByTask(events);
+
+  const flags: RegressionFlag[] = [];
+  for (const row of byTask) {
+    const target = targets[row.taskType];
+    if (target === undefined) continue;
+    if (row.avgClicks > target) {
+      flags.push({
+        taskType: row.taskType,
+        avgClicks: row.avgClicks,
+        target,
+        overBy: round2(row.avgClicks - target),
+      });
+    }
+  }
+
+  flags.sort((a, b) => b.overBy - a.overBy);
+  return flags;
+}


### PR DESCRIPTION
## Phase 12 Track 3 — AI Scheduling Engine & Automation

Completes the scheduling-engine track. The core algorithms (no-show prediction, cadence, slot recommender, reminder orchestration, intake gate, provider prefs/burnout) and the SMS / RPM / access-log / practice-analytics surfaces were already in place; this PR fills the remaining algorithm gaps and wires the analytics cockpit to a pure metrics engine.

### New pure modules — `src/lib/scheduling/` (DB-free, deterministic, fully unit-tested)

| Ticket | Module | What it does |
|--------|--------|--------------|
| **EMR-210** | `waitlist.ts` | Ranks a waitlist against an open slot (urgency, cadence overdue-ness, no-show-risk fit, flexibility, VIP, wait time), hard-filters ineligible entries, produces staggered offer waves (top-3 → next-5 → blast), and computes cancellation fill-rate / fill-time metrics. |
| **EMR-213** | `recurring.ts` | Expands weekly/biweekly/monthly series (end-of-month clamping), recurring provider blocks, group-visit roster management, interval conflict detection, and missed-session backfill. |
| **EMR-215** | `analytics.ts` | Fill/no-show/cancel rates, lead-time percentiles, new-patient conversion, revenue-per-slot, provider utilization, slice-by-dimension, 30/60/90-day demand forecast, bottleneck detection, and action triggers. |
| **EMR-104** | `workflow-efficiency.ts` | Click-counter / time-on-task aggregation by task/user/role with regression flags vs per-task click targets ("avg clicks to finalize a note: 7, target 5"). |
| — | `index.ts` | Barrel re-exporting the pure scheduling engines. |

### Interface — `src/app/(operator)/ops/schedule/`
- The **analytics cockpit** now consumes `analytics.ts` (replacing inline math) and adds lead-time percentiles, a 30/60/90-day demand forecast, per-provider bottleneck callouts, and an action-required banner driven by `actionTriggers`.

### Tickets covered
- **New work here:** EMR-210, EMR-213, EMR-215, EMR-104
- **Already shipped, verified in place:** EMR-012 (SMS), EMR-120 (RPM eval), EMR-121 (access log), EMR-103 (practice analytics), EMR-206 (booking flows), EMR-207 (no-show), EMR-208 (cadence), EMR-209 (slot recommender), EMR-211 (reminders), EMR-212 (intake gate), EMR-214 (provider prefs/burnout)

### Verification
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on changed files
- ✅ `vitest run src/lib/scheduling` — **71 tests pass** (52 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)