### PR TITLE
feat(clinic): staff review queue — accept kiosk lobby submissions into the chart (EMR-915)

### DIFF
--- a/src/app/(clinician)/clinic/lobby-submissions/actions.ts
+++ b/src/app/(clinician)/clinic/lobby-submissions/actions.ts
@@ -1,0 +1,180 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { assertChartAccess, requirePermission } from "@/lib/rbac/permissions";
+import { dispatch } from "@/lib/orchestration/dispatch";
+import { logger } from "@/lib/observability/log";
+import {
+  parseIntakePayload,
+  parseConsentPayload,
+  patientUpdateFromIntake,
+} from "@/lib/check-in/lobby-submission-review";
+
+// Staff review of staged kiosk-lobby submissions (EMR-915). This is the loop
+// closer: patient-entered intake/consent sits as `pending` until a staff member
+// with chart access ACCEPTS it into the record (or rejects it). Nothing the
+// patient submitted touches the chart without this human step.
+
+export interface PendingSubmission {
+  id: string;
+  patientId: string;
+  patientName: string;
+  kind: string;
+  createdAt: string;
+}
+
+/** Org-scoped list of pending submissions for the review queue. */
+export async function listPendingLobbySubmissions(): Promise<PendingSubmission[]> {
+  const user = await requireUser();
+  requirePermission(user, "patient.demographics.edit");
+  const orgId = user.organizationId;
+  if (!orgId) return [];
+
+  const rows = await prisma.kioskLobbySubmission.findMany({
+    where: { organizationId: orgId, status: "pending" },
+    orderBy: { createdAt: "asc" },
+    take: 200,
+  });
+  if (rows.length === 0) return [];
+
+  const patients = await prisma.patient.findMany({
+    where: { id: { in: [...new Set(rows.map((r) => r.patientId))] }, organizationId: orgId },
+    select: { id: true, firstName: true, lastName: true },
+  });
+  const nameById = new Map(patients.map((p) => [p.id, `${p.firstName} ${p.lastName}`.trim()]));
+
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patientId,
+    patientName: nameById.get(r.patientId) ?? "Unknown patient",
+    kind: r.kind,
+    createdAt: r.createdAt.toISOString(),
+  }));
+}
+
+export type ReviewResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Accept a staged submission into the chart. Gated by chart access +
+ * demographics.edit. Atomic: claims the pending row and performs the chart
+ * write in one transaction, so a double-click or race can't double-apply.
+ */
+export async function acceptLobbySubmission(submissionId: string): Promise<ReviewResult> {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) return { ok: false, error: "No organization in session." };
+
+  const sub = await prisma.kioskLobbySubmission.findFirst({
+    where: { id: submissionId, organizationId: orgId, status: "pending" },
+  });
+  if (!sub) return { ok: false, error: "This submission was already reviewed." };
+
+  // Chart-access + permission gate, scoped to the submission's patient.
+  await assertChartAccess(user, sub.patientId);
+  requirePermission(user, "patient.demographics.edit");
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Claim the row first; if we don't win, abort the whole transaction.
+      const claimed = await tx.kioskLobbySubmission.updateMany({
+        where: { id: sub.id, status: "pending" },
+        data: { status: "accepted", reviewedByUserId: user.id, reviewedAt: new Date() },
+      });
+      if (claimed.count === 0) throw new Error("ALREADY_REVIEWED");
+
+      if (sub.kind === "intake") {
+        const payload = parseIntakePayload(sub.payload);
+        if (!payload) throw new Error("BAD_PAYLOAD");
+        const update = patientUpdateFromIntake(payload);
+        if (Object.keys(update).length > 0) {
+          await tx.patient.update({
+            where: { id: sub.patientId },
+            data: update as Prisma.PatientUpdateInput,
+          });
+        }
+      } else if (sub.kind === "consent") {
+        const payload = parseConsentPayload(sub.payload);
+        if (!payload) throw new Error("BAD_PAYLOAD");
+        await tx.signedConsent.create({
+          data: {
+            patientId: sub.patientId,
+            templateId: payload.templateId,
+            templateName: payload.templateName,
+            version: payload.version,
+            responses: payload.responses as Prisma.InputJsonValue,
+            signatureData: payload.signatureData ?? null,
+          },
+        });
+      } else {
+        throw new Error("UNKNOWN_KIND");
+      }
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "error";
+    if (msg === "ALREADY_REVIEWED") return { ok: false, error: "This submission was already reviewed." };
+    if (msg === "BAD_PAYLOAD") return { ok: false, error: "This submission couldn't be read. Please reject it." };
+    logger.error({ event: "kiosk.lobby.submission.accept_failed", submissionId });
+    return { ok: false, error: "Couldn't accept this submission. Please try again." };
+  }
+
+  // Intake changes feed the chart-summary regeneration, same as portal intake.
+  if (sub.kind === "intake") {
+    await dispatch({ name: "patient.intake.updated", patientId: sub.patientId, organizationId: orgId });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: orgId,
+      actorUserId: user.id,
+      action: "kiosk.lobby.submission.accepted",
+      subjectType: "Patient",
+      subjectId: sub.patientId,
+      metadata: { kind: sub.kind, submissionId: sub.id },
+    },
+  });
+
+  revalidatePath("/clinic/lobby-submissions");
+  return { ok: true };
+}
+
+/** Reject a staged submission (it never touches the chart). Audited. */
+export async function rejectLobbySubmission(
+  submissionId: string,
+  reason?: string,
+): Promise<ReviewResult> {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) return { ok: false, error: "No organization in session." };
+
+  const sub = await prisma.kioskLobbySubmission.findFirst({
+    where: { id: submissionId, organizationId: orgId, status: "pending" },
+    select: { id: true, patientId: true, kind: true },
+  });
+  if (!sub) return { ok: false, error: "This submission was already reviewed." };
+
+  await assertChartAccess(user, sub.patientId);
+  requirePermission(user, "patient.demographics.edit");
+
+  const claimed = await prisma.kioskLobbySubmission.updateMany({
+    where: { id: sub.id, status: "pending" },
+    data: { status: "rejected", reviewedByUserId: user.id, reviewedAt: new Date() },
+  });
+  if (claimed.count === 0) return { ok: false, error: "This submission was already reviewed." };
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: orgId,
+      actorUserId: user.id,
+      action: "kiosk.lobby.submission.rejected",
+      subjectType: "Patient",
+      subjectId: sub.patientId,
+      metadata: reason ? { kind: sub.kind, submissionId: sub.id, reason } : { kind: sub.kind, submissionId: sub.id },
+    },
+  });
+
+  revalidatePath("/clinic/lobby-submissions");
+  return { ok: true };
+}

