### PR TITLE
[codex] Refine AI Visit Completion checkout flow

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -30,6 +30,8 @@ import {
 import { MarkdownEditor } from "@/components/ui/markdown-editor";
 import { NoteTemplatePicker, type PickerBlock } from "@/components/clinical/note-template-picker";
 import { NOTE_BLOCK_LABELS as NB_LABELS } from "@/lib/domain/notes";
+import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
+import { VisitCompletionPanel } from "./visit-completion-panel";
 
 interface NoteBlock {
   type?: NoteBlockType;
@@ -48,7 +50,9 @@ interface HallucinationFlag {
 interface NoteEditorProps {
   noteId: string;
   patientId: string;
+  patientFirstName: string;
   encounterId: string;
+  hasFutureAppointment: boolean;
   initialBlocks: NoteBlock[];
   status: string;
   aiDrafted: boolean;
@@ -98,7 +102,9 @@ function scrubMessage(raw: string): string {
 export function NoteEditor({
   noteId,
   patientId,
+  patientFirstName,
   encounterId,
+  hasFutureAppointment,
   initialBlocks,
   status,
   aiDrafted,
@@ -165,6 +171,15 @@ export function NoteEditor({
   }
 
   const isEditable = currentStatus === "draft" || currentStatus === "needs_review";
+  const visitCompletionBundle =
+    currentStatus === "finalized"
+      ? buildVisitCompletionBundle({
+          patientFirstName,
+          blocks,
+          codingSuggestion,
+          hasFutureAppointment,
+        })
+      : null;
 
   // Whole-visit dictation (SOAP routing). The Objective opt-in is a
   // per-physician setting (default off — staff document vitals), stored in the
@@ -700,6 +715,8 @@ export function NoteEditor({
           </CardContent>
         </Card>
       )}
+
+      {visitCompletionBundle && <VisitCompletionPanel bundle={visitCompletionBundle} />}
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -177,7 +177,9 @@ export default async function NoteDetailPage({ params }: PageProps) {
         <NoteEditor
           noteId={note.id}
           patientId={params.id}
+          patientFirstName={patient.firstName}
           encounterId={note.encounterId}
+          hasFutureAppointment={Boolean(futureAppointment)}
           initialBlocks={blocks}
           status={note.status}
           aiDrafted={note.aiDrafted}
@@ -207,7 +209,7 @@ export default async function NoteDetailPage({ params }: PageProps) {
         <ReadOnlyNote blocks={blocks} />
       )}
 
-      {visitCompletionBundle && (
+      {!canEditNotes && visitCompletionBundle && (
         <VisitCompletionPanel bundle={visitCompletionBundle} />
       )}
 

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as React from "react";
-import util from "util";
+import { renderToStaticMarkup } from "react-dom/server";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import { VisitCompletionPanel } from "./visit-completion-panel";
 
 function dump(node: React.ReactElement | null): string {
-  return util.inspect(node, { depth: null });
+  return renderToStaticMarkup(node);
 }
 
 describe("VisitCompletionPanel", () => {
@@ -30,11 +30,22 @@ describe("VisitCompletionPanel", () => {
 
     expect(str).toContain("AI Visit Completion");
     expect(str).toContain("Suggested Next Best Actions");
+    expect(str).toContain("Suggested next actions before sign-off");
     expect(str).toContain("Release Care Plan");
+    expect(str).toContain("Select Care Actions");
     expect(str).toContain("Suggested Orders");
     expect(str).toContain("Follow-Up Plan");
     expect(str).toContain("Patient Communication");
     expect(str).toContain("Practice Readiness");
+    expect(str).toContain(
+      "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    );
+    expect(str).toContain("Review orders");
+    expect(str).toContain("Send to front desk");
+    expect(str).toContain("Preview message");
+    expect(str).toContain("Create staff tasks");
+    expect(str).toContain("Review selected actions");
+    expect(str).toContain("Release is staged for review only in this MVP.");
     expect(str).toContain("Physician remains in control.");
     expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
   });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,10 +1,28 @@
 import * as React from "react";
+import {
+  Check,
+  ClipboardCheck,
+  Clock3,
+  Eye,
+  FileCheck2,
+  FileText,
+  MessageSquareText,
+  Pencil,
+  Printer,
+  Send,
+  ShieldCheck,
+  UserRoundCheck,
+  X,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils/cn";
 import type {
+  VisitCompletionAction,
   VisitCompletionBundle,
+  VisitCompletionCard,
+  VisitCompletionCardId,
+  VisitCompletionDataMode,
   VisitCompletionItem,
   VisitCompletionTone,
 } from "@/lib/domain/visit-completion";
@@ -12,6 +30,31 @@ import type {
 interface VisitCompletionPanelProps {
   bundle: VisitCompletionBundle;
 }
+
+const cardIcons: Record<VisitCompletionCardId, React.ComponentType<{ className?: string }>> = {
+  orders: ClipboardCheck,
+  follow_up: Clock3,
+  patient_message: MessageSquareText,
+  practice_readiness: ShieldCheck,
+};
+
+const actionIcons: Record<string, React.ComponentType<{ className?: string }>> = {
+  review_orders: Eye,
+  approve_item: Check,
+  remove_item: X,
+  edit_item: Pencil,
+  defer_item: Clock3,
+  send_to_front_desk: UserRoundCheck,
+  text_scheduling_link: Send,
+  edit_interval: Pencil,
+  preview_message: Eye,
+  edit_message: Pencil,
+  send_to_portal: Send,
+  print_summary: Printer,
+  view_checks: FileCheck2,
+  review_coding: FileText,
+  create_staff_tasks: UserRoundCheck,
+};
 
 const toneDot: Record<VisitCompletionTone, string> = {
   neutral: "bg-accent/70",
@@ -25,99 +68,139 @@ const toneBadge: Record<VisitCompletionTone, "neutral" | "warning" | "danger"> =
   alert: "danger",
 };
 
+const dataModeLabel: Record<VisitCompletionDataMode, string> = {
+  mvp_mock: "Draft",
+  deterministic_heuristic: "Heuristic",
+  agent_output: "Agent",
+};
+
 export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
   return (
-    <Card tone="raised" className="mt-8 overflow-hidden">
-      <CardContent className="p-0">
-        <div className="flex flex-col gap-5 border-b border-border/70 bg-gradient-to-r from-accent-soft via-surface to-surface px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
-          <div className="max-w-3xl">
+    <section
+      aria-labelledby="ai-visit-completion-heading"
+      className="mt-8 overflow-hidden rounded-lg border border-border bg-surface shadow-sm"
+    >
+      <div className="flex flex-col gap-5 border-b border-border/70 bg-surface-muted/60 px-5 py-5 lg:flex-row lg:items-start lg:justify-between lg:px-6">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap items-center gap-2">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
               {bundle.sectionLabel}
             </p>
-            <h2 className="mt-2 font-display text-2xl font-semibold tracking-tight text-text md:text-3xl">
-              {bundle.heading}
-            </h2>
-            <p className="mt-2 text-sm leading-relaxed text-text-muted">
-              Based on the finalized note, active problems, patient history, and practice
-              patterns. Review the bundle, then approve, remove, edit, or send work to staff.
-            </p>
+            <Badge tone="accent">{bundle.strategyLabel}</Badge>
           </div>
-
-          <div className="flex flex-col items-stretch gap-2 lg:items-end">
-            <Button size="md" disabled={!bundle.releaseEnabled}>
-              {bundle.primaryActionLabel}
-            </Button>
-            <p className="max-w-[260px] text-left text-xs leading-relaxed text-text-muted lg:text-right">
-              {bundle.summary}
-            </p>
-          </div>
+          <h2
+            id="ai-visit-completion-heading"
+            className="mt-2 font-display text-2xl font-semibold tracking-tight text-text md:text-3xl"
+          >
+            {bundle.heading}
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-text-muted">
+            Based on the finalized note, active problems, patient history, and practice
+            patterns. Review, approve, remove, edit, defer, or route the proposed work.
+          </p>
+          <p className="mt-2 text-sm font-medium leading-relaxed text-text">
+            {bundle.safetyCopy}
+          </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
-          {bundle.cards.map((card) => (
-            <article
-              key={card.id}
-              className="flex min-h-[250px] flex-col overflow-hidden rounded-lg border border-border/80 bg-surface"
-            >
-              <div className="border-b border-border/60 px-4 py-4">
-                <div className="flex items-start justify-between gap-2">
-                  <h3 className="text-base font-semibold text-text">{card.title}</h3>
-                  {card.items.some((item) => item.tone !== "neutral") && (
-                    <Badge
-                      tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}
-                    >
-                      Review
-                    </Badge>
-                  )}
-                </div>
-                <p className="mt-1.5 text-xs leading-relaxed text-text-muted">
-                  {card.subtitle}
-                </p>
-              </div>
+        <ReleaseCarePlanButton bundle={bundle} />
+      </div>
 
-              <ul className="flex-1 space-y-3 px-4 py-4">
-                {card.items.map((item) => (
-                  <VisitCompletionLine key={item.id} item={item} />
-                ))}
-              </ul>
-
-              <div className="flex flex-wrap gap-2 px-4 pb-4">
-                {card.actions.map((action) => (
-                  <Button
-                    key={action.id}
-                    size="sm"
-                    variant={action.variant === "primary" ? "secondary" : "ghost"}
-                    className={cn(
-                      "h-8 rounded-full px-3 text-xs",
-                      action.variant === "primary" &&
-                        "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
-                    )}
-                  >
-                    {action.label}
-                  </Button>
-                ))}
-              </div>
-            </article>
-          ))}
-        </div>
-
-        <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
+      <div className="border-b border-border/70 px-5 py-4 lg:px-6">
+        <div className="flex flex-col gap-1 md:flex-row md:items-end md:justify-between">
           <div>
-            <p className="text-sm font-semibold text-text">Physician remains in control.</p>
-            <p className="mt-1 text-xs leading-relaxed text-text-muted">
-              AI prepares the next actions; nothing is sent, ordered, billed, or assigned
-              until the care plan is released.
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
+              {bundle.selectionLabel}
             </p>
-            <p className="mt-1 text-xs leading-relaxed text-text-muted">
-              Learns from approvals, edits, removals, and deferrals.
-            </p>
+            <p className="mt-1 text-sm text-text-muted">{bundle.mockedDataNotice}</p>
           </div>
-          <Button size="sm" variant="highlight" className="shrink-0">
-            {bundle.supportActionLabel}
-          </Button>
+          <p className="text-sm font-medium text-text">{bundle.summary}</p>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
+        {bundle.cards.map((card) => (
+          <SuggestedActionCard key={card.id} card={card} />
+        ))}
+      </div>
+
+      <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-text">Physician remains in control.</p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            AI prepares the next actions; no clinical, billing, messaging, scheduling,
+            staffing, or chart action happens from this MVP panel.
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Learns from approvals, edits, removals, and deferrals.
+          </p>
+        </div>
+        <Badge tone="highlight" className="shrink-0">
+          Review-only MVP
+        </Badge>
+      </div>
+    </section>
+  );
+}
+
+function ReleaseCarePlanButton({ bundle }: { bundle: VisitCompletionBundle }) {
+  return (
+    <details className="group w-full lg:w-[300px]">
+      <summary
+        aria-disabled={!bundle.releaseEnabled}
+        className={cn(
+          "flex min-h-10 cursor-pointer list-none items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-ink shadow-seal transition hover:bg-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
+          !bundle.releaseEnabled && "pointer-events-none opacity-50",
+        )}
+      >
+        <span>{bundle.primaryActionLabel}</span>
+      </summary>
+      <div className="mt-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-sm">
+        <p className="text-sm font-semibold text-text">Review selected actions</p>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">
+          Release is staged for review only in this MVP.
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">
+          This confirmation surface will eventually show selected orders, messages,
+          scheduling tasks, staff tasks, and practice-readiness checks before anything
+          is released.
+        </p>
+      </div>
+    </details>
+  );
+}
+
+function SuggestedActionCard({ card }: { card: VisitCompletionCard }) {
+  const Icon = cardIcons[card.id];
+  const needsReview = card.items.some((item) => item.tone !== "neutral");
+
+  return (
+    <article className="flex min-h-[268px] flex-col overflow-hidden rounded-lg border border-border/80 bg-surface">
+      <div className="border-b border-border/60 px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-md bg-accent-soft text-accent">
+              <Icon className="h-4 w-4" />
+            </span>
+            <h3 className="text-base font-semibold text-text">{card.title}</h3>
+          </div>
+          {needsReview && (
+            <Badge tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}>
+              Review
+            </Badge>
+          )}
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-text-muted">{card.subtitle}</p>
+      </div>
+
+      <ul className="flex-1 space-y-3 px-4 py-4">
+        {card.items.map((item) => (
+          <VisitCompletionLine key={item.id} item={item} />
+        ))}
+      </ul>
+
+      <VisitCompletionActionList actions={card.actions} />
+    </article>
   );
 }
 
@@ -129,13 +212,44 @@ function VisitCompletionLine({ item }: { item: VisitCompletionItem }) {
         aria-hidden="true"
       />
       <span>
-        {item.label}
-        {item.reason && item.tone !== "neutral" && (
-          <Badge tone={toneBadge[item.tone]} className="ml-2 align-middle">
-            Source
-          </Badge>
-        )}
+        <span>{item.label}</span>
+        <span className="ml-2 inline-flex items-center gap-1 align-middle">
+          {item.dataMode !== "deterministic_heuristic" && (
+            <Badge tone="neutral">{dataModeLabel[item.dataMode]}</Badge>
+          )}
+          {item.reason && item.tone !== "neutral" && (
+            <Badge tone={toneBadge[item.tone]}>Source</Badge>
+          )}
+        </span>
       </span>
     </li>
+  );
+}
+
+function VisitCompletionActionList({ actions }: { actions: VisitCompletionAction[] }) {
+  return (
+    <div className="flex flex-wrap gap-2 px-4 pb-4">
+      {actions.map((action) => {
+        const Icon = actionIcons[action.id] ?? FileText;
+
+        return (
+          <Button
+            key={action.id}
+            size="sm"
+            variant={action.variant === "primary" ? "secondary" : "ghost"}
+            className={cn(
+              "h-8 rounded-md px-2.5 text-xs",
+              action.variant === "primary" &&
+                "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
+            )}
+            disabled
+            title={action.placeholderCopy}
+            leadingIcon={<Icon className="h-3.5 w-3.5" />}
+          >
+            {action.label}
+          </Button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/lib/domain/visit-completion.test.ts
+++ b/src/lib/domain/visit-completion.test.ts
@@ -22,15 +22,67 @@ describe("buildVisitCompletionBundle", () => {
     });
 
     expect(bundle.sectionLabel).toBe("AI Visit Completion");
-    expect(bundle.heading).toBe("Suggested Next Best Actions");
+    expect(bundle.strategyLabel).toBe("Suggested Next Best Actions");
+    expect(bundle.heading).toBe("Suggested next actions before sign-off");
     expect(bundle.primaryActionLabel).toBe("Release Care Plan");
-    expect(bundle.supportActionLabel).toBe("Approve all suggested actions");
+    expect(bundle.selectionLabel).toBe("Select Care Actions");
+    expect(bundle.safetyCopy).toBe(
+      "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    );
     expect(bundle.cards.map((card) => card.id)).toEqual([
       "orders",
       "follow_up",
       "patient_message",
       "practice_readiness",
     ]);
+  });
+
+  it("exposes safe placeholder action affordances for every card", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: false,
+    });
+
+    const labelsFor = (id: string) =>
+      bundle.cards.find((card) => card.id === id)?.actions.map((action) => action.label);
+
+    expect(labelsFor("orders")).toEqual(["Review orders", "Approve", "Remove", "Edit", "Defer"]);
+    expect(labelsFor("follow_up")).toEqual([
+      "Send to front desk",
+      "Text scheduling link",
+      "Edit interval",
+      "Defer",
+    ]);
+    expect(labelsFor("patient_message")).toEqual([
+      "Preview message",
+      "Edit",
+      "Send to portal",
+      "Print",
+      "Defer",
+    ]);
+    expect(labelsFor("practice_readiness")).toEqual([
+      "View checks",
+      "Review coding",
+      "Create staff tasks",
+      "Defer",
+    ]);
+
+    expect(bundle.cards.flatMap((card) => card.actions)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Send to portal",
+          requiresPhysicianApproval: true,
+          sideEffect: "none",
+        }),
+        expect.objectContaining({
+          label: "Create staff tasks",
+          requiresPhysicianApproval: true,
+          sideEffect: "none",
+        }),
+      ]),
+    );
   });
 
   it("exposes learning-loop metadata for physician action feedback", () => {
@@ -75,8 +127,28 @@ describe("buildVisitCompletionBundle", () => {
 
     expect(bundle.cards.find((card) => card.id === "follow_up")?.items[0]).toMatchObject({
       tone: "alert",
-      label: "Plan implies follow-up; no appointment scheduled",
+      label: "RTC in 6 weeks recommended. No appointment currently scheduled.",
+      requiresPhysicianApproval: true,
+      dataMode: "deterministic_heuristic",
     });
+  });
+
+  it("uses the MVP/mock diabetes order set without creating real clinical actions", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    expect(bundle.cards.find((card) => card.id === "orders")?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "A1C", dataMode: "mvp_mock" }),
+        expect.objectContaining({ label: "Urine albumin/creatinine", dataMode: "mvp_mock" }),
+        expect.objectContaining({ label: "CMP/eGFR", dataMode: "mvp_mock" }),
+        expect.objectContaining({ label: "Lipid panel if due", dataMode: "mvp_mock" }),
+      ]),
+    );
   });
 
   it("uses coding suggestions for practice readiness", () => {
@@ -110,10 +182,14 @@ describe("buildVisitCompletionBundle", () => {
       hasFutureAppointment: true,
     });
 
-    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items[0]).toMatchObject({
-      label: "No coding suggestion yet",
-      tone: "warning",
-    });
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "No coding suggestion yet",
+          tone: "warning",
+        }),
+      ]),
+    );
     expect(bundle.summary).toContain("billing readiness check");
   });
 });

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -10,12 +10,35 @@ export type VisitCompletionSource =
   | "problem_list"
   | "encounter"
   | "heuristic";
