### PR TITLE
Harden same-day visit spine

### DIFF
--- a/docs/superpowers/plans/2026-05-30-core-visit-spine-swarm.md
+++ b/docs/superpowers/plans/2026-05-30-core-visit-spine-swarm.md
@@ -1,0 +1,780 @@
+# Core Visit Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the same-day visit spine that front desk, MA, and physician workflows can share without duplicate encounters or ambiguous states.
+
+**Architecture:** `Encounter` becomes the same-day operational state spine; `Appointment` remains scheduling/reminder history and can link to an encounter. A central `visit-state` helper owns transitions and timestamp side effects; staff surfaces call that helper rather than writing status directly.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, Prisma, Vitest, server actions/API routes, existing AuditLog patterns.
+
+---
+
+## File Ownership
+
+Codex-owned files:
+
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/20260530000000_core_visit_spine/migration.sql`
+- Create: `src/lib/domain/visit-state.ts`
+- Create: `src/lib/domain/visit-state.test.ts`
+- Modify: `src/lib/domain/queue-board.ts`
+- Create: `src/lib/domain/queue-board.test.ts`
+- Modify: `src/app/(operator)/ops/queue/page.tsx`
+- Create: `src/app/(operator)/ops/queue/actions.ts`
+- Modify: `src/app/(operator)/ops/queue/queue-board.tsx`
+- Modify: `src/app/api/mobile/kiosk/check-in/route.ts`
+- Create: `src/app/api/mobile/kiosk/check-in/route.test.ts`
+
+Do not edit in Codex swarm unless coordinating a merge:
+
+- `src/app/(clinician)/clinic/patients/[id]/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts`
+- `src/lib/scheduling/send-reminders.ts`
+- `src/lib/scheduling/intake-gate.ts`
+- patient portal reminder/QR routes
+
+## External Swarm Boundaries
+
+Claude Code owns physician workflow:
+
+- start visit selection
+- briefing start permissions
+- note finalization idempotency
+- physician-visible rooming handoff
+
+Gemini owns patient pre-visit and QR rescue:
+
+- previsit readiness mapper
+- 7d/2d/morning-of reminders
+- non-PHI copy
+- QR token helper and route tests
+
+## Task 1: Visit State Schema And Helper
+
+**Files:**
+
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/20260530000000_core_visit_spine/migration.sql`
+- Create: `src/lib/domain/visit-state.ts`
+- Create: `src/lib/domain/visit-state.test.ts`
+
+- [ ] **Step 1: Write the failing visit-state tests**
+
+Create `src/lib/domain/visit-state.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  advanceVisitState,
+  isVisitSpineStatus,
+  type VisitSpineStatus,
+} from "./visit-state";
+
+describe("visit-state", () => {
+  it("allows scheduled visits to check in and stamps checkedInAt once", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "scheduled", checkedInAt: null },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(now);
+  });
+
+  it("does not replace an existing timestamp on idempotent transition", () => {
+    const checkedInAt = new Date("2026-05-30T15:45:00.000Z");
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "checked_in", checkedInAt },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(checkedInAt);
+  });
+
+  it("rejects jumping from scheduled directly to complete", () => {
+    const result = advanceVisitState(
+      { status: "scheduled", completedAt: null },
+      "complete",
+      new Date("2026-05-30T16:00:00.000Z"),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Cannot transition visit from scheduled to complete.",
+    });
+  });
+
+  it("keeps legacy in_progress compatible with active visit", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "in_progress", startedAt: null },
+      "in_visit",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("in_visit");
+    expect(result.data.startedAt).toEqual(now);
+  });
+
+  it("recognizes all canonical spine statuses", () => {
+    const statuses: VisitSpineStatus[] = [
+      "scheduled",
+      "checked_in",
+      "info_incomplete",
+      "ready",
+      "rooming",
+      "roomed",
+      "in_visit",
+      "wrap_up",
+      "complete",
+      "cancelled",
+      "no_show",
+    ];
+
+    expect(statuses.every(isVisitSpineStatus)).toBe(true);
+    expect(isVisitSpineStatus("in_progress")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts
+```
+
+Expected: fail because `src/lib/domain/visit-state.ts` does not exist.
+
+- [ ] **Step 3: Add schema changes**
+
+Modify `prisma/schema.prisma`:
+
+```prisma
+enum EncounterStatus {
+  scheduled
+  checked_in
+  info_incomplete
+  ready
+  rooming
+  roomed
+  in_visit
+  wrap_up
+  in_progress
+  complete
+  cancelled
+  no_show
+}
+```
+
+Add to `Encounter`:
+
+```prisma
+  appointmentId        String?         @unique
+  checkedInAt          DateTime?
+  roomingStartedAt     DateTime?
+  roomedAt             DateTime?
+  wrapUpAt             DateTime?
+  cancelledAt          DateTime?
+  noShowAt             DateTime?
+  appointment          Appointment?    @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+```
+
+Add to `Appointment`:
+
+```prisma
+  encounter Encounter?
+```
+
+Add to `Encounter` indexes:
+
+```prisma
+  @@index([organizationId, status, scheduledFor])
+```
+
+Create `prisma/migrations/20260530000000_core_visit_spine/migration.sql`:
+
+```sql
+-- Add the same-day visit-spine states while preserving legacy in_progress.
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'checked_in';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'info_incomplete';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'ready';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'rooming';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'roomed';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'in_visit';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'wrap_up';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'no_show';
+
+ALTER TABLE "Encounter"
+  ADD COLUMN IF NOT EXISTS "appointmentId" TEXT,
+  ADD COLUMN IF NOT EXISTS "checkedInAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomingStartedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "wrapUpAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "cancelledAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "noShowAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Encounter_appointmentId_key"
+  ON "Encounter"("appointmentId");
+
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_status_scheduledFor_idx"
+  ON "Encounter"("organizationId", "status", "scheduledFor");
+
+ALTER TABLE "Encounter"
+  ADD CONSTRAINT "Encounter_appointmentId_fkey"
+  FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+```
+
+- [ ] **Step 4: Implement visit-state helper**
+
+Create `src/lib/domain/visit-state.ts`:
+
+```ts
+export const VISIT_SPINE_STATUSES = [
+  "scheduled",
+  "checked_in",
+  "info_incomplete",
+  "ready",
+  "rooming",
+  "roomed",
+  "in_visit",
+  "wrap_up",
+  "complete",
+  "cancelled",
+  "no_show",
+] as const;
+
+export type VisitSpineStatus = (typeof VISIT_SPINE_STATUSES)[number];
+export type LegacyVisitStatus = "in_progress";
+export type VisitStatus = VisitSpineStatus | LegacyVisitStatus;
+
+export interface VisitStateFields {
+  status: string;
+  checkedInAt?: Date | null;
+  roomingStartedAt?: Date | null;
+  roomedAt?: Date | null;
+  startedAt?: Date | null;
+  wrapUpAt?: Date | null;
+  completedAt?: Date | null;
+  cancelledAt?: Date | null;
+  noShowAt?: Date | null;
+}
+
+export type VisitTransitionResult =
+  | { ok: true; data: Partial<VisitStateFields> }
+  | { ok: false; error: string };
+
+const STATUS_SET = new Set<string>(VISIT_SPINE_STATUSES);
+
+const ALLOWED_TRANSITIONS: Record<string, ReadonlySet<VisitSpineStatus>> = {
+  scheduled: new Set(["checked_in", "info_incomplete", "ready", "cancelled", "no_show"]),
+  checked_in: new Set(["info_incomplete", "ready", "rooming", "cancelled", "no_show"]),
+  info_incomplete: new Set(["ready", "cancelled", "no_show"]),
+  ready: new Set(["rooming", "roomed", "in_visit", "cancelled", "no_show"]),
+  rooming: new Set(["roomed", "ready", "cancelled"]),
+  roomed: new Set(["in_visit", "wrap_up", "cancelled"]),
+  in_visit: new Set(["wrap_up", "complete", "cancelled"]),
+  wrap_up: new Set(["complete", "in_visit"]),
+  complete: new Set([]),
+  cancelled: new Set([]),
+  no_show: new Set([]),
+  in_progress: new Set(["in_visit", "wrap_up", "complete", "cancelled"]),
+};
+
+export function isVisitSpineStatus(value: string): value is VisitSpineStatus {
+  return STATUS_SET.has(value);
+}
+
+export function advanceVisitState(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date = new Date(),
+): VisitTransitionResult {
+  if (current.status === target) {
+    return { ok: true, data: applyTimestamp(current, target, now) };
+  }
+
+  const allowed = ALLOWED_TRANSITIONS[current.status];
+  if (!allowed?.has(target)) {
+    return {
+      ok: false,
+      error: `Cannot transition visit from ${current.status} to ${target}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: target,
+      ...applyTimestamp(current, target, now),
+    },
+  };
+}
+
+function applyTimestamp(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date,
+): Partial<VisitStateFields> {
+  switch (target) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return { checkedInAt: current.checkedInAt ?? now };
+    case "rooming":
+      return { roomingStartedAt: current.roomingStartedAt ?? now };
+    case "roomed":
+      return { roomedAt: current.roomedAt ?? now };
+    case "in_visit":
+      return { startedAt: current.startedAt ?? now };
+    case "wrap_up":
+      return { wrapUpAt: current.wrapUpAt ?? now };
+    case "complete":
+      return { completedAt: current.completedAt ?? now };
+    case "cancelled":
+      return { cancelledAt: current.cancelledAt ?? now };
+    case "no_show":
+      return { noShowAt: current.noShowAt ?? now };
+    case "scheduled":
+      return {};
+  }
+}
+```
+
+- [ ] **Step 5: Run helper tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Queue Projection And Staff State Actions
+
+**Files:**
+
+- Modify: `src/lib/domain/queue-board.ts`
+- Create: `src/lib/domain/queue-board.test.ts`
+- Modify: `src/app/(operator)/ops/queue/page.tsx`
+- Create: `src/app/(operator)/ops/queue/actions.ts`
+
+- [ ] **Step 1: Write failing queue projection tests**
+
+Create `src/lib/domain/queue-board.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mapEncounterStatusToQueueStatus } from "./queue-board";
+
+describe("queue-board status mapping", () => {
+  it.each([
+    ["scheduled", "scheduled"],
+    ["checked_in", "arrived"],
+    ["info_incomplete", "arrived"],
+    ["ready", "arrived"],
+    ["rooming", "rooming"],
+    ["roomed", "rooming"],
+    ["in_visit", "in_visit"],
+    ["wrap_up", "checkout"],
+    ["complete", "completed"],
+    ["cancelled", "completed"],
+    ["no_show", "completed"],
+  ] as const)("maps %s to %s", (encounterStatus, queueStatus) => {
+    expect(mapEncounterStatusToQueueStatus(encounterStatus)).toBe(queueStatus);
+  });
+
+  it("keeps legacy in_progress visible as in visit", () => {
+    expect(mapEncounterStatusToQueueStatus("in_progress")).toBe("in_visit");
+  });
+});
+```
+
+- [ ] **Step 2: Run failing queue tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/queue-board.test.ts
+```
+
+Expected: fail because `mapEncounterStatusToQueueStatus` is not exported.
+
+- [ ] **Step 3: Implement queue projection helper**
+
+Modify `src/lib/domain/queue-board.ts`:
+
+```ts
+export function mapEncounterStatusToQueueStatus(status: string): QueueStatus {
+  switch (status) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return "arrived";
+    case "rooming":
+    case "roomed":
+      return "rooming";
+    case "in_visit":
+    case "in_progress":
+      return "in_visit";
+    case "wrap_up":
+      return "checkout";
+    case "complete":
+    case "cancelled":
+    case "no_show":
+      return "completed";
+    case "scheduled":
+    default:
+      return "scheduled";
+  }
+}
+```
+
+Extend `QueueEntry`:
+
+```ts
+  readinessFlags?: string[];
+  handoffNote?: string;
+```
+
+- [ ] **Step 4: Update queue page mapping**
+
+Modify `src/app/(operator)/ops/queue/page.tsx` to select `briefingContext` and use `mapEncounterStatusToQueueStatus(enc.status)`.
+
+Rooming context shape:
+
+```ts
+type RoomingContext = {
+  room?: string;
+  readinessFlags?: string[];
+  handoffNote?: string;
+};
+```
+
+Extract from `enc.briefingContext.rooming` when present and pass `room`, `readinessFlags`, and `handoffNote` into `QueueEntry`.
+
+- [ ] **Step 5: Add server actions for staff state changes**
+
+Create `src/app/(operator)/ops/queue/actions.ts`:
+
+```ts
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { advanceVisitState, type VisitSpineStatus } from "@/lib/domain/visit-state";
+
+const TransitionSchema = z.object({
+  encounterId: z.string().min(1),
+  target: z.enum(["checked_in", "info_incomplete", "ready", "rooming", "roomed", "wrap_up", "cancelled", "no_show"]),
+});
+
+export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchema>) {
+  const user = await requireUser();
+  const parsed = TransitionSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid queue transition." };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: { id: parsed.data.encounterId, organizationId: user.organizationId! },
+  });
+  if (!encounter) return { ok: false, error: "Encounter not found." };
+
+  const next = advanceVisitState(encounter, parsed.data.target as VisitSpineStatus);
+  if (!next.ok) return next;
+
+  await prisma.encounter.update({
+    where: { id: encounter.id },
+    data: next.data as any,
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: encounter.organizationId,
+      actorUserId: user.id,
+      action: "encounter.visit_state.updated",
+      subjectType: "Encounter",
+      subjectId: encounter.id,
+      metadata: { from: encounter.status, to: parsed.data.target },
+    },
+  });
+
+  revalidatePath("/ops/queue");
+  return { ok: true };
+}
+```
+
+- [ ] **Step 6: Run queue tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/queue-board.test.ts
+```
+
+Expected: pass.
+
+## Task 3: Kiosk Check-In Hardening
+
+**Files:**
+
+- Modify: `src/app/api/mobile/kiosk/check-in/route.ts`
+- Create: `src/app/api/mobile/kiosk/check-in/route.test.ts`
+
+- [ ] **Step 1: Write failing route tests**
+
+Create `src/app/api/mobile/kiosk/check-in/route.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    encounter: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    patient: {
+      update: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
+    },
+  };
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return { mockPrisma, logger };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: hoisted.logger,
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://example.com/api/mobile/kiosk/check-in", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/mobile/kiosk/check-in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "development";
+    hoisted.mockPrisma.patient.update.mockResolvedValue({ id: "pat_1" });
+    hoisted.mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  });
+
+  it("rejects mismatched encounter and patient ids", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    const res = await POST(
+      makeRequest({ encounterId: "enc_1", patientId: "wrong_pat" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Encounter not found for patient" });
+    expect(hoisted.mockPrisma.encounter.update).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("moves a verified scheduled encounter to checked_in and audits it", async () => {
+    const scheduledFor = new Date("2026-05-30T16:00:00.000Z");
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "scheduled",
+      scheduledFor,
+      checkedInAt: null,
+    });
+    hoisted.mockPrisma.encounter.update.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "checked_in",
+    });
+
+    const res = await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, status: "checked_in" });
+    expect(hoisted.mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: expect.objectContaining({
+        status: "checked_in",
+        checkedInAt: expect.any(Date),
+      }),
+    });
+    expect(hoisted.mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org_1",
+        action: "encounter.kiosk_check_in.completed",
+        subjectType: "Encounter",
+        subjectId: "enc_1",
+      }),
+    });
+  });
+
+  it("verifies encounter ownership before updating state", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+
+    expect(hoisted.mockPrisma.encounter.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "enc_1",
+        patientId: "pat_1",
+      },
+      include: {
+        patient: {
+          select: {
+            id: true,
+            intakeAnswers: true,
+            organizationId: true,
+          },
+        },
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing route tests**
+
+Run:
+
+```bash
+npm test -- src/app/api/mobile/kiosk/check-in/route.test.ts
+```
+
+Expected: fail because current route updates by encounter id only and writes no audit row.
+
+- [ ] **Step 3: Harden route**
+
+Modify route to:
+
+- parse with Zod
+- verify `encounter.id`, `encounter.patientId`, and `encounter.patient.organizationId`
+- use `advanceVisitState(encounter, "checked_in")`
+- write `AuditLog` action `encounter.kiosk_check_in.completed`
+- never write signed forms directly over the full `intakeAnswers` JSON without merging
+
+- [ ] **Step 4: Run route tests**
+
+Run:
+
+```bash
+npm test -- src/app/api/mobile/kiosk/check-in/route.test.ts
+```
+
+Expected: pass.
+
+## Task 4: Queue UI Hooks For Front Desk And MA
+
+**Files:**
+
+- Modify: `src/app/(operator)/ops/queue/queue-board.tsx`
+- Modify: `src/app/(operator)/ops/queue/actions.ts`
+
+- [ ] **Step 1: Wire context-menu actions to server actions**
+
+Replace placeholder `router.refresh()` handlers with calls to `moveQueueEncounter`:
+
+```ts
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "checked_in" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "rooming" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "roomed" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "wrap_up" });
+```
+
+- [ ] **Step 2: Add a minimal handoff action**
+
+Extend `actions.ts` with `saveRoomingHandoff`:
+
+```ts
+const RoomingSchema = z.object({
+  encounterId: z.string().min(1),
+  room: z.string().max(20).optional(),
+  handoffNote: z.string().max(1000).optional(),
+  readinessFlags: z.array(z.string().max(100)).max(10).default([]),
+});
+```
+
+This action merges into `briefingContext.rooming` and audits `encounter.rooming.updated`.
+
+- [ ] **Step 3: Keep UI minimal**
+
+Expose room/readiness/handoff text on queue cards if present. Use compact text only; do not build a large modal in this slice unless all previous tests are green.
+
+- [ ] **Step 4: Run targeted tests and typecheck**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts src/lib/domain/queue-board.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts
+npm run typecheck
+```
+
+Expected: tests pass and typecheck is clean.
+
+## Coordination Checkpoint
+
+- [ ] **Step 1: Reconcile with Claude Code physician swarm**
+
+Check whether Claude edited:
+
+- `src/app/(clinician)/clinic/patients/[id]/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts`
+
+If their code needs the visit-state helper, export stable types and avoid renaming functions.
+
+- [ ] **Step 2: Reconcile with Gemini pre-visit swarm**
+
+Check whether Gemini edited:
+
+- `src/lib/scheduling/send-reminders.ts`
+- `src/lib/scheduling/intake-gate.ts`
+- QR token helpers/routes
+
+If their readiness mapper needs encounter status, use the `Encounter.appointmentId` relation and `ready/info_incomplete` states.
+
+- [ ] **Step 3: Final verification**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts src/lib/domain/queue-board.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts
+npm run typecheck
+```
+
+Expected: all tests pass and typecheck is clean.

--- a/docs/superpowers/specs/2026-05-30-core-visit-spine-design.md
+++ b/docs/superpowers/specs/2026-05-30-core-visit-spine-design.md
@@ -1,0 +1,218 @@
+# Core Visit Spine Hardening Design
+
+## Goal
+
+Make the same-day visit workflow reliable from pre-visit reminders through front-desk check-in, patient completion, MA rooming, physician visit start, and visit completion.
+
+The weekend goal is not a fully polished practice-management suite. The goal is a durable workflow spine that prevents the failures seen at Go Live: missing check-in flow, unclear readiness, no reliable rooming handoff, duplicate encounters, and non-idempotent visit completion.
+
+## Current Failure Pattern
+
+The app has two disconnected scheduling concepts:
+
+- `Appointment` drives patient scheduling and reminders.
+- `Encounter` drives the clinical chart and today's queue.
+
+The queue already displays richer operational columns, but those columns are synthetic. `EncounterStatus` currently has only `scheduled`, `in_progress`, `complete`, and `cancelled`, so check-in, rooming, roomed, and active physician visit are collapsed into `in_progress`.
+
+This causes three high-risk behaviors:
+
+- A patient can have an appointment without appearing in the clinical queue.
+- Kiosk/front-desk check-in jumps directly to `in_progress`, which looks like the physician is already with the patient.
+- Physician start can create a new same-day encounter instead of claiming the one the staff already prepared.
+
+## Design Direction
+
+Use `Encounter` as the same-day visit spine. Keep `Appointment` as scheduling/reminder history, linked to the encounter when available.
+
+The spine states are:
+
+1. `scheduled`
+2. `checked_in`
+3. `info_incomplete`
+4. `ready`
+5. `rooming`
+6. `roomed`
+7. `in_visit`
+8. `wrap_up`
+9. `complete`
+10. `cancelled`
+11. `no_show`
+
+Keep legacy `in_progress` temporarily during migration. Do not remove it in the first implementation slice because existing code and seed data still reference it.
+
+## Weekend Scope
+
+### Core Visit State
+
+Add a central visit-state helper that owns allowed transitions and timestamp side effects. The helper should be the only place that decides whether a state move is valid.
+
+Required first transitions:
+
+- `scheduled` or legacy `in_progress` to `checked_in`, then derive `ready` or `info_incomplete`
+- `ready`, `roomed`, or `checked_in` to `in_visit`
+- `in_visit` or `wrap_up` to `complete`
+- `scheduled`, `checked_in`, `ready`, `rooming`, or `roomed` to `cancelled`
+- `scheduled` or `checked_in` to `no_show`
+
+The first slice should avoid over-modeling. Add timestamps needed for operational reliability: `checkedInAt`, `roomingStartedAt`, `roomedAt`, `wrapUpAt`, `cancelledAt`, and `noShowAt`.
+
+### Pre-Visit Reminders
+
+Patients should be nudged before arrival to complete missing required items through the portal.
+
+Reminder cadence:
+
+- 7 days before the appointment
+- 2 days before the appointment
+- Morning of the appointment
+
+Reminder channels:
+
+- Email now, where infrastructure exists.
+- SMS only if the existing SMS reminder path supports it safely.
+- Push notification later when the mobile app exists.
+
+Reminder copy must not include PHI. It should say only that pre-visit items are ready and link to the portal.
+
+### Front-Desk Check-In
+
+Front desk must be able to:
+
+- Locate today's appointment/encounter.
+- Verify patient identity in person.
+- Mark the patient checked in.
+- See required missing items.
+- Generate a day-of QR rescue link if the patient is incomplete or cannot handle portal login.
+- Avoid moving the patient to rooming until the visit is ready or an authorized staff override is recorded.
+
+### QR Rescue
+
+The QR path is a narrow check-in completion session, not a replacement portal.
+
+Rules:
+
+- Token is appointment-scoped and patient-scoped.
+- Token is short-lived.
+- No PHI appears in the QR URL.
+- Token is signed, or stored only as a hash if persisted.
+- Redemption verifies expiry, appointment window, appointment-patient relationship, and status.
+- Require DOB + SMS code when a phone is on file.
+- Allow DOB + last name as front-desk fallback.
+- Full chart, records, labs, and messages still require portal login.
+- Audit token generation, views, redemption, expired attempts, failed verification, submissions, and staff overrides.
+
+### MA Rooming
+
+Weekend implementation can store rooming handoff data in `Encounter.briefingContext.rooming` to avoid a broad clinical-observation migration.
+
+The rooming envelope should support:
+
+- room number
+- readiness flags
+- handoff note
+- vitals snapshot
+- roomed timestamp
+- rooming staff user id
+
+This is intentionally temporary. Vitals should graduate to structured `Observation` or `VitalSign` storage before quality measures, FHIR export, MIPS, or longitudinal trending depend on them.
+
+### Physician Workflow Boundary
+
+The physician workflow should be owned by the separate Claude Code swarm. Its contract is:
+
+- Start visit must claim the existing same-day roomed/ready/checked-in/scheduled encounter before creating any new encounter.
+- Start visit must preserve rooming and briefing context.
+- `startVisitWithBriefing` must enforce the same permissions and chart privacy checks as `startVisit`.
+- Note finalization must be idempotent.
+- `note.finalized` dispatches only when the note transitions into finalized.
+- `encounter.completed` dispatches only when the encounter transitions into complete.
+
+## Data Model
+
+Minimal schema changes:
+
+- Extend `EncounterStatus` with new spine states while preserving `in_progress`.
+- Add nullable `Encounter.appointmentId` with a unique relation to `Appointment`.
+- Add nullable operational timestamps:
+  - `checkedInAt`
+  - `roomingStartedAt`
+  - `roomedAt`
+  - `wrapUpAt`
+  - `cancelledAt`
+  - `noShowAt`
+- Add `Appointment.encounter` back relation.
+- Add an index for today's queue by organization, status, and scheduled time.
+
+## State Ownership
+
+Create `src/lib/domain/visit-state.ts`.
+
+This helper owns:
+
+- canonical visit states
+- legacy state compatibility
+- allowed transitions
+- timestamp updates
+- no-op/idempotent transition behavior
+- optional metadata merge helpers for `briefingContext`
+
+External swarms should call this helper when available and must not create a competing state machine.
+
+## Staff UI Ownership
+
+Codex swarm owns:
+
+- Prisma visit-spine schema and migration.
+- `src/lib/domain/visit-state.ts`.
+- queue projection in `src/lib/domain/queue-board.ts`.
+- operator queue page/actions under `src/app/(operator)/ops/queue/`.
+- kiosk/front-desk check-in route behavior.
+- rooming handoff envelope and front-desk/MA queue controls.
+
+Claude Code swarm owns:
+
+- physician start visit.
+- briefing start path.
+- note finalization idempotency.
+- physician-visible handoff/readiness surface.
+
+Gemini storm owns:
+
+- DB-to-gate previsit readiness mapper.
+- reminder cadence and non-PHI reminder copy.
+- QR token helper and redemption security tests.
+- QR rescue route/page if time allows.
+
+## Testing Strategy
+
+Tests must be written before production changes.
+
+Required coverage:
+
+- visit-state allowed and rejected transitions
+- timestamp side effects
+- idempotent no-op transitions
+- queue projection for new statuses and legacy `in_progress`
+- kiosk/check-in mutation verifies encounter-patient relationship
+- pre-visit reminder sends only when incomplete and does not include PHI
+- QR token validation rejects expired, mismatched, or tampered tokens
+- physician start claims existing encounter instead of creating duplicate
+- note finalization does not double-dispatch
+
+## Risks
+
+- `in_progress` is overloaded in existing data; migration cannot infer exact real-world phase for old rows.
+- `briefingContext` is becoming a temporary operational envelope. Keep its structure explicit and graduate persistent clinical facts later.
+- Appointment/Encounter drift will continue unless new appointment creation also creates or links an encounter.
+- External swarms may overlap on physician start or QR route code. File ownership boundaries above are mandatory.
+
+## Acceptance Criteria
+
+- Today's queue shows real same-day state rather than collapsing everything into `in_visit`.
+- Front desk can mark arrival and see incomplete versus ready.
+- Patient can be nudged before arrival and rescued day-of with QR without full portal-login friction.
+- MA can record a minimum rooming handoff.
+- Physician start uses the prepared encounter.
+- Completing the visit triggers downstream workflows once.
+- All changed behavior has targeted tests.

--- a/prisma/migrations/20260530000000_core_visit_spine/migration.sql
+++ b/prisma/migrations/20260530000000_core_visit_spine/migration.sql
@@ -1,0 +1,29 @@
+-- Add the same-day visit-spine states while preserving legacy in_progress.
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'checked_in';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'info_incomplete';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'ready';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'rooming';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'roomed';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'in_visit';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'wrap_up';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'no_show';
+
+ALTER TABLE "Encounter"
+  ADD COLUMN IF NOT EXISTS "appointmentId" TEXT,
+  ADD COLUMN IF NOT EXISTS "checkedInAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomingStartedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "wrapUpAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "cancelledAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "noShowAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Encounter_appointmentId_key"
+  ON "Encounter"("appointmentId");
+
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_status_scheduledFor_idx"
+  ON "Encounter"("organizationId", "status", "scheduledFor");
+
+ALTER TABLE "Encounter"
+  ADD CONSTRAINT "Encounter_appointmentId_fkey"
+  FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -520,9 +520,17 @@ model Document {
 
 enum EncounterStatus {
   scheduled
+  checked_in
+  info_incomplete
+  ready
+  rooming
+  roomed
+  in_visit
+  wrap_up
   in_progress
   complete
   cancelled
+  no_show
 }
 
 model Encounter {
@@ -530,10 +538,17 @@ model Encounter {
   organizationId      String
   patientId           String
   providerId          String?
+  appointmentId       String?         @unique
   status              EncounterStatus @default(scheduled)
   scheduledFor        DateTime?
+  checkedInAt         DateTime?
+  roomingStartedAt    DateTime?
+  roomedAt            DateTime?
   startedAt           DateTime?
+  wrapUpAt            DateTime?
   completedAt         DateTime?
+  cancelledAt         DateTime?
+  noShowAt            DateTime?
   chartingCompletedAt DateTime? // When the physician finalized all notes for this encounter. NULL while documentation is still in draft / incomplete.
   modality            String          @default("in_person") // in_person | video | phone
   placeOfService      String? // 2-digit POS code: 11=office, 02=telehealth
@@ -546,6 +561,7 @@ model Encounter {
   organization      Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   patient           Patient            @relation(fields: [patientId], references: [id], onDelete: Cascade)
   provider          Provider?          @relation(fields: [providerId], references: [id], onDelete: SetNull)
+  appointment       Appointment?       @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
   notes             Note[]
   documents         Document[]
   claims            Claim[]
@@ -555,6 +571,7 @@ model Encounter {
   @@index([patientId, status])
   @@index([providerId, scheduledFor])
   @@index([organizationId, status, createdAt])
+  @@index([organizationId, status, scheduledFor])
   // EMR-132 charting-time benchmark (clinic/patients/[id]/page.tsx#recentCharted).
   // Filters by organizationId + nulls-not-null on charting timestamps, orders
   // by chartingCompletedAt. Index audit 2026-05-09.
@@ -1705,6 +1722,7 @@ model Appointment {
 
   patient  Patient   @relation(fields: [patientId], references: [id], onDelete: Cascade)
   provider Provider? @relation(fields: [providerId], references: [id], onDelete: SetNull)
+  encounter Encounter?
 
   @@index([providerId, startAt])
   @@index([patientId, startAt])

--- a/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — physician visit spine.
+ * startVisit must reuse today's existing active encounter
+ * instead of minting a duplicate, and expose a readiness handoff.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    note: { findFirst: vi.fn() },
+    agentJob: { findMany: vi.fn() },
+    provider: { findFirst: vi.fn() },
+  };
+  return {
+    mockPrisma,
+    requireUserMock: vi.fn(),
+    dispatchMock: vi.fn(),
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { startVisit, getVisitReadiness } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function scheduledEncounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "sched_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    startedAt: null,
+    completedAt: null,
+    providerId: null,
+    renderingProviderId: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.findMany.mockResolvedValue([]);
+  mockPrisma.provider.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...scheduledEncounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.create.mockResolvedValue(scheduledEncounter({ id: "new_enc", status: "in_visit" }));
+  mockPrisma.note.findFirst.mockResolvedValue(null);
+  mockPrisma.agentJob.findMany.mockResolvedValue([]);
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("startVisit — encounter selection", () => {
+  it("reuses today's scheduled encounter instead of creating a duplicate", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+    // The reused encounter is advanced into the visit.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "sched_1" } }),
+    );
+  });
+
+  it("advances a reused scheduled encounter before short-circuiting to its note", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+    mockPrisma.note.findFirst.mockResolvedValue({ id: "note_9" });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/notes\/note_9/);
+
+    // The encounter must be marked with-provider even though we jump to the note.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "sched_1" },
+        data: expect.objectContaining({ status: "in_visit" }),
+      }),
+    );
+  });
+
+  it("creates a fresh in_visit encounter only when none exists today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startVisit — provider attribution", () => {
+  it("Dr B starting Dr A's scheduled encounter preserves ownership and stamps rendering provider", async () => {
+    // Dr A owns today's scheduled encounter; Dr B (current user) starts the visit.
+    const drA = scheduledEncounter({ providerId: "prov_A", renderingProviderId: null });
+    mockPrisma.encounter.findMany.mockResolvedValue([drA]);
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_B" });
+    // Preserve row fields across the advance update so assignVisitProvider sees provA.
+    const row: any = { ...drA };
+    mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => {
+      Object.assign(row, data);
+      return { ...row, id: where.id };
+    });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    // Rendering provider stamped to Dr B...
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "sched_1" },
+      data: { renderingProviderId: "prov_B" },
+    });
+    // ...and providerId (Dr A) is never reassigned.
+    const providerIdWrites = mockPrisma.encounter.update.mock.calls.filter(
+      (c) => c[0]?.data && "providerId" in c[0].data,
+    );
+    expect(providerIdWrites).toHaveLength(0);
+  });
+
+  it("claims an unowned reused encounter for the current provider", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({ status: "in_progress", providerId: null }),
+    ]);
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_B" });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "sched_1" },
+      data: { providerId: "prov_B" },
+    });
+  });
+});
+
+describe("startVisit — auth parity", () => {
+  it("redirects unauthorized (no notes.edit) users away", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    await expect(startVisit("patient_1")).rejects.toThrow(/error=unauthorized/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the chart is restricted and the user is not allowlisted", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(
+      patient({ chartRestricted: true, restrictedProviderIds: ["other_doc"] }),
+    );
+    await expect(startVisit("patient_1")).rejects.toThrow(/error=restricted/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("getVisitReadiness", () => {
+  it("returns a rooming/readiness handoff for today's encounter", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({
+        briefingContext: { intakeCompleted: true, patientDemeanor: "calm", patientSummary: "x" },
+      }),
+    ]);
+
+    const result = await getVisitReadiness("patient_1");
+    expect(result.hasEncounter).toBe(true);
+    expect(result.intakeCompleted).toBe(true);
+    expect(result.patientDemeanor).toBe("calm");
+  });
+
+  it("reports no encounter when none is active today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    const result = await getVisitReadiness("patient_1");
+    expect(result.hasEncounter).toBe(false);
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.ts
@@ -13,6 +13,16 @@ import {
   requirePermission,
 } from "@/lib/rbac/permissions";
 import { encodeSourceRef } from "@/lib/domain/unresolved-followups";
+import {
+  advanceVisitState,
+  assignVisitProvider,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
+} from "@/lib/domain/visit-state";
+import {
+  summarizeVisitReadiness,
+  type VisitReadiness,
+} from "@/lib/clinical/visit-readiness";
 
 /**
  * Start a visit: find or create an in-progress encounter for today,
@@ -52,30 +62,44 @@ export async function startVisit(patientId: string) {
     redirect(`/clinic/patients/${patientId}?tab=notes&error=not_found`);
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  // Prefer reusing today's existing active encounter (the
+  // patient was booked, checked-in, or roomed) before minting a new one —
+  // otherwise the front desk's encounter and the physician's diverge into
+  // duplicate encounters and duplicate downstream automation. Selection +
+  // transition go through the shared visit-state spine.
+  const currentProvider = await resolveProviderForUser(user.id, user.organizationId!);
 
-  let encounter = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      status: "in_progress",
-      createdAt: { gte: todayStart, lte: todayEnd },
-    },
-  });
+  let encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
 
-  if (!encounter) {
+  if (encounter) {
+    // Advance to in-progress FIRST — idempotent, never touches briefingContext —
+    // so a reused scheduled encounter is marked "with provider" even when we
+    // short-circuit to an already-drafted note below. Otherwise the queue board
+    // would still show the patient as waiting while the doc is documenting.
+    encounter = (await advanceVisitState(encounter, "in_visit", user.id)).encounter;
+
+    // Record who is rendering this visit without stealing a scheduled
+    // encounter's ownership (claims providerId if unset; else renderingProviderId).
+    encounter = await assignVisitProvider(encounter, currentProvider?.id ?? null);
+
+    const existingNote = await prisma.note.findFirst({
+      where: { encounterId: encounter.id },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existingNote) {
+      redirect(`/clinic/patients/${patientId}/notes/${existingNote.id}`);
+    }
+  } else {
     encounter = await prisma.encounter.create({
       data: {
         organizationId: user.organizationId!,
         patientId,
-        status: "in_progress",
+        status: "in_visit",
         modality: "in_person",
         reason: "Visit",
         startedAt: new Date(),
         scheduledFor: new Date(),
+        providerId: currentProvider?.id ?? undefined,
       },
     });
   }
@@ -122,6 +146,20 @@ export async function startVisit(patientId: string) {
   } else {
     redirect(`/clinic/patients/${patientId}?tab=notes&scribe=processing`);
   }
+}
+
+/**
+ * Rooming / pre-visit readiness handoff for today's encounter. Lets the chart
+ * and note-start path show the physician what the front desk and pre-visit
+ * surfaces already prepared (intake done, patient confirmed, briefing ready,
+ * emoji demeanor) before they start documenting. Read-only; gated by the same
+ * baseline chart access as opening the chart.
+ */
+export async function getVisitReadiness(patientId: string): Promise<VisitReadiness> {
+  const user = await requireUser();
+  await assertChartAccess(user, patientId);
+  const encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
+  return summarizeVisitReadiness(encounter);
 }
 
 export async function saveAllergy(patientId: string, drugName: string, reaction: string) {

--- a/src/app/(clinician)/clinic/patients/[id]/assessments/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/assessments/page.tsx
@@ -96,7 +96,9 @@ export default async function ChartAssessmentsPage({ params }: PageProps) {
 
   // Encounter currently in progress, if any — we default the
   // quick-entry form to it so a typical visit flow is one click away.
-  const activeEncounter = recentEncounters.find((e) => e.status === "in_progress");
+  const activeEncounter = recentEncounters.find((e) =>
+    ["in_visit", "in_progress"].includes(e.status),
+  );
 
   const encounterOptions = recentEncounters.map((e) => ({
     id: e.id,
@@ -107,7 +109,7 @@ export default async function ChartAssessmentsPage({ params }: PageProps) {
         : e.modality === "phone"
           ? "phone"
           : "in-person",
-      e.status === "in_progress" ? "(active)" : e.reason || null,
+      ["in_visit", "in_progress"].includes(e.status) ? "(active)" : e.reason || null,
     ]
       .filter(Boolean)
       .join(" · "),

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — note finalization must be idempotent:
+ *  - note.finalized dispatched only on the transition into finalized
+ *  - encounter.completed dispatched only on the transition into complete
+ *  - one timestamp shared by DB writes and the event payload
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+    note: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn(), dispatchMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/orchestration/runner", () => ({ runTick: vi.fn(), runJob: vi.fn() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { finalizeNote, saveAndFinalizeNote } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function note(over: Record<string, unknown> = {}) {
+  return {
+    id: "note_1",
+    encounterId: "enc_1",
+    status: "draft",
+    aiDrafted: false,
+    blocks: [],
+    authorUserId: null,
+    encounter: { id: "enc_1", patientId: "patient_1", status: "in_visit" },
+    ...over,
+  };
+}
+
+function encounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "in_visit",
+    startedAt: new Date("2026-05-29T15:00:00.000Z"),
+    completedAt: null,
+    ...over,
+  };
+}
+
+function dispatchCount(name: string) {
+  return dispatchMock.mock.calls.filter((c) => c[0]?.name === name).length;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(encounter());
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...encounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.note.findUnique.mockResolvedValue(note());
+  mockPrisma.note.update.mockResolvedValue(note({ status: "finalized" }));
+  mockPrisma.note.count.mockResolvedValue(0);
+  mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("finalizeNote idempotency", () => {
+  it("dispatches note.finalized + encounter.completed once on a fresh finalize", async () => {
+    const res = await finalizeNote("note_1");
+    expect(res).toEqual({ ok: true, status: "finalized" });
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(1);
+  });
+
+  it("does NOT re-dispatch when the note is already finalized", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "finalized" }));
+
+    const res = await finalizeNote("note_1");
+
+    expect(res.ok).toBe(true);
+    expect(dispatchCount("note.finalized")).toBe(0);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("dispatches note.finalized but NOT encounter.completed when the encounter is already complete", async () => {
+    // Second note on an encounter that a prior note already completed.
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ id: "note_2", encounter: { id: "enc_1", patientId: "patient_1", status: "complete" } }),
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(encounter({ status: "complete", completedAt: new Date() }));
+
+    await finalizeNote("note_2");
+
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+  });
+
+  it("uses one shared timestamp for the note write, encounter write, and event payload", async () => {
+    await finalizeNote("note_1");
+
+    const noteFinalizedAt = mockPrisma.note.update.mock.calls
+      .map((c) => c[0]?.data?.finalizedAt)
+      .find(Boolean) as Date;
+    const encounterCompletedAt = mockPrisma.encounter.update.mock.calls
+      .map((c) => c[0]?.data?.completedAt)
+      .find(Boolean) as Date;
+    const eventCompletedAt = dispatchMock.mock.calls
+      .map((c) => (c[0]?.name === "encounter.completed" ? c[0].completedAt : undefined))
+      .find(Boolean) as Date;
+
+    expect(noteFinalizedAt).toBeInstanceOf(Date);
+    expect(encounterCompletedAt.getTime()).toBe(noteFinalizedAt.getTime());
+    expect(eventCompletedAt.getTime()).toBe(noteFinalizedAt.getTime());
+  });
+
+  it("stamps chartingCompletedAt only when not already set, with the shared timestamp", async () => {
+    await finalizeNote("note_1");
+
+    expect(mockPrisma.encounter.updateMany).toHaveBeenCalledWith({
+      where: { id: "enc_1", chartingCompletedAt: null },
+      data: { chartingCompletedAt: expect.any(Date) },
+    });
+    const chartingAt = mockPrisma.encounter.updateMany.mock.calls[0][0].data.chartingCompletedAt;
+    const noteFinalizedAt = mockPrisma.note.update.mock.calls
+      .map((c) => c[0]?.data?.finalizedAt)
+      .find(Boolean) as Date;
+    expect(chartingAt.getTime()).toBe(noteFinalizedAt.getTime());
+  });
+});
+
+describe("saveAndFinalizeNote idempotency", () => {
+  const BLOCKS = [{ heading: "Subjective", body: "patient reports..." }];
+
+  it("dispatches note.finalized + encounter.completed once on a fresh save+finalize", async () => {
+    const res = await saveAndFinalizeNote("note_1", BLOCKS);
+    expect(res).toEqual({ ok: true, status: "finalized" });
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(1);
+  });
+
+  it("does NOT re-dispatch or re-write when the note is already finalized", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "finalized" }));
+
+    const res = await saveAndFinalizeNote("note_1", BLOCKS);
+
+    expect(res.ok).toBe(true);
+    expect(dispatchCount("note.finalized")).toBe(0);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fire encounter.completed when the encounter is already complete", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ id: "note_2", encounter: { id: "enc_1", patientId: "patient_1", status: "complete" } }),
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(encounter({ status: "complete", completedAt: new Date() }));
+
+    await saveAndFinalizeNote("note_2", BLOCKS);
+
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -30,6 +30,7 @@ import {
   PATIENT_DEMEANOR_OPTIONS,
   type PatientDemeanor,
 } from "@/lib/domain/notes";
+import { advanceVisitState } from "@/lib/domain/visit-state";
 
 const blockSchema = z.object({
   heading: z.string(),
@@ -135,6 +136,15 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     }
     throw err;
   }
+
+  // Idempotent finalize — a note already finalized must NOT re-run the
+  // transition side effects. dispatch() has no dedup, so a second
+  // note.finalized / encounter.completed duplicates physician tasks, patient
+  // outreach drafts, and clinical observations. Short-circuit on the terminal
+  // state (the cosign path below is reached only by non-finalized notes).
+  if (note.status === "finalized") {
+    return { ok: true, status: "finalized" };
+  }
   // EMR-784: Before finalizing, ensure an AI-drafted note still carries
   // the patient verbal-consent disclaimer. Defends against a clinician
   // deleting it during cleanup before signing.
@@ -165,27 +175,37 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     return { ok: true, status: "pending_cosign" };
   }
 
+  // One timestamp shared by the note write, the encounter completion, and the
+  // event payloads — so DB rows and downstream automation agree on the instant.
+  const finalizedAt = new Date();
+
   await prisma.note.update({
     where: { id: noteId },
     data: {
       ...(blocksAtFinalize ? { blocks: blocksAtFinalize as any } : {}),
       status: "finalized",
-      finalizedAt: new Date(),
+      finalizedAt,
       authorUserId: user.id,
     },
   });
 
-  // Also mark the encounter as complete
-  await prisma.encounter.update({
-    where: { id: note.encounterId },
-    data: { status: "complete", completedAt: new Date() },
-  });
+  // Move the encounter to complete through the visit-state spine.
+  // `transitioned` is true only on the actual transition into complete, so a
+  // second note finalizing on an already-complete encounter does not re-fire
+  // encounter.completed.
+  const { transitioned: encounterCompleted } = await advanceVisitState(
+    encounter,
+    "complete",
+    user.id,
+    { at: finalizedAt },
+  );
 
   // If every note for this encounter is now finalized, stamp
   // chartingCompletedAt so the Clinical Flow tile can compute carryover.
-  await markChartingCompletedIfReady(note.encounterId);
+  await markChartingCompletedIfReady(note.encounterId, finalizedAt);
 
-  // Dispatch note.finalized → triggers Coding Agent + Physician Nudge Agent
+  // note.finalized → Coding Agent + Physician Nudge Agent. This call is the
+  // transition into finalized (guarded above), so it fires exactly once.
   await dispatch({
     name: "note.finalized",
     noteId,
@@ -193,13 +213,16 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     finalizedBy: user.id,
   });
 
-  // Dispatch encounter.completed → triggers Patient Outreach Agent
-  await dispatch({
-    name: "encounter.completed",
-    encounterId: note.encounterId,
-    patientId: encounter.patientId,
-    completedAt: new Date(),
-  });
+  // encounter.completed → Patient Outreach / Outcome agents. Only on the
+  // transition into complete.
+  if (encounterCompleted) {
+    await dispatch({
+      name: "encounter.completed",
+      encounterId: note.encounterId,
+      patientId: encounter.patientId,
+      completedAt: finalizedAt,
+    });
+  }
 
   // In dev, run the queue inline so coding suggestions appear immediately
   if (process.env.NODE_ENV !== "production") {
@@ -216,15 +239,20 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
  * documentation-complete marker, distinct from completedAt (= when the
  * physician stopped seeing the patient).
  */
-async function markChartingCompletedIfReady(encounterId: string): Promise<void> {
+async function markChartingCompletedIfReady(
+  encounterId: string,
+  at: Date = new Date(),
+): Promise<void> {
   const unfinalized = await prisma.note.count({
     where: { encounterId, status: { not: "finalized" } },
   });
   if (unfinalized > 0) return;
 
-  await prisma.encounter.update({
-    where: { id: encounterId },
-    data: { chartingCompletedAt: new Date() },
+  // Stamp only if not already set — preserve the FIRST completion instant so a
+  // note added to an already-charted encounter doesn't rewrite history.
+  await prisma.encounter.updateMany({
+    where: { id: encounterId, chartingCompletedAt: null },
+    data: { chartingCompletedAt: at },
   });
 }
 
@@ -263,6 +291,11 @@ export async function saveAndFinalizeNote(
     }
     throw err;
   }
+  // Idempotent finalize — see finalizeNote. An already-finalized note must not
+  // re-dispatch the transition events (dispatch() has no dedup).
+  if (note.status === "finalized") {
+    return { ok: true, status: "finalized" };
+  }
   // EMR-784: AI-drafted notes (voice/ambient scribe) must keep the
   // patient verbal-consent disclaimer through finalize, even if the
   // clinician edited it out.
@@ -289,12 +322,15 @@ export async function saveAndFinalizeNote(
     return { ok: true, status: "pending_cosign" };
   }
 
+  // One shared timestamp for the note write, encounter completion, and events.
+  const finalizedAt = new Date();
+
   await prisma.note.update({
     where: { id: noteId },
     data: {
       blocks: blocksToFinalize as any,
       status: "finalized",
-      finalizedAt: new Date(),
+      finalizedAt,
       authorUserId: user.id,
     },
   });
@@ -312,15 +348,18 @@ export async function saveAndFinalizeNote(
     });
   }
 
-  // Also mark the encounter as complete
-  await prisma.encounter.update({
-    where: { id: note.encounterId },
-    data: { status: "complete", completedAt: new Date() },
-  });
+  // Move the encounter to complete via the visit-state spine — transition-gated
+  // so encounter.completed fires exactly once.
+  const { transitioned: encounterCompleted } = await advanceVisitState(
+    encounter,
+    "complete",
+    user.id,
+    { at: finalizedAt },
+  );
 
   // If every note for this encounter is now finalized, stamp
   // chartingCompletedAt so the Clinical Flow tile can compute carryover.
-  await markChartingCompletedIfReady(note.encounterId);
+  await markChartingCompletedIfReady(note.encounterId, finalizedAt);
 
   // Dispatch note.finalized → triggers Coding Agent + Physician Nudge Agent
   await dispatch({
@@ -330,13 +369,16 @@ export async function saveAndFinalizeNote(
     finalizedBy: user.id,
   });
 
-  // Dispatch encounter.completed → triggers Patient Outreach Agent
-  await dispatch({
-    name: "encounter.completed",
-    encounterId: note.encounterId,
-    patientId: encounter.patientId,
-    completedAt: new Date(),
-  });
+  // Dispatch encounter.completed → triggers Patient Outreach Agent. Only on the
+  // transition into complete.
+  if (encounterCompleted) {
+    await dispatch({
+      name: "encounter.completed",
+      encounterId: note.encounterId,
+      patientId: encounter.patientId,
+      completedAt: finalizedAt,
+    });
+  }
 
   if (process.env.NODE_ENV !== "production") {
     await runTick("inline-dev", 4);

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -311,7 +311,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
   // EMR-132: most recent in-progress encounter, used to anchor the
   // ChartingTimer to wall time across page navigations.
   const activeEncounter = patient.encounters.find(
-    (e: any) => e.status === "in_progress" && e.startedAt,
+    (e: any) => ["in_visit", "in_progress"].includes(e.status) && e.startedAt,
   );
 
   // EMR-132: trailing org charting-time benchmark (median seconds from

--- a/src/app/(clinician)/clinic/patients/[id]/prepare/actions.start-visit-briefing.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prepare/actions.start-visit-briefing.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — startVisitWithBriefing must reach parity with startVisit:
+ * same permission + chart-privacy gates, reuse today's encounter, and MERGE
+ * (never overwrite) briefingContext so rooming/demeanor data survives.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    note: { findFirst: vi.fn() },
+    agentJob: { findMany: vi.fn() },
+    provider: { findFirst: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn(), dispatchMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/agents/pre-visit-intelligence-agent", () => ({
+  preVisitIntelligenceAgent: { run: vi.fn() },
+}));
+vi.mock("@/lib/orchestration/model-client", () => ({ resolveModelClient: vi.fn() }));
+vi.mock("@/lib/orchestration/tool-registry", () => ({ buildToolRegistry: vi.fn() }));
+
+import { startVisitWithBriefing } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function scheduledEncounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "sched_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    startedAt: null,
+    completedAt: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+const BRIEFING = {
+  patientSummary: "62yo chronic low back pain",
+  lastVisitSummary: null,
+  talkingPoints: ["tolerability"],
+  sections: [],
+  riskFlags: [],
+  confidence: 0.8,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.findMany.mockResolvedValue([]);
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...scheduledEncounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.create.mockResolvedValue(
+    scheduledEncounter({ id: "new_enc", status: "in_visit" }),
+  );
+  mockPrisma.note.findFirst.mockResolvedValue(null);
+  mockPrisma.agentJob.findMany.mockResolvedValue([]);
+  mockPrisma.provider.findFirst.mockResolvedValue(null);
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("startVisitWithBriefing — permission + chart-privacy parity", () => {
+  it("denies users without notes.edit (front office)", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(
+      /error=unauthorized/,
+    );
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("denies a restricted chart when the user is not allowlisted", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(
+      patient({ chartRestricted: true, restrictedProviderIds: ["other_doc"] }),
+    );
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(
+      /error=restricted/,
+    );
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("startVisitWithBriefing — encounter selection", () => {
+  it("reuses today's scheduled encounter instead of creating a duplicate", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(/redirect:/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("startVisitWithBriefing — briefingContext merge", () => {
+  it("preserves existing rooming/demeanor keys while attaching the briefing", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({
+        briefingContext: {
+          patientDemeanor: "calm",
+          patientDemeanorRecordedAt: "2026-05-29T14:00:00.000Z",
+          intakeCompleted: true,
+        },
+      }),
+    ]);
+
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(/redirect:/);
+
+    // The merged briefingContext must keep demeanor/intake AND add the briefing.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          briefingContext: expect.objectContaining({
+            patientDemeanor: "calm",
+            intakeCompleted: true,
+            patientSummary: "62yo chronic low back pain",
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
@@ -5,6 +5,17 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { dispatch } from "@/lib/orchestration/dispatch";
+import {
+  ForbiddenError,
+  assertChartAccess,
+  hasPermission,
+} from "@/lib/rbac/permissions";
+import {
+  advanceVisitState,
+  assignVisitProvider,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
+} from "@/lib/domain/visit-state";
 import { preVisitIntelligenceAgent } from "@/lib/agents/pre-visit-intelligence-agent";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
 import { buildToolRegistry } from "@/lib/orchestration/tool-registry";
@@ -77,23 +88,14 @@ export async function generateBriefing(patientId: string): Promise<BriefingResul
   // attached. Passing encounterId here lets the Schedule tile's brief line
   // and any other downstream surface read the briefing the moment it's
   // generated, without waiting for the physician to start the visit.
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
-
-  const encounterForBriefing = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      OR: [
-        { status: "in_progress" },
-        { scheduledFor: { gte: todayStart, lte: todayEnd } },
-      ],
-    },
-    orderBy: [{ status: "asc" }, { scheduledFor: "asc" }],
-    select: { id: true },
-  });
+  // Attach the briefing to the SAME encounter startVisitWithBriefing will
+  // later reuse — via the shared visit-state selector — so briefing data and
+  // the started visit never land on different rows (incl. same-day walk-ins,
+  // which the old in_progress-OR-scheduled query missed).
+  const encounterForBriefing = await selectActiveVisitEncounter(
+    patientId,
+    user.organizationId!,
+  );
 
   // Build a mock context that captures logs as steps
   const logs: AgentLogEntry[] = [];
@@ -189,6 +191,23 @@ export async function startVisitWithBriefing(
 ) {
   const user = await requireUser();
 
+  // EMR-786 parity with startVisit — starting a (briefed) visit requires
+  // write access to clinical notes. Front/back-office staff are denied.
+  if (!hasPermission(user, "notes.edit")) {
+    redirect(`/clinic/patients/${patientId}?tab=notes&error=unauthorized`);
+  }
+
+  // Chart-privacy gate — a doctor-only chart the user is not allowlisted for
+  // must reject start-visit even with global notes.edit.
+  try {
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      redirect(`/clinic/patients/${patientId}?tab=notes&error=restricted`);
+    }
+    throw err;
+  }
+
   const patient = await prisma.patient.findFirst({
     where: {
       id: patientId,
@@ -200,40 +219,49 @@ export async function startVisitWithBriefing(
     redirect(`/clinic/patients/${patientId}?tab=notes&error=not_found`);
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  // Reuse today's active encounter before minting a new one —
+  // same selection as startVisit, via the shared visit-state spine.
+  const currentProvider = await resolveProviderForUser(user.id, user.organizationId!);
 
-  let encounter = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      status: "in_progress",
-      createdAt: { gte: todayStart, lte: todayEnd },
-    },
-  });
+  let encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
 
   if (!encounter) {
     encounter = await prisma.encounter.create({
       data: {
         organizationId: user.organizationId!,
         patientId,
-        status: "in_progress",
+        status: "in_visit",
         modality: "in_person",
         reason: "Visit",
         startedAt: new Date(),
         scheduledFor: new Date(),
+        providerId: currentProvider?.id ?? undefined,
         // Store the briefing context so the scribe can use it
         briefingContext: briefing ? (briefing as any) : undefined,
       },
     });
-  } else if (briefing) {
-    // Update existing encounter with briefing
-    await prisma.encounter.update({
-      where: { id: encounter.id },
-      data: { briefingContext: briefing as any },
-    });
+  } else {
+    // Capture the existing context BEFORE advancing — rooming/demeanor/intake
+    // keys written by the front desk and saveEmotionalVital must survive.
+    const existingCtx =
+      encounter.briefingContext && typeof encounter.briefingContext === "object"
+        ? (encounter.briefingContext as Record<string, unknown>)
+        : {};
+
+    // Advance the reused encounter into the visit (idempotent).
+    encounter = (await advanceVisitState(encounter, "in_visit", user.id)).encounter;
+
+    // Record the rendering provider without stealing scheduled ownership.
+    encounter = await assignVisitProvider(encounter, currentProvider?.id ?? null);
+
+    if (briefing) {
+      // MERGE, never overwrite — the scribe reads patientSummary/talkingPoints/
+      // riskFlags/sections; every other writer uses disjoint keys.
+      await prisma.encounter.update({
+        where: { id: encounter.id },
+        data: { briefingContext: { ...existingCtx, ...briefing } as any },
+      });
+    }
   }
 
   // Dispatch the scribe event

--- a/src/app/(clinician)/clinic/patients/[id]/superbill/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/superbill/page.tsx
@@ -34,7 +34,7 @@ export default async function SuperbillPage({ params }: PageProps) {
   const encounter = await prisma.encounter.findFirst({
     where: {
       patientId: params.id,
-      status: { in: ["complete", "in_progress"] },
+      status: { in: ["complete", "in_visit", "in_progress"] },
     },
     include: {
       notes: {

--- a/src/app/(clinician)/clinic/patients/[id]/telehealth/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/telehealth/page.tsx
@@ -35,7 +35,7 @@ export default async function TelehealthPage({ params }: PageProps) {
     where: {
       patientId: params.id,
       modality: "video",
-      status: { in: ["scheduled", "in_progress"] },
+      status: { in: ["scheduled", "in_visit", "in_progress"] },
     },
     orderBy: { scheduledFor: "desc" },
   });

--- a/src/app/(operator)/ops/queue/actions.ts
+++ b/src/app/(operator)/ops/queue/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { requireUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
@@ -29,12 +30,22 @@ const TransitionSchema = z.object({
   ]),
 });
 
+const RoomingSchema = z.object({
+  encounterId: z.string().min(1),
+  room: z.string().max(20).optional(),
+  handoffNote: z.string().max(1000).optional(),
+  readinessFlags: z.array(z.string().max(100)).max(10).default([]),
+});
+
+type QueueUser = Awaited<ReturnType<typeof requireUser>>;
+type QueueAuthResult =
+  | { ok: true; organizationId: string }
+  | { ok: false; error: string };
+
 export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchema>) {
   const user = await requireUser();
-  if (!user.organizationId) return { ok: false, error: "Missing organization." };
-  if (!user.roles.some((role) => QUEUE_STATE_ROLES.has(role))) {
-    return { ok: false, error: "Forbidden." };
-  }
+  const auth = authorizeQueueUser(user);
+  if (!auth.ok) return auth;
 
   const parsed = TransitionSchema.safeParse(payload);
   if (!parsed.success) return { ok: false, error: "Invalid queue transition." };
@@ -42,7 +53,7 @@ export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchem
   const encounter = await prisma.encounter.findFirst({
     where: {
       id: parsed.data.encounterId,
-      organizationId: user.organizationId,
+      organizationId: auth.organizationId,
     },
   });
   if (!encounter) return { ok: false, error: "Encounter not found." };
@@ -76,4 +87,80 @@ export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchem
 
   revalidatePath("/ops/queue");
   return { ok: true };
+}
+
+export async function saveRoomingHandoff(payload: z.infer<typeof RoomingSchema>) {
+  const user = await requireUser();
+  const auth = authorizeQueueUser(user);
+  if (!auth.ok) return auth;
+
+  const parsed = RoomingSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid rooming handoff." };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: {
+      id: parsed.data.encounterId,
+      organizationId: auth.organizationId,
+    },
+    select: {
+      id: true,
+      organizationId: true,
+      briefingContext: true,
+    },
+  });
+  if (!encounter) return { ok: false, error: "Encounter not found." };
+
+  const existingContext = readJsonObject(encounter.briefingContext);
+  const existingRooming = readJsonObject(existingContext.rooming);
+  const rooming: Record<string, unknown> = {
+    ...existingRooming,
+    readinessFlags: parsed.data.readinessFlags,
+    updatedAt: new Date().toISOString(),
+    updatedByUserId: user.id,
+  };
+  if (parsed.data.room !== undefined) rooming.room = parsed.data.room.trim();
+  if (parsed.data.handoffNote !== undefined) {
+    rooming.handoffNote = parsed.data.handoffNote.trim();
+  }
+
+  await prisma.encounter.update({
+    where: { id: encounter.id },
+    data: {
+      briefingContext: {
+        ...existingContext,
+        rooming,
+      } as Prisma.InputJsonValue,
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: encounter.organizationId,
+      actorUserId: user.id,
+      action: "encounter.rooming.updated",
+      subjectType: "Encounter",
+      subjectId: encounter.id,
+      metadata: {
+        roomSet: typeof rooming.room === "string" && rooming.room.length > 0,
+        readinessFlagCount: parsed.data.readinessFlags.length,
+      },
+    },
+  });
+
+  revalidatePath("/ops/queue");
+  return { ok: true };
+}
+
+function authorizeQueueUser(user: QueueUser): QueueAuthResult {
+  if (!user.organizationId) return { ok: false, error: "Missing organization." };
+  if (!user.roles.some((role) => QUEUE_STATE_ROLES.has(role))) {
+    return { ok: false, error: "Forbidden." };
+  }
+  return { ok: true, organizationId: user.organizationId };
+}
+
+function readJsonObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }

--- a/src/app/(operator)/ops/queue/actions.ts
+++ b/src/app/(operator)/ops/queue/actions.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { advanceVisitState, type VisitSpineStatus } from "@/lib/domain/visit-state";
+
+const QUEUE_STATE_ROLES = new Set([
+  "front_office",
+  "back_office",
+  "operator",
+  "practice_owner",
+  "practice_admin",
+  "system",
+]);
+
+const TransitionSchema = z.object({
+  encounterId: z.string().min(1),
+  target: z.enum([
+    "checked_in",
+    "info_incomplete",
+    "ready",
+    "rooming",
+    "roomed",
+    "wrap_up",
+    "cancelled",
+    "no_show",
+  ]),
+});
+
+export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchema>) {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "Missing organization." };
+  if (!user.roles.some((role) => QUEUE_STATE_ROLES.has(role))) {
+    return { ok: false, error: "Forbidden." };
+  }
+
+  const parsed = TransitionSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid queue transition." };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: {
+      id: parsed.data.encounterId,
+      organizationId: user.organizationId,
+    },
+  });
+  if (!encounter) return { ok: false, error: "Encounter not found." };
+
+  if (encounter.status === parsed.data.target) {
+    revalidatePath("/ops/queue");
+    return { ok: true };
+  }
+
+  const next = advanceVisitState(
+    encounter,
+    parsed.data.target as VisitSpineStatus,
+  );
+  if (!next.ok) return next;
+
+  await prisma.encounter.update({
+    where: { id: encounter.id },
+    data: next.data as any,
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: encounter.organizationId,
+      actorUserId: user.id,
+      action: "encounter.visit_state.updated",
+      subjectType: "Encounter",
+      subjectId: encounter.id,
+      metadata: { from: encounter.status, to: parsed.data.target },
+    },
+  });
+
+  revalidatePath("/ops/queue");
+  return { ok: true };
+}

--- a/src/app/(operator)/ops/queue/page.tsx
+++ b/src/app/(operator)/ops/queue/page.tsx
@@ -4,11 +4,17 @@ import { PageShell } from "@/components/shell/PageHeader";
 import { QueueBoard } from "./queue-board";
 import {
   calculateWaitTime,
+  mapEncounterStatusToQueueStatus,
   type QueueEntry,
-  type QueueStatus,
 } from "@/lib/domain/queue-board";
 
 export const metadata = { title: "Today's Queue" };
+
+type RoomingContext = {
+  room?: string;
+  readinessFlags?: string[];
+  handoffNote?: string;
+};
 
 /**
  * Front-desk Queue Board — server component.
@@ -41,7 +47,14 @@ export default async function QueueBoardPage() {
         { completedAt: { gte: startOfDay, lt: endOfDay } },
       ],
     },
-    include: {
+    select: {
+      id: true,
+      status: true,
+      scheduledFor: true,
+      createdAt: true,
+      modality: true,
+      reason: true,
+      briefingContext: true,
       patient: { select: { id: true, firstName: true, lastName: true } },
       provider: {
         select: {
@@ -52,18 +65,8 @@ export default async function QueueBoardPage() {
     orderBy: { scheduledFor: "asc" },
   });
 
-  // Map raw encounter rows into the QueueEntry shape the client expects.
-  // EncounterStatus is a 3-value enum (scheduled | in_progress | complete).
-  // We surface those into the broader QueueStatus vocabulary so the kanban
-  // has somewhere to put each card today; the empty intermediate columns
-  // (arrived / rooming / checkout) stand ready for future state hooks.
   const entries: QueueEntry[] = encounters.map((enc) => {
-    const queueStatus: QueueStatus =
-      enc.status === "complete"
-        ? "completed"
-        : enc.status === "in_progress"
-          ? "in_visit"
-          : "scheduled";
+    const queueStatus = mapEncounterStatusToQueueStatus(enc.status);
 
     const scheduledIso =
       enc.scheduledFor?.toISOString() ?? enc.createdAt.toISOString();
@@ -73,6 +76,7 @@ export default async function QueueBoardPage() {
       : undefined;
 
     const minutesWaiting = calculateWaitTime(scheduledIso, queueStatus) ?? undefined;
+    const rooming = readRoomingContext(enc.briefingContext);
 
     return {
       encounterId: enc.id,
@@ -84,6 +88,9 @@ export default async function QueueBoardPage() {
       modality: (enc.modality as QueueEntry["modality"]) ?? "in_person",
       reason: enc.reason ?? undefined,
       minutesWaiting,
+      room: rooming?.room,
+      readinessFlags: rooming?.readinessFlags,
+      handoffNote: rooming?.handoffNote,
     };
   });
 
@@ -92,4 +99,24 @@ export default async function QueueBoardPage() {
       <QueueBoard entries={entries} loadedAt={new Date().toISOString()} />
     </PageShell>
   );
+}
+
+function readRoomingContext(value: unknown): RoomingContext | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const rooming = (value as { rooming?: unknown }).rooming;
+  if (!rooming || typeof rooming !== "object" || Array.isArray(rooming)) {
+    return undefined;
+  }
+
+  const raw = rooming as RoomingContext;
+  return {
+    room: typeof raw.room === "string" ? raw.room : undefined,
+    readinessFlags: Array.isArray(raw.readinessFlags)
+      ? raw.readinessFlags.filter((flag): flag is string => typeof flag === "string")
+      : undefined,
+    handoffNote: typeof raw.handoffNote === "string" ? raw.handoffNote : undefined,
+  };
 }

--- a/src/app/(operator)/ops/queue/page.tsx
+++ b/src/app/(operator)/ops/queue/page.tsx
@@ -84,6 +84,7 @@ export default async function QueueBoardPage() {
       patientName: `${enc.patient.firstName} ${enc.patient.lastName}`,
       scheduledFor: scheduledIso,
       status: queueStatus,
+      visitStatus: enc.status,
       provider: providerName,
       modality: (enc.modality as QueueEntry["modality"]) ?? "in_person",
       reason: enc.reason ?? undefined,

--- a/src/app/(operator)/ops/queue/queue-board.tsx
+++ b/src/app/(operator)/ops/queue/queue-board.tsx
@@ -22,6 +22,7 @@ import {
 import { useDensity, densityClass } from "@/lib/ui/density";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { FreshnessIndicator } from "@/components/ui/freshness-indicator";
+import { moveQueueEncounter } from "./actions";
 
 const COLUMN_ORDER: QueueStatus[] = [
   "scheduled",
@@ -56,6 +57,65 @@ function formatTime(iso: string): string {
     hour: "numeric",
     minute: "2-digit",
   });
+}
+
+type QueueActionTarget =
+  | "checked_in"
+  | "info_incomplete"
+  | "ready"
+  | "rooming"
+  | "roomed"
+  | "wrap_up"
+  | "cancelled"
+  | "no_show";
+
+function visitStatusLabel(status?: string): { label: string; tone: "neutral" | "success" | "warning" | "info" } | null {
+  switch (status) {
+    case "info_incomplete":
+      return { label: "Needs info", tone: "warning" };
+    case "checked_in":
+      return { label: "Checked in", tone: "info" };
+    case "ready":
+      return { label: "Ready", tone: "success" };
+    case "rooming":
+      return { label: "Rooming", tone: "info" };
+    case "roomed":
+      return { label: "Roomed", tone: "success" };
+    case "wrap_up":
+      return { label: "Wrap-up", tone: "warning" };
+    default:
+      return null;
+  }
+}
+
+function canMoveVisit(entry: QueueEntry, target: QueueActionTarget): boolean {
+  const status = entry.visitStatus ?? entry.status;
+  switch (target) {
+    case "checked_in":
+      return status === "scheduled";
+    case "info_incomplete":
+      return status === "scheduled" || status === "checked_in";
+    case "ready":
+      return status === "scheduled" || status === "checked_in" || status === "info_incomplete";
+    case "rooming":
+      return status === "checked_in" || status === "ready";
+    case "roomed":
+      return status === "rooming" || status === "ready";
+    case "wrap_up":
+      return status === "roomed" || status === "in_visit";
+    case "cancelled":
+      return [
+        "scheduled",
+        "checked_in",
+        "info_incomplete",
+        "ready",
+        "rooming",
+        "roomed",
+        "in_visit",
+      ].includes(status);
+    case "no_show":
+      return status === "scheduled" || status === "checked_in" || status === "info_incomplete";
+  }
 }
 
 export function QueueBoard({
@@ -208,14 +268,28 @@ function QueueColumn({
 function QueueCard({ entry }: { entry: QueueEntry }) {
   const router = useRouter();
   const confirm = useConfirm();
+  const [mutating, setMutating] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const wait = entry.minutesWaiting;
   const waitClass = waitToneClass(wait);
+  const statusLabel = visitStatusLabel(entry.visitStatus);
 
-  // EMR-UX — right-click context menu so the front desk can drive the
-  // queue without ever leaving the board. Status mutations land on the
-  // existing `/api/ops/queue/[encounterId]/status` endpoint when wired;
-  // the menu currently routes to the canonical surfaces so the action
-  // surface is never silent. Cancel is the destructive last item.
+  const runMove = (target: QueueActionTarget) => {
+    setActionError(null);
+    setMutating(true);
+    void moveQueueEncounter({ encounterId: entry.encounterId, target })
+      .then((result) => {
+        if (!result.ok) {
+          setActionError(result.error ?? "Could not update the visit.");
+        }
+        router.refresh();
+      })
+      .catch(() => {
+        setActionError("Could not update the visit.");
+      })
+      .finally(() => setMutating(false));
+  };
+
   const items: ContextMenuItem[] = [
     {
       label: "Open chart",
@@ -229,18 +303,54 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
     {
       label: "Mark arrived",
       icon: ContextMenuIcons.Check,
-      disabled: entry.status !== "scheduled",
+      disabled: mutating || !canMoveVisit(entry, "checked_in"),
       onSelect: (c) => {
-        router.refresh();
+        runMove("checked_in");
+        c();
+      },
+    },
+    {
+      label: "Needs info",
+      icon: ContextMenuIcons.Calendar,
+      disabled: mutating || !canMoveVisit(entry, "info_incomplete"),
+      onSelect: (c) => {
+        runMove("info_incomplete");
+        c();
+      },
+    },
+    {
+      label: "Ready",
+      icon: ContextMenuIcons.Check,
+      disabled: mutating || !canMoveVisit(entry, "ready"),
+      onSelect: (c) => {
+        runMove("ready");
         c();
       },
     },
     {
       label: "Move to rooming",
       icon: ContextMenuIcons.Calendar,
-      disabled: entry.status === "completed",
+      disabled: mutating || !canMoveVisit(entry, "rooming"),
       onSelect: (c) => {
-        router.refresh();
+        runMove("rooming");
+        c();
+      },
+    },
+    {
+      label: "Mark roomed",
+      icon: ContextMenuIcons.Check,
+      disabled: mutating || !canMoveVisit(entry, "roomed"),
+      onSelect: (c) => {
+        runMove("roomed");
+        c();
+      },
+    },
+    {
+      label: "Send to checkout",
+      icon: ContextMenuIcons.Calendar,
+      disabled: mutating || !canMoveVisit(entry, "wrap_up"),
+      onSelect: (c) => {
+        runMove("wrap_up");
         c();
       },
     },
@@ -259,13 +369,20 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
     },
     { divider: true, label: "" },
     {
+      label: "Mark no-show",
+      icon: ContextMenuIcons.Archive,
+      disabled: mutating || !canMoveVisit(entry, "no_show"),
+      onSelect: (c) => {
+        runMove("no_show");
+        c();
+      },
+    },
+    {
       label: "Cancel visit",
       icon: ContextMenuIcons.Archive,
       danger: true,
+      disabled: mutating || !canMoveVisit(entry, "cancelled"),
       onSelect: (c) => {
-        // Close the context menu first so the confirm dialog can take focus
-        // cleanly. Then prompt — if confirmed, refresh the board so the
-        // entry drops out of the column.
         c();
         void (async () => {
           const ok = await confirm({
@@ -276,7 +393,7 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
             confirmLabel: "Cancel visit",
             cancelLabel: "Keep on queue",
           });
-          if (ok) router.refresh();
+          if (ok) runMove("cancelled");
         })();
       },
     },
@@ -304,6 +421,12 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
         </span>
       </div>
 
+      {statusLabel && (
+        <Badge tone={statusLabel.tone} className="mb-1.5">
+          {statusLabel.label}
+        </Badge>
+      )}
+
       <div className="flex items-center gap-2 text-[11px] text-text-muted tabular-nums">
         <span>{formatTime(entry.scheduledFor)}</span>
         {entry.provider && (
@@ -320,6 +443,22 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
         </p>
       )}
 
+      {!!entry.readinessFlags?.length && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {entry.readinessFlags.slice(0, 3).map((flag) => (
+            <Badge key={flag} tone="neutral" className="text-[10px]">
+              {flag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {entry.handoffNote && (
+        <p className="mt-2 text-[11px] leading-snug text-text-muted line-clamp-2">
+          {entry.handoffNote}
+        </p>
+      )}
+
       {entry.status !== "completed" && wait != null && (
         <div className="flex items-center justify-between mt-2 pt-2 border-t border-border/40">
           <span className={cn("text-[11px] tabular-nums", waitClass)}>
@@ -331,6 +470,11 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
             </span>
           )}
         </div>
+      )}
+      {actionError && (
+        <p role="alert" className="mt-2 text-[11px] leading-snug text-danger">
+          {actionError}
+        </p>
       )}
       {ctx.menu}
     </Card>

--- a/src/app/api/mobile/kiosk/check-in/route.test.ts
+++ b/src/app/api/mobile/kiosk/check-in/route.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    encounter: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    patient: {
+      update: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
+    },
+  };
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return { mockPrisma, logger };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: hoisted.logger,
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://example.com/api/mobile/kiosk/check-in", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/mobile/kiosk/check-in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NODE_ENV", "development");
+    hoisted.mockPrisma.patient.update.mockResolvedValue({ id: "pat_1" });
+    hoisted.mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects mismatched encounter and patient ids", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    const res = await POST(
+      makeRequest({ encounterId: "enc_1", patientId: "wrong_pat" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Encounter not found for patient" });
+    expect(hoisted.mockPrisma.encounter.update).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("moves a verified scheduled encounter to checked_in and audits it", async () => {
+    const scheduledFor = new Date("2026-05-30T16:00:00.000Z");
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "scheduled",
+      scheduledFor,
+      checkedInAt: null,
+      patient: {
+        id: "pat_1",
+        organizationId: "org_1",
+        intakeAnswers: { existing: true },
+      },
+    });
+    hoisted.mockPrisma.encounter.update.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "checked_in",
+    });
+
+    const res = await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, status: "checked_in" });
+    expect(hoisted.mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: expect.objectContaining({
+        status: "checked_in",
+        checkedInAt: expect.any(Date),
+      }),
+    });
+    expect(hoisted.mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org_1",
+        action: "encounter.kiosk_check_in.completed",
+        subjectType: "Encounter",
+        subjectId: "enc_1",
+      }),
+    });
+  });
+
+  it("verifies encounter ownership before updating state", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+
+    expect(hoisted.mockPrisma.encounter.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "enc_1",
+        patientId: "pat_1",
+      },
+      include: {
+        patient: {
+          select: {
+            id: true,
+            intakeAnswers: true,
+            organizationId: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("merges signed forms into intake answers instead of replacing them", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "scheduled",
+      checkedInAt: null,
+      patient: {
+        id: "pat_1",
+        organizationId: "org_1",
+        intakeAnswers: { demographics: { confirmed: true } },
+      },
+    });
+    hoisted.mockPrisma.encounter.update.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "checked_in",
+    });
+
+    await POST(
+      makeRequest({
+        encounterId: "enc_1",
+        patientId: "pat_1",
+        signedForms: { consent: { signedAt: "2026-05-30T16:00:00.000Z" } },
+      }),
+    );
+
+    expect(hoisted.mockPrisma.patient.update).toHaveBeenCalledWith({
+      where: { id: "pat_1" },
+      data: {
+        intakeAnswers: {
+          demographics: { confirmed: true },
+          signedForms: {
+            consent: { signedAt: "2026-05-30T16:00:00.000Z" },
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/app/api/mobile/kiosk/check-in/route.ts
+++ b/src/app/api/mobile/kiosk/check-in/route.ts
@@ -1,60 +1,132 @@
 import { NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
+import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
+import { advanceVisitState } from "@/lib/domain/visit-state";
 import { logger } from "@/lib/observability/log";
 
-// EMR-029: Patient Kiosk App API
-// Receives check-in payloads from the front-desk iPad kiosk. Updates the patient's
-// wait state and alerts the clinician.
+const CheckInSchema = z.object({
+  encounterId: z.string().min(1),
+  patientId: z.string().min(1),
+  signedForms: z.unknown().optional(),
+});
 
 export async function POST(req: Request) {
   try {
     const authHeader = req.headers.get("authorization") ?? "";
     const secret = process.env.KIOSK_SECRET ?? "";
-    
+
     if (process.env.NODE_ENV === "production" && authHeader !== `Bearer ${secret}`) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
 
-    const payload = await req.json();
-
-    if (!payload.encounterId || !payload.patientId) {
+    const parsed = CheckInSchema.safeParse(await req.json());
+    if (!parsed.success) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
 
-    // 1. Move the Encounter into the active queue.
-    // Schema's EncounterStatus enum doesn't have a dedicated `arrived` value yet;
-    // `in_progress` is the closest fit until the schema gains an explicit waiting-room state.
-    const encounter = await prisma.encounter.update({
-      where: { id: payload.encounterId },
-      data: {
-        status: "in_progress",
-        updatedAt: new Date()
-      }
+    const payload = parsed.data;
+    const encounter = await prisma.encounter.findFirst({
+      where: {
+        id: payload.encounterId,
+        patientId: payload.patientId,
+      },
+      include: {
+        patient: {
+          select: {
+            id: true,
+            intakeAnswers: true,
+            organizationId: true,
+          },
+        },
+      },
     });
 
-    // 2. Append forms if they signed any on the kiosk
-    if (payload.signedForms) {
-      await prisma.patient.update({
-        where: { id: payload.patientId },
+    if (!encounter) {
+      return NextResponse.json(
+        { error: "Encounter not found for patient" },
+        { status: 404 },
+      );
+    }
+
+    if (encounter.organizationId !== encounter.patient.organizationId) {
+      return NextResponse.json(
+        { error: "Encounter organization mismatch" },
+        { status: 409 },
+      );
+    }
+
+    const next = advanceVisitState(encounter, "checked_in");
+    if (!next.ok) {
+      return NextResponse.json({ error: next.error }, { status: 409 });
+    }
+
+    let status = "checked_in";
+    if (encounter.status !== "checked_in") {
+      const updated = await prisma.encounter.update({
+        where: { id: encounter.id },
+        data: next.data as Prisma.EncounterUpdateInput,
+      });
+      status = updated.status;
+
+      await prisma.auditLog.create({
         data: {
-          intakeAnswers: payload.signedForms
-        }
+          organizationId: encounter.organizationId,
+          actorUserId: null,
+          action: "encounter.kiosk_check_in.completed",
+          subjectType: "Encounter",
+          subjectId: encounter.id,
+          metadata: {
+            from: encounter.status,
+            to: "checked_in",
+            channel: "kiosk",
+          },
+        },
       });
     }
 
-    logger.info({ 
-      event: "kiosk.check_in.success", 
-      encounterId: encounter.id, 
-      patientId: payload.patientId 
+    if (payload.signedForms !== undefined) {
+      await prisma.patient.update({
+        where: { id: encounter.patient.id },
+        data: {
+          intakeAnswers: mergeSignedForms(
+            encounter.patient.intakeAnswers,
+            payload.signedForms,
+          ) as Prisma.InputJsonValue,
+        },
+      });
+    }
+
+    logger.info({
+      event: "kiosk.check_in.success",
+      encounterId: encounter.id,
+      patientId: payload.patientId,
     });
 
-    return NextResponse.json({ 
-      success: true, 
-      status: "arrived"
+    return NextResponse.json({
+      success: true,
+      status,
     });
 
   } catch (error) {
     logger.error({ event: "kiosk.check_in.failed", error });
     return NextResponse.json({ error: "Failed to process kiosk check-in" }, { status: 500 });
   }
+}
+
+function mergeSignedForms(intakeAnswers: unknown, signedForms: unknown): Record<string, unknown> {
+  const current = isRecord(intakeAnswers) ? intakeAnswers : {};
+  const existingForms = isRecord(current.signedForms) ? current.signedForms : {};
+
+  return {
+    ...current,
+    signedForms: {
+      ...existingForms,
+      ...(isRecord(signedForms) ? signedForms : { value: signedForms }),
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/lib/clinical/visit-readiness.test.ts
+++ b/src/lib/clinical/visit-readiness.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { summarizeVisitReadiness } from "./visit-readiness";
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function enc(briefingContext: Record<string, unknown> | null, over: Record<string, unknown> = {}) {
+  return {
+    status: "scheduled" as const,
+    scheduledFor: TODAY,
+    startedAt: null,
+    briefingContext: briefingContext as never,
+    ...over,
+  };
+}
+
+describe("summarizeVisitReadiness", () => {
+  it("reports no encounter when given null", () => {
+    const r = summarizeVisitReadiness(null);
+    expect(r.hasEncounter).toBe(false);
+    expect(r.handoffLine).toMatch(/no.*encounter|not.*scheduled/i);
+  });
+
+  it("surfaces rooming/pre-visit signals from briefingContext", () => {
+    const r = summarizeVisitReadiness(
+      enc({
+        intakeCompleted: true,
+        patientConfirmedAt: "2026-05-28T10:00:00.000Z",
+        patientSummary: "62yo with chronic low back pain...",
+        patientDemeanor: "calm",
+        reminderSentAt: "2026-05-29T08:00:00.000Z",
+      }),
+    );
+    expect(r.hasEncounter).toBe(true);
+    expect(r.intakeCompleted).toBe(true);
+    expect(r.patientConfirmed).toBe(true);
+    expect(r.briefingReady).toBe(true);
+    expect(r.patientDemeanor).toBe("calm");
+    expect(r.reminderSent).toBe(true);
+  });
+
+  it("treats a started encounter as started", () => {
+    const r = summarizeVisitReadiness(enc(null, { status: "in_progress", startedAt: TODAY }));
+    expect(r.started).toBe(true);
+  });
+
+  it("does not invent signals when briefingContext is empty", () => {
+    const r = summarizeVisitReadiness(enc({}));
+    expect(r.intakeCompleted).toBe(false);
+    expect(r.patientConfirmed).toBe(false);
+    expect(r.briefingReady).toBe(false);
+    expect(r.patientDemeanor).toBeNull();
+    expect(r.reminderSent).toBe(false);
+  });
+
+  it("checks the actual field, not mere presence of other context", () => {
+    // Context has rooming data but NO patientSummary → briefing is not ready,
+    // and an empty-string summary must not count as ready either.
+    const r = summarizeVisitReadiness(
+      enc({ patientDemeanor: "calm", intakeCompleted: true, patientSummary: "" }),
+    );
+    expect(r.briefingReady).toBe(false);
+    expect(r.intakeCompleted).toBe(true);
+    expect(r.patientDemeanor).toBe("calm");
+  });
+
+  it("builds a human handoff line mentioning the ready items", () => {
+    const r = summarizeVisitReadiness(
+      enc({ intakeCompleted: true, patientSummary: "x", patientDemeanor: "anxious" }),
+    );
+    expect(r.handoffLine.toLowerCase()).toContain("intake");
+    expect(r.handoffLine.toLowerCase()).toContain("briefing");
+    expect(r.handoffLine.toLowerCase()).toContain("anxious");
+  });
+});

--- a/src/lib/clinical/visit-readiness.ts
+++ b/src/lib/clinical/visit-readiness.ts
@@ -1,0 +1,82 @@
+import type { Encounter } from "@prisma/client";
+
+/**
+ * visit-readiness — physician-facing rooming/pre-visit handoff summary.
+ *
+ * Derives a compact, non-PHI-leaking readiness snapshot from the encounter's
+ * `briefingContext` (written by front-desk/pre-visit/rooming surfaces) plus the
+ * encounter's own timing fields. Used to surface "is this patient ready?" on the
+ * chart / note-start path so the physician sees the rooming handoff before
+ * documenting. Pure function — easy to unit test and safe to call from a Server
+ * Component or action.
+ */
+export interface VisitReadiness {
+  hasEncounter: boolean;
+  scheduledFor: string | null;
+  started: boolean;
+  intakeCompleted: boolean;
+  patientConfirmed: boolean;
+  briefingReady: boolean;
+  patientDemeanor: string | null;
+  reminderSent: boolean;
+  /** Compact one-line handoff for a chart/note-start header chip. */
+  handoffLine: string;
+}
+
+type ReadyEncounter = Pick<
+  Encounter,
+  "status" | "scheduledFor" | "startedAt" | "briefingContext"
+>;
+
+export function summarizeVisitReadiness(
+  encounter: ReadyEncounter | null,
+): VisitReadiness {
+  if (!encounter) {
+    return {
+      hasEncounter: false,
+      scheduledFor: null,
+      started: false,
+      intakeCompleted: false,
+      patientConfirmed: false,
+      briefingReady: false,
+      patientDemeanor: null,
+      reminderSent: false,
+      handoffLine: "No encounter scheduled today",
+    };
+  }
+
+  const ctx =
+    encounter.briefingContext && typeof encounter.briefingContext === "object"
+      ? (encounter.briefingContext as Record<string, unknown>)
+      : {};
+
+  const intakeCompleted = ctx.intakeCompleted === true;
+  const patientConfirmed = typeof ctx.patientConfirmedAt === "string" && ctx.patientConfirmedAt.length > 0;
+  const briefingReady = typeof ctx.patientSummary === "string" && ctx.patientSummary.length > 0;
+  const patientDemeanor =
+    typeof ctx.patientDemeanor === "string" && ctx.patientDemeanor.length > 0
+      ? ctx.patientDemeanor
+      : null;
+  const reminderSent = typeof ctx.reminderSentAt === "string" && ctx.reminderSentAt.length > 0;
+  const started = encounter.status === "in_progress" || encounter.startedAt != null;
+
+  // Compact, non-PHI handoff chip text. Order from "front desk" → "pre-visit".
+  const parts: string[] = [];
+  parts.push(intakeCompleted ? "Intake complete" : "Intake pending");
+  if (patientConfirmed) parts.push("Confirmed");
+  if (briefingReady) parts.push("Briefing ready");
+  if (patientDemeanor) parts.push(`Demeanor: ${patientDemeanor}`);
+  const handoffLine = parts.join(" · ");
+
+  return {
+    hasEncounter: true,
+    scheduledFor: encounter.scheduledFor ? encounter.scheduledFor.toISOString() : null,
+    started,
+    intakeCompleted,
+    patientConfirmed,
+    briefingReady,
+    patientDemeanor,
+    reminderSent,
+    handoffLine,
+  };
+}

--- a/src/lib/domain/queue-board.test.ts
+++ b/src/lib/domain/queue-board.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { mapEncounterStatusToQueueStatus } from "./queue-board";
+
+describe("queue-board status mapping", () => {
+  it.each([
+    ["scheduled", "scheduled"],
+    ["checked_in", "arrived"],
+    ["info_incomplete", "arrived"],
+    ["ready", "arrived"],
+    ["rooming", "rooming"],
+    ["roomed", "rooming"],
+    ["in_visit", "in_visit"],
+    ["wrap_up", "checkout"],
+    ["complete", "completed"],
+    ["cancelled", "completed"],
+    ["no_show", "completed"],
+  ] as const)("maps %s to %s", (encounterStatus, queueStatus) => {
+    expect(mapEncounterStatusToQueueStatus(encounterStatus)).toBe(queueStatus);
+  });
+
+  it("keeps legacy in_progress visible as in visit", () => {
+    expect(mapEncounterStatusToQueueStatus("in_progress")).toBe("in_visit");
+  });
+});

--- a/src/lib/domain/queue-board.ts
+++ b/src/lib/domain/queue-board.ts
@@ -9,6 +9,7 @@ export interface QueueEntry {
   patientName: string;
   scheduledFor: string;
   status: QueueStatus;
+  visitStatus?: string;
   provider?: string;
   modality: "in_person" | "video" | "phone";
   reason?: string;

--- a/src/lib/domain/queue-board.ts
+++ b/src/lib/domain/queue-board.ts
@@ -14,6 +14,8 @@ export interface QueueEntry {
   reason?: string;
   minutesWaiting?: number;
   room?: string;
+  readinessFlags?: string[];
+  handoffNote?: string;
 }
 
 export const QUEUE_STATUS_CONFIG: Record<QueueStatus, { label: string; color: string; order: number }> = {
@@ -30,4 +32,28 @@ export function calculateWaitTime(scheduledFor: string, status: QueueStatus): nu
   const scheduled = new Date(scheduledFor).getTime();
   const now = Date.now();
   return Math.max(0, Math.round((now - scheduled) / 60000));
+}
+
+export function mapEncounterStatusToQueueStatus(status: string): QueueStatus {
+  switch (status) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return "arrived";
+    case "rooming":
+    case "roomed":
+      return "rooming";
+    case "in_visit":
+    case "in_progress":
+      return "in_visit";
+    case "wrap_up":
+      return "checkout";
+    case "complete":
+    case "cancelled":
+    case "no_show":
+      return "completed";
+    case "scheduled":
+    default:
+      return "scheduled";
+  }
 }

--- a/src/lib/domain/visit-state.test.ts
+++ b/src/lib/domain/visit-state.test.ts
@@ -1,11 +1,66 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    encounter: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    provider: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+
 import {
+  ACTIVE_VISIT_STATUSES,
   advanceVisitState,
+  assignVisitProvider,
   isVisitSpineStatus,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
   type VisitSpineStatus,
 } from "./visit-state";
 
-describe("visit-state", () => {
+const { mockPrisma } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function enc(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    checkedInAt: null,
+    roomingStartedAt: null,
+    roomedAt: null,
+    startedAt: null,
+    wrapUpAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    noShowAt: null,
+    providerId: null,
+    renderingProviderId: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...enc(),
+    id: where.id,
+    ...data,
+  }));
+});
+
+describe("visit-state pure transitions", () => {
   it("allows scheduled visits to check in and stamps checkedInAt once", () => {
     const now = new Date("2026-05-30T16:00:00.000Z");
     const result = advanceVisitState(
@@ -48,7 +103,21 @@ describe("visit-state", () => {
     });
   });
 
-  it("keeps legacy in_progress compatible with active visit", () => {
+  it("lets the physician start a same-day scheduled visit directly", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "scheduled", startedAt: null },
+      "in_visit",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("in_visit");
+    expect(result.data.startedAt).toEqual(now);
+  });
+
+  it("keeps legacy in_progress compatible with the canonical active visit state", () => {
     const now = new Date("2026-05-30T16:00:00.000Z");
     const result = advanceVisitState(
       { status: "in_progress", startedAt: null },
@@ -79,5 +148,200 @@ describe("visit-state", () => {
 
     expect(statuses.every(isVisitSpineStatus)).toBe(true);
     expect(isVisitSpineStatus("in_progress")).toBe(false);
+  });
+});
+
+describe("selectActiveVisitEncounter", () => {
+  it("scopes the lookup to today's non-terminal encounters for the patient + org", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+
+    await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+
+    const arg = mockPrisma.encounter.findMany.mock.calls[0][0];
+    expect(arg.where.patientId).toBe("patient_1");
+    expect(arg.where.organizationId).toBe("org_1");
+    expect(arg.where.status).toEqual({ in: [...ACTIVE_VISIT_STATUSES] });
+  });
+
+  it("returns null when there is no active encounter today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result).toBeNull();
+  });
+
+  it("reuses today's scheduled encounter so the visit is not a fresh row", async () => {
+    const scheduled = enc({ id: "sched_1", status: "scheduled" });
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduled]);
+
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result?.id).toBe("sched_1");
+  });
+
+  it("prefers an already in-visit encounter over a scheduled one", async () => {
+    const scheduled = enc({ id: "sched_1", status: "scheduled" });
+    const inVisit = enc({ id: "invisit_1", status: "in_visit" });
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduled, inVisit]);
+
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result?.id).toBe("invisit_1");
+  });
+
+  it("still prefers legacy in_progress over a scheduled one", async () => {
+    const scheduled = enc({ id: "sched_1", status: "scheduled" });
+    const inProgress = enc({ id: "inprog_1", status: "in_progress" });
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduled, inProgress]);
+
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result?.id).toBe("inprog_1");
+  });
+});
+
+describe("advanceVisitState database mode", () => {
+  it("transitions a scheduled encounter into in_visit and stamps startedAt", async () => {
+    const at = new Date("2026-05-29T16:00:00.000Z");
+    const { encounter, transitioned } = await advanceVisitState(
+      { id: "enc_1", status: "scheduled", startedAt: null },
+      "in_visit",
+      "user_1",
+      { at },
+    );
+
+    expect(transitioned).toBe(true);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { status: "in_visit", startedAt: at },
+    });
+    expect(encounter.status).toBe("in_visit");
+  });
+
+  it("is a no-op when the encounter is already in the target status", async () => {
+    const { transitioned } = await advanceVisitState(
+      { id: "enc_1", status: "in_visit", startedAt: TODAY },
+      "in_visit",
+      "user_1",
+    );
+    expect(transitioned).toBe(false);
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("moves a legacy in_progress encounter to the canonical in_visit status", async () => {
+    const at = new Date("2026-05-29T16:00:00.000Z");
+    await advanceVisitState(
+      { id: "enc_1", status: "in_progress", startedAt: null },
+      "in_visit",
+      "user_1",
+      { at },
+    );
+
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { status: "in_visit", startedAt: at },
+    });
+  });
+
+  it("completes an in_visit encounter exactly once", async () => {
+    const at = new Date("2026-05-29T17:00:00.000Z");
+
+    const first = await advanceVisitState(
+      { id: "enc_1", status: "in_visit", startedAt: TODAY },
+      "complete",
+      "user_1",
+      { at },
+    );
+    expect(first.transitioned).toBe(true);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { status: "complete", completedAt: at },
+    });
+
+    const second = await advanceVisitState(
+      { id: "enc_1", status: "complete", startedAt: TODAY },
+      "complete",
+      "user_1",
+      { at },
+    );
+    expect(second.transitioned).toBe(false);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-stamp startedAt when the encounter already started", async () => {
+    await advanceVisitState(
+      { id: "enc_1", status: "scheduled", startedAt: TODAY },
+      "in_visit",
+      "user_1",
+      { at: new Date("2026-05-29T18:00:00.000Z") },
+    );
+    const data = mockPrisma.encounter.update.mock.calls[0][0].data;
+    expect(data.startedAt).toBeUndefined();
+    expect(data.status).toBe("in_visit");
+  });
+});
+
+describe("resolveProviderForUser", () => {
+  it("scopes the lookup to the user + organization", async () => {
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_1" });
+    const r = await resolveProviderForUser("user_1", "org_1");
+    expect(r).toEqual({ id: "prov_1" });
+    expect(mockPrisma.provider.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user_1", organizationId: "org_1" },
+      select: { id: true },
+    });
+  });
+});
+
+describe("assignVisitProvider", () => {
+  it("is a no-op when the user has no Provider record", async () => {
+    const e = enc({ providerId: null }) as any;
+    const r = await assignVisitProvider(e, null);
+    expect(r).toBe(e);
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("claims an unowned encounter", async () => {
+    await assignVisitProvider(enc({ providerId: null }) as any, "prov_x");
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { providerId: "prov_x" },
+    });
+  });
+
+  it("preserves a different owner and stamps renderingProviderId", async () => {
+    await assignVisitProvider(
+      enc({ providerId: "prov_a", renderingProviderId: null }) as any,
+      "prov_b",
+    );
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { renderingProviderId: "prov_b" },
+    });
+  });
+
+  it("is a no-op when the current user already owns the encounter", async () => {
+    await assignVisitProvider(enc({ providerId: "prov_b" }) as any, "prov_b");
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the current user is already the rendering provider", async () => {
+    await assignVisitProvider(
+      enc({ providerId: "prov_a", renderingProviderId: "prov_b" }) as any,
+      "prov_b",
+    );
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("ACTIVE_VISIT_STATUSES", () => {
+  it("only includes non-terminal persisted statuses", () => {
+    expect([...ACTIVE_VISIT_STATUSES]).toEqual([
+      "scheduled",
+      "checked_in",
+      "info_incomplete",
+      "ready",
+      "rooming",
+      "roomed",
+      "in_visit",
+      "wrap_up",
+      "in_progress",
+    ]);
   });
 });

--- a/src/lib/domain/visit-state.test.ts
+++ b/src/lib/domain/visit-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceVisitState,
+  isVisitSpineStatus,
+  type VisitSpineStatus,
+} from "./visit-state";
+
+describe("visit-state", () => {
+  it("allows scheduled visits to check in and stamps checkedInAt once", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "scheduled", checkedInAt: null },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(now);
+  });
+
+  it("does not replace an existing timestamp on idempotent transition", () => {
+    const checkedInAt = new Date("2026-05-30T15:45:00.000Z");
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "checked_in", checkedInAt },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(checkedInAt);
+  });
+
+  it("rejects jumping from scheduled directly to complete", () => {
+    const result = advanceVisitState(
+      { status: "scheduled", completedAt: null },
+      "complete",
+      new Date("2026-05-30T16:00:00.000Z"),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Cannot transition visit from scheduled to complete.",
+    });
+  });
+
+  it("keeps legacy in_progress compatible with active visit", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "in_progress", startedAt: null },
+      "in_visit",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("in_visit");
+    expect(result.data.startedAt).toEqual(now);
+  });
+
+  it("recognizes all canonical spine statuses", () => {
+    const statuses: VisitSpineStatus[] = [
+      "scheduled",
+      "checked_in",
+      "info_incomplete",
+      "ready",
+      "rooming",
+      "roomed",
+      "in_visit",
+      "wrap_up",
+      "complete",
+      "cancelled",
+      "no_show",
+    ];
+
+    expect(statuses.every(isVisitSpineStatus)).toBe(true);
+    expect(isVisitSpineStatus("in_progress")).toBe(false);
+  });
+});

