### PR TITLE
feat(scheduling): Clinical Assessment Rules Engine — Tier 1 + Tier 3 core (EMR-917)

### DIFF
--- a/src/lib/scheduling/assessment-rules.test.ts
+++ b/src/lib/scheduling/assessment-rules.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ASSESSMENT_POLICY,
+  evaluateAssessmentPolicy,
+  outstandingAssessments,
+  type AssessmentContext,
+  type AssessmentPolicy,
+} from "./assessment-rules";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+// An illustrative policy for tests only — NOT the shipped default (which is empty).
+const POLICY: AssessmentPolicy = [
+  { concern: "depression", assessmentSlug: "phq-9", assessmentLabel: "PHQ-9", freshnessDays: 30, requirement: "required" },
+  { concern: "anxiety", assessmentSlug: "gad-7", assessmentLabel: "GAD-7", freshnessDays: 30, requirement: "required" },
+  { concern: "chronic_pain", assessmentSlug: "pain-scale", assessmentLabel: "Pain Scale", freshnessDays: 30, requirement: "recommended" },
+];
+
+function ctx(overrides: Partial<AssessmentContext> = {}): AssessmentContext {
+  return {
+    indicatedConcerns: [],
+    latestByAssessment: {},
+    ...overrides,
+  };
+}
+
+describe("evaluateAssessmentPolicy", () => {
+  it("ships inert: the default empty policy yields no findings", () => {
+    expect(
+      evaluateAssessmentPolicy(DEFAULT_ASSESSMENT_POLICY, ctx({ indicatedConcerns: ["depression"] }), NOW),
+    ).toEqual([]);
+  });
+
+  it("only evaluates rules whose concern is indicated for the patient", () => {
+    const findings = evaluateAssessmentPolicy(POLICY, ctx({ indicatedConcerns: ["anxiety"] }), NOW);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].assessmentSlug).toBe("gad-7");
+  });
+
+  it("flags an indicated assessment that was never taken as missing", () => {
+    const [f] = evaluateAssessmentPolicy(POLICY, ctx({ indicatedConcerns: ["depression"] }), NOW);
+    expect(f.status).toBe("missing");
+    expect(f.ageDays).toBeNull();
+  });
+
+  it("flags a submission older than the freshness window as stale", () => {
+    const [f] = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({
+        indicatedConcerns: ["depression"],
+        latestByAssessment: { "phq-9": new Date("2026-01-01T00:00:00.000Z") }, // ~150 days
+      }),
+      NOW,
+    );
+    expect(f.status).toBe("stale");
+    expect(f.ageDays).toBeGreaterThan(30);
+  });
+
+  it("treats a submission within the window as fresh", () => {
+    const [f] = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({
+        indicatedConcerns: ["depression"],
+        latestByAssessment: { "phq-9": new Date("2026-05-20T00:00:00.000Z") }, // ~12 days
+      }),
+      NOW,
+    );
+    expect(f.status).toBe("fresh");
+  });
+
+  it("honors a Tier-3 not_applicable / skip override", () => {
+    const [f] = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({ indicatedConcerns: ["depression"], overrides: { "phq-9": "not_applicable" } }),
+      NOW,
+    );
+    expect(f.status).toBe("not_applicable");
+  });
+
+  it("lets a Tier-3 require override bump a recommended rule to required", () => {
+    const [f] = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({ indicatedConcerns: ["chronic_pain"], overrides: { "pain-scale": "require" } }),
+      NOW,
+    );
+    expect(f.requirement).toBe("required");
+  });
+
+  it("clamps a future-dated submission (clock skew) to fresh, age 0", () => {
+    const [f] = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({
+        indicatedConcerns: ["depression"],
+        latestByAssessment: { "phq-9": new Date("2026-06-10T00:00:00.000Z") }, // after NOW
+      }),
+      NOW,
+    );
+    expect(f.status).toBe("fresh");
+    expect(f.ageDays).toBe(0);
+  });
+});
+
+describe("outstandingAssessments", () => {
+  it("returns only missing/stale findings (fresh + not_applicable filtered out)", () => {
+    const findings = evaluateAssessmentPolicy(
+      POLICY,
+      ctx({
+        indicatedConcerns: ["depression", "anxiety", "chronic_pain"],
+        latestByAssessment: {
+          "phq-9": new Date("2026-01-01T00:00:00.000Z"), // stale
+          "gad-7": new Date("2026-05-25T00:00:00.000Z"), // fresh
+          // pain-scale: missing
+        },
+      }),
+      NOW,
+    );
+    const outstanding = outstandingAssessments(findings).map((f) => f.assessmentSlug).sort();
+    expect(outstanding).toEqual(["pain-scale", "phq-9"]);
+  });
+});

