### PR TITLE
fix(check-in): atomic OTP attempt counter — preserve brute-force bound (EMR-915)

### DIFF
--- a/src/lib/check-in/otp.ts
+++ b/src/lib/check-in/otp.ts
@@ -168,8 +168,18 @@ export async function issueOtpCode(opts: {
 }
 
 /**
- * Verify an attempt against the latest active code. Atomically increments the
- * attempt counter, and consumes the code on success. Returns the pure reason.
+ * Verify an attempt against the latest active code. The attempt counter is the
+ * ONLY brute-force bound on the 6-digit code (issuance rate-limiting caps how
+ * many codes are minted, not how many guesses are made), so it MUST be spent
+ * atomically: a read-then-write increment lets N concurrent guesses all observe
+ * the same pre-increment `attempts` and sail past `maxAttempts` together.
+ *
+ * We spend the budget with a single conditional `updateMany` guarded on
+ * `attempts < maxAttempts` (the same atomic-claim pattern as the hand-off token
+ * consume). Only a request that wins a slot may compare the hash; the compare
+ * therefore happens at most `maxAttempts` times across all concurrent callers.
+ * Consume-on-success is likewise a conditional update so two correct guesses
+ * can't both consume.
  */
 export async function verifyOtpCode(opts: {
   patientId: string;
@@ -185,35 +195,68 @@ export async function verifyOtpCode(opts: {
     orderBy: { createdAt: "desc" },
   });
 
-  const decision = evaluateOtpVerification(
-    record
-      ? {
-          codeHash: record.codeHash,
-          expiresAt: record.expiresAt,
-          attempts: record.attempts,
-          maxAttempts: record.maxAttempts,
-          consumedAt: record.consumedAt,
-        }
-      : null,
-    opts.attemptCode,
-    now,
-  );
-
-  if (record) {
-    if (decision.ok) {
-      await prisma.smsOtpCode.update({
-        where: { id: record.id },
-        data: { attempts: { increment: 1 }, consumedAt: now },
-      });
-    } else if (decision.reason === "mismatch" || decision.reason === "too_many_attempts") {
-      // Count the failed attempt so brute-force burns the budget.
-      await prisma.smsOtpCode.update({
-        where: { id: record.id },
-        data: { attempts: { increment: 1 } },
-      });
-    }
+  // Decisions that must NOT spend an attempt (no record / expired / already
+  // consumed) are settled purely up front — exactly the prior behaviour.
+  if (!record) {
+    return finishVerify(opts, now, { ok: false, reason: "no_active_code" });
+  }
+  const snapshot = {
+    codeHash: record.codeHash,
+    expiresAt: record.expiresAt,
+    attempts: record.attempts,
+    maxAttempts: record.maxAttempts,
+    consumedAt: record.consumedAt,
+  };
+  const pre = evaluateOtpVerification(snapshot, opts.attemptCode, now);
+  if (
+    pre.reason === "no_active_code" ||
+    pre.reason === "expired" ||
+    pre.reason === "already_consumed"
+  ) {
+    return finishVerify(opts, now, pre);
   }
 
+  // A real guess (ok / mismatch / lockout). Atomically claim one attempt slot:
+  // increments ONLY while the code is unconsumed, unexpired, and under budget.
+  // `maxAttempts` is immutable post-issuance, so the snapshot value is a safe
+  // literal bound. count === 0 ⇒ we lost the race / the budget is spent.
+  const claim = await prisma.smsOtpCode.updateMany({
+    where: {
+      id: record.id,
+      consumedAt: null,
+      expiresAt: { gt: now },
+      attempts: { lt: record.maxAttempts },
+    },
+    data: { attempts: { increment: 1 } },
+  });
+  if (claim.count === 0) {
+    return finishVerify(opts, now, { ok: false, reason: "too_many_attempts" });
+  }
+
+  // We hold a counted attempt. Compare the hash off the snapshot (the codeHash
+  // is immutable for the life of the code).
+  if (!hashesEqual(hashOtp(opts.attemptCode), snapshot.codeHash)) {
+    return finishVerify(opts, now, { ok: false, reason: "mismatch" });
+  }
+
+  // Correct code: consume atomically so a concurrent correct guess can't also
+  // win. Losing this race means someone else already consumed it.
+  const consumed = await prisma.smsOtpCode.updateMany({
+    where: { id: record.id, consumedAt: null },
+    data: { consumedAt: now },
+  });
+  if (consumed.count === 0) {
+    return finishVerify(opts, now, { ok: false, reason: "already_consumed" });
+  }
+  return finishVerify(opts, now, { ok: true, reason: "ok" });
+}
+
+/** Emit the PHI-free audit row for a verify outcome and return it. */
+async function finishVerify(
+  opts: { patientId: string; organizationId: string; purpose: OtpPurpose },
+  _now: Date,
+  decision: { ok: boolean; reason: OtpVerifyReason },
+): Promise<{ ok: boolean; reason: OtpVerifyReason }> {
   await audit(
     opts.organizationId,
     opts.patientId,
@@ -221,7 +264,6 @@ export async function verifyOtpCode(opts: {
     opts.purpose,
     decision.ok ? undefined : decision.reason,
   );
-
   return decision;
 }
 

--- a/src/lib/check-in/otp.verify.test.ts
+++ b/src/lib/check-in/otp.verify.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * EMR-915 review — verifyOtpCode DB orchestration.
+ *
+ * The attempt counter is the ONLY brute-force bound on the 6-digit code, so it
+ * must be spent atomically. These tests pin the conditional-`updateMany` claim:
+ * a guess may compare the hash ONLY if it wins a slot guarded on
+ * `attempts < maxAttempts` in the DB — never on a stale read snapshot.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    smsOtpCode: {
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    auditLog: { create: vi.fn() },
+  };
+  return { mockPrisma };
+});
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/sms/adapter", () => ({
+  getSmsAdapter: () => ({ send: vi.fn() }),
+  normalizePhone: (p: string | null) => p,
+}));
+
+import { hashOtp, verifyOtpCode } from "./otp";
+
+const { mockPrisma } = hoisted;
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function activeRecord(over: Record<string, unknown> = {}) {
+  return {
+    id: "otp_1",
+    patientId: "pat_1",
+    purpose: "kiosk_lobby_handoff",
+    codeHash: hashOtp("123456"),
+    expiresAt: new Date(NOW.getTime() + 5 * 60 * 1000),
+    attempts: 0,
+    maxAttempts: 5,
+    consumedAt: null,
+    createdAt: NOW,
+    ...over,
+  };
+}
+
+const baseOpts = {
+  patientId: "pat_1",
+  organizationId: "org_1",
+  purpose: "kiosk_lobby_handoff" as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.auditLog.create.mockResolvedValue({});
+});
+
+describe("verifyOtpCode — atomic attempt accounting", () => {
+  it("never touches the counter when there is no active code", async () => {
+    mockPrisma.smsOtpCode.findFirst.mockResolvedValue(null);
+
+    const res = await verifyOtpCode({ ...baseOpts, attemptCode: "123456", now: NOW });
+
+    expect(res).toEqual({ ok: false, reason: "no_active_code" });
+    expect(mockPrisma.smsOtpCode.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("claims a slot guarded on attempts < maxAttempts, then consumes on the correct code", async () => {
+    mockPrisma.smsOtpCode.findFirst.mockResolvedValue(activeRecord());
+    mockPrisma.smsOtpCode.updateMany
+      .mockResolvedValueOnce({ count: 1 }) // claim
+      .mockResolvedValueOnce({ count: 1 }); // consume
+
+    const res = await verifyOtpCode({ ...baseOpts, attemptCode: "123456", now: NOW });
+
+    expect(res).toEqual({ ok: true, reason: "ok" });
+    // First call is the atomic claim: increment only while under budget.
+    const claim = mockPrisma.smsOtpCode.updateMany.mock.calls[0][0];
+    expect(claim.where).toMatchObject({
+      id: "otp_1",
+      consumedAt: null,
+      attempts: { lt: 5 },
+    });
+    expect(claim.data).toEqual({ attempts: { increment: 1 } });
+    // Second call consumes only while still unconsumed.
+    const consume = mockPrisma.smsOtpCode.updateMany.mock.calls[1][0];
+    expect(consume.where).toMatchObject({ id: "otp_1", consumedAt: null });
+    expect(consume.data).toEqual({ consumedAt: NOW });
+  });
+
+  it("THE RACE: snapshot shows budget left, but a lost atomic claim still locks out", async () => {
+    // attempts=4 (< 5) so the pure snapshot check would PASS the lockout gate —
+    // but a concurrent caller already spent the last slot, so the DB claim
+    // matches no row. The old read-then-write code would have compared the hash
+    // here; the atomic version must refuse.
+    mockPrisma.smsOtpCode.findFirst.mockResolvedValue(activeRecord({ attempts: 4 }));
+    mockPrisma.smsOtpCode.updateMany.mockResolvedValueOnce({ count: 0 }); // claim lost
+
+    const res = await verifyOtpCode({ ...baseOpts, attemptCode: "123456", now: NOW });
+
+    expect(res).toEqual({ ok: false, reason: "too_many_attempts" });
+    // Only the claim ran; we never reached the consume step.
+    expect(mockPrisma.smsOtpCode.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("spends an attempt on a wrong code but does not consume", async () => {
+    mockPrisma.smsOtpCode.findFirst.mockResolvedValue(activeRecord());
+    mockPrisma.smsOtpCode.updateMany.mockResolvedValueOnce({ count: 1 }); // claim
+
+    const res = await verifyOtpCode({ ...baseOpts, attemptCode: "000000", now: NOW });
+
+    expect(res).toEqual({ ok: false, reason: "mismatch" });
+    // Claim happened; no consume on a mismatch.
+    expect(mockPrisma.smsOtpCode.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spend an attempt when the code has expired", async () => {
+    mockPrisma.smsOtpCode.findFirst.mockResolvedValue(
+      activeRecord({ expiresAt: new Date(NOW.getTime() - 1) }),
+    );
+
+    const res = await verifyOtpCode({ ...baseOpts, attemptCode: "123456", now: NOW });
+
+    expect(res).toEqual({ ok: false, reason: "expired" });
+    expect(mockPrisma.smsOtpCode.updateMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

`verifyOtpCode` spent the OTP attempt budget with a **read-then-write** increment: it read the active code with `findFirst`, checked `attempts >= maxAttempts` against that *snapshot*, then incremented in a separate `update`. Under concurrency, N parallel verify requests all observe the same pre-increment `attempts`, all pass the bound, and all compare the hash — defeating the `maxAttempts` (5) cap.

That cap is the **only** brute-force bound on the 6-digit SMS code: issuance rate-limiting (3/15min) caps how many codes are *minted*, not how many guesses are made against a live one. In the lobby challenge DOB is checked *before* OTP, so an attacker who knows the patient's DOB (low entropy) could fire concurrent `lobbyVerifyIdentity` calls with different guesses and brute the 1e6 space within the 10-min TTL — minting a scoped lobby session for the victim. The docstring even claimed the increment was "atomic"; it wasn't.

## Fix

Spend the attempt with a single **conditional `updateMany`** guarded on `attempts < maxAttempts`, run in the DB — the same atomic-claim pattern already used for the hand-off token consume. Only a request that wins a slot compares the hash, so the compare runs at most `maxAttempts` times across all concurrent callers. Consume-on-success is likewise a conditional `updateMany` on `consumedAt: null` so two correct guesses can't both consume. Decisions that must *not* spend an attempt (no code / expired / already consumed) are still settled purely up front, preserving prior behaviour. **No schema change.**

## Tests

Adds `otp.verify.test.ts` (5 tests) covering claim→consume ordering, mismatch-spends-but-doesn't-consume, expired-doesn't-spend, and the key regression: **snapshot shows budget remaining but the atomic claim is lost → locked out** (the exact case the old code mishandled). Full `src/lib/check-in` suite green (75 tests), `tsc` clean, eslint clean.

## Provenance

Found by an adversarial multi-agent security review of the merged kiosk→phone lobby hand-off (#560/#561). This was the single HIGH finding; all other lenses — cookie path-scoping, hand-off token single-use atomicity, cross-org isolation, staff-accept authz/idempotency, guard hosting/caching, PHI-free audit — came back clean. Three lower-severity findings (terminal-state UX, duplicate-pending-row race, empty-intake) are written up separately for a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)