### PR TITLE
fix: harden patient chart structured intake display

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -63,6 +63,12 @@ import { BirthdayBadge } from "@/components/patient/birthday-badge";
 import { logger } from "@/lib/observability/log";
 import { BirthdayBanner } from "./birthday-banner";
 import { MessagePatientDock } from "@/app/(clinician)/clinic/messages/dock-compose";
+import {
+  formatDemographicValue,
+  formatEmergencyContact,
+  formatInsuranceMemberId,
+  formatInsurancePlan,
+} from "@/lib/patient/chart-demographics";
 // UX inline editing — Notion / Linear-style click-to-edit on chart
 // demographics + insurance. See src/components/ui/inline-edit.tsx.
 import { InlineDemographicsCard } from "./inline-demographics-card";
@@ -946,14 +952,15 @@ function DemographicsTab({
   const intake = (patient.intakeAnswers ?? {}) as Record<string, any>;
   const pmh = pastConditions;
   const psh = pastSurgeries;
-  const sex = intake.sex ?? intake.gender ?? "Not recorded";
-  const race = intake.race ?? intake.ethnicity ?? "Not recorded";
-  const maritalStatus = intake.maritalStatus ?? "Not recorded";
+  const sex = formatDemographicValue(intake.sex ?? intake.gender);
+  const race = formatDemographicValue(intake.race ?? intake.ethnicity);
+  const maritalStatus = formatDemographicValue(intake.maritalStatus);
   const allergies = intake.allergies ?? patient.chartSummary?.allergies ?? "None documented";
-  const uniqueThing = intake.uniqueThing ?? intake.aboutYou ?? null;
-  const insurancePlan = intake.insurancePlan ?? intake.insurance ?? "Not on file";
-  const insuranceId = intake.insuranceId ?? intake.memberId ?? null;
-  const emergencyContact = intake.emergencyContact ?? null;
+  const uniqueThing =
+    formatDemographicValue(intake.uniqueThing ?? intake.aboutYou, "") || null;
+  const insurancePlan = formatInsurancePlan(intake);
+  const insuranceId = formatInsuranceMemberId(intake);
+  const emergencyContact = formatEmergencyContact(intake.emergencyContact);
 
   return (
     <div className="space-y-6">
@@ -1061,10 +1068,7 @@ function DemographicsTab({
               <DemoField label="Marital status" value={maritalStatus} />
               <DemoField label="Patient ID" value={patient.id.slice(0, 12).toUpperCase()} mono />
               {emergencyContact && (
-                <DemoField
-                  label="Emergency contact"
-                  value={typeof emergencyContact === "string" ? emergencyContact : `${emergencyContact.name} — ${emergencyContact.phone}`}
-                />
+                <DemoField label="Emergency contact" value={emergencyContact} />
               )}
               {age != null && (
                 <DemoField label="Age" value={`${age} (${ageBand})`} />

--- a/src/lib/patient/chart-demographics.test.ts
+++ b/src/lib/patient/chart-demographics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDemographicValue,
+  formatEmergencyContact,
+  formatInsuranceMemberId,
+  formatInsurancePlan,
+} from "./chart-demographics";
+
+describe("chart demographics display helpers", () => {
+  it("formats structured insurance without returning a React-hostile object", () => {
+    const plan = formatInsurancePlan({
+      insurance: {
+        providerName: "Blue Shield",
+        planName: "Gold PPO",
+        memberId: "MEM-123",
+      },
+    });
+
+    expect(plan).toBe("Blue Shield - Gold PPO");
+  });
+
+  it("finds a member id inside structured insurance", () => {
+    expect(
+      formatInsuranceMemberId({
+        insurance: { providerName: "Blue Shield", memberId: "MEM-123" },
+      }),
+    ).toBe("MEM-123");
+  });
+
+  it("keeps demographic text renderable when intake stores arrays or objects", () => {
+    expect(formatDemographicValue(["Asian", "White"])).toBe("Asian, White");
+    expect(formatDemographicValue({ label: "Declined" })).toBe("Declined");
+    expect(formatDemographicValue({ unexpected: true })).toBe("Not recorded");
+  });
+
+  it("formats structured emergency contacts defensively", () => {
+    expect(formatEmergencyContact({ name: "Ava", phone: "555-0100" })).toBe(
+      "Ava - 555-0100",
+    );
+    expect(formatEmergencyContact({ name: "Ava" })).toBe("Ava");
+  });
+});

--- a/src/lib/patient/chart-demographics.ts
+++ b/src/lib/patient/chart-demographics.ts
@@ -1,0 +1,114 @@
+type Intake = Record<string, unknown>;
+
+function asText(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function objectText(
+  value: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const text = asText(value[key]);
+    if (text) return text;
+  }
+  return null;
+}
+
+export function formatDemographicValue(
+  value: unknown,
+  fallback = "Not recorded",
+): string {
+  const scalar = asText(value);
+  if (scalar) return scalar;
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => formatDemographicValue(item, ""))
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join(", ") : fallback;
+  }
+
+  if (value && typeof value === "object") {
+    const text = objectText(value as Record<string, unknown>, [
+      "label",
+      "display",
+      "name",
+      "value",
+      "text",
+      "title",
+    ]);
+    return text ?? fallback;
+  }
+
+  return fallback;
+}
+
+export function formatInsurancePlan(intake: Intake): string {
+  const explicit = asText(intake.insurancePlan);
+  if (explicit) return explicit;
+
+  const insurance = intake.insurance;
+  const scalar = asText(insurance);
+  if (scalar) return scalar;
+
+  if (insurance && typeof insurance === "object" && !Array.isArray(insurance)) {
+    const record = insurance as Record<string, unknown>;
+    const payer = objectText(record, [
+      "providerName",
+      "payerName",
+      "carrier",
+      "company",
+      "name",
+    ]);
+    const plan = objectText(record, ["planName", "plan", "planType"]);
+    const parts = [payer, plan].filter((part): part is string => Boolean(part));
+    return parts.length > 0 ? parts.join(" - ") : "On file";
+  }
+
+  return "Not on file";
+}
+
+export function formatInsuranceMemberId(intake: Intake): string | null {
+  const topLevel = asText(intake.insuranceId) ?? asText(intake.memberId);
+  if (topLevel) return topLevel;
+
+  const insurance = intake.insurance;
+  if (insurance && typeof insurance === "object" && !Array.isArray(insurance)) {
+    return objectText(insurance as Record<string, unknown>, [
+      "memberId",
+      "subscriberId",
+      "policyNumber",
+      "id",
+    ]);
+  }
+
+  return null;
+}
+
+export function formatEmergencyContact(value: unknown): string | null {
+  const scalar = asText(value);
+  if (scalar) return scalar;
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const name = objectText(record, ["name", "fullName", "contactName"]);
+  const relationship = objectText(record, ["relationship"]);
+  const phone = objectText(record, ["phone", "phoneNumber", "mobile"]);
+  const email = objectText(record, ["email"]);
+  const parts = [name, relationship, phone, email].filter(
+    (part): part is string => Boolean(part),
+  );
+
+  return parts.length > 0 ? parts.join(" - ") : null;
+}


### PR DESCRIPTION
## Summary
- Normalize structured intake values before rendering the patient demographics tab.
- Format structured insurance and emergency contact payloads into strings.
- Add regression coverage for JSON/array/object intake shapes that can otherwise crash the Server Component render.

## Root cause
The production patient chart can receive structured intake JSON for fields such as `insurance`, `race`, `sex`, `maritalStatus`, `uniqueThing`, or `emergencyContact`. The demographics tab rendered some of those values directly, so an object could reach React as a child and trigger the generic production Server Components error boundary.

## Validation
- `npm test -- src/lib/patient/chart-demographics.test.ts`
- `npm run typecheck`

## Production note
This is code-only and does not change PHI storage, auth, or permissions. The separate Clerk production-key warning still needs the Render/Clerk environment update.