### PR TITLE
feat(check-in): scoped kiosk lobby session (EMR-915)

### DIFF
--- a/prisma/migrations/20260531060000_kiosk_lobby_session/migration.sql
+++ b/prisma/migrations/20260531060000_kiosk_lobby_session/migration.sql
@@ -1,0 +1,17 @@
+-- EMR-915 — scoped non-Clerk "lobby" session for the kiosk→phone hand-off.
+-- Mirrors VendorSession: opaque token in cookie, SHA-256 hash stored here.
+CREATE TABLE IF NOT EXISTS "KioskLobbySession" (
+  "id"               TEXT NOT NULL,
+  "patientId"        TEXT NOT NULL,
+  "organizationId"   TEXT NOT NULL,
+  "sessionTokenHash" TEXT NOT NULL,
+  "expiresAt"        TIMESTAMP(3) NOT NULL,
+  "ipAddress"        TEXT,
+  "userAgent"        TEXT,
+  "createdAt"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "KioskLobbySession_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "KioskLobbySession_sessionTokenHash_key" ON "KioskLobbySession"("sessionTokenHash");
+CREATE INDEX IF NOT EXISTS "KioskLobbySession_patientId_idx" ON "KioskLobbySession"("patientId");
+CREATE INDEX IF NOT EXISTS "KioskLobbySession_expiresAt_idx" ON "KioskLobbySession"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4988,6 +4988,29 @@ model SmsOtpCode {
 }
 
 // --------------------------------------------------------------
+// EMR-915 — scoped "lobby" session for the kiosk→phone hand-off.
+// A patient who passed the kiosk hand-off (handoff token + SMS OTP) gets a
+// short-lived, NON-Clerk session that authorizes ONLY their own pre-visit
+// completion surfaces — never chart / records / messages. Mirrors VendorSession:
+// opaque token in an HTTPOnly cookie, SHA-256 hash stored here, path-scoped to
+// /kiosk/lobby. No FK relation (throwaway rows; patientId is a scope key).
+// --------------------------------------------------------------
+
+model KioskLobbySession {
+  id               String   @id @default(cuid())
+  patientId        String
+  organizationId   String
+  sessionTokenHash String   @unique
+  expiresAt        DateTime
+  ipAddress        String?
+  userAgent        String?
+  createdAt        DateTime @default(now())
+
+  @@index([patientId])
+  @@index([expiresAt])
+}
+
+// --------------------------------------------------------------
 // EMR-107 — ChatCB AI Coach
 // --------------------------------------------------------------
 

--- a/src/lib/check-in/kiosk-lobby-session.test.ts
+++ b/src/lib/check-in/kiosk-lobby-session.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  generateLobbySessionToken,
+  isLobbySessionExpired,
+} from "./kiosk-lobby-session";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+describe("isLobbySessionExpired", () => {
+  it("is expired at or past the expiry instant", () => {
+    expect(isLobbySessionExpired(new Date(NOW.getTime() - 1), NOW)).toBe(true);
+    expect(isLobbySessionExpired(NOW, NOW)).toBe(true);
+  });
+  it("is not expired while there is time left", () => {
+    expect(isLobbySessionExpired(new Date(NOW.getTime() + 1000), NOW)).toBe(false);
+  });
+});
+
+describe("generateLobbySessionToken", () => {
+  it("produces a 64-char hex opaque token that differs each call", () => {
+    const a = generateLobbySessionToken();
+    const b = generateLobbySessionToken();
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/check-in/kiosk-lobby-session.ts
+++ b/src/lib/check-in/kiosk-lobby-session.ts
@@ -1,0 +1,131 @@
+// SAFE: dead-export-allowed reason="EMR-915 lobby session primitive; /kiosk/lobby route consumer is a later slice"
+// EMR-915 — scoped "lobby" session for the kiosk→phone hand-off.
+//
+// Minted only after a patient clears the hand-off challenge (valid handoff
+// token + SMS OTP) on their phone. Deliberately distinct from both the clinical
+// Clerk session and the vendor session:
+//   1. Different cookie name (`kiosk_lobby_session`)
+//   2. Different cookie path (`/kiosk/lobby`) so the browser NEVER sends it to
+//      clinical/portal/api routes — a lobby cookie can't ride along to PHI.
+//   3. Different table (`KioskLobbySession`), holding only patientId + org.
+//
+// This session is an *identity*, not an authorization: it says "this device is
+// acting as patient X of org Y for pre-visit completion." It grants nothing on
+// its own — the scoped completion surface (later slice) is what restricts which
+// pages/actions a lobby session may reach, and it must NEVER expose chart /
+// records / messages.
+//
+// Cookie holds a plaintext opaque token; DB stores its SHA-256. A DB leak alone
+// can't impersonate. Mirrors vendor-auth/session.ts.
+
+import { cookies } from "next/headers";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { prisma } from "@/lib/db/prisma";
+
+export const KIOSK_LOBBY_COOKIE = "kiosk_lobby_session";
+export const KIOSK_LOBBY_COOKIE_PATH = "/kiosk/lobby";
+export const KIOSK_LOBBY_TTL_MINUTES = 30;
+
+/** Scoped identity carried by a lobby session — NOT a user, NOT a role. */
+export interface KioskLobbyIdentity {
+  patientId: string;
+  organizationId: string;
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function generateLobbySessionToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/** Pure: is a session past its expiry as of `now`? */
+export function isLobbySessionExpired(expiresAt: Date, now: Date = new Date()): boolean {
+  return expiresAt.getTime() <= now.getTime();
+}
+
+export async function createKioskLobbySession(opts: {
+  patientId: string;
+  organizationId: string;
+  ipAddress?: string;
+  userAgent?: string;
+  now?: Date;
+}): Promise<{ token: string; expiresAt: Date }> {
+  const now = opts.now ?? new Date();
+  const token = generateLobbySessionToken();
+  const expiresAt = new Date(now.getTime() + KIOSK_LOBBY_TTL_MINUTES * 60 * 1000);
+  await prisma.kioskLobbySession.create({
+    data: {
+      patientId: opts.patientId,
+      organizationId: opts.organizationId,
+      sessionTokenHash: hashToken(token),
+      expiresAt,
+      ipAddress: opts.ipAddress,
+      userAgent: opts.userAgent,
+    },
+  });
+  return { token, expiresAt };
+}
+
+export async function setKioskLobbyCookie(token: string, expiresAt: Date): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(KIOSK_LOBBY_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: KIOSK_LOBBY_COOKIE_PATH,
+    expires: expiresAt,
+  });
+}
+
+export async function clearKioskLobbyCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(KIOSK_LOBBY_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: KIOSK_LOBBY_COOKIE_PATH,
+    maxAge: 0,
+  });
+}
+
+/**
+ * Resolve the current lobby identity from the cookie, or null. Constant-time
+ * hash check + expiry. Never returns anything beyond patientId + org.
+ */
+export async function getCurrentKioskLobby(now: Date = new Date()): Promise<KioskLobbyIdentity | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(KIOSK_LOBBY_COOKIE)?.value;
+  if (!token) return null;
+
+  const session = await prisma.kioskLobbySession.findUnique({
+    where: { sessionTokenHash: hashToken(token) },
+  });
+  if (!session) return null;
+
+  // Double-check the stored hash constant-time (defense vs a near-match bug).
+  const expected = Buffer.from(session.sessionTokenHash, "hex");
+  const actual = Buffer.from(hashToken(token), "hex");
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    return null;
+  }
+
+  if (isLobbySessionExpired(session.expiresAt, now)) return null;
+
+  return { patientId: session.patientId, organizationId: session.organizationId };
+}
+
+/** Throwing variant for route handlers. */
+export async function requireKioskLobby(): Promise<KioskLobbyIdentity> {
+  const identity = await getCurrentKioskLobby();
+  if (!identity) throw new Error("KIOSK_LOBBY_UNAUTHORIZED");
+  return identity;
+}
+
+export async function pruneExpiredKioskLobbySessions(now: Date = new Date()): Promise<number> {
+  const result = await prisma.kioskLobbySession.deleteMany({
+    where: { expiresAt: { lt: now } },
+  });
+  return result.count;
+}


