### PR TITLE
fix(check-in): reject empty lobby intake before staging (EMR-915)

### DIFF
--- a/src/app/kiosk/lobby/actions.ts
+++ b/src/app/kiosk/lobby/actions.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/check-in/kiosk-handoff";
 import { issueOtpCode, verifyOtpCode } from "@/lib/check-in/otp";
 import { DEFAULT_TEMPLATES } from "@/lib/domain/consent-forms";
+import { intakeHasContent } from "@/lib/check-in/lobby-submission-review";
 import {
   createKioskLobbySession,
   setKioskLobbyCookie,
@@ -216,6 +217,19 @@ export async function lobbySubmitIntake(
     reportedBenefits: splitList(parsed.data.reportedBenefits),
   };
 
+  const intakePayload = {
+    presentingConcerns: parsed.data.presentingConcerns || null,
+    treatmentGoals: parsed.data.treatmentGoals || null,
+    cannabisHistory,
+  };
+
+  // Reject a wholly-empty intake before staging: it satisfies no readiness
+  // requirement and would only add a noise row to the staff queue while telling
+  // the patient they finished a task that did nothing (EMR-915 review).
+  if (!intakeHasContent(intakePayload)) {
+    return { ok: false, error: "Please tell us a little about why you're here before submitting." };
+  }
+
   // Idempotent: a re-submit supersedes the prior un-reviewed intake rather than
   // piling up pending rows for staff (EMR-915 review — single pending per kind).
   await prisma.kioskLobbySubmission.deleteMany({
@@ -232,11 +246,7 @@ export async function lobbySubmitIntake(
       organizationId: identity.organizationId,
       kind: "intake",
       status: "pending",
-      payload: {
-        presentingConcerns: parsed.data.presentingConcerns || null,
-        treatmentGoals: parsed.data.treatmentGoals || null,
-        cannabisHistory,
-      },
+      payload: intakePayload,
     },
   });
 

--- a/src/lib/check-in/lobby-submission-review.test.ts
+++ b/src/lib/check-in/lobby-submission-review.test.ts
@@ -4,7 +4,30 @@ import {
   parseIntakePayload,
   parseConsentPayload,
   patientUpdateFromIntake,
+  intakeHasContent,
 } from "./lobby-submission-review";
+
+describe("intakeHasContent", () => {
+  it("is false for a wholly-empty intake", () => {
+    expect(
+      intakeHasContent({
+        presentingConcerns: null,
+        treatmentGoals: null,
+        cannabisHistory: { priorUse: false, formats: [], reportedBenefits: [] },
+      }),
+    ).toBe(false);
+  });
+  it("is false when text fields are only whitespace", () => {
+    expect(intakeHasContent({ presentingConcerns: "   ", treatmentGoals: "\t" })).toBe(false);
+  });
+  it("is true when any substantive field is present", () => {
+    expect(intakeHasContent({ presentingConcerns: "back pain" })).toBe(true);
+    expect(intakeHasContent({ treatmentGoals: "sleep" })).toBe(true);
+    expect(intakeHasContent({ cannabisHistory: { priorUse: true } })).toBe(true);
+    expect(intakeHasContent({ cannabisHistory: { formats: ["tincture"] } })).toBe(true);
+    expect(intakeHasContent({ cannabisHistory: { reportedBenefits: ["calm"] } })).toBe(true);
+  });
+});
 
 describe("parseIntakePayload", () => {
   it("accepts a well-formed staged intake payload", () => {

--- a/src/lib/check-in/lobby-submission-review.ts
+++ b/src/lib/check-in/lobby-submission-review.ts
@@ -47,6 +47,26 @@ export function parseConsentPayload(payload: unknown): ConsentPayload | null {
   return r.success ? r.data : null;
 }
 
+/**
+ * Does a staged intake carry any substantive content? An intake where every
+ * field is blank satisfies no readiness requirement yet still lands in the staff
+ * queue as a meaningless review item — and tells the patient they "completed" a
+ * task that did nothing. The lobby action rejects an empty intake before staging
+ * using this predicate. Mirrors the consent flow, which already gates on
+ * completeness.
+ */
+export function intakeHasContent(p: IntakePayload): boolean {
+  if (p.presentingConcerns?.trim()) return true;
+  if (p.treatmentGoals?.trim()) return true;
+  const h = p.cannabisHistory;
+  if (h) {
+    if (h.priorUse) return true;
+    if ((h.formats?.length ?? 0) > 0) return true;
+    if ((h.reportedBenefits?.length ?? 0) > 0) return true;
+  }
+  return false;
+}
+
 /** The Patient fields an accepted intake submission writes (chart-bound shape). */
 export function patientUpdateFromIntake(p: IntakePayload): {
   presentingConcerns?: string;


### PR DESCRIPTION
## What

`intakeSchema` makes every meaningful field optional, so a patient could tap **Submit** on a blank intake. The action staged a pending `KioskLobbySubmission` with an empty payload, showed the green success screen, and satisfied **no** readiness requirement — leaving a noise row for staff to triage and telling the patient they completed a task that did nothing. (The consent flow already gates on completeness.)

## Fix

Add a pure, unit-tested `intakeHasContent` predicate in `lobby-submission-review.ts` and reject an empty intake in `lobbySubmitIntake` *before* staging, with a friendly message. The staged-payload object is now built once and reused. No schema change.

## Tests

3 new cases on `intakeHasContent` (empty → false, whitespace-only → false, any substantive field → true). `lobby-submission-review` suite green (10), `tsc` clean, eslint clean.

## Provenance

LOW finding #4 from the adversarial review of the merged kiosk→phone lobby (#560/#561). The HIGH (OTP attempt-counter atomicity) shipped in #562. Two remaining findings (terminal-state UX, duplicate-pending-row race) are tracked on EMR-915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)