### PR TITLE
feat(portal): "Get ready for your visit" banner (EMR-914 slice 2)

### DIFF
--- a/src/app/(patient)/portal/dashboard/page.tsx
+++ b/src/app/(patient)/portal/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { requireRole } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
 import { ModularDashboard } from "@/components/patient/ModularDashboard";
+import { PrevisitReadinessBanner } from "../previsit-readiness-banner";
 
 export const metadata = { title: "Dashboard" };
 
@@ -103,6 +104,8 @@ export default async function PatientDashboardPage() {
           Drag widgets to rearrange. Your layout is saved to this device.
         </p>
       </div>
+
+      <PrevisitReadinessBanner patientId={patient.id} />
 
       <ModularDashboard
         data={{

--- a/src/app/(patient)/portal/previsit-banner-view.test.ts
+++ b/src/app/(patient)/portal/previsit-banner-view.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPrevisitBannerView, describeWhen } from "./previsit-banner-view";
+import type { UpcomingVisitReadiness } from "@/lib/scheduling/previsit-readiness";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function view(overrides: Partial<UpcomingVisitReadiness> = {}): UpcomingVisitReadiness {
+  return {
+    appointmentId: "appt_1",
+    startAt: new Date("2026-06-06T16:00:00.000Z"), // 5 days out
+    readiness: { isReady: false, missingRequiredIds: ["consent"], outstandingRequiredCount: 1, completionPct: 0.5 },
+    missingRequirements: [{ id: "consent", label: "Visit consent", href: "/patient/consents" }],
+    ...overrides,
+  };
+}
+
+describe("buildPrevisitBannerView", () => {
+  it("hides when there is no upcoming visit", () => {
+    expect(buildPrevisitBannerView(null, NOW)).toBeNull();
+  });
+
+  it("hides when the patient is already ready", () => {
+    expect(
+      buildPrevisitBannerView(
+        view({ readiness: { isReady: true, missingRequiredIds: [], outstandingRequiredCount: 0, completionPct: 1 } }),
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it("hides when nothing is outstanding even if not flagged ready", () => {
+    expect(buildPrevisitBannerView(view({ missingRequirements: [] }), NOW)).toBeNull();
+  });
+
+  it("surfaces percent, when-label, and the deep-linked items", () => {
+    const banner = buildPrevisitBannerView(view(), NOW);
+    expect(banner).toEqual({
+      completionPct: 50,
+      whenLabel: "in 5 days",
+      items: [{ id: "consent", label: "Visit consent", href: "/patient/consents" }],
+    });
+  });
+});
+
+describe("describeWhen", () => {
+  it("frames same-day and past as today", () => {
+    expect(describeWhen(new Date("2026-06-01T18:00:00Z"), NOW)).toBe("today");
+    expect(describeWhen(new Date("2026-05-30T18:00:00Z"), NOW)).toBe("today");
+  });
+  it("frames tomorrow and multi-day", () => {
+    expect(describeWhen(new Date("2026-06-02T12:00:00Z"), NOW)).toBe("tomorrow");
+    expect(describeWhen(new Date("2026-06-08T12:00:00Z"), NOW)).toBe("in 7 days");
+  });
+});

--- a/src/app/(patient)/portal/previsit-banner-view.ts
+++ b/src/app/(patient)/portal/previsit-banner-view.ts
@@ -1,0 +1,54 @@
+// EMR-914 — pure view-model for the portal "Get ready for your visit" banner.
+// Kept separate from the server component so the show/hide + framing logic is
+// unit-testable without rendering React or touching the DB.
+
+import type {
+  MissingRequirement,
+  UpcomingVisitReadiness,
+} from "@/lib/scheduling/previsit-readiness";
+
+const DAY_MS = 24 * 60 * 60_000;
+
+export interface PrevisitBannerView {
+  /** 0..100, for the progress bar. */
+  completionPct: number;
+  /** Human framing of how soon the visit is ("today" / "tomorrow" / "in 5 days"). */
+  whenLabel: string;
+  /** The outstanding items to surface, label + deep link. */
+  items: MissingRequirement[];
+}
+
+/**
+ * Decide whether the banner shows and, if so, its framing. Returns null when
+ * there's no upcoming visit, the patient is already ready, or nothing
+ * phone/portal-actionable is outstanding — the banner should not render at all
+ * in those cases (no "you're all done" noise on the dashboard).
+ */
+export function buildPrevisitBannerView(
+  view: UpcomingVisitReadiness | null,
+  now: Date,
+): PrevisitBannerView | null {
+  if (!view) return null;
+  if (view.readiness.isReady) return null;
+  if (view.missingRequirements.length === 0) return null;
+
+  return {
+    completionPct: Math.round(view.readiness.completionPct * 100),
+    whenLabel: describeWhen(view.startAt, now),
+    items: view.missingRequirements,
+  };
+}
+
+/**
+ * Countdown copy by UTC calendar day (so "in 5 days" matches the patient's sense
+ * of the date, and lines up with the nudge engine's 7/2/0-day milestones).
+ * Clamps today/past to "today".
+ */
+export function describeWhen(startAt: Date, now: Date): string {
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(startAt.getUTCFullYear(), startAt.getUTCMonth(), startAt.getUTCDate());
+  const days = Math.round((b - a) / DAY_MS);
+  if (days <= 0) return "today";
+  if (days === 1) return "tomorrow";
+  return `in ${days} days`;
+}

--- a/src/app/(patient)/portal/previsit-readiness-banner.tsx
+++ b/src/app/(patient)/portal/previsit-readiness-banner.tsx
@@ -1,0 +1,76 @@
+// EMR-914 — patient-portal "Get ready for your visit" banner.
+//
+// Reads the CANONICAL readiness SoT for the patient's next appointment and, when
+// blocking items remain, surfaces them as a tappable checklist deep-linked via
+// the gate's own resolveHref. Renders NOTHING when there's no upcoming visit or
+// the patient is already ready — no dashboard noise. Server component: it fetches
+// its own data from the patient id the page already resolved.
+
+import Link from "next/link";
+
+import { getNextAppointmentReadinessForPatient } from "@/lib/scheduling/previsit-readiness";
+import { Card, CardContent } from "@/components/ui/card";
+import { buildPrevisitBannerView } from "./previsit-banner-view";
+
+export async function PrevisitReadinessBanner({ patientId }: { patientId: string }) {
+  const view = await getNextAppointmentReadinessForPatient(patientId, new Date());
+  const banner = buildPrevisitBannerView(view, new Date());
+  if (!banner) return null;
+
+  const remaining = banner.items.length;
+
+  return (
+    <Card tone="glass" className="mb-6">
+      <CardContent className="py-6">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+            Get ready for your visit
+          </p>
+          <span className="text-[11px] font-medium text-text-subtle">
+            {banner.completionPct}% ready
+          </span>
+        </div>
+
+        <h2 className="font-display text-xl text-text tracking-tight mb-1">
+          Your visit is {banner.whenLabel}
+        </h2>
+        <p className="text-sm text-text-muted mb-4 leading-relaxed">
+          {remaining === 1
+            ? "There's 1 thing to finish so your care team is ready for you."
+            : `There are ${remaining} things to finish so your care team is ready for you.`}
+        </p>
+
+        <div className="relative h-2 bg-surface-muted rounded-full overflow-hidden mb-5">
+          <div
+            className="h-full bg-gradient-to-r from-accent to-[#3A8560] transition-all"
+            style={{ width: `${banner.completionPct}%` }}
+          />
+        </div>
+
+        <ul className="space-y-2">
+          {banner.items.map((item) => {
+            const label = (
+              <span className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-surface px-4 py-3">
+                <span className="text-[15px] font-medium text-text">{item.label}</span>
+                <span aria-hidden="true" className="text-text-subtle">
+                  ›
+                </span>
+              </span>
+            );
+            return (
+              <li key={item.id}>
+                {item.href ? (
+                  <Link href={item.href} className="block transition-all hover:opacity-80">
+                    {label}
+                  </Link>
+                ) : (
+                  label
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/scheduling/previsit-readiness.test.ts
+++ b/src/lib/scheduling/previsit-readiness.test.ts
@@ -4,6 +4,7 @@ import {
   deriveVisitType,
   evaluatePrevisitReadiness,
   mapSnapshotToGateInput,
+  missingBlockingRequirements,
   type PrevisitSnapshot,
 } from "./previsit-readiness";
 
@@ -87,6 +88,37 @@ describe("mapSnapshotToGateInput", () => {
   it("passes self-pay attestation through", () => {
     const input = mapSnapshotToGateInput(fullSnapshot({ selfPayAttested: true, coverages: [] }));
     expect(input.insurance.selfPayAttested).toBe(true);
+  });
+});
+
+describe("missingBlockingRequirements", () => {
+  it("is empty for a fully-ready snapshot", () => {
+    expect(missingBlockingRequirements(fullSnapshot(), NOW)).toEqual([]);
+  });
+
+  it("returns id + label + the gate's resolveHref for each missing blocking item", () => {
+    const missing = missingBlockingRequirements(
+      fullSnapshot({
+        patient: { ...fullSnapshot().patient, presentingConcerns: null, ageVerifiedAt: null },
+      }),
+      NOW,
+    );
+    const byId = Object.fromEntries(missing.map((m) => [m.id, m]));
+    expect(byId.presenting_concerns).toMatchObject({
+      label: "Reason for this visit",
+      href: "/patient/intake/concerns",
+    });
+    expect(byId.id_age_verification).toMatchObject({ href: "/patient/verify" });
+  });
+
+  it("excludes non-blocking (advisory) items even when unsatisfied", () => {
+    // A titration follow-up with no outcome log => advisory outcome_log is
+    // unsatisfied but NOT blocking, so it must not appear here.
+    const missing = missingBlockingRequirements(
+      fullSnapshot({ visitType: "follow_up", treatmentPhase: "titration", outcomeLogsSinceLastVisit: 0 }),
+      NOW,
+    );
+    expect(missing.some((m) => m.id === "outcome_log_since_last_visit")).toBe(false);
   });
 });
 

--- a/src/lib/scheduling/previsit-readiness.ts
+++ b/src/lib/scheduling/previsit-readiness.ts
@@ -18,6 +18,7 @@ import { prisma } from "@/lib/db/prisma";
 import {
   evaluateIntakeGate,
   type IntakeGateInput,
+  type GateRequirementId,
 } from "./intake-gate";
 
 // ---------------------------------------------------------------------------
@@ -175,6 +176,30 @@ export function evaluatePrevisitReadiness(
   };
 }
 
+/**
+ * A missing blocking requirement with its display label + deep link, for UI
+ * surfaces (the portal "get ready" banner, the clinician dashboard). Labels are
+ * static UI strings — not PHI — but this richer view is intentionally kept OFF
+ * the PHI-free `PrevisitReadiness` summary so labels never ride into nudge
+ * routing or audit metadata. The href is the gate's own `resolveHref`, so the
+ * "where do I fix this" mapping lives in ONE place (EMR-914).
+ */
+export interface MissingRequirement {
+  id: GateRequirementId;
+  label: string;
+  href?: string;
+}
+
+export function missingBlockingRequirements(
+  snapshot: PrevisitSnapshot,
+  now: Date,
+): MissingRequirement[] {
+  const gate = evaluateIntakeGate(mapSnapshotToGateInput(snapshot), now);
+  return gate.requirements
+    .filter((r) => r.blocking && !r.satisfied)
+    .map((r) => ({ id: r.id, label: r.label, href: r.resolveHref }));
+}
+
 // ---------------------------------------------------------------------------
 // Prisma loader (thin DB read -> snapshot)
 // ---------------------------------------------------------------------------
@@ -282,6 +307,8 @@ function lastVisitBefore(startAt: Date): Date {
 
 export interface AppointmentReadiness {
   readiness: PrevisitReadiness;
+  /** Missing blocking requirements with labels + deep links, for UI surfaces. */
+  missingRequirements: MissingRequirement[];
   patientId: string;
   organizationId: string;
 }
@@ -309,7 +336,48 @@ export async function getAppointmentReadiness(
   if (!loaded) return null;
   return {
     readiness: evaluatePrevisitReadiness(loaded.snapshot, now),
+    missingRequirements: missingBlockingRequirements(loaded.snapshot, now),
     patientId: loaded.patientId,
     organizationId: loaded.organizationId,
+  };
+}
+
+export interface UpcomingVisitReadiness {
+  appointmentId: string;
+  startAt: Date;
+  readiness: PrevisitReadiness;
+  missingRequirements: MissingRequirement[];
+}
+
+/**
+ * Readiness for a PATIENT's next upcoming appointment (the portal "get ready"
+ * banner's entry point). Resolves the soonest still-open appointment, then reads
+ * the canonical readiness for it. Returns null when the patient has no upcoming
+ * appointment. Mirrors the nudge engine's appointment scope (requested/confirmed,
+ * in the future) so the banner and the SMS/email nudges agree on "next visit".
+ */
+export async function getNextAppointmentReadinessForPatient(
+  patientId: string,
+  now: Date,
+): Promise<UpcomingVisitReadiness | null> {
+  const appt = await prisma.appointment.findFirst({
+    where: {
+      patientId,
+      status: { in: ["requested", "confirmed"] },
+      startAt: { gt: now },
+    },
+    orderBy: { startAt: "asc" },
+    select: { id: true, startAt: true },
+  });
+  if (!appt) return null;
+
+  const r = await getAppointmentReadiness(appt.id, now);
+  if (!r) return null;
+
+  return {
+    appointmentId: appt.id,
+    startAt: appt.startAt,
+    readiness: r.readiness,
+    missingRequirements: r.missingRequirements,
   };
 }


### PR DESCRIPTION
Second slice of **EMR-914 — Phase 1**. The multi-channel nudge engine shipped in #565; this brings the same readiness to the patient *inside* the portal.

## What

On the patient dashboard, when their **next appointment** still has blocking intake items outstanding, a "Get ready for your visit" banner appears with a progress bar and a tappable checklist of exactly what's missing — each item **deep-linked via the gate's own `resolveHref`**. It renders **nothing** when there's no upcoming visit or the patient is already ready (no "all done" noise).

## How it reuses the canonical SoT

- **Enriched `getAppointmentReadiness`** to also return `missingRequirements` (`id` + `label` + the gate's `resolveHref`). The "where do I fix this" mapping therefore lives in **one place** (the gate), not duplicated in the UI.
- Added pure `missingBlockingRequirements(snapshot)` and a patient-scoped `getNextAppointmentReadinessForPatient(patientId)` that mirrors the nudge engine's appointment scope, so the banner and the SMS/email nudges agree on "next visit."
- Labels stay **off** the PHI-free `PrevisitReadiness` summary, so they never ride into nudge routing or audit metadata. The banner itself is behind portal login showing the patient their own items.
- Pure view-model (`buildPrevisitBannerView` / `describeWhen`, UTC calendar-day countdown) is unit-tested; the server component is a thin renderer using the portal's existing `Card` + progress-bar idiom.

## Tests

+9: missing-requirement mapping (label + `resolveHref`, and advisory items correctly excluded) and banner show/hide + countdown framing. Full scheduling + lobby-scope suites green (135), `tsc` + eslint clean. The additive `AppointmentReadiness` field doesn't disturb the nudge engine.

## Next

Slice 3 — clinician dashboard "upcoming visits with missing info" (the same SoT, staff side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)