### PR TITLE
Add pre-visit QR rescue reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/portal
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/portal
 
+# Bare HTTPS portal origin used by pre-visit completion reminders.
+# Leave blank locally to keep those nudges quarantined.
+PREVISIT_PORTAL_URL=
+
 # --- Super-admin bootstrap ---
 # Comma-separated emails that get auto-promoted to super_admin on first
 # sign-in / on `npm run db:seed`. This is the recovery path; once one of

--- a/render.yaml
+++ b/render.yaml
@@ -136,6 +136,8 @@ services:
         value: production
       - key: DATABASE_URL
         sync: false
+      - key: PREVISIT_PORTAL_URL
+        value: https://leafjourney.com
 
 databases:
   - name: emr-postgres

--- a/src/lib/check-in/audit-actions.test.ts
+++ b/src/lib/check-in/audit-actions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { CHECK_IN_AUDIT_ACTIONS } from "./audit-actions";
+
+describe("CHECK_IN_AUDIT_ACTIONS", () => {
+  it("are all namespaced under checkin.* and unique", () => {
+    const values = Object.values(CHECK_IN_AUDIT_ACTIONS);
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) expect(v).toMatch(/^checkin\./);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("cover generation, view, redeem, and failed-attempt", () => {
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_GENERATED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_VIEWED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_REDEEMED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_REDEEM_FAILED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.INTAKE_SUBMITTED).toBeDefined();
+  });
+});

--- a/src/lib/check-in/audit-actions.ts
+++ b/src/lib/check-in/audit-actions.ts
@@ -1,0 +1,26 @@
+// SAFE: dead-export-allowed reason="quarantined QR rescue helper awaiting route wiring"
+// Canonical audit action names for the QR rescue check-in surfaces.
+//
+// Audit rules (security contract): record QR generation, QR view, QR
+// redeem, failed/expired token attempts, and intake submissions. NEVER log raw
+// tokens or free-text PHI — metadata is limited to opaque ids, the QR token
+// *hash* (not the token), milestone/channel, and a failure reason enum.
+//
+// The pre-visit completion reminder audit action lives with the sender as
+// PREVISIT_COMPLETION_REMINDER_ACTION ("previsit.completion.reminder.sent").
+
+export const CHECK_IN_AUDIT_ACTIONS = {
+  /** A QR rescue token was generated for an appointment. */
+  QR_GENERATED: "checkin.qr.generated",
+  /** The QR landing page was viewed (token presented, pre-identity-challenge). */
+  QR_VIEWED: "checkin.qr.viewed",
+  /** A QR token was successfully redeemed (identity verified, single-use spent). */
+  QR_REDEEMED: "checkin.qr.redeemed",
+  /** A QR redemption attempt failed (invalid/expired/mismatch/out-of-window/identity). */
+  QR_REDEEM_FAILED: "checkin.qr.redeem_failed",
+  /** A pre-visit intake item was submitted via the rescue path. */
+  INTAKE_SUBMITTED: "checkin.intake.submitted",
+} as const;
+
+export type CheckInAuditAction =
+  (typeof CHECK_IN_AUDIT_ACTIONS)[keyof typeof CHECK_IN_AUDIT_ACTIONS];

--- a/src/lib/check-in/identity-challenge.test.ts
+++ b/src/lib/check-in/identity-challenge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chooseChallengeMode,
+  verifyCheckInIdentity,
+  type IdentityExpectation,
+} from "./identity-challenge";
+
+const DOB = "1985-04-12";
+
+const withPhone: IdentityExpectation = {
+  dateOfBirth: DOB,
+  lastName: "Rivers",
+  smsCode: "418293",
+  hasPhone: true,
+};
+
+const withoutPhone: IdentityExpectation = {
+  dateOfBirth: DOB,
+  lastName: "Rivers",
+  smsCode: null,
+  hasPhone: false,
+};
+
+describe("chooseChallengeMode", () => {
+  it("prefers DOB + SMS code when a phone is on file and a code was issued", () => {
+    expect(chooseChallengeMode(withPhone)).toBe("dob_sms");
+  });
+
+  it("falls back to DOB + last name (front-desk assisted) without a phone", () => {
+    expect(chooseChallengeMode(withoutPhone)).toBe("dob_lastname");
+  });
+
+  it("falls back to last name when a phone exists but no code was issued yet", () => {
+    expect(chooseChallengeMode({ ...withPhone, smsCode: null })).toBe("dob_lastname");
+  });
+});
+
+describe("verifyCheckInIdentity", () => {
+  it("accepts a correct DOB + SMS code", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, smsCode: "418293" });
+    expect(r).toMatchObject({ ok: true, mode: "dob_sms" });
+  });
+
+  it("rejects a wrong SMS code even with correct DOB", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, smsCode: "000000" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("does NOT accept the last-name fallback when a phone+code exist (must use SMS)", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, lastName: "Rivers" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts DOB + last name when no phone is on file (assisted path)", () => {
+    const r = verifyCheckInIdentity(withoutPhone, { dateOfBirth: DOB, lastName: "rivers" });
+    expect(r).toMatchObject({ ok: true, mode: "dob_lastname" });
+  });
+
+  it("rejects a wrong DOB regardless of the second factor", () => {
+    expect(verifyCheckInIdentity(withoutPhone, { dateOfBirth: "1990-01-01", lastName: "Rivers" }).ok).toBe(false);
+    expect(verifyCheckInIdentity(withPhone, { dateOfBirth: "1990-01-01", smsCode: "418293" }).ok).toBe(false);
+  });
+
+  it("is case- and whitespace-insensitive for last name", () => {
+    const r = verifyCheckInIdentity(withoutPhone, { dateOfBirth: DOB, lastName: "  RIVERS " });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects an empty attempt", () => {
+    expect(verifyCheckInIdentity(withoutPhone, {}).ok).toBe(false);
+    expect(verifyCheckInIdentity(withPhone, {}).ok).toBe(false);
+  });
+});

