### PR TITLE
feat(kiosk): 'Continue on my phone' hand-off issuance + QR (EMR-915)

### DIFF
--- a/prisma/migrations/20260531063000_kiosk_handoff_token/migration.sql
+++ b/prisma/migrations/20260531063000_kiosk_handoff_token/migration.sql
@@ -1,0 +1,16 @@
+-- EMR-915 — persisted hash of the kiosk→phone hand-off "claim ticket".
+-- Stores only the SHA-256 of the HMAC-signed token; single-use via redeemedAt.
+CREATE TABLE IF NOT EXISTS "KioskHandoffToken" (
+  "id"             TEXT NOT NULL,
+  "patientId"      TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "tokenHash"      TEXT NOT NULL,
+  "expiresAt"      TIMESTAMP(3) NOT NULL,
+  "redeemedAt"     TIMESTAMP(3),
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "KioskHandoffToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "KioskHandoffToken_tokenHash_key" ON "KioskHandoffToken"("tokenHash");
+CREATE INDEX IF NOT EXISTS "KioskHandoffToken_patientId_idx" ON "KioskHandoffToken"("patientId");
+CREATE INDEX IF NOT EXISTS "KioskHandoffToken_expiresAt_idx" ON "KioskHandoffToken"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5011,6 +5011,26 @@ model KioskLobbySession {
 }
 
 // --------------------------------------------------------------
+// EMR-915 — the "claim ticket" minted at the kiosk and encoded in the QR.
+// Stores only the SHA-256 hash of the HMAC-signed token (never the raw token).
+// Single-use via `redeemedAt`; consumed when the /kiosk/lobby route mints a
+// lobby session. patientId/organizationId are scope keys (no FK; short-lived).
+// --------------------------------------------------------------
+
+model KioskHandoffToken {
+  id             String    @id @default(cuid())
+  patientId      String
+  organizationId String
+  tokenHash      String    @unique
+  expiresAt      DateTime
+  redeemedAt     DateTime?
+  createdAt      DateTime  @default(now())
+
+  @@index([patientId])
+  @@index([expiresAt])
+}
+
+// --------------------------------------------------------------
 // EMR-107 — ChatCB AI Coach
 // --------------------------------------------------------------
 

--- a/src/app/kiosk/actions.ts
+++ b/src/app/kiosk/actions.ts
@@ -6,6 +6,7 @@ import { requireRole } from "@/lib/auth/session";
 import { patientMatchesQuery } from "@/lib/search/patient-search";
 import { computeQueueTransition } from "@/lib/domain/visit-state";
 import { logger } from "@/lib/observability/log";
+import { appOrigin, issueHandoffToken } from "@/lib/check-in/kiosk-handoff";
 
 // Server actions for the front-desk check-in kiosk.
 //
@@ -238,4 +239,61 @@ export async function kioskCheckIn(patientId: string): Promise<KioskCheckInResul
   logger.info({ event: "kiosk.check_in.success", encounterId: enc.id, orgId });
 
   return { ok: true, status: updated.status, alreadyCheckedIn: false };
+}
+
+export interface KioskHandoffResult {
+  ok: boolean;
+  error?: string;
+  /** URL the QR encodes — the patient's phone opens this. */
+  lobbyUrl?: string;
+  /** A ready-to-render QR image URL for that lobby URL. */
+  qrUrl?: string;
+  expiresAt?: string;
+}
+
+/**
+ * Mint a hand-off "claim ticket" for the identified patient and return a QR the
+ * walk-in can scan to continue on their own phone. Re-verifies the patient is
+ * in the kiosk's own org; never trusts the client id.
+ */
+export async function issueKioskHandoff(patientId: string): Promise<KioskHandoffResult> {
+  const user = await requireRole("kiosk");
+  const orgId = user.organizationId;
+  if (!orgId) return { ok: false, error: "This kiosk isn't linked to a clinic yet." };
+
+  const patient = await prisma.patient.findFirst({
+    where: { id: patientId, organizationId: orgId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) {
+    return { ok: false, error: "We couldn't find your record. Please see the front desk." };
+  }
+
+  // Phone hand-off needs a public origin to point the QR at; if unset, the
+  // kiosk should just let them continue here rather than render a broken QR.
+  if (!appOrigin()) {
+    return { ok: false, error: "Phone hand-off isn't set up here yet — please continue on the kiosk." };
+  }
+
+  const issued = await issueHandoffToken({ patientId: patient.id, organizationId: orgId });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: orgId,
+      actorUserId: user.id,
+      action: "kiosk.handoff.issued",
+      subjectType: "Patient",
+      subjectId: patient.id,
+      metadata: { channel: "kiosk_qr" },
+    },
+  });
+
+  logger.info({ event: "kiosk.handoff.issued", orgId });
+
+  return {
+    ok: true,
+    lobbyUrl: issued.lobbyUrl,
+    qrUrl: issued.qrUrl,
+    expiresAt: issued.expiresAt.toISOString(),
+  };
 }

