### PR TITLE
fix(portal): correct adherence ring default for patients with no logs

### DIFF
--- a/src/app/(patient)/portal/widgets.tsx
+++ b/src/app/(patient)/portal/widgets.tsx
@@ -338,7 +338,7 @@ export async function RhythmsWidget({ userId }: { userId: string }) {
             </p>
             <HealthRings 
               checkinProgress={hasCheckedInToday ? 1 : 0} 
-              adherenceProgress={latestAdherence !== null ? latestAdherence / 100 : 0.2} 
+              adherenceProgress={latestAdherence !== undefined ? latestAdherence / 100 : 0.2}
               intakeProgress={intakeComplete / 100} 
               size={120} 
               strokeWidth={12} 


### PR DESCRIPTION
## What

One-line fix in the Patient Home `RhythmsWidget`: the daily-rings adherence
progress used a `!== null` guard, but `latestAdherence` is read from a
`Record<string, number>` lookup, so it's `undefined` — not `null` — when a
patient has no `adherence` outcome log.

```diff
- adherenceProgress={latestAdherence !== null ? latestAdherence / 100 : 0.2}
+ adherenceProgress={latestAdherence !== undefined ? latestAdherence / 100 : 0.2}
```

## Why

With the old guard, `undefined !== null` is `true`, so `undefined / 100`
(`NaN`) was passed to `HealthRings` instead of the intended `0.2` default for
patients who haven't logged adherence yet.

## Context

Surfaced while investigating a reported "Patient Home page is going to error".
The 500 itself turned out to be a transient stale-`.next` dev-cache error
(`Cannot read properties of undefined (reading 'clientModules')`) that cleared
on recompile — not a code bug. This `NaN` was the one real defect found in
[widgets.tsx](src/app/(patient)/portal/widgets.tsx) along the way.

## Test

Verified `/portal` renders 200 on a clean dev server before/after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)