--- a/src/lib/domain/visit-state.ts
+++ b/src/lib/domain/visit-state.ts
@@ -1,3 +1,6 @@
+import { prisma } from "@/lib/db/prisma";
+import type { Encounter } from "@prisma/client";
+
 export const VISIT_SPINE_STATUSES = [
   "scheduled",
   "checked_in",
@@ -15,8 +18,22 @@ export const VISIT_SPINE_STATUSES = [
 export type VisitSpineStatus = (typeof VISIT_SPINE_STATUSES)[number];
 export type LegacyVisitStatus = "in_progress";
 export type VisitStatus = VisitSpineStatus | LegacyVisitStatus;
+export type VisitPhase = "in_visit" | "wrap_up" | "complete";
+
+export const ACTIVE_VISIT_STATUSES = [
+  "scheduled",
+  "checked_in",
+  "info_incomplete",
+  "ready",
+  "rooming",
+  "roomed",
+  "in_visit",
+  "wrap_up",
+  "in_progress",
+] as const satisfies readonly VisitStatus[];
 
 export interface VisitStateFields {
+  id?: string;
   status: string;
   checkedInAt?: Date | null;
   roomingStartedAt?: Date | null;
@@ -32,14 +49,26 @@ export type VisitTransitionResult =
   | { ok: true; data: Partial<VisitStateFields> }
   | { ok: false; error: string };
 
+export interface AdvanceResult {
+  encounter: Encounter;
+  transitioned: boolean;
+}
+
 const STATUS_SET = new Set<string>(VISIT_SPINE_STATUSES);
 
 const ALLOWED_TRANSITIONS: Record<string, ReadonlySet<VisitSpineStatus>> = {
-  scheduled: new Set(["checked_in", "info_incomplete", "ready", "cancelled", "no_show"]),
-  checked_in: new Set(["info_incomplete", "ready", "rooming", "cancelled", "no_show"]),
-  info_incomplete: new Set(["ready", "cancelled", "no_show"]),
+  scheduled: new Set([
+    "checked_in",
+    "info_incomplete",
+    "ready",
+    "in_visit",
+    "cancelled",
+    "no_show",
+  ]),
+  checked_in: new Set(["info_incomplete", "ready", "rooming", "in_visit", "cancelled", "no_show"]),
+  info_incomplete: new Set(["ready", "in_visit", "cancelled", "no_show"]),
   ready: new Set(["rooming", "roomed", "in_visit", "cancelled", "no_show"]),
-  rooming: new Set(["roomed", "ready", "cancelled"]),
+  rooming: new Set(["roomed", "ready", "in_visit", "cancelled"]),
   roomed: new Set(["in_visit", "wrap_up", "cancelled"]),
   in_visit: new Set(["wrap_up", "complete", "cancelled"]),
   wrap_up: new Set(["complete", "in_visit"]),
@@ -49,11 +78,168 @@ const ALLOWED_TRANSITIONS: Record<string, ReadonlySet<VisitSpineStatus>> = {
   in_progress: new Set(["in_visit", "wrap_up", "complete", "cancelled"]),
 };
 
+const ACTIVE_VISIT_PRIORITY: Record<string, number> = {
+  in_visit: 0,
+  in_progress: 1,
+  wrap_up: 2,
+  roomed: 3,
+  rooming: 4,
+  ready: 5,
+  checked_in: 6,
+  info_incomplete: 7,
+  scheduled: 8,
+};
+
 export function isVisitSpineStatus(value: string): value is VisitSpineStatus {
   return STATUS_SET.has(value);
 }
 
 export function advanceVisitState(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now?: Date,
+): VisitTransitionResult;
+export function advanceVisitState(
+  encounter: Pick<Encounter, "id" | "status" | "startedAt">,
+  phase: VisitPhase,
+  actorUserId: string,
+  opts?: { at?: Date },
+): Promise<AdvanceResult>;
+export function advanceVisitState(
+  current: VisitStateFields,
+  target: VisitSpineStatus | VisitPhase,
+  nowOrActor: Date | string = new Date(),
+  opts: { at?: Date } = {},
+): VisitTransitionResult | Promise<AdvanceResult> {
+  if (typeof nowOrActor === "string") {
+    return advanceEncounterVisitState(current, target as VisitPhase, opts);
+  }
+
+  return computeVisitTransition(current, target as VisitSpineStatus, nowOrActor);
+}
+
+export async function selectActiveVisitEncounter(
+  patientId: string,
+  organizationId: string,
+  opts: { now?: Date } = {},
+): Promise<Encounter | null> {
+  const now = opts.now ?? new Date();
+  const { start, end } = dayBounds(now);
+
+  const candidates = await prisma.encounter.findMany({
+    where: {
+      patientId,
+      organizationId,
+      status: { in: [...ACTIVE_VISIT_STATUSES] },
+      OR: [
+        { scheduledFor: { gte: start, lte: end } },
+        { createdAt: { gte: start, lte: end } },
+      ],
+    },
+    orderBy: [{ scheduledFor: "asc" }, { createdAt: "asc" }],
+  });
+
+  if (candidates.length === 0) return null;
+
+  return [...candidates].sort(compareActiveEncounters)[0] ?? null;
+}
+
+export async function resolveProviderForUser(
+  userId: string,
+  organizationId: string,
+): Promise<{ id: string } | null> {
+  return prisma.provider.findFirst({
+    where: { userId, organizationId },
+    select: { id: true },
+  });
+}
+
+export async function assignVisitProvider(
+  encounter: Encounter,
+  currentProviderId: string | null,
+): Promise<Encounter> {
+  if (!currentProviderId) return encounter;
+
+  if (!encounter.providerId) {
+    return prisma.encounter.update({
+      where: { id: encounter.id },
+      data: { providerId: currentProviderId },
+    });
+  }
+
+  if (
+    encounter.providerId !== currentProviderId &&
+    encounter.renderingProviderId !== currentProviderId
+  ) {
+    return prisma.encounter.update({
+      where: { id: encounter.id },
+      data: { renderingProviderId: currentProviderId },
+    });
+  }
+
+  return encounter;
+}
+
+async function advanceEncounterVisitState(
+  encounter: VisitStateFields,
+  phase: VisitPhase,
+  opts: { at?: Date } = {},
+): Promise<AdvanceResult> {
+  if (!encounter.id) {
+    throw new Error("Encounter id is required to advance visit state.");
+  }
+
+  if (encounter.status === phase) {
+    return { encounter: encounter as Encounter, transitioned: false };
+  }
+
+  const at = opts.at ?? new Date();
+  const transition = computeVisitTransition(encounter, phase, at);
+  if (!transition.ok) {
+    throw new Error(transition.error);
+  }
+
+  const data = omitUnchangedTimestamps(encounter, transition.data);
+  const updated = await prisma.encounter.update({
+    where: { id: encounter.id },
+    data: data as any,
+  });
+
+  return { encounter: updated, transitioned: true };
+}
+
+function omitUnchangedTimestamps(
+  current: VisitStateFields,
+  data: Partial<VisitStateFields>,
+): Partial<VisitStateFields> {
+  const next = { ...data };
+  const timestampFields: Array<keyof VisitStateFields> = [
+    "checkedInAt",
+    "roomingStartedAt",
+    "roomedAt",
+    "startedAt",
+    "wrapUpAt",
+    "completedAt",
+    "cancelledAt",
+    "noShowAt",
+  ];
+
+  for (const field of timestampFields) {
+    const currentValue = current[field];
+    const nextValue = next[field];
+    if (
+      currentValue instanceof Date &&
+      nextValue instanceof Date &&
+      currentValue.getTime() === nextValue.getTime()
+    ) {
+      delete next[field];
+    }
+  }
+
+  return next;
+}
+
+function computeVisitTransition(
   current: VisitStateFields,
   target: VisitSpineStatus,
   now: Date = new Date(),
@@ -112,4 +298,25 @@ function applyTimestamp(
     case "scheduled":
       return {};
   }
+}
+
+function dayBounds(now: Date): { start: Date; end: Date } {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+function compareActiveEncounters(a: Encounter, b: Encounter): number {
+  const statusOrder =
+    (ACTIVE_VISIT_PRIORITY[a.status] ?? Number.MAX_SAFE_INTEGER) -
+    (ACTIVE_VISIT_PRIORITY[b.status] ?? Number.MAX_SAFE_INTEGER);
+  if (statusOrder !== 0) return statusOrder;
+
+  return encounterSortTime(a) - encounterSortTime(b);
+}
+
+function encounterSortTime(encounter: Encounter): number {
+  return (encounter.scheduledFor ?? encounter.createdAt).getTime();
 }

--- a/src/lib/domain/visit-state.ts
+++ b/src/lib/domain/visit-state.ts
@@ -1,0 +1,115 @@
+export const VISIT_SPINE_STATUSES = [
+  "scheduled",
+  "checked_in",
+  "info_incomplete",
+  "ready",
+  "rooming",
+  "roomed",
+  "in_visit",
+  "wrap_up",
+  "complete",
+  "cancelled",
+  "no_show",
+] as const;
+
+export type VisitSpineStatus = (typeof VISIT_SPINE_STATUSES)[number];
+export type LegacyVisitStatus = "in_progress";
+export type VisitStatus = VisitSpineStatus | LegacyVisitStatus;
+
+export interface VisitStateFields {
+  status: string;
+  checkedInAt?: Date | null;
+  roomingStartedAt?: Date | null;
+  roomedAt?: Date | null;
+  startedAt?: Date | null;
+  wrapUpAt?: Date | null;
+  completedAt?: Date | null;
+  cancelledAt?: Date | null;
+  noShowAt?: Date | null;
+}
+
+export type VisitTransitionResult =
+  | { ok: true; data: Partial<VisitStateFields> }
+  | { ok: false; error: string };
+
+const STATUS_SET = new Set<string>(VISIT_SPINE_STATUSES);
+
+const ALLOWED_TRANSITIONS: Record<string, ReadonlySet<VisitSpineStatus>> = {
+  scheduled: new Set(["checked_in", "info_incomplete", "ready", "cancelled", "no_show"]),
+  checked_in: new Set(["info_incomplete", "ready", "rooming", "cancelled", "no_show"]),
+  info_incomplete: new Set(["ready", "cancelled", "no_show"]),
+  ready: new Set(["rooming", "roomed", "in_visit", "cancelled", "no_show"]),
+  rooming: new Set(["roomed", "ready", "cancelled"]),
+  roomed: new Set(["in_visit", "wrap_up", "cancelled"]),
+  in_visit: new Set(["wrap_up", "complete", "cancelled"]),
+  wrap_up: new Set(["complete", "in_visit"]),
+  complete: new Set([]),
+  cancelled: new Set([]),
+  no_show: new Set([]),
+  in_progress: new Set(["in_visit", "wrap_up", "complete", "cancelled"]),
+};
+
+export function isVisitSpineStatus(value: string): value is VisitSpineStatus {
+  return STATUS_SET.has(value);
+}
+
+export function advanceVisitState(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date = new Date(),
+): VisitTransitionResult {
+  if (current.status === target) {
+    return {
+      ok: true,
+      data: {
+        status: target,
+        ...applyTimestamp(current, target, now),
+      },
+    };
+  }
+
+  const allowed = ALLOWED_TRANSITIONS[current.status];
+  if (!allowed?.has(target)) {
+    return {
+      ok: false,
+      error: `Cannot transition visit from ${current.status} to ${target}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: target,
+      ...applyTimestamp(current, target, now),
+    },
+  };
+}
+
+function applyTimestamp(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date,
+): Partial<VisitStateFields> {
+  switch (target) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return { checkedInAt: current.checkedInAt ?? now };
+    case "rooming":
+      return { roomingStartedAt: current.roomingStartedAt ?? now };
+    case "roomed":
+      return { roomedAt: current.roomedAt ?? now };
+    case "in_visit":
+      return { startedAt: current.startedAt ?? now };
+    case "wrap_up":
+      return { wrapUpAt: current.wrapUpAt ?? now };
+    case "complete":
+      return { completedAt: current.completedAt ?? now };
+    case "cancelled":
+      return { cancelledAt: current.cancelledAt ?? now };
+    case "no_show":
+      return { noShowAt: current.noShowAt ?? now };
+    case "scheduled":
+      return {};
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the canonical same-day visit spine from check-in through rooming, in-visit, wrap-up, completion, cancellation, and no-show.
- Wires the operator queue actions and kiosk check-in hardening onto the spine.
- Integrates the physician workflow fixes: reuse today’s encounter, preserve scheduled provider ownership, stamp rendering provider, keep briefing/rooming context, and make note finalization idempotent.
- Keeps legacy `in_progress` compatible while moving physician start to canonical `in_visit`.

## Verification
- `npm test -- src/lib/domain/visit-state.test.ts src/lib/domain/queue-board.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts 'src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts' 'src/app/(clinician)/clinic/patients/[id]/prepare/actions.start-visit-briefing.test.ts' 'src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts' src/lib/clinical/visit-readiness.test.ts` -> 66 tests passed
- `DIRECT_URL=postgresql://user:pass@localhost:5432/db DATABASE_URL=postgresql://user:pass@localhost:5432/db npx prisma validate` -> valid
- `npx prisma generate` -> generated Prisma client
- `npm run typecheck` -> passed
- `git diff --check origin/main..HEAD` -> passed
- `npx eslint --no-eslintrc --config .eslintrc.json --resolve-plugins-relative-to . <touched files>` -> passed

Note: `npm run lint` is blocked in this nested `.worktrees` checkout by a duplicate parent ESLint config conflict, so I linted the touched files directly with the same repo config and plugin resolution.