--- a/src/app/(clinician)/clinic/lobby-submissions/page.tsx
+++ b/src/app/(clinician)/clinic/lobby-submissions/page.tsx
@@ -1,0 +1,31 @@
+import { getCurrentUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/rbac/permissions";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { listPendingLobbySubmissions } from "./actions";
+import { SubmissionsList } from "./submissions-list";
+
+// Force dynamic — this is a per-org review queue, never cached.
+export const dynamic = "force-dynamic";
+
+export default async function LobbySubmissionsPage() {
+  const user = await getCurrentUser();
+  const canReview = !!user && hasPermission(user, "patient.demographics.edit");
+  const submissions = canReview ? await listPendingLobbySubmissions() : [];
+
+  return (
+    <PageShell>
+      <PageHeader
+        eyebrow="Front desk"
+        title="Lobby submissions"
+        description="Intake and consent that patients completed on their phones from the kiosk hand-off. Review each — accepting adds it to the chart; nothing was written automatically."
+      />
+      {!canReview ? (
+        <p className="text-[15px] text-text-muted">
+          You don&rsquo;t have access to review lobby submissions.
+        </p>
+      ) : (
+        <SubmissionsList initial={submissions} />
+      )}
+    </PageShell>
+  );
+}

--- a/src/app/(clinician)/clinic/lobby-submissions/submissions-list.tsx
+++ b/src/app/(clinician)/clinic/lobby-submissions/submissions-list.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  acceptLobbySubmission,
+  rejectLobbySubmission,
+  type PendingSubmission,
+  type ReviewResult,
+} from "./actions";
+
+const KIND_LABEL: Record<string, string> = {
+  intake: "Intake",
+  consent: "Consent",
+};
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+export function SubmissionsList({ initial }: { initial: PendingSubmission[] }) {
+  const [items, setItems] = useState(initial);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function run(id: string, fn: (id: string) => Promise<ReviewResult>) {
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const result = await fn(id);
+      setBusyId(null);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setItems((prev) => prev.filter((i) => i.id !== id));
+    });
+  }
+
+  if (items.length === 0) {
+    return <p className="text-[15px] text-text-muted">No submissions waiting for review.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && <p className="text-sm text-danger">{error}</p>}
+      <ul className="space-y-2">
+        {items.map((s) => (
+          <li
+            key={s.id}
+            className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-surface px-5 py-4"
+          >
+            <div className="min-w-0">
+              <p className="text-[15px] font-medium text-text truncate">{s.patientName}</p>
+              <p className="text-xs text-text-subtle">
+                <span className="uppercase tracking-[0.1em] text-accent">
+                  {KIND_LABEL[s.kind] ?? s.kind}
+                </span>
+                {" · "}
+                {formatWhen(s.createdAt)}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => run(s.id, (id) => rejectLobbySubmission(id))}
+                disabled={busyId === s.id}
+              >
+                Reject
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => run(s.id, acceptLobbySubmission)}
+                disabled={busyId === s.id}
+              >
+                {busyId === s.id ? "Working…" : "Accept to chart"}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -148,11 +148,13 @@ export default async function ClinicianLayout({
         { label: "Messages", href: "/clinic/messages" },
         // EMR-165: unified sign-off queue rolls up labs + refills +
         // notes + messages — clinician's single place to clear the day.
-        { 
-          label: "Sign-off", 
+        {
+          label: "Sign-off",
           href: "/clinic/sign-off",
           badge: computeApprovalsBadge({ pendingCount, emergencyCount }) // Or a combined badge
         },
+        // EMR-915: kiosk→phone lobby intake/consent waiting to be accepted into the chart.
+        { label: "Lobby submissions", href: "/clinic/lobby-submissions" },
       ],
     },
     {

--- a/src/lib/check-in/lobby-submission-review.test.ts
+++ b/src/lib/check-in/lobby-submission-review.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseIntakePayload,
+  parseConsentPayload,
+  patientUpdateFromIntake,
+} from "./lobby-submission-review";
+
+describe("parseIntakePayload", () => {
+  it("accepts a well-formed staged intake payload", () => {
+    const p = parseIntakePayload({
+      presentingConcerns: "back pain",
+      treatmentGoals: "sleep better",
+      cannabisHistory: { priorUse: true, formats: ["tincture"], reportedBenefits: ["calm"] },
+    });
+    expect(p?.presentingConcerns).toBe("back pain");
+  });
+  it("rejects a malformed payload (wrong types)", () => {
+    expect(parseIntakePayload({ presentingConcerns: 42 })).toBeNull();
+    expect(parseIntakePayload("nope")).toBeNull();
+  });
+});
+
+describe("patientUpdateFromIntake", () => {
+  it("only includes fields the patient actually provided", () => {
+    const u = patientUpdateFromIntake({ presentingConcerns: "x" });
+    expect(u).toEqual({ presentingConcerns: "x" });
+    expect("treatmentGoals" in u).toBe(false);
+  });
+  it("normalizes cannabisHistory defaults", () => {
+    const u = patientUpdateFromIntake({ cannabisHistory: { priorUse: true } });
+    expect(u.cannabisHistory).toEqual({ priorUse: true, formats: [], reportedBenefits: [] });
+  });
+  it("drops empty strings rather than blanking the chart", () => {
+    const u = patientUpdateFromIntake({ presentingConcerns: "", treatmentGoals: "" });
+    expect(u).toEqual({});
+  });
+});
+
+describe("parseConsentPayload", () => {
+  it("accepts a well-formed staged consent payload", () => {
+    const p = parseConsentPayload({
+      templateId: "consent-treatment",
+      templateName: "General Treatment Consent",
+      version: "1.0",
+      responses: { f2: true },
+      signatureData: "data:image/png;base64,AAAA",
+    });
+    expect(p?.templateId).toBe("consent-treatment");
+  });
+  it("rejects a payload missing the template identity", () => {
+    expect(parseConsentPayload({ responses: { f2: true } })).toBeNull();
+  });
+});

--- a/src/lib/check-in/lobby-submission-review.ts
+++ b/src/lib/check-in/lobby-submission-review.ts
@@ -1,0 +1,67 @@
+// SAFE: dead-export-allowed reason="EMR-915 staff review mapping; the clinic review actions/page consume it in the same PR"
+// EMR-915 — staff review of staged kiosk-lobby submissions.
+//
+// A KioskLobbySubmission is patient-entered data parked in a review queue; it is
+// NEVER trusted as chart data until a staff member accepts it. These pure
+// validators re-parse the staged JSON payload into the exact shape we'll write
+// to the chart (patient intake fields, or a SignedConsent row) — defense in
+// depth: even though the lobby actions validated on the way in, we never write a
+// raw staged blob to the record on the way out.
+
+import { z } from "zod";
+
+export const intakePayloadSchema = z.object({
+  presentingConcerns: z.string().max(2000).nullable().optional(),
+  treatmentGoals: z.string().max(2000).nullable().optional(),
+  cannabisHistory: z
+    .object({
+      priorUse: z.boolean().optional(),
+      formats: z.array(z.string()).optional(),
+      reportedBenefits: z.array(z.string()).optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+export type IntakePayload = z.infer<typeof intakePayloadSchema>;
+
+export const consentPayloadSchema = z.object({
+  templateId: z.string().min(1).max(120),
+  templateName: z.string().min(1).max(200),
+  version: z.string().min(1).max(40),
+  responses: z.record(z.union([z.string(), z.boolean()])),
+  signatureData: z.string().max(200_000).nullable().optional(),
+});
+
+export type ConsentPayload = z.infer<typeof consentPayloadSchema>;
+
+/** Parse a staged intake payload, or null if it doesn't validate. */
+export function parseIntakePayload(payload: unknown): IntakePayload | null {
+  const r = intakePayloadSchema.safeParse(payload);
+  return r.success ? r.data : null;
+}
+
+/** Parse a staged consent payload, or null if it doesn't validate. */
+export function parseConsentPayload(payload: unknown): ConsentPayload | null {
+  const r = consentPayloadSchema.safeParse(payload);
+  return r.success ? r.data : null;
+}
+
+/** The Patient fields an accepted intake submission writes (chart-bound shape). */
+export function patientUpdateFromIntake(p: IntakePayload): {
+  presentingConcerns?: string;
+  treatmentGoals?: string;
+  cannabisHistory?: { priorUse: boolean; formats: string[]; reportedBenefits: string[] };
+} {
+  const update: ReturnType<typeof patientUpdateFromIntake> = {};
+  if (p.presentingConcerns) update.presentingConcerns = p.presentingConcerns;
+  if (p.treatmentGoals) update.treatmentGoals = p.treatmentGoals;
+  if (p.cannabisHistory) {
+    update.cannabisHistory = {
+      priorUse: p.cannabisHistory.priorUse ?? false,
+      formats: p.cannabisHistory.formats ?? [],
+      reportedBenefits: p.cannabisHistory.reportedBenefits ?? [],
+    };
+  }
+  return update;
+}


### PR DESCRIPTION
Closes the kiosk hand-off loop. Patient intake/consent completed on their phone (PR #560) lands as `pending` `KioskLobbySubmission` rows — this gives staff a place to **review and accept** them into the chart. Nothing the patient submitted touches the record without this human step.

## What
- **`lib/check-in/lobby-submission-review.ts`** — pure, tested validators that re-parse the staged JSON into chart-bound shapes (intake → patient fields; consent → `SignedConsent`). We never write a raw staged blob to the record.
- **`/clinic/lobby-submissions`** review queue (Inbox nav) — lists pending submissions with **Accept to chart** / **Reject**, gated by `requireUser` + `assertChartAccess` + `patient.demographics.edit`, org-scoped.
- **`acceptLobbySubmission`** claims the pending row and writes to the chart in **one transaction** (no double-apply on race/double-click). Intake dispatches `patient.intake.updated` (chart summary regenerates); consent persists a `SignedConsent`. **`rejectLobbySubmission`** marks rejected. Both audited.

## Notes
- This also lights up **`SignedConsent` persistence** — previously nothing created those rows.
- Safety model intact: staged → human-reviewed → accepted; never silent.

7 unit tests; source `tsc` clean.

Follow-on: kiosk session lifecycle console (monitor/revoke/resume); Phase 3 hardening (EMR-916).

Refs: EMR-912, EMR-915

🤖 Generated with [Claude Code](https://claude.com/claude-code)