### PR TITLE
feat(scheduling): consent-freshness gate + canonical readiness SoT (EMR-913)

### DIFF
--- a/src/lib/scheduling/intake-gate.test.ts
+++ b/src/lib/scheduling/intake-gate.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateIntakeGate, type IntakeGateInput } from "./intake-gate";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+// A fully-satisfied, in-person new-patient gate input. Override per test.
+function passingInput(overrides: Partial<IntakeGateInput> = {}): IntakeGateInput {
+  return {
+    visitType: "new_patient",
+    treatmentPhase: "intake",
+    isVirtual: false,
+    patient: {
+      dateOfBirth: new Date("1985-04-12T00:00:00.000Z"),
+      addressLine1: "1 Main St",
+      state: "CA",
+      allergiesScreenedAt: new Date("2026-05-02T00:00:00.000Z"),
+      cannabisHistory: { priorUse: "occasional" },
+      presentingConcerns: "Chronic lower back pain for 6 months",
+      intakeAnswers: { done: true },
+      ageVerifiedAt: new Date("2026-05-01T00:00:00.000Z"),
+    },
+    consent: {
+      visitConsentSignedAt: new Date("2026-05-10T00:00:00.000Z"),
+      telehealthConsentSignedAt: null,
+    },
+    insurance: { coverageVerified: true, selfPayAttested: false },
+    outcomeLogsSinceLastVisit: 0,
+    ...overrides,
+  };
+}
+
+function consentReq(input: IntakeGateInput) {
+  return evaluateIntakeGate(input, NOW).requirements.find((r) => r.id === "consent")!;
+}
+
+describe("evaluateIntakeGate — consent freshness", () => {
+  it("treats a signed consent as valid forever when no max-age window is set (legacy behaviour)", () => {
+    const input = passingInput({
+      consent: {
+        visitConsentSignedAt: new Date("2022-01-01T00:00:00.000Z"), // 4+ years old
+        telehealthConsentSignedAt: null,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(true);
+    expect(evaluateIntakeGate(input, NOW).allowConfirm).toBe(true);
+  });
+
+  it("accepts a consent signed within the freshness window", () => {
+    const input = passingInput({
+      consent: {
+        visitConsentSignedAt: new Date("2026-05-10T00:00:00.000Z"), // ~22 days before NOW
+        telehealthConsentSignedAt: null,
+        visitConsentMaxAgeDays: 365,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(true);
+  });
+
+  it("rejects a consent signed outside the freshness window and blocks confirmation", () => {
+    const input = passingInput({
+      consent: {
+        visitConsentSignedAt: new Date("2024-01-01T00:00:00.000Z"), // ~880 days before NOW
+        telehealthConsentSignedAt: null,
+        visitConsentMaxAgeDays: 365,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(false);
+    const result = evaluateIntakeGate(input, NOW);
+    expect(result.allowConfirm).toBe(false);
+    expect(result.blockReason).toContain("consent");
+  });
+
+  it("for a virtual visit, a stale telehealth consent blocks even when the visit consent is fresh", () => {
+    const input = passingInput({
+      isVirtual: true,
+      consent: {
+        visitConsentSignedAt: new Date("2026-05-10T00:00:00.000Z"),
+        telehealthConsentSignedAt: new Date("2025-01-01T00:00:00.000Z"), // stale
+        visitConsentMaxAgeDays: 365,
+        telehealthConsentMaxAgeDays: 30,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(false);
+  });
+
+  it("treats a future-dated signature (clock skew) as fresh rather than failing the patient", () => {
+    const input = passingInput({
+      consent: {
+        visitConsentSignedAt: new Date("2026-06-05T00:00:00.000Z"), // after NOW
+        telehealthConsentSignedAt: null,
+        visitConsentMaxAgeDays: 365,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(true);
+  });
+
+  it("still fails when there is no signature at all, regardless of window", () => {
+    const input = passingInput({
+      consent: {
+        visitConsentSignedAt: null,
+        telehealthConsentSignedAt: null,
+        visitConsentMaxAgeDays: 365,
+      },
+    });
+    expect(consentReq(input).satisfied).toBe(false);
+  });
+});

--- a/src/lib/scheduling/intake-gate.ts
+++ b/src/lib/scheduling/intake-gate.ts
@@ -57,6 +57,14 @@ export interface IntakeGateInput {
   consent: {
     visitConsentSignedAt: Date | null;
     telehealthConsentSignedAt: Date | null;
+    /**
+     * Max age (days) for the visit consent to still count as fresh. A consent
+     * older than this is treated as unsatisfied — the patient must re-sign.
+     * `null`/omitted means the consent never expires (the legacy behaviour).
+     */
+    visitConsentMaxAgeDays?: number | null;
+    /** Max age (days) for the telehealth consent. `null`/omitted = never expires. */
+    telehealthConsentMaxAgeDays?: number | null;
   };
   insurance: {
     coverageVerified: boolean;
@@ -98,6 +106,8 @@ export const IntakeGateInputSchema = z.object({
   consent: z.object({
     visitConsentSignedAt: z.date().nullable(),
     telehealthConsentSignedAt: z.date().nullable(),
+    visitConsentMaxAgeDays: z.number().positive().nullable().optional(),
+    telehealthConsentMaxAgeDays: z.number().positive().nullable().optional(),
   }),
   insurance: z.object({
     coverageVerified: z.boolean(),
@@ -112,7 +122,10 @@ export const IntakeGateInputSchema = z.object({
  * issued — booking page (EMR-206), waitlist fill (EMR-210), and the slot
  * recommender's confirm path.
  */
-export function evaluateIntakeGate(input: IntakeGateInput): IntakeGateResult {
+export function evaluateIntakeGate(
+  input: IntakeGateInput,
+  now: Date = new Date(),
+): IntakeGateResult {
   const reqs: GateRequirement[] = [];
 
   reqs.push({
@@ -161,9 +174,16 @@ export function evaluateIntakeGate(input: IntakeGateInput): IntakeGateResult {
   });
 
   // Visit consent always required; telehealth consent only for virtual visits.
+  // A consent counts only if it is signed AND still fresh per its max-age window
+  // (a null/omitted window means it never expires — the legacy behaviour).
   const consentOk =
-    input.consent.visitConsentSignedAt instanceof Date &&
-    (!input.isVirtual || input.consent.telehealthConsentSignedAt instanceof Date);
+    isConsentFresh(input.consent.visitConsentSignedAt, input.consent.visitConsentMaxAgeDays, now) &&
+    (!input.isVirtual ||
+      isConsentFresh(
+        input.consent.telehealthConsentSignedAt,
+        input.consent.telehealthConsentMaxAgeDays,
+        now,
+      ));
   reqs.push({
     id: "consent",
     label: input.isVirtual ? "Visit + telehealth consent" : "Visit consent",
@@ -207,6 +227,25 @@ export function evaluateIntakeGate(input: IntakeGateInput): IntakeGateResult {
     : `Complete ${blockingUnsatisfied.length} step${blockingUnsatisfied.length === 1 ? "" : "s"} before confirming: ${blockingUnsatisfied.map((r) => r.label).join(", ")}.`;
 
   return { allowConfirm, requirements: reqs, blockReason, completionPct };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A consent satisfies the gate when it is signed and — if a freshness window is
+ * configured — was signed within `maxAgeDays` of `now`. A `null`/`undefined`
+ * window means the consent never expires. A future `signedAt` (clock skew) is
+ * treated as fresh rather than failing the patient.
+ */
+function isConsentFresh(
+  signedAt: Date | null | undefined,
+  maxAgeDays: number | null | undefined,
+  now: Date,
+): boolean {
+  if (!(signedAt instanceof Date)) return false;
+  if (maxAgeDays == null) return true;
+  const ageMs = now.getTime() - signedAt.getTime();
+  return ageMs <= maxAgeDays * DAY_MS;
 }
 
 function hasMeaningfulRecord(value: unknown): boolean {

--- a/src/lib/scheduling/previsit-readiness.ts
+++ b/src/lib/scheduling/previsit-readiness.ts
@@ -62,6 +62,23 @@ export interface PrevisitSnapshot {
 // Pure mapping
 // ---------------------------------------------------------------------------
 
+/**
+ * Consent freshness policy, in days (`null` = the consent never expires).
+ *
+ * Defaults to `null`/`null` so this change is behaviour-preserving: existing
+ * signed consents keep satisfying the gate exactly as before. Turning freshness
+ * ON (the plan's recommendation — visit/treatment ~365d, telehealth per-visit)
+ * is a one-line product decision tracked in EMR-913 + the plan doc §1, made here
+ * so the policy lives in one place rather than scattered through callers.
+ */
+export const CONSENT_FRESHNESS_POLICY: {
+  visitConsentMaxAgeDays: number | null;
+  telehealthConsentMaxAgeDays: number | null;
+} = {
+  visitConsentMaxAgeDays: null,
+  telehealthConsentMaxAgeDays: null,
+};
+
 /** A consent is "telehealth" if its template name mentions telehealth/virtual. */
 function isTelehealthConsent(name: string): boolean {
   return /telehealth|telemedicine|virtual/i.test(name);
@@ -109,6 +126,8 @@ export function mapSnapshotToGateInput(snapshot: PrevisitSnapshot): IntakeGateIn
     consent: {
       visitConsentSignedAt: latestSignedAt(snapshot.consents, isVisitConsent),
       telehealthConsentSignedAt: latestSignedAt(snapshot.consents, isTelehealthConsent),
+      visitConsentMaxAgeDays: CONSENT_FRESHNESS_POLICY.visitConsentMaxAgeDays,
+      telehealthConsentMaxAgeDays: CONSENT_FRESHNESS_POLICY.telehealthConsentMaxAgeDays,
     },
     insurance: {
       coverageVerified: hasVerifiedCoverage(snapshot.coverages),
@@ -141,9 +160,9 @@ export interface PrevisitReadiness {
  */
 export function evaluatePrevisitReadiness(
   snapshot: PrevisitSnapshot,
-  _now: Date,
+  now: Date,
 ): PrevisitReadiness {
-  const gate = evaluateIntakeGate(mapSnapshotToGateInput(snapshot));
+  const gate = evaluateIntakeGate(mapSnapshotToGateInput(snapshot), now);
   const missingRequiredIds = gate.requirements
     .filter((r) => r.blocking && !r.satisfied)
     .map((r) => r.id);
@@ -253,6 +272,17 @@ export interface AppointmentReadiness {
 /**
  * Load + evaluate readiness for an appointment in one call. Returns null when
  * the appointment can't be found. The returned readiness is PHI-free.
+ *
+ * CANONICAL SOURCE OF TRUTH (EMR-913). This is *the* answer to "is this patient
+ * ready for this visit / what's still missing." Every surface — the pre-visit
+ * nudge engine (sendDuePrevisitCompletionReminders), the patient portal "get
+ * ready" banner, the clinician readiness dashboard, and the kiosk/lobby
+ * completion flow — must read readiness from here (or `evaluatePrevisitReadiness`
+ * for an in-memory snapshot), NOT from the chart-completeness score
+ * (intake-agent's 0–100 on ChartSummary) and NOT from ad-hoc `briefingContext`
+ * signals. Chart completeness is an *input* to a productive visit, not a
+ * parallel definition of "ready" — keeping one definition here is what stops the
+ * three readiness notions from drifting apart again.
  */
 export async function getAppointmentReadiness(
   appointmentId: string,


### PR DESCRIPTION
Kicks off **EMR-912** (Pre-Visit Readiness & Kiosk Hand-off) with the first slice of **Phase 0 — EMR-913**.

## What
- **Time-aware intake gate.** `evaluateIntakeGate(input, now)` now treats a consent as satisfied only if it's signed **and** within an optional per-type freshness window (`visitConsentMaxAgeDays` / `telehealthConsentMaxAgeDays`). A `null`/omitted window = never expires.
- **Behaviour-preserving.** `CONSENT_FRESHNESS_POLICY` defaults to `null`/`null`, so nothing changes for existing patients until windows are dialed in — which is the product decision the plan flagged (recommended: visit/treatment ~365d, telehealth per-visit). Centralized in one place.
- **Threaded `now`** from `evaluatePrevisitReadiness` into the gate (previously accepted but ignored).
- **Documented `getAppointmentReadiness` as THE canonical readiness source of truth** — the fix for the three-disconnected-readiness-notions problem. Reminders, the portal banner, the clinician dashboard, and the kiosk/lobby all read here; chart-completeness is an *input*, not a parallel truth.

## Tests
New `intake-gate.test.ts` (6 cases): legacy no-window passes a 4-yr-old consent; fresh passes; stale blocks (+ blockReason); virtual stale-telehealth blocks; future-dated clock skew treated fresh; missing signature still fails. Existing `previsit-readiness.test.ts` green. Full `tsc` clean.

## Scope / not in this PR
No schema migrations. Remaining Phase 0 follow-ons (separate commits): `allergiesScreenedAt` column, `Appointment.visitType`/`treatmentPhase`, assessment freshness as a requirement.

Refs: EMR-912, EMR-913 · plan: `docs/plans/previsit-readiness-and-kiosk-handoff.md` §1

🤖 Generated with [Claude Code](https://claude.com/claude-code)