### PR TITLE
[codex] Add AI Visit Completion panel

### DIFF
--- a/docs/superpowers/plans/2026-05-30-ai-visit-completion.md
+++ b/docs/superpowers/plans/2026-05-30-ai-visit-completion.md
@@ -1,0 +1,280 @@
+# AI Visit Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the physician-facing AI Visit Completion strip below finalized notes with deterministic Suggested Next Best Actions.
+
+**Architecture:** Build a pure `visit-completion` domain projection that turns note blocks, coding suggestions, and follow-up context into a typed bundle. Include learning-loop metadata that maps physician actions to the existing `AgentFeedback` spine, then render the bundle in a focused note-route panel component and wire the note detail page to build it only for finalized notes.
+
+**Tech Stack:** Next.js 14 App Router, React, TypeScript, Prisma query data, Vitest node tests, existing `Card`, `Badge`, and `Button` UI primitives.
+
+---
+
+## File Structure
+
+- Create `src/lib/domain/visit-completion.ts`: pure types and deterministic bundle builder.
+- Create `src/lib/domain/visit-completion.test.ts`: unit tests for stable cards, follow-up warning, coding degradation, and summary counts.
+- Create `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`: server-renderable panel component for the approved UI.
+- Create `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx`: node-safe React element inspection test that locks key product language.
+- Modify `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx`: query future appointment context, build bundle for finalized notes, render panel below `NoteEditor`.
+
+## Task 1: Domain Bundle Builder
+
+**Files:**
+- Create: `src/lib/domain/visit-completion.ts`
+- Create: `src/lib/domain/visit-completion.test.ts`
+
+- [ ] **Step 1: Write failing domain tests**
+
+Add tests that import `buildVisitCompletionBundle` and expect:
+
+```ts
+expect(bundle.cards.map((card) => card.id)).toEqual([
+  "orders",
+  "follow_up",
+  "patient_message",
+  "practice_readiness",
+]);
+expect(bundle.primaryActionLabel).toBe("Release Care Plan");
+expect(bundle.learningLoop.agentName).toBe("visitCompletion");
+expect(bundle.learningLoop.signals).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ actionId: "release_care_plan", feedbackAction: "approved" }),
+    expect.objectContaining({ actionId: "edit_item", feedbackAction: "approved_with_edits" }),
+    expect.objectContaining({ actionId: "remove_item", feedbackAction: "rejected" }),
+    expect.objectContaining({ actionId: "defer_item", feedbackAction: "dismissed" }),
+  ]),
+);
+expect(bundle.cards.find((card) => card.id === "follow_up")?.items[0]).toMatchObject({
+  tone: "alert",
+  label: "Plan implies follow-up; no appointment scheduled",
+});
+expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ label: "Suggested E/M: 99214" }),
+    expect.objectContaining({ label: "ICD-10 candidate: E11.9 Diabetes mellitus" }),
+  ]),
+);
+```
+
+- [ ] **Step 2: Run red test**
+
+Run: `npm test -- src/lib/domain/visit-completion.test.ts`
+
+Expected: fail because `src/lib/domain/visit-completion.ts` does not exist.
+
+- [ ] **Step 3: Implement minimal builder**
+
+Create types:
+
+```ts
+export type VisitCompletionCardId = "orders" | "follow_up" | "patient_message" | "practice_readiness";
+export type VisitCompletionTone = "neutral" | "warning" | "alert";
+export type VisitCompletionSource = "note" | "coding" | "problem_list" | "encounter" | "heuristic";
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: VisitCompletionTone;
+  source: VisitCompletionSource;
+  reason?: string;
+}
+
+export interface VisitCompletionAction {
+  id: string;
+  label: string;
+  variant: "primary" | "secondary";
+}
+
+export interface VisitCompletionCard {
+  id: VisitCompletionCardId;
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionBundle {
+  sectionLabel: "AI Visit Completion";
+  heading: "Suggested Next Best Actions";
+  primaryActionLabel: "Release Care Plan";
+  supportActionLabel: "Approve all suggested actions";
+  summary: string;
+  releaseEnabled: boolean;
+  learningLoop: VisitCompletionLearningLoop;
+  cards: VisitCompletionCard[];
+}
+
+export interface VisitCompletionLearningLoop {
+  agentName: "visitCompletion";
+  agentVersion: "1.0.0";
+  signals: VisitCompletionLearningSignal[];
+}
+
+export interface VisitCompletionLearningSignal {
+  actionId: "release_care_plan" | "approve_all" | "edit_item" | "remove_item" | "defer_item";
+  feedbackAction: "approved" | "approved_with_edits" | "rejected" | "dismissed";
+  meaning: string;
+}
+```
+
+Implement `buildVisitCompletionBundle(input)` with deterministic heuristics:
+
+- always returns the four cards in stable order
+- flags follow-up language when no future appointment exists
+- uses `codingSuggestion.emLevel` and ICD-10 labels when present
+- degrades Practice Readiness to `No coding suggestion yet` when absent
+- computes summary from card items
+- includes learning-loop metadata that can be persisted through `src/lib/agents/memory/agent-feedback.ts`
+
+- [ ] **Step 4: Run green domain test**
+
+Run: `npm test -- src/lib/domain/visit-completion.test.ts`
+
+Expected: pass.
+
+## Task 2: AI Visit Completion Panel
+
+**Files:**
+- Create: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+- Create: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx`
+
+- [ ] **Step 1: Write failing panel test**
+
+Render the component as a React element in node and inspect it with `util.inspect`, following `src/components/ui/button.test.tsx`.
+
+Assert the tree contains:
+
+```ts
+expect(str).toContain("AI Visit Completion");
+expect(str).toContain("Suggested Next Best Actions");
+expect(str).toContain("Release Care Plan");
+expect(str).toContain("Suggested Orders");
+expect(str).toContain("Follow-Up Plan");
+expect(str).toContain("Patient Communication");
+expect(str).toContain("Practice Readiness");
+expect(str).toContain("Physician remains in control.");
+expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+```
+
+- [ ] **Step 2: Run red panel test**
+
+Run: `npm test -- "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"`
+
+Expected: fail because the panel file does not exist.
+
+- [ ] **Step 3: Implement panel component**
+
+Create `VisitCompletionPanel({ bundle })` that:
+
+- uses `Card`, `CardContent`, `Badge`, and `Button`
+- renders the approved language
+- maps card item tones to compact colored dots
+- renders actions as small buttons
+- renders **Release Care Plan** as the primary button
+- stacks cards on mobile with `grid-cols-1 lg:grid-cols-4`
+- includes the control note: "Physician remains in control."
+- includes learning-loop copy that makes the toolchain support visible without making the UI feel like telemetry
+
+- [ ] **Step 4: Run green panel test**
+
+Run: `npm test -- "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"`
+
+Expected: pass.
+
+## Task 3: Route Integration
+
+**Files:**
+- Modify: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx`
+
+- [ ] **Step 1: Add integration imports and future appointment query**
+
+Import:
+
+```ts
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
+```
+
+Query one future appointment for the same patient:
+
+```ts
+const futureAppointment = await prisma.appointment.findFirst({
+  where: {
+    patientId: params.id,
+    startAt: { gt: new Date() },
+    status: { notIn: ["cancelled", "no_show"] },
+  },
+  select: { id: true },
+});
+```
+
+- [ ] **Step 2: Build the bundle only for finalized notes**
+
+After `codingSuggestion` parsing:
+
+```ts
+const visitCompletionBundle =
+  note.status === "finalized"
+    ? buildVisitCompletionBundle({
+        patientFirstName: patient.firstName,
+        blocks,
+        codingSuggestion,
+        hasFutureAppointment: Boolean(futureAppointment),
+      })
+    : null;
+```
+
+- [ ] **Step 3: Render panel below `NoteEditor`**
+
+Add:
+
+```tsx
+{visitCompletionBundle && (
+  <VisitCompletionPanel bundle={visitCompletionBundle} />
+)}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-completion.test.ts "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"
+```
+
+Expected: pass.
+
+## Task 4: Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: exit 0.
+
+- [ ] **Step 2: Inspect final diff**
+
+Run: `git diff --stat && git diff -- src/lib/domain/visit-completion.ts src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/page.tsx`
+
+Expected: diff is limited to the planned files and approved UI language.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add src/lib/domain/visit-completion.ts src/lib/domain/visit-completion.test.ts src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.test.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/page.tsx docs/superpowers/plans/2026-05-30-ai-visit-completion.md
+git commit -m "feat: add ai visit completion panel"
+```
+
+Expected: commit succeeds.
+
+## Plan Self-Review
+
+- Spec coverage: the plan covers the typed bundle, the four cards, route rendering, approved language, first-slice no-live-model behavior, learning-loop metadata, and tests.
+- Scoped deferral: release persistence, task creation, patient-message sending, billing workflow dispatch, and actual feedback writes are intentionally deferred behind the same bundle contract and existing `AgentFeedback` primitive.
+- Placeholder scan: no placeholders or undefined task references remain.

--- a/docs/superpowers/plans/2026-05-30-core-visit-spine-swarm.md
+++ b/docs/superpowers/plans/2026-05-30-core-visit-spine-swarm.md
@@ -1,0 +1,780 @@
+# Core Visit Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the same-day visit spine that front desk, MA, and physician workflows can share without duplicate encounters or ambiguous states.
+
+**Architecture:** `Encounter` becomes the same-day operational state spine; `Appointment` remains scheduling/reminder history and can link to an encounter. A central `visit-state` helper owns transitions and timestamp side effects; staff surfaces call that helper rather than writing status directly.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, Prisma, Vitest, server actions/API routes, existing AuditLog patterns.
+
+---
+
+## File Ownership
+
+Codex-owned files:
+
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/20260530000000_core_visit_spine/migration.sql`
+- Create: `src/lib/domain/visit-state.ts`
+- Create: `src/lib/domain/visit-state.test.ts`
+- Modify: `src/lib/domain/queue-board.ts`
+- Create: `src/lib/domain/queue-board.test.ts`
+- Modify: `src/app/(operator)/ops/queue/page.tsx`
+- Create: `src/app/(operator)/ops/queue/actions.ts`
+- Modify: `src/app/(operator)/ops/queue/queue-board.tsx`
+- Modify: `src/app/api/mobile/kiosk/check-in/route.ts`
+- Create: `src/app/api/mobile/kiosk/check-in/route.test.ts`
+
+Do not edit in Codex swarm unless coordinating a merge:
+
+- `src/app/(clinician)/clinic/patients/[id]/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts`
+- `src/lib/scheduling/send-reminders.ts`
+- `src/lib/scheduling/intake-gate.ts`
+- patient portal reminder/QR routes
+
+## External Swarm Boundaries
+
+Claude Code owns physician workflow:
+
+- start visit selection
+- briefing start permissions
+- note finalization idempotency
+- physician-visible rooming handoff
+
+Gemini owns patient pre-visit and QR rescue:
+
+- previsit readiness mapper
+- 7d/2d/morning-of reminders
+- non-PHI copy
+- QR token helper and route tests
+
+## Task 1: Visit State Schema And Helper
+
+**Files:**
+
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/20260530000000_core_visit_spine/migration.sql`
+- Create: `src/lib/domain/visit-state.ts`
+- Create: `src/lib/domain/visit-state.test.ts`
+
+- [ ] **Step 1: Write the failing visit-state tests**
+
+Create `src/lib/domain/visit-state.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  advanceVisitState,
+  isVisitSpineStatus,
+  type VisitSpineStatus,
+} from "./visit-state";
+
+describe("visit-state", () => {
+  it("allows scheduled visits to check in and stamps checkedInAt once", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "scheduled", checkedInAt: null },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(now);
+  });
+
+  it("does not replace an existing timestamp on idempotent transition", () => {
+    const checkedInAt = new Date("2026-05-30T15:45:00.000Z");
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "checked_in", checkedInAt },
+      "checked_in",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("checked_in");
+    expect(result.data.checkedInAt).toEqual(checkedInAt);
+  });
+
+  it("rejects jumping from scheduled directly to complete", () => {
+    const result = advanceVisitState(
+      { status: "scheduled", completedAt: null },
+      "complete",
+      new Date("2026-05-30T16:00:00.000Z"),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Cannot transition visit from scheduled to complete.",
+    });
+  });
+
+  it("keeps legacy in_progress compatible with active visit", () => {
+    const now = new Date("2026-05-30T16:00:00.000Z");
+    const result = advanceVisitState(
+      { status: "in_progress", startedAt: null },
+      "in_visit",
+      now,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.status).toBe("in_visit");
+    expect(result.data.startedAt).toEqual(now);
+  });
+
+  it("recognizes all canonical spine statuses", () => {
+    const statuses: VisitSpineStatus[] = [
+      "scheduled",
+      "checked_in",
+      "info_incomplete",
+      "ready",
+      "rooming",
+      "roomed",
+      "in_visit",
+      "wrap_up",
+      "complete",
+      "cancelled",
+      "no_show",
+    ];
+
+    expect(statuses.every(isVisitSpineStatus)).toBe(true);
+    expect(isVisitSpineStatus("in_progress")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts
+```
+
+Expected: fail because `src/lib/domain/visit-state.ts` does not exist.
+
+- [ ] **Step 3: Add schema changes**
+
+Modify `prisma/schema.prisma`:
+
+```prisma
+enum EncounterStatus {
+  scheduled
+  checked_in
+  info_incomplete
+  ready
+  rooming
+  roomed
+  in_visit
+  wrap_up
+  in_progress
+  complete
+  cancelled
+  no_show
+}
+```
+
+Add to `Encounter`:
+
+```prisma
+  appointmentId        String?         @unique
+  checkedInAt          DateTime?
+  roomingStartedAt     DateTime?
+  roomedAt             DateTime?
+  wrapUpAt             DateTime?
+  cancelledAt          DateTime?
+  noShowAt             DateTime?
+  appointment          Appointment?    @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+```
+
+Add to `Appointment`:
+
+```prisma
+  encounter Encounter?
+```
+
+Add to `Encounter` indexes:
+
+```prisma
+  @@index([organizationId, status, scheduledFor])
+```
+
+Create `prisma/migrations/20260530000000_core_visit_spine/migration.sql`:
+
+```sql
+-- Add the same-day visit-spine states while preserving legacy in_progress.
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'checked_in';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'info_incomplete';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'ready';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'rooming';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'roomed';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'in_visit';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'wrap_up';
+ALTER TYPE "EncounterStatus" ADD VALUE IF NOT EXISTS 'no_show';
+
+ALTER TABLE "Encounter"
+  ADD COLUMN IF NOT EXISTS "appointmentId" TEXT,
+  ADD COLUMN IF NOT EXISTS "checkedInAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomingStartedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "roomedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "wrapUpAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "cancelledAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "noShowAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Encounter_appointmentId_key"
+  ON "Encounter"("appointmentId");
+
+CREATE INDEX IF NOT EXISTS "Encounter_organizationId_status_scheduledFor_idx"
+  ON "Encounter"("organizationId", "status", "scheduledFor");
+
+ALTER TABLE "Encounter"
+  ADD CONSTRAINT "Encounter_appointmentId_fkey"
+  FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+```
+
+- [ ] **Step 4: Implement visit-state helper**
+
+Create `src/lib/domain/visit-state.ts`:
+
+```ts
+export const VISIT_SPINE_STATUSES = [
+  "scheduled",
+  "checked_in",
+  "info_incomplete",
+  "ready",
+  "rooming",
+  "roomed",
+  "in_visit",
+  "wrap_up",
+  "complete",
+  "cancelled",
+  "no_show",
+] as const;
+
+export type VisitSpineStatus = (typeof VISIT_SPINE_STATUSES)[number];
+export type LegacyVisitStatus = "in_progress";
+export type VisitStatus = VisitSpineStatus | LegacyVisitStatus;
+
+export interface VisitStateFields {
+  status: string;
+  checkedInAt?: Date | null;
+  roomingStartedAt?: Date | null;
+  roomedAt?: Date | null;
+  startedAt?: Date | null;
+  wrapUpAt?: Date | null;
+  completedAt?: Date | null;
+  cancelledAt?: Date | null;
+  noShowAt?: Date | null;
+}
+
+export type VisitTransitionResult =
+  | { ok: true; data: Partial<VisitStateFields> }
+  | { ok: false; error: string };
+
+const STATUS_SET = new Set<string>(VISIT_SPINE_STATUSES);
+
+const ALLOWED_TRANSITIONS: Record<string, ReadonlySet<VisitSpineStatus>> = {
+  scheduled: new Set(["checked_in", "info_incomplete", "ready", "cancelled", "no_show"]),
+  checked_in: new Set(["info_incomplete", "ready", "rooming", "cancelled", "no_show"]),
+  info_incomplete: new Set(["ready", "cancelled", "no_show"]),
+  ready: new Set(["rooming", "roomed", "in_visit", "cancelled", "no_show"]),
+  rooming: new Set(["roomed", "ready", "cancelled"]),
+  roomed: new Set(["in_visit", "wrap_up", "cancelled"]),
+  in_visit: new Set(["wrap_up", "complete", "cancelled"]),
+  wrap_up: new Set(["complete", "in_visit"]),
+  complete: new Set([]),
+  cancelled: new Set([]),
+  no_show: new Set([]),
+  in_progress: new Set(["in_visit", "wrap_up", "complete", "cancelled"]),
+};
+
+export function isVisitSpineStatus(value: string): value is VisitSpineStatus {
+  return STATUS_SET.has(value);
+}
+
+export function advanceVisitState(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date = new Date(),
+): VisitTransitionResult {
+  if (current.status === target) {
+    return { ok: true, data: applyTimestamp(current, target, now) };
+  }
+
+  const allowed = ALLOWED_TRANSITIONS[current.status];
+  if (!allowed?.has(target)) {
+    return {
+      ok: false,
+      error: `Cannot transition visit from ${current.status} to ${target}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: target,
+      ...applyTimestamp(current, target, now),
+    },
+  };
+}
+
+function applyTimestamp(
+  current: VisitStateFields,
+  target: VisitSpineStatus,
+  now: Date,
+): Partial<VisitStateFields> {
+  switch (target) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return { checkedInAt: current.checkedInAt ?? now };
+    case "rooming":
+      return { roomingStartedAt: current.roomingStartedAt ?? now };
+    case "roomed":
+      return { roomedAt: current.roomedAt ?? now };
+    case "in_visit":
+      return { startedAt: current.startedAt ?? now };
+    case "wrap_up":
+      return { wrapUpAt: current.wrapUpAt ?? now };
+    case "complete":
+      return { completedAt: current.completedAt ?? now };
+    case "cancelled":
+      return { cancelledAt: current.cancelledAt ?? now };
+    case "no_show":
+      return { noShowAt: current.noShowAt ?? now };
+    case "scheduled":
+      return {};
+  }
+}
+```
+
+- [ ] **Step 5: Run helper tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Queue Projection And Staff State Actions
+
+**Files:**
+
+- Modify: `src/lib/domain/queue-board.ts`
+- Create: `src/lib/domain/queue-board.test.ts`
+- Modify: `src/app/(operator)/ops/queue/page.tsx`
+- Create: `src/app/(operator)/ops/queue/actions.ts`
+
+- [ ] **Step 1: Write failing queue projection tests**
+
+Create `src/lib/domain/queue-board.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mapEncounterStatusToQueueStatus } from "./queue-board";
+
+describe("queue-board status mapping", () => {
+  it.each([
+    ["scheduled", "scheduled"],
+    ["checked_in", "arrived"],
+    ["info_incomplete", "arrived"],
+    ["ready", "arrived"],
+    ["rooming", "rooming"],
+    ["roomed", "rooming"],
+    ["in_visit", "in_visit"],
+    ["wrap_up", "checkout"],
+    ["complete", "completed"],
+    ["cancelled", "completed"],
+    ["no_show", "completed"],
+  ] as const)("maps %s to %s", (encounterStatus, queueStatus) => {
+    expect(mapEncounterStatusToQueueStatus(encounterStatus)).toBe(queueStatus);
+  });
+
+  it("keeps legacy in_progress visible as in visit", () => {
+    expect(mapEncounterStatusToQueueStatus("in_progress")).toBe("in_visit");
+  });
+});
+```
+
+- [ ] **Step 2: Run failing queue tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/queue-board.test.ts
+```
+
+Expected: fail because `mapEncounterStatusToQueueStatus` is not exported.
+
+- [ ] **Step 3: Implement queue projection helper**
+
+Modify `src/lib/domain/queue-board.ts`:
+
+```ts
+export function mapEncounterStatusToQueueStatus(status: string): QueueStatus {
+  switch (status) {
+    case "checked_in":
+    case "info_incomplete":
+    case "ready":
+      return "arrived";
+    case "rooming":
+    case "roomed":
+      return "rooming";
+    case "in_visit":
+    case "in_progress":
+      return "in_visit";
+    case "wrap_up":
+      return "checkout";
+    case "complete":
+    case "cancelled":
+    case "no_show":
+      return "completed";
+    case "scheduled":
+    default:
+      return "scheduled";
+  }
+}
+```
+
+Extend `QueueEntry`:
+
+```ts
+  readinessFlags?: string[];
+  handoffNote?: string;
+```
+
+- [ ] **Step 4: Update queue page mapping**
+
+Modify `src/app/(operator)/ops/queue/page.tsx` to select `briefingContext` and use `mapEncounterStatusToQueueStatus(enc.status)`.
+
+Rooming context shape:
+
+```ts
+type RoomingContext = {
+  room?: string;
+  readinessFlags?: string[];
+  handoffNote?: string;
+};
+```
+
+Extract from `enc.briefingContext.rooming` when present and pass `room`, `readinessFlags`, and `handoffNote` into `QueueEntry`.
+
+- [ ] **Step 5: Add server actions for staff state changes**
+
+Create `src/app/(operator)/ops/queue/actions.ts`:
+
+```ts
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { advanceVisitState, type VisitSpineStatus } from "@/lib/domain/visit-state";
+
+const TransitionSchema = z.object({
+  encounterId: z.string().min(1),
+  target: z.enum(["checked_in", "info_incomplete", "ready", "rooming", "roomed", "wrap_up", "cancelled", "no_show"]),
+});
+
+export async function moveQueueEncounter(payload: z.infer<typeof TransitionSchema>) {
+  const user = await requireUser();
+  const parsed = TransitionSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid queue transition." };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: { id: parsed.data.encounterId, organizationId: user.organizationId! },
+  });
+  if (!encounter) return { ok: false, error: "Encounter not found." };
+
+  const next = advanceVisitState(encounter, parsed.data.target as VisitSpineStatus);
+  if (!next.ok) return next;
+
+  await prisma.encounter.update({
+    where: { id: encounter.id },
+    data: next.data as any,
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: encounter.organizationId,
+      actorUserId: user.id,
+      action: "encounter.visit_state.updated",
+      subjectType: "Encounter",
+      subjectId: encounter.id,
+      metadata: { from: encounter.status, to: parsed.data.target },
+    },
+  });
+
+  revalidatePath("/ops/queue");
+  return { ok: true };
+}
+```
+
+- [ ] **Step 6: Run queue tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/queue-board.test.ts
+```
+
+Expected: pass.
+
+## Task 3: Kiosk Check-In Hardening
+
+**Files:**
+
+- Modify: `src/app/api/mobile/kiosk/check-in/route.ts`
+- Create: `src/app/api/mobile/kiosk/check-in/route.test.ts`
+
+- [ ] **Step 1: Write failing route tests**
+
+Create `src/app/api/mobile/kiosk/check-in/route.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    encounter: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    patient: {
+      update: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
+    },
+  };
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return { mockPrisma, logger };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+vi.mock("@/lib/observability/log", () => ({
+  logger: hoisted.logger,
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://example.com/api/mobile/kiosk/check-in", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/mobile/kiosk/check-in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "development";
+    hoisted.mockPrisma.patient.update.mockResolvedValue({ id: "pat_1" });
+    hoisted.mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  });
+
+  it("rejects mismatched encounter and patient ids", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    const res = await POST(
+      makeRequest({ encounterId: "enc_1", patientId: "wrong_pat" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Encounter not found for patient" });
+    expect(hoisted.mockPrisma.encounter.update).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("moves a verified scheduled encounter to checked_in and audits it", async () => {
+    const scheduledFor = new Date("2026-05-30T16:00:00.000Z");
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "scheduled",
+      scheduledFor,
+      checkedInAt: null,
+    });
+    hoisted.mockPrisma.encounter.update.mockResolvedValue({
+      id: "enc_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+      status: "checked_in",
+    });
+
+    const res = await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, status: "checked_in" });
+    expect(hoisted.mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: expect.objectContaining({
+        status: "checked_in",
+        checkedInAt: expect.any(Date),
+      }),
+    });
+    expect(hoisted.mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org_1",
+        action: "encounter.kiosk_check_in.completed",
+        subjectType: "Encounter",
+        subjectId: "enc_1",
+      }),
+    });
+  });
+
+  it("verifies encounter ownership before updating state", async () => {
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue(null);
+
+    await POST(makeRequest({ encounterId: "enc_1", patientId: "pat_1" }));
+
+    expect(hoisted.mockPrisma.encounter.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "enc_1",
+        patientId: "pat_1",
+      },
+      include: {
+        patient: {
+          select: {
+            id: true,
+            intakeAnswers: true,
+            organizationId: true,
+          },
+        },
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing route tests**
+
+Run:
+
+```bash
+npm test -- src/app/api/mobile/kiosk/check-in/route.test.ts
+```
+
+Expected: fail because current route updates by encounter id only and writes no audit row.
+
+- [ ] **Step 3: Harden route**
+
+Modify route to:
+
+- parse with Zod
+- verify `encounter.id`, `encounter.patientId`, and `encounter.patient.organizationId`
+- use `advanceVisitState(encounter, "checked_in")`
+- write `AuditLog` action `encounter.kiosk_check_in.completed`
+- never write signed forms directly over the full `intakeAnswers` JSON without merging
+
+- [ ] **Step 4: Run route tests**
+
+Run:
+
+```bash
+npm test -- src/app/api/mobile/kiosk/check-in/route.test.ts
+```
+
+Expected: pass.
+
+## Task 4: Queue UI Hooks For Front Desk And MA
+
+**Files:**
+
+- Modify: `src/app/(operator)/ops/queue/queue-board.tsx`
+- Modify: `src/app/(operator)/ops/queue/actions.ts`
+
+- [ ] **Step 1: Wire context-menu actions to server actions**
+
+Replace placeholder `router.refresh()` handlers with calls to `moveQueueEncounter`:
+
+```ts
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "checked_in" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "rooming" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "roomed" });
+await moveQueueEncounter({ encounterId: entry.encounterId, target: "wrap_up" });
+```
+
+- [ ] **Step 2: Add a minimal handoff action**
+
+Extend `actions.ts` with `saveRoomingHandoff`:
+
+```ts
+const RoomingSchema = z.object({
+  encounterId: z.string().min(1),
+  room: z.string().max(20).optional(),
+  handoffNote: z.string().max(1000).optional(),
+  readinessFlags: z.array(z.string().max(100)).max(10).default([]),
+});
+```
+
+This action merges into `briefingContext.rooming` and audits `encounter.rooming.updated`.
+
+- [ ] **Step 3: Keep UI minimal**
+
+Expose room/readiness/handoff text on queue cards if present. Use compact text only; do not build a large modal in this slice unless all previous tests are green.
+
+- [ ] **Step 4: Run targeted tests and typecheck**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts src/lib/domain/queue-board.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts
+npm run typecheck
+```
+
+Expected: tests pass and typecheck is clean.
+
+## Coordination Checkpoint
+
+- [ ] **Step 1: Reconcile with Claude Code physician swarm**
+
+Check whether Claude edited:
+
+- `src/app/(clinician)/clinic/patients/[id]/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/prepare/actions.ts`
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts`
+
+If their code needs the visit-state helper, export stable types and avoid renaming functions.
+
+- [ ] **Step 2: Reconcile with Gemini pre-visit swarm**
+
+Check whether Gemini edited:
+
+- `src/lib/scheduling/send-reminders.ts`
+- `src/lib/scheduling/intake-gate.ts`
+- QR token helpers/routes
+
+If their readiness mapper needs encounter status, use the `Encounter.appointmentId` relation and `ready/info_incomplete` states.
+
+- [ ] **Step 3: Final verification**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-state.test.ts src/lib/domain/queue-board.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts
+npm run typecheck
+```
+
+Expected: all tests pass and typecheck is clean.

--- a/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
+++ b/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
@@ -163,6 +163,22 @@ Responsibilities:
 
 The existing note editor is already doing too much. The panel should be a separate component and the route page should pass the projected bundle alongside `codingSuggestion`.
 
+## AI Toolchain and Learning Loop
+
+AI Visit Completion should plug into the existing agent learning spine instead of becoming an isolated suggestion widget.
+
+The app already has `AgentFeedback` and `recordFeedback()` for approve, approve-with-edits, reject, and dismiss signals. The visit-completion bundle should expose metadata that maps physician actions onto those signals:
+
+- **Release Care Plan** → `approved`
+- **Approve all suggested actions** → `approved`
+- **Edit item** → `approved_with_edits`
+- **Remove item** → `rejected`
+- **Defer item** → `dismissed`
+
+The first UI slice can ship with this metadata and visible learning-loop language while persistence remains staged. The next release action should record the physician's choices with note id, reviewer id, organization id, selected items, and optional edit/reason text. These rows become the recursive improvement loop for future suggestions, physician preference learning, and agent-quality reporting.
+
+Feedback capture must never block care-plan release. If feedback persistence fails, the clinical or operational action should still proceed and log a warning.
+
 ## Release Behavior
 
 The first implementation can make **Release Care Plan** a staged client action with clear disabled/degraded states if back-end mutation support is not ready.

--- a/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
+++ b/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
@@ -1,0 +1,230 @@
+# AI Visit Completion Design
+
+## Goal
+
+Turn the finalized-note ending into a physician-controlled care-plan release moment.
+
+The current note page finalizes the note, shows coding suggestions when available, and offers print/leaflet actions. That is clinically useful, but it misses the high-leverage moment immediately after the physician has expressed intent in the plan. The new surface should translate that intent into concrete next actions while keeping the physician in control.
+
+The product feeling should be: "I am still deciding, but I am no longer doing clerical assembly by hand."
+
+## Design Direction
+
+Add an **AI Visit Completion** section directly beneath the finalized note content. It is not a separate dashboard and not a multi-step administrative wizard. It is a thin co-pilot strip with four action cards and one primary release action.
+
+Primary language:
+
+- Section: **AI Visit Completion**
+- Main heading: **Suggested Next Best Actions**
+- Primary action: **Release Care Plan**
+- Supporting action: **Approve all suggested actions**
+- Card labels:
+  - **Suggested Orders**
+  - **Follow-Up Plan**
+  - **Patient Communication**
+  - **Practice Readiness**
+
+Avoid language that makes the physician feel trapped in revenue-cycle tooling. Use "Practice Readiness" instead of "Billing launch", "Select Care Actions" instead of "Choose send-off actions", and "Release Care Plan" instead of "Complete checkout bundle".
+
+## User Experience
+
+When a note is finalized, the lower portion of the note detail page shows the AI Visit Completion section.
+
+The header explains that suggested actions were generated from the finalized note, active problems, patient history, and practice patterns. The primary action is visible on the right on desktop and full-width on mobile.
+
+The primary action includes a compact summary such as:
+
+> Includes 2 care actions, 1 patient message, 2 staff tasks, and billing readiness check.
+
+The physician can:
+
+- Review each card.
+- Approve all suggested actions.
+- Remove a suggestion.
+- Edit a suggestion before release.
+- Send an item to staff.
+- Defer an item.
+- Release the care plan when comfortable.
+
+Nothing is ordered, messaged, billed, assigned, or submitted until the physician releases the plan or explicitly sends a specific item.
+
+## Action Cards
+
+### Suggested Orders
+
+Shows clinically reasonable orders and care actions based on the note and chart context.
+
+First slice examples:
+
+- medication refill check
+- lab or screening item if due and determinable
+- education or monitoring instruction
+- regimen-safety follow-up
+
+Future AI-backed examples:
+
+- diagnosis-aware order sets for diabetes, hypertension, CKD, depression, obesity, chronic pain, asthma, COPD, anticoagulation, and post-hospital follow-up
+- due-status evidence from last result dates
+- physician preference patterns
+
+### Follow-Up Plan
+
+Detects whether the plan implies or states follow-up and whether a matching appointment exists.
+
+First slice examples:
+
+- "Plan implies follow-up; no appointment scheduled"
+- "Recommend return visit in 6 weeks"
+- "Send scheduling task to front desk before patient leaves"
+
+This is one of the highest-value cards because it converts clinical intent into scheduling action while the patient is still reachable.
+
+### Patient Communication
+
+Shows the patient-facing version of the plan.
+
+First slice examples:
+
+- portal message draft
+- printable or Leaflet handoff
+- translation action when relevant
+- plain-language next steps
+
+The card should make it clear that the physician can preview and edit before sending.
+
+### Practice Readiness
+
+Keeps coding, documentation, prior authorization, and staff-operation checks present but not dominant.
+
+First slice examples:
+
+- suggested E/M level when coding suggestions exist
+- ICD-10 candidates from Coding Readiness Agent output
+- documentation gap that would make coding, prior auth, or patient handoff stronger
+- staff task warning if a plan item lacks an owner
+
+The tone should be quiet revenue protection and operational completeness, not coding anxiety.
+
+## Data Flow
+
+The first implementation should use a typed server-side projection rather than wiring a new autonomous agent end to end.
+
+Recommended helper:
+
+`src/lib/domain/visit-completion.ts`
+
+Responsibilities:
+
+- Accept note, encounter, patient context, coding suggestion, and existing follow-up/task/order/message facts where available.
+- Return a `VisitCompletionBundle` with stable sections, counts, and source metadata.
+- Use deterministic heuristics first so the UI can ship safely.
+- Leave room for model-generated suggestions later without changing the UI contract.
+
+Example shape:
+
+```ts
+export interface VisitCompletionBundle {
+  summary: string;
+  cards: VisitCompletionCard[];
+  releaseEnabled: boolean;
+  warnings: VisitCompletionWarning[];
+}
+
+export interface VisitCompletionCard {
+  id: "orders" | "follow_up" | "patient_message" | "practice_readiness";
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: "neutral" | "warning" | "alert";
+  source: "note" | "coding" | "problem_list" | "encounter" | "heuristic";
+  reason?: string;
+}
+```
+
+## UI Components
+
+Add a focused component near the note detail route:
+
+`src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+
+Responsibilities:
+
+- Render the AI Visit Completion header.
+- Render the four cards.
+- Keep card controls visually compact and physician-friendly.
+- Support empty, loading, and degraded states.
+- Accept a fully built bundle as props.
+
+The existing note editor is already doing too much. The panel should be a separate component and the route page should pass the projected bundle alongside `codingSuggestion`.
+
+## Release Behavior
+
+The first implementation can make **Release Care Plan** a staged client action with clear disabled/degraded states if back-end mutation support is not ready.
+
+Preferred behavior when mutations are available:
+
+- Release creates or updates staff tasks.
+- Release queues or stores patient-message drafts for approval/sending.
+- Release records selected/deferred items and source metadata.
+- Release dispatches billing/readiness workflow events only once.
+- Release writes an audit event with user id, note id, encounter id, selected items, and timestamp.
+
+High-risk actions must remain gated:
+
+- orders require physician approval
+- portal messages require preview or explicit send
+- billing submission remains downstream and approval-gated according to existing billing-agent rules
+
+## Error Handling
+
+If the bundle cannot be built, show a calm degraded state:
+
+> AI Visit Completion is unavailable for this note. The finalized note and coding suggestions are still saved.
+
+If only one data source is missing, keep the section visible and mark the affected card:
+
+- "No coding suggestion yet"
+- "No follow-up appointment found"
+- "Patient messaging unavailable"
+- "Chart context incomplete"
+
+Never block note finalization because the visit-completion bundle failed.
+
+## Testing Strategy
+
+Tests should be written before production changes.
+
+Required coverage:
+
+- bundle builder returns all four card ids in stable order
+- finalized note with coding suggestions populates Practice Readiness
+- plan text with follow-up language and no appointment creates a Follow-Up Plan warning
+- missing coding suggestion degrades Practice Readiness without crashing
+- panel renders Release Care Plan and all four cards
+- controls do not appear for actions that are unavailable
+- release mutation, when implemented, is idempotent and audit-logged
+
+## Acceptance Criteria
+
+- Finalized notes show AI Visit Completion below the note content.
+- The section uses the approved product language.
+- The four cards appear in a coherent bottom-third strip on desktop and stack cleanly on mobile.
+- The primary action is **Release Care Plan**.
+- The UI makes it clear that the physician controls what happens.
+- Billing/coding support is present under Practice Readiness but does not dominate the flow.
+- The first slice can run without a live model call.
+- Failures in the bundle do not block note finalization.
+
+## Reference Mockup
+
+The approved visual direction was explored in the local brainstorming preview:
+
+`.superpowers/brainstorm/27616-1780203190/content/ai-visit-completion-v1.html`
+
+That file is a disposable visual companion artifact and should not be committed as product code.

--- a/docs/superpowers/specs/2026-05-30-core-visit-spine-design.md
+++ b/docs/superpowers/specs/2026-05-30-core-visit-spine-design.md
@@ -1,0 +1,218 @@
+# Core Visit Spine Hardening Design
+
+## Goal
+
+Make the same-day visit workflow reliable from pre-visit reminders through front-desk check-in, patient completion, MA rooming, physician visit start, and visit completion.
+
+The weekend goal is not a fully polished practice-management suite. The goal is a durable workflow spine that prevents the failures seen at Go Live: missing check-in flow, unclear readiness, no reliable rooming handoff, duplicate encounters, and non-idempotent visit completion.
+
+## Current Failure Pattern
+
+The app has two disconnected scheduling concepts:
+
+- `Appointment` drives patient scheduling and reminders.
+- `Encounter` drives the clinical chart and today's queue.
+
+The queue already displays richer operational columns, but those columns are synthetic. `EncounterStatus` currently has only `scheduled`, `in_progress`, `complete`, and `cancelled`, so check-in, rooming, roomed, and active physician visit are collapsed into `in_progress`.
+
+This causes three high-risk behaviors:
+
+- A patient can have an appointment without appearing in the clinical queue.
+- Kiosk/front-desk check-in jumps directly to `in_progress`, which looks like the physician is already with the patient.
+- Physician start can create a new same-day encounter instead of claiming the one the staff already prepared.
+
+## Design Direction
+
+Use `Encounter` as the same-day visit spine. Keep `Appointment` as scheduling/reminder history, linked to the encounter when available.
+
+The spine states are:
+
+1. `scheduled`
+2. `checked_in`
+3. `info_incomplete`
+4. `ready`
+5. `rooming`
+6. `roomed`
+7. `in_visit`
+8. `wrap_up`
+9. `complete`
+10. `cancelled`
+11. `no_show`
+
+Keep legacy `in_progress` temporarily during migration. Do not remove it in the first implementation slice because existing code and seed data still reference it.
+
+## Weekend Scope
+
+### Core Visit State
+
+Add a central visit-state helper that owns allowed transitions and timestamp side effects. The helper should be the only place that decides whether a state move is valid.
+
+Required first transitions:
+
+- `scheduled` or legacy `in_progress` to `checked_in`, then derive `ready` or `info_incomplete`
+- `ready`, `roomed`, or `checked_in` to `in_visit`
+- `in_visit` or `wrap_up` to `complete`
+- `scheduled`, `checked_in`, `ready`, `rooming`, or `roomed` to `cancelled`
+- `scheduled` or `checked_in` to `no_show`
+
+The first slice should avoid over-modeling. Add timestamps needed for operational reliability: `checkedInAt`, `roomingStartedAt`, `roomedAt`, `wrapUpAt`, `cancelledAt`, and `noShowAt`.
+
+### Pre-Visit Reminders
+
+Patients should be nudged before arrival to complete missing required items through the portal.
+
+Reminder cadence:
+
+- 7 days before the appointment
+- 2 days before the appointment
+- Morning of the appointment
+
+Reminder channels:
+
+- Email now, where infrastructure exists.
+- SMS only if the existing SMS reminder path supports it safely.
+- Push notification later when the mobile app exists.
+
+Reminder copy must not include PHI. It should say only that pre-visit items are ready and link to the portal.
+
+### Front-Desk Check-In
+
+Front desk must be able to:
+
+- Locate today's appointment/encounter.
+- Verify patient identity in person.
+- Mark the patient checked in.
+- See required missing items.
+- Generate a day-of QR rescue link if the patient is incomplete or cannot handle portal login.
+- Avoid moving the patient to rooming until the visit is ready or an authorized staff override is recorded.
+
+### QR Rescue
+
+The QR path is a narrow check-in completion session, not a replacement portal.
+
+Rules:
+
+- Token is appointment-scoped and patient-scoped.
+- Token is short-lived.
+- No PHI appears in the QR URL.
+- Token is signed, or stored only as a hash if persisted.
+- Redemption verifies expiry, appointment window, appointment-patient relationship, and status.
+- Require DOB + SMS code when a phone is on file.
+- Allow DOB + last name as front-desk fallback.
+- Full chart, records, labs, and messages still require portal login.
+- Audit token generation, views, redemption, expired attempts, failed verification, submissions, and staff overrides.
+
+### MA Rooming
+
+Weekend implementation can store rooming handoff data in `Encounter.briefingContext.rooming` to avoid a broad clinical-observation migration.
+
+The rooming envelope should support:
+
+- room number
+- readiness flags
+- handoff note
+- vitals snapshot
+- roomed timestamp
+- rooming staff user id
+
+This is intentionally temporary. Vitals should graduate to structured `Observation` or `VitalSign` storage before quality measures, FHIR export, MIPS, or longitudinal trending depend on them.
+
+### Physician Workflow Boundary
+
+The physician workflow should be owned by the separate Claude Code swarm. Its contract is:
+
+- Start visit must claim the existing same-day roomed/ready/checked-in/scheduled encounter before creating any new encounter.
+- Start visit must preserve rooming and briefing context.
+- `startVisitWithBriefing` must enforce the same permissions and chart privacy checks as `startVisit`.
+- Note finalization must be idempotent.
+- `note.finalized` dispatches only when the note transitions into finalized.
+- `encounter.completed` dispatches only when the encounter transitions into complete.
+
+## Data Model
+
+Minimal schema changes:
+
+- Extend `EncounterStatus` with new spine states while preserving `in_progress`.
+- Add nullable `Encounter.appointmentId` with a unique relation to `Appointment`.
+- Add nullable operational timestamps:
+  - `checkedInAt`
+  - `roomingStartedAt`
+  - `roomedAt`
+  - `wrapUpAt`
+  - `cancelledAt`
+  - `noShowAt`
+- Add `Appointment.encounter` back relation.
+- Add an index for today's queue by organization, status, and scheduled time.
+
+## State Ownership
+
+Create `src/lib/domain/visit-state.ts`.
+
+This helper owns:
+
+- canonical visit states
+- legacy state compatibility
+- allowed transitions
+- timestamp updates
+- no-op/idempotent transition behavior
+- optional metadata merge helpers for `briefingContext`
+
+External swarms should call this helper when available and must not create a competing state machine.
+
+## Staff UI Ownership
+
+Codex swarm owns:
+
+- Prisma visit-spine schema and migration.
+- `src/lib/domain/visit-state.ts`.
+- queue projection in `src/lib/domain/queue-board.ts`.
+- operator queue page/actions under `src/app/(operator)/ops/queue/`.
+- kiosk/front-desk check-in route behavior.
+- rooming handoff envelope and front-desk/MA queue controls.
+
+Claude Code swarm owns:
+
+- physician start visit.
+- briefing start path.
+- note finalization idempotency.
+- physician-visible handoff/readiness surface.
+
+Gemini storm owns:
+
+- DB-to-gate previsit readiness mapper.
+- reminder cadence and non-PHI reminder copy.
+- QR token helper and redemption security tests.
+- QR rescue route/page if time allows.
+
+## Testing Strategy
+
+Tests must be written before production changes.
+
+Required coverage:
+
+- visit-state allowed and rejected transitions
+- timestamp side effects
+- idempotent no-op transitions
+- queue projection for new statuses and legacy `in_progress`
+- kiosk/check-in mutation verifies encounter-patient relationship
+- pre-visit reminder sends only when incomplete and does not include PHI
+- QR token validation rejects expired, mismatched, or tampered tokens
+- physician start claims existing encounter instead of creating duplicate
+- note finalization does not double-dispatch
+
+## Risks
+
+- `in_progress` is overloaded in existing data; migration cannot infer exact real-world phase for old rows.
+- `briefingContext` is becoming a temporary operational envelope. Keep its structure explicit and graduate persistent clinical facts later.
+- Appointment/Encounter drift will continue unless new appointment creation also creates or links an encounter.
+- External swarms may overlap on physician start or QR route code. File ownership boundaries above are mandatory.
+
+## Acceptance Criteria
+
+- Today's queue shows real same-day state rather than collapsing everything into `in_visit`.
+- Front desk can mark arrival and see incomplete versus ready.
+- Patient can be nudged before arrival and rescued day-of with QR without full portal-login friction.
+- MA can record a minimum rooming handoff.
+- Physician start uses the prepared encounter.
+- Completing the visit triggers downstream workflows once.
+- All changed behavior has targeted tests.

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/utils/format";
 import { NoteEditor } from "./note-editor";
 import { NoteCommentsPanel } from "@/components/collaboration/note-comments-panel";
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
 
 interface PageProps {
   params: { id: string; noteId: string };
@@ -38,6 +40,14 @@ export default async function NoteDetailPage({ params }: PageProps) {
   if (note.encounter.patientId !== params.id) notFound();
 
   const patient = note.encounter.patient;
+  const futureAppointment = await prisma.appointment.findFirst({
+    where: {
+      patientId: params.id,
+      startAt: { gt: new Date() },
+      status: { notIn: ["cancelled", "no_show"] },
+    },
+    select: { id: true },
+  });
 
   // Parse blocks — they are stored as JSON. Strip the internal `_guardrails`
   // metadata block planted by the scribe agent: it carries hallucination /
@@ -64,6 +74,15 @@ export default async function NoteDetailPage({ params }: PageProps) {
         rationale: note.codingSuggestion.rationale,
       }
     : null;
+  const visitCompletionBundle =
+    note.status === "finalized"
+      ? buildVisitCompletionBundle({
+          patientFirstName: patient.firstName,
+          blocks,
+          codingSuggestion,
+          hasFutureAppointment: Boolean(futureAppointment),
+        })
+      : null;
 
   return (
     <PageShell maxWidth="max-w-[900px]">
@@ -105,6 +124,10 @@ export default async function NoteDetailPage({ params }: PageProps) {
             : null
         }
       />
+
+      {visitCompletionBundle && (
+        <VisitCompletionPanel bundle={visitCompletionBundle} />
+      )}
 
       {/* ux/comments-mentions-collab — inline collaboration on chart notes */}
       <div className="mt-8">

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import * as React from "react";
+import util from "util";
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
+
+function dump(node: React.ReactElement | null): string {
+  return util.inspect(node, { depth: null });
+}
+
+describe("VisitCompletionPanel", () => {
+  it("renders the physician co-pilot language and four action cards", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      hasFutureAppointment: false,
+      blocks: [
+        {
+          heading: "Plan",
+          body: "Return to clinic in 6 weeks after medication adjustment.",
+        },
+      ],
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "G89.29", label: "Chronic pain", confidence: 0.88 }],
+      },
+    });
+
+    const str = dump(VisitCompletionPanel({ bundle }));
+
+    expect(str).toContain("AI Visit Completion");
+    expect(str).toContain("Suggested Next Best Actions");
+    expect(str).toContain("Release Care Plan");
+    expect(str).toContain("Suggested Orders");
+    expect(str).toContain("Follow-Up Plan");
+    expect(str).toContain("Patient Communication");
+    expect(str).toContain("Practice Readiness");
+    expect(str).toContain("Physician remains in control.");
+    expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,0 +1,141 @@
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils/cn";
+import type {
+  VisitCompletionBundle,
+  VisitCompletionItem,
+  VisitCompletionTone,
+} from "@/lib/domain/visit-completion";
+
+interface VisitCompletionPanelProps {
+  bundle: VisitCompletionBundle;
+}
+
+const toneDot: Record<VisitCompletionTone, string> = {
+  neutral: "bg-accent/70",
+  warning: "bg-highlight",
+  alert: "bg-danger",
+};
+
+const toneBadge: Record<VisitCompletionTone, "neutral" | "warning" | "danger"> = {
+  neutral: "neutral",
+  warning: "warning",
+  alert: "danger",
+};
+
+export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
+  return (
+    <Card tone="raised" className="mt-8 overflow-hidden">
+      <CardContent className="p-0">
+        <div className="flex flex-col gap-5 border-b border-border/70 bg-gradient-to-r from-accent-soft via-surface to-surface px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
+              {bundle.sectionLabel}
+            </p>
+            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-text md:text-3xl">
+              {bundle.heading}
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-text-muted">
+              Based on the finalized note, active problems, patient history, and practice
+              patterns. Review the bundle, then approve, remove, edit, or send work to staff.
+            </p>
+          </div>
+
+          <div className="flex flex-col items-stretch gap-2 lg:items-end">
+            <Button size="md" disabled={!bundle.releaseEnabled}>
+              {bundle.primaryActionLabel}
+            </Button>
+            <p className="max-w-[260px] text-left text-xs leading-relaxed text-text-muted lg:text-right">
+              {bundle.summary}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
+          {bundle.cards.map((card) => (
+            <article
+              key={card.id}
+              className="flex min-h-[250px] flex-col overflow-hidden rounded-lg border border-border/80 bg-surface"
+            >
+              <div className="border-b border-border/60 px-4 py-4">
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="text-base font-semibold text-text">{card.title}</h3>
+                  {card.items.some((item) => item.tone !== "neutral") && (
+                    <Badge
+                      tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}
+                    >
+                      Review
+                    </Badge>
+                  )}
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-text-muted">
+                  {card.subtitle}
+                </p>
+              </div>
+
+              <ul className="flex-1 space-y-3 px-4 py-4">
+                {card.items.map((item) => (
+                  <VisitCompletionLine key={item.id} item={item} />
+                ))}
+              </ul>
+
+              <div className="flex flex-wrap gap-2 px-4 pb-4">
+                {card.actions.map((action) => (
+                  <Button
+                    key={action.id}
+                    size="sm"
+                    variant={action.variant === "primary" ? "secondary" : "ghost"}
+                    className={cn(
+                      "h-8 rounded-full px-3 text-xs",
+                      action.variant === "primary" &&
+                        "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
+                    )}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-text">Physician remains in control.</p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              AI prepares the next actions; nothing is sent, ordered, billed, or assigned
+              until the care plan is released.
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              Learns from approvals, edits, removals, and deferrals.
+            </p>
+          </div>
+          <Button size="sm" variant="highlight" className="shrink-0">
+            {bundle.supportActionLabel}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function VisitCompletionLine({ item }: { item: VisitCompletionItem }) {
+  return (
+    <li className="grid grid-cols-[14px_1fr] gap-2 text-sm leading-relaxed text-text">
+      <span
+        className={cn("mt-2 h-2 w-2 rounded-full", toneDot[item.tone])}
+        aria-hidden="true"
+      />
+      <span>
+        {item.label}
+        {item.reason && item.tone !== "neutral" && (
+          <Badge tone={toneBadge[item.tone]} className="ml-2 align-middle">
+            Source
+          </Badge>
+        )}
+      </span>
+    </li>
+  );
+}

--- a/src/lib/check-in/audit-actions.test.ts
+++ b/src/lib/check-in/audit-actions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { CHECK_IN_AUDIT_ACTIONS } from "./audit-actions";
+
+describe("CHECK_IN_AUDIT_ACTIONS", () => {
+  it("are all namespaced under checkin.* and unique", () => {
+    const values = Object.values(CHECK_IN_AUDIT_ACTIONS);
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) expect(v).toMatch(/^checkin\./);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("cover generation, view, redeem, and failed-attempt", () => {
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_GENERATED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_VIEWED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_REDEEMED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.QR_REDEEM_FAILED).toBeDefined();
+    expect(CHECK_IN_AUDIT_ACTIONS.INTAKE_SUBMITTED).toBeDefined();
+  });
+});

--- a/src/lib/check-in/audit-actions.ts
+++ b/src/lib/check-in/audit-actions.ts
@@ -1,0 +1,25 @@
+// Canonical audit action names for the QR rescue check-in surfaces.
+//
+// Audit rules (security contract): record QR generation, QR view, QR
+// redeem, failed/expired token attempts, and intake submissions. NEVER log raw
+// tokens or free-text PHI — metadata is limited to opaque ids, the QR token
+// *hash* (not the token), milestone/channel, and a failure reason enum.
+//
+// The pre-visit completion reminder audit action lives with the sender as
+// PREVISIT_COMPLETION_REMINDER_ACTION ("previsit.completion.reminder.sent").
+
+export const CHECK_IN_AUDIT_ACTIONS = {
+  /** A QR rescue token was generated for an appointment. */
+  QR_GENERATED: "checkin.qr.generated",
+  /** The QR landing page was viewed (token presented, pre-identity-challenge). */
+  QR_VIEWED: "checkin.qr.viewed",
+  /** A QR token was successfully redeemed (identity verified, single-use spent). */
+  QR_REDEEMED: "checkin.qr.redeemed",
+  /** A QR redemption attempt failed (invalid/expired/mismatch/out-of-window/identity). */
+  QR_REDEEM_FAILED: "checkin.qr.redeem_failed",
+  /** A pre-visit intake item was submitted via the rescue path. */
+  INTAKE_SUBMITTED: "checkin.intake.submitted",
+} as const;
+
+export type CheckInAuditAction =
+  (typeof CHECK_IN_AUDIT_ACTIONS)[keyof typeof CHECK_IN_AUDIT_ACTIONS];

--- a/src/lib/check-in/identity-challenge.test.ts
+++ b/src/lib/check-in/identity-challenge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chooseChallengeMode,
+  verifyCheckInIdentity,
+  type IdentityExpectation,
+} from "./identity-challenge";
+
+const DOB = "1985-04-12";
+
+const withPhone: IdentityExpectation = {
+  dateOfBirth: DOB,
+  lastName: "Rivers",
+  smsCode: "418293",
+  hasPhone: true,
+};
+
+const withoutPhone: IdentityExpectation = {
+  dateOfBirth: DOB,
+  lastName: "Rivers",
+  smsCode: null,
+  hasPhone: false,
+};
+
+describe("chooseChallengeMode", () => {
+  it("prefers DOB + SMS code when a phone is on file and a code was issued", () => {
+    expect(chooseChallengeMode(withPhone)).toBe("dob_sms");
+  });
+
+  it("falls back to DOB + last name (front-desk assisted) without a phone", () => {
+    expect(chooseChallengeMode(withoutPhone)).toBe("dob_lastname");
+  });
+
+  it("falls back to last name when a phone exists but no code was issued yet", () => {
+    expect(chooseChallengeMode({ ...withPhone, smsCode: null })).toBe("dob_lastname");
+  });
+});
+
+describe("verifyCheckInIdentity", () => {
+  it("accepts a correct DOB + SMS code", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, smsCode: "418293" });
+    expect(r).toMatchObject({ ok: true, mode: "dob_sms" });
+  });
+
+  it("rejects a wrong SMS code even with correct DOB", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, smsCode: "000000" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("does NOT accept the last-name fallback when a phone+code exist (must use SMS)", () => {
+    const r = verifyCheckInIdentity(withPhone, { dateOfBirth: DOB, lastName: "Rivers" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts DOB + last name when no phone is on file (assisted path)", () => {
+    const r = verifyCheckInIdentity(withoutPhone, { dateOfBirth: DOB, lastName: "rivers" });
+    expect(r).toMatchObject({ ok: true, mode: "dob_lastname" });
+  });
+
+  it("rejects a wrong DOB regardless of the second factor", () => {
+    expect(verifyCheckInIdentity(withoutPhone, { dateOfBirth: "1990-01-01", lastName: "Rivers" }).ok).toBe(false);
+    expect(verifyCheckInIdentity(withPhone, { dateOfBirth: "1990-01-01", smsCode: "418293" }).ok).toBe(false);
+  });
+
+  it("is case- and whitespace-insensitive for last name", () => {
+    const r = verifyCheckInIdentity(withoutPhone, { dateOfBirth: DOB, lastName: "  RIVERS " });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects an empty attempt", () => {
+    expect(verifyCheckInIdentity(withoutPhone, {}).ok).toBe(false);
+    expect(verifyCheckInIdentity(withPhone, {}).ok).toBe(false);
+  });
+});

--- a/src/lib/check-in/identity-challenge.ts
+++ b/src/lib/check-in/identity-challenge.ts
@@ -1,0 +1,75 @@
+// Day-of check-in identity challenge.
+//
+// Older adults shouldn't have to fight portal login in the lobby, so the QR
+// rescue path uses a minimal two-factor challenge instead:
+//   - Preferred: DOB + a one-time SMS code (when a phone is on file AND a code
+//     has been issued).
+//   - Fallback: DOB + last name (front-desk assisted; no phone / no code).
+//
+// This gates ONLY the rescue check-in. Full chart / messages / labs / records
+// still require real portal login. Pure + timing-safe; logs nothing.
+
+import { timingSafeEqual } from "node:crypto";
+
+export type ChallengeMode = "dob_sms" | "dob_lastname";
+
+export interface IdentityExpectation {
+  /** Expected DOB, ISO yyyy-mm-dd. */
+  dateOfBirth: string;
+  /** Expected last name. */
+  lastName: string;
+  /** Expected one-time SMS code, if one was issued. */
+  smsCode: string | null;
+  /** Whether a phone number is on file. */
+  hasPhone: boolean;
+}
+
+export interface IdentityAttempt {
+  dateOfBirth?: string;
+  smsCode?: string;
+  lastName?: string;
+}
+
+export interface IdentityResult {
+  ok: boolean;
+  mode: ChallengeMode;
+}
+
+export function chooseChallengeMode(exp: IdentityExpectation): ChallengeMode {
+  return exp.hasPhone && exp.smsCode != null ? "dob_sms" : "dob_lastname";
+}
+
+function norm(s: string | undefined | null): string {
+  return (s ?? "").trim().toLowerCase();
+}
+
+/** Constant-time-ish equality that also rejects empty expected/attempt values. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length === 0 || ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function verifyCheckInIdentity(
+  expectation: IdentityExpectation,
+  attempt: IdentityAttempt,
+): IdentityResult {
+  const mode = chooseChallengeMode(expectation);
+
+  // DOB is required in both modes.
+  if (!safeEqual(norm(attempt.dateOfBirth), norm(expectation.dateOfBirth))) {
+    return { ok: false, mode };
+  }
+
+  if (mode === "dob_sms") {
+    // Must use the SMS code; last name is NOT accepted when a phone+code exist.
+    const codeOk =
+      expectation.smsCode != null &&
+      safeEqual(norm(attempt.smsCode), norm(expectation.smsCode));
+    return { ok: codeOk, mode };
+  }
+
+  // Fallback: DOB + last name.
+  return { ok: safeEqual(norm(attempt.lastName), norm(expectation.lastName)), mode };
+}

--- a/src/lib/check-in/qr-token.test.ts
+++ b/src/lib/check-in/qr-token.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCheckInToken,
+  hashCheckInToken,
+  parseCheckInToken,
+  verifyCheckInToken,
+  type CheckInVerifyContext,
+} from "./qr-token";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+const APPT = "appt_abc";
+const PATIENT = "pat_xyz";
+
+const NOW = new Date("2026-06-01T15:00:00.000Z");
+const STARTS_AT = new Date("2026-06-01T15:30:00.000Z");
+const ENDS_AT = new Date("2026-06-01T16:00:00.000Z");
+const EXPIRES_AT = new Date("2026-06-01T16:30:00.000Z");
+
+function makeToken() {
+  return createCheckInToken({
+    appointmentId: APPT,
+    patientId: PATIENT,
+    expiresAt: EXPIRES_AT,
+    secret: SECRET,
+    nonce: "nonce-1",
+  });
+}
+
+function ctx(overrides: Partial<CheckInVerifyContext> = {}): CheckInVerifyContext {
+  return {
+    secret: SECRET,
+    now: NOW,
+    appointment: {
+      id: APPT,
+      patientId: PATIENT,
+      status: "confirmed",
+      startAt: STARTS_AT,
+      endAt: ENDS_AT,
+    },
+    storedTokenHash: hashCheckInToken(makeToken().token),
+    redeemedAt: null,
+    ...overrides,
+  };
+}
+
+describe("createCheckInToken", () => {
+  it("produces an opaque token with no PHI and a separate storage hash", () => {
+    const { token, tokenHash, payload } = makeToken();
+    expect(token).not.toMatch(/1985|jordan|rivers|dob/i);
+    expect(tokenHash).not.toEqual(token);
+    expect(tokenHash).toEqual(hashCheckInToken(token));
+    expect(payload.appointmentId).toBe(APPT);
+    expect(payload.patientId).toBe(PATIENT);
+    expect(payload.purpose).toBe("qr_rescue");
+  });
+
+  it("is deterministic for identical inputs so the stored hash matches", () => {
+    const a = makeToken();
+    const b = makeToken();
+    expect(a.token).toEqual(b.token);
+    expect(a.tokenHash).toEqual(b.tokenHash);
+  });
+});
+
+describe("parseCheckInToken", () => {
+  it("rejects a token signed with a different secret", () => {
+    expect(parseCheckInToken(makeToken().token, "wrong-secret")).toBeNull();
+  });
+
+  it("rejects a tampered payload", () => {
+    const { token } = makeToken();
+    const [body, sig] = token.split(".");
+    expect(parseCheckInToken(`${body}x.${sig}`, SECRET)).toBeNull();
+  });
+
+  it("round-trips a valid token to its payload", () => {
+    const { token, payload } = makeToken();
+    expect(parseCheckInToken(token, SECRET)).toEqual(payload);
+  });
+});
+
+describe("verifyCheckInToken", () => {
+  it("accepts a valid, unredeemed, in-window token", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx());
+    expect(r.valid).toBe(true);
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("rejects a bad signature", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx({ secret: "nope" }));
+    expect(r).toMatchObject({ valid: false, reason: "invalid_signature" });
+  });
+
+  it("rejects an expired token", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(EXPIRES_AT.getTime() + 1000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "expired" });
+  });
+
+  it("rejects when the stored hash does not match (rotated/revoked)", () => {
+    const r = verifyCheckInToken(makeToken().token, ctx({ storedTokenHash: "deadbeef" }));
+    expect(r).toMatchObject({ valid: false, reason: "unknown_token" });
+  });
+
+  it("rejects when the token patient != appointment patient", () => {
+    const c = ctx();
+    c.appointment.patientId = "someone_else";
+    const r = verifyCheckInToken(makeToken().token, c);
+    expect(r).toMatchObject({ valid: false, reason: "relationship_mismatch" });
+  });
+
+  it("rejects a non-checkinable appointment status", () => {
+    for (const status of ["cancelled", "completed", "no_show"]) {
+      const r = verifyCheckInToken(
+        makeToken().token,
+        ctx({
+          appointment: { id: APPT, patientId: PATIENT, status, startAt: STARTS_AT, endAt: ENDS_AT },
+        }),
+      );
+      expect(r, `status ${status}`).toMatchObject({
+        valid: false,
+        reason: "appointment_not_checkinable",
+      });
+    }
+  });
+
+  it("rejects when outside the appointment check-in window (too early)", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(STARTS_AT.getTime() - 3 * 60 * 60 * 1000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "outside_window" });
+  });
+
+  it("rejects an already-redeemed token", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ redeemedAt: new Date(NOW.getTime() - 60_000) }),
+    );
+    expect(r).toMatchObject({ valid: false, reason: "already_redeemed" });
+  });
+
+  it("accepts within the early window (default 60m before start)", () => {
+    const r = verifyCheckInToken(
+      makeToken().token,
+      ctx({ now: new Date(STARTS_AT.getTime() - 30 * 60_000) }),
+    );
+    expect(r.valid).toBe(true);
+  });
+});

--- a/src/lib/check-in/qr-token.ts
+++ b/src/lib/check-in/qr-token.ts
@@ -1,0 +1,220 @@
+// QR "rescue" check-in token.
+//
+// Day-of check-in path for patients (esp. older adults) who can't fight portal
+// login in the lobby. Security contract:
+//   - Appointment-scoped, short-lived, minimal.
+//   - NO PHI in the token or the URL — payload is opaque ids + signature only.
+//   - Signed (HMAC-SHA256) so a tampered/forged token is rejected offline.
+//   - Persisted as a SHA-256 *hash* (never the raw token) so a DB leak can't
+//     replay tokens; redemption matches the presented token's hash against the
+//     stored hash.
+//   - Redemption verifies: signature, expiry, appointment<->patient
+//     relationship, appointment status, the check-in time window, and
+//     single-use (not already redeemed).
+//
+// Pure/deterministic. The DB read (appointment row + stored hash + redeemedAt)
+// is supplied by the caller via CheckInVerifyContext, so the public check-in
+// route (Codex/app layer) owns the Prisma binding. This module never logs.
+
+import { createHmac, createHash, timingSafeEqual } from "node:crypto";
+
+export const CHECK_IN_PURPOSE = "qr_rescue" as const;
+
+/** Default minutes before startAt that a QR check-in becomes valid. */
+export const DEFAULT_EARLY_WINDOW_MINUTES = 60;
+/** Default grace minutes after endAt during which a QR check-in still works. */
+export const DEFAULT_LATE_GRACE_MINUTES = 30;
+
+/** Default token lifetime if a caller wants a helper to compute expiry. */
+export const DEFAULT_TOKEN_TTL_MINUTES = 180;
+
+export interface CheckInTokenPayload {
+  appointmentId: string;
+  patientId: string;
+  /** Expiry as epoch milliseconds. */
+  exp: number;
+  /** Opaque uniqueness so two appointments never collide / aren't guessable. */
+  nonce: string;
+  purpose: typeof CHECK_IN_PURPOSE;
+}
+
+export interface CreateCheckInTokenInput {
+  appointmentId: string;
+  patientId: string;
+  expiresAt: Date;
+  secret: string;
+  nonce: string;
+}
+
+export interface CreatedCheckInToken {
+  /** Opaque token to embed in the QR URL. */
+  token: string;
+  /** SHA-256 hash to persist (never store the raw token). */
+  tokenHash: string;
+  payload: CheckInTokenPayload;
+  expiresAt: Date;
+}
+
+export interface CheckInAppointmentSnapshot {
+  id: string;
+  patientId: string;
+  status: string;
+  startAt: Date;
+  endAt: Date | null;
+}
+
+export interface CheckInVerifyContext {
+  secret: string;
+  now: Date;
+  appointment: CheckInAppointmentSnapshot;
+  /** The hash persisted when the token was generated. */
+  storedTokenHash: string;
+  /** When the token was redeemed, if ever (single-use enforcement). */
+  redeemedAt: Date | null;
+  earlyWindowMinutes?: number;
+  lateGraceMinutes?: number;
+}
+
+export type CheckInVerifyFailure =
+  | "invalid_signature"
+  | "unknown_token"
+  | "relationship_mismatch"
+  | "appointment_not_checkinable"
+  | "already_redeemed"
+  | "expired"
+  | "outside_window";
+
+export interface CheckInVerifyResult {
+  valid: boolean;
+  reason?: CheckInVerifyFailure;
+  payload?: CheckInTokenPayload;
+}
+
+const CHECKINABLE_STATUSES = new Set(["requested", "confirmed"]);
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function sign(body: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(body).digest());
+}
+
+function safeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export function hashCheckInToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function createCheckInToken(
+  input: CreateCheckInTokenInput,
+): CreatedCheckInToken {
+  const payload: CheckInTokenPayload = {
+    appointmentId: input.appointmentId,
+    patientId: input.patientId,
+    exp: input.expiresAt.getTime(),
+    nonce: input.nonce,
+    purpose: CHECK_IN_PURPOSE,
+  };
+
+  const body = base64url(Buffer.from(JSON.stringify(payload)));
+  const sig = sign(body, input.secret);
+  const token = `${body}.${sig}`;
+
+  return {
+    token,
+    tokenHash: hashCheckInToken(token),
+    payload,
+    expiresAt: input.expiresAt,
+  };
+}
+
+/** Verify signature + structure. Returns the payload, or null if invalid. */
+export function parseCheckInToken(
+  token: string,
+  secret: string,
+): CheckInTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [body, sig] = parts;
+  if (!safeEqualStr(sig, sign(body, secret))) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const p = parsed as Record<string, unknown>;
+  if (
+    typeof p.appointmentId !== "string" ||
+    typeof p.patientId !== "string" ||
+    typeof p.exp !== "number" ||
+    typeof p.nonce !== "string" ||
+    p.purpose !== CHECK_IN_PURPOSE
+  ) {
+    return null;
+  }
+
+  return {
+    appointmentId: p.appointmentId,
+    patientId: p.patientId,
+    exp: p.exp,
+    nonce: p.nonce,
+    purpose: CHECK_IN_PURPOSE,
+  };
+}
+
+export function verifyCheckInToken(
+  token: string,
+  ctx: CheckInVerifyContext,
+): CheckInVerifyResult {
+  const payload = parseCheckInToken(token, ctx.secret);
+  if (!payload) return { valid: false, reason: "invalid_signature" };
+
+  // The presented token must hash to exactly what we persisted. A rotated or
+  // revoked token (or a stale hash) is "unknown".
+  if (!safeEqualStr(hashCheckInToken(token), ctx.storedTokenHash)) {
+    return { valid: false, reason: "unknown_token", payload };
+  }
+
+  // The appointment<->patient relationship the token claims must match the row.
+  if (
+    payload.appointmentId !== ctx.appointment.id ||
+    payload.patientId !== ctx.appointment.patientId
+  ) {
+    return { valid: false, reason: "relationship_mismatch", payload };
+  }
+
+  if (!CHECKINABLE_STATUSES.has(ctx.appointment.status)) {
+    return { valid: false, reason: "appointment_not_checkinable", payload };
+  }
+
+  if (ctx.redeemedAt != null) {
+    return { valid: false, reason: "already_redeemed", payload };
+  }
+
+  const nowMs = ctx.now.getTime();
+  if (nowMs > payload.exp) {
+    return { valid: false, reason: "expired", payload };
+  }
+
+  const earlyMs =
+    (ctx.earlyWindowMinutes ?? DEFAULT_EARLY_WINDOW_MINUTES) * 60_000;
+  const lateMs = (ctx.lateGraceMinutes ?? DEFAULT_LATE_GRACE_MINUTES) * 60_000;
+  const windowOpens = ctx.appointment.startAt.getTime() - earlyMs;
+  const windowCloses =
+    (ctx.appointment.endAt ?? ctx.appointment.startAt).getTime() + lateMs;
+  if (nowMs < windowOpens || nowMs > windowCloses) {
+    return { valid: false, reason: "outside_window", payload };
+  }
+
+  return { valid: true, payload };
+}

--- a/src/lib/domain/visit-completion.test.ts
+++ b/src/lib/domain/visit-completion.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { buildVisitCompletionBundle } from "./visit-completion";
+
+const followUpBlocks = [
+  {
+    heading: "Assessment",
+    body: "Diabetes follow-up with worsening glycemic control.",
+  },
+  {
+    heading: "Plan",
+    body: "Repeat labs and return to clinic in 6 weeks to review A1C and medication response.",
+  },
+];
+
+describe("buildVisitCompletionBundle", () => {
+  it("returns the four visit completion cards in stable order", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.sectionLabel).toBe("AI Visit Completion");
+    expect(bundle.heading).toBe("Suggested Next Best Actions");
+    expect(bundle.primaryActionLabel).toBe("Release Care Plan");
+    expect(bundle.supportActionLabel).toBe("Approve all suggested actions");
+    expect(bundle.cards.map((card) => card.id)).toEqual([
+      "orders",
+      "follow_up",
+      "patient_message",
+      "practice_readiness",
+    ]);
+  });
+
+  it("exposes learning-loop metadata for physician action feedback", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.learningLoop.agentName).toBe("visitCompletion");
+    expect(bundle.learningLoop.agentVersion).toBe("1.0.0");
+    expect(bundle.learningLoop.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actionId: "release_care_plan",
+          feedbackAction: "approved",
+        }),
+        expect.objectContaining({
+          actionId: "edit_item",
+          feedbackAction: "approved_with_edits",
+        }),
+        expect.objectContaining({
+          actionId: "remove_item",
+          feedbackAction: "rejected",
+        }),
+        expect.objectContaining({
+          actionId: "defer_item",
+          feedbackAction: "dismissed",
+        }),
+      ]),
+    );
+  });
+
+  it("flags follow-up language when no future appointment exists", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: false,
+    });
+
+    expect(bundle.cards.find((card) => card.id === "follow_up")?.items[0]).toMatchObject({
+      tone: "alert",
+      label: "Plan implies follow-up; no appointment scheduled",
+    });
+  });
+
+  it("uses coding suggestions for practice readiness", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      hasFutureAppointment: true,
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [
+          { code: "E11.9", label: "Diabetes mellitus", confidence: 0.91 },
+          { code: "I10", label: "Essential hypertension", confidence: 0.82 },
+        ],
+      },
+    });
+
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Suggested E/M: 99214" }),
+        expect.objectContaining({ label: "ICD-10 candidate: E11.9 Diabetes mellitus" }),
+      ]),
+    );
+  });
+
+  it("degrades practice readiness when coding is not available yet", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items[0]).toMatchObject({
+      label: "No coding suggestion yet",
+      tone: "warning",
+    });
+    expect(bundle.summary).toContain("billing readiness check");
+  });
+});

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -1,0 +1,373 @@
+export type VisitCompletionCardId =
+  | "orders"
+  | "follow_up"
+  | "patient_message"
+  | "practice_readiness";
+export type VisitCompletionTone = "neutral" | "warning" | "alert";
+export type VisitCompletionSource =
+  | "note"
+  | "coding"
+  | "problem_list"
+  | "encounter"
+  | "heuristic";
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: VisitCompletionTone;
+  source: VisitCompletionSource;
+  reason?: string;
+}
+
+export interface VisitCompletionAction {
+  id: string;
+  label: string;
+  variant: "primary" | "secondary";
+}
+
+export interface VisitCompletionCard {
+  id: VisitCompletionCardId;
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionLearningSignal {
+  actionId:
+    | "release_care_plan"
+    | "approve_all"
+    | "edit_item"
+    | "remove_item"
+    | "defer_item";
+  feedbackAction: "approved" | "approved_with_edits" | "rejected" | "dismissed";
+  meaning: string;
+}
+
+export interface VisitCompletionLearningLoop {
+  agentName: "visitCompletion";
+  agentVersion: "1.0.0";
+  signals: VisitCompletionLearningSignal[];
+}
+
+export interface VisitCompletionBundle {
+  sectionLabel: "AI Visit Completion";
+  heading: "Suggested Next Best Actions";
+  primaryActionLabel: "Release Care Plan";
+  supportActionLabel: "Approve all suggested actions";
+  summary: string;
+  releaseEnabled: boolean;
+  learningLoop: VisitCompletionLearningLoop;
+  cards: VisitCompletionCard[];
+}
+
+export interface VisitCompletionCodingSuggestion {
+  icd10: { code: string; label: string; confidence?: number }[];
+  emLevel: string | null;
+  rationale?: string | null;
+}
+
+export interface VisitCompletionBlock {
+  heading: string;
+  body: string;
+}
+
+export interface BuildVisitCompletionBundleInput {
+  patientFirstName: string;
+  blocks: VisitCompletionBlock[];
+  codingSuggestion: VisitCompletionCodingSuggestion | null;
+  hasFutureAppointment: boolean;
+}
+
+const learningLoop: VisitCompletionLearningLoop = {
+  agentName: "visitCompletion",
+  agentVersion: "1.0.0",
+  signals: [
+    {
+      actionId: "release_care_plan",
+      feedbackAction: "approved",
+      meaning: "Physician released the generated visit-completion bundle.",
+    },
+    {
+      actionId: "approve_all",
+      feedbackAction: "approved",
+      meaning: "Physician accepted the suggested actions without item-level edits.",
+    },
+    {
+      actionId: "edit_item",
+      feedbackAction: "approved_with_edits",
+      meaning: "Physician kept the suggestion but changed clinical or operational details.",
+    },
+    {
+      actionId: "remove_item",
+      feedbackAction: "rejected",
+      meaning: "Physician removed a suggested action as inappropriate for this visit.",
+    },
+    {
+      actionId: "defer_item",
+      feedbackAction: "dismissed",
+      meaning: "Physician deferred a suggested action without rejecting the concept.",
+    },
+  ],
+};
+
+export function buildVisitCompletionBundle(
+  input: BuildVisitCompletionBundleInput,
+): VisitCompletionBundle {
+  const text = noteText(input.blocks);
+  const cards: VisitCompletionCard[] = [
+    buildOrdersCard(text),
+    buildFollowUpCard(text, input.hasFutureAppointment),
+    buildPatientMessageCard(input.patientFirstName, text),
+    buildPracticeReadinessCard(input.codingSuggestion),
+  ];
+
+  return {
+    sectionLabel: "AI Visit Completion",
+    heading: "Suggested Next Best Actions",
+    primaryActionLabel: "Release Care Plan",
+    supportActionLabel: "Approve all suggested actions",
+    summary: buildSummary(cards),
+    releaseEnabled: cards.some((card) => card.items.length > 0),
+    learningLoop,
+    cards,
+  };
+}
+
+function noteText(blocks: VisitCompletionBlock[]): string {
+  return blocks
+    .map((block) => `${block.heading}\n${block.body}`)
+    .join("\n\n")
+    .toLowerCase();
+}
+
+function buildOrdersCard(text: string): VisitCompletionCard {
+  const diabetes = /\b(diabetes|diabetic|a1c|hba1c|glycemic)\b/.test(text);
+  const medication = /\b(medication|med|dose|dosing|refill|regimen|prescribed)\b/.test(text);
+  const pain = /\b(pain|arthritis|arthritic|somnolence|cbd|topical)\b/.test(text);
+
+  const items: VisitCompletionItem[] = diabetes
+    ? [
+        item("a1c-due", "A1C if due or worsening control noted", "neutral", "heuristic"),
+        item(
+          "urine-albumin",
+          "Urine albumin/creatinine screening if due",
+          "neutral",
+          "heuristic",
+        ),
+        item("renal-metabolic", "CMP / creatinine / eGFR check if due", "neutral", "heuristic"),
+      ]
+    : [
+        item(
+          "refill-check",
+          medication ? "Medication refill check" : "Medication and regimen review",
+          "neutral",
+          "heuristic",
+        ),
+        item(
+          "education-monitoring",
+          pain
+            ? "Monitor daytime somnolence after dose changes"
+            : "Education or monitoring instruction from today’s plan",
+          pain ? "warning" : "neutral",
+          "note",
+        ),
+      ];
+
+  return {
+    id: "orders",
+    title: "Suggested Orders",
+    subtitle: "Based on today's assessment and active problems.",
+    items,
+    actions: [
+      action("review_orders", "Review", "primary"),
+      action("remove_item", "Remove", "secondary"),
+      action("edit_item", "Edit", "secondary"),
+    ],
+  };
+}
+
+function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCompletionCard {
+  const mentionsFollowUp =
+    /\b(return to clinic|rtc|follow[-\s]?up|next visit|recheck|see (?:you|patient) in)\b/.test(text) ||
+    /\bin \d+\s*(?:day|days|week|weeks|month|months)\b/.test(text);
+
+  const items: VisitCompletionItem[] = [];
+  if (mentionsFollowUp && !hasFutureAppointment) {
+    items.push(
+      item(
+        "follow-up-missing",
+        "Plan implies follow-up; no appointment scheduled",
+        "alert",
+        "note",
+        "Follow-up language appears in the finalized plan.",
+      ),
+      item(
+        "front-desk-scheduling",
+        "Send scheduling task to front desk before patient leaves",
+        "neutral",
+        "heuristic",
+      ),
+    );
+  } else if (mentionsFollowUp) {
+    items.push(
+      item(
+        "follow-up-scheduled",
+        "Follow-up mentioned and appointment already scheduled",
+        "neutral",
+        "encounter",
+      ),
+    );
+  } else {
+    items.push(
+      item(
+        "follow-up-review",
+        "Confirm follow-up timing before releasing the care plan",
+        "warning",
+        "heuristic",
+      ),
+    );
+  }
+
+  return {
+    id: "follow_up",
+    title: "Follow-Up Plan",
+    subtitle: "Recommended next touchpoint and scheduling handoff.",
+    items,
+    actions: [
+      action("send_to_staff", "Send to staff", "primary"),
+      action("defer_item", "Defer", "secondary"),
+    ],
+  };
+}
+
+function buildPatientMessageCard(
+  patientFirstName: string,
+  text: string,
+): VisitCompletionCard {
+  const hasLabs = /\b(lab|labs|a1c|cmp|lipid|urine)\b/.test(text);
+  const hasEducation = /\b(goal|education|instructions|monitor|treatment)\b/.test(text);
+
+  const items: VisitCompletionItem[] = [
+    item(
+      "portal-summary",
+      `Portal summary drafted for ${patientFirstName}`,
+      "neutral",
+      "heuristic",
+    ),
+    item(
+      "next-steps",
+      hasLabs
+        ? "Patient message includes lab instructions and follow-up timing"
+        : "Patient message includes plain-language next steps",
+      "neutral",
+      "note",
+    ),
+  ];
+
+  if (hasEducation) {
+    items.push(
+      item("education", "Education handoff ready for portal or print", "neutral", "heuristic"),
+    );
+  }
+
+  return {
+    id: "patient_message",
+    title: "Patient Communication",
+    subtitle: "Plain-language summary ready for portal or print.",
+    items,
+    actions: [
+      action("preview_message", "Preview", "primary"),
+      action("translate_message", "Translate", "secondary"),
+      action("print_summary", "Print", "secondary"),
+    ],
+  };
+}
+
+function buildPracticeReadinessCard(
+  codingSuggestion: VisitCompletionCodingSuggestion | null,
+): VisitCompletionCard {
+  const items: VisitCompletionItem[] = [];
+
+  if (!codingSuggestion) {
+    items.push(
+      item(
+        "coding-pending",
+        "No coding suggestion yet",
+        "warning",
+        "coding",
+        "Coding Readiness Agent has not attached metadata to this note yet.",
+      ),
+    );
+  } else {
+    if (codingSuggestion.emLevel) {
+      items.push(
+        item(
+          "em-level",
+          `Suggested E/M: ${codingSuggestion.emLevel}`,
+          "neutral",
+          "coding",
+        ),
+      );
+    }
+    for (const candidate of codingSuggestion.icd10.slice(0, 2)) {
+      items.push(
+        item(
+          `icd10-${candidate.code}`,
+          `ICD-10 candidate: ${candidate.code} ${candidate.label}`,
+          "neutral",
+          "coding",
+        ),
+      );
+    }
+    if (codingSuggestion.rationale) {
+      items.push(
+        item(
+          "coding-rationale",
+          "Coding rationale available for review",
+          "neutral",
+          "coding",
+          codingSuggestion.rationale,
+        ),
+      );
+    }
+  }
+
+  return {
+    id: "practice_readiness",
+    title: "Practice Readiness",
+    subtitle: "Coding, documentation, and operational checks.",
+    items,
+    actions: [
+      action("view_checks", "View checks", "primary"),
+      action("edit_note", "Edit note", "secondary"),
+    ],
+  };
+}
+
+function buildSummary(cards: VisitCompletionCard[]): string {
+  const orders = cards.find((card) => card.id === "orders")?.items.length ?? 0;
+  const followUpTasks = cards.find((card) => card.id === "follow_up")?.items.length ?? 0;
+  const patientMessages =
+    cards.find((card) => card.id === "patient_message")?.items.length ?? 0;
+
+  return `Includes ${orders} care actions, ${patientMessages > 0 ? 1 : 0} patient message, ${followUpTasks} staff tasks, and billing readiness check.`;
+}
+
+function item(
+  id: string,
+  label: string,
+  tone: VisitCompletionTone,
+  source: VisitCompletionSource,
+  reason?: string,
+): VisitCompletionItem {
+  return { id, label, tone, source, reason };
+}
+
+function action(
+  id: string,
+  label: string,
+  variant: VisitCompletionAction["variant"],
+): VisitCompletionAction {
+  return { id, label, variant };
+}

--- a/src/lib/scheduling/previsit-readiness.test.ts
+++ b/src/lib/scheduling/previsit-readiness.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluatePrevisitReadiness,
+  mapSnapshotToGateInput,
+  type PrevisitSnapshot,
+} from "./previsit-readiness";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function fullSnapshot(overrides: Partial<PrevisitSnapshot> = {}): PrevisitSnapshot {
+  return {
+    visitType: "new_patient",
+    treatmentPhase: "intake",
+    isVirtual: false,
+    patient: {
+      dateOfBirth: new Date("1985-04-12T00:00:00.000Z"),
+      addressLine1: "1 Main St",
+      state: "CA",
+      ageVerifiedAt: new Date("2026-05-01T00:00:00.000Z"),
+      allergiesScreenedAt: new Date("2026-05-02T00:00:00.000Z"),
+      cannabisHistory: { priorUse: "occasional" },
+      presentingConcerns: "Chronic lower back pain for 6 months",
+      intakeAnswers: { done: true },
+    },
+    consents: [
+      { templateName: "Visit Consent", version: "1.0", signedAt: new Date("2026-05-10T00:00:00.000Z") },
+    ],
+    coverages: [
+      { type: "primary", active: true, eligibilityStatus: "active" },
+    ],
+    selfPayAttested: false,
+    outcomeLogsSinceLastVisit: 0,
+    ...overrides,
+  };
+}
+
+describe("mapSnapshotToGateInput", () => {
+  it("derives visit consent date from a matching signed consent", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot());
+    expect(input.consent.visitConsentSignedAt).toEqual(new Date("2026-05-10T00:00:00.000Z"));
+    expect(input.consent.telehealthConsentSignedAt).toBeNull();
+  });
+
+  it("derives telehealth consent only from a telehealth-classified consent", () => {
+    const input = mapSnapshotToGateInput(
+      fullSnapshot({
+        isVirtual: true,
+        consents: [
+          { templateName: "Visit Consent", version: "1.0", signedAt: new Date("2026-05-10T00:00:00.000Z") },
+          { templateName: "Telehealth Informed Consent", version: "2.0", signedAt: new Date("2026-05-11T00:00:00.000Z") },
+        ],
+      }),
+    );
+    expect(input.consent.telehealthConsentSignedAt).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+  });
+
+  it("treats an active+eligible coverage as coverageVerified", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot());
+    expect(input.insurance.coverageVerified).toBe(true);
+  });
+
+  it("does not treat an inactive or unverified coverage as verified", () => {
+    const input = mapSnapshotToGateInput(
+      fullSnapshot({
+        coverages: [
+          { type: "primary", active: false, eligibilityStatus: "active" },
+          { type: "secondary", active: true, eligibilityStatus: "unknown" },
+        ],
+      }),
+    );
+    expect(input.insurance.coverageVerified).toBe(false);
+  });
+
+  it("passes self-pay attestation through", () => {
+    const input = mapSnapshotToGateInput(fullSnapshot({ selfPayAttested: true, coverages: [] }));
+    expect(input.insurance.selfPayAttested).toBe(true);
+  });
+});
+
+describe("evaluatePrevisitReadiness", () => {
+  it("is ready when a complete snapshot satisfies every blocking requirement", () => {
+    const r = evaluatePrevisitReadiness(fullSnapshot(), NOW);
+    expect(r.isReady).toBe(true);
+    expect(r.missingRequiredIds).toEqual([]);
+    expect(r.completionPct).toBe(1);
+  });
+
+  it("reports the blocking requirement ids that are still missing", () => {
+    const r = evaluatePrevisitReadiness(
+      fullSnapshot({
+        patient: {
+          ...fullSnapshot().patient,
+          presentingConcerns: null,
+          ageVerifiedAt: null,
+        },
+      }),
+      NOW,
+    );
+    expect(r.isReady).toBe(false);
+    // presenting_concerns (always blocking) + id_age_verification (blocking for new_patient)
+    expect(r.missingRequiredIds).toContain("presenting_concerns");
+    expect(r.missingRequiredIds).toContain("id_age_verification");
+    expect(r.completionPct).toBeLessThan(1);
+  });
+
+  it("exposes a non-PHI summary safe for reminder routing decisions", () => {
+    const r = evaluatePrevisitReadiness(
+      fullSnapshot({ patient: { ...fullSnapshot().patient, presentingConcerns: null } }),
+      NOW,
+    );
+    // The summary must carry counts/ids only — never patient identifiers.
+    expect(JSON.stringify(r)).not.toMatch(/1985|Main St|priorUse|back pain/);
+    expect(r.outstandingRequiredCount).toBe(r.missingRequiredIds.length);
+  });
+});

--- a/src/lib/scheduling/previsit-readiness.ts
+++ b/src/lib/scheduling/previsit-readiness.ts
@@ -1,0 +1,268 @@
+// EMR-212 follow-on — DB-to-gate mapper for pre-visit readiness.
+//
+// `evaluateIntakeGate` (./intake-gate) is pure and takes an already-shaped
+// IntakeGateInput. This module is the binding between *stored* patient /
+// appointment / consent / coverage data and that gate:
+//
+//   PrevisitSnapshot  --mapSnapshotToGateInput-->  IntakeGateInput
+//                     --evaluateIntakeGate------->  IntakeGateResult
+//                     --(summarize, drop PHI)----->  PrevisitReadiness
+//
+// The snapshot is deliberately a plain, serializable shape (no Prisma types)
+// so the mapping is unit-testable with zero DB. `loadPrevisitSnapshot` is the
+// thin Prisma read that produces a snapshot; Codex/app layer can swap or extend
+// it without touching the pure mapping/decision logic.
+
+import { prisma } from "@/lib/db/prisma";
+
+import {
+  evaluateIntakeGate,
+  type IntakeGateInput,
+} from "./intake-gate";
+
+// ---------------------------------------------------------------------------
+// Snapshot shape (storage-agnostic)
+// ---------------------------------------------------------------------------
+
+export interface PrevisitConsentRecord {
+  templateName: string;
+  version: string;
+  signedAt: Date;
+}
+
+export interface PrevisitCoverageRecord {
+  type: string;
+  active: boolean;
+  /** Matches PatientCoverage.eligibilityStatus enum, e.g. "active" | "unknown". */
+  eligibilityStatus: string;
+}
+
+export interface PrevisitSnapshot {
+  visitType: IntakeGateInput["visitType"];
+  treatmentPhase: IntakeGateInput["treatmentPhase"];
+  isVirtual: boolean;
+  patient: {
+    dateOfBirth: Date | null;
+    addressLine1: string | null;
+    state: string | null;
+    ageVerifiedAt: Date | null;
+    allergiesScreenedAt: Date | null;
+    cannabisHistory: unknown;
+    presentingConcerns: string | null;
+    intakeAnswers: unknown;
+  };
+  consents: PrevisitConsentRecord[];
+  coverages: PrevisitCoverageRecord[];
+  /** Self-pay attestation captured outside the coverage table. */
+  selfPayAttested: boolean;
+  outcomeLogsSinceLastVisit: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure mapping
+// ---------------------------------------------------------------------------
+
+/** A consent is "telehealth" if its template name mentions telehealth/virtual. */
+function isTelehealthConsent(name: string): boolean {
+  return /telehealth|telemedicine|virtual/i.test(name);
+}
+
+/** A consent is the general visit consent if it is signed and not telehealth. */
+function isVisitConsent(name: string): boolean {
+  return !isTelehealthConsent(name);
+}
+
+function latestSignedAt(
+  consents: PrevisitConsentRecord[],
+  predicate: (name: string) => boolean,
+): Date | null {
+  const matches = consents
+    .filter((c) => predicate(c.templateName))
+    .map((c) => c.signedAt)
+    .filter((d): d is Date => d instanceof Date);
+  if (matches.length === 0) return null;
+  return matches.reduce((a, b) => (b.getTime() > a.getTime() ? b : a));
+}
+
+/** Coverage counts as verified when an active row reports active eligibility. */
+function hasVerifiedCoverage(coverages: PrevisitCoverageRecord[]): boolean {
+  return coverages.some(
+    (c) => c.active && c.eligibilityStatus.toLowerCase() === "active",
+  );
+}
+
+export function mapSnapshotToGateInput(snapshot: PrevisitSnapshot): IntakeGateInput {
+  return {
+    visitType: snapshot.visitType,
+    treatmentPhase: snapshot.treatmentPhase,
+    isVirtual: snapshot.isVirtual,
+    patient: {
+      dateOfBirth: snapshot.patient.dateOfBirth,
+      addressLine1: snapshot.patient.addressLine1,
+      state: snapshot.patient.state,
+      allergiesScreenedAt: snapshot.patient.allergiesScreenedAt,
+      cannabisHistory: snapshot.patient.cannabisHistory,
+      presentingConcerns: snapshot.patient.presentingConcerns,
+      intakeAnswers: snapshot.patient.intakeAnswers,
+      ageVerifiedAt: snapshot.patient.ageVerifiedAt,
+    },
+    consent: {
+      visitConsentSignedAt: latestSignedAt(snapshot.consents, isVisitConsent),
+      telehealthConsentSignedAt: latestSignedAt(snapshot.consents, isTelehealthConsent),
+    },
+    insurance: {
+      coverageVerified: hasVerifiedCoverage(snapshot.coverages),
+      selfPayAttested: snapshot.selfPayAttested,
+    },
+    outcomeLogsSinceLastVisit: snapshot.outcomeLogsSinceLastVisit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Readiness decision (PHI-free summary)
+// ---------------------------------------------------------------------------
+
+export interface PrevisitReadiness {
+  /** True when no *blocking* gate requirement is outstanding. */
+  isReady: boolean;
+  /** Blocking requirement ids still outstanding (no labels/PHI). */
+  missingRequiredIds: string[];
+  /** Count of outstanding blocking requirements (drives nudge metadata). */
+  outstandingRequiredCount: number;
+  /** Completion 0..1 across all requirements (for progress UI). */
+  completionPct: number;
+}
+
+/**
+ * Evaluate readiness from a snapshot. The result is intentionally PHI-free —
+ * only requirement ids and counts — so it is safe to attach to reminder-routing
+ * decisions and audit metadata. `now` is accepted for parity with callers that
+ * key off the current tick; the gate itself is time-independent today.
+ */
+export function evaluatePrevisitReadiness(
+  snapshot: PrevisitSnapshot,
+  _now: Date,
+): PrevisitReadiness {
+  const gate = evaluateIntakeGate(mapSnapshotToGateInput(snapshot));
+  const missingRequiredIds = gate.requirements
+    .filter((r) => r.blocking && !r.satisfied)
+    .map((r) => r.id);
+
+  return {
+    isReady: gate.allowConfirm,
+    missingRequiredIds,
+    outstandingRequiredCount: missingRequiredIds.length,
+    completionPct: gate.completionPct,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prisma loader (thin DB read -> snapshot)
+// ---------------------------------------------------------------------------
+
+const VISIT_TYPE_BY_MODALITY: Record<string, IntakeGateInput["visitType"]> = {
+  // Default mapping; the appointment table tracks modality, not visit type,
+  // so we treat every booked appointment as a new_patient gate unless a richer
+  // visit-type signal is wired in later (Codex handoff).
+};
+
+/**
+ * Load a PrevisitSnapshot for an appointment from the database. This is the
+ * only DB-touching function here; everything above is pure. Returns null when
+ * the appointment (or its patient) can't be found.
+ *
+ * NOTE (Codex handoff): visitType/treatmentPhase are not modeled on Appointment
+ * today, so they default to new_patient/intake. When the visit-state spine adds
+ * those fields, populate them here — the gate + readiness logic already handles
+ * every visit type.
+ */
+export async function loadPrevisitSnapshot(
+  appointmentId: string,
+): Promise<{ snapshot: PrevisitSnapshot; patientId: string; organizationId: string } | null> {
+  const appt = await prisma.appointment.findUnique({
+    where: { id: appointmentId },
+    include: {
+      patient: {
+        include: {
+          signedConsents: {
+            select: { templateName: true, version: true, signedAt: true },
+            orderBy: { signedAt: "desc" },
+            take: 25,
+          },
+          coverages: {
+            where: { active: true },
+            select: { type: true, active: true, eligibilityStatus: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!appt || !appt.patient) return null;
+  const p = appt.patient;
+
+  const outcomeLogsSinceLastVisit = await prisma.outcomeLog.count({
+    where: { patientId: p.id, loggedAt: { gt: lastVisitBefore(appt.startAt) } },
+  });
+
+  const snapshot: PrevisitSnapshot = {
+    visitType: VISIT_TYPE_BY_MODALITY[appt.modality] ?? "new_patient",
+    treatmentPhase: "intake",
+    isVirtual: appt.modality === "video" || appt.modality === "phone",
+    patient: {
+      dateOfBirth: p.dateOfBirth,
+      addressLine1: p.addressLine1,
+      state: p.state,
+      ageVerifiedAt: p.ageVerifiedAt,
+      // allergiesScreenedAt isn't a column; treat a populated allergies/contra
+      // array as "screened". Codex can replace with a real screened-at column.
+      allergiesScreenedAt:
+        p.allergies.length > 0 || p.contraindications.length > 0 ? p.updatedAt : null,
+      cannabisHistory: p.cannabisHistory,
+      presentingConcerns: p.presentingConcerns,
+      intakeAnswers: p.intakeAnswers,
+    },
+    consents: p.signedConsents.map((c) => ({
+      templateName: c.templateName,
+      version: c.version,
+      signedAt: c.signedAt,
+    })),
+    coverages: p.coverages.map((c) => ({
+      type: c.type,
+      active: c.active,
+      eligibilityStatus: String(c.eligibilityStatus),
+    })),
+    selfPayAttested: false,
+    outcomeLogsSinceLastVisit,
+  };
+
+  return { snapshot, patientId: p.id, organizationId: p.organizationId };
+}
+
+/** A coarse "since last visit" floor: 120 days before this appointment. */
+function lastVisitBefore(startAt: Date): Date {
+  return new Date(startAt.getTime() - 120 * 24 * 60 * 60_000);
+}
+
+export interface AppointmentReadiness {
+  readiness: PrevisitReadiness;
+  patientId: string;
+  organizationId: string;
+}
+
+/**
+ * Load + evaluate readiness for an appointment in one call. Returns null when
+ * the appointment can't be found. The returned readiness is PHI-free.
+ */
+export async function getAppointmentReadiness(
+  appointmentId: string,
+  now: Date,
+): Promise<AppointmentReadiness | null> {
+  const loaded = await loadPrevisitSnapshot(appointmentId);
+  if (!loaded) return null;
+  return {
+    readiness: evaluatePrevisitReadiness(loaded.snapshot, now),
+    patientId: loaded.patientId,
+    organizationId: loaded.organizationId,
+  };
+}

--- a/src/lib/scheduling/previsit-reminders.test.ts
+++ b/src/lib/scheduling/previsit-reminders.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const prisma = {
+    appointment: { findMany: vi.fn() },
+    auditLog: { findMany: vi.fn(), create: vi.fn() },
+  };
+  return { prisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
+vi.mock("./previsit-readiness", () => ({
+  getAppointmentReadiness: vi.fn(),
+}));
+
+import {
+  sendDuePrevisitCompletionReminders,
+  pickPrevisitMilestone,
+  PREVISIT_COMPLETION_REMINDER_ACTION,
+} from "./send-reminders";
+import { getAppointmentReadiness } from "./previsit-readiness";
+import { getMockSmsAdapter } from "@/lib/sms/adapter";
+
+const { prisma } = hoisted;
+const day = 24 * 60 * 60_000;
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+const PORTAL = "https://portal.leafjourney.com";
+
+function makeAppt(overrides: Partial<any> = {}) {
+  return {
+    id: "appt_1",
+    status: "confirmed",
+    startAt: new Date("2026-06-08T16:00:00.000Z"), // 7 calendar days out
+    modality: "video",
+    patient: { id: "pat_1", phone: "+15551234567", organizationId: "org_1" },
+    ...overrides,
+  };
+}
+
+const incomplete = {
+  readiness: { isReady: false, missingRequiredIds: ["consent", "insurance_or_attestation"], outstandingRequiredCount: 2, completionPct: 0.6 },
+  patientId: "pat_1",
+  organizationId: "org_1",
+};
+const complete = {
+  readiness: { isReady: true, missingRequiredIds: [], outstandingRequiredCount: 0, completionPct: 1 },
+  patientId: "pat_1",
+  organizationId: "org_1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMockSmsAdapter().reset();
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_FROM_NUMBER;
+  prisma.auditLog.findMany.mockResolvedValue([]);
+  prisma.auditLog.create.mockResolvedValue({});
+});
+
+describe("pickPrevisitMilestone", () => {
+  it("maps 7 / 2 / 0 UTC-calendar-day offsets to milestones", () => {
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-08T09:00:00Z"))).toBe("7day");
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-03T23:00:00Z"))).toBe("2day");
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-01T18:00:00Z"))).toBe("morning_of");
+  });
+
+  it("returns null off-cadence and once the visit has started", () => {
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-05T09:00:00Z"))).toBeNull();
+    expect(pickPrevisitMilestone(NOW, new Date("2026-06-01T11:00:00Z"))).toBeNull();
+  });
+});
+
+describe("sendDuePrevisitCompletionReminders", () => {
+  it("sends a PHI-free portal CTA when due + incomplete, then audits it", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1);
+    expect(res.details[0]).toMatchObject({ appointmentId: "appt_1", milestone: "7day", result: "sent" });
+
+    const sent = getMockSmsAdapter().getSent();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe("+15551234567");
+    expect(sent[0].body).toContain(PORTAL);
+    // No PHI in the body or the send context.
+    expect(sent[0].body).not.toMatch(/pat_1|1985|consent|insurance/i);
+    expect(JSON.stringify(sent[0].context ?? {})).not.toMatch(/1985|firstName|lastName|dateOfBirth/i);
+
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+    const data = prisma.auditLog.create.mock.calls[0][0].data;
+    expect(data.action).toBe(PREVISIT_COMPLETION_REMINDER_ACTION);
+    expect(data.subjectId).toBe("appt_1");
+    expect(data.metadata).toMatchObject({ milestone: "7day", outstandingCount: 2 });
+    // audit metadata must not carry the requirement *labels* or any PHI
+    expect(JSON.stringify(data.metadata)).not.toMatch(/1985|firstName|back pain/i);
+  });
+
+  it("does NOT nudge a patient who has completed all required items", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(complete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:complete");
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0);
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("skips appointments off the 7d/2d/morning-of cadence", async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ startAt: new Date("2026-06-05T16:00:00.000Z") }), // 4 days out
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:out-of-window");
+    // readiness shouldn't even be consulted off-cadence
+    expect(getAppointmentReadiness).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — does not resend the same milestone for the same appointment", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+    prisma.auditLog.findMany.mockResolvedValue([{ metadata: { milestone: "7day" } }]);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:already-sent");
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0);
+  });
+
+  it("skips when there is no deliverable channel (no phone on file)", async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ patient: { id: "pat_1", phone: null, organizationId: "org_1" } }),
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    expect(res.sent).toBe(0);
+    expect(res.details[0].result).toBe("skipped:no-channel");
+  });
+
+  it("does not write an audit row when the channel send fails", async () => {
+    // An un-normalizable phone makes the SMS adapter return ok:false.
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ patient: { id: "pat_1", phone: "123", organizationId: "org_1" } }),
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+    // "123" fails normalizePhone -> treated as no deliverable channel.
+    expect(res.sent).toBe(0);
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/scheduling/send-reminders.ts
+++ b/src/lib/scheduling/send-reminders.ts
@@ -9,7 +9,12 @@ import {
   renderAppointmentReminder,
   type ReminderOffset,
 } from "@/lib/sms/templates";
+import {
+  renderPrevisitReminder,
+  type PrevisitMilestone,
+} from "@/lib/sms/previsit-templates";
 import { logger } from "@/lib/observability/log";
+import { getAppointmentReadiness } from "./previsit-readiness";
 
 export interface SendDueRemindersInput {
   /** Current time, injected for testability. */
@@ -185,5 +190,188 @@ async function alreadySent(
   return rows.some((r) => {
     const meta = r.metadata as { reminderType?: string } | null;
     return meta?.reminderType === reminderType;
+  });
+}
+
+// ===========================================================================
+// Pre-visit COMPLETION reminders (EMR-212 follow-on)
+//
+// Distinct from the appointment reminders above. These nudge a patient to
+// finish outstanding *intake* requirements through the portal, and are sent
+// ONLY when required items remain incomplete, on a 7d / 2d / morning-of
+// cadence. The copy is STRICTLY PHI-free: it says "you have pre-visit items
+// ready" and links to the bare portal origin — identity/appointment specifics
+// live behind portal login. Sends are idempotent per appointment+milestone and
+// audited with opaque ids + counts only (never labels or PHI).
+// ===========================================================================
+
+/** Audit action for a pre-visit completion nudge. */
+export const PREVISIT_COMPLETION_REMINDER_ACTION =
+  "previsit.completion.reminder.sent" as const;
+
+const PREVISIT_MS_DAY = 24 * 60 * 60_000;
+
+/**
+ * Which completion-reminder milestone (if any) is due today for an appointment
+ * starting at `startAt`. Uses UTC calendar-day offsets so a once-daily job
+ * fires exactly one nudge per milestone. Returns null off-cadence or once the
+ * visit has started.
+ */
+export function pickPrevisitMilestone(
+  now: Date,
+  startAt: Date,
+): PrevisitMilestone | null {
+  if (now.getTime() >= startAt.getTime()) return null;
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(
+    startAt.getUTCFullYear(),
+    startAt.getUTCMonth(),
+    startAt.getUTCDate(),
+  );
+  const days = Math.round((b - a) / PREVISIT_MS_DAY);
+  if (days === 7) return "7day";
+  if (days === 2) return "2day";
+  if (days === 0) return "morning_of";
+  return null;
+}
+
+export interface SendPrevisitRemindersInput {
+  now: Date;
+  /** Generic portal origin; no PHI/path/query (validated by the renderer). */
+  portalUrl: string;
+}
+
+export type PrevisitReminderResult =
+  | "sent"
+  | "skipped:out-of-window"
+  | "skipped:complete"
+  | "skipped:already-sent"
+  | "skipped:no-channel"
+  | "failed";
+
+export interface PrevisitReminderOutcome {
+  appointmentId: string;
+  milestone: PrevisitMilestone | null;
+  result: PrevisitReminderResult;
+  error?: string;
+}
+
+export interface SendPrevisitRemindersResult {
+  sent: number;
+  skipped: number;
+  details: PrevisitReminderOutcome[];
+}
+
+export async function sendDuePrevisitCompletionReminders(
+  input: SendPrevisitRemindersInput,
+): Promise<SendPrevisitRemindersResult> {
+  const now = input.now;
+  const windowEnd = new Date(now.getTime() + 7 * PREVISIT_MS_DAY + 60 * 60_000);
+
+  const appointments = await prisma.appointment.findMany({
+    where: {
+      status: { in: ["requested", "confirmed"] },
+      startAt: { gt: now, lte: windowEnd },
+    },
+    include: {
+      patient: { select: { id: true, phone: true, organizationId: true } },
+    },
+  });
+
+  const details: PrevisitReminderOutcome[] = [];
+  let sent = 0;
+  let skipped = 0;
+
+  for (const appt of appointments) {
+    const milestone = pickPrevisitMilestone(now, appt.startAt);
+    if (!milestone) {
+      details.push({ appointmentId: appt.id, milestone: null, result: "skipped:out-of-window" });
+      skipped += 1;
+      continue;
+    }
+
+    // Only nudge patients with outstanding required items.
+    const readiness = await getAppointmentReadiness(appt.id, now);
+    if (!readiness || readiness.readiness.isReady) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:complete" });
+      skipped += 1;
+      continue;
+    }
+
+    const phone = normalizePhone(appt.patient.phone);
+    if (!phone) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:no-channel" });
+      skipped += 1;
+      continue;
+    }
+
+    if (await alreadySentPrevisit(appt.id, milestone)) {
+      details.push({ appointmentId: appt.id, milestone, result: "skipped:already-sent" });
+      skipped += 1;
+      continue;
+    }
+
+    const body = renderPrevisitReminder(milestone, { portalUrl: input.portalUrl });
+    const adapter = getSmsAdapter();
+    const res = await adapter.send({
+      to: phone,
+      body,
+      // Context is for delivery/idempotency only — opaque ids, no PHI.
+      context: { appointmentId: appt.id, milestone, kind: "previsit_completion" },
+    });
+
+    if (!res.ok) {
+      details.push({ appointmentId: appt.id, milestone, result: "failed", error: res.error });
+      logger.warn({
+        event: "scheduler.previsit.reminder.failed",
+        appointmentId: appt.id,
+        milestone,
+        error: res.error,
+      });
+      continue;
+    }
+
+    await prisma.auditLog.create({
+      data: {
+        organizationId: appt.patient.organizationId,
+        actorAgent: "scheduler:previsitCompletionReminder@1.0.0",
+        action: PREVISIT_COMPLETION_REMINDER_ACTION,
+        subjectType: "Appointment",
+        subjectId: appt.id,
+        // PHI-free metadata: milestone, channel, and a count of outstanding
+        // required items. Never the requirement labels or any patient field.
+        metadata: {
+          milestone,
+          channel: "sms",
+          messageId: res.messageId,
+          adapter: res.adapter,
+          outstandingCount: readiness.readiness.outstandingRequiredCount,
+        } as any,
+      },
+    });
+
+    details.push({ appointmentId: appt.id, milestone, result: "sent" });
+    sent += 1;
+  }
+
+  return { sent, skipped, details };
+}
+
+async function alreadySentPrevisit(
+  appointmentId: string,
+  milestone: PrevisitMilestone,
+): Promise<boolean> {
+  const rows = await prisma.auditLog.findMany({
+    where: {
+      action: PREVISIT_COMPLETION_REMINDER_ACTION,
+      subjectType: "Appointment",
+      subjectId: appointmentId,
+    },
+    select: { metadata: true },
+    take: 10,
+  });
+  return rows.some((r) => {
+    const meta = r.metadata as { milestone?: string } | null;
+    return meta?.milestone === milestone;
   });
 }

--- a/src/lib/sms/previsit-templates.test.ts
+++ b/src/lib/sms/previsit-templates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREVISIT_PORTAL_CTA,
+  renderPrevisitReminder,
+  type PrevisitMilestone,
+} from "./previsit-templates";
+
+const PORTAL = "https://portal.leafjourney.com";
+
+// Tokens that would indicate PHI leaked into the copy. NONE of these are passed
+// into the renderer, so none may ever appear in the output for any milestone.
+const PHI_NEEDLES = [
+  "maya",
+  "patel",
+  "1985",
+  "diagnos",
+  "cannabis",
+  "insurance",
+  "allerg",
+  "mrn",
+  "+1555",
+  "appointment with dr",
+];
+
+const MILESTONES: PrevisitMilestone[] = ["7day", "2day", "morning_of"];
+
+describe("renderPrevisitReminder", () => {
+  it("includes the portal origin and a generic CTA", () => {
+    const body = renderPrevisitReminder("7day", { portalUrl: PORTAL });
+    expect(body).toContain(PORTAL);
+    expect(body).toContain(PREVISIT_PORTAL_CTA);
+  });
+
+  it("never contains PHI for any milestone", () => {
+    for (const milestone of MILESTONES) {
+      const body = renderPrevisitReminder(milestone, { portalUrl: PORTAL }).toLowerCase();
+      for (const needle of PHI_NEEDLES) {
+        expect(body, `milestone ${milestone} leaked "${needle}"`).not.toContain(needle);
+      }
+    }
+  });
+
+  it("keeps the body within a single SMS segment and links exactly once", () => {
+    for (const milestone of MILESTONES) {
+      const body = renderPrevisitReminder(milestone, { portalUrl: PORTAL });
+      expect(body.length).toBeLessThanOrEqual(160);
+      const urls = body.match(/https?:\/\/\S+/g) ?? [];
+      expect(urls).toHaveLength(1);
+    }
+  });
+
+  it("uses morning-of urgency wording only for the morning_of milestone", () => {
+    expect(renderPrevisitReminder("morning_of", { portalUrl: PORTAL }).toLowerCase()).toContain(
+      "today",
+    );
+    expect(renderPrevisitReminder("7day", { portalUrl: PORTAL }).toLowerCase()).not.toContain(
+      "today",
+    );
+  });
+
+  it("rejects a portal url that smuggles a path/query (a PHI carrier)", () => {
+    expect(() =>
+      renderPrevisitReminder("7day", { portalUrl: `${PORTAL}/appt/appt_1?dob=1985-01-01` }),
+    ).toThrow(/portal url/i);
+  });
+
+  it("rejects a non-https portal url", () => {
+    expect(() => renderPrevisitReminder("7day", { portalUrl: "http://portal.leafjourney.com" })).toThrow(
+      /portal url/i,
+    );
+  });
+});

--- a/src/lib/sms/previsit-templates.ts
+++ b/src/lib/sms/previsit-templates.ts
@@ -1,0 +1,67 @@
+// Pre-visit *completion* reminder copy. STRICTLY no PHI.
+//
+// This is distinct from the appointment reminders in ./templates.ts (which
+// greet the patient by name and name the provider). A pre-visit completion
+// nudge is sent only when required intake items remain incomplete, and it must
+// reveal nothing about the patient, the visit, or the clinical context — it
+// says only "you have pre-visit items ready" and links to the bare portal
+// origin. Identity/appointment specifics live behind portal login.
+//
+// Kept pure + deterministic so the "no PHI" property is unit-testable and the
+// nudge can be sent from a cron tick with no token cost.
+
+export type PrevisitMilestone = "7day" | "2day" | "morning_of";
+
+export interface PrevisitReminderInput {
+  /** Generic portal origin, e.g. https://portal.leafjourney.com. No path/query. */
+  portalUrl: string;
+}
+
+export const PREVISIT_PORTAL_CTA = "Finish your pre-visit check-in";
+
+const URGENCY: Record<PrevisitMilestone, string> = {
+  "7day": "before your upcoming visit",
+  "2day": "before your visit in 2 days",
+  morning_of: "before your visit today",
+};
+
+/**
+ * Guard against a portal URL carrying a path/query/hash — a classic vector for
+ * smuggling an appointment id / DOB / token into otherwise "no PHI" copy. We
+ * only ever link to the bare https origin.
+ */
+function assertGenericPortalUrl(portalUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(portalUrl);
+  } catch {
+    throw new Error(`Invalid portal url: ${portalUrl}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("Invalid portal url: must be https");
+  }
+  const hasExtras =
+    (parsed.pathname && parsed.pathname !== "/") ||
+    parsed.search !== "" ||
+    parsed.hash !== "";
+  if (hasExtras) {
+    throw new Error(
+      "Invalid portal url: pre-visit reminders link to the bare origin only (no path/query/hash)",
+    );
+  }
+  return parsed.origin;
+}
+
+/**
+ * Render the SMS/email/push body for a pre-visit completion nudge. Single
+ * sentence + single link so it fits one SMS segment and reads the same across
+ * channels. No greeting-by-name (PHI) — the CTA stands on its own.
+ */
+export function renderPrevisitReminder(
+  milestone: PrevisitMilestone,
+  input: PrevisitReminderInput,
+): string {
+  const origin = assertGenericPortalUrl(input.portalUrl);
+  const urgency = URGENCY[milestone];
+  return `You have pre-visit items ready. ${PREVISIT_PORTAL_CTA} ${urgency}: ${origin}`;
+}


### PR DESCRIPTION
## Summary
- Adds the finalized-note AI Visit Completion panel with Suggested Next Best Actions and Release Care Plan language.
- Adds a deterministic visit-completion bundle builder with learning-loop metadata for approvals, edits, removals, and deferrals.
- Updates the design spec and adds the implementation plan for the first shippable slice.

## Validation
- `npm test` — 214 files, 2135 tests passed.
- `npm run typecheck` — passed.

## Notes
- Browser preview was attempted locally, but the screenshot note IDs returned 404 in the sandboxed dev server. The static visual mockup was used during design review and the implementation is covered by focused unit tests plus full typecheck/test suite.