--- a/src/lib/check-in/identity-challenge.ts
+++ b/src/lib/check-in/identity-challenge.ts
@@ -1,0 +1,76 @@
+// SAFE: dead-export-allowed reason="quarantined QR rescue helper awaiting route wiring"
+// Day-of check-in identity challenge.
+//
+// Older adults shouldn't have to fight portal login in the lobby, so the QR
+// rescue path uses a minimal two-factor challenge instead:
+//   - Preferred: DOB + a one-time SMS code (when a phone is on file AND a code
+//     has been issued).
+//   - Fallback: DOB + last name (front-desk assisted; no phone / no code).
+//
+// This gates ONLY the rescue check-in. Full chart / messages / labs / records
+// still require real portal login. Pure + timing-safe; logs nothing.
+
+import { timingSafeEqual } from "node:crypto";
+
+export type ChallengeMode = "dob_sms" | "dob_lastname";
+
+export interface IdentityExpectation {
+  /** Expected DOB, ISO yyyy-mm-dd. */
+  dateOfBirth: string;
+  /** Expected last name. */
+  lastName: string;
+  /** Expected one-time SMS code, if one was issued. */
+  smsCode: string | null;
+  /** Whether a phone number is on file. */
+  hasPhone: boolean;
+}
+
+export interface IdentityAttempt {
+  dateOfBirth?: string;
+  smsCode?: string;
+  lastName?: string;
+}
+
+export interface IdentityResult {
+  ok: boolean;
+  mode: ChallengeMode;
+}
+
+export function chooseChallengeMode(exp: IdentityExpectation): ChallengeMode {
+  return exp.hasPhone && exp.smsCode != null ? "dob_sms" : "dob_lastname";
+}
+
+function norm(s: string | undefined | null): string {
+  return (s ?? "").trim().toLowerCase();
+}
+
+/** Constant-time-ish equality that also rejects empty expected/attempt values. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length === 0 || ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function verifyCheckInIdentity(
+  expectation: IdentityExpectation,
+  attempt: IdentityAttempt,
+): IdentityResult {
+  const mode = chooseChallengeMode(expectation);
+
+  // DOB is required in both modes.
+  if (!safeEqual(norm(attempt.dateOfBirth), norm(expectation.dateOfBirth))) {
+    return { ok: false, mode };
+  }
+
+  if (mode === "dob_sms") {
+    // Must use the SMS code; last name is NOT accepted when a phone+code exist.
+    const codeOk =
+      expectation.smsCode != null &&
+      safeEqual(norm(attempt.smsCode), norm(expectation.smsCode));
+    return { ok: codeOk, mode };
+  }
+
+  // Fallback: DOB + last name.
+  return { ok: safeEqual(norm(attempt.lastName), norm(expectation.lastName)), mode };
+}

--- a/src/lib/check-in/qr-token.test.ts
+++ b/src/lib/check-in/qr-token.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCheckInToken,
+  hashCheckInToken,
+  parseCheckInToken,
+  verifyCheckInToken,
+  type CheckInVerifyContext,
+} from "./qr-token";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+const APPT = "appt_abc";
+const PATIENT = "pat_xyz";
+
+const NOW = new Date("2026-06-01T15:00:00.000Z");
+const STARTS_AT = new Date("2026-06-01T15:30:00.000Z");
+const ENDS_AT = new Date("2026-06-01T16:00:00.000Z");
+const EXPIRES_AT = new Date("2026-06-01T16:30:00.000Z");
+
+function makeToken() {
+  return createCheckInToken({
+    appointmentId: APPT,
+    patientId: PATIENT,
+    expiresAt: EXPIRES_AT,
+    secret: SECRET,
+    nonce: "nonce-1",
+  });
+}
+
+function ctx(overrides: Partial<CheckInVerifyContext> = {}): CheckInVerifyContext {
+  return {
+    secret: SECRET,
+    now: NOW,
+    appointment: {
+      id: APPT,
+      patientId: PATIENT,
+      status: "confirmed",
+      startAt: STARTS_AT,
+      endAt: ENDS_AT,
+    },
+    storedTokenHash: hashCheckInToken(makeToken().token),
+    redeemedAt: null,
+    ...overrides,
+  };
+}
+
+describe("createCheckInToken", () => {
+  it("produces an opaque token with no PHI and a separate storage hash", () => {
+    const { token, tokenHash, payload } = makeToken();
+    expect(token).not.toMatch(/1985|jordan|rivers|dob/i);
+    expect(tokenHash).not.toEqual(token);
+    expect(tokenHash).toEqual(hashCheckInToken(token));
+    expect(payload.appointmentId).toBe(APPT);
+    expect(payload.patientId).toBe(PATIENT);
+    expect(payload.purpose).toBe("qr_rescue");
+  });
+
+  it("is deterministic for identical inputs so the stored hash matches", () => {
+    const a = makeToken();
+    const b = makeToken();
+    expect(a.token).toEqual(b.token);
+    expect(a.tokenHash).toEqual(b.tokenHash);
+  });
+});
+
+describe("parseCheckInToken", () => {
+  it("rejects a token signed with a different secret", () => {
+    expect(parseCheckInToken(makeToken().token, "wrong-secret")).toBeNull();
+  });
+
+  it("rejects a tampered payload", () => {
+    const { token } = makeToken();
+    const [body, sig] = token.split(".");
+    expect(parseCheckInToken(`${body}x.${sig}`, SECRET)).toBeNull();
+  });
+
+  it("round-trips a valid token to its payload", () => {
+    const { token, payload } = makeToken();
+    expect(parseCheckInToken(token, SECRET)).toEqual(payload);
+  });
+});
+
+describe("verifyCheckInToken", () => {
+  it("accepts a valid, unredeemed, in-window token", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx());
+    expect(r.valid).toBe(true);
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("rejects a bad signature", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx({ secret: "nope" }));
+    expect(r).toMatchObject({ valid: false, reason: "invalid_signature" });
+  });
+
+  it("rejects an expired token", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(EXPIRES_AT.getTime() + 1000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "expired" });
+  });
+
+  it("rejects when the stored hash does not match (rotated/revoked)", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx({ storedTokenHash: "deadbeef" }));
+    expect(r).toMatchObject({ valid: false, reason: "unknown_token" });
+  });
+
+  it("rejects when the token patient != appointment patient", () => {
+    const c = ctx();
+    c.appointment.patientId = "someone_else";
+    const r = verifyCheckInToken(makeToken().token, c);
+    expect(r).toMatchObject({ valid: false, reason: "relationship_mismatch" });
+  });
+
+  it("rejects a non-checkinable appointment status", () => {
+    for (const status of ["cancelled", "completed", "no_show"]) {
+      const r = verifyCheckInToken(
+        makeToken().token,
+        ctx({
+          appointment: { id: APPT, patientId: PATIENT, status, startAt: STARTS_AT, endAt: ENDS_AT },
+        }),
+      );
+      expect(r, `status ${status}`).toMatchObject({
+        valid: false,
+        reason: "appointment_not_checkinable",
+      });
+    }
+  });
+
+  it("rejects when outside the appointment check-in window (too early)", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(STARTS_AT.getTime() - 3 * 60 * 60 * 1000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "outside_window" });
+  });
+
+  it("rejects an already-redeemed token", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ redeemedAt: new Date(NOW.getTime() - 60_000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "already_redeemed" });
+  });
+
+  it("accepts within the early window (default 60m before start)", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(STARTS_AT.getTime() - 30 * 60_000) }),
+    );
+    expect(r.valid).toBe(true);
+  });
+});

--- a/src/lib/check-in/qr-token.ts
+++ b/src/lib/check-in/qr-token.ts
@@ -1,0 +1,221 @@
+// SAFE: dead-export-allowed reason="quarantined QR rescue helper awaiting route wiring"
+// QR "rescue" check-in token.
+//
+// Day-of check-in path for patients (esp. older adults) who can't fight portal
+// login in the lobby. Security contract:
+//   - Appointment-scoped, short-lived, minimal.
+//   - NO PHI in the token or the URL — payload is opaque ids + signature only.
+//   - Signed (HMAC-SHA256) so a tampered/forged token is rejected offline.
+//   - Persisted as a SHA-256 *hash* (never the raw token) so a DB leak can't
+//     replay tokens; redemption matches the presented token's hash against the
+//     stored hash.
+//   - Redemption verifies: signature, expiry, appointment<->patient
+//     relationship, appointment status, the check-in time window, and
+//     single-use (not already redeemed).
+//
+// Pure/deterministic. The DB read (appointment row + stored hash + redeemedAt)
+// is supplied by the caller via CheckInVerifyContext, so the public check-in
+// route (Codex/app layer) owns the Prisma binding. This module never logs.
+
+import { createHmac, createHash, timingSafeEqual } from "node:crypto";
+
+export const CHECK_IN_PURPOSE = "qr_rescue" as const;
+
+/** Default minutes before startAt that a QR check-in becomes valid. */
+export const DEFAULT_EARLY_WINDOW_MINUTES = 60;
+/** Default grace minutes after endAt during which a QR check-in still works. */
+export const DEFAULT_LATE_GRACE_MINUTES = 30;
+
+/** Default token lifetime if a caller wants a helper to compute expiry. */
+export const DEFAULT_TOKEN_TTL_MINUTES = 180;
+
+export interface CheckInTokenPayload {
+  appointmentId: string;
+  patientId: string;
+  /** Expiry as epoch milliseconds. */
+  exp: number;
+  /** Opaque uniqueness so two appointments never collide / aren't guessable. */
+  nonce: string;
+  purpose: typeof CHECK_IN_PURPOSE;
+}
+
+export interface CreateCheckInTokenInput {
+  appointmentId: string;
+  patientId: string;
+  expiresAt: Date;
+  secret: string;
+  nonce: string;
+}
+
+export interface CreatedCheckInToken {
+  /** Opaque token to embed in the QR URL. */
+  token: string;
+  /** SHA-256 hash to persist (never store the raw token). */
+  tokenHash: string;
+  payload: CheckInTokenPayload;
+  expiresAt: Date;
+}
+
+export interface CheckInAppointmentSnapshot {
+  id: string;
+  patientId: string;
+  status: string;
+  startAt: Date;
+  endAt: Date | null;
+}
+
+export interface CheckInVerifyContext {
+  secret: string;
+  now: Date;
+  appointment: CheckInAppointmentSnapshot;
+  /** The hash persisted when the token was generated. */
+  storedTokenHash: string;
+  /** When the token was redeemed, if ever (single-use enforcement). */
+  redeemedAt: Date | null;
+  earlyWindowMinutes?: number;
+  lateGraceMinutes?: number;
+}
+
+export type CheckInVerifyFailure =
+  | "invalid_signature"
+  | "unknown_token"
+  | "relationship_mismatch"
+  | "appointment_not_checkinable"
+  | "already_redeemed"
+  | "expired"
+  | "outside_window";
+
+export interface CheckInVerifyResult {
+  valid: boolean;
+  reason?: CheckInVerifyFailure;
+  payload?: CheckInTokenPayload;
+}
+
+const CHECKINABLE_STATUSES = new Set(["requested", "confirmed"]);
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function sign(body: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(body).digest());
+}
+
+function safeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function hashCheckInToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function createCheckInToken(
+  input: CreateCheckInTokenInput,
+): CreatedCheckInToken {
+  const payload: CheckInTokenPayload = {
+    appointmentId: input.appointmentId,
+    patientId: input.patientId,
+    exp: input.expiresAt.getTime(),
+    nonce: input.nonce,
+    purpose: CHECK_IN_PURPOSE,
+  };
+
+  const body = base64url(Buffer.from(JSON.stringify(payload)));
+  const sig = sign(body, input.secret);
+  const token = `${body}.${sig}`;
+
+  return {
+    token,
+    tokenHash: hashCheckInToken(token),
+    payload,
+    expiresAt: input.expiresAt,
+  };
+}
+
+/** Verify signature + structure. Returns the payload, or null if invalid. */
+export function parseCheckInToken(
+  token: string,
+  secret: string,
+): CheckInTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [body, sig] = parts;
+  if (!safeEqualStr(sig, sign(body, secret))) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const p = parsed as Record<string, unknown>;
+  if (
+    typeof p.appointmentId !== "string" ||
+    typeof p.patientId !== "string" ||
+    typeof p.exp !== "number" ||
+    typeof p.nonce !== "string" ||
+    p.purpose !== CHECK_IN_PURPOSE
+  ) {
+    return null;
+  }
+
+  return {
+    appointmentId: p.appointmentId,
+    patientId: p.patientId,
+    exp: p.exp,
+    nonce: p.nonce,
+    purpose: CHECK_IN_PURPOSE,
+  };
+}
+
+export function verifyCheckInToken(
+  token: string,
+  ctx: CheckInVerifyContext,
+): CheckInVerifyResult {
+  const payload = parseCheckInToken(token, ctx.secret);
+  if (!payload) return { valid: false, reason: "invalid_signature" };
+
+  // The presented token must hash to exactly what we persisted. A rotated or
+  // revoked token (or a stale hash) is "unknown".
+  if (!safeEqualStr(hashCheckInToken(token), ctx.storedTokenHash)) {
+    return { valid: false, reason: "unknown_token", payload };
+  }
+
+  // The appointment<->patient relationship the token claims must match the row.
+  if (
+    payload.appointmentId !== ctx.appointment.id ||
+    payload.patientId !== ctx.appointment.patientId
+  ) {
+    return { valid: false, reason: "relationship_mismatch", payload };
+  }
+
+  if (!CHECKINABLE_STATUSES.has(ctx.appointment.status)) {
+    return { valid: false, reason: "appointment_not_checkinable", payload };
+  }
+
+  if (ctx.redeemedAt != null) {
+    return { valid: false, reason: "already_redeemed", payload };
+  }
+
+  const nowMs = ctx.now.getTime();
+  if (nowMs > payload.exp) {
+    return { valid: false, reason: "expired", payload };
+  }
+
+  const earlyMs =
+    (ctx.earlyWindowMinutes ?? DEFAULT_EARLY_WINDOW_MINUTES) * 60_000;
+  const lateMs = (ctx.lateGraceMinutes ?? DEFAULT_LATE_GRACE_MINUTES) * 60_000;
+  const windowOpens = ctx.appointment.startAt.getTime() - earlyMs;
+  const windowCloses =
+    (ctx.appointment.endAt ?? ctx.appointment.startAt).getTime() + lateMs;
+  if (nowMs < windowOpens || nowMs > windowCloses) {
+    return { valid: false, reason: "outside_window", payload };
+  }
+
+  return { valid: true, payload };
+}