### PR DESCRIPTION
Phase 2 slice 3 of **EMR-915** — the last primitive before the route/UI wiring.

## What
- New `KioskLobbySession` table + `src/lib/check-in/kiosk-lobby-session.ts`, mirroring `vendor-auth/session.ts`: opaque token in an **HTTPOnly cookie**, **SHA-256 hash** stored, **constant-time** verify, **30-min TTL**.
- **Distinct cookie name + path (`/kiosk/lobby`)** so the browser never sends it to clinical/portal/api routes — a lobby cookie can't ride along to PHI.
- Resolves to a scoped **identity only** (`patientId` + `organizationId`), never a user or role. **It authorizes nothing on its own** — the scoped completion surface (next slice) enforces what a lobby session may reach and must never expose chart/records/messages.

## Tests
Pure `isLobbySessionExpired` + token-format helpers unit-tested (3 tests); cookie/DB orchestration is a thin binding (same convention as `vendor-auth`). Additive migration applied idempotently to the dev DB. `tsc` clean.

## Now unblocked
All three hand-off primitives are in: **OTP (#551) + handoff token (#552) + lobby session (this)**. Next is the integration: the `/kiosk/lobby/[token]` route + 'Continue on my phone' button + the scoped completion surface (the PHI-boundary crux).

Refs: EMR-912, EMR-915 · plan §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)