### PR TITLE
feat(scheduling): Tier-3 per-patient assessment override persistence (EMR-917)

### DIFF
--- a/prisma/migrations/20260601013000_patient_assessment_override/migration.sql
+++ b/prisma/migrations/20260601013000_patient_assessment_override/migration.sql
@@ -1,0 +1,18 @@
+-- EMR-917 — Tier-3 per-patient clinician override for the Clinical Assessment
+-- Rules Engine. One override per (patient, assessment): require / skip /
+-- not_applicable. Consumed by the pure engine in assessment-rules.ts.
+CREATE TABLE IF NOT EXISTS "PatientAssessmentOverride" (
+  "id"             TEXT NOT NULL,
+  "patientId"      TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "assessmentSlug" TEXT NOT NULL,
+  "override"       TEXT NOT NULL,
+  "reason"         TEXT,
+  "setByUserId"    TEXT NOT NULL,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "PatientAssessmentOverride_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PatientAssessmentOverride_patientId_assessmentSlug_key" ON "PatientAssessmentOverride"("patientId", "assessmentSlug");
+CREATE INDEX IF NOT EXISTS "PatientAssessmentOverride_organizationId_idx" ON "PatientAssessmentOverride"("organizationId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5054,6 +5054,27 @@ model KioskLobbySubmission {
   @@index([patientId, kind])
 }
 
+// EMR-917 — Tier-3 per-patient clinician override for the Clinical Assessment
+// Rules Engine. A clinician declares, for one patient + one assessment, that it
+// is required / should be skipped / is not applicable — overriding the Tier-1
+// policy default. The pure engine (assessment-rules.ts) consumes these; this is
+// the persistence layer. Scoped to the patient's org; one override per
+// (patient, assessment).
+model PatientAssessmentOverride {
+  id             String   @id @default(cuid())
+  patientId      String
+  organizationId String
+  assessmentSlug String
+  override       String // "require" | "skip" | "not_applicable"
+  reason         String?
+  setByUserId    String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([patientId, assessmentSlug])
+  @@index([organizationId])
+}
+
 // --------------------------------------------------------------
 // EMR-107 — ChatCB AI Coach
 // --------------------------------------------------------------

--- a/src/app/(clinician)/clinic/patients/[id]/assessments/override-actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/assessments/override-actions.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  prisma: {
+    patientAssessmentOverride: { upsert: vi.fn(), deleteMany: vi.fn() },
+    auditLog: { create: vi.fn() },
+  },
+  requireUser: vi.fn(),
+  assertChartAccess: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUser() }));
+vi.mock("@/lib/rbac/permissions", () => ({ assertChartAccess: (...a: unknown[]) => hoisted.assertChartAccess(...a) }));
+
+import { setAssessmentOverride, clearAssessmentOverride } from "./override-actions";
+
+const { prisma, requireUser, assertChartAccess } = hoisted;
+
+function form(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUser.mockResolvedValue({ id: "user_1", organizationId: "org_1" });
+  assertChartAccess.mockResolvedValue({});
+  prisma.patientAssessmentOverride.upsert.mockResolvedValue({ id: "ov_1" });
+  prisma.patientAssessmentOverride.deleteMany.mockResolvedValue({ count: 1 });
+  prisma.auditLog.create.mockResolvedValue({});
+});
+
+describe("setAssessmentOverride", () => {
+  it("upserts one override per (patient, assessment) and audits it (PHI-free)", async () => {
+    const res = await setAssessmentOverride(
+      null,
+      form({ patientId: "pat_1", assessmentSlug: "phq-9", override: "require" }),
+    );
+
+    expect(res).toEqual({ ok: true });
+    expect(assertChartAccess).toHaveBeenCalledWith({ id: "user_1", organizationId: "org_1" }, "pat_1");
+
+    const upsert = prisma.patientAssessmentOverride.upsert.mock.calls[0][0];
+    expect(upsert.where).toEqual({ patientId_assessmentSlug: { patientId: "pat_1", assessmentSlug: "phq-9" } });
+    expect(upsert.create).toMatchObject({
+      patientId: "pat_1",
+      organizationId: "org_1",
+      assessmentSlug: "phq-9",
+      override: "require",
+      setByUserId: "user_1",
+    });
+
+    const audit = prisma.auditLog.create.mock.calls[0][0].data;
+    expect(audit).toMatchObject({ action: "assessment.override.set", subjectId: "pat_1", metadata: { assessmentSlug: "phq-9", override: "require" } });
+    expect(JSON.stringify(audit.metadata)).not.toMatch(/dob|1985|firstName/i);
+  });
+
+  it("rejects an unknown override value at the schema boundary", async () => {
+    const res = await setAssessmentOverride(null, form({ patientId: "pat_1", assessmentSlug: "phq-9", override: "delete" }));
+    expect(res.ok).toBe(false);
+    expect(prisma.patientAssessmentOverride.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the clinician lacks chart access — no write, no audit", async () => {
+    assertChartAccess.mockRejectedValue(new Error("FORBIDDEN"));
+    const res = await setAssessmentOverride(null, form({ patientId: "pat_x", assessmentSlug: "phq-9", override: "skip" }));
+    expect(res).toEqual({ ok: false, error: "You don't have access to this patient's chart." });
+    expect(prisma.patientAssessmentOverride.upsert).not.toHaveBeenCalled();
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearAssessmentOverride", () => {
+  it("deletes org-scoped and audits when a row was removed", async () => {
+    const res = await clearAssessmentOverride("pat_1", "phq-9");
+    expect(res).toEqual({ ok: true });
+    expect(prisma.patientAssessmentOverride.deleteMany).toHaveBeenCalledWith({
+      where: { patientId: "pat_1", assessmentSlug: "phq-9", organizationId: "org_1" },
+    });
+    expect(prisma.auditLog.create.mock.calls[0][0].data.action).toBe("assessment.override.cleared");
+  });
+
+  it("does not audit when nothing was cleared", async () => {
+    prisma.patientAssessmentOverride.deleteMany.mockResolvedValue({ count: 0 });
+    await clearAssessmentOverride("pat_1", "phq-9");
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/assessments/override-actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/assessments/override-actions.ts
@@ -1,0 +1,109 @@
+// SAFE: dead-export-allowed reason="EMR-917 Tier-3 persistence; the assessments-page override control is a later slice in the build sequence"
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { assertChartAccess } from "@/lib/rbac/permissions";
+
+// EMR-917 — clinician sets/clears a Tier-3 per-patient assessment override
+// (require / skip / not_applicable). This records clinical INTENT for one
+// patient + one assessment; the pure rules engine applies it. Authorization is
+// chart access for this patient in the clinician's org (assertChartAccess) — the
+// same bar as viewing the chart, since an override is a clinical annotation.
+
+export type OverrideResult = { ok: true } | { ok: false; error: string };
+
+const setSchema = z.object({
+  patientId: z.string().min(1),
+  assessmentSlug: z.string().min(1).max(80),
+  override: z.enum(["require", "skip", "not_applicable"]),
+  reason: z.string().max(500).optional().nullable(),
+});
+
+export async function setAssessmentOverride(
+  _prev: OverrideResult | null,
+  formData: FormData,
+): Promise<OverrideResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "No clinic affiliation on file." };
+
+  const parsed = setSchema.safeParse({
+    patientId: formData.get("patientId"),
+    assessmentSlug: formData.get("assessmentSlug"),
+    override: formData.get("override"),
+    reason: formData.get("reason") || null,
+  });
+  if (!parsed.success) return { ok: false, error: "Missing or malformed input." };
+  const { patientId, assessmentSlug, override, reason } = parsed.data;
+
+  try {
+    await assertChartAccess(user, patientId);
+  } catch {
+    return { ok: false, error: "You don't have access to this patient's chart." };
+  }
+
+  await prisma.patientAssessmentOverride.upsert({
+    where: { patientId_assessmentSlug: { patientId, assessmentSlug } },
+    update: { override, reason: reason ?? null, setByUserId: user.id, organizationId: user.organizationId },
+    create: {
+      patientId,
+      organizationId: user.organizationId,
+      assessmentSlug,
+      override,
+      reason: reason ?? null,
+      setByUserId: user.id,
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      action: "assessment.override.set",
+      subjectType: "Patient",
+      subjectId: patientId,
+      // PHI-free: the assessment slug + the declared override, no patient data.
+      metadata: { assessmentSlug, override },
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${patientId}/assessments`);
+  return { ok: true };
+}
+
+export async function clearAssessmentOverride(
+  patientId: string,
+  assessmentSlug: string,
+): Promise<OverrideResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "No clinic affiliation on file." };
+
+  try {
+    await assertChartAccess(user, patientId);
+  } catch {
+    return { ok: false, error: "You don't have access to this patient's chart." };
+  }
+
+  // Org-scoped delete so a clinician can only clear overrides in their own org.
+  const res = await prisma.patientAssessmentOverride.deleteMany({
+    where: { patientId, assessmentSlug, organizationId: user.organizationId },
+  });
+
+  if (res.count > 0) {
+    await prisma.auditLog.create({
+      data: {
+        organizationId: user.organizationId,
+        actorUserId: user.id,
+        action: "assessment.override.cleared",
+        subjectType: "Patient",
+        subjectId: patientId,
+        metadata: { assessmentSlug },
+      },
+    });
+  }
+
+  revalidatePath(`/clinic/patients/${patientId}/assessments`);
+  return { ok: true };
+}

--- a/src/lib/scheduling/assessment-overrides.test.ts
+++ b/src/lib/scheduling/assessment-overrides.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  prisma: { patientAssessmentOverride: { findMany: vi.fn() } },
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
+
+import { isAssessmentOverride, loadAssessmentOverrides } from "./assessment-overrides";
+
+const { prisma } = hoisted;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("isAssessmentOverride", () => {
+  it("accepts only the three engine override values", () => {
+    expect(isAssessmentOverride("require")).toBe(true);
+    expect(isAssessmentOverride("skip")).toBe(true);
+    expect(isAssessmentOverride("not_applicable")).toBe(true);
+    expect(isAssessmentOverride("REQUIRE")).toBe(false);
+    expect(isAssessmentOverride("")).toBe(false);
+    expect(isAssessmentOverride("delete")).toBe(false);
+  });
+});
+
+describe("loadAssessmentOverrides", () => {
+  it("maps stored rows into the engine's overrides record, org-scoped", async () => {
+    prisma.patientAssessmentOverride.findMany.mockResolvedValue([
+      { assessmentSlug: "phq-9", override: "require" },
+      { assessmentSlug: "gad-7", override: "skip" },
+    ]);
+
+    const out = await loadAssessmentOverrides("pat_1", "org_1");
+
+    expect(out).toEqual({ "phq-9": "require", "gad-7": "skip" });
+    expect(prisma.patientAssessmentOverride.findMany).toHaveBeenCalledWith({
+      where: { patientId: "pat_1", organizationId: "org_1" },
+      select: { assessmentSlug: true, override: true },
+    });
+  });
+
+  it("drops any stored value the engine doesn't understand", async () => {
+    prisma.patientAssessmentOverride.findMany.mockResolvedValue([
+      { assessmentSlug: "phq-9", override: "require" },
+      { assessmentSlug: "c-ssrs", override: "garbage" },
+    ]);
+
+    const out = await loadAssessmentOverrides("pat_1", "org_1");
+    expect(out).toEqual({ "phq-9": "require" });
+  });
+});

--- a/src/lib/scheduling/assessment-overrides.ts
+++ b/src/lib/scheduling/assessment-overrides.ts
@@ -1,0 +1,38 @@
+// SAFE: dead-export-allowed reason="EMR-917 Tier-3 persistence; the assessments-page control + readiness consumer are later slices in the build sequence"
+// EMR-917 — persistence for Tier-3 per-patient assessment overrides.
+//
+// The pure engine (assessment-rules.ts) takes overrides as an in-memory
+// `Record<assessmentSlug, AssessmentOverride>`. This module is the thin DB
+// binding that produces that record for a patient, and validates the stored
+// string against the override enum so a bad row can never widen the engine's
+// contract.
+
+import { prisma } from "@/lib/db/prisma";
+import type { AssessmentOverride } from "./assessment-rules";
+
+const OVERRIDE_VALUES: readonly AssessmentOverride[] = ["require", "skip", "not_applicable"];
+
+export function isAssessmentOverride(value: string): value is AssessmentOverride {
+  return (OVERRIDE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Load the clinician's Tier-3 overrides for a patient, as the engine's
+ * `overrides` map. Org-scoped so a session can't read across orgs. Unknown
+ * stored values are dropped (defensive — the engine only knows the three).
+ */
+export async function loadAssessmentOverrides(
+  patientId: string,
+  organizationId: string,
+): Promise<Record<string, AssessmentOverride>> {
+  const rows = await prisma.patientAssessmentOverride.findMany({
+    where: { patientId, organizationId },
+    select: { assessmentSlug: true, override: true },
+  });
+
+  const out: Record<string, AssessmentOverride> = {};
+  for (const r of rows) {
+    if (isAssessmentOverride(r.override)) out[r.assessmentSlug] = r.override;
+  }
+  return out;
+}


### PR DESCRIPTION
Step 2 of **EMR-917 — Clinical Assessment Rules Engine**. #550 shipped the pure engine (Tier-1 policy + Tier-3 application); this adds the **persistence** for Tier-3 overrides. **Ships inert** — nothing reads these yet, same as the engine.

## What

The pure `evaluateAssessmentPolicy` already applies a Tier-3 `overrides` map (`require` / `skip` / `not_applicable`), but it was always passed empty — there was no store and no setter.

- **`PatientAssessmentOverride` model** + additive migration: one override per `(patient, assessment)`, org-scoped, with `setByUserId` + `reason` for the audit trail. Migration is **hand-authored, not applied** against the shared dev DB (avoids `migrate dev` drift on a multi-actor database); it lands via the normal deploy pipeline. `prisma generate` is clean, so types compile.
- **`loadAssessmentOverrides(patientId, orgId)`** → the engine's `overrides` record; drops any stored value the engine doesn't understand (defensive — the client type can't widen the engine's contract).
- **Clinician `setAssessmentOverride` / `clearAssessmentOverride`** server actions, gated by `assertChartAccess` (an override is a clinical annotation; chart access is the right bar). Upsert keeps it single per `(patient, assessment)`; both paths write a **PHI-free** audit row (slug + override only).

## Principle

Agentic **assistance, not agentic medicine** — this records a clinician's explicit per-patient intent; it never infers policy from free text.

## Scope / next

The assessments-page UI control to set/clear an override, and the readiness consumer that loads overrides into the engine, are later slices (steps 3–4: Tier-2 AI surfacing, Tier-1 policy editor).

## Tests

+8 (loader mapping + unknown-value drop; action upsert + PHI-free audit + chart-access refusal; clear org-scoped + no-audit-when-nothing-cleared). Full assessment suite green (17), `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)