### PR TITLE
feat(check-in): SMS OTP issuance + verification primitive (EMR-915)

### DIFF
--- a/prisma/migrations/20260531053000_sms_otp_code/migration.sql
+++ b/prisma/migrations/20260531053000_sms_otp_code/migration.sql
@@ -1,0 +1,17 @@
+-- EMR-915 — one-time SMS codes for the kiosk→phone hand-off identity challenge.
+-- Hash-at-rest (never plaintext); minutes-lived; `purpose`-scoped to one flow.
+CREATE TABLE IF NOT EXISTS "SmsOtpCode" (
+  "id"          TEXT NOT NULL,
+  "patientId"   TEXT NOT NULL,
+  "purpose"     TEXT NOT NULL,
+  "codeHash"    TEXT NOT NULL,
+  "expiresAt"   TIMESTAMP(3) NOT NULL,
+  "attempts"    INTEGER NOT NULL DEFAULT 0,
+  "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+  "consumedAt"  TIMESTAMP(3),
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SmsOtpCode_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "SmsOtpCode_patientId_purpose_idx" ON "SmsOtpCode"("patientId", "purpose");
+CREATE INDEX IF NOT EXISTS "SmsOtpCode_expiresAt_idx" ON "SmsOtpCode"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4964,6 +4964,30 @@ model FreezeToken {
 }
 
 // --------------------------------------------------------------
+// EMR-915 — one-time SMS codes (kiosk→phone hand-off identity challenge).
+// Short-lived (minutes). The code is never stored in plaintext — only its
+// SHA-256 hash — and is sent to the patient solely over SMS. `purpose` scopes
+// a code to one flow so it can't be replayed elsewhere. No FK relation: these
+// are throwaway rows that expire on their own; `patientId` is just an indexed
+// scope key.
+// --------------------------------------------------------------
+
+model SmsOtpCode {
+  id          String    @id @default(cuid())
+  patientId   String
+  purpose     String // e.g. "kiosk_lobby_handoff"
+  codeHash    String // SHA-256 of the numeric code
+  expiresAt   DateTime
+  attempts    Int       @default(0)
+  maxAttempts Int       @default(5)
+  consumedAt  DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([patientId, purpose])
+  @@index([expiresAt])
+}
+
+// --------------------------------------------------------------
 // EMR-107 — ChatCB AI Coach
 // --------------------------------------------------------------
 

--- a/src/lib/check-in/otp.test.ts
+++ b/src/lib/check-in/otp.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateOtpVerification,
+  generateOtpCode,
+  hashOtp,
+  hashesEqual,
+  isIssueRateLimited,
+  type OtpRecordState,
+} from "./otp";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function record(overrides: Partial<OtpRecordState> = {}): OtpRecordState {
+  return {
+    codeHash: hashOtp("123456"),
+    expiresAt: new Date(NOW.getTime() + 5 * 60 * 1000), // 5 min out
+    attempts: 0,
+    maxAttempts: 5,
+    consumedAt: null,
+    ...overrides,
+  };
+}
+
+describe("generateOtpCode", () => {
+  it("produces a zero-padded numeric code of the requested length", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generateOtpCode(6);
+      expect(code).toMatch(/^\d{6}$/);
+    }
+  });
+});
+
+describe("hashOtp / hashesEqual", () => {
+  it("hashes deterministically and ignores surrounding whitespace", () => {
+    expect(hashOtp("123456")).toBe(hashOtp(" 123456 "));
+  });
+  it("matches equal hashes and rejects different / empty ones", () => {
+    expect(hashesEqual(hashOtp("123456"), hashOtp("123456"))).toBe(true);
+    expect(hashesEqual(hashOtp("123456"), hashOtp("000000"))).toBe(false);
+    expect(hashesEqual("", "")).toBe(false);
+  });
+});
+
+describe("evaluateOtpVerification", () => {
+  it("fails with no_active_code when there is no record", () => {
+    expect(evaluateOtpVerification(null, "123456", NOW)).toEqual({
+      ok: false,
+      reason: "no_active_code",
+    });
+  });
+
+  it("accepts the correct code on a fresh, unconsumed record", () => {
+    expect(evaluateOtpVerification(record(), "123456", NOW)).toEqual({
+      ok: true,
+      reason: "ok",
+    });
+  });
+
+  it("rejects an incorrect code as mismatch", () => {
+    expect(evaluateOtpVerification(record(), "000000", NOW).reason).toBe("mismatch");
+  });
+
+  it("rejects an already-consumed code before comparing", () => {
+    const r = record({ consumedAt: new Date(NOW.getTime() - 1000) });
+    // Even with the *correct* code, a consumed record never succeeds.
+    expect(evaluateOtpVerification(r, "123456", NOW)).toEqual({
+      ok: false,
+      reason: "already_consumed",
+    });
+  });
+
+  it("rejects an expired code before comparing", () => {
+    const r = record({ expiresAt: new Date(NOW.getTime() - 1) });
+    expect(evaluateOtpVerification(r, "123456", NOW)).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  it("locks out once attempts have reached the max, even with the right code", () => {
+    const r = record({ attempts: 5, maxAttempts: 5 });
+    expect(evaluateOtpVerification(r, "123456", NOW)).toEqual({
+      ok: false,
+      reason: "too_many_attempts",
+    });
+  });
+
+  it("precedence: consumed beats expired beats lockout beats mismatch", () => {
+    const r = record({
+      consumedAt: new Date(NOW.getTime() - 1000),
+      expiresAt: new Date(NOW.getTime() - 1000),
+      attempts: 99,
+    });
+    expect(evaluateOtpVerification(r, "000000", NOW).reason).toBe("already_consumed");
+  });
+});
+
+describe("isIssueRateLimited", () => {
+  it("blocks once the recent count reaches the max", () => {
+    expect(isIssueRateLimited(2, 3)).toBe(false);
+    expect(isIssueRateLimited(3, 3)).toBe(true);
+    expect(isIssueRateLimited(4, 3)).toBe(true);
+  });
+});

--- a/src/lib/check-in/otp.ts
+++ b/src/lib/check-in/otp.ts
@@ -1,0 +1,247 @@
+// SAFE: dead-export-allowed reason="EMR-915 OTP primitive; kiosk-lobby route consumer is a later slice in the build sequence"
+// EMR-915 — one-time SMS code issuance + verification for the kiosk→phone
+// hand-off identity challenge.
+//
+// identity-challenge.ts VERIFIES a "DOB + SMS code" challenge but assumes the
+// code was issued elsewhere. This is that elsewhere.
+//
+// Security shape (mirrors vendor-auth/session.ts):
+//   - The numeric code is NEVER stored in plaintext — only its SHA-256 hash —
+//     and only ever leaves the server over SMS.
+//   - Single active code per (patient, purpose): issuing a new one consumes any
+//     prior unconsumed code.
+//   - Bounded attempts + short expiry; constant-time comparison on verify.
+//   - Issuance is rate-limited per (patient, purpose).
+//
+// The pure decision helpers below carry the security-critical logic and are
+// unit-tested; the DB/SMS orchestration is a thin binding (untested by unit
+// tests, same convention as loadPrevisitSnapshot).
+
+import { createHash, randomInt, timingSafeEqual } from "node:crypto";
+import { prisma } from "@/lib/db/prisma";
+import { getSmsAdapter, normalizePhone } from "@/lib/sms/adapter";
+
+const CODE_LENGTH = 6;
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_MAX_ATTEMPTS = 5;
+/** Max codes that may be issued for one (patient, purpose) within the window. */
+const ISSUE_RATE_MAX = 3;
+const ISSUE_RATE_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+export type OtpPurpose = "kiosk_lobby_handoff";
+
+// ── Pure helpers (security-critical; unit-tested) ──────────────────────────
+
+/** A cryptographically-random zero-padded numeric code. */
+export function generateOtpCode(length: number = CODE_LENGTH): string {
+  const max = 10 ** length;
+  return String(randomInt(0, max)).padStart(length, "0");
+}
+
+export function hashOtp(code: string): string {
+  return createHash("sha256").update(code.trim()).digest("hex");
+}
+
+/** Constant-time hash comparison; rejects empty/length-mismatched inputs. */
+export function hashesEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length === 0 || ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export type OtpVerifyReason =
+  | "ok"
+  | "no_active_code"
+  | "expired"
+  | "already_consumed"
+  | "too_many_attempts"
+  | "mismatch";
+
+export interface OtpRecordState {
+  codeHash: string;
+  expiresAt: Date;
+  attempts: number;
+  maxAttempts: number;
+  consumedAt: Date | null;
+}
+
+/**
+ * Pure verification decision. Given the stored record state and an attempt,
+ * decide the outcome. Order matters: a consumed/expired/locked code fails
+ * before we ever compare hashes (no oracle, no wasted compare).
+ */
+export function evaluateOtpVerification(
+  record: OtpRecordState | null,
+  attemptCode: string,
+  now: Date,
+): { ok: boolean; reason: OtpVerifyReason } {
+  if (!record) return { ok: false, reason: "no_active_code" };
+  if (record.consumedAt) return { ok: false, reason: "already_consumed" };
+  if (record.expiresAt.getTime() <= now.getTime()) {
+    return { ok: false, reason: "expired" };
+  }
+  // The attempt about to be made would be attempts+1; block once we'd exceed.
+  if (record.attempts >= record.maxAttempts) {
+    return { ok: false, reason: "too_many_attempts" };
+  }
+  if (!hashesEqual(hashOtp(attemptCode), record.codeHash)) {
+    return { ok: false, reason: "mismatch" };
+  }
+  return { ok: true, reason: "ok" };
+}
+
+/** Pure rate-limit decision for issuance. */
+export function isIssueRateLimited(
+  recentCount: number,
+  max: number = ISSUE_RATE_MAX,
+): boolean {
+  return recentCount >= max;
+}
+
+// ── DB / SMS orchestration (thin binding) ──────────────────────────────────
+
+export interface IssueOtpResult {
+  ok: boolean;
+  reason?: "rate_limited" | "no_phone" | "sms_failed";
+  expiresAt?: Date;
+}
+
+/**
+ * Issue a fresh code: rate-limit, consume any prior active code, store the hash,
+ * and send the plaintext over SMS. The code is never returned to the caller.
+ */
+export async function issueOtpCode(opts: {
+  patientId: string;
+  organizationId: string;
+  purpose: OtpPurpose;
+  phone: string | null;
+  now?: Date;
+  ttlMs?: number;
+}): Promise<IssueOtpResult> {
+  const now = opts.now ?? new Date();
+  const to = normalizePhone(opts.phone);
+  if (!to) return { ok: false, reason: "no_phone" };
+
+  const recentCount = await prisma.smsOtpCode.count({
+    where: {
+      patientId: opts.patientId,
+      purpose: opts.purpose,
+      createdAt: { gt: new Date(now.getTime() - ISSUE_RATE_WINDOW_MS) },
+    },
+  });
+  if (isIssueRateLimited(recentCount)) {
+    await audit(opts.organizationId, opts.patientId, "otp.issue.rate_limited", opts.purpose);
+    return { ok: false, reason: "rate_limited" };
+  }
+
+  // Single active code per (patient, purpose): retire any unconsumed ones.
+  await prisma.smsOtpCode.updateMany({
+    where: { patientId: opts.patientId, purpose: opts.purpose, consumedAt: null },
+    data: { consumedAt: now },
+  });
+
+  const code = generateOtpCode();
+  const expiresAt = new Date(now.getTime() + (opts.ttlMs ?? DEFAULT_TTL_MS));
+  await prisma.smsOtpCode.create({
+    data: {
+      patientId: opts.patientId,
+      purpose: opts.purpose,
+      codeHash: hashOtp(code),
+      expiresAt,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    },
+  });
+
+  const sent = await getSmsAdapter().send({
+    to,
+    body: `Your check-in code is ${code}. It expires in 10 minutes.`,
+    context: { patientId: opts.patientId, purpose: opts.purpose },
+  });
+  if (!sent.ok) {
+    await audit(opts.organizationId, opts.patientId, "otp.issue.sms_failed", opts.purpose);
+    return { ok: false, reason: "sms_failed" };
+  }
+
+  await audit(opts.organizationId, opts.patientId, "otp.issued", opts.purpose);
+  return { ok: true, expiresAt };
+}
+
+/**
+ * Verify an attempt against the latest active code. Atomically increments the
+ * attempt counter, and consumes the code on success. Returns the pure reason.
+ */
+export async function verifyOtpCode(opts: {
+  patientId: string;
+  organizationId: string;
+  purpose: OtpPurpose;
+  attemptCode: string;
+  now?: Date;
+}): Promise<{ ok: boolean; reason: OtpVerifyReason }> {
+  const now = opts.now ?? new Date();
+
+  const record = await prisma.smsOtpCode.findFirst({
+    where: { patientId: opts.patientId, purpose: opts.purpose, consumedAt: null },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const decision = evaluateOtpVerification(
+    record
+      ? {
+          codeHash: record.codeHash,
+          expiresAt: record.expiresAt,
+          attempts: record.attempts,
+          maxAttempts: record.maxAttempts,
+          consumedAt: record.consumedAt,
+        }
+      : null,
+    opts.attemptCode,
+    now,
+  );
+
+  if (record) {
+    if (decision.ok) {
+      await prisma.smsOtpCode.update({
+        where: { id: record.id },
+        data: { attempts: { increment: 1 }, consumedAt: now },
+      });
+    } else if (decision.reason === "mismatch" || decision.reason === "too_many_attempts") {
+      // Count the failed attempt so brute-force burns the budget.
+      await prisma.smsOtpCode.update({
+        where: { id: record.id },
+        data: { attempts: { increment: 1 } },
+      });
+    }
+  }
+
+  await audit(
+    opts.organizationId,
+    opts.patientId,
+    decision.ok ? "otp.verified_success" : "otp.verified_failed",
+    opts.purpose,
+    decision.ok ? undefined : decision.reason,
+  );
+
+  return decision;
+}
+
+async function audit(
+  organizationId: string,
+  patientId: string,
+  action: string,
+  purpose: string,
+  reason?: string,
+): Promise<void> {
+  // PHI-free metadata only: purpose + (for failures) the machine reason. No code,
+  // no phone, no patient identifiers beyond the opaque id in subjectId.
+  await prisma.auditLog.create({
+    data: {
+      organizationId,
+      actorUserId: null,
+      action,
+      subjectType: "Patient",
+      subjectId: patientId,
+      metadata: reason ? { purpose, reason } : { purpose },
+    },
+  });
+}


### PR DESCRIPTION
First slice of **Phase 2 — kiosk→phone hand-off (EMR-915)**. `identity-challenge.ts` verifies a 'DOB + SMS code' challenge but assumed the code was issued *elsewhere* — this is that elsewhere.

## What
- **`SmsOtpCode` table** — hash-at-rest (never plaintext), minutes-lived, `purpose`-scoped so a code can't be replayed across flows. No FK (throwaway rows). Additive migration.
- **`src/lib/check-in/otp.ts`**:
  - `issueOtpCode` — rate-limited per (patient, purpose), retires any prior active code, stores the **hash**, sends the plaintext **only over SMS**, never returns the code.
  - `verifyOtpCode` — bounded attempts, expiry, **constant-time** compare, consume-on-success.
- **Pure, unit-tested security core** — `evaluateOtpVerification` with strict precedence (consumed → expired → lockout → mismatch), rate-limit, and hashing. DB/SMS orchestration is a thin binding (same convention as `loadPrevisitSnapshot`).
- **PHI-free audit** — `otp.issued` / `otp.verified_success` / `otp.verified_failed` (purpose + machine reason only; no code, no phone).

## Not in this PR (follow-on per EMR-915)
Handoff token + QR · `/kiosk/lobby/[token]` route that composes DOB + this OTP · `KioskLobbySession` · scoped completion surface.

11 unit tests; `tsc` clean.

Refs: EMR-912, EMR-915 · plan §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)