### PR TITLE
feat(scheduling): multi-channel pre-visit nudges — email + in-app (EMR-914 slice 1)

### DIFF
--- a/src/lib/scheduling/previsit-channels.test.ts
+++ b/src/lib/scheduling/previsit-channels.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolvePrevisitChannels,
+  readPrevisitCategoryToggles,
+} from "./previsit-channels";
+
+describe("resolvePrevisitChannels (opt-out model)", () => {
+  it("uses every reachable channel when there is no preference row", () => {
+    expect(
+      resolvePrevisitChannels({
+        hasPhone: true,
+        hasEmail: true,
+        hasPortalUser: true,
+        prefs: null,
+      }),
+    ).toEqual(["sms", "email", "inapp"]);
+  });
+
+  it("preserves SMS-to-anyone-with-a-phone (no opt-in gate)", () => {
+    expect(
+      resolvePrevisitChannels({ hasPhone: true, hasEmail: false, hasPortalUser: false, prefs: null }),
+    ).toEqual(["sms"]);
+  });
+
+  it("drops a channel only when EXPLICITLY turned off per category", () => {
+    expect(
+      resolvePrevisitChannels({
+        hasPhone: true,
+        hasEmail: true,
+        hasPortalUser: true,
+        prefs: { category: { sms: false } },
+      }),
+    ).toEqual(["email", "inapp"]);
+  });
+
+  it("suppresses email when emailFrequency is off", () => {
+    expect(
+      resolvePrevisitChannels({
+        hasPhone: true,
+        hasEmail: true,
+        hasPortalUser: false,
+        prefs: { emailFrequency: "off" },
+      }),
+    ).toEqual(["sms"]);
+  });
+
+  it("suppresses email when the category disables it", () => {
+    expect(
+      resolvePrevisitChannels({
+        hasPhone: false,
+        hasEmail: true,
+        hasPortalUser: false,
+        prefs: { category: { email: false } },
+      }),
+    ).toEqual([]);
+  });
+
+  it("only offers in-app to patients with a portal account", () => {
+    expect(
+      resolvePrevisitChannels({ hasPhone: false, hasEmail: false, hasPortalUser: false, prefs: null }),
+    ).toEqual([]);
+    expect(
+      resolvePrevisitChannels({
+        hasPhone: false,
+        hasEmail: false,
+        hasPortalUser: true,
+        prefs: { category: { inapp: false } },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("readPrevisitCategoryToggles", () => {
+  it("returns empty for missing/malformed preferences (opt-out default stands)", () => {
+    expect(readPrevisitCategoryToggles(null)).toEqual({});
+    expect(readPrevisitCategoryToggles("nope")).toEqual({});
+    expect(readPrevisitCategoryToggles({})).toEqual({});
+    expect(readPrevisitCategoryToggles({ appointments: "x" })).toEqual({});
+  });
+
+  it("prefers a previsit block over the broader appointments block", () => {
+    expect(
+      readPrevisitCategoryToggles({
+        appointments: { sms: true, email: true },
+        previsit: { sms: false },
+      }),
+    ).toEqual({ sms: false, email: undefined, inapp: undefined });
+  });
+
+  it("falls back to the appointments block and ignores non-booleans", () => {
+    expect(
+      readPrevisitCategoryToggles({ appointments: { sms: false, email: "yes", inapp: true } }),
+    ).toEqual({ sms: false, email: undefined, inapp: true });
+  });
+});

--- a/src/lib/scheduling/previsit-channels.ts
+++ b/src/lib/scheduling/previsit-channels.ts
@@ -1,0 +1,75 @@
+// EMR-914 — which channels a pre-visit completion nudge should go out on for a
+// given patient, derived from CommunicationPreference.
+//
+// PRODUCT DECISION (opt-OUT model): a channel is used whenever the patient is
+// reachable on it AND hasn't EXPLICITLY turned it off. This preserves today's
+// behaviour (SMS to anyone with a phone) and *adds* email + in-app, rather than
+// silently going dark by gating SMS on the default-false `smsOptIn`. The
+// explicit off switches are:
+//   - SMS:   per-category `sms: false`
+//   - Email: `emailFrequency === "off"` OR per-category `email: false`
+//   - In-app: requires a portal account; per-category `inapp: false`
+// No CommunicationPreference row at all ⇒ every reachable channel is used.
+//
+// Pure + deterministic so the policy is unit-testable away from the DB.
+
+export type PrevisitChannel = "sms" | "email" | "inapp";
+
+/** Per-category channel toggles, read from `CommunicationPreference.preferences`. */
+export interface PrevisitCategoryToggles {
+  sms?: boolean;
+  email?: boolean;
+  inapp?: boolean;
+}
+
+export interface PrevisitChannelPrefs {
+  /** `CommunicationPreference.emailFrequency`; "off" suppresses email. */
+  emailFrequency?: string | null;
+  /** `preferences.previsit ?? preferences.appointments` toggles. */
+  category?: PrevisitCategoryToggles | null;
+}
+
+export interface PrevisitChannelInputs {
+  /** True only when the patient has a deliverable (normalizable) phone. */
+  hasPhone: boolean;
+  /** True only when the patient has an email on file. */
+  hasEmail: boolean;
+  /** True only when the patient has a linked portal User (for in-app). */
+  hasPortalUser: boolean;
+  /** The patient's preferences, or null when there is no row. */
+  prefs: PrevisitChannelPrefs | null;
+}
+
+export function resolvePrevisitChannels(input: PrevisitChannelInputs): PrevisitChannel[] {
+  const cat = input.prefs?.category ?? {};
+  const channels: PrevisitChannel[] = [];
+
+  // SMS — opt-out: send unless explicitly disabled for this category.
+  if (input.hasPhone && cat.sms !== false) channels.push("sms");
+
+  // Email — needs an address, a non-"off" frequency, and category not disabled.
+  const emailFrequency = input.prefs?.emailFrequency ?? "instant";
+  if (input.hasEmail && emailFrequency !== "off" && cat.email !== false) {
+    channels.push("email");
+  }
+
+  // In-app — only patients with a portal account, category not disabled.
+  if (input.hasPortalUser && cat.inapp !== false) channels.push("inapp");
+
+  return channels;
+}
+
+/**
+ * Pull the pre-visit category toggles out of the free-form
+ * `CommunicationPreference.preferences` JSON. Prefers a `previsit` block, falls
+ * back to the broader `appointments` block, and tolerates any shape (returns an
+ * empty object when absent/malformed, so the opt-out default stands).
+ */
+export function readPrevisitCategoryToggles(preferences: unknown): PrevisitCategoryToggles {
+  if (!preferences || typeof preferences !== "object") return {};
+  const p = preferences as Record<string, unknown>;
+  const block = (p.previsit ?? p.appointments) as Record<string, unknown> | undefined;
+  if (!block || typeof block !== "object") return {};
+  const pick = (v: unknown): boolean | undefined => (typeof v === "boolean" ? v : undefined);
+  return { sms: pick(block.sms), email: pick(block.email), inapp: pick(block.inapp) };
+}

--- a/src/lib/scheduling/previsit-reminders.test.ts
+++ b/src/lib/scheduling/previsit-reminders.test.ts
@@ -4,14 +4,18 @@ const hoisted = vi.hoisted(() => {
   const prisma = {
     appointment: { findMany: vi.fn() },
     auditLog: { findMany: vi.fn(), create: vi.fn() },
+    communicationPreference: { findUnique: vi.fn() },
+    notification: { create: vi.fn() },
   };
-  return { prisma };
+  const sendEmail = vi.fn();
+  return { prisma, sendEmail };
 });
 
 vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
 vi.mock("./previsit-readiness", () => ({
   getAppointmentReadiness: vi.fn(),
 }));
+vi.mock("@/lib/email/resend", () => ({ sendEmail: hoisted.sendEmail }));
 
 import {
   sendDueVisitReminders,
@@ -22,7 +26,7 @@ import {
 import { getAppointmentReadiness } from "./previsit-readiness";
 import { getMockSmsAdapter } from "@/lib/sms/adapter";
 
-const { prisma } = hoisted;
+const { prisma, sendEmail } = hoisted;
 const day = 24 * 60 * 60_000;
 const NOW = new Date("2026-06-01T12:00:00.000Z");
 const PORTAL = "https://portal.leafjourney.com";
@@ -60,6 +64,9 @@ beforeEach(() => {
   delete process.env.TWILIO_FROM_NUMBER;
   prisma.auditLog.findMany.mockResolvedValue([]);
   prisma.auditLog.create.mockResolvedValue({});
+  prisma.communicationPreference.findUnique.mockResolvedValue(null);
+  prisma.notification.create.mockResolvedValue({ id: "note_1" });
+  sendEmail.mockResolvedValue({ ok: true, id: "email_1" });
 });
 
 describe("pickPrevisitMilestone", () => {
@@ -160,6 +167,93 @@ describe("sendDuePrevisitCompletionReminders", () => {
     // "123" fails normalizePhone -> treated as no deliverable channel.
     expect(res.sent).toBe(0);
     expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendDuePrevisitCompletionReminders — multi-channel (EMR-914)", () => {
+  const multiChannelPatient = {
+    id: "pat_1",
+    firstName: "Maya",
+    phone: "+15551234567",
+    email: "maya@example.com",
+    userId: "user_1",
+    organizationId: "org_1",
+  };
+
+  it("fans out to SMS + email + in-app, auditing each channel once", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt({ patient: multiChannelPatient })]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(3);
+    expect(getMockSmsAdapter().getSent()).toHaveLength(1);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(prisma.notification.create).toHaveBeenCalledTimes(1);
+
+    // The in-app Notification is PHI-free and points at the bare portal origin.
+    const note = prisma.notification.create.mock.calls[0][0].data;
+    expect(note).toMatchObject({ userId: "user_1", type: "previsit_reminder", href: PORTAL });
+    expect(JSON.stringify(note)).not.toMatch(/1985|Maya|consent|insurance/i);
+
+    // The email is PHI-free too.
+    const email = sendEmail.mock.calls[0][0];
+    expect(email.to).toEqual(["maya@example.com"]);
+    expect(JSON.stringify({ s: email.subject, t: email.text, h: email.html })).not.toMatch(
+      /Maya|1985|consent|insurance/i,
+    );
+
+    // One audit per channel, with distinct channel tags.
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(3);
+    const channels = prisma.auditLog.create.mock.calls.map((c) => c[0].data.metadata.channel);
+    expect(new Set(channels)).toEqual(new Set(["sms", "email", "inapp"]));
+  });
+
+  it("is idempotent PER channel — a sent SMS doesn't block email/in-app", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt({ patient: multiChannelPatient })]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+    prisma.auditLog.findMany.mockResolvedValue([{ metadata: { milestone: "7day", channel: "sms" } }]);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(2); // email + in-app
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0); // SMS already sent
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(prisma.notification.create).toHaveBeenCalledTimes(1);
+    expect(res.details.find((d) => d.channel === "sms")?.result).toBe("skipped:already-sent");
+  });
+
+  it("treats an unconfigured email transport as a skip, not a failure or audit", async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      makeAppt({ patient: { ...multiChannelPatient, userId: null } }), // sms + email only
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+    sendEmail.mockResolvedValue({ ok: false, reason: "no-api-key" });
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1); // SMS only
+    expect(res.details.find((d) => d.channel === "email")?.result).toBe(
+      "skipped:channel-unconfigured",
+    );
+    // Only the SMS send is audited.
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+    expect(prisma.auditLog.create.mock.calls[0][0].data.metadata.channel).toBe("sms");
+  });
+
+  it("honors an explicit per-category SMS opt-out while still emailing", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt({ patient: multiChannelPatient })]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+    prisma.communicationPreference.findUnique.mockResolvedValue({
+      emailFrequency: "instant",
+      preferences: { previsit: { sms: false } },
+    });
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(getMockSmsAdapter().getSent()).toHaveLength(0);
+    const channels = new Set(res.details.filter((d) => d.result === "sent").map((d) => d.channel));
+    expect(channels).toEqual(new Set(["email", "inapp"]));
   });
 });
 

--- a/src/lib/scheduling/send-reminders.ts
+++ b/src/lib/scheduling/send-reminders.ts
@@ -11,10 +11,18 @@ import {
 } from "@/lib/sms/templates";
 import {
   renderPrevisitReminder,
+  renderPrevisitEmail,
+  renderPrevisitInApp,
   type PrevisitMilestone,
 } from "@/lib/sms/previsit-templates";
+import { sendEmail } from "@/lib/email/resend";
 import { logger } from "@/lib/observability/log";
 import { getAppointmentReadiness } from "./previsit-readiness";
+import {
+  resolvePrevisitChannels,
+  readPrevisitCategoryToggles,
+  type PrevisitChannel,
+} from "./previsit-channels";
 
 export interface SendDueRemindersInput {
   /** Current time, injected for testability. */
@@ -247,11 +255,14 @@ export type PrevisitReminderResult =
   | "skipped:complete"
   | "skipped:already-sent"
   | "skipped:no-channel"
+  | "skipped:channel-unconfigured"
   | "failed";
 
 export interface PrevisitReminderOutcome {
   appointmentId: string;
   milestone: PrevisitMilestone | null;
+  /** Which channel this outcome is for. Null for whole-appointment skips. */
+  channel?: PrevisitChannel | null;
   result: PrevisitReminderResult;
   error?: string;
 }
@@ -289,7 +300,9 @@ export async function sendDuePrevisitCompletionReminders(
       startAt: { gt: now, lte: windowEnd },
     },
     include: {
-      patient: { select: { id: true, phone: true, organizationId: true } },
+      patient: {
+        select: { id: true, phone: true, email: true, userId: true, organizationId: true },
+      },
     },
   });
 
@@ -313,63 +326,158 @@ export async function sendDuePrevisitCompletionReminders(
       continue;
     }
 
+    // Which channels may we use? Opt-out model keyed on CommunicationPreference
+    // (loaded only when the patient has a portal account); a normalizable phone
+    // gates SMS, an address gates email, a portal user gates in-app.
     const phone = normalizePhone(appt.patient.phone);
-    if (!phone) {
-      details.push({ appointmentId: appt.id, milestone, result: "skipped:no-channel" });
-      skipped += 1;
-      continue;
-    }
-
-    if (await alreadySentPrevisit(appt.id, milestone)) {
-      details.push({ appointmentId: appt.id, milestone, result: "skipped:already-sent" });
-      skipped += 1;
-      continue;
-    }
-
-    const body = renderPrevisitReminder(milestone, { portalUrl: input.portalUrl });
-    const adapter = getSmsAdapter();
-    const res = await adapter.send({
-      to: phone,
-      body,
-      // Context is for delivery/idempotency only — opaque ids, no PHI.
-      context: { appointmentId: appt.id, milestone, kind: "previsit_completion" },
+    const prefRow = appt.patient.userId
+      ? await prisma.communicationPreference.findUnique({
+          where: { userId: appt.patient.userId },
+          select: { emailFrequency: true, preferences: true },
+        })
+      : null;
+    const channels = resolvePrevisitChannels({
+      hasPhone: phone != null,
+      hasEmail: Boolean(appt.patient.email),
+      hasPortalUser: Boolean(appt.patient.userId),
+      prefs: prefRow
+        ? {
+            emailFrequency: prefRow.emailFrequency,
+            category: readPrevisitCategoryToggles(prefRow.preferences),
+          }
+        : null,
     });
 
-    if (!res.ok) {
-      details.push({ appointmentId: appt.id, milestone, result: "failed", error: res.error });
-      logger.warn({
-        event: "scheduler.previsit.reminder.failed",
-        appointmentId: appt.id,
+    if (channels.length === 0) {
+      details.push({ appointmentId: appt.id, milestone, channel: null, result: "skipped:no-channel" });
+      skipped += 1;
+      continue;
+    }
+
+    for (const channel of channels) {
+      // Channel-aware idempotency: each (appointment, milestone, channel) fires
+      // at most once, so SMS + email + in-app each send once per milestone.
+      if (await alreadySentPrevisit(appt.id, milestone, channel)) {
+        details.push({ appointmentId: appt.id, milestone, channel, result: "skipped:already-sent" });
+        skipped += 1;
+        continue;
+      }
+
+      const send = await sendPrevisitChannel({
+        channel,
         milestone,
-        error: res.error,
+        portalUrl: input.portalUrl,
+        phone,
+        email: appt.patient.email,
+        userId: appt.patient.userId,
       });
-      continue;
-    }
 
-    await prisma.auditLog.create({
-      data: {
-        organizationId: appt.patient.organizationId,
-        actorAgent: "scheduler:previsitCompletionReminder@1.0.0",
-        action: PREVISIT_COMPLETION_REMINDER_ACTION,
-        subjectType: "Appointment",
-        subjectId: appt.id,
-        // PHI-free metadata: milestone, channel, and a count of outstanding
-        // required items. Never the requirement labels or any patient field.
-        metadata: {
+      if (send.outcome === "unconfigured") {
+        details.push({ appointmentId: appt.id, milestone, channel, result: "skipped:channel-unconfigured" });
+        skipped += 1;
+        continue;
+      }
+      if (send.outcome === "failed") {
+        details.push({ appointmentId: appt.id, milestone, channel, result: "failed", error: send.error });
+        logger.warn({
+          event: "scheduler.previsit.reminder.failed",
+          appointmentId: appt.id,
           milestone,
-          channel: "sms",
-          messageId: res.messageId,
-          adapter: res.adapter,
-          outstandingCount: readiness.readiness.outstandingRequiredCount,
-        } as any,
-      },
-    });
+          channel,
+          error: send.error,
+        });
+        continue;
+      }
 
-    details.push({ appointmentId: appt.id, milestone, result: "sent" });
-    sent += 1;
+      await prisma.auditLog.create({
+        data: {
+          organizationId: appt.patient.organizationId,
+          actorAgent: "scheduler:previsitCompletionReminder@1.0.0",
+          action: PREVISIT_COMPLETION_REMINDER_ACTION,
+          subjectType: "Appointment",
+          subjectId: appt.id,
+          // PHI-free metadata: milestone, channel, opaque delivery id, and a
+          // count of outstanding required items. Never the labels or any field.
+          metadata: {
+            milestone,
+            channel,
+            outstandingCount: readiness.readiness.outstandingRequiredCount,
+            ...send.meta,
+          } as any,
+        },
+      });
+
+      details.push({ appointmentId: appt.id, milestone, channel, result: "sent" });
+      sent += 1;
+    }
   }
 
   return { sent, skipped, details };
+}
+
+type ChannelSendResult =
+  | { outcome: "sent"; meta: Record<string, unknown> }
+  | { outcome: "failed"; error?: string }
+  | { outcome: "unconfigured" };
+
+/**
+ * Deliver one pre-visit nudge on one channel. PHI-free copy throughout; returns
+ * "unconfigured" when a channel's transport isn't set up (e.g. no Resend key) so
+ * the caller records a skip rather than a failure and never audits a non-send.
+ */
+async function sendPrevisitChannel(args: {
+  channel: PrevisitChannel;
+  milestone: PrevisitMilestone;
+  portalUrl: string;
+  phone: string | null;
+  email: string | null;
+  userId: string | null;
+}): Promise<ChannelSendResult> {
+  const { channel, milestone, portalUrl } = args;
+
+  if (channel === "sms") {
+    if (!args.phone) return { outcome: "unconfigured" };
+    const body = renderPrevisitReminder(milestone, { portalUrl });
+    const res = await getSmsAdapter().send({
+      to: args.phone,
+      body,
+      // Context is for delivery/idempotency only — opaque ids, no PHI.
+      context: { milestone, channel, kind: "previsit_completion" },
+    });
+    if (!res.ok) return { outcome: "failed", error: res.error };
+    return { outcome: "sent", meta: { messageId: res.messageId, adapter: res.adapter } };
+  }
+
+  if (channel === "email") {
+    if (!args.email) return { outcome: "unconfigured" };
+    const content = renderPrevisitEmail(milestone, { portalUrl });
+    const res = await sendEmail({
+      to: [args.email],
+      subject: content.subject,
+      text: content.text,
+      html: content.html,
+    });
+    if (res.ok) return { outcome: "sent", meta: { messageId: res.id } };
+    // A missing API key is a config gap, not a delivery failure — skip quietly.
+    if (res.reason === "no-api-key") return { outcome: "unconfigured" };
+    return { outcome: "failed", error: res.message };
+  }
+
+  // in-app — write a portal Notification (only patients with a portal account).
+  if (!args.userId) return { outcome: "unconfigured" };
+  const content = renderPrevisitInApp(milestone, { portalUrl });
+  const note = await prisma.notification.create({
+    data: {
+      userId: args.userId,
+      type: "previsit_reminder",
+      priority: "normal",
+      title: content.title,
+      body: content.body,
+      href: content.href,
+    },
+    select: { id: true },
+  });
+  return { outcome: "sent", meta: { notificationId: note.id } };
 }
 
 export async function sendDueVisitReminders(
@@ -423,6 +531,7 @@ function normalizePrevisitPortalOrigin(
 async function alreadySentPrevisit(
   appointmentId: string,
   milestone: PrevisitMilestone,
+  channel: PrevisitChannel,
 ): Promise<boolean> {
   const rows = await prisma.auditLog.findMany({
     where: {
@@ -431,10 +540,15 @@ async function alreadySentPrevisit(
       subjectId: appointmentId,
     },
     select: { metadata: true },
-    take: 10,
+    take: 20,
   });
   return rows.some((r) => {
-    const meta = r.metadata as { milestone?: string } | null;
-    return meta?.milestone === milestone;
+    const meta = r.metadata as { milestone?: string; channel?: string } | null;
+    if (meta?.milestone !== milestone) return false;
+    // Channel-aware. Legacy rows predate the channel field and were all SMS, so
+    // treat a channel-less row as having satisfied the SMS channel — avoids a
+    // one-time re-send of SMS nudges already delivered before this change.
+    if (meta.channel === channel) return true;
+    return channel === "sms" && meta.channel === undefined;
   });
 }

--- a/src/lib/sms/previsit-templates.ts
+++ b/src/lib/sms/previsit-templates.ts
@@ -65,3 +65,61 @@ export function renderPrevisitReminder(
   const urgency = URGENCY[milestone];
   return `You have pre-visit items ready. ${PREVISIT_PORTAL_CTA} ${urgency}: ${origin}`;
 }
+
+export interface PrevisitEmailContent {
+  subject: string;
+  /** Plain-text fallback (also the body for text-only clients). */
+  text: string;
+  /** Minimal branded HTML. Still STRICTLY PHI-free — no name, no visit detail. */
+  html: string;
+}
+
+/**
+ * Render the EMAIL form of the pre-visit completion nudge. Branded but under the
+ * same PHI-free contract as the SMS copy: it names no patient, no provider, no
+ * appointment, and links only to the bare portal origin. The subject is generic
+ * so it leaks nothing in a lock-screen preview.
+ */
+export function renderPrevisitEmail(
+  milestone: PrevisitMilestone,
+  input: PrevisitReminderInput,
+): PrevisitEmailContent {
+  const origin = assertGenericPortalUrl(input.portalUrl);
+  const urgency = URGENCY[milestone];
+  const subject = PREVISIT_PORTAL_CTA;
+  const text = `You have pre-visit items ready. ${PREVISIT_PORTAL_CTA} ${urgency}: ${origin}`;
+  const html = [
+    `<div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#1a1a1a">`,
+    `<h1 style="font-size:20px;margin:0 0 12px">${PREVISIT_PORTAL_CTA}</h1>`,
+    `<p style="font-size:15px;line-height:1.5;margin:0 0 20px">You have pre-visit items ready. Finishing them now keeps your visit on time — it only takes a minute.</p>`,
+    `<p style="margin:0 0 20px"><a href="${origin}" style="display:inline-block;background:#16a34a;color:#fff;text-decoration:none;padding:12px 20px;border-radius:10px;font-weight:600">Open your patient portal</a></p>`,
+    `<p style="font-size:13px;color:#6b7280;margin:0">Please complete them ${urgency}.</p>`,
+    `</div>`,
+  ].join("");
+  return { subject, text, html };
+}
+
+export interface PrevisitInAppContent {
+  title: string;
+  body: string;
+  /** Deep link target. In-app notifications live behind portal login, so this
+   * may be a real link; we keep it to the bare origin in v1 (no appt id). */
+  href: string;
+}
+
+/**
+ * Render the IN-APP (portal Notification) form. Stored in our own DB behind
+ * portal login — not in transit to a third party — but we keep the same
+ * PHI-free copy for consistency and so a future push mirror stays safe.
+ */
+export function renderPrevisitInApp(
+  milestone: PrevisitMilestone,
+  input: PrevisitReminderInput,
+): PrevisitInAppContent {
+  const origin = assertGenericPortalUrl(input.portalUrl);
+  return {
+    title: PREVISIT_PORTAL_CTA,
+    body: `You have pre-visit items ready — please complete them ${URGENCY[milestone]}.`,
+    href: origin,
+  };
+}


### PR DESCRIPTION
First slice of **EMR-914 — Phase 1: multi-channel pre-visit completeness alerts**. Extends the existing nudge engine (`sendDuePrevisitCompletionReminders`) rather than replacing it.

## What

Today the pre-visit completion nudge is **SMS-only** and its idempotency keys on `(appointment, milestone)`, ignoring channel. This adds **email + in-app** alongside SMS, gated by `CommunicationPreference`, idempotent per channel.

- **`resolvePrevisitChannels`** (new pure module): the channel policy. **Opt-out model** (product decision — see below): a channel is used when the patient is reachable on it and hasn't *explicitly* turned it off. No preference row ⇒ every reachable channel. SMS keeps going to anyone with a phone (explicit `sms:false` is the off switch); email needs an address + `emailFrequency≠"off"`; in-app needs a portal account.
- **PHI-free renderers** `renderPrevisitEmail` / `renderPrevisitInApp` next to the SMS one, under the same bare-origin, no-name contract (`assertGenericPortalUrl`).
- **Channel-aware idempotency**: `(appointment, milestone, channel)` each fires once. Legacy channel-less audit rows are treated as the SMS channel, so in-flight nudges don't re-fire once on deploy.
- **Email** via the Resend adapter degrades gracefully — a missing API key is a *config skip*, never a failure, and is never audited as a send.
- **In-app** writes a portal `Notification` (first server-side use of the model), only for patients with a linked portal account.

## Product decision baked in

SMS uses an **opt-out** model (send unless explicitly off), chosen by the product owner over enforcing the default-false `smsOptIn` — so this preserves today's SMS reach and *adds* channels rather than reducing volume.

## Deferred (tracked on EMR-914)

- **Per-org portal URL** — needs an `Organization` URL column; today it's a global env. Engine still takes `portalUrl`, so this is a drop-in later.
- **Quiet-hours windows** — need a patient timezone to honor `quietHoursStart/End` correctly; shipping a UTC guess would mis-time sends. Left out deliberately.
- **Portal banner** + **clinician "upcoming visits with missing info" dashboard** — follow-up slices.

## Tests

+9 tests: pure resolver + category-toggle parsing, and 4 engine cases (fan-out to all three channels with per-channel audit; per-channel idempotency; unconfigured-email skip; explicit per-category SMS opt-out). Engine signature unchanged → scheduler wiring untouched. Full scheduling+sms suite green (64), `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)