--- a/src/lib/scheduling/previsit-readiness.test.ts
+++ b/src/lib/scheduling/previsit-readiness.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluatePrevisitReadiness,
+  mapSnapshotToGateInput,
+  type PrevisitSnapshot,
+} from "./previsit-readiness";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function fullSnapshot(overrides: Partial<PrevisitSnapshot> = {}): PrevisitSnapshot {
+  return {
+    visitType: "new_patient",
+    treatmentPhase: "intake",
+    isVirtual: false,
+    patient: {
+      dateOfBirth: new Date("1985-04-12T00:00:00.000Z"),
+      addressLine1: "1 Main St",
+      state: "CA",
+      ageVerifiedAt: new Date("2026-05-01T00:00:00.000Z"),
+      allergiesScreenedAt: new Date("2026-05-02T00:00:00.000Z"),
+      cannabisHistory: { priorUse: "occasional" },
+      presentingConcerns: "Chronic lower back pain for 6 months",
+      intakeAnswers: { done: true },
+    },
+    consents: [
+      { templateName: "Visit Consent", version: "1.0", signedAt: new Date("2026-05-10T00:00:00.000Z") },
+    ],
+    coverages: [
+      { type: "primary", active: true, eligibilityStatus: "active" },
+    ],
+    selfPayAttested: false,
+    outcomeLogsSinceLastVisit: 0,
+    ...overrides,
+  };
+}
+
+describe("mapSnapshotToGateInput", () => {
+  it("derives visit consent date from a matching signed consent", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot());
+    expect(input.consent.visitConsentSignedAt).toEqual(new Date("2026-05-10T00:00:00.000Z"));
+    expect(input.consent.telehealthConsentSignedAt).toBeNull();
+  });
+
+  it("derives telehealth consent only from a telehealth-classified consent", () => {
+    const input = mapSnapshotToGateInput(
+      fullSnapshot({
+        isVirtual: true,
+        consents: [
+          { templateName: "Visit Consent", version: "1.0", signedAt: new Date("2026-05-10T00:00:00.000Z") },
+          { templateName: "Telehealth Informed Consent", version: "2.0", signedAt: new Date("2026-05-11T00:00:00.000Z") },
+        ],
+      }),
+    );
+    expect(input.consent.telehealthConsentSignedAt).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+
+  it("treats an active+eligible coverage as coverageVerified", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot());
+    expect(input.insurance.coverageVerified).toBe(true);
+  });
+
+  it("does not treat an inactive or unverified coverage as verified", () => {
+    const input = mapSnapshotToGateInput(
+      fullSnapshot({
+        coverages: [
+          { type: "primary", active: false, eligibilityStatus: "active" },
+          { type: "secondary", active: true, eligibilityStatus: "unknown" },
+        ],
+      }),
+    );
+    expect(input.insurance.coverageVerified).toBe(false);
+  });
+
+  it("passes self-pay attestation through", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot({ selfPayAttested: true, coverages: [] }));
+    expect(input.insurance.selfPayAttested).toBe(true);
+  });
+});
+
+describe("evaluatePrevisitReadiness", () => {
+  it("is ready when a complete snapshot satisfies every blocking requirement", () => {
+    const r = evaluatePrevisitReadiness(fullSnapshot(), NOW);
+    expect(r.isReady).toBe(true);
+    expect(r.missingRequiredIds).toEqual([]);
+    expect(r.completionPct).toBe(1);
+  });
+
+  it("reports the blocking requirement ids that are still missing", () => {
+    const r = evaluatePrevisitReadiness(
+      fullSnapshot({
+        patient: {
+          ...fullSnapshot().patient,
+          presentingConcerns: null,
+          ageVerifiedAt: null,
+        },
+      }),
+      NOW,
+    );
+    expect(r.isReady).toBe(false);
+    // presenting_concerns (always blocking) + id_age_verification (blocking for new_patient)
+    expect(r.missingRequiredIds).toContain("presenting_concerns");
+    expect(r.missingRequiredIds).toContain("id_age_verification");
+    expect(r.completionPct).toBeLessThan(1);
+  });
+
+  it("exposes a non-PHI summary safe for reminder routing decisions", () => {
+    const r = evaluatePrevisitReadiness(
+      fullSnapshot({ patient: { ...fullSnapshot().patient, presentingConcerns: null } }),
+      NOW,
+    );
+    // The summary must carry counts/ids only — never patient identifiers.
+    expect(JSON.stringify(r)).not.toMatch(/1985|Main St|priorUse|back pain/);
+    expect(r.outstandingRequiredCount).toBe(r.missingRequiredIds.length);
+  });
+});

