### PR TITLE
feat(clinic): physician visit spine hardening

### DIFF
--- a/launch_overnight_sprint.sh
+++ b/launch_overnight_sprint.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Century Blitz Overnight Sprint Orchestrator
+# Dispatches 8 parallel Claude agents to tackle 101 tickets in conflict-free tracks.
+
+export PATH="/Users/scottwayman/.hermes/node/bin:/usr/local/bin:$PATH"
+mkdir -p .agents/logs
+
+echo "===================================================================="
+echo "🌙 Starting Century Blitz Overnight Sprint (101 Tickets, 8 Tracks) 🌙"
+echo "===================================================================="
+
+# Ensure we are in the correct directory
+cd /Users/scottwayman/EMR
+
+# Track 1: UI/UX Consolidation & Urgent Bugs (11 tickets)
+echo "Dispatching Track 1 (UI/UX & Portal Consolidation)..."
+nohup claude --permission-mode auto --worktree sprint-track-1-ux-consolidation -p "You are assigned to Phase 12 Track 1: UI/UX Consolidation & Urgent Bugs. Complete the following tickets:
+- EMR-117: iOS Portrait Mode Nav
+- EMR-119: Tab Consolidation Audit
+- EMR-122: In-App Translation + Captions
+- EMR-124: Tab Reduction (dup of EMR-119)
+- EMR-128: Universal Feedback Icon with Annotation
+- EMR-133: Patient Medication Explainer (3rd grade + cartoons)
+- EMR-134: Emotional Vitals Emoji Scale in APSO Notes
+- EMR-138: Mindfulness Emojis for Lifestyle
+- EMR-150: Cannabis Combo Wheel on Patient Tab + Landing Page
+- EMR-157: Fix Claude Processing GIF Scroll Glitch
+- EMR-201: Cannabis Combo Wheel — colors POP + larger wheel & letters
+
+Focus strictly on frontend layouts, styles, and components in src/components/ and src/app/portal/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_1.log 2>&1 &
+
+# Track 2: Clinical Workflows & Charting (10 tickets)
+echo "Dispatching Track 2 (Clinical Workflows & Charting)..."
+nohup claude --permission-mode auto --worktree sprint-track-2-clinical-workflows -p "You are assigned to Phase 12 Track 2: Clinical Workflows & Charting. Complete the following tickets:
+- EMR-129: Provider Breathing Break Popup (30-min timer)
+- EMR-131: AI Clinic Notes with Guardrails + Snapshot + APSO
+- EMR-132: Charting Timer (selling point vs other EMRs)
+- EMR-135: Voice Dictation (better than Dragon)
+- EMR-141: Patient Imaging Tab (Read-Only Annotations)
+- EMR-155: Hover-Over Lab/Result Explanations (Canopy/Enterprise)
+- EMR-158: Collapsible/Expandable Patient Outcomes Check-Ins
+- EMR-159: Remove or Merge 'Care Plan' Patient Tab
+- EMR-162: Rework My Story → Focus on Storybook
+- EMR-163: Create 'My Results' Patient Tab
+
+Work within src/app/(clinician)/ and src/components/clinical/. Do not modify the database or billing layers. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_2.log 2>&1 &
+
+# Track 3: AI Scheduling Engine & Automation (15 tickets)
+echo "Dispatching Track 3 (AI Scheduling Engine)..."
+nohup claude --permission-mode auto --worktree sprint-track-3-scheduling-engine -p "You are assigned to Phase 12 Track 3: AI Scheduling Engine & Automation. Complete the following tickets:
+- EMR-012: Scheduling Module + SMS
+- EMR-120: Medicare RPM Integration
+- EMR-121: Master Access Log + Click Analytics
+- EMR-103: Practice Analytics Deep Dive
+- EMR-104: Click Counter / Workflow Efficiency
+- EMR-206: Self-Serve Online Scheduling
+- EMR-207: No-Show Prediction Model + De-Risking
+- EMR-208: Algorithmic Follow-Up Cadence per Condition
+- EMR-209: Smart Slot Recommender
+- EMR-210: Intelligent Waitlist + Cancellation Fill
+- EMR-211: Multi-Channel Reminder Orchestration
+- EMR-212: New-Patient Intake-to-Visit Gate Pipeline
+- EMR-213: Group Visit + Block + Recurring Scheduling
+- EMR-214: Provider Preference Engine + Burnout Guardrails
+- EMR-215: Scheduling Analytics Cockpit
+
+Implement schemas, algorithms, and interfaces in src/lib/scheduling/ and src/app/(operator)/ops/schedule/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_3.log 2>&1 &
+
+# Track 4: EDI Claims & Reimbursement (15 tickets)
+echo "Dispatching Track 4 (EDI Claims & Reimbursement)..."
+nohup claude --permission-mode auto --worktree sprint-track-4-edi-claims -p "You are assigned to Phase 12 Track 4: EDI Claims & Reimbursement. Complete the following tickets:
+- EMR-045: Insurance Billing AI Agents
+- EMR-101: Full CPT/ICD-10 Code Book + Superbills
+- EMR-102: Novel Cannabis ICD-10 Code Proposal
+- EMR-107: Expected Reimbursement Rate
+- EMR-108: Full Revenue Cycle System
+- EMR-116: International Multi-Country Billing
+- EMR-145: Cannabis Dispensary Billing + CMS $500 Reimbursement
+- EMR-216: Real EDI 837P generator (ANSI X12 v5010)
+- EMR-217: Availity/Waystar/Change Healthcare gateway client
+- EMR-218: Payer rules → DB model + admin editor
+- EMR-219: Secondary claim filing (Loop 2320 CAS)
+- EMR-220: Provider + Organization NPI + Tax ID schema
+- EMR-222: Full NCCI / MUE reference table (CMS quarterly)
+- EMR-223: Per-payer contract allowable tables
+- EMR-229: Prior-auth workflow + payer portal adapters
+
+Implement these features inside src/lib/billing/ and src/app/(operator)/ops/billing/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_4.log 2>&1 &
+
+# Track 5: Financial Operations & Lockbox (15 tickets)
+echo "Dispatching Track 5 (Financial Operations & Lockbox)..."
+nohup claude --permission-mode auto --worktree sprint-track-5-financial-ops -p "You are assigned to Phase 12 Track 5: Financial Operations & Lockbox. Complete the following tickets:
+- EMR-068: Patient Billing Portal
+- EMR-076: AI Prior Authorization
+- EMR-105: Philanthropy / Donations Module
+- EMR-106: Hospital System Integration
+- EMR-114: Credit Card + ACH Storage
+- EMR-115: EOB Into Portals
+- EMR-127: Leafjourney Charitable Fund + Transparent Ledger
+- EMR-172: Patient Mail/Fax OCR Scan + Insurance Cross-Check
+- EMR-221: ERA / 835 raw-file ingestion pipeline
+- EMR-224: Lockbox / bank deposit matching
+- EMR-225: Patient statement auto-generator + e-delivery
+- EMR-226: Payment plan engine + card-on-file autopay
+- EMR-227: NSF / chargeback handler
+- EMR-228: Appeal tracker + outcome learning loop
+- EMR-230: RCM daily-close report + exception dashboard
+
+Implement ERA parser, lockbox matcher, and operations dashboard under src/lib/billing/ and src/app/(operator)/ops/revenue/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_5.log 2>&1 &
+
+# Track 6: Gamification, Loyalty & Rebrand (10 tickets)
+echo "Dispatching Track 6 (Gamification & Loyalty)..."
+nohup claude --permission-mode auto --worktree sprint-track-6-gamification-loyalty -p "You are assigned to Phase 12 Track 6: Gamification, Loyalty & Rebrand. Complete the following tickets:
+- EMR-061: Motivational Quotes
+- EMR-072: Lifestyle Checkboxes → Plant Growth
+- EMR-125: Volunteer & Donation Module (Constitutional Art. VII)
+- EMR-126: Provider CME Credits via Research
+- EMR-151: Symptom/Diagnosis Supplement Combo Wheel
+- EMR-152: Heart-Centric EMR Consciousness (Art. IV)
+- EMR-161: Merge Achievements + Lifestyle + Wearable Integration
+- EMR-176: Make EMR Fun and Engaging for ALL Users
+- EMR-313: Loyalty/points system + gift cards
+- EMR-314: Rebrand to 'Seed Trove' / nurture-harvest-fruit lexicon
+
+Work in src/components/gamification/ and src/app/portal/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_6.log 2>&1 &
+
+# Track 7: Leafmart Marketplace & Growth (12 tickets)
+echo "Dispatching Track 7 (Leafmart Marketplace & Growth)..."
+nohup claude --permission-mode auto --worktree sprint-track-7-marketplace-growth -p "You are assigned to Phase 12 Track 7: Leafmart Marketplace & Growth. Complete the following tickets:
+- EMR-007: AI-Powered Supply Store
+- EMR-153: Marketing + Business Plan + Target Groups
+- EMR-156: Subscription Pricing vs EPIC/Cerner/Practice Fusion
+- EMR-170: C-Suite About Page Skeleton
+- EMR-188: Integrated Marketplace/Store — Amazon-style ecosystem inside EMR
+- EMR-302: Distributor model
+- EMR-303: Rival Amazon benchmark
+- EMR-305: Product Q&A tab
+- EMR-306: Reviews with photos
+- EMR-307: AI-curated Product Details
+- EMR-310: Checkout Compare sim
+- EMR-315: Vendor tax docs + analytics dashboards
+
+Work in src/app/shop/, src/app/vendor/, and src/components/store/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_7.log 2>&1 &
+
+# Track 8: Education & Clinical Integrations (13 tickets)
+echo "Dispatching Track 8 (Education & Clinical Integrations)..."
+nohup claude --permission-mode auto --worktree sprint-track-8-education-integrations -p "You are assigned to Phase 12 Track 8: Clinical Education & Integrations. Complete the following tickets:
+- EMR-002: Dispensary Integration & SKU Scanning
+- EMR-003: Milligram-Based Dosing Display
+- EMR-013: Conventional EMR Integration
+- EMR-017: Dispensary Locator (Google Maps)
+- EMR-018: Leafly Strain Database Integration
+- EMR-071: AI Chatbot + DoxGPT
+- EMR-080: Cannabis Education Library
+- EMR-111: Cannabis Education Database
+- EMR-173: 15-Day Cannabis EMR Launch Readiness
+- EMR-179: Research Articles Hyperlinked + Open in New Tab
+- EMR-202: Education page — Justin Kander research PDF under Research tab
+- EMR-203: LeafJourney Trifold Reference Guide (cannabinoids + terpenes + bioavailability)
+- EMR-204: Landing page — fix 'POTENCY 710' label + remove unconfirmed partner brands
+
+Work in src/lib/integrations/ and src/app/education/. Ensure all TS checks and lints pass. Commit and create a PR to main." > .agents/logs/sprint_track_8.log 2>&1 &
+
+echo "===================================================================="
+echo "✅ All 8 parallel tracks have been successfully dispatched!"
+echo "You can monitor logs at:"
+echo "  tail -f .agents/logs/sprint_track_1.log"
+echo "  tail -f .agents/logs/sprint_track_2.log"
+echo "  tail -f .agents/logs/sprint_track_3.log"
+echo "  tail -f .agents/logs/sprint_track_4.log"
+echo "  tail -f .agents/logs/sprint_track_5.log"
+echo "  tail -f .agents/logs/sprint_track_6.log"
+echo "  tail -f .agents/logs/sprint_track_7.log"
+echo "  tail -f .agents/logs/sprint_track_8.log"
+echo "===================================================================="

