### PR TITLE
feat(clinic): "Upcoming visits with missing info" widget (EMR-914 slice 3)

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -32,6 +32,7 @@ import {
   URGENCY_TAG_CONFIG,
 } from "@/lib/domain/queue-urgency";
 import { QueueRailClient, type QueueRailCard } from "./queue-rail-client";
+import { UpcomingVisitsMissingInfo } from "./upcoming-visits-missing-info";
 
 // EMR-205: guard the mission-control fan-out so a single hung query
 // can never wedge the Suspense boundary and strand clinicians on the
@@ -1120,6 +1121,9 @@ export default async function ClinicHomePage() {
               )}
             </CardContent>
           </Card>
+
+          {/* Upcoming visits still missing intake (EMR-914) */}
+          <UpcomingVisitsMissingInfo organizationId={organizationId} />
 
           {/* Research shortcut */}
           {showQuickResearch && (

--- a/src/app/(clinician)/clinic/upcoming-readiness.test.ts
+++ b/src/app/(clinician)/clinic/upcoming-readiness.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildUpcomingMissingRows,
+  whenLabel,
+  type UpcomingReadinessItem,
+} from "./upcoming-readiness";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+function item(over: Partial<UpcomingReadinessItem> = {}): UpcomingReadinessItem {
+  return {
+    appointmentId: "appt_1",
+    patientId: "pat_1",
+    firstName: "Maya",
+    lastName: "Singh",
+    startAt: new Date("2026-06-04T16:00:00.000Z"), // 3 days out
+    readiness: { isReady: false, missingRequiredIds: ["consent"], outstandingRequiredCount: 1, completionPct: 0.75 },
+    missingRequirements: [{ id: "consent", label: "Visit consent", href: "/patient/consents" }],
+    ...over,
+  };
+}
+
+describe("buildUpcomingMissingRows", () => {
+  it("excludes ready patients and those with nothing outstanding", () => {
+    const rows = buildUpcomingMissingRows(
+      [
+        item({ appointmentId: "ready", readiness: { isReady: true, missingRequiredIds: [], outstandingRequiredCount: 0, completionPct: 1 } }),
+        item({ appointmentId: "empty", missingRequirements: [] }),
+        item({ appointmentId: "keep" }),
+      ],
+      NOW,
+    );
+    expect(rows.map((r) => r.appointmentId)).toEqual(["keep"]);
+  });
+
+  it("orders soonest-first and shapes the row (name, when, labels, pct)", () => {
+    const rows = buildUpcomingMissingRows(
+      [
+        item({ appointmentId: "later", startAt: new Date("2026-06-08T10:00:00Z") }),
+        item({
+          appointmentId: "sooner",
+          startAt: new Date("2026-06-02T10:00:00Z"),
+          firstName: "Ada",
+          lastName: "Lovelace",
+          missingRequirements: [
+            { id: "consent", label: "Visit consent", href: "/patient/consents" },
+            { id: "presenting_concerns", label: "Reason for this visit", href: "/patient/intake/concerns" },
+          ],
+          readiness: { isReady: false, missingRequiredIds: ["consent", "presenting_concerns"], outstandingRequiredCount: 2, completionPct: 0.5 },
+        }),
+      ],
+      NOW,
+    );
+    expect(rows.map((r) => r.appointmentId)).toEqual(["sooner", "later"]);
+    expect(rows[0]).toMatchObject({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      whenLabel: "tomorrow",
+      missingLabels: ["Visit consent", "Reason for this visit"],
+      outstandingCount: 2,
+      completionPct: 50,
+    });
+  });
+
+  it("caps the number of rows", () => {
+    const many = Array.from({ length: 20 }, (_, i) =>
+      item({ appointmentId: `a${i}`, startAt: new Date(NOW.getTime() + (i + 1) * 3600_000) }),
+    );
+    expect(buildUpcomingMissingRows(many, NOW, 8)).toHaveLength(8);
+  });
+});
+
+describe("whenLabel", () => {
+  it("frames today / tomorrow / multi-day by UTC calendar day", () => {
+    expect(whenLabel(new Date("2026-06-01T20:00:00Z"), NOW)).toBe("today");
+    expect(whenLabel(new Date("2026-06-02T08:00:00Z"), NOW)).toBe("tomorrow");
+    expect(whenLabel(new Date("2026-06-06T08:00:00Z"), NOW)).toBe("in 5 days");
+  });
+});

--- a/src/app/(clinician)/clinic/upcoming-readiness.ts
+++ b/src/app/(clinician)/clinic/upcoming-readiness.ts
@@ -1,0 +1,127 @@
+// EMR-914 — clinician-facing "upcoming visits with missing info".
+//
+// Reads the CANONICAL readiness SoT (getAppointmentReadiness) for each upcoming
+// org appointment and surfaces the ones still missing blocking intake items, so
+// front-desk / clinicians can chase them before the visit. Composition lives
+// here (not in the PHI-free SoT module) because it joins readiness with patient
+// NAMES for a staff surface.
+
+import { prisma } from "@/lib/db/prisma";
+import {
+  getAppointmentReadiness,
+  type PrevisitReadiness,
+  type MissingRequirement,
+} from "@/lib/scheduling/previsit-readiness";
+
+const DAY_MS = 24 * 60 * 60_000;
+const LOOKAHEAD_DAYS = 7;
+/** Bound the per-appointment readiness fan-out + the rendered list. */
+const MAX_APPOINTMENTS_SCANNED = 60;
+const MAX_ROWS = 8;
+
+export interface UpcomingMissingRow {
+  appointmentId: string;
+  patientId: string;
+  firstName: string;
+  lastName: string;
+  /** "today" / "tomorrow" / "in N days". */
+  whenLabel: string;
+  /** Labels of the missing blocking requirements (from the gate). */
+  missingLabels: string[];
+  outstandingCount: number;
+  /** 0..100, for a compact readiness chip. */
+  completionPct: number;
+}
+
+export interface UpcomingReadinessItem {
+  appointmentId: string;
+  patientId: string;
+  firstName: string;
+  lastName: string;
+  startAt: Date;
+  readiness: PrevisitReadiness;
+  missingRequirements: MissingRequirement[];
+}
+
+/** Countdown copy by UTC calendar day; today/past clamp to "today". */
+export function whenLabel(startAt: Date, now: Date): string {
+  const a = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const b = Date.UTC(startAt.getUTCFullYear(), startAt.getUTCMonth(), startAt.getUTCDate());
+  const days = Math.round((b - a) / DAY_MS);
+  if (days <= 0) return "today";
+  if (days === 1) return "tomorrow";
+  return `in ${days} days`;
+}
+
+/**
+ * Pure shaping: keep only not-ready appointments with outstanding items, soonest
+ * first, capped. Separated from the DB/readiness fan-out so it's unit-testable.
+ */
+export function buildUpcomingMissingRows(
+  items: UpcomingReadinessItem[],
+  now: Date,
+  limit: number = MAX_ROWS,
+): UpcomingMissingRow[] {
+  return items
+    .filter((it) => !it.readiness.isReady && it.missingRequirements.length > 0)
+    .sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+    .slice(0, limit)
+    .map((it) => ({
+      appointmentId: it.appointmentId,
+      patientId: it.patientId,
+      firstName: it.firstName,
+      lastName: it.lastName,
+      whenLabel: whenLabel(it.startAt, now),
+      missingLabels: it.missingRequirements.map((m) => m.label),
+      outstandingCount: it.readiness.outstandingRequiredCount,
+      completionPct: Math.round(it.readiness.completionPct * 100),
+    }));
+}
+
+/**
+ * Load the org's upcoming appointments (next 7 days, still open) and resolve
+ * readiness for each in parallel, returning the ones with missing blocking
+ * items. Org-scoped via patient.organizationId (Appointment has no org column).
+ */
+export async function loadUpcomingVisitsMissingInfo(
+  organizationId: string,
+  now: Date,
+): Promise<UpcomingMissingRow[]> {
+  const windowEnd = new Date(now.getTime() + LOOKAHEAD_DAYS * DAY_MS);
+
+  const appts = await prisma.appointment.findMany({
+    where: {
+      patient: { organizationId },
+      status: { in: ["requested", "confirmed"] },
+      startAt: { gt: now, lte: windowEnd },
+    },
+    orderBy: { startAt: "asc" },
+    take: MAX_APPOINTMENTS_SCANNED,
+    select: {
+      id: true,
+      startAt: true,
+      patient: { select: { id: true, firstName: true, lastName: true } },
+    },
+  });
+
+  const evaluated = await Promise.all(
+    appts.map(async (a): Promise<UpcomingReadinessItem | null> => {
+      const r = await getAppointmentReadiness(a.id, now);
+      if (!r) return null;
+      return {
+        appointmentId: a.id,
+        patientId: a.patient.id,
+        firstName: a.patient.firstName,
+        lastName: a.patient.lastName,
+        startAt: a.startAt,
+        readiness: r.readiness,
+        missingRequirements: r.missingRequirements,
+      };
+    }),
+  );
+
+  return buildUpcomingMissingRows(
+    evaluated.filter((x): x is UpcomingReadinessItem => x !== null),
+    now,
+  );
+}

--- a/src/app/(clinician)/clinic/upcoming-visits-missing-info.tsx
+++ b/src/app/(clinician)/clinic/upcoming-visits-missing-info.tsx
@@ -1,0 +1,61 @@
+// EMR-914 — clinician dashboard widget: upcoming visits still missing intake.
+// Server component; fetches its own org-scoped data. Renders the SoT-derived
+// list (who / what's missing / how soon), each row deep-linking to the patient's
+// pre-visit prepare page.
+
+import Link from "next/link";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar } from "@/components/ui/avatar";
+import { loadUpcomingVisitsMissingInfo } from "./upcoming-readiness";
+
+export async function UpcomingVisitsMissingInfo({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const rows = await loadUpcomingVisitsMissingInfo(organizationId, new Date());
+
+  return (
+    <Card tone="default">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span className="h-2 w-2 rounded-full bg-highlight" aria-hidden="true" />
+          Upcoming visits with missing info
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-sm text-text-muted py-4 text-center">
+            All upcoming visits are ready.
+          </p>
+        ) : (
+          <ul className="space-y-1 -mx-2">
+            {rows.map((row) => (
+              <li key={row.appointmentId}>
+                <Link
+                  href={`/clinic/patients/${row.patientId}/prepare`}
+                  className="flex items-start gap-3 px-3 py-2 rounded-lg hover:bg-surface-muted/50 transition-colors group"
+                >
+                  <Avatar firstName={row.firstName} lastName={row.lastName} size="sm" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-text truncate group-hover:text-accent transition-colors">
+                        {row.firstName} {row.lastName}
+                      </p>
+                      <Badge tone="warning">{row.whenLabel}</Badge>
+                    </div>
+                    <p className="text-[11px] text-text-subtle mt-0.5 truncate">
+                      {row.outstandingCount} missing · {row.missingLabels.join(" · ")}
+                    </p>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Third and final slice of **EMR-914 — Phase 1**. Engine shipped in #565, patient banner in #566; this is the staff side.

## What

On the clinician **Mission Control** dashboard, a new right-rail widget lists the org's **upcoming appointments (next 7 days) that still have blocking intake items outstanding** — patient, how soon ("today / tomorrow / in N days"), and exactly what's missing — each row deep-linking to `/clinic/patients/[id]/prepare`. Shows "All upcoming visits are ready." when the queue is clear.

## How

- **Reuses the canonical SoT** (`getAppointmentReadiness`, now carrying `missingRequirements` from #566) — so nudges, the patient banner, and this staff view all share one definition of "ready" and one source for "what's missing."
- **Org-scoped** via `patient.organizationId` (Appointment has no org column, consistent with the nudge engine).
- **Bounded + parallel**: scans ≤60 upcoming appts, fans out readiness with `Promise.all`, renders ≤8 rows — keeps the Mission Control server render cheap.
- Pure `buildUpcomingMissingRows` (filter not-ready + outstanding, soonest-first, cap) is split from the DB/readiness shell and unit-tested. Injection into `clinic/page.tsx` is a 2-line additive change (import + one render in the existing right column).

## Tests

+4 (row shaping: exclude ready/empty, soonest-first ordering, cap; countdown framing). `tsc` + eslint clean.

## EMR-914 now complete

| Slice | PR |
|---|---|
| Multi-channel nudge engine (SMS+email+in-app) | #565 ✅ |
| Patient "Get ready for your visit" banner | #566 ✅ |
| Clinician "upcoming visits with missing info" | this PR |

Deferred (tracked on EMR-914): per-org portal URL + quiet-hours windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)