--- a/src/app/kiosk/kiosk-flow.tsx
+++ b/src/app/kiosk/kiosk-flow.tsx
@@ -6,6 +6,7 @@ import {
   kioskSearchPatients,
   getKioskCheckInContext,
   kioskCheckIn,
+  issueKioskHandoff,
   type KioskPatientHit,
   type KioskCheckInContext,
 } from "./actions";
@@ -24,6 +25,7 @@ import {
 type Step =
   | { kind: "search" }
   | { kind: "confirm"; hit: KioskPatientHit }
+  | { kind: "handoff"; firstName: string; qrUrl: string; lobbyUrl: string }
   | { kind: "done"; context: KioskCheckInContext | null; alreadyCheckedIn: boolean };
 
 const MIN_QUERY_LENGTH = 3;
@@ -65,6 +67,18 @@ export function KioskFlow() {
         onDone={(context, alreadyCheckedIn) =>
           setStep({ kind: "done", context, alreadyCheckedIn })
         }
+        onHandoff={(firstName, qrUrl, lobbyUrl) =>
+          setStep({ kind: "handoff", firstName, qrUrl, lobbyUrl })
+        }
+      />
+    );
+  }
+  if (step.kind === "handoff") {
+    return (
+      <HandoffStep
+        firstName={step.firstName}
+        qrUrl={step.qrUrl}
+        onReset={() => setStep({ kind: "search" })}
       />
     );
   }