+export type VisitCompletionDataMode =
+  | "mvp_mock"
+  | "deterministic_heuristic"
+  | "agent_output";
+export type VisitCompletionStatus = "suggested" | "needs_review" | "unavailable";
+export type VisitCompletionProposedActionType =
+  | "order_review"
+  | "approve"
+  | "remove"
+  | "edit"
+  | "defer"
+  | "send_to_staff"
+  | "send_to_patient"
+  | "text_scheduling_link"
+  | "print"
+  | "coding_review"
+  | "create_staff_task"
+  | "view_checks";
 
 export interface VisitCompletionItem {
   id: string;
   label: string;
   tone: VisitCompletionTone;
   source: VisitCompletionSource;
+  dataMode: VisitCompletionDataMode;
+  status: VisitCompletionStatus;
+  proposedActionType: VisitCompletionProposedActionType;
+  requiresPhysicianApproval: true;
+  confidence?: number;
   reason?: string;
 }
 
@@ -23,6 +46,10 @@ export interface VisitCompletionAction {
   id: string;
   label: string;
   variant: "primary" | "secondary";
+  proposedActionType: VisitCompletionProposedActionType;
+  requiresPhysicianApproval: true;
+  sideEffect: "none";
+  placeholderCopy: string;
 }
 
 export interface VisitCompletionCard {
@@ -52,9 +79,12 @@ export interface VisitCompletionLearningLoop {
 
 export interface VisitCompletionBundle {
   sectionLabel: "AI Visit Completion";
-  heading: "Suggested Next Best Actions";
+  strategyLabel: "Suggested Next Best Actions";
+  heading: "Suggested next actions before sign-off";
   primaryActionLabel: "Release Care Plan";
-  supportActionLabel: "Approve all suggested actions";
+  selectionLabel: "Select Care Actions";
+  safetyCopy: "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.";
+  mockedDataNotice: string;
   summary: string;
   releaseEnabled: boolean;
   learningLoop: VisitCompletionLearningLoop;
@@ -124,9 +154,14 @@ export function buildVisitCompletionBundle(
 
   return {
     sectionLabel: "AI Visit Completion",
-    heading: "Suggested Next Best Actions",
+    strategyLabel: "Suggested Next Best Actions",
+    heading: "Suggested next actions before sign-off",
     primaryActionLabel: "Release Care Plan",
-    supportActionLabel: "Approve all suggested actions",
+    selectionLabel: "Select Care Actions",
+    safetyCopy:
+      "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    mockedDataNotice:
+      "Draft suggestions only. This MVP prepares the review surface without submitting orders, messages, billing, scheduling, staff assignments, or chart writes.",
     summary: buildSummary(cards),
     releaseEnabled: cards.some((card) => card.items.length > 0),
     learningLoop,
@@ -148,14 +183,24 @@ function buildOrdersCard(text: string): VisitCompletionCard {
 
   const items: VisitCompletionItem[] = diabetes
     ? [
-        item("a1c-due", "A1C if due or worsening control noted", "neutral", "heuristic"),
+        item("a1c-due", "A1C", "neutral", "heuristic", "mvp_mock", "order_review"),
         item(
           "urine-albumin",
-          "Urine albumin/creatinine screening if due",
+          "Urine albumin/creatinine",
           "neutral",
           "heuristic",
+          "mvp_mock",
+          "order_review",
         ),
-        item("renal-metabolic", "CMP / creatinine / eGFR check if due", "neutral", "heuristic"),
+        item("renal-metabolic", "CMP/eGFR", "neutral", "heuristic", "mvp_mock", "order_review"),
+        item(
+          "lipid-panel",
+          "Lipid panel if due",
+          "neutral",
+          "heuristic",
+          "mvp_mock",
+          "order_review",
+        ),
       ]
     : [
         item(
@@ -163,6 +208,8 @@ function buildOrdersCard(text: string): VisitCompletionCard {
           medication ? "Medication refill check" : "Medication and regimen review",
           "neutral",
           "heuristic",
+          "deterministic_heuristic",
+          "order_review",
         ),
         item(
           "education-monitoring",
@@ -171,6 +218,8 @@ function buildOrdersCard(text: string): VisitCompletionCard {
             : "Education or monitoring instruction from today’s plan",
           pain ? "warning" : "neutral",
           "note",
+          "deterministic_heuristic",
+          "order_review",
         ),
       ];
 
@@ -180,9 +229,11 @@ function buildOrdersCard(text: string): VisitCompletionCard {
     subtitle: "Based on today's assessment and active problems.",
     items,
     actions: [
-      action("review_orders", "Review", "primary"),
-      action("remove_item", "Remove", "secondary"),
-      action("edit_item", "Edit", "secondary"),
+      action("review_orders", "Review orders", "primary", "order_review"),
+      action("approve_item", "Approve", "secondary", "approve"),
+      action("remove_item", "Remove", "secondary", "remove"),
+      action("edit_item", "Edit", "secondary", "edit"),
+      action("defer_item", "Defer", "secondary", "defer"),
     ],
   };
 }
@@ -191,15 +242,20 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
   const mentionsFollowUp =
     /\b(return to clinic|rtc|follow[-\s]?up|next visit|recheck|see (?:you|patient) in)\b/.test(text) ||
     /\bin \d+\s*(?:day|days|week|weeks|month|months)\b/.test(text);
+  const followUpInterval = text.match(/\bin\s+(\d+\s*(?:day|days|week|weeks|month|months))\b/)?.[1];
 
   const items: VisitCompletionItem[] = [];
   if (mentionsFollowUp && !hasFutureAppointment) {
     items.push(
       item(
         "follow-up-missing",
-        "Plan implies follow-up; no appointment scheduled",
+        followUpInterval
+          ? `RTC in ${followUpInterval} recommended. No appointment currently scheduled.`
+          : "Plan implies follow-up; no appointment scheduled.",
         "alert",
         "note",
+        "deterministic_heuristic",
+        "send_to_staff",
         "Follow-up language appears in the finalized plan.",
       ),
       item(
@@ -207,6 +263,8 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
         "Send scheduling task to front desk before patient leaves",
         "neutral",
         "heuristic",
+        "deterministic_heuristic",
+        "send_to_staff",
       ),
     );
   } else if (mentionsFollowUp) {
@@ -216,6 +274,8 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
         "Follow-up mentioned and appointment already scheduled",
         "neutral",
         "encounter",
+        "deterministic_heuristic",
+        "send_to_staff",
       ),
     );
   } else {
@@ -225,6 +285,8 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
         "Confirm follow-up timing before releasing the care plan",
         "warning",
         "heuristic",
+        "deterministic_heuristic",
+        "edit",
       ),
     );
   }
@@ -235,8 +297,10 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
     subtitle: "Recommended next touchpoint and scheduling handoff.",
     items,
     actions: [
-      action("send_to_staff", "Send to staff", "primary"),
-      action("defer_item", "Defer", "secondary"),
+      action("send_to_front_desk", "Send to front desk", "primary", "send_to_staff"),
+      action("text_scheduling_link", "Text scheduling link", "secondary", "text_scheduling_link"),
+      action("edit_interval", "Edit interval", "secondary", "edit"),
+      action("defer_item", "Defer", "secondary", "defer"),
     ],
   };
 }
@@ -247,13 +311,18 @@ function buildPatientMessageCard(
 ): VisitCompletionCard {
   const hasLabs = /\b(lab|labs|a1c|cmp|lipid|urine)\b/.test(text);
   const hasEducation = /\b(goal|education|instructions|monitor|treatment)\b/.test(text);
+  const hasFollowUp = /\b(return to clinic|rtc|follow[-\s]?up|next visit|recheck)\b/.test(text);
 
   const items: VisitCompletionItem[] = [
     item(
       "portal-summary",
-      `Portal summary drafted for ${patientFirstName}`,
+      hasLabs || hasFollowUp
+        ? "Portal summary drafted with lab instructions and follow-up timing."
+        : `Portal summary drafted for ${patientFirstName} with plain-language next steps.`,
       "neutral",
       "heuristic",
+      "mvp_mock",
+      "send_to_patient",
     ),
     item(
       "next-steps",
@@ -262,12 +331,21 @@ function buildPatientMessageCard(
         : "Patient message includes plain-language next steps",
       "neutral",
       "note",
+      "deterministic_heuristic",
+      "send_to_patient",
     ),
   ];
 
   if (hasEducation) {
     items.push(
-      item("education", "Education handoff ready for portal or print", "neutral", "heuristic"),
+      item(
+        "education",
+        "Education handoff ready for portal or print",
+        "neutral",
+        "heuristic",
+        "deterministic_heuristic",
+        "send_to_patient",
+      ),
     );
   }
 
@@ -277,9 +355,11 @@ function buildPatientMessageCard(
     subtitle: "Plain-language summary ready for portal or print.",
     items,
     actions: [
-      action("preview_message", "Preview", "primary"),
-      action("translate_message", "Translate", "secondary"),
-      action("print_summary", "Print", "secondary"),
+      action("preview_message", "Preview message", "primary", "send_to_patient"),
+      action("edit_message", "Edit", "secondary", "edit"),
+      action("send_to_portal", "Send to portal", "secondary", "send_to_patient"),
+      action("print_summary", "Print", "secondary", "print"),
+      action("defer_item", "Defer", "secondary", "defer"),
     ],
   };
 }
@@ -287,7 +367,16 @@ function buildPatientMessageCard(
 function buildPracticeReadinessCard(
   codingSuggestion: VisitCompletionCodingSuggestion | null,
 ): VisitCompletionCard {
-  const items: VisitCompletionItem[] = [];
+  const items: VisitCompletionItem[] = [
+    item(
+      "practice-readiness-overview",
+      "Coding support, prior auth risk, documentation gaps, and staff tasks.",
+      "neutral",
+      "heuristic",
+      "mvp_mock",
+      "view_checks",
+    ),
+  ];
 
   if (!codingSuggestion) {
     items.push(
@@ -296,6 +385,8 @@ function buildPracticeReadinessCard(
         "No coding suggestion yet",
         "warning",
         "coding",
+        "deterministic_heuristic",
+        "coding_review",
         "Coding Readiness Agent has not attached metadata to this note yet.",
       ),
     );
@@ -307,6 +398,8 @@ function buildPracticeReadinessCard(
           `Suggested E/M: ${codingSuggestion.emLevel}`,
           "neutral",
           "coding",
+          "agent_output",
+          "coding_review",
         ),
       );
     }
@@ -317,6 +410,8 @@ function buildPracticeReadinessCard(
           `ICD-10 candidate: ${candidate.code} ${candidate.label}`,
           "neutral",
           "coding",
+          "agent_output",
+          "coding_review",
         ),
       );
     }
@@ -327,6 +422,8 @@ function buildPracticeReadinessCard(
           "Coding rationale available for review",
           "neutral",
           "coding",
+          "agent_output",
+          "coding_review",
           codingSuggestion.rationale,
         ),
       );