--- a/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — physician visit spine.
+ * startVisit must reuse today's existing scheduled/in_progress encounter
+ * instead of minting a duplicate, and expose a readiness handoff.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    note: { findFirst: vi.fn() },
+    agentJob: { findMany: vi.fn() },
+    provider: { findFirst: vi.fn() },
+  };
+  return {
+    mockPrisma,
+    requireUserMock: vi.fn(),
+    dispatchMock: vi.fn(),
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { startVisit, getVisitReadiness } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function scheduledEncounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "sched_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    startedAt: null,
+    completedAt: null,
+    providerId: null,
+    renderingProviderId: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.findMany.mockResolvedValue([]);
+  mockPrisma.provider.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...scheduledEncounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.create.mockResolvedValue(scheduledEncounter({ id: "new_enc", status: "in_progress" }));
+  mockPrisma.note.findFirst.mockResolvedValue(null);
+  mockPrisma.agentJob.findMany.mockResolvedValue([]);
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("startVisit — encounter selection", () => {
+  it("reuses today's scheduled encounter instead of creating a duplicate", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+    // The reused encounter is advanced into the visit.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "sched_1" } }),
+    );
+  });
+
+  it("advances a reused scheduled encounter before short-circuiting to its note", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+    mockPrisma.note.findFirst.mockResolvedValue({ id: "note_9" });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/notes\/note_9/);
+
+    // The encounter must be marked in-progress even though we jump to the note.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "sched_1" },
+        data: expect.objectContaining({ status: "in_progress" }),
+      }),
+    );
+  });
+
+  it("creates a fresh in_progress encounter only when none exists today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startVisit — provider attribution", () => {
+  it("Dr B starting Dr A's scheduled encounter preserves ownership and stamps rendering provider", async () => {
+    // Dr A owns today's scheduled encounter; Dr B (current user) starts the visit.
+    const drA = scheduledEncounter({ providerId: "prov_A", renderingProviderId: null });
+    mockPrisma.encounter.findMany.mockResolvedValue([drA]);
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_B" });
+    // Preserve row fields across the advance update so assignVisitProvider sees provA.
+    const row: any = { ...drA };
+    mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => {
+      Object.assign(row, data);
+      return { ...row, id: where.id };
+    });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    // Rendering provider stamped to Dr B...
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "sched_1" },
+      data: { renderingProviderId: "prov_B" },
+    });
+    // ...and providerId (Dr A) is never reassigned.
+    const providerIdWrites = mockPrisma.encounter.update.mock.calls.filter(
+      (c) => c[0]?.data && "providerId" in c[0].data,
+    );
+    expect(providerIdWrites).toHaveLength(0);
+  });
+
+  it("claims an unowned reused encounter for the current provider", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({ status: "in_progress", providerId: null }),
+    ]);
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_B" });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "sched_1" },
+      data: { providerId: "prov_B" },
+    });
+  });
+});
+
+describe("startVisit — auth parity", () => {
+  it("redirects unauthorized (no notes.edit) users away", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    await expect(startVisit("patient_1")).rejects.toThrow(/error=unauthorized/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the chart is restricted and the user is not allowlisted", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(
+      patient({ chartRestricted: true, restrictedProviderIds: ["other_doc"] }),
+    );
+    await expect(startVisit("patient_1")).rejects.toThrow(/error=restricted/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("getVisitReadiness", () => {
+  it("returns a rooming/readiness handoff for today's encounter", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({
+        briefingContext: { intakeCompleted: true, patientDemeanor: "calm", patientSummary: "x" },
+      }),
+    ]);
+
+    const result = await getVisitReadiness("patient_1");
+    expect(result.hasEncounter).toBe(true);
+    expect(result.intakeCompleted).toBe(true);
+    expect(result.patientDemeanor).toBe("calm");
+  });
+
+  it("reports no encounter when none is active today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    const result = await getVisitReadiness("patient_1");
+    expect(result.hasEncounter).toBe(false);
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.ts
@@ -13,6 +13,16 @@ import {
   requirePermission,
 } from "@/lib/rbac/permissions";
 import { encodeSourceRef } from "@/lib/domain/unresolved-followups";
+import {
+  advanceVisitState,
+  assignVisitProvider,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
+} from "@/lib/domain/visit-state";
+import {
+  summarizeVisitReadiness,
+  type VisitReadiness,
+} from "@/lib/clinical/visit-readiness";
 
 /**
  * Start a visit: find or create an in-progress encounter for today,
@@ -52,21 +62,34 @@ export async function startVisit(patientId: string) {
     redirect(`/clinic/patients/${patientId}?tab=notes&error=not_found`);
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  // Prefer reusing today's existing scheduled/in_progress encounter (the
+  // patient was booked, checked-in, or roomed) before minting a new one —
+  // otherwise the front desk's encounter and the physician's diverge into
+  // duplicate encounters and duplicate downstream automation. Selection +
+  // transition go through the shared visit-state spine.
+  const currentProvider = await resolveProviderForUser(user.id, user.organizationId!);
 
-  let encounter = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      status: "in_progress",
-      createdAt: { gte: todayStart, lte: todayEnd },
-    },
-  });
+  let encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
 
-  if (!encounter) {
+  if (encounter) {
+    // Advance to in-progress FIRST — idempotent, never touches briefingContext —
+    // so a reused scheduled encounter is marked "with provider" even when we
+    // short-circuit to an already-drafted note below. Otherwise the queue board
+    // would still show the patient as waiting while the doc is documenting.
+    encounter = (await advanceVisitState(encounter, "in_visit", user.id)).encounter;
+
+    // Record who is rendering this visit without stealing a scheduled
+    // encounter's ownership (claims providerId if unset; else renderingProviderId).
+    encounter = await assignVisitProvider(encounter, currentProvider?.id ?? null);
+
+    const existingNote = await prisma.note.findFirst({
+      where: { encounterId: encounter.id },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existingNote) {
+      redirect(`/clinic/patients/${patientId}/notes/${existingNote.id}`);
+    }
+  } else {
     encounter = await prisma.encounter.create({
       data: {
         organizationId: user.organizationId!,
@@ -76,6 +99,7 @@ export async function startVisit(patientId: string) {
         reason: "Visit",
         startedAt: new Date(),
         scheduledFor: new Date(),
+        providerId: currentProvider?.id ?? undefined,
       },
     });
   }
@@ -122,6 +146,20 @@ export async function startVisit(patientId: string) {
   } else {
     redirect(`/clinic/patients/${patientId}?tab=notes&scribe=processing`);
   }
+}
+
+/**
+ * Rooming / pre-visit readiness handoff for today's encounter. Lets the chart
+ * and note-start path show the physician what the front desk and pre-visit
+ * surfaces already prepared (intake done, patient confirmed, briefing ready,
+ * emoji demeanor) before they start documenting. Read-only; gated by the same
+ * baseline chart access as opening the chart.
+ */
+export async function getVisitReadiness(patientId: string): Promise<VisitReadiness> {
+  const user = await requireUser();
+  await assertChartAccess(user, patientId);
+  const encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
+  return summarizeVisitReadiness(encounter);
 }
 
 export async function saveAllergy(patientId: string, drugName: string, reaction: string) {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — note finalization must be idempotent:
+ *  - note.finalized dispatched only on the transition into finalized
+ *  - encounter.completed dispatched only on the transition into complete
+ *  - one timestamp shared by DB writes and the event payload
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+    note: { findUnique: vi.fn(), update: vi.fn(), count: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn(), dispatchMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/orchestration/runner", () => ({ runTick: vi.fn(), runJob: vi.fn() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { finalizeNote, saveAndFinalizeNote } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function note(over: Record<string, unknown> = {}) {
+  return {
+    id: "note_1",
+    encounterId: "enc_1",
+    status: "draft",
+    aiDrafted: false,
+    blocks: [],
+    authorUserId: null,
+    encounter: { id: "enc_1", patientId: "patient_1", status: "in_progress" },
+    ...over,
+  };
+}
+
+function encounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "in_progress",
+    startedAt: new Date("2026-05-29T15:00:00.000Z"),
+    completedAt: null,
+    ...over,
+  };
+}
+
+function dispatchCount(name: string) {
+  return dispatchMock.mock.calls.filter((c) => c[0]?.name === name).length;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(encounter());
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...encounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.note.findUnique.mockResolvedValue(note());
+  mockPrisma.note.update.mockResolvedValue(note({ status: "finalized" }));
+  mockPrisma.note.count.mockResolvedValue(0);
+  mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("finalizeNote idempotency", () => {
+  it("dispatches note.finalized + encounter.completed once on a fresh finalize", async () => {
+    const res = await finalizeNote("note_1");
+    expect(res).toEqual({ ok: true, status: "finalized" });
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(1);
+  });
+
+  it("does NOT re-dispatch when the note is already finalized", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "finalized" }));
+
+    const res = await finalizeNote("note_1");
+
+    expect(res.ok).toBe(true);
+    expect(dispatchCount("note.finalized")).toBe(0);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("dispatches note.finalized but NOT encounter.completed when the encounter is already complete", async () => {
+    // Second note on an encounter that a prior note already completed.
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ id: "note_2", encounter: { id: "enc_1", patientId: "patient_1", status: "complete" } }),
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(encounter({ status: "complete", completedAt: new Date() }));
+
+    await finalizeNote("note_2");
+
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+  });
+
+  it("uses one shared timestamp for the note write, encounter write, and event payload", async () => {
+    await finalizeNote("note_1");
+
+    const noteFinalizedAt = mockPrisma.note.update.mock.calls
+      .map((c) => c[0]?.data?.finalizedAt)
+      .find(Boolean) as Date;
+    const encounterCompletedAt = mockPrisma.encounter.update.mock.calls
+      .map((c) => c[0]?.data?.completedAt)
+      .find(Boolean) as Date;
+    const eventCompletedAt = dispatchMock.mock.calls
+      .map((c) => (c[0]?.name === "encounter.completed" ? c[0].completedAt : undefined))
+      .find(Boolean) as Date;
+
+    expect(noteFinalizedAt).toBeInstanceOf(Date);
+    expect(encounterCompletedAt.getTime()).toBe(noteFinalizedAt.getTime());
+    expect(eventCompletedAt.getTime()).toBe(noteFinalizedAt.getTime());
+  });
+
+  it("stamps chartingCompletedAt only when not already set, with the shared timestamp", async () => {
+    await finalizeNote("note_1");
+
+    expect(mockPrisma.encounter.updateMany).toHaveBeenCalledWith({
+      where: { id: "enc_1", chartingCompletedAt: null },
+      data: { chartingCompletedAt: expect.any(Date) },
+    });
+    const chartingAt = mockPrisma.encounter.updateMany.mock.calls[0][0].data.chartingCompletedAt;
+    const noteFinalizedAt = mockPrisma.note.update.mock.calls
+      .map((c) => c[0]?.data?.finalizedAt)
+      .find(Boolean) as Date;
+    expect(chartingAt.getTime()).toBe(noteFinalizedAt.getTime());
+  });
+});
+
+describe("saveAndFinalizeNote idempotency", () => {
+  const BLOCKS = [{ heading: "Subjective", body: "patient reports..." }];
+
+  it("dispatches note.finalized + encounter.completed once on a fresh save+finalize", async () => {
+    const res = await saveAndFinalizeNote("note_1", BLOCKS);
+    expect(res).toEqual({ ok: true, status: "finalized" });
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(1);
+  });
+
+  it("does NOT re-dispatch or re-write when the note is already finalized", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "finalized" }));
+
+    const res = await saveAndFinalizeNote("note_1", BLOCKS);
+
+    expect(res.ok).toBe(true);
+    expect(dispatchCount("note.finalized")).toBe(0);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fire encounter.completed when the encounter is already complete", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ id: "note_2", encounter: { id: "enc_1", patientId: "patient_1", status: "complete" } }),
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(encounter({ status: "complete", completedAt: new Date() }));
+
+    await saveAndFinalizeNote("note_2", BLOCKS);
+
+    expect(dispatchCount("note.finalized")).toBe(1);
+    expect(dispatchCount("encounter.completed")).toBe(0);
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -30,6 +30,7 @@ import {
   PATIENT_DEMEANOR_OPTIONS,
   type PatientDemeanor,
 } from "@/lib/domain/notes";