--- a/src/lib/scheduling/previsit-readiness.ts
+++ b/src/lib/scheduling/previsit-readiness.ts
@@ -1,0 +1,268 @@
+// EMR-212 follow-on — DB-to-gate mapper for pre-visit readiness.
+//
+// `evaluateIntakeGate` (./intake-gate) is pure and takes an already-shaped
+// IntakeGateInput. This module is the binding between *stored* patient /
+// appointment / consent / coverage data and that gate:
+//
+//   PrevisitSnapshot  --mapSnapshotToGateInput-->  IntakeGateInput
+//                     --evaluateIntakeGate------->  IntakeGateResult
+//                     --(summarize, drop PHI)----->  PrevisitReadiness
+//
+// The snapshot is deliberately a plain, serializable shape (no Prisma types)
+// so the mapping is unit-testable with zero DB. `loadPrevisitSnapshot` is the
+// thin Prisma read that produces a snapshot; Codex/app layer can swap or extend
+// it without touching the pure mapping/decision logic.
+
+import { prisma } from "@/lib/db/prisma";
+
+import {
+  evaluateIntakeGate,
+  type IntakeGateInput,
+} from "./intake-gate";
+
+// ---------------------------------------------------------------------------
+// Snapshot shape (storage-agnostic)
+// ---------------------------------------------------------------------------
+
+export interface PrevisitConsentRecord {
+  templateName: string;
+  version: string;
+  signedAt: Date;
+}
+
+export interface PrevisitCoverageRecord {
+  type: string;
+  active: boolean;
+  /** Matches PatientCoverage.eligibilityStatus enum, e.g. "active" | "unknown". */
+  eligibilityStatus: string;
+}
+
+export interface PrevisitSnapshot {
+  visitType: IntakeGateInput["visitType"];
+  treatmentPhase: IntakeGateInput["treatmentPhase"];
+  isVirtual: boolean;
+  patient: {
+    dateOfBirth: Date | null;
+    addressLine1: string | null;
+    state: string | null;
+    ageVerifiedAt: Date | null;
+    allergiesScreenedAt: Date | null;
+    cannabisHistory: unknown;
+    presentingConcerns: string | null;
+    intakeAnswers: unknown;
+  };
+  consents: PrevisitConsentRecord[];
+  coverages: PrevisitCoverageRecord[];
+  /** Self-pay attestation captured outside the coverage table. */
+  selfPayAttested: boolean;
+  outcomeLogsSinceLastVisit: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure mapping
+// ---------------------------------------------------------------------------
+
+/** A consent is "telehealth" if its template name mentions telehealth/virtual. */
+function isTelehealthConsent(name: string): boolean {
+  return /telehealth|telemedicine|virtual/i.test(name);
+}
+
+/** A consent is the general visit consent if it is signed and not telehealth. */
+function isVisitConsent(name: string): boolean {
+  return !isTelehealthConsent(name);
+}
+
+function latestSignedAt(
+  consents: PrevisitConsentRecord[],
+  predicate: (name: string) => boolean,
+): Date | null {
+  const matches = consents
+    .filter((c) => predicate(c.templateName))
+    .map((c) => c.signedAt)
+    .filter((d): d is Date => d instanceof Date);
+  if (matches.length === 0) return null;
+  return matches.reduce((a, b) => (b.getTime() > a.getTime() ? b : a));
+}
+
+/** Coverage counts as verified when an active row reports active eligibility. */
+function hasVerifiedCoverage(coverages: PrevisitCoverageRecord[]): boolean {
+  return coverages.some(
+    (c) => c.active && c.eligibilityStatus.toLowerCase() === "active",
+  );
+}
+
+export function mapSnapshotToGateInput(snapshot: PrevisitSnapshot): IntakeGateInput {
+  return {
+    visitType: snapshot.visitType,
+    treatmentPhase: snapshot.treatmentPhase,
+    isVirtual: snapshot.isVirtual,
+    patient: {
+      dateOfBirth: snapshot.patient.dateOfBirth,
+      addressLine1: snapshot.patient.addressLine1,
+      state: snapshot.patient.state,
+      allergiesScreenedAt: snapshot.patient.allergiesScreenedAt,
+      cannabisHistory: snapshot.patient.cannabisHistory,
+      presentingConcerns: snapshot.patient.presentingConcerns,
+      intakeAnswers: snapshot.patient.intakeAnswers,
+      ageVerifiedAt: snapshot.patient.ageVerifiedAt,
+    },
+    consent: {
+      visitConsentSignedAt: latestSignedAt(snapshot.consents, isVisitConsent),
+      telehealthConsentSignedAt: latestSignedAt(snapshot.consents, isTelehealthConsent),
+    },
+    insurance: {
+      coverageVerified: hasVerifiedCoverage(snapshot.coverages),
+      selfPayAttested: snapshot.selfPayAttested,
+    },
+    outcomeLogsSinceLastVisit: snapshot.outcomeLogsSinceLastVisit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Readiness decision (PHI-free summary)
+// ---------------------------------------------------------------------------
+
+export interface PrevisitReadiness {
+  /** True when no *blocking* gate requirement is outstanding. */
+  isReady: boolean;
+  /** Blocking requirement ids still outstanding (no labels/PHI). */
+  missingRequiredIds: string[];
+  /** Count of outstanding blocking requirements (drives nudge metadata). */
+  outstandingRequiredCount: number;
+  /** Completion 0..1 across all requirements (for progress UI). */
+  completionPct: number;
+}
+
+/**
+ * Evaluate readiness from a snapshot. The result is intentionally PHI-free —
+ * only requirement ids and counts — so it is safe to attach to reminder-routing
+ * decisions and audit metadata. `now` is accepted for parity with callers that
+ * key off the current tick; the gate itself is time-independent today.
+ */
+export function evaluatePrevisitReadiness(
+  snapshot: PrevisitSnapshot,
+  _now: Date,
+): PrevisitReadiness {
+  const gate = evaluateIntakeGate(mapSnapshotToGateInput(snapshot));
+  const missingRequiredIds = gate.requirements
+    .filter((r) => r.blocking && !r.satisfied)
+    .map((r) => r.id);
+
+  return {
+    isReady: gate.allowConfirm,
+    missingRequiredIds,
+    outstandingRequiredCount: missingRequiredIds.length,
+    completionPct: gate.completionPct,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prisma loader (thin DB read -> snapshot)
+// ---------------------------------------------------------------------------
+
+const VISIT_TYPE_BY_MODALITY: Record<string, IntakeGateInput["visitType"]> = {
+  // Default mapping; the appointment table tracks modality, not visit type,
+  // so we treat every booked appointment as a new_patient gate unless a richer
+  // visit-type signal is wired in later (Codex handoff).
+};
+
+/**
+ * Load a PrevisitSnapshot for an appointment from the database. This is the
+ * only DB-touching function here; everything above is pure. Returns null when
+ * the appointment (or its patient) can't be found.
+ *
+ * NOTE (Codex handoff): visitType/treatmentPhase are not modeled on Appointment
+ * today, so they default to new_patient/intake. When the visit-state spine adds
+ * those fields, populate them here — the gate + readiness logic already handles
+ * every visit type.
+ */
+export async function loadPrevisitSnapshot(
+  appointmentId: string,
+): Promise<{ snapshot: PrevisitSnapshot; patientId: string; organizationId: string } | null> {
+  const appt = await prisma.appointment.findUnique({
+    where: { id: appointmentId },
+    include: {
+      patient: {
+        include: {
+          signedConsents: {
+            select: { templateName: true, version: true, signedAt: true },
+            orderBy: { signedAt: "desc" },
+            take: 25,
+          },
+          coverages: {
+            where: { active: true },
+            select: { type: true, active: true, eligibilityStatus: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!appt || !appt.patient) return null;
+  const p = appt.patient;
+
+  const outcomeLogsSinceLastVisit = await prisma.outcomeLog.count({
+    where: { patientId: p.id, loggedAt: { gt: lastVisitBefore(appt.startAt) } },
+  });
+
+  const snapshot: PrevisitSnapshot = {
+    visitType: VISIT_TYPE_BY_MODALITY[appt.modality] ?? "new_patient",
+    treatmentPhase: "intake",
+    isVirtual: appt.modality === "video" || appt.modality === "phone",
+    patient: {
+      dateOfBirth: p.dateOfBirth,
+      addressLine1: p.addressLine1,
+      state: p.state,
+      ageVerifiedAt: p.ageVerifiedAt,
+      // allergiesScreenedAt isn't a column; treat a populated allergies/contra
+      // array as "screened". Codex can replace with a real screened-at column.
+      allergiesScreenedAt:
+        p.allergies.length > 0 || p.contraindications.length > 0 ? p.updatedAt : null,
+      cannabisHistory: p.cannabisHistory,
+      presentingConcerns: p.presentingConcerns,
+      intakeAnswers: p.intakeAnswers,
+    },
+    consents: p.signedConsents.map((c) => ({
+      templateName: c.templateName,
+      version: c.version,
+      signedAt: c.signedAt,
+    })),
+    coverages: p.coverages.map((c) => ({
+      type: c.type,
+      active: c.active,
+      eligibilityStatus: String(c.eligibilityStatus),
+    })),
+    selfPayAttested: false,
+    outcomeLogsSinceLastVisit,
+  };
+
+  return { snapshot, patientId: p.id, organizationId: p.organizationId };
+}
+
+/** A coarse "since last visit" floor: 120 days before this appointment. */
+function lastVisitBefore(startAt: Date): Date {
+  return new Date(startAt.getTime() - 120 * 24 * 60 * 60_000);
+}
+
+export interface AppointmentReadiness {
+  readiness: PrevisitReadiness;
+  patientId: string;
+  organizationId: string;
+}
+
+/**
+ * Load + evaluate readiness for an appointment in one call. Returns null when
+ * the appointment can't be found. The returned readiness is PHI-free.
+ */
+export async function getAppointmentReadiness(
+  appointmentId: string,
+  now: Date,
+): Promise<AppointmentReadiness | null> {
+  const loaded = await loadPrevisitSnapshot(appointmentId);
+  if (!loaded) return null;
+  return {
+    readiness: evaluatePrevisitReadiness(loaded.snapshot, now),
+    patientId: loaded.patientId,
+    organizationId: loaded.organizationId,
+  };
+}

--- a/src/lib/scheduling/previsit-reminders.test.ts
+++ b/src/lib/scheduling/previsit-reminders.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const prisma = {
+    appointment: { findMany: vi.fn() },
+    auditLog: { findMany: vi.fn(), create: vi.fn() },
+  };
+  return { prisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
+vi.mock("./previsit-readiness", () => ({
+  getAppointmentReadiness: vi.fn(),
+}));
+
+import {
+  sendDueVisitReminders,
+  sendDuePrevisitCompletionReminders,
+  pickPrevisitMilestone,
+  PREVISIT_COMPLETION_REMINDER_ACTION,
+} from "./send-reminders";
+import { getAppointmentReadiness } from "./previsit-readiness";
+import { getMockSmsAdapter } from "@/lib/sms/adapter";
+
+const { prisma } = hoisted;
+const day = 24 * 60 * 60_000;
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+const PORTAL = "https://portal.leafjourney.com";
+
+function makeAppt(overrides: Partial<any> = {}) {
+  return {
+    id: "appt_1",
+    status: "confirmed",
+    startAt: new Date("2026-06-08T16:00:00.000Z"), // 7 calendar days out
+    modality: "video",
+    patient: { id: "pat_1", firstName: "Maya", phone: "+15551234567", organizationId: "org_1" },
+    provider: { title: "Dr.", user: { firstName: "Sanjay", lastName: "Patel" } },
+    ...overrides,
+  };
+}
+
+const incomplete = {
+  readiness: { isReady: false, missingRequiredIds: ["consent", "insurance_or_attestation"], outstandingRequiredCount: 2, completionPct: 0.6 },
+  patientId: "pat_1",
+  organizationId: "org_1",
+};
+const complete = {
+  readiness: { isReady: true, missingRequiredIds: [], outstandingRequiredCount: 0, completionPct: 1 },
+  patientId: "pat_1",
+  organizationId: "org_1",
+};
+const dueAppointmentReminder = () =>
+  makeAppt({ id: "appt_sms", startAt: new Date("2026-06-08T12:00:00.000Z") });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMockSmsAdapter().reset();
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_FROM_NUMBER;
+  prisma.auditLog.findMany.mockResolvedValue([]);
+  prisma.auditLog.create.mockResolvedValue({});
+});
+
+describe("pickPrevisitMilestone", () => {
+  it("maps 7 / 2 / 0 UTC-calendar-day offsets to milestones", () => {
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-08T09:00:00Z"))).toBe("7day");
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-03T23:00:00Z"))).toBe("2day");
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-01T18:00:00Z"))).toBe("morning_of");
+  });
+
+  it("returns null off-cadence and once the visit has started", () => {
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-05T09:00:00Z"))).toBeNull();
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-01T11:00:00Z"))).toBeNull();
+  });
+});
+
+describe("sendDuePrevisitCompletionReminders", () => {
+  it("sends a PHI-free portal CTA when due + incomplete, then audits it", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1);
+    expect(res.details[0]).toMatchObject({ appointmentId: "appt_1", milestone: "7day", result: "sent" });
+
+    const sent = getMockSmsAdapter().getSent();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe("+15551234567");
+    expect(sent[0].body).toContain(PORTAL);
+    // No PHI in the body or the send context.
+    expect(sent[0].body).not.toMatch(/pat_1|1985|consent|insurance/i);
+    expect(JSON.stringify(sent[0].context ?? {})).not.toMatch(/1985|firstName|lastName|dateOfBirth/i);
+
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+    const data = prisma.auditLog.create.mock.calls[0][0].data;
+    expect(data.action).toBe(PREVISIT_COMPLETION_REMINDER_ACTION);
+    expect(data.subjectId).toBe("appt_1");
+    expect(data.metadata).toMatchObject({ milestone: "7day", outstandingCount: 2 });
+    // audit metadata must not carry the requirement *labels* or any PHI
+    expect(JSON.stringify(data.metadata)).not.toMatch(/1985|firstName|back pain/i);
+  });
+
+  it("does NOT nudge a patient who has completed all required items", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(complete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:complete");
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0);
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("skips appointments off the 7d/2d/morning-of cadence", async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ startAt: new Date("2026-06-05T16:00:00.000Z") }), // 4 days out
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:out-of-window");
+    // readiness shouldn't even be consulted off-cadence
+    expect(getAppointmentReadiness).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — does not resend the same milestone for the same appointment", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+    prisma.auditLog.findMany.mockResolvedValue([{ metadata: { milestone: "7day" } }]);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:already-sent");
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0);
+  });
+
+  it("skips when there is no deliverable channel (no phone on file)", async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ patient: { id: "pat_1", phone: null, organizationId: "org_1" } }),
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:no-channel");
+  });
+
+  it("does not write an audit row when the channel send fails", async () => {
+    // An un-normalizable phone makes the SMS adapter return ok:false.
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ patient: { id: "pat_1", phone: "123", organizationId: "org_1" } }),
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    // "123" fails normalizePhone -> treated as no deliverable channel.
+    expect(res.sent).toBe(0);
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendDueVisitReminders", () => {
+  it("runs appointment reminders and pre-visit completion reminders in one scheduler tick", async () => {
+    prisma.appointment.findMany
+      .mockResolvedValueOnce([dueAppointmentReminder()])
+      .mockResolvedValueOnce([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDueVisitReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.appointment.sent).toBe(1);
+    expect(res.previsit?.sent).toBe(1);
+    expect(getMockSmsAdapter().getSent()).toHaveLength(2);
+  });
+
+  it("quarantines pre-visit nudges when no portal origin is configured", async () => {
+    prisma.appointment.findMany.mockResolvedValueOnce([dueAppointmentReminder()]);
+
+    const res = await sendDueVisitReminders({ now: NOW });
+
+    expect(res.appointment.sent).toBe(1);
+    expect(res.previsit).toBeNull();
+    expect(res.previsitSkippedReason).toBe("portal-url-missing");
+    expect(getAppointmentReadiness).not.toHaveBeenCalled();
+  });
+
+  it("quarantines pre-visit nudges when the portal origin is not a bare HTTPS origin", async () => {
+    prisma.appointment.findMany.mockResolvedValueOnce([dueAppointmentReminder()]);
+
+    const res = await sendDueVisitReminders({
+      now: NOW,
+      portalUrl: "http://portal.leafjourney.com/check-in?appointment=appt_1",
+    });
+
+    expect(res.appointment.sent).toBe(1);
+    expect(res.previsit).toBeNull();
+    expect(res.previsitSkippedReason).toBe("portal-url-invalid");
+    expect(getAppointmentReadiness).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/scheduling/send-reminders.ts
+++ b/src/lib/scheduling/send-reminders.ts
@@ -9,7 +9,12 @@ import {
   renderAppointmentReminder,
   type ReminderOffset,
 } from "@/lib/sms/templates";
+import {
+  renderPrevisitReminder,
+  type PrevisitMilestone,
+} from "@/lib/sms/previsit-templates";
 import { logger } from "@/lib/observability/log";
+import { getAppointmentReadiness } from "./previsit-readiness";
 
 export interface SendDueRemindersInput {
   /** Current time, injected for testability. */
@@ -185,5 +190,251 @@ async function alreadySent(
   return rows.some((r) => {
     const meta = r.metadata as { reminderType?: string } | null;
     return meta?.reminderType === reminderType;
+  });
+}
+
+// ===========================================================================
+// Pre-visit COMPLETION reminders (EMR-212 follow-on)
+//
+// Distinct from the appointment reminders above. These nudge a patient to
+// finish outstanding *intake* requirements through the portal, and are sent
+// ONLY when required items remain incomplete, on a 7d / 2d / morning-of
+// cadence. The copy is STRICTLY PHI-free: it says "you have pre-visit items
+// ready" and links to the bare portal origin — identity/appointment specifics
+// live behind portal login. Sends are idempotent per appointment+milestone and
+// audited with opaque ids + counts only (never labels or PHI).
+// ===========================================================================
+
+/** Audit action for a pre-visit completion nudge. */
+export const PREVISIT_COMPLETION_REMINDER_ACTION =
+  "previsit.completion.reminder.sent" as const;
+
+const PREVISIT_MS_DAY = 24 * 60 * 60_000;
+
+/**
+ * Which completion-reminder milestone (if any) is due today for an appointment
+ * starting at `startAt`. Uses UTC calendar-day offsets so a once-daily job
+ * fires exactly one nudge per milestone. Returns null off-cadence or once the
+ * visit has started.
+ */
+export function pickPrevisitMilestone(
+  now: Date,
+  startAt: Date,
+): PrevisitMilestone | null {
+  if (now.getTime() >= startAt.getTime()) return null;
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(
+    startAt.getUTCFullYear(),
+    startAt.getUTCMonth(),
+    startAt.getUTCDate(),
+  );
+  const days = Math.round((b - a) / PREVISIT_MS_DAY);
+  if (days === 7) return "7day";
+  if (days === 2) return "2day";
+  if (days === 0) return "morning_of";
+  return null;
+}
+
+export interface SendPrevisitRemindersInput {
+  now: Date;
+  /** Generic portal origin; no PHI/path/query (validated by the renderer). */
+  portalUrl: string;
+}
+
+export type PrevisitReminderResult =
+  | "sent"
+  | "skipped:out-of-window"
+  | "skipped:complete"
+  | "skipped:already-sent"
+  | "skipped:no-channel"
+  | "failed";
+
+export interface PrevisitReminderOutcome {
+  appointmentId: string;
+  milestone: PrevisitMilestone | null;
+  result: PrevisitReminderResult;
+  error?: string;
+}
+
+export interface SendPrevisitRemindersResult {
+  sent: number;
+  skipped: number;
+  details: PrevisitReminderOutcome[];
+}
+
+export type PrevisitReminderSkippedReason =
+  | "portal-url-missing"
+  | "portal-url-invalid";
+
+export interface SendDueVisitRemindersInput extends SendDueRemindersInput {
+  /** Bare HTTPS portal origin. If absent/invalid, pre-visit nudges stay quarantined. */
+  portalUrl?: string | null;
+}
+
+export interface SendDueVisitRemindersResult {
+  appointment: SendDueRemindersResult;
+  previsit: SendPrevisitRemindersResult | null;
+  previsitSkippedReason?: PrevisitReminderSkippedReason;
+}
+
+export async function sendDuePrevisitCompletionReminders(
+  input: SendPrevisitRemindersInput,
+): Promise<SendPrevisitRemindersResult> {
+  const now = input.now;
+  const windowEnd = new Date(now.getTime() + 7 * PREVISIT_MS_DAY + 60 * 60_000);
+
+  const appointments = await prisma.appointment.findMany({
+    where: {
+      status: { in: ["requested", "confirmed"] },
+      startAt: { gt: now, lte: windowEnd },
+    },
+    include: {
+      patient: { select: { id: true, phone: true, organizationId: true } },
+    },
+  });
+
+  const details: PrevisitReminderOutcome[] = [];
+  let sent = 0;
+  let skipped = 0;
+
+  for (const appt of appointments) {
+    const milestone = pickPrevisitMilestone(now, appt.startAt);
+    if (!milestone) {
+      details.push({ appointmentId: appt.id, milestone: null, result: "skipped:out-of-window" });
+      skipped += 1;
+      continue;
+    }
+
+    // Only nudge patients with outstanding required items.
+    const readiness = await getAppointmentReadiness(appt.id, now);
+    if (!readiness || readiness.readiness.isReady) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:complete" });
+      skipped += 1;
+      continue;
+    }
+
+    const phone = normalizePhone(appt.patient.phone);
+    if (!phone) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:no-channel" });
+      skipped += 1;
+      continue;
+    }
+
+    if (await alreadySentPrevisit(appt.id, milestone)) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:already-sent" });
+      skipped += 1;
+      continue;
+    }
+
+    const body = renderPrevisitReminder(milestone, { portalUrl: input.portalUrl });
+    const adapter = getSmsAdapter();
+    const res = await adapter.send({
+      to: phone,
+      body,
+      // Context is for delivery/idempotency only — opaque ids, no PHI.
+      context: { appointmentId: appt.id, milestone, kind: "previsit_completion" },
+    });
+
+    if (!res.ok) {
+      details.push({ appointmentId: appt.id, milestone, result: "failed", error: res.error });
+      logger.warn({
+        event: "scheduler.previsit.reminder.failed",
+        appointmentId: appt.id,
+        milestone,
+        error: res.error,
+      });
+      continue;
+    }
+
+    await prisma.auditLog.create({
+      data: {
+        organizationId: appt.patient.organizationId,
+        actorAgent: "scheduler:previsitCompletionReminder@1.0.0",
+        action: PREVISIT_COMPLETION_REMINDER_ACTION,
+        subjectType: "Appointment",
+        subjectId: appt.id,
+        // PHI-free metadata: milestone, channel, and a count of outstanding
+        // required items. Never the requirement labels or any patient field.
+        metadata: {
+          milestone,
+          channel: "sms",
+          messageId: res.messageId,
+          adapter: res.adapter,
+          outstandingCount: readiness.readiness.outstandingRequiredCount,
+        } as any,
+      },
+    });
+
+    details.push({ appointmentId: appt.id, milestone, result: "sent" });
+    sent += 1;
+  }
+
+  return { sent, skipped, details };
+}
+
+export async function sendDueVisitReminders(
+  input: SendDueVisitRemindersInput,
+): Promise<SendDueVisitRemindersResult> {
+  const appointment = await sendDueAppointmentReminders(input);
+  const portal = normalizePrevisitPortalOrigin(input.portalUrl);
+
+  if (!portal.ok) {
+    return {
+      appointment,
+      previsit: null,
+      previsitSkippedReason: portal.reason,
+    };
+  }
+
+  const previsit = await sendDuePrevisitCompletionReminders({
+    now: input.now,
+    portalUrl: portal.portalUrl,
+  });
+
+  return { appointment, previsit };
+}
+
+function normalizePrevisitPortalOrigin(
+  portalUrl: string | null | undefined,
+):
+  | { ok: true; portalUrl: string }
+  | { ok: false; reason: PrevisitReminderSkippedReason } {
+  const trimmed = portalUrl?.trim();
+  if (!trimmed) return { ok: false, reason: "portal-url-missing" };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, reason: "portal-url-invalid" };
+  }
+
+  const hasExtras =
+    (parsed.pathname && parsed.pathname !== "/") ||
+    parsed.search !== "" ||
+    parsed.hash !== "";
+  if (parsed.protocol !== "https:" || hasExtras) {
+    return { ok: false, reason: "portal-url-invalid" };
+  }
+
+  return { ok: true, portalUrl: parsed.origin };
+}
+
+async function alreadySentPrevisit(
+  appointmentId: string,
+  milestone: PrevisitMilestone,
+): Promise<boolean> {
+  const rows = await prisma.auditLog.findMany({
+    where: {
+      action: PREVISIT_COMPLETION_REMINDER_ACTION,
+      subjectType: "Appointment",
+      subjectId: appointmentId,
+    },
+    select: { metadata: true },
+    take: 10,
+  });
+  return rows.some((r) => {
+    const meta = r.metadata as { milestone?: string } | null;
+    return meta?.milestone === milestone;
   });
 }

--- a/src/lib/sms/previsit-templates.test.ts
+++ b/src/lib/sms/previsit-templates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREVISIT_PORTAL_CTA,
+  renderPrevisitReminder,
+  type PrevisitMilestone,
+} from "./previsit-templates";
+
+const PORTAL = "https://portal.leafjourney.com";
+
+// Tokens that would indicate PHI leaked into the copy. NONE of these are passed
+// into the renderer, so none may ever appear in the output for any milestone.
+const PHI_NEEDLES = [
+  "maya",
+  "patel",
+  "1985",
+  "diagnos",
+  "cannabis",
+  "insurance",
+  "allerg",
+  "mrn",
+  "+1555",
+  "appointment with dr",
+];
+
+const MILESTONES: PrevisitMilestone[] = ["7day", "2day", "morning_of"];
+
+describe("renderPrevisitReminder", () => {
+  it("includes the portal origin and a generic CTA", () => {
+    const body = renderPrevisitReminder("7day", { portalUrl: PORTAL });
+    expect(body).toContain(PORTAL);
+    expect(body).toContain(PREVISIT_PORTAL_CTA);
+  });
+
+  it("never contains PHI for any milestone", () => {
+    for (const milestone of MILESTONES) {
+      const body = renderPrevisitReminder(milestone, { portalUrl: PORTAL }).toLowerCase();
+      for (const needle of PHI_NEEDLES) {
+        expect(body, `milestone ${milestone} leaked "${needle}"`).not.toContain(needle);
+      }
+    }
+  });
+
+  it("keeps the body within a single SMS segment and links exactly once", () => {
+    for (const milestone of MILESTONES) {
+      const body = renderPrevisitReminder(milestone, { portalUrl: PORTAL });
+      expect(body.length).toBeLessThanOrEqual(160);
+      const urls = body.match(/https?:\/\/\S+/g) ?? [];
+      expect(urls).toHaveLength(1);
+    }
+  });
+
+  it("uses morning-of urgency wording only for the morning_of milestone", () => {
+    expect(renderPrevisitReminder("morning_of", { portalUrl: PORTAL }).toLowerCase()).toContain(
+      "today",
+    );
+    expect(renderPrevisitReminder("7day", { portalUrl: PORTAL }).toLowerCase()).not.toContain(
+      "today",
+    );
+  });
+
+  it("rejects a portal url that smuggles a path/query (a PHI carrier)", () => {
+    expect(() =>
+      renderPrevisitReminder("7day", { portalUrl: `${PORTAL}/appt/appt_1?dob=1985-01-01` }),
+    ).toThrow(/portal url/i);
+  });
+
+  it("rejects a non-https portal url", () => {
+    expect(() => renderPrevisitReminder("7day", { portalUrl: "http://portal.leafjourney.com" })).toThrow(
+      /portal url/i,
+    );
+  });
+});

--- a/src/lib/sms/previsit-templates.ts
+++ b/src/lib/sms/previsit-templates.ts
@@ -1,0 +1,67 @@
+// Pre-visit *completion* reminder copy. STRICTLY no PHI.
+//
+// This is distinct from the appointment reminders in ./templates.ts (which
+// greet the patient by name and name the provider). A pre-visit completion
+// nudge is sent only when required intake items remain incomplete, and it must
+// reveal nothing about the patient, the visit, or the clinical context — it
+// says only "you have pre-visit items ready" and links to the bare portal
+// origin. Identity/appointment specifics live behind portal login.
+//
+// Kept pure + deterministic so the "no PHI" property is unit-testable and the
+// nudge can be sent from a cron tick with no token cost.
+
+export type PrevisitMilestone = "7day" | "2day" | "morning_of";
+
+export interface PrevisitReminderInput {
+  /** Generic portal origin, e.g. https://portal.leafjourney.com. No path/query. */
+  portalUrl: string;
+}
+
+export const PREVISIT_PORTAL_CTA = "Finish your pre-visit check-in";
+
+const URGENCY: Record<PrevisitMilestone, string> = {
+  "7day": "before your upcoming visit",
+  "2day": "before your visit in 2 days",
+  morning_of: "before your visit today",
+};
+
+/**
+ * Guard against a portal URL carrying a path/query/hash — a classic vector for
+ * smuggling an appointment id / DOB / token into otherwise "no PHI" copy. We
+ * only ever link to the bare https origin.
+ */
+function assertGenericPortalUrl(portalUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(portalUrl);
+  } catch {
+    throw new Error(`Invalid portal url: ${portalUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("Invalid portal url: must be https");
+  }
+  const hasExtras =
+    (parsed.pathname && parsed.pathname !== "/") ||
+    parsed.search !== "" ||
+    parsed.hash !== "";
+  if (hasExtras) {
+    throw new Error(
+      "Invalid portal url: pre-visit reminders link to the bare origin only (no path/query/hash)",
+    );
+  }
+  return parsed.origin;
+}
+
+/**
+ * Render the SMS/email/push body for a pre-visit completion nudge. Single
+ * sentence + single link so it fits one SMS segment and reads the same across
+ * channels. No greeting-by-name (PHI) — the CTA stands on its own.
+ */
+export function renderPrevisitReminder(
+  milestone: PrevisitMilestone,
+  input: PrevisitReminderInput,
+): string {
+  const origin = assertGenericPortalUrl(input.portalUrl);
+  const urgency = URGENCY[milestone];
+  return `You have pre-visit items ready. ${PREVISIT_PORTAL_CTA} ${urgency}: ${origin}`;
+}

--- a/src/workers/scheduler.ts
+++ b/src/workers/scheduler.ts
@@ -6,20 +6,25 @@
 
 import { prisma } from "../lib/db/prisma";
 import { dispatch } from "../lib/orchestration/dispatch";
-import { sendDueAppointmentReminders } from "../lib/scheduling/send-reminders";
+import { sendDueVisitReminders } from "../lib/scheduling/send-reminders";
 import { getDefaultAdapter } from "../lib/billing/clearinghouse/gateway";
 import { parse999, parse277CA, decide277Actions } from "../lib/billing/clearinghouse-ack";
 import { recordDeadLetter } from "../lib/billing/clearinghouse/dead-letter";
 import { derivePrimaryControlNumbers } from "../lib/agents/billing/clearinghouse-submission-agent";
 import { writeAgentAudit } from "../lib/orchestration/context";
 
+function resolvePrevisitPortalUrl(env: NodeJS.ProcessEnv): string | null {
+  return env.PREVISIT_PORTAL_URL ?? env.NEXT_PUBLIC_APP_URL ?? env.APP_URL ?? null;
+}
+
 async function main() {
   console.log("[scheduler] tick");
+  const now = new Date();
 
   // 1. Outcome tracker refresh for every active patient that's been active
   //    in the last 30 days but has no check-in logged in the last 5 days.
-  const cutoffActive = new Date(Date.now() - 30 * 86400000);
-  const cutoffCheckin = new Date(Date.now() - 5 * 86400000);
+  const cutoffActive = new Date(now.getTime() - 30 * 86400000);
+  const cutoffCheckin = new Date(now.getTime() - 5 * 86400000);
 
   const patients = await prisma.patient.findMany({
     where: {
@@ -35,12 +40,12 @@ async function main() {
       name: "encounter.completed",
       encounterId: `virtual:${p.id}`,
       patientId: p.id,
-      completedAt: new Date(),
+      completedAt: now,
     });
   }
 
   // 2. Intake stalled nudge for prospects with incomplete intake > 48h.
-  const cutoffStalled = new Date(Date.now() - 48 * 3600000);
+  const cutoffStalled = new Date(now.getTime() - 48 * 3600000);
   const stalled = await prisma.patient.findMany({
     where: {
       status: "prospect",
@@ -62,8 +67,8 @@ async function main() {
   //    The scheduler runs every 15 minutes; gating on hour+minute keeps
   //    this fleet-wide scan to a single execution per day.
   let adherenceEnqueued = 0;
-  const utcHour = new Date().getUTCHours();
-  const utcMinute = new Date().getUTCMinutes();
+  const utcHour = now.getUTCHours();
+  const utcMinute = now.getUTCMinutes();
   if (utcHour === 9 && utcMinute < 15) {
     const withActiveRegimen = await prisma.patient.findMany({
       where: {
@@ -88,7 +93,7 @@ async function main() {
   //    KPI dashboard, and CFO narrative briefing.
   let cfoEnqueued = 0;
   const isMondayMorning =
-    new Date().getUTCDay() === 1 && utcHour === 6 && utcMinute < 15;
+    now.getUTCDay() === 1 && utcHour === 6 && utcMinute < 15;
   if (isMondayMorning) {
     const orgs = await prisma.organization.findMany({ select: { id: true } });
     for (const o of orgs) {
@@ -103,7 +108,7 @@ async function main() {
 
   // 5. CFO monthly briefing — 1st of month, 07:00 UTC.
   const isFirstOfMonth =
-    new Date().getUTCDate() === 1 && utcHour === 7 && utcMinute < 15;
+    now.getUTCDate() === 1 && utcHour === 7 && utcMinute < 15;
   if (isFirstOfMonth) {
     const orgs = await prisma.organization.findMany({ select: { id: true } });
     for (const o of orgs) {
@@ -116,16 +121,22 @@ async function main() {
     cfoEnqueued += orgs.length;
   }
 
-  // 6. SMS appointment reminders — 7 days, 2 days, 1 day before the
-  //    appointment start. The scheduler runs every 15 minutes; the helper
-  //    scans every upcoming appointment within a 7d+1h window and sends
-  //    the SMS whose target window covers `now`. Idempotency is enforced
-  //    inside the helper via AuditLog.
-  const reminderResult = await sendDueAppointmentReminders({ now: new Date() });
+  // 6. Visit SMS reminders. Appointment reminders always run; pre-visit
+  //    completion nudges only run when a bare HTTPS portal origin is configured.
+  const reminderResult = await sendDueVisitReminders({
+    now,
+    portalUrl: resolvePrevisitPortalUrl(process.env),
+  });
+  const previsitSent = reminderResult.previsit?.sent ?? 0;
+  const previsitSkipped = reminderResult.previsit?.skipped ?? 0;
+  const previsitQuarantine = reminderResult.previsitSkippedReason
+    ? ` quarantine=${reminderResult.previsitSkippedReason}`
+    : "";
 
   console.log(
     `[scheduler] enqueued outcome=${patients.length} stalled=${stalled.length} adherence=${adherenceEnqueued} cfo=${cfoEnqueued} ` +
-      `sms=${reminderResult.sent} (skipped=${reminderResult.skipped})`,
+      `sms=${reminderResult.appointment.sent} (skipped=${reminderResult.appointment.skipped}) ` +
+      `previsit=${previsitSent} (skipped=${previsitSkipped}${previsitQuarantine})`,
   );
 
   // 6. Clearinghouse functional/payer acknowledgment polling


### PR DESCRIPTION
## Summary
- Add QR rescue/check-in helpers for opaque tokens, identity challenge, and PHI-minimal audit actions.
- Add appointment readiness and PHI-free pre-visit completion reminder helpers with idempotent audit logging.
- Wire the scheduler to run appointment reminders plus pre-visit nudges, with missing/invalid portal origins quarantining only the new nudges.
- Configure the Render scheduler with `PREVISIT_PORTAL_URL=https://leafjourney.com` and document the local kill switch in `.env.example`.

## Verification
- `npm test -- src/lib/check-in/audit-actions.test.ts src/lib/check-in/identity-challenge.test.ts src/lib/check-in/qr-token.test.ts src/lib/scheduling/previsit-readiness.test.ts src/lib/scheduling/previsit-reminders.test.ts src/lib/scheduling/send-reminders.test.ts src/lib/sms/previsit-templates.test.ts` — 59 tests passed.
- `npm test` — 235 files / 2,293 tests passed.
- `npm run typecheck` — passed.
- `DIRECT_URL=postgresql://postgres:postgres@localhost:5432/emr DATABASE_URL=postgresql://postgres:postgres@localhost:5432/emr npx prisma validate` — passed.
- `npm run manifests:lint` — passed.
- `npx eslint --no-eslintrc --config .eslintrc.json --resolve-plugins-relative-to . <touched files>` — passed. Local `next lint` is blocked by the nested worktree ESLint plugin conflict; CI will run it from a normal checkout.
- `DATABASE_URL=postgresql://user:pass@localhost:5432/ci DIRECT_URL=postgresql://user:pass@localhost:5432/ci SESSION_SECRET=ci-placeholder-secret-value-at-least-32-chars npm run build` — passed; emitted only existing baseline static-generation/database warnings with the placeholder DB.