### PR TITLE
fix(observability): remove server-only guard from logger — fixes scheduler crash

### DIFF
--- a/src/lib/observability/log.ts
+++ b/src/lib/observability/log.ts
@@ -10,9 +10,10 @@
 //     follow-up; this module is the interface that swap will be
 //     drop-in for. The body is just console.* with structured
 //     enrichment for now.
-//   - Server-only — must work in Node + Next.js Edge runtimes.
-//     Avoid `process.env` reads at module load (Edge restricts that
-//     to compile time); read inside the call sites.
+//   - Node-safe — works in Next.js server components, API routes,
+//     AND standalone Node workers/schedulers (tsx-executed). No
+//     server-only guard; import safety is enforced via ESLint rules
+//     on the client component boundary instead.
 //   - PHI-aware — `redact` strips known sensitive keys before
 //     emission. Add to REDACT_KEYS as new sensitive fields land.
 //
@@ -24,8 +25,6 @@
 // Bound logger for a request scope:
 //   const log = logger.with({ requestId, route: "api/admin/super-admins" });
 //   log.warn({ event: "rate_limit.hit", actor: user.id });
-
-import "server-only";
 
 type Level = "debug" | "info" | "warn" | "error";
 


### PR DESCRIPTION
## Problem

The `emr-scheduler` cron job has been failing every 15 minutes since **May 25** (last successful run). Root cause:

```
src/workers/scheduler.ts
  → src/lib/scheduling/send-reminders.ts
  → src/lib/observability/log.ts
  → import "server-only"   ← 💥 crashes tsx-executed process
```

`server-only` is a Next.js compile-time fence that throws at module load when evaluated outside the Next.js runtime. The scheduler runs via `npx tsx` — not inside Next.js — so it exits with status 1 before doing any work.

Same issue would affect the `emr-agent-worker` for any agent that imports `logger` (pre-visit intelligence, insurance billing, research, memory agents).

## Fix

Remove `import "server-only"` from `log.ts`. One line change.

The actual safety properties of the logger — PHI redaction via `redact()`, structured JSON output — are entirely in the runtime implementation and are unaffected. Client-component safety is enforced at the ESLint level, not by this guard.

## Impact

- `emr-scheduler` resumes running every 15 minutes ✅
- `emr-agent-worker` can use `logger` without crashing ✅
- Zero behavior change in Next.js app routes/server components ✅

## Files changed

- `src/lib/observability/log.ts` — remove `import "server-only"`, update comment