+import { advanceVisitState } from "@/lib/domain/visit-state";
 
 const blockSchema = z.object({
   heading: z.string(),
@@ -135,6 +136,15 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     }
     throw err;
   }
+
+  // Idempotent finalize — a note already finalized must NOT re-run the
+  // transition side effects. dispatch() has no dedup, so a second
+  // note.finalized / encounter.completed duplicates physician tasks, patient
+  // outreach drafts, and clinical observations. Short-circuit on the terminal
+  // state (the cosign path below is reached only by non-finalized notes).
+  if (note.status === "finalized") {
+    return { ok: true, status: "finalized" };
+  }
   // EMR-784: Before finalizing, ensure an AI-drafted note still carries
   // the patient verbal-consent disclaimer. Defends against a clinician
   // deleting it during cleanup before signing.
@@ -165,27 +175,37 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     return { ok: true, status: "pending_cosign" };
   }
 
+  // One timestamp shared by the note write, the encounter completion, and the
+  // event payloads — so DB rows and downstream automation agree on the instant.
+  const finalizedAt = new Date();
+
   await prisma.note.update({
     where: { id: noteId },
     data: {
       ...(blocksAtFinalize ? { blocks: blocksAtFinalize as any } : {}),
       status: "finalized",
-      finalizedAt: new Date(),
+      finalizedAt,
       authorUserId: user.id,
     },
   });
 
