### PR TITLE
feat(check-in): patient-reachable terminal state for the lobby (EMR-915)

### DIFF
--- a/src/app/kiosk/lobby/actions.ts
+++ b/src/app/kiosk/lobby/actions.ts
@@ -232,23 +232,27 @@ export async function lobbySubmitIntake(
 
   // Idempotent: a re-submit supersedes the prior un-reviewed intake rather than
   // piling up pending rows for staff (EMR-915 review — single pending per kind).
-  await prisma.kioskLobbySubmission.deleteMany({
-    where: {
-      patientId: identity.patientId,
-      organizationId: identity.organizationId,
-      kind: "intake",
-      status: "pending",
-    },
-  });
-  await prisma.kioskLobbySubmission.create({
-    data: {
-      patientId: identity.patientId,
-      organizationId: identity.organizationId,
-      kind: "intake",
-      status: "pending",
-      payload: intakePayload,
-    },
-  });
+  // Supersede + create run in one transaction so a failed create can't leave the
+  // patient with neither their old nor their new submission.
+  await prisma.$transaction([
+    prisma.kioskLobbySubmission.deleteMany({
+      where: {
+        patientId: identity.patientId,
+        organizationId: identity.organizationId,
+        kind: "intake",
+        status: "pending",
+      },
+    }),
+    prisma.kioskLobbySubmission.create({
+      data: {
+        patientId: identity.patientId,
+        organizationId: identity.organizationId,
+        kind: "intake",
+        status: "pending",
+        payload: intakePayload,
+      },
+    }),
+  ]);
 
   await auditLobby(identity.organizationId, identity.patientId, "kiosk.lobby.submission.staged", {
     kind: "intake",
@@ -290,30 +294,34 @@ export async function lobbySubmitConsent(
 
   // Idempotent per template: a re-sign of the SAME form supersedes its prior
   // un-reviewed submission; different forms each keep their own pending row.
-  await prisma.kioskLobbySubmission.deleteMany({
-    where: {
-      patientId: identity.patientId,
-      organizationId: identity.organizationId,
-      kind: "consent",
-      status: "pending",
-      payload: { path: ["templateId"], equals: template.id },
-    },
-  });
-  await prisma.kioskLobbySubmission.create({
-    data: {
-      patientId: identity.patientId,
-      organizationId: identity.organizationId,
-      kind: "consent",
-      status: "pending",
-      payload: {
-        templateId: template.id,
-        templateName: template.name,
-        version: template.version,
-        responses: parsed.data.responses,
-        signatureData: parsed.data.signatureData ?? null,
+  // Supersede + create run in one transaction so a failed create can't drop the
+  // patient's prior signed consent without recording the new one.
+  await prisma.$transaction([
+    prisma.kioskLobbySubmission.deleteMany({
+      where: {
+        patientId: identity.patientId,
+        organizationId: identity.organizationId,
+        kind: "consent",
+        status: "pending",
+        payload: { path: ["templateId"], equals: template.id },
       },
-    },
-  });
+    }),
+    prisma.kioskLobbySubmission.create({
+      data: {
+        patientId: identity.patientId,
+        organizationId: identity.organizationId,
+        kind: "consent",
+        status: "pending",
+        payload: {
+          templateId: template.id,
+          templateName: template.name,
+          version: template.version,
+          responses: parsed.data.responses,
+          signatureData: parsed.data.signatureData ?? null,
+        },
+      },
+    }),
+  ]);
 
   await auditLobby(identity.organizationId, identity.patientId, "kiosk.lobby.submission.staged", {
     kind: "consent",

--- a/src/app/kiosk/lobby/page.tsx
+++ b/src/app/kiosk/lobby/page.tsx
@@ -16,21 +16,27 @@ export default async function LobbyHomePage() {
 
   const view = await getLobbyReadinessView(identity.patientId, identity.organizationId);
 
+  // "All set" with no tasks at all is a pure terminal screen; "all set" WITH
+  // tasks means everything's been submitted and is awaiting review (still
+  // editable). Anything outstanding-and-unsubmitted is the working to-do state.
+  const headline = view.allDone ? "You're all set" : "A couple things before your visit";
+  const subtext = !view.allDone
+    ? "Finish these from your seat. Each one takes a minute, and your care team reviews everything before your visit."
+    : view.tasks.length === 0
+      ? "Thanks — there's nothing else to do here. Please have a seat and we'll call you shortly."
+      : "Everything's submitted and with your care team for review. Have a seat — and if you need to change an answer, you still can below.";
+
   return (
     <div className="flex-1 flex flex-col">
       <p className="text-[11px] uppercase tracking-[0.2em] text-accent font-medium mb-2">
         You&rsquo;re in
       </p>
       <h1 className="font-display text-3xl text-text tracking-tight leading-tight mb-2">
-        {view.allDone ? "You're all set" : "A couple things before your visit"}
+        {headline}
       </h1>
-      <p className="text-[15px] text-text-muted mb-8 leading-relaxed">
-        {view.allDone
-          ? "Thanks — there's nothing else to do here. Please have a seat and we'll call you shortly."
-          : "Finish these from your seat. Each one takes a minute, and your care team reviews everything before your visit."}
-      </p>
+      <p className="text-[15px] text-text-muted mb-8 leading-relaxed">{subtext}</p>
 
-      {!view.allDone && (
+      {view.tasks.length > 0 && (
         <ul className="space-y-3">
           {view.tasks.map((task) => (
             <li key={task.workflow}>
@@ -38,7 +44,14 @@ export default async function LobbyHomePage() {
                 href={task.href}
                 className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-surface px-5 py-5 hover:border-accent hover:bg-accent/5 transition-all"
               >
-                <span className="text-lg font-medium text-text">{task.label}</span>
+                <span className="flex flex-col">
+                  <span className="text-lg font-medium text-text">{task.label}</span>
+                  {task.submitted && (
+                    <span className="text-[13px] text-accent font-medium mt-0.5">
+                      ✓ Submitted · tap to edit
+                    </span>
+                  )}
+                </span>
                 <span aria-hidden="true" className="text-text-subtle text-xl">
                   ›
                 </span>

--- a/src/lib/check-in/lobby-scope.test.ts
+++ b/src/lib/check-in/lobby-scope.test.ts
@@ -66,4 +66,22 @@ describe("resolveLobbyTasks", () => {
       expect(LOBBY_WORKFLOWS).toContain(t.workflow);
     }
   });
+
+  it("marks tasks as not-submitted by default", () => {
+    const tasks = resolveLobbyTasks(["presenting_concerns", "consent"]);
+    expect(tasks.map((t) => t.submitted)).toEqual([false, false]);
+  });
+
+  it("flags only the workflows with a staged submission, but keeps them in scope", () => {
+    const tasks = resolveLobbyTasks(
+      ["presenting_concerns", "consent"],
+      new Set(["intake" as const]),
+    );
+    // intake submitted, consent not — and BOTH remain outstanding tasks (the
+    // chart isn't written until staff accept, so scope is unchanged).
+    expect(tasks.map((t) => [t.workflow, t.submitted])).toEqual([
+      ["intake", true],
+      ["consent", false],
+    ]);
+  });
 });

--- a/src/lib/check-in/lobby-scope.ts
+++ b/src/lib/check-in/lobby-scope.ts
@@ -61,6 +61,15 @@ export interface LobbyTask {
    * the URL — they re-derive the patient from the path-scoped cookie.
    */
   href: string;
+  /**
+   * True once the patient has staged a (still-pending) submission for this
+   * workflow. The task stays IN SCOPE — they can re-open it to edit — but it's
+   * rendered as "submitted, pending review" so the lobby has a terminal state the
+   * patient reaches by their own action, instead of a perpetual to-do. A staged
+   * submission satisfies NOTHING in the clinical readiness gate; this flag is
+   * display state only and never widens `allowed`.
+   */
+  submitted: boolean;
 }
 
 const TASK_LABELS: Record<LobbyWorkflow, string> = {
@@ -72,8 +81,14 @@ const TASK_LABELS: Record<LobbyWorkflow, string> = {
  * Resolve the patient's outstanding lobby tasks from readiness. `missingIds`
  * are the blocking requirement ids from PrevisitReadiness; we keep only the
  * ones a phone workflow can resolve, de-duplicated, in workflow order.
+ * `submittedWorkflows` are those with a staged-but-pending submission, flagged
+ * for display — they remain outstanding tasks (the chart isn't written until
+ * staff accept) but render as already submitted.
  */
-export function resolveLobbyTasks(missingIds: readonly string[]): LobbyTask[] {
+export function resolveLobbyTasks(
+  missingIds: readonly string[],
+  submittedWorkflows: ReadonlySet<LobbyWorkflow> = new Set(),
+): LobbyTask[] {
   const outstanding = new Set<LobbyWorkflow>();
   for (const id of missingIds) {
     const wf = workflowForRequirement(id);
@@ -83,6 +98,7 @@ export function resolveLobbyTasks(missingIds: readonly string[]): LobbyTask[] {
     workflow: wf,
     label: TASK_LABELS[wf],
     href: `/kiosk/lobby/${wf}`,
+    submitted: submittedWorkflows.has(wf),
   }));
 }
 
@@ -91,7 +107,12 @@ export interface LobbyReadinessView {
   tasks: LobbyTask[];
   /** Workflows still outstanding (the lobby's effective allow-scope). */
   allowed: LobbyWorkflow[];
-  /** True when nothing the phone can resolve is outstanding. */
+  /**
+   * True when there's nothing left for the patient to DO here: either no
+   * phone-resolvable task is outstanding, or every outstanding task has already
+   * been submitted and is awaiting staff review. The terminal "you're all set"
+   * state — reachable by the patient's own action, not only after staff accept.
+   */
   allDone: boolean;
 }
 
@@ -156,9 +177,39 @@ export async function getLobbyReadinessView(
     missingIds = [...LOBBY_WORKFLOWS];
   }
 
-  const tasks = resolveLobbyTasks(missingIds);
+  const submittedWorkflows = await loadSubmittedWorkflows(patientId, organizationId);
+  const tasks = resolveLobbyTasks(missingIds, submittedWorkflows);
+
+  // Scope is the outstanding tasks — UNCHANGED by submission state, so a patient
+  // can re-open a submitted workflow to correct an answer (getLobbyScopeFor keys
+  // off this, never the `submitted` display flag).
   const allowed = tasks.map((t) => t.workflow);
-  return { readiness, tasks, allowed, allDone: tasks.length === 0 };
+
+  // Terminal once there's nothing left to do: no outstanding task, OR every
+  // outstanding task is already submitted and waiting on staff review.
+  const allDone = tasks.length === 0 || tasks.every((t) => t.submitted);
+
+  return { readiness, tasks, allowed, allDone };
+}
+
+/**
+ * Which lobby workflows the patient has already staged a still-pending
+ * submission for. Used only to render "submitted, pending review" — staged data
+ * never satisfies the clinical readiness gate.
+ */
+async function loadSubmittedWorkflows(
+  patientId: string,
+  organizationId: string,
+): Promise<Set<LobbyWorkflow>> {
+  const rows = await prisma.kioskLobbySubmission.findMany({
+    where: { patientId, organizationId, status: "pending" },
+    select: { kind: true },
+  });
+  const submitted = new Set<LobbyWorkflow>();
+  for (const r of rows) {
+    if (isLobbyWorkflow(r.kind)) submitted.add(r.kind);
+  }
+  return submitted;
 }
 
 function emptyReadiness(): PrevisitReadiness {


### PR DESCRIPTION
## What

Lobby tasks were derived **purely** from chart-backed readiness, and submissions only *stage* (the chart isn't written until staff accept). So a patient who finished intake/consent still saw *"a couple things before your visit"*, could re-submit indefinitely, and **never reached a terminal state by their own action** — "You're all set" only appeared after a staff member later accepted the submission, by which point the 30-min session was usually gone.

## Fix (allow-edit, not lock-out)

- `getLobbyReadinessView` now loads the patient's **pending** submissions and flags each task `submitted`. `allDone` is true when every outstanding task has been submitted (or none is outstanding) → a real *"everything's submitted, pending review"* terminal screen.
- The task **stays in scope**: `allowed` is unchanged, so `getLobbyScopeFor` still authorizes re-opening a workflow to correct an answer. The `submitted` flag is **display-only** and a staged submission still satisfies **nothing** in the clinical readiness gate. This deliberately avoids the authz regression a lock-after-submit design would cause (re-submits falsely rejected as "session expired").
- The lobby home renders the terminal copy and marks submitted tasks **"✓ Submitted · tap to edit"**.

Also **hardens the supersede**: the `deleteMany` + `create` in both intake and consent staging now run in one `$transaction`, so a failed create can't leave the patient with neither their prior nor their new submission.

## Scope note (deferred, tracked on EMR-915)

The *full* dedup of concurrent duplicate **pending** rows (LOW finding #4) needs a **partial unique index** (`WHERE status='pending'`, with a JSON-extracted templateId for consent). This repo has **no** partial/expression-index precedent, and a DB-only partial index risks Prisma `migrate dev` drift in a multi-actor repo — so it's left for a deliberate team call rather than introduced here. Accept remains atomic per-row, bounding the residual to rare duplicate rows.

## Tests

`resolveLobbyTasks` now takes a `submittedWorkflows` set; +2 cases (default not-submitted; flags submitted while keeping the task in scope). Full `lib/check-in` suite green (80), `tsc` clean, eslint clean.

## Provenance

MEDIUM finding from the adversarial review of the merged kiosk→phone lobby (#560/#561). Completes the actionable findings: HIGH (#562, merged), LOW empty-intake (#563, merged), this MEDIUM, plus the #4 hardening. Remaining full-dedup item documented on EMR-915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)