@@ -336,11 +433,13 @@ function buildPracticeReadinessCard(
   return {
     id: "practice_readiness",
     title: "Practice Readiness",
-    subtitle: "Coding, documentation, and operational checks.",
+    subtitle: "Coding, documentation, prior auth, billing readiness, and staff task checks.",
     items,
     actions: [
-      action("view_checks", "View checks", "primary"),
-      action("edit_note", "Edit note", "secondary"),
+      action("view_checks", "View checks", "primary", "view_checks"),
+      action("review_coding", "Review coding", "secondary", "coding_review"),
+      action("create_staff_tasks", "Create staff tasks", "secondary", "create_staff_task"),
+      action("defer_item", "Defer", "secondary", "defer"),
     ],
   };
 }
@@ -359,15 +458,38 @@ function item(
   label: string,
   tone: VisitCompletionTone,
   source: VisitCompletionSource,
+  dataMode: VisitCompletionDataMode,
+  proposedActionType: VisitCompletionProposedActionType,
   reason?: string,
 ): VisitCompletionItem {
-  return { id, label, tone, source, reason };
+  return {
+    id,
+    label,
+    tone,
+    source,
+    dataMode,
+    status: tone === "alert" ? "needs_review" : "suggested",
+    proposedActionType,
+    requiresPhysicianApproval: true,
+    confidence: dataMode === "agent_output" ? undefined : 0.72,
+    reason,
+  };
 }
 
 function action(
   id: string,
   label: string,
   variant: VisitCompletionAction["variant"],
+  proposedActionType: VisitCompletionProposedActionType,
 ): VisitCompletionAction {
-  return { id, label, variant };
+  return {
+    id,
+    label,
+    variant,
+    proposedActionType,
+    requiresPhysicianApproval: true,
+    sideEffect: "none",
+    placeholderCopy:
+      "Review-only MVP. This control records no orders, messages, billing, scheduling, staffing, or chart writes.",
+  };
 }