@@ -156,12 +170,15 @@ function ConfirmStep({
   hit,
   onBack,
   onDone,
+  onHandoff,
 }: {
   hit: KioskPatientHit;
   onBack: () => void;
   onDone: (context: KioskCheckInContext | null, alreadyCheckedIn: boolean) => void;
+  onHandoff: (firstName: string, qrUrl: string, lobbyUrl: string) => void;
 }) {
   const [isPending, startTransition] = useTransition();
+  const [handoffPending, startHandoff] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
   function handleConfirm() {
@@ -177,7 +194,20 @@ function ConfirmStep({
     });
   }
 
+  function handlePhoneHandoff() {
+    setError(null);
+    startHandoff(async () => {
+      const result = await issueKioskHandoff(hit.id);
+      if (!result.ok || !result.qrUrl || !result.lobbyUrl) {
+        setError(result.error ?? "Couldn't start the phone hand-off. Please continue here.");
+        return;
+      }
+      onHandoff(hit.firstName, result.qrUrl, result.lobbyUrl);
+    });
+  }
+
   const dob = formatDob(hit.dob);
+  const busy = isPending || handoffPending;
 
   return (
     <div className="space-y-6">
@@ -192,13 +222,65 @@ function ConfirmStep({
       {error && <p className="text-sm text-danger">{error}</p>}
 
       <div className="flex flex-col gap-3">
-        <Button size="lg" variant="primary" onClick={handleConfirm} disabled={isPending}>
+        <Button size="lg" variant="primary" onClick={handleConfirm} disabled={busy}>
           {isPending ? "Checking you in…" : "Yes, check me in"}
         </Button>
-        <Button size="lg" variant="ghost" onClick={onBack} disabled={isPending}>
+        <Button size="lg" variant="secondary" onClick={handlePhoneHandoff} disabled={busy}>
+          {handoffPending ? "Preparing…" : "Continue on my phone"}
+        </Button>
+        <Button size="lg" variant="ghost" onClick={onBack} disabled={busy}>
           No, that&rsquo;s not me
         </Button>
       </div>
+    </div>
+  );
+}
+
+function HandoffStep({
+  firstName,
+  qrUrl,
+  onReset,
+}: {
+  firstName: string;
+  qrUrl: string;
+  onReset: () => void;
+}) {
+  // Reset to search after a dwell so the kiosk is free for the next walk-in
+  // once this patient has scanned and walked away with their phone.
+  useEffect(() => {
+    const t = setTimeout(onReset, 60_000);
+    return () => clearTimeout(t);
+  }, [onReset]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="font-display text-3xl text-text tracking-tight">
+          Continue on your phone, {firstName}
+        </h2>
+        <p className="text-text-muted mt-2">
+          Point your phone&rsquo;s camera at the code, then finish your check-in from your seat.
+        </p>
+      </div>
+
+      <div className="flex justify-center">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={qrUrl}
+          alt="QR code to continue check-in on your phone"
+          width={280}
+          height={280}
+          className="rounded-2xl border border-border bg-white p-3"
+        />
+      </div>
+
+      <p className="text-xs text-text-subtle">
+        We&rsquo;ll text you a code to confirm it&rsquo;s you. This code expires in 10 minutes.
+      </p>
+
+      <Button size="lg" variant="ghost" onClick={onReset}>
+        Done
+      </Button>
     </div>
   );
 }

--- a/src/lib/check-in/kiosk-handoff.test.ts
+++ b/src/lib/check-in/kiosk-handoff.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { lobbyUrl, qrImageUrl } from "./kiosk-handoff";
+
+describe("lobbyUrl", () => {
+  it("builds an origin-rooted /kiosk/lobby URL with the token url-encoded", () => {
+    expect(lobbyUrl("https://app.leafjourney.com", "abc.def")).toBe(
+      "https://app.leafjourney.com/kiosk/lobby/abc.def",
+    );
+  });
+  it("encodes a token so reserved characters survive the path", () => {
+    expect(lobbyUrl("https://x", "a/b+c")).toBe("https://x/kiosk/lobby/a%2Fb%2Bc");
+  });
+});
+
+describe("qrImageUrl", () => {
+  it("points at the qrserver endpoint with the data url-encoded", () => {
+    const url = qrImageUrl("https://x/kiosk/lobby/tok", 280);
+    expect(url).toContain("https://api.qrserver.com/v1/create-qr-code/");
+    expect(url).toContain("size=280x280");
+    expect(url).toContain(encodeURIComponent("https://x/kiosk/lobby/tok"));
+  });
+});

--- a/src/lib/check-in/kiosk-handoff.ts
+++ b/src/lib/check-in/kiosk-handoff.ts
@@ -1,0 +1,127 @@
+// EMR-915 — kiosk→phone hand-off orchestration: config + pure URL helpers +
+// the DB binding around the pure kiosk-handoff-token primitive.
+//
+// Mint (kiosk): issueHandoffToken stores the token hash and returns the lobby
+// URL + a QR image URL. Redeem (the /kiosk/lobby route): validateHandoffToken
+// checks the ticket without consuming it (so a scan alone doesn't burn it), and
+// consumeHandoffToken atomically marks it single-used once the OTP challenge
+// passes and a lobby session is about to be minted.
+
+import { randomBytes } from "node:crypto";
+import { prisma } from "@/lib/db/prisma";
+import {
+  createKioskHandoffToken,
+  hashKioskHandoffToken,
+  verifyKioskHandoffToken,
+  DEFAULT_HANDOFF_TTL_MINUTES,
+  type KioskHandoffVerifyFailure,
+} from "./kiosk-handoff-token";
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+/** HMAC secret for hand-off tokens. Required in prod; dev gets a fixed fallback. */
+export function handoffSecret(): string {
+  const s = process.env.KIOSK_HANDOFF_SECRET;
+  if (s && s.length > 0) return s;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("KIOSK_HANDOFF_SECRET is required in production");
+  }
+  return "dev-kiosk-handoff-secret-not-for-prod";
+}
+
+/** Public origin the QR points at (no trailing slash). Empty if unconfigured. */
+export function appOrigin(): string {
+  return (process.env.NEXT_PUBLIC_APP_URL ?? process.env.PREVISIT_PORTAL_URL ?? "").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+// ── Pure URL helpers ─────────────────────────────────────────────────────────
+
+export function lobbyUrl(origin: string, token: string): string {
+  return `${origin}/kiosk/lobby/${encodeURIComponent(token)}`;
+}
+
+/** External QR image (qrserver.com) — same no-auth approach as emergency cards. */
+export function qrImageUrl(data: string, size = 280): string {
+  return `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&margin=2&data=${encodeURIComponent(
+    data,
+  )}`;
+}
+
+// ── DB binding ───────────────────────────────────────────────────────────────
+
+export interface IssuedHandoff {
+  token: string;
+  expiresAt: Date;
+  lobbyUrl: string;
+  qrUrl: string;
+}
+
+export async function issueHandoffToken(opts: {
+  patientId: string;
+  organizationId: string;
+  now?: Date;
+}): Promise<IssuedHandoff> {
+  const now = opts.now ?? new Date();
+  const expiresAt = new Date(now.getTime() + DEFAULT_HANDOFF_TTL_MINUTES * 60 * 1000);
+  const { token, tokenHash } = createKioskHandoffToken({
+    patientId: opts.patientId,
+    organizationId: opts.organizationId,
+    expiresAt,
+    secret: handoffSecret(),
+    nonce: randomBytes(12).toString("hex"),
+  });
+  await prisma.kioskHandoffToken.create({
+    data: {
+      patientId: opts.patientId,
+      organizationId: opts.organizationId,
+      tokenHash,
+      expiresAt,
+    },
+  });
+  const url = lobbyUrl(appOrigin(), token);
+  return { token, expiresAt, lobbyUrl: url, qrUrl: qrImageUrl(url) };
+}
+
+export type HandoffValidation =
+  | { ok: true; patientId: string; organizationId: string }
+  | { ok: false; reason: KioskHandoffVerifyFailure | "unknown_token" };
+
+/** Validate WITHOUT consuming — a scan alone must not burn the token. */
+export async function validateHandoffToken(
+  token: string,
+  now: Date = new Date(),
+): Promise<HandoffValidation> {
+  const row = await prisma.kioskHandoffToken.findUnique({
+    where: { tokenHash: hashKioskHandoffToken(token) },
+  });
+  if (!row) return { ok: false, reason: "unknown_token" };
+
+  const result = verifyKioskHandoffToken(token, {
+    secret: handoffSecret(),
+    now,
+    storedTokenHash: row.tokenHash,
+    redeemedAt: row.redeemedAt,
+    expectedPatientId: row.patientId,
+    expectedOrganizationId: row.organizationId,
+  });
+  if (!result.valid) return { ok: false, reason: result.reason ?? "unknown_token" };
+  return { ok: true, patientId: row.patientId, organizationId: row.organizationId };
+}
+
+/**
+ * Atomically mark the token single-used. Returns false if it was already
+ * redeemed (lost the race), so the caller refuses to mint a second session.
+ */
+export async function consumeHandoffToken(
+  token: string,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const updated = await prisma.kioskHandoffToken.updateMany({
+    where: { tokenHash: hashKioskHandoffToken(token), redeemedAt: null },
+    data: { redeemedAt: now },
+  });
+  return updated.count > 0;
+}


### PR DESCRIPTION
Phase 2 **integration slice A** (kiosk side) of EMR-915. The walk-in, once identified at the kiosk, can now tap **Continue on my phone** and get a QR to finish in the lobby.

## What
- **`KioskHandoffToken` table** — hash-at-rest claim ticket, single-use via `redeemedAt`. Additive migration.
- **`src/lib/check-in/kiosk-handoff.ts`** — config (HMAC secret + app origin), pure `lobbyUrl`/`qrImageUrl` helpers (tested), and the DB binding: `issueHandoffToken` (mint + store hash + build QR url) plus `validateHandoffToken`/`consumeHandoffToken` the lobby route will use next.
- **`issueKioskHandoff` server action** — `requireRole('kiosk')`, re-verifies the patient is in the kiosk's org, returns lobby + QR urls, refuses cleanly when no public origin is configured, PHI-free audit (`kiosk.handoff.issued`).
- **Kiosk UI** — confirm screen gains **Continue on my phone** → `HandoffStep` renders the QR (qrserver.com, emergency-card precedent) with a 60s auto-reset.

## Heads-up
The QR points at `/kiosk/lobby/[token]`, built in **slice B** (route + DOB/OTP challenge → mint `KioskLobbySession`). Until that lands, a scan 404s **by design** — this slice is the kiosk-side issuance only.

`tsc` + lint clean; pure helper tests pass.

Refs: EMR-912, EMR-915 · plan §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)