### PR TITLE
[codex] Add AI Visit Completion panel

### DIFF
--- a/docs/superpowers/plans/2026-05-30-ai-visit-completion.md
+++ b/docs/superpowers/plans/2026-05-30-ai-visit-completion.md
@@ -1,0 +1,280 @@
+# AI Visit Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the physician-facing AI Visit Completion strip below finalized notes with deterministic Suggested Next Best Actions.
+
+**Architecture:** Build a pure `visit-completion` domain projection that turns note blocks, coding suggestions, and follow-up context into a typed bundle. Include learning-loop metadata that maps physician actions to the existing `AgentFeedback` spine, then render the bundle in a focused note-route panel component and wire the note detail page to build it only for finalized notes.
+
+**Tech Stack:** Next.js 14 App Router, React, TypeScript, Prisma query data, Vitest node tests, existing `Card`, `Badge`, and `Button` UI primitives.
+
+---
+
+## File Structure
+
+- Create `src/lib/domain/visit-completion.ts`: pure types and deterministic bundle builder.
+- Create `src/lib/domain/visit-completion.test.ts`: unit tests for stable cards, follow-up warning, coding degradation, and summary counts.
+- Create `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`: server-renderable panel component for the approved UI.
+- Create `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx`: node-safe React element inspection test that locks key product language.
+- Modify `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx`: query future appointment context, build bundle for finalized notes, render panel below `NoteEditor`.
+
+## Task 1: Domain Bundle Builder
+
+**Files:**
+- Create: `src/lib/domain/visit-completion.ts`
+- Create: `src/lib/domain/visit-completion.test.ts`
+
+- [ ] **Step 1: Write failing domain tests**
+
+Add tests that import `buildVisitCompletionBundle` and expect:
+
+```ts
+expect(bundle.cards.map((card) => card.id)).toEqual([
+  "orders",
+  "follow_up",
+  "patient_message",
+  "practice_readiness",
+]);
+expect(bundle.primaryActionLabel).toBe("Release Care Plan");
+expect(bundle.learningLoop.agentName).toBe("visitCompletion");
+expect(bundle.learningLoop.signals).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ actionId: "release_care_plan", feedbackAction: "approved" }),
+    expect.objectContaining({ actionId: "edit_item", feedbackAction: "approved_with_edits" }),
+    expect.objectContaining({ actionId: "remove_item", feedbackAction: "rejected" }),
+    expect.objectContaining({ actionId: "defer_item", feedbackAction: "dismissed" }),
+  ]),
+);
+expect(bundle.cards.find((card) => card.id === "follow_up")?.items[0]).toMatchObject({
+  tone: "alert",
+  label: "Plan implies follow-up; no appointment scheduled",
+});
+expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ label: "Suggested E/M: 99214" }),
+    expect.objectContaining({ label: "ICD-10 candidate: E11.9 Diabetes mellitus" }),
+  ]),
+);
+```
+
+- [ ] **Step 2: Run red test**
+
+Run: `npm test -- src/lib/domain/visit-completion.test.ts`
+
+Expected: fail because `src/lib/domain/visit-completion.ts` does not exist.
+
+- [ ] **Step 3: Implement minimal builder**
+
+Create types:
+
+```ts
+export type VisitCompletionCardId = "orders" | "follow_up" | "patient_message" | "practice_readiness";
+export type VisitCompletionTone = "neutral" | "warning" | "alert";
+export type VisitCompletionSource = "note" | "coding" | "problem_list" | "encounter" | "heuristic";
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: VisitCompletionTone;
+  source: VisitCompletionSource;
+  reason?: string;
+}
+
+export interface VisitCompletionAction {
+  id: string;
+  label: string;
+  variant: "primary" | "secondary";
+}
+
+export interface VisitCompletionCard {
+  id: VisitCompletionCardId;
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionBundle {
+  sectionLabel: "AI Visit Completion";
+  heading: "Suggested Next Best Actions";
+  primaryActionLabel: "Release Care Plan";
+  supportActionLabel: "Approve all suggested actions";
+  summary: string;
+  releaseEnabled: boolean;
+  learningLoop: VisitCompletionLearningLoop;
+  cards: VisitCompletionCard[];
+}
+
+export interface VisitCompletionLearningLoop {
+  agentName: "visitCompletion";
+  agentVersion: "1.0.0";
+  signals: VisitCompletionLearningSignal[];
+}
+
+export interface VisitCompletionLearningSignal {
+  actionId: "release_care_plan" | "approve_all" | "edit_item" | "remove_item" | "defer_item";
+  feedbackAction: "approved" | "approved_with_edits" | "rejected" | "dismissed";
+  meaning: string;
+}
+```
+
+Implement `buildVisitCompletionBundle(input)` with deterministic heuristics:
+
+- always returns the four cards in stable order
+- flags follow-up language when no future appointment exists
+- uses `codingSuggestion.emLevel` and ICD-10 labels when present
+- degrades Practice Readiness to `No coding suggestion yet` when absent
+- computes summary from card items
+- includes learning-loop metadata that can be persisted through `src/lib/agents/memory/agent-feedback.ts`
+
+- [ ] **Step 4: Run green domain test**
+
+Run: `npm test -- src/lib/domain/visit-completion.test.ts`
+
+Expected: pass.
+
+## Task 2: AI Visit Completion Panel
+
+**Files:**
+- Create: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+- Create: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx`
+
+- [ ] **Step 1: Write failing panel test**
+
+Render the component as a React element in node and inspect it with `util.inspect`, following `src/components/ui/button.test.tsx`.
+
+Assert the tree contains:
+
+```ts
+expect(str).toContain("AI Visit Completion");
+expect(str).toContain("Suggested Next Best Actions");
+expect(str).toContain("Release Care Plan");
+expect(str).toContain("Suggested Orders");
+expect(str).toContain("Follow-Up Plan");
+expect(str).toContain("Patient Communication");
+expect(str).toContain("Practice Readiness");
+expect(str).toContain("Physician remains in control.");
+expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+```
+
+- [ ] **Step 2: Run red panel test**
+
+Run: `npm test -- "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"`
+
+Expected: fail because the panel file does not exist.
+
+- [ ] **Step 3: Implement panel component**
+
+Create `VisitCompletionPanel({ bundle })` that:
+
+- uses `Card`, `CardContent`, `Badge`, and `Button`
+- renders the approved language
+- maps card item tones to compact colored dots
+- renders actions as small buttons
+- renders **Release Care Plan** as the primary button
+- stacks cards on mobile with `grid-cols-1 lg:grid-cols-4`
+- includes the control note: "Physician remains in control."
+- includes learning-loop copy that makes the toolchain support visible without making the UI feel like telemetry
+
+- [ ] **Step 4: Run green panel test**
+
+Run: `npm test -- "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"`
+
+Expected: pass.
+
+## Task 3: Route Integration
+
+**Files:**
+- Modify: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx`
+
+- [ ] **Step 1: Add integration imports and future appointment query**
+
+Import:
+
+```ts
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
+```
+
+Query one future appointment for the same patient:
+
+```ts
+const futureAppointment = await prisma.appointment.findFirst({
+  where: {
+    patientId: params.id,
+    startAt: { gt: new Date() },
+    status: { notIn: ["cancelled", "no_show"] },
+  },
+  select: { id: true },
+});
+```
+
+- [ ] **Step 2: Build the bundle only for finalized notes**
+
+After `codingSuggestion` parsing:
+
+```ts
+const visitCompletionBundle =
+  note.status === "finalized"
+    ? buildVisitCompletionBundle({
+        patientFirstName: patient.firstName,
+        blocks,
+        codingSuggestion,
+        hasFutureAppointment: Boolean(futureAppointment),
+      })
+    : null;
+```
+
+- [ ] **Step 3: Render panel below `NoteEditor`**
+
+Add:
+
+```tsx
+{visitCompletionBundle && (
+  <VisitCompletionPanel bundle={visitCompletionBundle} />
+)}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+npm test -- src/lib/domain/visit-completion.test.ts "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"
+```
+
+Expected: pass.
+
+## Task 4: Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: exit 0.
+
+- [ ] **Step 2: Inspect final diff**
+
+Run: `git diff --stat && git diff -- src/lib/domain/visit-completion.ts src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/page.tsx`
+
+Expected: diff is limited to the planned files and approved UI language.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add src/lib/domain/visit-completion.ts src/lib/domain/visit-completion.test.ts src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/visit-completion-panel.test.tsx src/app/'(clinician)'/clinic/patients/'[id]'/notes/'[noteId]'/page.tsx docs/superpowers/plans/2026-05-30-ai-visit-completion.md
+git commit -m "feat: add ai visit completion panel"
+```
+
+Expected: commit succeeds.
+
+## Plan Self-Review
+
+- Spec coverage: the plan covers the typed bundle, the four cards, route rendering, approved language, first-slice no-live-model behavior, learning-loop metadata, and tests.
+- Scoped deferral: release persistence, task creation, patient-message sending, billing workflow dispatch, and actual feedback writes are intentionally deferred behind the same bundle contract and existing `AgentFeedback` primitive.
+- Placeholder scan: no placeholders or undefined task references remain.

--- a/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
+++ b/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
@@ -163,6 +163,22 @@ Responsibilities:
 
 The existing note editor is already doing too much. The panel should be a separate component and the route page should pass the projected bundle alongside `codingSuggestion`.
 
+## AI Toolchain and Learning Loop
+
+AI Visit Completion should plug into the existing agent learning spine instead of becoming an isolated suggestion widget.
+
+The app already has `AgentFeedback` and `recordFeedback()` for approve, approve-with-edits, reject, and dismiss signals. The visit-completion bundle should expose metadata that maps physician actions onto those signals:
+
+- **Release Care Plan** → `approved`
+- **Approve all suggested actions** → `approved`
+- **Edit item** → `approved_with_edits`
+- **Remove item** → `rejected`
+- **Defer item** → `dismissed`
+
+The first UI slice can ship with this metadata and visible learning-loop language while persistence remains staged. The next release action should record the physician's choices with note id, reviewer id, organization id, selected items, and optional edit/reason text. These rows become the recursive improvement loop for future suggestions, physician preference learning, and agent-quality reporting.
+
+Feedback capture must never block care-plan release. If feedback persistence fails, the clinical or operational action should still proceed and log a warning.
+
 ## Release Behavior
 
 The first implementation can make **Release Care Plan** a staged client action with clear disabled/degraded states if back-end mutation support is not ready.

--- a/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
+++ b/docs/superpowers/specs/2026-05-30-ai-visit-completion-design.md
@@ -1,0 +1,230 @@
+# AI Visit Completion Design
+
+## Goal
+
+Turn the finalized-note ending into a physician-controlled care-plan release moment.
+
+The current note page finalizes the note, shows coding suggestions when available, and offers print/leaflet actions. That is clinically useful, but it misses the high-leverage moment immediately after the physician has expressed intent in the plan. The new surface should translate that intent into concrete next actions while keeping the physician in control.
+
+The product feeling should be: "I am still deciding, but I am no longer doing clerical assembly by hand."
+
+## Design Direction
+
+Add an **AI Visit Completion** section directly beneath the finalized note content. It is not a separate dashboard and not a multi-step administrative wizard. It is a thin co-pilot strip with four action cards and one primary release action.
+
+Primary language:
+
+- Section: **AI Visit Completion**
+- Main heading: **Suggested Next Best Actions**
+- Primary action: **Release Care Plan**
+- Supporting action: **Approve all suggested actions**
+- Card labels:
+  - **Suggested Orders**
+  - **Follow-Up Plan**
+  - **Patient Communication**
+  - **Practice Readiness**
+
+Avoid language that makes the physician feel trapped in revenue-cycle tooling. Use "Practice Readiness" instead of "Billing launch", "Select Care Actions" instead of "Choose send-off actions", and "Release Care Plan" instead of "Complete checkout bundle".
+
+## User Experience
+
+When a note is finalized, the lower portion of the note detail page shows the AI Visit Completion section.
+
+The header explains that suggested actions were generated from the finalized note, active problems, patient history, and practice patterns. The primary action is visible on the right on desktop and full-width on mobile.
+
+The primary action includes a compact summary such as:
+
+> Includes 2 care actions, 1 patient message, 2 staff tasks, and billing readiness check.
+
+The physician can:
+
+- Review each card.
+- Approve all suggested actions.
+- Remove a suggestion.
+- Edit a suggestion before release.
+- Send an item to staff.
+- Defer an item.
+- Release the care plan when comfortable.
+
+Nothing is ordered, messaged, billed, assigned, or submitted until the physician releases the plan or explicitly sends a specific item.
+
+## Action Cards
+
+### Suggested Orders
+
+Shows clinically reasonable orders and care actions based on the note and chart context.
+
+First slice examples:
+
+- medication refill check
+- lab or screening item if due and determinable
+- education or monitoring instruction
+- regimen-safety follow-up
+
+Future AI-backed examples:
+
+- diagnosis-aware order sets for diabetes, hypertension, CKD, depression, obesity, chronic pain, asthma, COPD, anticoagulation, and post-hospital follow-up
+- due-status evidence from last result dates
+- physician preference patterns
+
+### Follow-Up Plan
+
+Detects whether the plan implies or states follow-up and whether a matching appointment exists.
+
+First slice examples:
+
+- "Plan implies follow-up; no appointment scheduled"
+- "Recommend return visit in 6 weeks"
+- "Send scheduling task to front desk before patient leaves"
+
+This is one of the highest-value cards because it converts clinical intent into scheduling action while the patient is still reachable.
+
+### Patient Communication
+
+Shows the patient-facing version of the plan.
+
+First slice examples:
+
+- portal message draft
+- printable or Leaflet handoff
+- translation action when relevant
+- plain-language next steps
+
+The card should make it clear that the physician can preview and edit before sending.
+
+### Practice Readiness
+
+Keeps coding, documentation, prior authorization, and staff-operation checks present but not dominant.
+
+First slice examples:
+
+- suggested E/M level when coding suggestions exist
+- ICD-10 candidates from Coding Readiness Agent output
+- documentation gap that would make coding, prior auth, or patient handoff stronger
+- staff task warning if a plan item lacks an owner
+
+The tone should be quiet revenue protection and operational completeness, not coding anxiety.
+
+## Data Flow
+
+The first implementation should use a typed server-side projection rather than wiring a new autonomous agent end to end.
+
+Recommended helper:
+
+`src/lib/domain/visit-completion.ts`
+
+Responsibilities:
+
+- Accept note, encounter, patient context, coding suggestion, and existing follow-up/task/order/message facts where available.
+- Return a `VisitCompletionBundle` with stable sections, counts, and source metadata.
+- Use deterministic heuristics first so the UI can ship safely.
+- Leave room for model-generated suggestions later without changing the UI contract.
+
+Example shape:
+
+```ts
+export interface VisitCompletionBundle {
+  summary: string;
+  cards: VisitCompletionCard[];
+  releaseEnabled: boolean;
+  warnings: VisitCompletionWarning[];
+}
+
+export interface VisitCompletionCard {
+  id: "orders" | "follow_up" | "patient_message" | "practice_readiness";
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: "neutral" | "warning" | "alert";
+  source: "note" | "coding" | "problem_list" | "encounter" | "heuristic";
+  reason?: string;
+}
+```
+
+## UI Components
+
+Add a focused component near the note detail route:
+
+`src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+
+Responsibilities:
+
+- Render the AI Visit Completion header.
+- Render the four cards.
+- Keep card controls visually compact and physician-friendly.
+- Support empty, loading, and degraded states.
+- Accept a fully built bundle as props.
+
+The existing note editor is already doing too much. The panel should be a separate component and the route page should pass the projected bundle alongside `codingSuggestion`.
+
+## Release Behavior
+
+The first implementation can make **Release Care Plan** a staged client action with clear disabled/degraded states if back-end mutation support is not ready.
+
+Preferred behavior when mutations are available:
+
+- Release creates or updates staff tasks.
+- Release queues or stores patient-message drafts for approval/sending.
+- Release records selected/deferred items and source metadata.
+- Release dispatches billing/readiness workflow events only once.
+- Release writes an audit event with user id, note id, encounter id, selected items, and timestamp.
+
+High-risk actions must remain gated:
+
+- orders require physician approval
+- portal messages require preview or explicit send
+- billing submission remains downstream and approval-gated according to existing billing-agent rules
+
+## Error Handling
+
+If the bundle cannot be built, show a calm degraded state:
+
+> AI Visit Completion is unavailable for this note. The finalized note and coding suggestions are still saved.
+
+If only one data source is missing, keep the section visible and mark the affected card:
+
+- "No coding suggestion yet"
+- "No follow-up appointment found"
+- "Patient messaging unavailable"
+- "Chart context incomplete"
+
+Never block note finalization because the visit-completion bundle failed.
+
+## Testing Strategy
+
+Tests should be written before production changes.
+
+Required coverage:
+
+- bundle builder returns all four card ids in stable order
+- finalized note with coding suggestions populates Practice Readiness
+- plan text with follow-up language and no appointment creates a Follow-Up Plan warning
+- missing coding suggestion degrades Practice Readiness without crashing
+- panel renders Release Care Plan and all four cards
+- controls do not appear for actions that are unavailable
+- release mutation, when implemented, is idempotent and audit-logged
+
+## Acceptance Criteria
+
+- Finalized notes show AI Visit Completion below the note content.
+- The section uses the approved product language.
+- The four cards appear in a coherent bottom-third strip on desktop and stack cleanly on mobile.
+- The primary action is **Release Care Plan**.
+- The UI makes it clear that the physician controls what happens.
+- Billing/coding support is present under Practice Readiness but does not dominate the flow.
+- The first slice can run without a live model call.
+- Failures in the bundle do not block note finalization.
+
+## Reference Mockup
+
+The approved visual direction was explored in the local brainstorming preview:
+
+`.superpowers/brainstorm/27616-1780203190/content/ai-visit-completion-v1.html`
+
+That file is a disposable visual companion artifact and should not be committed as product code.

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -11,6 +11,8 @@ import { StaffObjectiveEditor } from "./staff-objective-editor";
 import { NoteCommentsPanel } from "@/components/collaboration/note-comments-panel";
 import { hasPermission, canDocumentObjective } from "@/lib/rbac/permissions";
 import { coerceVitals } from "@/lib/clinical/objective-vitals";
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
 
 interface PageProps {
   params: { id: string; noteId: string };
@@ -42,6 +44,14 @@ export default async function NoteDetailPage({ params }: PageProps) {
   if (note.encounter.patientId !== params.id) notFound();
 
   const patient = note.encounter.patient;
+  const futureAppointment = await prisma.appointment.findFirst({
+    where: {
+      patientId: params.id,
+      startAt: { gt: new Date() },
+      status: { notIn: ["cancelled", "no_show"] },
+    },
+    select: { id: true },
+  });
 
   // Parse blocks — they are stored as JSON. Strip the internal `_guardrails`
   // metadata block planted by the scribe agent: it carries hallucination /
@@ -130,6 +140,15 @@ export default async function NoteDetailPage({ params }: PageProps) {
         rationale: note.codingSuggestion.rationale,
       }
     : null;
+  const visitCompletionBundle =
+    note.status === "finalized"
+      ? buildVisitCompletionBundle({
+          patientFirstName: patient.firstName,
+          blocks,
+          codingSuggestion,
+          hasFutureAppointment: Boolean(futureAppointment),
+        })
+      : null;
 
   return (
     <PageShell maxWidth="max-w-[900px]">
@@ -186,6 +205,10 @@ export default async function NoteDetailPage({ params }: PageProps) {
         />
       ) : (
         <ReadOnlyNote blocks={blocks} />
+      )}
+
+      {visitCompletionBundle && (
+        <VisitCompletionPanel bundle={visitCompletionBundle} />
       )}
 
       {/* ux/comments-mentions-collab — inline collaboration on chart notes */}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import * as React from "react";
+import util from "util";
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
+
+function dump(node: React.ReactElement | null): string {
+  return util.inspect(node, { depth: null });
+}
+
+describe("VisitCompletionPanel", () => {
+  it("renders the physician co-pilot language and four action cards", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      hasFutureAppointment: false,
+      blocks: [
+        {
+          heading: "Plan",
+          body: "Return to clinic in 6 weeks after medication adjustment.",
+        },
+      ],
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "G89.29", label: "Chronic pain", confidence: 0.88 }],
+      },
+    });
+
+    const str = dump(VisitCompletionPanel({ bundle }));
+
+    expect(str).toContain("AI Visit Completion");
+    expect(str).toContain("Suggested Next Best Actions");
+    expect(str).toContain("Release Care Plan");
+    expect(str).toContain("Suggested Orders");
+    expect(str).toContain("Follow-Up Plan");
+    expect(str).toContain("Patient Communication");
+    expect(str).toContain("Practice Readiness");
+    expect(str).toContain("Physician remains in control.");
+    expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,0 +1,141 @@
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils/cn";
+import type {
+  VisitCompletionBundle,
+  VisitCompletionItem,
+  VisitCompletionTone,
+} from "@/lib/domain/visit-completion";
+
+interface VisitCompletionPanelProps {
+  bundle: VisitCompletionBundle;
+}
+
+const toneDot: Record<VisitCompletionTone, string> = {
+  neutral: "bg-accent/70",
+  warning: "bg-highlight",
+  alert: "bg-danger",
+};
+
+const toneBadge: Record<VisitCompletionTone, "neutral" | "warning" | "danger"> = {
+  neutral: "neutral",
+  warning: "warning",
+  alert: "danger",
+};
+
+export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
+  return (
+    <Card tone="raised" className="mt-8 overflow-hidden">
+      <CardContent className="p-0">
+        <div className="flex flex-col gap-5 border-b border-border/70 bg-gradient-to-r from-accent-soft via-surface to-surface px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
+              {bundle.sectionLabel}
+            </p>
+            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-text md:text-3xl">
+              {bundle.heading}
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-text-muted">
+              Based on the finalized note, active problems, patient history, and practice
+              patterns. Review the bundle, then approve, remove, edit, or send work to staff.
+            </p>
+          </div>
+
+          <div className="flex flex-col items-stretch gap-2 lg:items-end">
+            <Button size="md" disabled={!bundle.releaseEnabled}>
+              {bundle.primaryActionLabel}
+            </Button>
+            <p className="max-w-[260px] text-left text-xs leading-relaxed text-text-muted lg:text-right">
+              {bundle.summary}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
+          {bundle.cards.map((card) => (
+            <article
+              key={card.id}
+              className="flex min-h-[250px] flex-col overflow-hidden rounded-lg border border-border/80 bg-surface"
+            >
+              <div className="border-b border-border/60 px-4 py-4">
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="text-base font-semibold text-text">{card.title}</h3>
+                  {card.items.some((item) => item.tone !== "neutral") && (
+                    <Badge
+                      tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}
+                    >
+                      Review
+                    </Badge>
+                  )}
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-text-muted">
+                  {card.subtitle}
+                </p>
+              </div>
+
+              <ul className="flex-1 space-y-3 px-4 py-4">
+                {card.items.map((item) => (
+                  <VisitCompletionLine key={item.id} item={item} />
+                ))}
+              </ul>
+
+              <div className="flex flex-wrap gap-2 px-4 pb-4">
+                {card.actions.map((action) => (
+                  <Button
+                    key={action.id}
+                    size="sm"
+                    variant={action.variant === "primary" ? "secondary" : "ghost"}
+                    className={cn(
+                      "h-8 rounded-full px-3 text-xs",
+                      action.variant === "primary" &&
+                        "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
+                    )}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-text">Physician remains in control.</p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              AI prepares the next actions; nothing is sent, ordered, billed, or assigned
+              until the care plan is released.
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              Learns from approvals, edits, removals, and deferrals.
+            </p>
+          </div>
+          <Button size="sm" variant="highlight" className="shrink-0">
+            {bundle.supportActionLabel}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function VisitCompletionLine({ item }: { item: VisitCompletionItem }) {
+  return (
+    <li className="grid grid-cols-[14px_1fr] gap-2 text-sm leading-relaxed text-text">
+      <span
+        className={cn("mt-2 h-2 w-2 rounded-full", toneDot[item.tone])}
+        aria-hidden="true"
+      />
+      <span>
+        {item.label}
+        {item.reason && item.tone !== "neutral" && (
+          <Badge tone={toneBadge[item.tone]} className="ml-2 align-middle">
+            Source
+          </Badge>
+        )}
+      </span>
+    </li>
+  );
+}

--- a/src/lib/domain/visit-completion.test.ts
+++ b/src/lib/domain/visit-completion.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { buildVisitCompletionBundle } from "./visit-completion";
+
+const followUpBlocks = [
+  {
+    heading: "Assessment",
+    body: "Diabetes follow-up with worsening glycemic control.",
+  },
+  {
+    heading: "Plan",
+    body: "Repeat labs and return to clinic in 6 weeks to review A1C and medication response.",
+  },
+];
+
+describe("buildVisitCompletionBundle", () => {
+  it("returns the four visit completion cards in stable order", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.sectionLabel).toBe("AI Visit Completion");
+    expect(bundle.heading).toBe("Suggested Next Best Actions");
+    expect(bundle.primaryActionLabel).toBe("Release Care Plan");
+    expect(bundle.supportActionLabel).toBe("Approve all suggested actions");
+    expect(bundle.cards.map((card) => card.id)).toEqual([
+      "orders",
+      "follow_up",
+      "patient_message",
+      "practice_readiness",
+    ]);
+  });
+
+  it("exposes learning-loop metadata for physician action feedback", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.learningLoop.agentName).toBe("visitCompletion");
+    expect(bundle.learningLoop.agentVersion).toBe("1.0.0");
+    expect(bundle.learningLoop.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actionId: "release_care_plan",
+          feedbackAction: "approved",
+        }),
+        expect.objectContaining({
+          actionId: "edit_item",
+          feedbackAction: "approved_with_edits",
+        }),
+        expect.objectContaining({
+          actionId: "remove_item",
+          feedbackAction: "rejected",
+        }),
+        expect.objectContaining({
+          actionId: "defer_item",
+          feedbackAction: "dismissed",
+        }),
+      ]),
+    );
+  });
+
+  it("flags follow-up language when no future appointment exists", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: false,
+    });
+
+    expect(bundle.cards.find((card) => card.id === "follow_up")?.items[0]).toMatchObject({
+      tone: "alert",
+      label: "Plan implies follow-up; no appointment scheduled",
+    });
+  });
+
+  it("uses coding suggestions for practice readiness", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      hasFutureAppointment: true,
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [
+          { code: "E11.9", label: "Diabetes mellitus", confidence: 0.91 },
+          { code: "I10", label: "Essential hypertension", confidence: 0.82 },
+        ],
+      },
+    });
+
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Suggested E/M: 99214" }),
+        expect.objectContaining({ label: "ICD-10 candidate: E11.9 Diabetes mellitus" }),
+      ]),
+    );
+  });
+
+  it("degrades practice readiness when coding is not available yet", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items[0]).toMatchObject({
+      label: "No coding suggestion yet",
+      tone: "warning",
+    });
+    expect(bundle.summary).toContain("billing readiness check");
+  });
+});

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -1,0 +1,373 @@
+export type VisitCompletionCardId =
+  | "orders"
+  | "follow_up"
+  | "patient_message"
+  | "practice_readiness";
+export type VisitCompletionTone = "neutral" | "warning" | "alert";
+export type VisitCompletionSource =
+  | "note"
+  | "coding"
+  | "problem_list"
+  | "encounter"
+  | "heuristic";
+
+export interface VisitCompletionItem {
+  id: string;
+  label: string;
+  tone: VisitCompletionTone;
+  source: VisitCompletionSource;
+  reason?: string;
+}
+
+export interface VisitCompletionAction {
+  id: string;
+  label: string;
+  variant: "primary" | "secondary";
+}
+
+export interface VisitCompletionCard {
+  id: VisitCompletionCardId;
+  title: string;
+  subtitle: string;
+  items: VisitCompletionItem[];
+  actions: VisitCompletionAction[];
+}
+
+export interface VisitCompletionLearningSignal {
+  actionId:
+    | "release_care_plan"
+    | "approve_all"
+    | "edit_item"
+    | "remove_item"
+    | "defer_item";
+  feedbackAction: "approved" | "approved_with_edits" | "rejected" | "dismissed";
+  meaning: string;
+}
+
+export interface VisitCompletionLearningLoop {
+  agentName: "visitCompletion";
+  agentVersion: "1.0.0";
+  signals: VisitCompletionLearningSignal[];
+}
+
+export interface VisitCompletionBundle {
+  sectionLabel: "AI Visit Completion";
+  heading: "Suggested Next Best Actions";
+  primaryActionLabel: "Release Care Plan";
+  supportActionLabel: "Approve all suggested actions";
+  summary: string;
+  releaseEnabled: boolean;
+  learningLoop: VisitCompletionLearningLoop;
+  cards: VisitCompletionCard[];
+}
+
+export interface VisitCompletionCodingSuggestion {
+  icd10: { code: string; label: string; confidence?: number }[];
+  emLevel: string | null;
+  rationale?: string | null;
+}
+
+export interface VisitCompletionBlock {
+  heading: string;
+  body: string;
+}
+
+export interface BuildVisitCompletionBundleInput {
+  patientFirstName: string;
+  blocks: VisitCompletionBlock[];
+  codingSuggestion: VisitCompletionCodingSuggestion | null;
+  hasFutureAppointment: boolean;
+}
+
+const learningLoop: VisitCompletionLearningLoop = {
+  agentName: "visitCompletion",
+  agentVersion: "1.0.0",
+  signals: [
+    {
+      actionId: "release_care_plan",
+      feedbackAction: "approved",
+      meaning: "Physician released the generated visit-completion bundle.",
+    },
+    {
+      actionId: "approve_all",
+      feedbackAction: "approved",
+      meaning: "Physician accepted the suggested actions without item-level edits.",
+    },
+    {
+      actionId: "edit_item",
+      feedbackAction: "approved_with_edits",
+      meaning: "Physician kept the suggestion but changed clinical or operational details.",
+    },
+    {
+      actionId: "remove_item",
+      feedbackAction: "rejected",
+      meaning: "Physician removed a suggested action as inappropriate for this visit.",
+    },
+    {
+      actionId: "defer_item",
+      feedbackAction: "dismissed",
+      meaning: "Physician deferred a suggested action without rejecting the concept.",
+    },
+  ],
+};
+
+export function buildVisitCompletionBundle(
+  input: BuildVisitCompletionBundleInput,
+): VisitCompletionBundle {
+  const text = noteText(input.blocks);
+  const cards: VisitCompletionCard[] = [
+    buildOrdersCard(text),
+    buildFollowUpCard(text, input.hasFutureAppointment),
+    buildPatientMessageCard(input.patientFirstName, text),
+    buildPracticeReadinessCard(input.codingSuggestion),
+  ];
+
+  return {
+    sectionLabel: "AI Visit Completion",
+    heading: "Suggested Next Best Actions",
+    primaryActionLabel: "Release Care Plan",
+    supportActionLabel: "Approve all suggested actions",
+    summary: buildSummary(cards),
+    releaseEnabled: cards.some((card) => card.items.length > 0),
+    learningLoop,
+    cards,
+  };
+}
+
+function noteText(blocks: VisitCompletionBlock[]): string {
+  return blocks
+    .map((block) => `${block.heading}\n${block.body}`)
+    .join("\n\n")
+    .toLowerCase();
+}
+
+function buildOrdersCard(text: string): VisitCompletionCard {
+  const diabetes = /\b(diabetes|diabetic|a1c|hba1c|glycemic)\b/.test(text);
+  const medication = /\b(medication|med|dose|dosing|refill|regimen|prescribed)\b/.test(text);
+  const pain = /\b(pain|arthritis|arthritic|somnolence|cbd|topical)\b/.test(text);
+
+  const items: VisitCompletionItem[] = diabetes
+    ? [
+        item("a1c-due", "A1C if due or worsening control noted", "neutral", "heuristic"),
+        item(
+          "urine-albumin",
+          "Urine albumin/creatinine screening if due",
+          "neutral",
+          "heuristic",
+        ),
+        item("renal-metabolic", "CMP / creatinine / eGFR check if due", "neutral", "heuristic"),
+      ]
+    : [
+        item(
+          "refill-check",
+          medication ? "Medication refill check" : "Medication and regimen review",
+          "neutral",
+          "heuristic",
+        ),
+        item(
+          "education-monitoring",
+          pain
+            ? "Monitor daytime somnolence after dose changes"
+            : "Education or monitoring instruction from today’s plan",
+          pain ? "warning" : "neutral",
+          "note",
+        ),
+      ];
+
+  return {
+    id: "orders",
+    title: "Suggested Orders",
+    subtitle: "Based on today's assessment and active problems.",
+    items,
+    actions: [
+      action("review_orders", "Review", "primary"),
+      action("remove_item", "Remove", "secondary"),
+      action("edit_item", "Edit", "secondary"),
+    ],
+  };
+}
+
+function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCompletionCard {
+  const mentionsFollowUp =
+    /\b(return to clinic|rtc|follow[-\s]?up|next visit|recheck|see (?:you|patient) in)\b/.test(text) ||
+    /\bin \d+\s*(?:day|days|week|weeks|month|months)\b/.test(text);
+
+  const items: VisitCompletionItem[] = [];
+  if (mentionsFollowUp && !hasFutureAppointment) {
+    items.push(
+      item(
+        "follow-up-missing",
+        "Plan implies follow-up; no appointment scheduled",
+        "alert",
+        "note",
+        "Follow-up language appears in the finalized plan.",
+      ),
+      item(
+        "front-desk-scheduling",
+        "Send scheduling task to front desk before patient leaves",
+        "neutral",
+        "heuristic",
+      ),
+    );
+  } else if (mentionsFollowUp) {
+    items.push(
+      item(
+        "follow-up-scheduled",
+        "Follow-up mentioned and appointment already scheduled",
+        "neutral",
+        "encounter",
+      ),
+    );
+  } else {
+    items.push(
+      item(
+        "follow-up-review",
+        "Confirm follow-up timing before releasing the care plan",
+        "warning",
+        "heuristic",
+      ),
+    );
+  }
+
+  return {
+    id: "follow_up",
+    title: "Follow-Up Plan",
+    subtitle: "Recommended next touchpoint and scheduling handoff.",
+    items,
+    actions: [
+      action("send_to_staff", "Send to staff", "primary"),
+      action("defer_item", "Defer", "secondary"),
+    ],
+  };
+}
+
+function buildPatientMessageCard(
+  patientFirstName: string,
+  text: string,
+): VisitCompletionCard {
+  const hasLabs = /\b(lab|labs|a1c|cmp|lipid|urine)\b/.test(text);
+  const hasEducation = /\b(goal|education|instructions|monitor|treatment)\b/.test(text);
+
+  const items: VisitCompletionItem[] = [
+    item(
+      "portal-summary",
+      `Portal summary drafted for ${patientFirstName}`,
+      "neutral",
+      "heuristic",
+    ),
+    item(
+      "next-steps",
+      hasLabs
+        ? "Patient message includes lab instructions and follow-up timing"
+        : "Patient message includes plain-language next steps",
+      "neutral",
+      "note",
+    ),
+  ];
+
+  if (hasEducation) {
+    items.push(
+      item("education", "Education handoff ready for portal or print", "neutral", "heuristic"),
+    );
+  }
+
+  return {
+    id: "patient_message",
+    title: "Patient Communication",
+    subtitle: "Plain-language summary ready for portal or print.",
+    items,
+    actions: [
+      action("preview_message", "Preview", "primary"),
+      action("translate_message", "Translate", "secondary"),
+      action("print_summary", "Print", "secondary"),
+    ],
+  };
+}
+
+function buildPracticeReadinessCard(
+  codingSuggestion: VisitCompletionCodingSuggestion | null,
+): VisitCompletionCard {
+  const items: VisitCompletionItem[] = [];
+
+  if (!codingSuggestion) {
+    items.push(
+      item(
+        "coding-pending",
+        "No coding suggestion yet",
+        "warning",
+        "coding",
+        "Coding Readiness Agent has not attached metadata to this note yet.",
+      ),
+    );
+  } else {
+    if (codingSuggestion.emLevel) {
+      items.push(
+        item(
+          "em-level",
+          `Suggested E/M: ${codingSuggestion.emLevel}`,
+          "neutral",
+          "coding",
+        ),
+      );
+    }
+    for (const candidate of codingSuggestion.icd10.slice(0, 2)) {
+      items.push(
+        item(
+          `icd10-${candidate.code}`,
+          `ICD-10 candidate: ${candidate.code} ${candidate.label}`,
+          "neutral",
+          "coding",
+        ),
+      );
+    }
+    if (codingSuggestion.rationale) {
+      items.push(
+        item(
+          "coding-rationale",
+          "Coding rationale available for review",
+          "neutral",
+          "coding",
+          codingSuggestion.rationale,
+        ),
+      );
+    }
+  }
+
+  return {
+    id: "practice_readiness",
+    title: "Practice Readiness",
+    subtitle: "Coding, documentation, and operational checks.",
+    items,
+    actions: [
+      action("view_checks", "View checks", "primary"),
+      action("edit_note", "Edit note", "secondary"),
+    ],
+  };
+}
+
+function buildSummary(cards: VisitCompletionCard[]): string {
+  const orders = cards.find((card) => card.id === "orders")?.items.length ?? 0;
+  const followUpTasks = cards.find((card) => card.id === "follow_up")?.items.length ?? 0;
+  const patientMessages =
+    cards.find((card) => card.id === "patient_message")?.items.length ?? 0;
+
+  return `Includes ${orders} care actions, ${patientMessages > 0 ? 1 : 0} patient message, ${followUpTasks} staff tasks, and billing readiness check.`;
+}
+
+function item(
+  id: string,
+  label: string,
+  tone: VisitCompletionTone,
+  source: VisitCompletionSource,
+  reason?: string,
+): VisitCompletionItem {
+  return { id, label, tone, source, reason };
+}
+
+function action(
+  id: string,
+  label: string,
+  variant: VisitCompletionAction["variant"],
+): VisitCompletionAction {
+  return { id, label, variant };
+}


### PR DESCRIPTION
## Summary
- Adds the finalized-note AI Visit Completion panel with Suggested Next Best Actions and Release Care Plan language.
- Adds a deterministic visit-completion bundle builder with learning-loop metadata for approvals, edits, removals, and deferrals.
- Updates the design spec and adds the implementation plan for the first shippable slice.

## Validation
- `npm run db:generate` — generated Prisma Client for the current branch before typecheck.
- `npm test -- src/lib/domain/visit-completion.test.ts "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"` — 2 files, 6 tests passed.
- `npm run typecheck` — passed.
- `npm test` — 253 files, 2445 tests passed.
- Read-only merge check against `origin/main` — clean.

## Notes
- Browser preview was attempted locally, but the screenshot note IDs returned 404 in the sandboxed dev server. The static visual mockup was used during design review and the implementation is covered by focused unit tests plus full typecheck/test suite.