### PR DESCRIPTION
## Summary
- Refines the AI Visit Completion surface into a safer physician-controlled checkout flow with exact safety copy, Select Care Actions language, and a Release Care Plan review state.
- Expands all four cards with the requested action affordances while marking every MVP control as review-only/no-side-effect metadata.
- Renders the panel inside the client note editor once a draft is finalized, while preserving the server-rendered path for non-editor finalized note views.

## What is intentionally placeholdered
- Orders, staff tasks, scheduling, portal messages, billing, and chart writes are not submitted by this MVP.
- Release Care Plan opens a review placeholder; future mutation work should persist selections, audit release, and record AgentFeedback without blocking clinical release.

## Validation
- `npm test -- src/lib/domain/visit-completion.test.ts "src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx"` — 2 files, 8 tests passed.
- `npm run db:generate && npm run typecheck` — passed.
- `npm test` — 255 files, 2453 tests passed.
- `npm run lint` — exit 0 with existing warnings outside this feature.
- `npm run build` — exit 0 with existing build-time warnings/noisy logs around placeholder DB host `base`, Clerk static rendering, metadataBase, and Sentry/OpenTelemetry dynamic dependencies.

## Browser QA
- Started local dev server on port 3001 and opened the real note route in the in-app browser.
- Live route rendered the app error screen because local auth lookup tried to reach unavailable database host `base`; no visual product QA was possible in this sandboxed environment.