--- a/src/lib/scheduling/assessment-rules.ts
+++ b/src/lib/scheduling/assessment-rules.ts
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="EMR-917 foundation engine; readiness/gate consumer is the next slice in the build sequence"
 /**
  * EMR-917 — Clinical Assessment Rules Engine (Tier 1 + Tier 3).
  *

--- a/src/lib/scheduling/assessment-rules.ts
+++ b/src/lib/scheduling/assessment-rules.ts
@@ -1,0 +1,162 @@
+/**
+ * EMR-917 — Clinical Assessment Rules Engine (Tier 1 + Tier 3).
+ *
+ * Principle: **agentic assistance, not agentic medicine.** This engine NEVER
+ * decides clinical policy and NEVER guesses what a patient needs from free text.
+ * It is a pure evaluator over:
+ *
+ *   - Tier 1: a clinician-owned policy table (concern → assessment → freshness
+ *     window → required/recommended). Ships EMPTY by default, so nothing becomes
+ *     mandatory until a clinician populates it.
+ *   - Tier 3: per-patient clinician overrides (require / skip / not_applicable).
+ *
+ * The patient's *indicated concerns* are passed in by the caller and must come
+ * from explicit, structured clinician/intake signals — NOT keyword-matching of
+ * free text (that would accidentally build a clinical triage engine). Tier 2
+ * (an AI layer that *suggests* concerns/assessments) lives elsewhere and only
+ * ever feeds suggestions a human confirms; it does not call into policy here.
+ *
+ * Output is advisory data. Whether a finding blocks anything is the consumer's
+ * call (the pre-visit gate defaults missing/stale assessments to advisory —
+ * we don't bounce patients off booking over a questionnaire).
+ */
+import { z } from "zod";
+
+/** A single clinician-defined rule. */
+export interface AssessmentRule {
+  /** Structured presenting-concern key this rule applies to (clinician-owned). */
+  concern: string;
+  /** Assessment identifier (e.g. "phq-9", "gad-7", "c-ssrs"). */
+  assessmentSlug: string;
+  /** Human label for the assessment ("PHQ-9"). */
+  assessmentLabel: string;
+  /** How recent a submission must be to count as fresh, in days. */
+  freshnessDays: number;
+  /**
+   * Clinician's declared strength. Even "required" is surfaced as advisory by
+   * the pre-visit gate today — this records clinical intent, not enforcement.
+   */
+  requirement: "required" | "recommended";
+}
+
+export type AssessmentPolicy = AssessmentRule[];
+
+/** Tier-3 per-patient clinician override, keyed by assessment slug. */
+export type AssessmentOverride = "require" | "skip" | "not_applicable";
+
+export interface AssessmentContext {
+  /**
+   * Concerns explicitly indicated for this patient via structured clinician /
+   * intake signals. NOT derived by parsing free text here.
+   */
+  indicatedConcerns: string[];
+  /** Latest submission timestamp per assessment slug (null/absent = never taken). */
+  latestByAssessment: Record<string, Date | null>;
+  /** Optional Tier-3 clinician overrides per assessment slug. */
+  overrides?: Record<string, AssessmentOverride>;
+}
+
+export type AssessmentStatus = "missing" | "stale" | "fresh" | "not_applicable";
+
+export interface AssessmentFinding {
+  assessmentSlug: string;
+  assessmentLabel: string;
+  concern: string;
+  status: AssessmentStatus;
+  /** Effective strength after applying any Tier-3 override. */
+  requirement: "required" | "recommended";
+  /** Age of the latest submission in whole days, or null if never taken. */
+  ageDays: number | null;
+  freshnessDays: number;
+}
+
+export const AssessmentRuleSchema = z.object({
+  concern: z.string().min(1),
+  assessmentSlug: z.string().min(1),
+  assessmentLabel: z.string().min(1),
+  freshnessDays: z.number().int().positive(),
+  requirement: z.enum(["required", "recommended"]),
+});
+
+export const AssessmentPolicySchema = z.array(AssessmentRuleSchema);
+
+/**
+ * The default policy is EMPTY — the engine is inert until a clinician defines
+ * rules (Tier 1). Dr. Patel's illustrative table, kept here as documentation
+ * only (NOT active policy):
+ *
+ *   Depression       → PHQ-9   30d   required
+ *   Anxiety          → GAD-7   30d   required
+ *   Suicidal ideation→ C-SSRS   7d   required
+ *   Chronic pain     → Pain    30d   recommended
+ *   ADHD             → ASRS    90d   recommended
+ */
+export const DEFAULT_ASSESSMENT_POLICY: AssessmentPolicy = [];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function ageInDays(at: Date | null | undefined, now: Date): number | null {
+  if (!(at instanceof Date)) return null;
+  // Clamp future-dated submissions (clock skew) to 0 rather than negative.
+  return Math.max(0, Math.floor((now.getTime() - at.getTime()) / DAY_MS));
+}
+
+/**
+ * Evaluate the clinician policy against a patient context. Returns one finding
+ * per rule whose concern is indicated for the patient. Pure + deterministic.
+ *
+ * Tier-3 overrides:
+ *   - "not_applicable" / "skip" → status `not_applicable` (clinician has said
+ *     this assessment doesn't apply to this patient).
+ *   - "require" → bumps the finding's `requirement` to "required".
+ */
+export function evaluateAssessmentPolicy(
+  policy: AssessmentPolicy,
+  context: AssessmentContext,
+  now: Date = new Date(),
+): AssessmentFinding[] {
+  const indicated = new Set(context.indicatedConcerns);
+  const findings: AssessmentFinding[] = [];
+
+  for (const rule of policy) {
+    if (!indicated.has(rule.concern)) continue;
+
+    const override = context.overrides?.[rule.assessmentSlug];
+    const latest = context.latestByAssessment[rule.assessmentSlug] ?? null;
+    const age = ageInDays(latest, now);
+
+    let status: AssessmentStatus;
+    if (override === "skip" || override === "not_applicable") {
+      status = "not_applicable";
+    } else if (age === null) {
+      status = "missing";
+    } else if (age > rule.freshnessDays) {
+      status = "stale";
+    } else {
+      status = "fresh";
+    }
+
+    findings.push({
+      assessmentSlug: rule.assessmentSlug,
+      assessmentLabel: rule.assessmentLabel,
+      concern: rule.concern,
+      status,
+      requirement: override === "require" ? "required" : rule.requirement,
+      ageDays: age,
+      freshnessDays: rule.freshnessDays,
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Convenience: the assessments a patient should be nudged about — anything
+ * indicated that is missing or stale and not overridden away. Advisory by
+ * design; the caller decides how (or whether) to surface it.
+ */
+export function outstandingAssessments(
+  findings: AssessmentFinding[],
+): AssessmentFinding[] {
+  return findings.filter((f) => f.status === "missing" || f.status === "stale");
+}


### PR DESCRIPTION
First slice of **EMR-917** (spun out of EMR-913). **Agentic assistance, not agentic medicine** — the engine never decides clinical policy and never keyword-guesses from free text.

## What
- **`evaluateAssessmentPolicy(policy, context, now)`** — pure evaluator over:
  - **Tier 1** clinician-owned policy table: `concern → assessment → freshnessDays → required/recommended`
  - **Tier 3** per-patient clinician overrides: `require / skip / not_applicable`
  - → findings: `missing | stale | fresh | not_applicable`
- **`indicatedConcerns` are passed in** from structured clinician/intake signals; the engine does **not** parse free text (no accidental clinical triage engine).
- **`DEFAULT_ASSESSMENT_POLICY` is empty** — ships inert; nothing becomes required until a clinician populates it. Dr. Patel's illustrative table is kept as comments only.
- **`outstandingAssessments()`** — advisory missing/stale list for nudge surfaces.

## Not in this PR (follow-on per EMR-917)
Tier-3 override persistence · Tier-2 AI suggestion surface (suggests, never enforces) · gate/readiness wiring (advisory) · clinician policy-table editor.

9 unit tests; `tsc` clean. No schema, no behavior change.

Refs: EMR-912, EMR-917 · governance principle in repo memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)