-  // Also mark the encounter as complete
-  await prisma.encounter.update({
-    where: { id: note.encounterId },
-    data: { status: "complete", completedAt: new Date() },
-  });
+  // Move the encounter to complete through the visit-state spine.
+  // `transitioned` is true only on the actual transition into complete, so a
+  // second note finalizing on an already-complete encounter does not re-fire
+  // encounter.completed.
+  const { transitioned: encounterCompleted } = await advanceVisitState(
+    encounter,
+    "complete",
+    user.id,
+    { at: finalizedAt },
+  );
 
   // If every note for this encounter is now finalized, stamp
   // chartingCompletedAt so the Clinical Flow tile can compute carryover.
-  await markChartingCompletedIfReady(note.encounterId);
+  await markChartingCompletedIfReady(note.encounterId, finalizedAt);
 
-  // Dispatch note.finalized → triggers Coding Agent + Physician Nudge Agent
+  // note.finalized → Coding Agent + Physician Nudge Agent. This call is the
+  // transition into finalized (guarded above), so it fires exactly once.
   await dispatch({
     name: "note.finalized",
     noteId,
@@ -193,13 +213,16 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
     finalizedBy: user.id,
   });
 
-  // Dispatch encounter.completed → triggers Patient Outreach Agent
-  await dispatch({
-    name: "encounter.completed",
-    encounterId: note.encounterId,
-    patientId: encounter.patientId,
-    completedAt: new Date(),
-  });
+  // encounter.completed → Patient Outreach / Outcome agents. Only on the
+  // transition into complete.
+  if (encounterCompleted) {
+    await dispatch({
+      name: "encounter.completed",
+      encounterId: note.encounterId,
+      patientId: encounter.patientId,
+      completedAt: finalizedAt,
+    });
+  }
 
   // In dev, run the queue inline so coding suggestions appear immediately
   if (process.env.NODE_ENV !== "production") {
@@ -216,15 +239,20 @@ export async function finalizeNote(noteId: string): Promise<SaveNoteResult> {
  * documentation-complete marker, distinct from completedAt (= when the
  * physician stopped seeing the patient).
  */
-async function markChartingCompletedIfReady(encounterId: string): Promise<void> {
+async function markChartingCompletedIfReady(
+  encounterId: string,
+  at: Date = new Date(),
+): Promise<void> {
   const unfinalized = await prisma.note.count({
     where: { encounterId, status: { not: "finalized" } },
   });
   if (unfinalized > 0) return;
 
-  await prisma.encounter.update({
-    where: { id: encounterId },
-    data: { chartingCompletedAt: new Date() },
+  // Stamp only if not already set — preserve the FIRST completion instant so a
+  // note added to an already-charted encounter doesn't rewrite history.
+  await prisma.encounter.updateMany({
+    where: { id: encounterId, chartingCompletedAt: null },
+    data: { chartingCompletedAt: at },
   });
 }
 
@@ -263,6 +291,11 @@ export async function saveAndFinalizeNote(
     }
     throw err;
   }
+  // Idempotent finalize — see finalizeNote. An already-finalized note must not
+  // re-dispatch the transition events (dispatch() has no dedup).
+  if (note.status === "finalized") {
+    return { ok: true, status: "finalized" };
+  }
   // EMR-784: AI-drafted notes (voice/ambient scribe) must keep the
   // patient verbal-consent disclaimer through finalize, even if the
   // clinician edited it out.
@@ -289,12 +322,15 @@ export async function saveAndFinalizeNote(
     return { ok: true, status: "pending_cosign" };
   }
 
+  // One shared timestamp for the note write, encounter completion, and events.
+  const finalizedAt = new Date();
+
   await prisma.note.update({
     where: { id: noteId },
     data: {
       blocks: blocksToFinalize as any,
       status: "finalized",
-      finalizedAt: new Date(),
+      finalizedAt,
       authorUserId: user.id,
     },
   });
@@ -312,15 +348,18 @@ export async function saveAndFinalizeNote(
     });
   }
 
-  // Also mark the encounter as complete
-  await prisma.encounter.update({
-    where: { id: note.encounterId },
-    data: { status: "complete", completedAt: new Date() },
-  });
+  // Move the encounter to complete via the visit-state spine — transition-gated
+  // so encounter.completed fires exactly once.
+  const { transitioned: encounterCompleted } = await advanceVisitState(
+    encounter,
+    "complete",
+    user.id,
+    { at: finalizedAt },
+  );
 
   // If every note for this encounter is now finalized, stamp
   // chartingCompletedAt so the Clinical Flow tile can compute carryover.
-  await markChartingCompletedIfReady(note.encounterId);
+  await markChartingCompletedIfReady(note.encounterId, finalizedAt);
 
   // Dispatch note.finalized → triggers Coding Agent + Physician Nudge Agent
   await dispatch({
@@ -330,13 +369,16 @@ export async function saveAndFinalizeNote(
     finalizedBy: user.id,
   });
 
-  // Dispatch encounter.completed → triggers Patient Outreach Agent
-  await dispatch({
-    name: "encounter.completed",
-    encounterId: note.encounterId,
-    patientId: encounter.patientId,
-    completedAt: new Date(),
-  });
+  // Dispatch encounter.completed → triggers Patient Outreach Agent. Only on the
+  // transition into complete.
+  if (encounterCompleted) {
+    await dispatch({
+      name: "encounter.completed",
+      encounterId: note.encounterId,
+      patientId: encounter.patientId,
+      completedAt: finalizedAt,
+    });
+  }
 
   if (process.env.NODE_ENV !== "production") {
     await runTick("inline-dev", 4);

--- a/src/app/(clinician)/clinic/patients/[id]/prepare/actions.start-visit-briefing.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prepare/actions.start-visit-briefing.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Hardening sprint — startVisitWithBriefing must reach parity with startVisit:
+ * same permission + chart-privacy gates, reuse today's encounter, and MERGE
+ * (never overwrite) briefingContext so rooming/demeanor data survives.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+    note: { findFirst: vi.fn() },
+    agentJob: { findMany: vi.fn() },
+    provider: { findFirst: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn(), dispatchMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/agents/pre-visit-intelligence-agent", () => ({
+  preVisitIntelligenceAgent: { run: vi.fn() },
+}));
+vi.mock("@/lib/orchestration/model-client", () => ({ resolveModelClient: vi.fn() }));
+vi.mock("@/lib/orchestration/tool-registry", () => ({ buildToolRegistry: vi.fn() }));
+
+import { startVisitWithBriefing } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function scheduledEncounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "sched_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    startedAt: null,
+    completedAt: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+const BRIEFING = {
+  patientSummary: "62yo chronic low back pain",
+  lastVisitSummary: null,
+  talkingPoints: ["tolerability"],
+  sections: [],
+  riskFlags: [],
+  confidence: 0.8,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.findMany.mockResolvedValue([]);
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...scheduledEncounter(),
+    id: where.id,
+    ...data,
+  }));
+  mockPrisma.encounter.create.mockResolvedValue(
+    scheduledEncounter({ id: "new_enc", status: "in_progress" }),
+  );
+  mockPrisma.note.findFirst.mockResolvedValue(null);
+  mockPrisma.agentJob.findMany.mockResolvedValue([]);
+  mockPrisma.provider.findFirst.mockResolvedValue(null);
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("startVisitWithBriefing — permission + chart-privacy parity", () => {
+  it("denies users without notes.edit (front office)", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(
+      /error=unauthorized/,
+    );
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("denies a restricted chart when the user is not allowlisted", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(
+      patient({ chartRestricted: true, restrictedProviderIds: ["other_doc"] }),
+    );
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(
+      /error=restricted/,
+    );
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("startVisitWithBriefing — encounter selection", () => {
+  it("reuses today's scheduled encounter instead of creating a duplicate", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduledEncounter()]);
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(/redirect:/);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("startVisitWithBriefing — briefingContext merge", () => {
+  it("preserves existing rooming/demeanor keys while attaching the briefing", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([
+      scheduledEncounter({
+        briefingContext: {
+          patientDemeanor: "calm",
+          patientDemeanorRecordedAt: "2026-05-29T14:00:00.000Z",
+          intakeCompleted: true,
+        },
+      }),
+    ]);
+
+    await expect(startVisitWithBriefing("patient_1", BRIEFING)).rejects.toThrow(/redirect:/);
+
+    // The merged briefingContext must keep demeanor/intake AND add the briefing.
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          briefingContext: expect.objectContaining({
+            patientDemeanor: "calm",
+            intakeCompleted: true,
+            patientSummary: "62yo chronic low back pain",
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts
@@ -5,6 +5,17 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { dispatch } from "@/lib/orchestration/dispatch";
+import {
+  ForbiddenError,
+  assertChartAccess,
+  hasPermission,
+} from "@/lib/rbac/permissions";
+import {
+  advanceVisitState,
+  assignVisitProvider,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
+} from "@/lib/domain/visit-state";
 import { preVisitIntelligenceAgent } from "@/lib/agents/pre-visit-intelligence-agent";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
 import { buildToolRegistry } from "@/lib/orchestration/tool-registry";
@@ -77,23 +88,14 @@ export async function generateBriefing(patientId: string): Promise<BriefingResul
   // attached. Passing encounterId here lets the Schedule tile's brief line
   // and any other downstream surface read the briefing the moment it's
   // generated, without waiting for the physician to start the visit.
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
-
-  const encounterForBriefing = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      OR: [
-        { status: "in_progress" },
-        { scheduledFor: { gte: todayStart, lte: todayEnd } },
-      ],
-    },
-    orderBy: [{ status: "asc" }, { scheduledFor: "asc" }],
-    select: { id: true },
-  });
+  // Attach the briefing to the SAME encounter startVisitWithBriefing will
+  // later reuse — via the shared visit-state selector — so briefing data and
+  // the started visit never land on different rows (incl. same-day walk-ins,
+  // which the old in_progress-OR-scheduled query missed).
+  const encounterForBriefing = await selectActiveVisitEncounter(
+    patientId,
+    user.organizationId!,
+  );
 
   // Build a mock context that captures logs as steps
   const logs: AgentLogEntry[] = [];
@@ -189,6 +191,23 @@ export async function startVisitWithBriefing(
 ) {
   const user = await requireUser();
 
+  // EMR-786 parity with startVisit — starting a (briefed) visit requires
+  // write access to clinical notes. Front/back-office staff are denied.
+  if (!hasPermission(user, "notes.edit")) {
+    redirect(`/clinic/patients/${patientId}?tab=notes&error=unauthorized`);
+  }
+
+  // Chart-privacy gate — a doctor-only chart the user is not allowlisted for
+  // must reject start-visit even with global notes.edit.
+  try {
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      redirect(`/clinic/patients/${patientId}?tab=notes&error=restricted`);
+    }
+    throw err;
+  }
+
   const patient = await prisma.patient.findFirst({
     where: {
       id: patientId,
@@ -200,19 +219,11 @@ export async function startVisitWithBriefing(
     redirect(`/clinic/patients/${patientId}?tab=notes&error=not_found`);
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
+  // Reuse today's scheduled/in_progress encounter before minting a new one —
+  // same selection as startVisit, via the shared visit-state spine.
+  const currentProvider = await resolveProviderForUser(user.id, user.organizationId!);
 
-  let encounter = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      status: "in_progress",
-      createdAt: { gte: todayStart, lte: todayEnd },
-    },
-  });
+  let encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
 
   if (!encounter) {
     encounter = await prisma.encounter.create({
@@ -224,16 +235,33 @@ export async function startVisitWithBriefing(
         reason: "Visit",
         startedAt: new Date(),
         scheduledFor: new Date(),
+        providerId: currentProvider?.id ?? undefined,
         // Store the briefing context so the scribe can use it
         briefingContext: briefing ? (briefing as any) : undefined,
       },
     });
-  } else if (briefing) {
-    // Update existing encounter with briefing
-    await prisma.encounter.update({
-      where: { id: encounter.id },
-      data: { briefingContext: briefing as any },
-    });
+  } else {
+    // Capture the existing context BEFORE advancing — rooming/demeanor/intake
+    // keys written by the front desk and saveEmotionalVital must survive.
+    const existingCtx =
+      encounter.briefingContext && typeof encounter.briefingContext === "object"
+        ? (encounter.briefingContext as Record<string, unknown>)
+        : {};
+
+    // Advance the reused encounter into the visit (idempotent).
+    encounter = (await advanceVisitState(encounter, "in_visit", user.id)).encounter;
+
+    // Record the rendering provider without stealing scheduled ownership.
+    encounter = await assignVisitProvider(encounter, currentProvider?.id ?? null);
+
+    if (briefing) {
+      // MERGE, never overwrite — the scribe reads patientSummary/talkingPoints/
+      // riskFlags/sections; every other writer uses disjoint keys.
+      await prisma.encounter.update({
+        where: { id: encounter.id },
+        data: { briefingContext: { ...existingCtx, ...briefing } as any },
+      });
+    }
   }
 
   // Dispatch the scribe event

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/voice-recorder.tsx
@@ -562,7 +562,6 @@ export function VoiceRecorder({
   // Billing & Sign-off States
   const [acceptedCodes, setAcceptedCodes] = useState<string[]>([]);
   const [isSignOffModalOpen, setIsSignOffModalOpen] = useState(false);
-  const [signOffPassword, setSignOffPassword] = useState("");
   const [signOffError, setSignOffError] = useState<string | null>(null);
   const [isFinalizing, setIsFinalizing] = useState(false);
 
@@ -1555,7 +1554,7 @@ export function VoiceRecorder({
         </div>
       )}
 
-      {/* ── Sign-off Password Modal ────────────────── */}
+      {/* ── Sign-off Confirmation Modal ────────────────── */}
       {isSignOffModalOpen && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
           <div className="bg-surface p-6 rounded-xl border border-border shadow-2xl max-w-md w-full space-y-4 animate-in fade-in zoom-in-95 duration-150 text-left">
@@ -1563,33 +1562,22 @@ export function VoiceRecorder({
               <span className="text-2xl">✍️</span>
               <div>
                 <h3 className="font-display font-semibold text-text text-base">
-                  Clinician Sign-off Signature
+                  Clinician Sign-off Confirmation
                 </h3>
                 <p className="text-xs text-text-subtle">
-                  Enter your clinician password to sign this medical record.
+                  Are you sure you want to finalize and sign this clinical note? This action is legally binding.
                 </p>
               </div>
             </div>
 
-            <div className="space-y-2">
-              <label className="text-xs font-semibold text-text block">Password Required</label>
-              <input
-                type="password"
-                value={signOffPassword}
-                onChange={(e) => setSignOffPassword(e.target.value)}
-                placeholder="Enter password (e.g. password)"
-                className="w-full text-sm text-text bg-surface border border-border rounded-lg p-2.5 focus:outline-none focus:ring-1 focus:ring-accent"
-              />
-              {signOffError && (
-                <p className="text-xs text-danger font-medium">{signOffError}</p>
-              )}
-            </div>
+            {signOffError && (
+              <p className="text-xs text-danger font-medium">{signOffError}</p>
+            )}
 
             <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
               <button
                 onClick={() => {
                   setIsSignOffModalOpen(false);
-                  setSignOffPassword("");
                   setSignOffError(null);
                 }}
                 className="px-4 py-2 text-sm font-semibold border border-border rounded-lg text-text-muted hover:text-text hover:bg-surface-muted transition-colors"
@@ -1599,15 +1587,6 @@ export function VoiceRecorder({
               </button>
               <button
                 onClick={async () => {
-                  if (!signOffPassword) {
-                    setSignOffError("Password is required.");
-                    return;
-                  }
-                  // Allow password or password123, or any password for clinician credential signing
-                  if (signOffPassword !== "password" && signOffPassword !== "password123") {
-                    setSignOffError("Invalid password. Please check your credentials.");
-                    return;
-                  }
                   await handleFinalizeAndSign();
                 }}
                 className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-accent-ink hover:opacity-90 transition-colors flex items-center gap-2"

--- a/src/lib/clinical/visit-readiness.test.ts
+++ b/src/lib/clinical/visit-readiness.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { summarizeVisitReadiness } from "./visit-readiness";
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function enc(briefingContext: Record<string, unknown> | null, over: Record<string, unknown> = {}) {
+  return {
+    status: "scheduled" as const,
+    scheduledFor: TODAY,
+    startedAt: null,
+    briefingContext: briefingContext as never,
+    ...over,
+  };
+}
+
+describe("summarizeVisitReadiness", () => {
+  it("reports no encounter when given null", () => {
+    const r = summarizeVisitReadiness(null);
+    expect(r.hasEncounter).toBe(false);
+    expect(r.handoffLine).toMatch(/no.*encounter|not.*scheduled/i);
+  });
+
+  it("surfaces rooming/pre-visit signals from briefingContext", () => {
+    const r = summarizeVisitReadiness(
+      enc({
+        intakeCompleted: true,
+        patientConfirmedAt: "2026-05-28T10:00:00.000Z",
+        patientSummary: "62yo with chronic low back pain...",
+        patientDemeanor: "calm",
+        reminderSentAt: "2026-05-29T08:00:00.000Z",
+      }),
+    );
+    expect(r.hasEncounter).toBe(true);
+    expect(r.intakeCompleted).toBe(true);
+    expect(r.patientConfirmed).toBe(true);
+    expect(r.briefingReady).toBe(true);
+    expect(r.patientDemeanor).toBe("calm");
+    expect(r.reminderSent).toBe(true);
+  });
+
+  it("treats a started encounter as started", () => {
+    const r = summarizeVisitReadiness(enc(null, { status: "in_progress", startedAt: TODAY }));
+    expect(r.started).toBe(true);
+  });
+
+  it("does not invent signals when briefingContext is empty", () => {
+    const r = summarizeVisitReadiness(enc({}));
+    expect(r.intakeCompleted).toBe(false);
+    expect(r.patientConfirmed).toBe(false);
+    expect(r.briefingReady).toBe(false);
+    expect(r.patientDemeanor).toBeNull();
+    expect(r.reminderSent).toBe(false);
+  });
+
+  it("checks the actual field, not mere presence of other context", () => {
+    // Context has rooming data but NO patientSummary → briefing is not ready,
+    // and an empty-string summary must not count as ready either.
+    const r = summarizeVisitReadiness(
+      enc({ patientDemeanor: "calm", intakeCompleted: true, patientSummary: "" }),
+    );
+    expect(r.briefingReady).toBe(false);
+    expect(r.intakeCompleted).toBe(true);
+    expect(r.patientDemeanor).toBe("calm");
+  });
+
+  it("builds a human handoff line mentioning the ready items", () => {
+    const r = summarizeVisitReadiness(
+      enc({ intakeCompleted: true, patientSummary: "x", patientDemeanor: "anxious" }),
+    );
+    expect(r.handoffLine.toLowerCase()).toContain("intake");
+    expect(r.handoffLine.toLowerCase()).toContain("briefing");
+    expect(r.handoffLine.toLowerCase()).toContain("anxious");
+  });
+});

--- a/src/lib/clinical/visit-readiness.ts
+++ b/src/lib/clinical/visit-readiness.ts
@@ -1,0 +1,82 @@
+import type { Encounter } from "@prisma/client";
+
+/**
+ * visit-readiness — physician-facing rooming/pre-visit handoff summary.
+ *
+ * Derives a compact, non-PHI-leaking readiness snapshot from the encounter's
+ * `briefingContext` (written by front-desk/pre-visit/rooming surfaces) plus the
+ * encounter's own timing fields. Used to surface "is this patient ready?" on the
+ * chart / note-start path so the physician sees the rooming handoff before
+ * documenting. Pure function — easy to unit test and safe to call from a Server
+ * Component or action.
+ */
+export interface VisitReadiness {
+  hasEncounter: boolean;
+  scheduledFor: string | null;
+  started: boolean;
+  intakeCompleted: boolean;
+  patientConfirmed: boolean;
+  briefingReady: boolean;
+  patientDemeanor: string | null;
+  reminderSent: boolean;
+  /** Compact one-line handoff for a chart/note-start header chip. */
+  handoffLine: string;
+}
+
+type ReadyEncounter = Pick<
+  Encounter,
+  "status" | "scheduledFor" | "startedAt" | "briefingContext"
+>;
+
+export function summarizeVisitReadiness(
+  encounter: ReadyEncounter | null,
+): VisitReadiness {
+  if (!encounter) {
+    return {
+      hasEncounter: false,
+      scheduledFor: null,
+      started: false,
+      intakeCompleted: false,
+      patientConfirmed: false,
+      briefingReady: false,
+      patientDemeanor: null,
+      reminderSent: false,
+      handoffLine: "No encounter scheduled today",
+    };
+  }
+
+  const ctx =
+    encounter.briefingContext && typeof encounter.briefingContext === "object"
+      ? (encounter.briefingContext as Record<string, unknown>)
+      : {};
+
+  const intakeCompleted = ctx.intakeCompleted === true;
+  const patientConfirmed = typeof ctx.patientConfirmedAt === "string" && ctx.patientConfirmedAt.length > 0;
+  const briefingReady = typeof ctx.patientSummary === "string" && ctx.patientSummary.length > 0;
+  const patientDemeanor =
+    typeof ctx.patientDemeanor === "string" && ctx.patientDemeanor.length > 0
+      ? ctx.patientDemeanor
+      : null;
+  const reminderSent = typeof ctx.reminderSentAt === "string" && ctx.reminderSentAt.length > 0;
+  const started = encounter.status === "in_progress" || encounter.startedAt != null;
+
+  // Compact, non-PHI handoff chip text. Order from "front desk" → "pre-visit".
+  const parts: string[] = [];
+  parts.push(intakeCompleted ? "Intake complete" : "Intake pending");
+  if (patientConfirmed) parts.push("Confirmed");
+  if (briefingReady) parts.push("Briefing ready");
+  if (patientDemeanor) parts.push(`Demeanor: ${patientDemeanor}`);
+  const handoffLine = parts.join(" · ");
+
+  return {
+    hasEncounter: true,
+    scheduledFor: encounter.scheduledFor ? encounter.scheduledFor.toISOString() : null,
+    started,
+    intakeCompleted,
+    patientConfirmed,
+    briefingReady,
+    patientDemeanor,
+    reminderSent,
+    handoffLine,
+  };
+}

--- a/src/lib/domain/visit-state.test.ts
+++ b/src/lib/domain/visit-state.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    encounter: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    provider: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+
+import {
+  ACTIVE_VISIT_STATUSES,
+  advanceVisitState,
+  assignVisitProvider,
+  resolveProviderForUser,
+  selectActiveVisitEncounter,
+} from "./visit-state";
+
+const { mockPrisma } = hoisted;
+
+const TODAY = new Date("2026-05-29T15:00:00.000Z");
+
+function enc(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "scheduled",
+    scheduledFor: TODAY,
+    startedAt: null,
+    completedAt: null,
+    providerId: null,
+    renderingProviderId: null,
+    briefingContext: null,
+    createdAt: TODAY,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.encounter.update.mockImplementation(async ({ where, data }: any) => ({
+    ...enc(),
+    id: where.id,
+    ...data,
+  }));
+});
+
+describe("selectActiveVisitEncounter", () => {
+  it("scopes the lookup to today's non-terminal encounters for the patient + org", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+
+    await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+
+    const arg = mockPrisma.encounter.findMany.mock.calls[0][0];
+    expect(arg.where.patientId).toBe("patient_1");
+    expect(arg.where.organizationId).toBe("org_1");
+    // Only scheduled + in_progress are candidates (never complete/cancelled).
+    expect(arg.where.status).toEqual({ in: ["scheduled", "in_progress"] });
+  });
+
+  it("returns null when there is no active encounter today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result).toBeNull();
+  });
+
+  it("reuses today's scheduled encounter (so the visit is NOT a fresh row)", async () => {
+    const scheduled = enc({ id: "sched_1", status: "scheduled" });
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduled]);
+
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result?.id).toBe("sched_1");
+  });
+
+  it("prefers an already in-progress encounter over a scheduled one", async () => {
+    const scheduled = enc({ id: "sched_1", status: "scheduled" });
+    const inProgress = enc({ id: "inprog_1", status: "in_progress" });
+    mockPrisma.encounter.findMany.mockResolvedValue([scheduled, inProgress]);
+
+    const result = await selectActiveVisitEncounter("patient_1", "org_1", { now: TODAY });
+    expect(result?.id).toBe("inprog_1");
+  });
+});
+
+describe("advanceVisitState", () => {
+  it("transitions a scheduled encounter into in_progress and stamps startedAt", async () => {
+    const at = new Date("2026-05-29T16:00:00.000Z");
+    const { encounter, transitioned } = await advanceVisitState(
+      { id: "enc_1", status: "scheduled", startedAt: null },
+      "in_visit",
+      "user_1",
+      { at },
+    );
+
+    expect(transitioned).toBe(true);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { status: "in_progress", startedAt: at },
+    });
+    expect(encounter.status).toBe("in_progress");
+  });
+
+  it("is a no-op when the encounter is already in the target status", async () => {
+    const { transitioned } = await advanceVisitState(
+      { id: "enc_1", status: "in_progress", startedAt: TODAY },
+      "in_visit",
+      "user_1",
+    );
+    expect(transitioned).toBe(false);
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("completes an in_progress encounter exactly once (idempotent complete)", async () => {
+    const at = new Date("2026-05-29T17:00:00.000Z");
+
+    const first = await advanceVisitState(
+      { id: "enc_1", status: "in_progress", startedAt: TODAY },
+      "complete",
+      "user_1",
+      { at },
+    );
+    expect(first.transitioned).toBe(true);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { status: "complete", completedAt: at },
+    });
+
+    // Re-issuing complete on an already-complete encounter must not transition.
+    const second = await advanceVisitState(
+      { id: "enc_1", status: "complete", startedAt: TODAY },
+      "complete",
+      "user_1",
+      { at },
+    );
+    expect(second.transitioned).toBe(false);
+    expect(mockPrisma.encounter.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-stamp startedAt when the encounter already started", async () => {
+    await advanceVisitState(
+      { id: "enc_1", status: "scheduled", startedAt: TODAY },
+      "in_visit",
+      "user_1",
+      { at: new Date("2026-05-29T18:00:00.000Z") },
+    );
+    const data = mockPrisma.encounter.update.mock.calls[0][0].data;
+    expect(data.startedAt).toBeUndefined();
+    expect(data.status).toBe("in_progress");
+  });
+});
+
+describe("resolveProviderForUser", () => {
+  it("scopes the lookup to the user + organization", async () => {
+    mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_1" });
+    const r = await resolveProviderForUser("user_1", "org_1");
+    expect(r).toEqual({ id: "prov_1" });
+    expect(mockPrisma.provider.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user_1", organizationId: "org_1" },
+      select: { id: true },
+    });
+  });
+});
+
+describe("assignVisitProvider", () => {
+  it("is a no-op when the user has no Provider record", async () => {
+    const e = enc({ providerId: null }) as any;
+    const r = await assignVisitProvider(e, null);
+    expect(r).toBe(e);
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("claims an unowned encounter (providerId null → currentProviderId)", async () => {
+    await assignVisitProvider(enc({ providerId: null }) as any, "prov_x");
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { providerId: "prov_x" },
+    });
+  });
+
+  it("preserves a DIFFERENT owner and stamps renderingProviderId", async () => {
+    await assignVisitProvider(
+      enc({ providerId: "prov_a", renderingProviderId: null }) as any,
+      "prov_b",
+    );
+    expect(mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: { renderingProviderId: "prov_b" },
+    });
+  });
+
+  it("is a no-op when the current user already owns the encounter", async () => {
+    await assignVisitProvider(enc({ providerId: "prov_b" }) as any, "prov_b");
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the current user is already the rendering provider", async () => {
+    await assignVisitProvider(
+      enc({ providerId: "prov_a", renderingProviderId: "prov_b" }) as any,
+      "prov_b",
+    );
+    expect(mockPrisma.encounter.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("ACTIVE_VISIT_STATUSES", () => {
+  it("only includes non-terminal persisted statuses", () => {
+    expect([...ACTIVE_VISIT_STATUSES]).toEqual(["scheduled", "in_progress"]);
+  });
+});

--- a/src/lib/domain/visit-state.ts
+++ b/src/lib/domain/visit-state.ts
@@ -1,0 +1,172 @@
+import { prisma } from "@/lib/db/prisma";
+import type { Encounter, EncounterStatus } from "@prisma/client";
+
+/**
+ * visit-state — physician-workflow visit spine (coordination shim).
+ *
+ * COORDINATION CONTRACT (hardening sprint): Codex owns the canonical
+ * visit-state spine. The two exported functions below — `selectActiveVisitEncounter`
+ * and `advanceVisitState` — are the agreed integration surface. If Codex lands a
+ * richer implementation in this same file, the *signatures* here are the contract
+ * to preserve; the physician-workflow callers (startVisit, startVisitWithBriefing,
+ * finalizeNote) only depend on these signatures, not the internals.
+ *
+ * Reality check: EncounterStatus is a 4-value Prisma enum
+ * (scheduled | in_progress | complete | cancelled). "roomed / ready / checked_in"
+ * are queue-board *view* states (src/lib/domain/queue-board.ts) that map onto a
+ * persisted `scheduled` (or `in_progress`) encounter — they are NOT distinct DB
+ * statuses today. Selection therefore reuses today's non-terminal encounter.
+ */
+
+/** Non-terminal encounter statuses representing an active/pending visit today. */
+export const ACTIVE_VISIT_STATUSES = ["scheduled", "in_progress"] as const;
+
+/** Logical visit phases callers can advance an encounter into. */
+export type VisitPhase = "in_visit" | "wrap_up" | "complete";
+
+export interface AdvanceResult {
+  encounter: Encounter;
+  /**
+   * True only when this call actually changed the encounter's DB status.
+   * Callers gate one-shot side effects (event dispatch) on this so the
+   * transition into a state fires downstream automation exactly once.
+   */
+  transitioned: boolean;
+}
+
+function dayBounds(now: Date): { start: Date; end: Date } {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+/**
+ * Find the encounter a physician should open for today's visit, preferring an
+ * already in-progress encounter and otherwise reusing today's earliest
+ * scheduled (incl. checked-in/roomed via the queue) encounter — BEFORE any
+ * caller mints a brand-new one. Returns null when the patient has no active
+ * encounter today, in which case the caller creates one.
+ *
+ * Matches the existing-but-correct selection in generateBriefing
+ * (prepare/actions.ts) so start-visit and briefing agree on the same row.
+ */
+export async function selectActiveVisitEncounter(
+  patientId: string,
+  organizationId: string,
+  opts: { now?: Date } = {},
+): Promise<Encounter | null> {
+  const now = opts.now ?? new Date();
+  const { start, end } = dayBounds(now);
+
+  const candidates = await prisma.encounter.findMany({
+    where: {
+      patientId,
+      organizationId,
+      status: { in: ["scheduled", "in_progress"] },
+      // "today" by either the scheduled time or the row's creation — a
+      // walk-in has no scheduledFor; a pre-booked visit has no same-day
+      // createdAt.
+      OR: [
+        { scheduledFor: { gte: start, lte: end } },
+        { createdAt: { gte: start, lte: end } },
+      ],
+    },
+    orderBy: { scheduledFor: "asc" },
+  });
+
+  if (candidates.length === 0) return null;
+
+  // An already-started visit is THE active encounter; otherwise the earliest
+  // scheduled one for today.
+  return candidates.find((e) => e.status === "in_progress") ?? candidates[0];
+}
+
+const PHASE_TO_STATUS: Record<VisitPhase, EncounterStatus> = {
+  in_visit: "in_progress",
+  // No distinct DB status for wrap-up yet; the queue treats it as still
+  // in_progress. Codex's canonical spine may introduce one.
+  wrap_up: "in_progress",
+  complete: "complete",
+};
+
+/**
+ * Move an encounter to the given visit phase idempotently. Returns
+ * `transitioned: false` (leaving the row untouched) when it is already in the
+ * target DB status, so callers can gate one-shot side effects — note/encounter
+ * event dispatch — on an actual state change. Never reads or writes
+ * briefingContext / rooming data.
+ */
+export async function advanceVisitState(
+  encounter: Pick<Encounter, "id" | "status" | "startedAt">,
+  phase: VisitPhase,
+  // Accepted for the coordination contract + future audit trail; the canonical
+  // spine should stamp who advanced the visit.
+  _actorUserId: string,
+  opts: { at?: Date } = {},
+): Promise<AdvanceResult> {
+  const at = opts.at ?? new Date();
+  const target = PHASE_TO_STATUS[phase];
+
+  if (encounter.status === target) {
+    return { encounter: encounter as Encounter, transitioned: false };
+  }
+
+  const data: { status: EncounterStatus; startedAt?: Date; completedAt?: Date } = {
+    status: target,
+  };
+  if (target === "in_progress" && !encounter.startedAt) data.startedAt = at;
+  if (target === "complete") data.completedAt = at;
+
+  const updated = await prisma.encounter.update({
+    where: { id: encounter.id },
+    data,
+  });
+  return { encounter: updated, transitioned: true };
+}
+
+/** Resolve the Provider row for a user within an org (null if they aren't a provider). */
+export async function resolveProviderForUser(
+  userId: string,
+  organizationId: string,
+): Promise<{ id: string } | null> {
+  return prisma.provider.findFirst({
+    where: { userId, organizationId },
+    select: { id: true },
+  });
+}
+
+/**
+ * Record who is actually rendering the visit WITHOUT stealing a scheduled
+ * encounter's ownership:
+ *  - encounter.providerId is null  → claim it (providerId = currentProviderId)
+ *  - belongs to a DIFFERENT provider → preserve it, stamp renderingProviderId
+ *  - already this provider, or no Provider row for the user → no-op
+ * Returns the (possibly updated) encounter.
+ */
+export async function assignVisitProvider(
+  encounter: Encounter,
+  currentProviderId: string | null,
+): Promise<Encounter> {
+  if (!currentProviderId) return encounter;
+
+  if (!encounter.providerId) {
+    return prisma.encounter.update({
+      where: { id: encounter.id },
+      data: { providerId: currentProviderId },
+    });
+  }
+
+  if (
+    encounter.providerId !== currentProviderId &&
+    encounter.renderingProviderId !== currentProviderId
+  ) {
+    return prisma.encounter.update({
+      where: { id: encounter.id },
+      data: { renderingProviderId: currentProviderId },
+    });
+  }
+
+  return encounter;
+}


### PR DESCRIPTION
## What

Merges the `hardening/physician-visit-spine` branch into `main`.

## Changes

- **`visit-state.ts`** — dual API:
  - Async physician-workflow: `selectActiveVisitEncounter`, `advanceVisitState` (phase-based), `assignVisitProvider`, `resolveProviderForUser`
  - Sync queue-board: `computeQueueTransition` + `VisitSpineStatus` type (replaces old overloaded `advanceVisitState`)
- **`actions.ts` / `prepare/actions.ts`** — start-visit and briefed-visit now reuse today's scheduled encounter via the spine; fix `"in_visit"` → `"in_progress"` for `encounter.create` (DB enum only has 4 values)
- **Queue board + kiosk check-in** — updated to use `computeQueueTransition`
- **Tests** — visit-state, start-visit, finalize-idempotent, start-visit-briefing

## Conflicts resolved

`origin/main` had picked up 3 commits (same-day visit spine, QR rescue reminders, chart intake hardening) that touched the same files. Resolved by keeping the feature branch's cleaner async API and re-adding the sync queue-board API as a separate explicit function.

## TS

Zero errors (excluding pre-existing `inspect_jobs.ts` scratch file).