### PR TITLE
feat(scheduling): real allergiesScreenedAt column, replacing the screening proxy (EMR-913)

### DIFF
--- a/prisma/migrations/20260531040000_patient_allergies_screened_at/migration.sql
+++ b/prisma/migrations/20260531040000_patient_allergies_screened_at/migration.sql
@@ -1,0 +1,4 @@
+-- EMR-913 — explicit allergy-screening timestamp on Patient. Additive/nullable;
+-- backfills as NULL (= never screened), which the pre-visit gate already treats
+-- as unsatisfied. Replaces the brittle `allergies.length > 0` screening proxy.
+ALTER TABLE "Patient" ADD COLUMN IF NOT EXISTS "allergiesScreenedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -312,6 +312,11 @@ model Patient {
   // Clinical safety fields (EMR-113)
   allergies              String[]            @default([]) // e.g. ["Penicillin", "Sulfa", "Latex"]
   contraindications      String[]            @default([]) // e.g. ["MAOIs", "Blood thinners"]
+  // EMR-913 — explicit "allergies reviewed at" timestamp. Set on any allergy
+  // edit AND by an affirmative "reviewed / no known allergies" action, so an
+  // NKDA review counts as screened. Replaces the brittle `allergies.length > 0`
+  // proxy the pre-visit gate used to infer screening.
+  allergiesScreenedAt    DateTime?
   qualificationStatus    QualificationStatus @default(unknown)
   qualificationExpiresAt DateTime?
   // EMR-786 — Chart privacy. When chartRestricted=true the chart is

--- a/src/app/(clinician)/clinic/patients/[id]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.ts
@@ -175,9 +175,10 @@ export async function saveAllergy(patientId: string, drugName: string, reaction:
     allergies.push(newAllergy);
   }
 
+  // Editing the allergy list is itself a screening event (EMR-913).
   await prisma.patient.update({
     where: { id: patientId },
-    data: { allergies },
+    data: { allergies, allergiesScreenedAt: new Date() },
   });
 
   revalidatePath(`/clinic/patients/${patientId}`);
@@ -195,7 +196,31 @@ export async function removeAllergen(patientId: string, allergyStr: string) {
 
   await prisma.patient.update({
     where: { id: patientId },
-    data: { allergies },
+    data: { allergies, allergiesScreenedAt: new Date() },
+  });
+
+  revalidatePath(`/clinic/patients/${patientId}`);
+  return { ok: true };
+}
+
+/**
+ * EMR-913 — record that allergies were affirmatively reviewed without changing
+ * the list. This is the "no known drug allergies" / "reviewed, nothing to add"
+ * path: it stamps `allergiesScreenedAt` so the pre-visit gate counts the patient
+ * as screened even when the allergy array is (correctly) empty — the exact case
+ * the old `allergies.length > 0` proxy got wrong.
+ */
+export async function markAllergiesReviewed(patientId: string) {
+  const user = await requireUser();
+  const patient = await prisma.patient.findFirst({
+    where: { id: patientId, organizationId: user.organizationId!, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) throw new Error("Patient not found");
+
+  await prisma.patient.update({
+    where: { id: patientId },
+    data: { allergiesScreenedAt: new Date() },
   });
 
   revalidatePath(`/clinic/patients/${patientId}`);

--- a/src/lib/scheduling/previsit-readiness.ts
+++ b/src/lib/scheduling/previsit-readiness.ts
@@ -233,10 +233,10 @@ export async function loadPrevisitSnapshot(
       addressLine1: p.addressLine1,
       state: p.state,
       ageVerifiedAt: p.ageVerifiedAt,
-      // allergiesScreenedAt isn't a column; treat a populated allergies/contra
-      // array as "screened". Codex can replace with a real screened-at column.
-      allergiesScreenedAt:
-        p.allergies.length > 0 || p.contraindications.length > 0 ? p.updatedAt : null,
+      // EMR-913 — real screened-at column. Set on any allergy edit and by the
+      // explicit "reviewed / no known allergies" action, so an NKDA review
+      // counts as screened (the old `allergies.length > 0` proxy did not).
+      allergiesScreenedAt: p.allergiesScreenedAt,
       cannabisHistory: p.cannabisHistory,
       presentingConcerns: p.presentingConcerns,
       intakeAnswers: p.intakeAnswers,


### PR DESCRIPTION
Phase 0 of **EMR-912** — next gate gap from **EMR-913**.

## Problem
The pre-visit gate inferred 'allergies screened' from `allergies.length > 0 || contraindications.length > 0`. That's brittle: a patient correctly reviewed as **No Known Drug Allergies** (empty array) looked identical to one never screened.

## What
- **`Patient.allergiesScreenedAt`** (nullable; additive migration `20260531040000`).
- **Stamp on edits** — `saveAllergy` / `removeAllergen` set `allergiesScreenedAt = now` (editing the list is a screening event).
- **`markAllergiesReviewed(patientId)`** — affirmative 'reviewed / NKDA' action that stamps the timestamp without changing the array. This is what makes the NKDA case satisfiable.
- **`loadPrevisitSnapshot`** reads the real column instead of the `updatedAt` proxy.

## Behaviour
Existing rows backfill `NULL` = unscreened, which the gate already treats as an outstanding (non-urgent) requirement — correct, and now satisfiable by a real review (including NKDA).

## Scope
UI hookup of `markAllergiesReviewed` is a follow-on (`AllergyProfile` isn't mounted in any route yet). `tsc` clean; 96 scheduling tests pass.

Refs: EMR-912, EMR-913 · plan §1

🤖 Generated with [Claude Code](https://claude.com/claude-code)