### PR TITLE
feat: implement backend release contract, tests, and UI state lockdown for AI Visit Completion

### DIFF
--- a/docs/superpowers/plans/2026-05-31-visit-completion-card-detail-confirmation.md
+++ b/docs/superpowers/plans/2026-05-31-visit-completion-card-detail-confirmation.md
@@ -1,0 +1,95 @@
+# Visit Completion Card Detail Confirmation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each AI Visit Completion card click into a trustworthy physician confirmation surface before Release Care Plan.
+
+**Architecture:** Keep the behavior local to the existing visit-completion domain and panel files. The selection model remains the source of release readiness, while the panel explains what each explicit disposition will create after physician release.
+
+**Tech Stack:** Next.js App Router, React server-action form flow, TypeScript, Vitest, Prisma-backed release action.
+
+---
+
+### Task 1: Truthful Release Payload Semantics
+
+**Files:**
+- Modify: `src/lib/domain/visit-completion-selection.test.ts`
+- Modify: `src/lib/domain/visit-completion-selection.ts`
+
+- [ ] **Step 1: Write the failing payload test**
+
+Add assertions that a releasable payload with orders, follow-up, and patient communication included reports `mode: "physician_release_v1"` and marks only drafted/routed artifacts as enabled: `patientCommunication`, `staffAssignment`, and `scheduling`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/domain/visit-completion-selection.test.ts`
+Expected: FAIL because the current payload still says `review_only_mvp` and all side effects are false.
+
+- [ ] **Step 3: Implement minimal domain change**
+
+Update `VisitCompletionReleasePayload.mode` to allow and emit `"physician_release_v1"`. Compute side-effect flags from included sections:
+- `clinical: false`
+- `billing: false`
+- `chartWrite: false`
+- `patientCommunication: true` only when `patient_message` is included
+- `staffAssignment: true` when `orders` or `follow_up` is included
+- `scheduling: true` only when `follow_up` is included
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/domain/visit-completion-selection.test.ts`
+Expected: PASS.
+
+### Task 2: Rich Card Detail Confirmation UI
+
+**Files:**
+- Modify: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx`
+- Modify: `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+- Modify: `src/lib/domain/visit-completion.ts`
+
+- [ ] **Step 1: Write the failing panel test**
+
+Assert that the card detail panel renders:
+- `What release will do`
+- a card-specific release outcome, such as back-office task creation for Suggested Orders
+- item-level source/confidence/approval metadata
+- truthful release copy saying draft messages/tasks are created only after physician release
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- 'src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx'`
+Expected: FAIL because the panel lacks the release impact block and still contains review-only copy.
+
+- [ ] **Step 3: Implement minimal UI change**
+
+Add card-specific release impact copy to the detail panel, render item metadata, and replace stale “review-only/no side effect” language with explicit safe-release language:
+- release can create tasks and drafts
+- release does not place orders, send portal messages, submit billing, book appointments, or overwrite chart data
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- 'src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx'`
+Expected: PASS.
+
+### Task 3: Verification
+
+**Files:**
+- No new implementation files.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+`npm test -- src/lib/domain/visit-completion-selection.test.ts 'src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx'`
+Expected: PASS.
+
+- [ ] **Step 2: Run broader checks**
+
+Run:
+`npm run lint`
+`npm run typecheck`
+Expected: PASS, allowing pre-existing lint warnings only.
+
+- [ ] **Step 3: Commit**
+
+Commit with:
+`git commit -m "feat: enrich visit completion card confirmation"`

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model Organization {
   payToAddress   Json? // optional override for 2010AB pay-to address when different from billingAddress
 
   memberships              Membership[]
+  visitCompletions         VisitCompletion[]
   patients                 Patient[]
   providers                Provider[]
   encounters               Encounter[]
@@ -209,6 +210,7 @@ model User {
   lastLoginAt  DateTime?
 
   memberships               Membership[]
+  releasedVisitCompletions  VisitCompletion[]           @relation("VisitCompletionReleaseUser")
   patientProfile            Patient?                    @relation("PatientUser")
   providerProfile           Provider?                   @relation("ProviderUser")
   sentMessages              Message[]                   @relation("MessageSender")
@@ -334,6 +336,7 @@ model Patient {
   updatedAt              DateTime            @updatedAt
 
   user                     User?                     @relation("PatientUser", fields: [userId], references: [id])
+  visitCompletions         VisitCompletion[]
   organization             Organization              @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   chartSummary             ChartSummary?
   encounters               Encounter[]
@@ -624,6 +627,7 @@ model Note {
 
   encounter        Encounter         @relation(fields: [encounterId], references: [id], onDelete: Cascade)
   codingSuggestion CodingSuggestion?
+  visitCompletion  VisitCompletion?
 
   @@index([encounterId, status])
   // Clinic dashboard "recently finalized notes" activity feed
@@ -641,6 +645,25 @@ model CodingSuggestion {
   generatedAt DateTime @default(now())
 
   note Note @relation(fields: [noteId], references: [id], onDelete: Cascade)
+}
+
+model VisitCompletion {
+  id              String   @id @default(cuid())
+  noteId          String   @unique
+  organizationId  String
+  patientId       String
+  releasedById    String
+  releasedAt      DateTime @default(now())
+  payload         Json
+
+  note            Note         @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  releasedBy      User         @relation("VisitCompletionReleaseUser", fields: [releasedById], references: [id])
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  patient         Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@index([noteId])
+  @@index([organizationId])
+  @@index([patientId])
 }
 
 // --------------------------------------------------------------

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1466,6 +1466,21 @@ async function main() {
     },
   });
 
+  // Kiosk
+  const kioskUser = await prisma.user.upsert({
+    where: { email: "kiosk@demo.health" },
+    update: { passwordHash },
+    create: {
+      email: "kiosk@demo.health",
+      passwordHash,
+      firstName: "Front",
+      lastName: "Desk",
+      memberships: {
+        create: { organizationId: org.id, role: Role.kiosk },
+      },
+    },
+  });
+
   // ------------------------------------------------------------------
   // Patient 1 — Maya Reyes (active, richest record)
   // ------------------------------------------------------------------
@@ -4450,6 +4465,7 @@ async function main() {
   console.log("  Patient 1: patient@demo.health (Maya)   / Longbeach2026!");
   console.log("  Patient 2: james.chen@demo.health       / Longbeach2026!");
   console.log("  Patient 3: sarah.thompson@demo.health   / Longbeach2026!");
+  console.log("  Kiosk:     kiosk@demo.health            / Longbeach2026!");
 }
 
 async function seedEducationCompounds() {

--- a/scripts/sync-clerk-seed.ts
+++ b/scripts/sync-clerk-seed.ts
@@ -21,6 +21,7 @@ async function syncClerkUsers() {
     { email: "patient@demo.health", password: "Longbeach2026!" },
     { email: "james.chen@demo.health", password: "Longbeach2026!" },
     { email: "sarah.thompson@demo.health", password: "Longbeach2026!" },
+    { email: "kiosk@demo.health", password: "Longbeach2026!" },
   ];
 
   console.log("Syncing seeded users to Clerk...");

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForbiddenError } from "@/lib/rbac/permissions";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn() },
+    note: { findUnique: vi.fn() },
+    auditLog: { create: vi.fn() },
+    visitCompletion: { findUnique: vi.fn(), create: vi.fn() },
+    task: { create: vi.fn() },
+    messageThread: { findFirst: vi.fn(), create: vi.fn() },
+    message: { create: vi.fn() },
+    $transaction: vi.fn(async (cb) => cb(mockPrisma)),
+  };
+  return { mockPrisma, requireUserMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: vi.fn() }));
+vi.mock("@/lib/orchestration/runner", () => ({ runTick: vi.fn(), runJob: vi.fn() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// Mock assertChartAccess to allow testing chart restriction gates
+vi.mock("@/lib/rbac/permissions", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/rbac/permissions")>();
+  return {
+    ...original,
+    assertChartAccess: vi.fn().mockImplementation(async (user, patientId) => {
+      if (patientId === "restricted_patient") {
+        throw new ForbiddenError({
+          reason: "chart_restricted",
+          message: "Forbidden: chart is restricted",
+        });
+      }
+    }),
+  };
+});
+
+import { releaseVisitCompletion } from "./actions";
+import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
+
+const { mockPrisma, requireUserMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    ...over,
+  };
+}
+
+function note(over: Record<string, unknown> = {}) {
+  return {
+    id: "note_1",
+    encounterId: "enc_1",
+    status: "finalized",
+    aiDrafted: false,
+    blocks: [],
+    authorUserId: "user_1",
+    encounter: { id: "enc_1", patientId: "patient_1", status: "complete" },
+    ...over,
+  };
+}
+
+function encounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "complete",
+    startedAt: new Date("2026-05-29T15:00:00.000Z"),
+    completedAt: new Date("2026-05-29T16:00:00.000Z"),
+    ...over,
+  };
+}
+
+function validPayload(over: Partial<VisitCompletionReleasePayload> = {}): VisitCompletionReleasePayload {
+  return {
+    version: "visit-completion-release/v1",
+    releaseActionLabel: "Release Care Plan",
+    mode: "review_only_mvp",
+    status: "ready_for_physician_release",
+    canRelease: true,
+    summary: {
+      totalCards: 4,
+      includedCards: 3,
+      heldOutCards: 1,
+      unresolvedCards: 0,
+    },
+    sideEffects: {
+      clinical: false,
+      billing: false,
+      patientCommunication: false,
+      scheduling: false,
+      staffAssignment: false,
+      chartWrite: false,
+    },
+    includedSections: [
+      {
+        cardId: "orders",
+        title: "Suggested Orders",
+        status: "confirmed",
+        disposition: "include",
+        labels: ["Order CBC"],
+        confirmationNote: "Approved CBC order",
+        requiresPhysicianApproval: true,
+      },
+      {
+        cardId: "follow_up",
+        title: "Follow-Up Plan",
+        status: "confirmed",
+        disposition: "include",
+        labels: ["Follow up in 2 weeks"],
+        confirmationNote: "Book follow-up",
+        requiresPhysicianApproval: true,
+      },
+      {
+        cardId: "patient_message",
+        title: "Patient Communication",
+        status: "confirmed",
+        disposition: "include",
+        labels: ["Hello, here is your care plan."],
+        confirmationNote: "Drafted patient email",
+        requiresPhysicianApproval: true,
+      },
+    ],
+    heldOutSections: [
+      {
+        cardId: "practice_readiness",
+        title: "Practice Readiness",
+        status: "deferred",
+        disposition: "hold_out",
+        labels: ["Prior auth"],
+        requiresPhysicianApproval: true,
+      },
+    ],
+    unresolvedSections: [],
+    blockingCardIds: [],
+    auditEvents: [],
+    feedbackSignals: [],
+    safetyCopy: "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.encounter.findFirst.mockResolvedValue(encounter());
+  mockPrisma.note.findUnique.mockResolvedValue(note());
+  mockPrisma.visitCompletion.findUnique.mockResolvedValue(null);
+  mockPrisma.visitCompletion.create.mockResolvedValue({ id: "vc_1" });
+  mockPrisma.task.create.mockResolvedValue({ id: "task_1" });
+  mockPrisma.messageThread.findFirst.mockResolvedValue({ id: "thread_1" });
+  mockPrisma.messageThread.create.mockResolvedValue({ id: "thread_1" });
+  mockPrisma.message.create.mockResolvedValue({ id: "msg_1" });
+  mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+});
+
+describe("releaseVisitCompletion server action", () => {
+  it("successfully releases a completion payload and creates EMR side effects", async () => {
+    const payload = validPayload();
+    const result = await releaseVisitCompletion("note_1", payload);
+
+    expect(result).toEqual({ ok: true });
+
+    // 1. Verify VisitCompletion record is created
+    expect(mockPrisma.visitCompletion.create).toHaveBeenCalledWith({
+      data: {
+        noteId: "note_1",
+        organizationId: "org_1",
+        patientId: "patient_1",
+        releasedById: "user_1",
+        payload: payload,
+      },
+    });
+
+    // 2. Verify back-office task is created for orders
+    expect(mockPrisma.task.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: "org_1",
+        patientId: "patient_1",
+        title: "Orders: Order CBC",
+        description: "Suggested orders released by physician.\n\nNote: Approved CBC order",
+        status: "open",
+        assigneeRole: "back_office",
+      },
+    });
+
+    // 3. Verify front-office task is created for follow-up
+    expect(mockPrisma.task.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: "org_1",
+        patientId: "patient_1",
+        title: "Follow-Up: Follow up in 2 weeks",
+        description: "Follow-up plan released by physician.\n\nNote: Book follow-up",
+        status: "open",
+        assigneeRole: "front_office",
+      },
+    });
+
+    // 4. Verify draft patient message is created in the latest thread
+    expect(mockPrisma.messageThread.findFirst).toHaveBeenCalledWith({
+      where: { patientId: "patient_1" },
+      orderBy: { lastMessageAt: "desc" },
+    });
+    expect(mockPrisma.message.create).toHaveBeenCalledWith({
+      data: {
+        threadId: "thread_1",
+        senderUserId: "user_1",
+        status: "draft",
+        body: "Drafted patient email",
+        aiDrafted: true,
+        sentAt: null,
+      },
+    });
+
+    // 5. Verify audit log entry with minimized metadata (no patient PHI)
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: "org_1",
+        actorUserId: "user_1",
+        action: "visit_completion.released",
+        subjectType: "VisitCompletion",
+        subjectId: "note_1",
+        metadata: {
+          totalCards: 4,
+          includedCards: 3,
+          heldOutCards: 1,
+          version: "visit-completion-release/v1",
+        },
+      },
+    });
+  });
+
+  it("provisions a new message thread if the patient has no existing thread", async () => {
+    mockPrisma.messageThread.findFirst.mockResolvedValue(null);
+
+    const payload = validPayload();
+    const result = await releaseVisitCompletion("note_1", payload);
+
+    expect(result).toEqual({ ok: true });
+
+    expect(mockPrisma.messageThread.create).toHaveBeenCalledWith({
+      data: {
+        patientId: "patient_1",
+        subject: "Care Plan & Next Steps",
+        lastMessageAt: expect.any(Date),
+      },
+    });
+    expect(mockPrisma.message.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        threadId: "thread_1",
+        status: "draft",
+      }),
+    });
+  });
+
+  it("fails if the user lacks notes.edit permission", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "Forbidden: read-only access to notes" });
+    expect(mockPrisma.visitCompletion.create).not.toHaveBeenCalled();
+  });
+
+  it("fails if the note does not exist", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(null);
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "Note not found" });
+  });
+
+  it("fails if the note is not finalized", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "draft" }));
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "This note is not finalized and cannot be completed." });
+  });
+
+  it("fails if the patient chart is restricted and user is not allowed", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ encounter: { id: "enc_1", patientId: "restricted_patient", status: "complete" } })
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(
+      encounter({ patientId: "restricted_patient" })
+    );
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "Forbidden: chart is restricted" });
+  });
+
+  it("fails if payload.canRelease is false", async () => {
+    const payload = validPayload({ canRelease: false });
+    const result = await releaseVisitCompletion("note_1", payload);
+
+    expect(result).toEqual({ ok: false, error: "Release is blocked; unresolved sections remain." });
+  });
+
+  it("fails if a visit completion has already been released (idempotency)", async () => {
+    mockPrisma.visitCompletion.findUnique.mockResolvedValue({ id: "existing_vc" });
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "Visit completion has already been released." });
+    expect(mockPrisma.visitCompletion.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -103,7 +103,7 @@ function validPayload(over: Partial<VisitCompletionReleasePayload> = {}): VisitC
   return {
     version: "visit-completion-release/v1",
     releaseActionLabel: "Release Care Plan",
-    mode: "review_only_mvp",
+    mode: "physician_release_v1",
     status: "ready_for_physician_release",
     canRelease: true,
     summary: {
@@ -115,9 +115,9 @@ function validPayload(over: Partial<VisitCompletionReleasePayload> = {}): VisitC
     sideEffects: {
       clinical: false,
       billing: false,
-      patientCommunication: false,
-      scheduling: false,
-      staffAssignment: false,
+      patientCommunication: true,
+      scheduling: true,
+      staffAssignment: true,
       chartWrite: false,
     },
     includedSections: [

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -335,4 +335,19 @@ describe("releaseVisitCompletion server action", () => {
     expect(result).toEqual({ ok: false, error: "Visit completion has already been released." });
     expect(mockPrisma.visitCompletion.create).not.toHaveBeenCalled();
   });
+
+  it("handles a duplicate release race without creating downstream side effects", async () => {
+    mockPrisma.visitCompletion.findUnique.mockResolvedValue(null);
+    mockPrisma.visitCompletion.create.mockRejectedValue({
+      code: "P2002",
+      message: "Unique constraint failed on the fields: (`noteId`)",
+    });
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: false, error: "Visit completion has already been released." });
+    expect(mockPrisma.task.create).not.toHaveBeenCalled();
+    expect(mockPrisma.message.create).not.toHaveBeenCalled();
+    expect(mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -13,7 +13,7 @@ const hoisted = vi.hoisted(() => {
     message: { create: vi.fn() },
     $transaction: vi.fn(async (cb) => cb(mockPrisma)),
   };
-  return { mockPrisma, requireUserMock: vi.fn() };
+  return { mockPrisma, requireUserMock: vi.fn(), recordFeedbackMock: vi.fn() };
 });
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -27,6 +27,9 @@ vi.mock("@/lib/orchestration/model-client", () => ({
 }));
 vi.mock("@/lib/observability/log", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/lib/agents/memory/agent-feedback", () => ({
+  recordFeedback: hoisted.recordFeedbackMock,
 }));
 
 // Mock assertChartAccess to allow testing chart restriction gates
@@ -48,7 +51,7 @@ vi.mock("@/lib/rbac/permissions", async (importOriginal) => {
 import { releaseVisitCompletion } from "./actions";
 import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
 
-const { mockPrisma, requireUserMock } = hoisted;
+const { mockPrisma, requireUserMock, recordFeedbackMock } = hoisted;
 
 function clinician(over: Record<string, unknown> = {}) {
   return {
@@ -181,6 +184,7 @@ beforeEach(() => {
   mockPrisma.messageThread.create.mockResolvedValue({ id: "thread_1" });
   mockPrisma.message.create.mockResolvedValue({ id: "msg_1" });
   mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  recordFeedbackMock.mockResolvedValue({ id: "feedback_1" });
 });
 
 describe("releaseVisitCompletion server action", () => {
@@ -349,5 +353,71 @@ describe("releaseVisitCompletion server action", () => {
     expect(mockPrisma.task.create).not.toHaveBeenCalled();
     expect(mockPrisma.message.create).not.toHaveBeenCalled();
     expect(mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("records visit-completion feedback signals after a successful release", async () => {
+    const payload = validPayload({
+      feedbackSignals: [
+        {
+          cardId: "orders",
+          feedbackAction: "approved",
+          meaning: "Physician kept the suggested orders.",
+        },
+        {
+          cardId: "patient_message",
+          feedbackAction: "approved_with_edits",
+          meaning: "Physician edited the patient communication.",
+        },
+        {
+          cardId: "practice_readiness",
+          feedbackAction: "dismissed",
+          meaning: "Physician deferred practice readiness.",
+        },
+      ],
+    });
+
+    const result = await releaseVisitCompletion("note_1", payload);
+
+    expect(result).toEqual({ ok: true });
+    expect(recordFeedbackMock).toHaveBeenCalledTimes(3);
+    expect(recordFeedbackMock).toHaveBeenCalledWith({
+      agentName: "visitCompletion",
+      agentVersion: "1.0.0",
+      organizationId: "org_1",
+      noteId: "note_1",
+      action: "approved",
+      reviewerId: "user_1",
+      reviewerNote: "Suggested Orders: Physician kept the suggested orders.",
+      editDelta: null,
+    });
+    expect(recordFeedbackMock).toHaveBeenCalledWith({
+      agentName: "visitCompletion",
+      agentVersion: "1.0.0",
+      organizationId: "org_1",
+      noteId: "note_1",
+      action: "approved_with_edits",
+      reviewerId: "user_1",
+      reviewerNote: "Patient Communication: Physician edited the patient communication.",
+      editDelta: "Drafted patient email",
+    });
+  });
+
+  it("does not fail the care-plan release if feedback persistence fails", async () => {
+    recordFeedbackMock.mockRejectedValue(new Error("feedback store unavailable"));
+
+    const payload = validPayload({
+      feedbackSignals: [
+        {
+          cardId: "orders",
+          feedbackAction: "approved",
+          meaning: "Physician kept the suggested orders.",
+        },
+      ],
+    });
+
+    const result = await releaseVisitCompletion("note_1", payload);
+
+    expect(result).toEqual({ ok: true });
+    expect(mockPrisma.visitCompletion.create).toHaveBeenCalled();
   });
 });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -31,6 +31,7 @@ import {
   type PatientDemeanor,
 } from "@/lib/domain/notes";
 import { advanceVisitState } from "@/lib/domain/visit-state";
+import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
 
 const blockSchema = z.object({
   heading: z.string(),
@@ -680,4 +681,155 @@ Return ONLY the refined text — no JSON, no markdown, no explanation. Just the 
       code: "unknown",
     };
   }
+}
+
+export async function releaseVisitCompletion(
+  noteId: string,
+  payload: VisitCompletionReleasePayload,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser();
+
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: read-only access to notes" };
+  }
+
+  const note = await prisma.note.findUnique({
+    where: { id: noteId },
+    include: { encounter: true },
+  });
+  if (!note) return { ok: false, error: "Note not found" };
+
+  if (note.status !== "finalized") {
+    return { ok: false, error: "This note is not finalized and cannot be completed." };
+  }
+
+  // Verify org access
+  const encounter = await prisma.encounter.findFirst({
+    where: {
+      id: note.encounterId,
+      organizationId: user.organizationId!,
+    },
+  });
+  if (!encounter) return { ok: false, error: "Unauthorized" };
+
+  // Chart privacy gate
+  try {
+    await assertChartAccess(user, encounter.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Forbidden: chart is restricted" };
+    }
+    throw err;
+  }
+
+  if (!payload.canRelease) {
+    return { ok: false, error: "Release is blocked; unresolved sections remain." };
+  }
+
+  // Idempotency: verify no existing release
+  const existing = await prisma.visitCompletion.findUnique({
+    where: { noteId },
+  });
+  if (existing) {
+    return { ok: false, error: "Visit completion has already been released." };
+  }
+
+  // Run the release inside a transaction to ensure all side-effects and DB entries land atomically
+  await prisma.$transaction(async (tx) => {
+    // 1. Create the VisitCompletion record
+    await tx.visitCompletion.create({
+      data: {
+        noteId,
+        organizationId: user.organizationId!,
+        patientId: encounter.patientId,
+        releasedById: user.id,
+        payload: payload as any,
+      },
+    });
+
+    // 2. Suggested Orders: Create a Task for the back-office order queue
+    const ordersSection = payload.includedSections.find((s) => s.cardId === "orders");
+    if (ordersSection && ordersSection.labels.length > 0) {
+      await tx.task.create({
+        data: {
+          organizationId: user.organizationId!,
+          patientId: encounter.patientId,
+          title: `Orders: ${ordersSection.labels.join(", ")}`,
+          description: `Suggested orders released by physician.\n\nNote: ${
+            ordersSection.editNote || ordersSection.confirmationNote || "Approved"
+          }`,
+          status: "open",
+          assigneeRole: "back_office",
+        },
+      });
+    }
+
+    // 3. Follow-Up Plan: Create a Task for front-office scheduling
+    const followUpSection = payload.includedSections.find((s) => s.cardId === "follow_up");
+    if (followUpSection && followUpSection.labels.length > 0) {
+      await tx.task.create({
+        data: {
+          organizationId: user.organizationId!,
+          patientId: encounter.patientId,
+          title: `Follow-Up: ${followUpSection.labels.join(", ")}`,
+          description: `Follow-up plan released by physician.\n\nNote: ${
+            followUpSection.editNote || followUpSection.confirmationNote || "Approved"
+          }`,
+          status: "open",
+          assigneeRole: "front_office",
+        },
+      });
+    }
+
+    // 4. Patient Communication: Create a draft Message to the patient
+    const commsSection = payload.includedSections.find((s) => s.cardId === "patient_message");
+    if (commsSection && commsSection.labels.length > 0) {
+      const thread = await tx.messageThread.findFirst({
+        where: { patientId: encounter.patientId },
+        orderBy: { lastMessageAt: "desc" },
+      });
+      const threadId =
+        thread?.id ??
+        (
+          await tx.messageThread.create({
+            data: {
+              patientId: encounter.patientId,
+              subject: "Care Plan & Next Steps",
+              lastMessageAt: new Date(),
+            },
+          })
+        ).id;
+
+      await tx.message.create({
+        data: {
+          threadId,
+          senderUserId: user.id,
+          status: "draft",
+          body: commsSection.editNote || commsSection.confirmationNote || commsSection.labels.join("\n"),
+          aiDrafted: true,
+          sentAt: null,
+        },
+      });
+    }
+
+    // 5. Create audit log entry (minimize PHI)
+    await tx.auditLog.create({
+      data: {
+        organizationId: user.organizationId!,
+        actorUserId: user.id,
+        action: "visit_completion.released",
+        subjectType: "VisitCompletion",
+        subjectId: noteId,
+        metadata: {
+          totalCards: payload.summary.totalCards,
+          includedCards: payload.summary.includedCards,
+          heldOutCards: payload.summary.heldOutCards,
+          version: payload.version,
+        } as any,
+      },
+    });
+  });
+
+  revalidatePath(`/clinic/patients/${encounter.patientId}`);
+  return { ok: true };
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -734,102 +734,124 @@ export async function releaseVisitCompletion(
     return { ok: false, error: "Visit completion has already been released." };
   }
 
-  // Run the release inside a transaction to ensure all side-effects and DB entries land atomically
-  await prisma.$transaction(async (tx) => {
-    // 1. Create the VisitCompletion record
-    await tx.visitCompletion.create({
-      data: {
-        noteId,
-        organizationId: user.organizationId!,
-        patientId: encounter.patientId,
-        releasedById: user.id,
-        payload: payload as any,
-      },
-    });
-
-    // 2. Suggested Orders: Create a Task for the back-office order queue
-    const ordersSection = payload.includedSections.find((s) => s.cardId === "orders");
-    if (ordersSection && ordersSection.labels.length > 0) {
-      await tx.task.create({
+  try {
+    // Run the release inside a transaction to ensure all side-effects and DB entries land atomically.
+    // The VisitCompletion unique noteId insert is intentionally first, so a concurrent release
+    // attempt fails before tasks, messages, or audit rows are created.
+    await prisma.$transaction(async (tx) => {
+      // 1. Create the VisitCompletion record
+      await tx.visitCompletion.create({
         data: {
+          noteId,
           organizationId: user.organizationId!,
           patientId: encounter.patientId,
-          title: `Orders: ${ordersSection.labels.join(", ")}`,
-          description: `Suggested orders released by physician.\n\nNote: ${
-            ordersSection.editNote || ordersSection.confirmationNote || "Approved"
-          }`,
-          status: "open",
-          assigneeRole: "back_office",
+          releasedById: user.id,
+          payload: payload as any,
         },
       });
-    }
 
-    // 3. Follow-Up Plan: Create a Task for front-office scheduling
-    const followUpSection = payload.includedSections.find((s) => s.cardId === "follow_up");
-    if (followUpSection && followUpSection.labels.length > 0) {
-      await tx.task.create({
+      // 2. Suggested Orders: Create a Task for the back-office order queue
+      const ordersSection = payload.includedSections.find((s) => s.cardId === "orders");
+      if (ordersSection && ordersSection.labels.length > 0) {
+        await tx.task.create({
+          data: {
+            organizationId: user.organizationId!,
+            patientId: encounter.patientId,
+            title: `Orders: ${ordersSection.labels.join(", ")}`,
+            description: `Suggested orders released by physician.\n\nNote: ${
+              ordersSection.editNote || ordersSection.confirmationNote || "Approved"
+            }`,
+            status: "open",
+            assigneeRole: "back_office",
+          },
+        });
+      }
+
+      // 3. Follow-Up Plan: Create a Task for front-office scheduling
+      const followUpSection = payload.includedSections.find((s) => s.cardId === "follow_up");
+      if (followUpSection && followUpSection.labels.length > 0) {
+        await tx.task.create({
+          data: {
+            organizationId: user.organizationId!,
+            patientId: encounter.patientId,
+            title: `Follow-Up: ${followUpSection.labels.join(", ")}`,
+            description: `Follow-up plan released by physician.\n\nNote: ${
+              followUpSection.editNote || followUpSection.confirmationNote || "Approved"
+            }`,
+            status: "open",
+            assigneeRole: "front_office",
+          },
+        });
+      }
+
+      // 4. Patient Communication: Create a draft Message to the patient
+      const commsSection = payload.includedSections.find((s) => s.cardId === "patient_message");
+      if (commsSection && commsSection.labels.length > 0) {
+        const thread = await tx.messageThread.findFirst({
+          where: { patientId: encounter.patientId },
+          orderBy: { lastMessageAt: "desc" },
+        });
+        const threadId =
+          thread?.id ??
+          (
+            await tx.messageThread.create({
+              data: {
+                patientId: encounter.patientId,
+                subject: "Care Plan & Next Steps",
+                lastMessageAt: new Date(),
+              },
+            })
+          ).id;
+
+        await tx.message.create({
+          data: {
+            threadId,
+            senderUserId: user.id,
+            status: "draft",
+            body:
+              commsSection.editNote ||
+              commsSection.confirmationNote ||
+              commsSection.labels.join("\n"),
+            aiDrafted: true,
+            sentAt: null,
+          },
+        });
+      }
+
+      // 5. Create audit log entry (minimize PHI)
+      await tx.auditLog.create({
         data: {
           organizationId: user.organizationId!,
-          patientId: encounter.patientId,
-          title: `Follow-Up: ${followUpSection.labels.join(", ")}`,
-          description: `Follow-up plan released by physician.\n\nNote: ${
-            followUpSection.editNote || followUpSection.confirmationNote || "Approved"
-          }`,
-          status: "open",
-          assigneeRole: "front_office",
+          actorUserId: user.id,
+          action: "visit_completion.released",
+          subjectType: "VisitCompletion",
+          subjectId: noteId,
+          metadata: {
+            totalCards: payload.summary.totalCards,
+            includedCards: payload.summary.includedCards,
+            heldOutCards: payload.summary.heldOutCards,
+            version: payload.version,
+          } as any,
         },
       });
-    }
-
-    // 4. Patient Communication: Create a draft Message to the patient
-    const commsSection = payload.includedSections.find((s) => s.cardId === "patient_message");
-    if (commsSection && commsSection.labels.length > 0) {
-      const thread = await tx.messageThread.findFirst({
-        where: { patientId: encounter.patientId },
-        orderBy: { lastMessageAt: "desc" },
-      });
-      const threadId =
-        thread?.id ??
-        (
-          await tx.messageThread.create({
-            data: {
-              patientId: encounter.patientId,
-              subject: "Care Plan & Next Steps",
-              lastMessageAt: new Date(),
-            },
-          })
-        ).id;
-
-      await tx.message.create({
-        data: {
-          threadId,
-          senderUserId: user.id,
-          status: "draft",
-          body: commsSection.editNote || commsSection.confirmationNote || commsSection.labels.join("\n"),
-          aiDrafted: true,
-          sentAt: null,
-        },
-      });
-    }
-
-    // 5. Create audit log entry (minimize PHI)
-    await tx.auditLog.create({
-      data: {
-        organizationId: user.organizationId!,
-        actorUserId: user.id,
-        action: "visit_completion.released",
-        subjectType: "VisitCompletion",
-        subjectId: noteId,
-        metadata: {
-          totalCards: payload.summary.totalCards,
-          includedCards: payload.summary.includedCards,
-          heldOutCards: payload.summary.heldOutCards,
-          version: payload.version,
-        } as any,
-      },
     });
-  });
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      return { ok: false, error: "Visit completion has already been released." };
+    }
+    throw err;
+  }
 
   revalidatePath(`/clinic/patients/${encounter.patientId}`);
   return { ok: true };
+}
+
+function isUniqueConstraintError(err: unknown): boolean {
+  const code = typeof err === "object" && err !== null && "code" in err ? (err as any).code : null;
+  const message =
+    typeof err === "object" && err !== null && "message" in err
+      ? String((err as any).message)
+      : "";
+
+  return code === "P2002" || message.includes("Unique constraint");
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 import { freezeNoteSnapshot } from "@/lib/agents/guardrails/note-guardrails";
 import { ensureConsentDisclaimerBlock } from "@/lib/clinical/ai-consent-disclaimer";
 import { logger } from "@/lib/observability/log";
+import { recordFeedback } from "@/lib/agents/memory/agent-feedback";
 import {
   PATIENT_DEMEANOR_OPTIONS,
   type PatientDemeanor,
@@ -842,8 +843,67 @@ export async function releaseVisitCompletion(
     throw err;
   }
 
+  await recordVisitCompletionFeedback({
+    payload,
+    noteId,
+    organizationId: user.organizationId!,
+    reviewerId: user.id,
+  });
+
   revalidatePath(`/clinic/patients/${encounter.patientId}`);
   return { ok: true };
+}
+
+async function recordVisitCompletionFeedback({
+  payload,
+  noteId,
+  organizationId,
+  reviewerId,
+}: {
+  payload: VisitCompletionReleasePayload;
+  noteId: string;
+  organizationId: string;
+  reviewerId: string;
+}): Promise<void> {
+  if (payload.feedbackSignals.length === 0) {
+    return;
+  }
+
+  const sections = [
+    ...payload.includedSections,
+    ...payload.heldOutSections,
+    ...payload.unresolvedSections,
+  ];
+
+  const settled = await Promise.allSettled(
+    payload.feedbackSignals.map((signal) => {
+      const section = sections.find((candidate) => candidate.cardId === signal.cardId);
+
+      return recordFeedback({
+        agentName: "visitCompletion",
+        agentVersion: "1.0.0",
+        organizationId,
+        noteId,
+        action: signal.feedbackAction,
+        reviewerId,
+        reviewerNote: section
+          ? `${section.title}: ${signal.meaning}`
+          : signal.meaning,
+        editDelta:
+          signal.feedbackAction === "approved_with_edits"
+            ? section?.editNote ?? section?.confirmationNote ?? null
+            : null,
+      });
+    }),
+  );
+
+  if (settled.some((result) => result.status === "rejected")) {
+    logger.warn({
+      event: "visit_completion.feedback.persist_failed",
+      noteId,
+      failedCount: settled.filter((result) => result.status === "rejected").length,
+    });
+  }
 }
 
 function isUniqueConstraintError(err: unknown): boolean {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -67,6 +67,7 @@ interface NoteEditorProps {
     rationale: string | null;
   } | null;
   initialDemeanor?: PatientDemeanor | null;
+  releasedPayload?: any;
 }
 
 const REFINE_OPTIONS: { mode: RefineMode; label: string; icon: string }[] = [
@@ -113,6 +114,7 @@ export function NoteEditor({
   hallucinationConfidence,
   codingSuggestion,
   initialDemeanor,
+  releasedPayload,
 }: NoteEditorProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -716,7 +718,13 @@ export function NoteEditor({
         </Card>
       )}
 
-      {visitCompletionBundle && <VisitCompletionPanel bundle={visitCompletionBundle} />}
+      {visitCompletionBundle && (
+        <VisitCompletionPanel
+          bundle={visitCompletionBundle}
+          releasedPayload={releasedPayload}
+          noteId={noteId}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft, Printer } from "lucide-react";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
@@ -167,10 +168,20 @@ export default async function NoteDetailPage({ params }: PageProps) {
               target="_blank"
               rel="noopener"
             >
-              <Button variant="ghost">Print note</Button>
+              <Button
+                variant="ghost"
+                leadingIcon={<Printer className="h-4 w-4" />}
+              >
+                Print note
+              </Button>
             </Link>
             <Link href={`/clinic/patients/${params.id}?tab=notes`}>
-              <Button variant="secondary">Back to chart</Button>
+              <Button
+                variant="secondary"
+                leadingIcon={<ArrowLeft className="h-4 w-4" />}
+              >
+                Back to chart
+              </Button>
             </Link>
           </div>
         }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -36,6 +36,7 @@ export default async function NoteDetailPage({ params }: PageProps) {
         },
       },
       codingSuggestion: true,
+      visitCompletion: true,
     },
   });
 
@@ -149,7 +150,9 @@ export default async function NoteDetailPage({ params }: PageProps) {
           hasFutureAppointment: Boolean(futureAppointment),
         })
       : null;
-
+  const releasedPayload = note.visitCompletion
+    ? (note.visitCompletion.payload as any)
+    : null;
   return (
     <PageShell maxWidth="max-w-[900px]">
       <PageHeader
@@ -194,6 +197,7 @@ export default async function NoteDetailPage({ params }: PageProps) {
               ? ((note.encounter.briefingContext as Record<string, unknown>).patientDemeanor as any)
               : null
           }
+          releasedPayload={releasedPayload}
         />
       ) : canDocObjective ? (
         <StaffObjectiveEditor
@@ -210,7 +214,11 @@ export default async function NoteDetailPage({ params }: PageProps) {
       )}
 
       {!canEditNotes && visitCompletionBundle && (
-        <VisitCompletionPanel bundle={visitCompletionBundle} />
+        <VisitCompletionPanel
+          bundle={visitCompletionBundle}
+          releasedPayload={releasedPayload}
+          noteId={note.id}
+        />
       )}
 
       {/* ux/comments-mentions-collab — inline collaboration on chart notes */}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -26,7 +26,7 @@ describe("VisitCompletionPanel", () => {
       },
     });
 
-    const str = dump(VisitCompletionPanel({ bundle }));
+    const str = dump(<VisitCompletionPanel bundle={bundle} />);
 
     expect(str).toContain("AI Visit Completion");
     expect(str).toContain("Suggested Next Best Actions");
@@ -46,7 +46,14 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Create staff tasks");
     expect(str).toContain("Review selected actions");
     expect(str).toContain("Release is staged for review only in this MVP.");
+    expect(str).toContain("No actions have been released.");
+    expect(str).toContain("Selected for release");
+    expect(str).toContain("Open release review");
+    expect(str).toContain(
+      "Review-only; no order, message, billing, scheduling, staff task, or chart write is sent.",
+    );
     expect(str).toContain("Physician remains in control.");
     expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+    expect(str).not.toContain("disabled=\"\"");
   });
 });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
-import { VisitCompletionPanel } from "./visit-completion-panel";
+import {
+  VisitCompletionDetailsDrawer,
+  VisitCompletionPanel,
+} from "./visit-completion-panel";
 import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
 
 vi.mock("next/navigation", () => ({
@@ -71,17 +74,9 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("0 of 4 cards resolved");
     expect(str).toContain("Confirmation required before release.");
     expect(str).toContain("Click in to confirm");
-    expect(str).toContain("Confirm this card");
     expect(str).toContain("Open details");
     expect(str).toContain("aria-label=\"Open Suggested Orders details\"");
     expect(str).toContain("tabindex=\"0\"");
-    expect(str).toContain("What release will do");
-    expect(str).toContain("Creates a back-office task with reviewed order suggestions.");
-    expect(str).toContain("Does not place clinical orders automatically.");
-    expect(str).toContain("Item evidence");
-    expect(str).toContain("Source: heuristic");
-    expect(str).toContain("Confidence 72%");
-    expect(str).toContain("Physician approval required");
     expect(str).toContain("Final release review");
     expect(str).toContain("Structured release payload");
     expect(str).toContain("Preview release payload");
@@ -101,6 +96,50 @@ describe("VisitCompletionPanel", () => {
     );
     // The Release Care Plan button should be disabled because not all cards are resolved
     expect(str).toContain("disabled");
+  });
+
+  it("renders card details in a right-side drawer surface", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      hasFutureAppointment: false,
+      blocks: [
+        {
+          heading: "Plan",
+          body: "Return to clinic in 6 weeks after medication adjustment.",
+        },
+      ],
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "G89.29", label: "Chronic pain", confidence: 0.88 }],
+      },
+    });
+
+    const str = dump(
+      <VisitCompletionDetailsDrawer
+        card={bundle.cards[0]}
+        cardState={{ status: "selected" }}
+        onClose={() => undefined}
+        onConfirm={() => undefined}
+        onEdit={() => undefined}
+        onRemove={() => undefined}
+        onDefer={() => undefined}
+        isReleased={false}
+      />,
+    );
+
+    expect(str).toContain("role=\"dialog\"");
+    expect(str).toContain("Review details drawer");
+    expect(str).toContain("Close details");
+    expect(str).toContain("Confirm this card");
+    expect(str).toContain("What release will do");
+    expect(str).toContain("Creates a back-office task with reviewed order suggestions.");
+    expect(str).toContain("Does not place clinical orders automatically.");
+    expect(str).toContain("Item evidence");
+    expect(str).toContain("Source: heuristic");
+    expect(str).toContain("Confidence 72%");
+    expect(str).toContain("Physician approval required");
+    expect(str).toContain("fixed inset-y-0 right-0");
   });
 
   it("renders the released state and locks controls when releasedPayload is provided", () => {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -68,6 +68,8 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Click in to confirm");
     expect(str).toContain("Confirm this card");
     expect(str).toContain("Open details");
+    expect(str).toContain("aria-label=\"Open Suggested Orders details\"");
+    expect(str).toContain("tabindex=\"0\"");
     expect(str).toContain("What release will do");
     expect(str).toContain("Creates a back-office task with reviewed order suggestions.");
     expect(str).toContain("Does not place clinical orders automatically.");

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -122,6 +122,8 @@ describe("VisitCompletionPanel", () => {
         onClose={() => undefined}
         onConfirm={() => undefined}
         onEdit={() => undefined}
+        onSaveEdit={() => undefined}
+        onCancelEdit={() => undefined}
         onRemove={() => undefined}
         onDefer={() => undefined}
         isReleased={false}
@@ -140,6 +142,49 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Confidence 72%");
     expect(str).toContain("Physician approval required");
     expect(str).toContain("fixed inset-y-0 right-0");
+  });
+
+  it("renders structured edit controls inside the details drawer", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      hasFutureAppointment: false,
+      blocks: [
+        {
+          heading: "Plan",
+          body: "Repeat labs and return to clinic in 6 weeks after medication adjustment.",
+        },
+      ],
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "E11.9", label: "Diabetes mellitus", confidence: 0.88 }],
+      },
+    });
+
+    const str = dump(
+      <VisitCompletionDetailsDrawer
+        card={bundle.cards[1]}
+        cardState={{ status: "selected" }}
+        mode="edit"
+        onClose={() => undefined}
+        onConfirm={() => undefined}
+        onEdit={() => undefined}
+        onSaveEdit={() => undefined}
+        onCancelEdit={() => undefined}
+        onRemove={() => undefined}
+        onDefer={() => undefined}
+        isReleased={false}
+      />,
+    );
+
+    expect(str).toContain("Edit Follow-Up Plan");
+    expect(str).toContain("Included actions");
+    expect(str).toContain("Follow-up interval");
+    expect(str).toContain("Scheduling handoff");
+    expect(str).toContain("Add custom action");
+    expect(str).toContain("Physician note");
+    expect(str).toContain("Save and confirm");
+    expect(str).toContain("Cancel edit");
   });
 
   it("renders the released state and locks controls when releasedPayload is provided", () => {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -56,13 +56,18 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Preview message");
     expect(str).toContain("Create staff tasks");
     expect(str).toContain("Review selected actions");
+    expect(str).toContain("Progress toward release");
+    expect(str).toContain("Next suggested step");
+    expect(str).toContain("Review Practice Readiness");
+    expect(str).toContain("Practice Readiness feedback");
+    expect(str).toContain("Documentation gap");
     expect(str).toContain(
       "Release creates only reviewed tasks, drafts, and audit records after physician approval.",
     );
     expect(str).toContain("No actions have been released.");
     expect(str).toContain("Selected for release");
-    expect(str).toContain("Open release review");
     expect(str).toContain("Release readiness");
+    expect(str).toContain("Final release review");
     expect(str).toContain("0 of 4 cards resolved");
     expect(str).toContain("Confirmation required before release.");
     expect(str).toContain("Click in to confirm");
@@ -91,6 +96,9 @@ describe("VisitCompletionPanel", () => {
     );
     expect(str).toContain("Physician remains in control.");
     expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
+    expect(str.lastIndexOf("Release Care Plan</button>")).toBeGreaterThan(
+      str.indexOf("Review selected actions"),
+    );
     // The Release Care Plan button should be disabled because not all cards are resolved
     expect(str).toContain("disabled");
   });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -55,6 +55,15 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Click in to confirm");
     expect(str).toContain("Confirm this card");
     expect(str).toContain("Open details");
+    expect(str).toContain("Final release review");
+    expect(str).toContain("Structured release payload");
+    expect(str).toContain("Preview release payload");
+    expect(str).toContain(
+      "Release Care Plan is blocked until every card has an explicit physician disposition.",
+    );
+    expect(str).toContain(
+      "Payload is review-only and creates no clinical, billing, messaging, scheduling, staff, or chart side effects.",
+    );
     expect(str).toContain(
       "Review-only; no order, message, billing, scheduling, staff task, or chart write is sent.",
     );

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import {
+  FinalReleaseReviewPanel,
   VisitCompletionDetailsDrawer,
   VisitCompletionPanel,
 } from "./visit-completion-panel";
@@ -185,6 +186,92 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Physician note");
     expect(str).toContain("Save and confirm");
     expect(str).toContain("Cancel edit");
+  });
+
+  it("surfaces structured edits in the final release review", () => {
+    const payload: VisitCompletionReleasePayload = {
+      version: "visit-completion-release/v1",
+      releaseActionLabel: "Release Care Plan",
+      mode: "physician_release_v1",
+      status: "ready_for_physician_release",
+      canRelease: true,
+      summary: {
+        totalCards: 4,
+        includedCards: 2,
+        heldOutCards: 0,
+        unresolvedCards: 0,
+      },
+      sideEffects: {
+        clinical: false,
+        billing: false,
+        patientCommunication: true,
+        scheduling: true,
+        staffAssignment: true,
+        chartWrite: false,
+      },
+      includedSections: [
+        {
+          cardId: "follow_up",
+          title: "Follow-Up Plan",
+          status: "edited",
+          disposition: "include",
+          labels: [
+            "RTC in 6 weeks recommended. No appointment currently scheduled.",
+            "Follow-up interval: 6 weeks",
+            "Scheduling handoff: front desk scheduling task",
+          ],
+          editNote:
+            "Follow-up interval: 6 weeks; scheduling handoff: front desk scheduling task.",
+          structuredEdit: {
+            followUpInterval: "6 weeks",
+            followUpRouting: "front_desk",
+          },
+          requiresPhysicianApproval: true,
+        },
+        {
+          cardId: "patient_message",
+          title: "Patient Communication",
+          status: "edited",
+          disposition: "include",
+          labels: [
+            "Portal summary drafted with lab instructions and follow-up timing.",
+            "Patient message channel: portal draft",
+          ],
+          editNote: "Please complete labs before your 6-week follow-up.",
+          structuredEdit: {
+            patientMessageChannel: "portal",
+            patientMessageDraft: "Please complete labs before your 6-week follow-up.",
+          },
+          requiresPhysicianApproval: true,
+        },
+      ],
+      heldOutSections: [],
+      unresolvedSections: [],
+      blockingCardIds: [],
+      auditEvents: [],
+      feedbackSignals: [],
+      safetyCopy:
+        "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    };
+
+    const str = dump(
+      <FinalReleaseReviewPanel
+        payload={payload}
+        isOpen
+        onToggle={() => undefined}
+        isReleasing={false}
+        releaseError={null}
+        onRelease={() => undefined}
+        isReleased={false}
+      />,
+    );
+
+    expect(str).toContain("Physician-edited release details");
+    expect(str).toContain("Interval: 6 weeks");
+    expect(str).toContain("Handoff: front desk scheduling task");
+    expect(str).toContain("Channel: portal draft");
+    expect(str).toContain("Patient draft edited");
+    expect(str).toContain("Please complete labs before your 6-week follow-up.");
   });
 
   it("renders the released state and locks controls when releasedPayload is provided", () => {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -49,6 +49,12 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("No actions have been released.");
     expect(str).toContain("Selected for release");
     expect(str).toContain("Open release review");
+    expect(str).toContain("Release readiness");
+    expect(str).toContain("0 of 4 cards resolved");
+    expect(str).toContain("Confirmation required before release.");
+    expect(str).toContain("Click in to confirm");
+    expect(str).toContain("Confirm this card");
+    expect(str).toContain("Open details");
     expect(str).toContain(
       "Review-only; no order, message, billing, scheduling, staff task, or chart write is sent.",
     );

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -56,7 +56,9 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Preview message");
     expect(str).toContain("Create staff tasks");
     expect(str).toContain("Review selected actions");
-    expect(str).toContain("Release is staged for review only in this MVP.");
+    expect(str).toContain(
+      "Release creates only reviewed tasks, drafts, and audit records after physician approval.",
+    );
     expect(str).toContain("No actions have been released.");
     expect(str).toContain("Selected for release");
     expect(str).toContain("Open release review");
@@ -66,6 +68,13 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Click in to confirm");
     expect(str).toContain("Confirm this card");
     expect(str).toContain("Open details");
+    expect(str).toContain("What release will do");
+    expect(str).toContain("Creates a back-office task with reviewed order suggestions.");
+    expect(str).toContain("Does not place clinical orders automatically.");
+    expect(str).toContain("Item evidence");
+    expect(str).toContain("Source: heuristic");
+    expect(str).toContain("Confidence 72%");
+    expect(str).toContain("Physician approval required");
     expect(str).toContain("Final release review");
     expect(str).toContain("Structured release payload");
     expect(str).toContain("Preview release payload");
@@ -73,10 +82,10 @@ describe("VisitCompletionPanel", () => {
       "Release Care Plan is blocked until every card has an explicit physician disposition.",
     );
     expect(str).toContain(
-      "Payload is review-only and creates no clinical, billing, messaging, scheduling, staff, or chart side effects.",
+      "Release Care Plan creates reviewed tasks/drafts and an audit record after physician approval.",
     );
     expect(str).toContain(
-      "Review-only; no order, message, billing, scheduling, staff task, or chart write is sent.",
+      "It does not place clinical orders, send patient messages, submit billing, book appointments, or overwrite chart data.",
     );
     expect(str).toContain("Physician remains in control.");
     expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
@@ -104,7 +113,7 @@ describe("VisitCompletionPanel", () => {
     const releasedPayload: VisitCompletionReleasePayload = {
       version: "visit-completion-release/v1",
       releaseActionLabel: "Release Care Plan",
-      mode: "review_only_mvp",
+      mode: "physician_release_v1",
       status: "ready_for_physician_release",
       canRelease: true,
       summary: {
@@ -116,9 +125,9 @@ describe("VisitCompletionPanel", () => {
       sideEffects: {
         clinical: false,
         billing: false,
-        patientCommunication: false,
-        scheduling: false,
-        staffAssignment: false,
+        patientCommunication: true,
+        scheduling: true,
+        staffAssignment: true,
         chartWrite: false,
       },
       includedSections: [
@@ -162,4 +171,3 @@ describe("VisitCompletionPanel", () => {
     expect(str).not.toContain("Release Care Plan</button>");
   });
 });
-

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import { VisitCompletionPanel } from "./visit-completion-panel";
+import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("./actions", () => ({
+  releaseVisitCompletion: vi.fn(),
+}));
 
 function dump(node: React.ReactElement | null): string {
   return renderToStaticMarkup(node);
@@ -26,7 +37,7 @@ describe("VisitCompletionPanel", () => {
       },
     });
 
-    const str = dump(<VisitCompletionPanel bundle={bundle} />);
+    const str = dump(<VisitCompletionPanel bundle={bundle} noteId="note_1" />);
 
     expect(str).toContain("AI Visit Completion");
     expect(str).toContain("Suggested Next Best Actions");
@@ -69,6 +80,86 @@ describe("VisitCompletionPanel", () => {
     );
     expect(str).toContain("Physician remains in control.");
     expect(str).toContain("Learns from approvals, edits, removals, and deferrals.");
-    expect(str).not.toContain("disabled=\"\"");
+    // The Release Care Plan button should be disabled because not all cards are resolved
+    expect(str).toContain("disabled");
+  });
+
+  it("renders the released state and locks controls when releasedPayload is provided", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      hasFutureAppointment: false,
+      blocks: [
+        {
+          heading: "Plan",
+          body: "Return to clinic in 6 weeks after medication adjustment.",
+        },
+      ],
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "G89.29", label: "Chronic pain", confidence: 0.88 }],
+      },
+    });
+
+    const releasedPayload: VisitCompletionReleasePayload = {
+      version: "visit-completion-release/v1",
+      releaseActionLabel: "Release Care Plan",
+      mode: "review_only_mvp",
+      status: "ready_for_physician_release",
+      canRelease: true,
+      summary: {
+        totalCards: 4,
+        includedCards: 4,
+        heldOutCards: 0,
+        unresolvedCards: 0,
+      },
+      sideEffects: {
+        clinical: false,
+        billing: false,
+        patientCommunication: false,
+        scheduling: false,
+        staffAssignment: false,
+        chartWrite: false,
+      },
+      includedSections: [
+        {
+          cardId: "orders" as const,
+          title: "Suggested Orders",
+          status: "confirmed" as const,
+          disposition: "include",
+          labels: ["Order CBC", "Order BMP"],
+          confirmationNote: "Approved",
+          requiresPhysicianApproval: true,
+        },
+      ],
+      heldOutSections: [],
+      unresolvedSections: [],
+      blockingCardIds: [],
+      auditEvents: [],
+      feedbackSignals: [],
+      safetyCopy: "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
+    };
+
+    const str = dump(
+      <VisitCompletionPanel
+        bundle={bundle}
+        releasedPayload={releasedPayload}
+        noteId="note_1"
+      />
+    );
+
+    // Released status checks
+    expect(str).toContain("Care Plan Released");
+    expect(str).toContain("Released");
+    expect(str).toContain("Care actions have been durably saved and routed.");
+    expect(str).toContain("Care Plan released.");
+    expect(str).toContain(
+      "Audited physician actions have been durably saved and task handoffs are routed to queues."
+    );
+
+    // UI components lock down check (buttons like Confirm this card or release action CTA should not render or should be disabled)
+    expect(str).not.toContain("Confirm this card");
+    expect(str).not.toContain("Release Care Plan</button>");
   });
 });
+

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -27,6 +27,8 @@ import type {
   VisitCompletionCardId,
   VisitCompletionDataMode,
   VisitCompletionItem,
+  VisitCompletionSource,
+  VisitCompletionStatus,
   VisitCompletionTone,
 } from "@/lib/domain/visit-completion";
 import {
@@ -114,28 +116,56 @@ const statusLabel: Record<VisitCompletionCardSelectionStatus, string> = {
 
 const detailCopy: Record<
   VisitCompletionCardId,
-  { instruction: string; question: string; confirmNote: string }
+  {
+    instruction: string;
+    question: string;
+    confirmNote: string;
+    releaseWillDo: string;
+    releaseWillNotDo: string;
+  }
 > = {
   orders: {
     instruction: "Review proposed orders, screenings, and care-gap items before release.",
     question: "Are these suggested orders and care actions appropriate for this visit?",
     confirmNote: "Orders reviewed in the card detail panel.",
+    releaseWillDo: "Creates a back-office task with reviewed order suggestions.",
+    releaseWillNotDo: "Does not place clinical orders automatically.",
   },
   follow_up: {
     instruction: "Confirm interval, routing, scheduling handoff, and any patient link.",
     question: "Is this follow-up handoff clinically and operationally correct?",
     confirmNote: "Follow-up plan reviewed in the card detail panel.",
+    releaseWillDo: "Creates a front-office scheduling task from the reviewed follow-up plan.",
+    releaseWillNotDo: "Does not book an appointment or text the patient automatically.",
   },
   patient_message: {
     instruction: "Preview the patient-facing plan, channel, print needs, and translation needs.",
     question: "Is this communication ready to include in the care plan release review?",
     confirmNote: "Patient communication reviewed in the card detail panel.",
+    releaseWillDo: "Creates an AI-drafted patient message in the patient thread.",
+    releaseWillNotDo: "Does not send a portal message automatically.",
   },
   practice_readiness: {
     instruction: "Confirm coding, documentation, prior authorization, and staff-task checks.",
     question: "Are the practice readiness checks acceptable for release review?",
     confirmNote: "Practice readiness reviewed in the card detail panel.",
+    releaseWillDo: "Stores readiness decisions with the release record for audit and follow-up.",
+    releaseWillNotDo: "Does not submit billing or change coding automatically.",
   },
+};
+
+const itemSourceLabel: Record<VisitCompletionSource, string> = {
+  note: "note",
+  coding: "coding",
+  problem_list: "problem list",
+  encounter: "encounter",
+  heuristic: "heuristic",
+};
+
+const itemStatusLabel: Record<VisitCompletionStatus, string> = {
+  suggested: "Suggested",
+  needs_review: "Needs review",
+  unavailable: "Unavailable",
 };
 
 function isResolvedStatus(status: VisitCompletionCardSelectionStatus): boolean {
@@ -436,14 +466,19 @@ export function VisitCompletionPanel({
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
             {isReleased
               ? "Audited physician actions have been durably saved and task handoffs are routed to queues."
-              : "AI prepares the next actions; no clinical, billing, messaging, scheduling, staffing, or chart action happens from this MVP panel."}
+              : "AI prepares the next actions; Release Care Plan creates only reviewed tasks, drafts, and audit records after physician approval."}
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            {isReleased
+              ? "No additional orders, messages, billing, scheduling, staffing, or chart writes can be triggered from this locked view."
+              : "It does not place clinical orders, send patient messages, submit billing, book appointments, or overwrite chart data."}
           </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
             Learns from approvals, edits, removals, and deferrals.
           </p>
         </div>
         <Badge tone={isReleased ? "success" : "highlight"} className="shrink-0">
-          {isReleased ? "Released" : "Review-only MVP"}
+          {isReleased ? "Released" : "Physician release required"}
         </Badge>
       </div>
     </section>
@@ -735,48 +770,79 @@ function VisitCompletionCardDetailPanel({
           <p className="text-sm font-semibold text-text">{copy.question}</p>
           <ul className="mt-3 space-y-2">
             {card.items.map((item) => (
-              <li key={item.id} className="flex gap-2 text-sm leading-relaxed text-text-muted">
-                <span
-                  className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", toneDot[item.tone])}
-                  aria-hidden="true"
-                />
-                <span>
-                  {item.label}
-                  {item.reason && (
-                    <span className="mt-1 block text-xs text-text-subtle">
-                      Source: {item.reason}
-                    </span>
-                  )}
-                </span>
-              </li>
+              <VisitCompletionDetailItem key={item.id} item={item} />
             ))}
           </ul>
         </div>
 
-        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
-            Confirmation state
-          </p>
-          <p className="mt-2 text-sm font-semibold text-text">
-            {resolved ? "Resolved for release review" : "Confirmation required before release."}
-          </p>
-          <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            Confirmation stays local in this MVP. No order, message, billing, scheduling,
-            staff task, or chart write is sent from this panel.
-          </p>
-          {cardState.confirmationNote && (
-            <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
-              Confirmation note: {cardState.confirmationNote}
+        <div className="space-y-3">
+          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              What release will do
             </p>
-          )}
-          {cardState.editNote && (
-            <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
-              Edit note: {cardState.editNote}
+            <p className="mt-2 text-sm font-semibold text-text">{copy.releaseWillDo}</p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              {copy.releaseWillNotDo}
             </p>
-          )}
+          </div>
+
+          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Confirmation state
+            </p>
+            <p className="mt-2 text-sm font-semibold text-text">
+              {resolved ? "Resolved for release review" : "Confirmation required before release."}
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              Nothing is routed until the physician releases the care plan. Release creates only
+              the reviewed task, draft, and audit artifacts described above.
+            </p>
+            {cardState.confirmationNote && (
+              <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
+                Confirmation note: {cardState.confirmationNote}
+              </p>
+            )}
+            {cardState.editNote && (
+              <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
+                Edit note: {cardState.editNote}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+function VisitCompletionDetailItem({ item }: { item: VisitCompletionItem }) {
+  return (
+    <li className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="flex gap-2 text-sm leading-relaxed text-text">
+        <span
+          className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", toneDot[item.tone])}
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p>{item.label}</p>
+          {item.reason && (
+            <p className="mt-1 text-xs leading-relaxed text-text-subtle">{item.reason}</p>
+          )}
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <Badge tone={toneBadge[item.tone]}>{itemStatusLabel[item.status]}</Badge>
+        <Badge tone="neutral">Source: {itemSourceLabel[item.source]}</Badge>
+        {typeof item.confidence === "number" && (
+          <Badge tone="neutral">Confidence {Math.round(item.confidence * 100)}%</Badge>
+        )}
+        {item.requiresPhysicianApproval && (
+          <Badge tone="accent">Physician approval required</Badge>
+        )}
+      </div>
+      <p className="mt-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+        Item evidence
+      </p>
+    </li>
   );
 }
 
@@ -860,11 +926,12 @@ function VisitCompletionReviewPanel({
               : "Confirmation required before release."}
           </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            Release is staged for review only in this MVP.
+            Release creates only reviewed tasks, drafts, and audit records after physician
+            approval.
           </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            Review-only; no order, message, billing, scheduling, staff task, or chart write is
-            sent.
+            It does not place clinical orders, send patient messages, submit billing, book
+            appointments, or overwrite chart data.
           </p>
         </div>
         <div className="grid grid-cols-3 gap-2 text-center">
@@ -880,7 +947,7 @@ function VisitCompletionReviewPanel({
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
               Selected for release
             </p>
-            <Badge tone="accent">Local review state only</Badge>
+            <Badge tone="accent">Physician release required</Badge>
           </div>
           <ReviewSectionList sections={review.selectedSections} onSelectCard={onSelectCard} />
         </div>
@@ -946,12 +1013,16 @@ function FinalReleaseReviewPanel({
           <h3 className="mt-1 text-lg font-semibold text-text">Structured release payload</h3>
           <p className="mt-1 max-w-3xl text-sm leading-relaxed text-text-muted">
             {payload.canRelease
-              ? "Release Care Plan is staged for final physician review."
+              ? "Release Care Plan is ready for final physician review."
               : "Release Care Plan is blocked until every card has an explicit physician disposition."}
           </p>
           <p className="mt-1 max-w-3xl text-xs leading-relaxed text-text-muted">
-            Payload is review-only and creates no clinical, billing, messaging, scheduling,
-            staff, or chart side effects.
+            Release Care Plan creates reviewed tasks/drafts and an audit record after physician
+            approval.
+          </p>
+          <p className="mt-1 max-w-3xl text-xs leading-relaxed text-text-muted">
+            It does not place clinical orders, send patient messages, submit billing, book
+            appointments, or overwrite chart data.
           </p>
         </div>
 
@@ -1077,7 +1148,7 @@ function PayloadSafetyFlag({ label, value }: { label: string; value: boolean }) 
   return (
     <div className="rounded-md border border-border bg-surface px-3 py-2">
       <dt className="font-medium text-text">{label}</dt>
-      <dd className="mt-1">{value ? "Side effect enabled" : "No side effect"}</dd>
+      <dd className="mt-1">{value ? "Draft/task artifact" : "No direct action"}</dd>
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -362,7 +362,7 @@ export function VisitCompletionPanel({
       aria-labelledby="ai-visit-completion-heading"
       className="mt-8 overflow-hidden rounded-lg border border-border bg-surface shadow-sm"
     >
-      <div className="flex flex-col gap-5 border-b border-border/70 bg-surface-muted/60 px-5 py-5 lg:flex-row lg:items-start lg:justify-between lg:px-6">
+      <div className="border-b border-border/70 bg-surface-muted/60 px-5 py-5 lg:px-6">
         <div className="max-w-3xl">
           <div className="flex flex-wrap items-center gap-2">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
@@ -384,14 +384,6 @@ export function VisitCompletionPanel({
             {bundle.safetyCopy}
           </p>
         </div>
-
-        <ReleaseCarePlanButton
-          bundle={bundle}
-          review={review}
-          isOpen={releaseReviewOpen}
-          onToggle={() => setReleaseReviewOpen((open) => !open)}
-          isReleased={isReleased}
-        />
       </div>
 
       <div className="border-b border-border/70 px-5 py-4 lg:px-6">
@@ -458,6 +450,13 @@ export function VisitCompletionPanel({
         />
       )}
 
+      <VisitCompletionProgressPanel
+        cards={bundle.cards}
+        review={review}
+        isReleased={isReleased}
+        onSelectCard={openCardDetails}
+      />
+
       <FinalReleaseReviewPanel
         payload={releasePayload}
         isOpen={releasePayloadOpen}
@@ -492,78 +491,6 @@ export function VisitCompletionPanel({
         </Badge>
       </div>
     </section>
-  );
-}
-
-function ReleaseCarePlanButton({
-  bundle,
-  review,
-  isOpen,
-  onToggle,
-  isReleased,
-}: {
-  bundle: VisitCompletionBundle;
-  review: VisitCompletionReview;
-  isOpen: boolean;
-  onToggle: () => void;
-  isReleased: boolean;
-}) {
-  if (isReleased) {
-    return (
-      <div className="w-full lg:w-[320px]">
-        <Button
-          size="md"
-          className="w-full"
-          disabled
-          leadingIcon={<Check className="h-4 w-4" />}
-        >
-          Care Plan Released
-        </Button>
-        <div className="mt-3 rounded-lg border border-success/35 bg-success-soft px-4 py-3 shadow-sm">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-text">Release status</p>
-            <Badge tone="success">Released</Badge>
-          </div>
-          <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            Care actions have been durably saved and routed.
-          </p>
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div className="w-full lg:w-[320px]">
-      <Button
-        size="md"
-        className="w-full"
-        aria-disabled={!bundle.releaseEnabled}
-        aria-label="Open release review"
-        onClick={onToggle}
-        title="Open release review"
-        leadingIcon={<Check className="h-4 w-4" />}
-      >
-        {bundle.primaryActionLabel}
-      </Button>
-      <div className="mt-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-sm">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-sm font-semibold text-text">Release readiness</p>
-          <Badge tone={review.isReadyForRelease ? "success" : isOpen ? "warning" : "neutral"}>
-            {review.isReadyForRelease ? "Ready" : isOpen ? "Review open" : "Review closed"}
-          </Badge>
-        </div>
-        <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          {review.resolvedCardCount} of {review.totalCardCount} cards resolved.
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          {review.isReadyForRelease
-            ? "Ready for physician release review."
-            : "Confirmation required before release."}
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          No actions have been released.
-        </p>
-      </div>
-    </div>
   );
 }
 
@@ -1013,6 +940,138 @@ function VisitCompletionReviewPanel({
         </div>
       </div>
     </div>
+  );
+}
+
+function VisitCompletionProgressPanel({
+  cards,
+  review,
+  isReleased,
+  onSelectCard,
+}: {
+  cards: VisitCompletionCard[];
+  review: VisitCompletionReview;
+  isReleased: boolean;
+  onSelectCard: (cardId: VisitCompletionCardId) => void;
+}) {
+  const progressPercent =
+    review.totalCardCount === 0
+      ? 0
+      : Math.round((review.resolvedCardCount / review.totalCardCount) * 100);
+  const displayedProgressPercent = isReleased ? 100 : progressPercent;
+  const practiceReadinessNext = review.needsConfirmationSections.find(
+    (section) => section.cardId === "practice_readiness",
+  );
+  const nextSection = isReleased
+    ? undefined
+    : practiceReadinessNext ?? review.needsConfirmationSections[0];
+  const nextLabel =
+    isReleased
+      ? "Care Plan Released"
+      : nextSection?.cardId === "practice_readiness"
+      ? "Review Practice Readiness"
+      : nextSection
+        ? `Review ${nextSection.title}`
+        : "Final release review";
+
+  return (
+    <div className="mx-5 mb-5 rounded-lg border border-accent/20 bg-surface px-4 py-4 shadow-sm lg:mx-6 lg:px-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
+              Progress toward release
+            </p>
+            <Badge tone={isReleased ? "success" : review.isReadyForRelease ? "success" : "warning"}>
+              {isReleased
+                ? "Released"
+                : review.isReadyForRelease
+                  ? "Ready"
+                  : `${review.needsConfirmationCount} left`}
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm font-semibold text-text">
+            {isReleased
+              ? "Care Plan Released"
+              : review.isReadyForRelease
+                ? "All confirmation workflows are resolved."
+                : `${review.resolvedCardCount} of ${review.totalCardCount} confirmations complete.`}
+          </p>
+          <div className="mt-3 h-2 overflow-hidden rounded-full bg-surface-muted">
+            <div
+              className="h-full rounded-full bg-accent transition-all"
+              style={{ width: `${displayedProgressPercent}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs leading-relaxed text-text-muted">
+            {isReleased
+              ? "Care actions have been durably saved and routed."
+              : review.isReadyForRelease
+              ? "Release Care Plan now sits after the confirmation workflow for final physician review."
+              : "Confirm, edit, remove, or defer each card. The final release remains blocked until every card has a physician disposition. No actions have been released."}
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 lg:w-[330px]">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            Next suggested step
+          </p>
+          <p className="mt-2 text-sm font-semibold text-text">{nextLabel}</p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            {isReleased
+              ? "Audited physician actions have been durably saved and task handoffs are routed to queues."
+              : nextSection?.cardId === "practice_readiness"
+              ? "AI is flagging Practice Readiness because coding support, documentation gaps, prior auth risk, and staff tasks are easiest to clean up before release."
+              : nextSection
+                ? "AI is keeping the next unresolved card visible so the checkout flow feels like forward motion, not a scavenger hunt."
+                : "Everything is resolved. The next action is final physician release review."}
+          </p>
+          {nextSection && !isReleased && (
+            <Button
+              size="sm"
+              variant="secondary"
+              className="mt-3"
+              onClick={() => onSelectCard(nextSection.cardId)}
+              leadingIcon={<Eye className="h-3.5 w-3.5" />}
+            >
+              {nextLabel}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-2 md:grid-cols-4">
+        {cards.map((card) => {
+          const section = progressSectionForCard(review, card.id);
+          const status = section?.status ?? "selected";
+
+          return (
+            <button
+              key={card.id}
+              type="button"
+              className="rounded-md border border-border bg-surface-muted/35 px-3 py-2 text-left transition hover:border-accent/35 hover:bg-accent-soft/35"
+              onClick={() => onSelectCard(card.id)}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-text">{card.title}</p>
+                <Badge tone={statusBadgeTone[status]}>{statusLabel[status]}</Badge>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function progressSectionForCard(
+  review: VisitCompletionReview,
+  cardId: VisitCompletionCardId,
+) {
+  return (
+    review.selectedSections.find((section) => section.cardId === cardId) ??
+    review.removedSections.find((section) => section.cardId === cardId) ??
+    review.deferredSections.find((section) => section.cardId === cardId)
   );
 }
 

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import {
   Check,
@@ -26,6 +28,15 @@ import type {
   VisitCompletionItem,
   VisitCompletionTone,
 } from "@/lib/domain/visit-completion";
+import {
+  applyVisitCompletionAction,
+  buildVisitCompletionReview,
+  initializeVisitCompletionSelection,
+  type VisitCompletionCardSelectionStatus,
+  type VisitCompletionReview,
+  type VisitCompletionSelectionAction,
+  type VisitCompletionSelectionState,
+} from "@/lib/domain/visit-completion-selection";
 
 interface VisitCompletionPanelProps {
   bundle: VisitCompletionBundle;
@@ -74,7 +85,91 @@ const dataModeLabel: Record<VisitCompletionDataMode, string> = {
   agent_output: "Agent",
 };
 
+const statusBadgeTone: Record<
+  VisitCompletionCardSelectionStatus,
+  "neutral" | "success" | "warning" | "danger" | "info"
+> = {
+  selected: "info",
+  approved: "success",
+  edited: "warning",
+  removed: "danger",
+  deferred: "neutral",
+};
+
+const statusLabel: Record<VisitCompletionCardSelectionStatus, string> = {
+  selected: "Selected for release",
+  approved: "Approved locally",
+  edited: "Edited locally",
+  removed: "Removed",
+  deferred: "Deferred",
+};
+
 export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
+  const [selectionState, setSelectionState] = React.useState<VisitCompletionSelectionState>(() =>
+    initializeVisitCompletionSelection(bundle),
+  );
+  const [releaseReviewOpen, setReleaseReviewOpen] = React.useState(true);
+  const [activeCardId, setActiveCardId] = React.useState<VisitCompletionCardId>(
+    bundle.cards[0]?.id ?? "orders",
+  );
+  const [editingCardId, setEditingCardId] = React.useState<VisitCompletionCardId | null>(null);
+  const [editDraft, setEditDraft] = React.useState("");
+
+  const review = React.useMemo(
+    () => buildVisitCompletionReview(bundle, selectionState),
+    [bundle, selectionState],
+  );
+
+  const activeCard = bundle.cards.find((card) => card.id === activeCardId) ?? bundle.cards[0];
+
+  function applyLocalAction(action: VisitCompletionSelectionAction) {
+    setSelectionState((current) => applyVisitCompletionAction(bundle, current, action));
+  }
+
+  function handleCardAction(card: VisitCompletionCard, action: VisitCompletionAction) {
+    setActiveCardId(card.id);
+
+    switch (action.proposedActionType) {
+      case "approve":
+      case "send_to_staff":
+      case "send_to_patient":
+      case "text_scheduling_link":
+      case "print":
+      case "create_staff_task":
+        applyLocalAction({ type: "approve_card", cardId: card.id });
+        setReleaseReviewOpen(true);
+        return;
+      case "remove":
+        applyLocalAction({ type: "remove_card", cardId: card.id });
+        setReleaseReviewOpen(true);
+        return;
+      case "defer":
+        applyLocalAction({ type: "defer_card", cardId: card.id });
+        setReleaseReviewOpen(true);
+        return;
+      case "edit":
+        setEditingCardId(card.id);
+        setEditDraft(selectionState.cardStates[card.id]?.editNote ?? "");
+        return;
+      case "order_review":
+      case "coding_review":
+      case "view_checks":
+        setReleaseReviewOpen(true);
+        return;
+    }
+  }
+
+  function saveEdit(cardId: VisitCompletionCardId) {
+    applyLocalAction({
+      type: "edit_card",
+      cardId,
+      note: editDraft.trim() || "Edited locally before release.",
+    });
+    setEditingCardId(null);
+    setEditDraft("");
+    setReleaseReviewOpen(true);
+  }
+
   return (
     <section
       aria-labelledby="ai-visit-completion-heading"
@@ -103,7 +198,12 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
           </p>
         </div>
 
-        <ReleaseCarePlanButton bundle={bundle} />
+        <ReleaseCarePlanButton
+          bundle={bundle}
+          review={review}
+          isOpen={releaseReviewOpen}
+          onToggle={() => setReleaseReviewOpen((open) => !open)}
+        />
       </div>
 
       <div className="border-b border-border/70 px-5 py-4 lg:px-6">
@@ -120,9 +220,30 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
 
       <div className="grid grid-cols-1 gap-4 p-5 lg:grid-cols-4">
         {bundle.cards.map((card) => (
-          <SuggestedActionCard key={card.id} card={card} />
+          <SuggestedActionCard
+            key={card.id}
+            card={card}
+            cardState={selectionState.cardStates[card.id] ?? { status: "selected" }}
+            isEditing={editingCardId === card.id}
+            editDraft={editDraft}
+            onEditDraftChange={setEditDraft}
+            onSaveEdit={() => saveEdit(card.id)}
+            onCancelEdit={() => {
+              setEditingCardId(null);
+              setEditDraft("");
+            }}
+            onAction={(action) => handleCardAction(card, action)}
+          />
         ))}
       </div>
+
+      {releaseReviewOpen && (
+        <VisitCompletionReviewPanel
+          review={review}
+          activeCard={activeCard}
+          onSelectCard={(cardId) => setActiveCardId(cardId)}
+        />
+      )}
 
       <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
         <div>
@@ -143,39 +264,79 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
   );
 }
 
-function ReleaseCarePlanButton({ bundle }: { bundle: VisitCompletionBundle }) {
+function ReleaseCarePlanButton({
+  bundle,
+  review,
+  isOpen,
+  onToggle,
+}: {
+  bundle: VisitCompletionBundle;
+  review: VisitCompletionReview;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
   return (
-    <details className="group w-full lg:w-[300px]">
-      <summary
+    <div className="w-full lg:w-[320px]">
+      <Button
+        size="md"
+        className="w-full"
         aria-disabled={!bundle.releaseEnabled}
-        className={cn(
-          "flex min-h-10 cursor-pointer list-none items-center justify-center rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-ink shadow-seal transition hover:bg-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
-          !bundle.releaseEnabled && "pointer-events-none opacity-50",
-        )}
+        aria-label="Open release review"
+        onClick={onToggle}
+        title="Open release review"
+        leadingIcon={<Check className="h-4 w-4" />}
       >
-        <span>{bundle.primaryActionLabel}</span>
-      </summary>
+        {bundle.primaryActionLabel}
+      </Button>
       <div className="mt-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-sm">
-        <p className="text-sm font-semibold text-text">Review selected actions</p>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-text">No actions have been released.</p>
+          <Badge tone={isOpen ? "accent" : "neutral"}>
+            {isOpen ? "Review open" : "Review closed"}
+          </Badge>
+        </div>
         <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          Release is staged for review only in this MVP.
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          This confirmation surface will eventually show selected orders, messages,
-          scheduling tasks, staff tasks, and practice-readiness checks before anything
-          is released.
+          {review.selectedCount} selected for release, {review.deferredCount} deferred,{" "}
+          {review.removedCount} removed.
         </p>
       </div>
-    </details>
+    </div>
   );
 }
 
-function SuggestedActionCard({ card }: { card: VisitCompletionCard }) {
+function SuggestedActionCard({
+  card,
+  cardState,
+  isEditing,
+  editDraft,
+  onEditDraftChange,
+  onSaveEdit,
+  onCancelEdit,
+  onAction,
+}: {
+  card: VisitCompletionCard;
+  cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
+  isEditing: boolean;
+  editDraft: string;
+  onEditDraftChange: (value: string) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onAction: (action: VisitCompletionAction) => void;
+}) {
   const Icon = cardIcons[card.id];
   const needsReview = card.items.some((item) => item.tone !== "neutral");
 
   return (
-    <article className="flex min-h-[268px] flex-col overflow-hidden rounded-lg border border-border/80 bg-surface">
+    <article
+      className={cn(
+        "flex min-h-[300px] flex-col overflow-hidden rounded-lg border bg-surface transition",
+        cardState.status === "removed"
+          ? "border-danger/30 bg-red-50/30"
+          : cardState.status === "deferred"
+            ? "border-border bg-surface-muted/40"
+            : "border-border/80",
+      )}
+    >
       <div className="border-b border-border/60 px-4 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-center gap-2">
@@ -184,11 +345,16 @@ function SuggestedActionCard({ card }: { card: VisitCompletionCard }) {
             </span>
             <h3 className="text-base font-semibold text-text">{card.title}</h3>
           </div>
-          {needsReview && (
-            <Badge tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}>
-              Review
-            </Badge>
-          )}
+          <div className="flex flex-col items-end gap-1">
+            <Badge tone={statusBadgeTone[cardState.status]}>{statusLabel[cardState.status]}</Badge>
+            {needsReview && (
+              <Badge
+                tone={card.items.some((item) => item.tone === "alert") ? "danger" : "warning"}
+              >
+                Review
+              </Badge>
+            )}
+          </div>
         </div>
         <p className="mt-2 text-xs leading-relaxed text-text-muted">{card.subtitle}</p>
       </div>
@@ -199,7 +365,36 @@ function SuggestedActionCard({ card }: { card: VisitCompletionCard }) {
         ))}
       </ul>
 
-      <VisitCompletionActionList actions={card.actions} />
+      {cardState.editNote && (
+        <p className="mx-4 mb-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
+          Edit note: {cardState.editNote}
+        </p>
+      )}
+
+      {isEditing && (
+        <div className="mx-4 mb-3 rounded-md border border-accent/20 bg-accent-soft/50 px-3 py-3">
+          <label className="text-xs font-semibold uppercase tracking-[0.12em] text-accent">
+            Edit proposed action
+          </label>
+          <textarea
+            className="mt-2 min-h-20 w-full resize-none rounded-md border border-border bg-surface px-3 py-2 text-sm text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+            value={editDraft}
+            onChange={(event) => onEditDraftChange(event.target.value)}
+            placeholder="Add the physician-approved change before release."
+          />
+          <p className="mt-2 text-xs text-text-muted">Local review state only.</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button size="sm" variant="secondary" onClick={onSaveEdit}>
+              Save edit
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onCancelEdit}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <VisitCompletionActionList actions={card.actions} onAction={onAction} />
     </article>
   );
 }
@@ -226,7 +421,13 @@ function VisitCompletionLine({ item }: { item: VisitCompletionItem }) {
   );
 }
 
-function VisitCompletionActionList({ actions }: { actions: VisitCompletionAction[] }) {
+function VisitCompletionActionList({
+  actions,
+  onAction,
+}: {
+  actions: VisitCompletionAction[];
+  onAction: (action: VisitCompletionAction) => void;
+}) {
   return (
     <div className="flex flex-wrap gap-2 px-4 pb-4">
       {actions.map((action) => {
@@ -242,14 +443,144 @@ function VisitCompletionActionList({ actions }: { actions: VisitCompletionAction
               action.variant === "primary" &&
                 "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
             )}
-            disabled
             title={action.placeholderCopy}
+            onClick={() => onAction(action)}
             leadingIcon={<Icon className="h-3.5 w-3.5" />}
           >
             {action.label}
           </Button>
         );
       })}
+    </div>
+  );
+}
+
+function VisitCompletionReviewPanel({
+  review,
+  activeCard,
+  onSelectCard,
+}: {
+  review: VisitCompletionReview;
+  activeCard?: VisitCompletionCard;
+  onSelectCard: (cardId: VisitCompletionCardId) => void;
+}) {
+  return (
+    <div className="mx-5 mb-5 rounded-lg border border-accent/20 bg-accent-soft/35 px-4 py-4 lg:px-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-text">Review selected actions</p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Release is staged for review only in this MVP.
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Review-only; no order, message, billing, scheduling, staff task, or chart write is
+            sent.
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <ReviewMetric label="Selected" value={review.selectedCount} />
+          <ReviewMetric label="Deferred" value={review.deferredCount} />
+          <ReviewMetric label="Removed" value={review.removedCount} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-lg border border-border bg-surface px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Selected for release
+            </p>
+            <Badge tone="accent">Local review state only</Badge>
+          </div>
+          <ReviewSectionList sections={review.selectedSections} onSelectCard={onSelectCard} />
+        </div>
+
+        <div className="space-y-3">
+          <div className="rounded-lg border border-border bg-surface px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Current focus
+            </p>
+            <p className="mt-2 text-sm font-semibold text-text">
+              {activeCard?.title ?? "No action selected"}
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-text-muted">
+              Use the card controls to approve, edit, remove, or defer before release.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Held out
+            </p>
+            <p className="mt-2 text-xs leading-relaxed text-text-muted">
+              {review.deferredCount + review.removedCount === 0
+                ? "Nothing has been removed or deferred."
+                : `${review.deferredCount} deferred and ${review.removedCount} removed from this release review.`}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReviewMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md border border-border bg-surface px-3 py-2">
+      <p className="text-lg font-semibold text-text">{value}</p>
+      <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-text-subtle">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function ReviewSectionList({
+  sections,
+  onSelectCard,
+}: {
+  sections: VisitCompletionReview["selectedSections"];
+  onSelectCard: (cardId: VisitCompletionCardId) => void;
+}) {
+  if (sections.length === 0) {
+    return (
+      <p className="mt-3 text-sm text-text-muted">
+        No selected care actions. Approve or edit a card to include it in the release review.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-3">
+      {sections.map((section) => (
+        <button
+          key={section.cardId}
+          type="button"
+          className="w-full rounded-md border border-border/80 bg-surface-muted/45 px-3 py-2 text-left transition hover:border-accent/35 hover:bg-accent-soft/40"
+          onClick={() => onSelectCard(section.cardId)}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-text">{section.title}</p>
+            <Badge tone={statusBadgeTone[section.status]}>{statusLabel[section.status]}</Badge>
+          </div>
+          <ul className="mt-2 space-y-1">
+            {section.labels.slice(0, 3).map((label) => (
+              <li key={label} className="text-xs leading-relaxed text-text-muted">
+                {label}
+              </li>
+            ))}
+          </ul>
+          {section.labels.length > 3 && (
+            <p className="mt-1 text-xs font-medium text-accent">
+              +{section.labels.length - 3} more
+            </p>
+          )}
+          {section.editNote && (
+            <p className="mt-2 text-xs leading-relaxed text-text-muted">
+              Edit note: {section.editNote}
+            </p>
+          )}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -172,6 +172,16 @@ function isResolvedStatus(status: VisitCompletionCardSelectionStatus): boolean {
   return ["confirmed", "edited", "removed", "deferred"].includes(status);
 }
 
+function shouldOpenDetailsFromCardActivation(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return true;
+  }
+
+  return !target.closest(
+    'button, a, input, textarea, select, summary, [role="button"], [role="link"]',
+  );
+}
+
 export function VisitCompletionPanel({
   bundle,
   releasedPayload,
@@ -586,10 +596,35 @@ function SuggestedActionCard({
   const needsReview = card.items.some((item) => item.tone !== "neutral");
   const needsConfirmation = !isResolvedStatus(cardState.status);
 
+  function handleCardClick(event: React.MouseEvent<HTMLElement>) {
+    if (!shouldOpenDetailsFromCardActivation(event.target)) {
+      return;
+    }
+
+    onOpenDetails();
+  }
+
+  function handleCardKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpenDetails();
+    }
+  }
+
   return (
     <article
+      role="group"
+      tabIndex={0}
+      aria-label={`Open ${card.title} details`}
+      title={`Open ${card.title} details`}
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
       className={cn(
-        "flex min-h-[300px] flex-col overflow-hidden rounded-lg border bg-surface transition",
+        "flex min-h-[300px] cursor-pointer flex-col overflow-hidden rounded-lg border bg-surface transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
         isActive && "border-accent/45 shadow-sm ring-1 ring-accent/15",
         cardState.status === "removed"
           ? "border-danger/30 bg-red-50/30"

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1584,7 +1584,7 @@ function progressSectionForCard(
   );
 }
 
-function FinalReleaseReviewPanel({
+export function FinalReleaseReviewPanel({
   payload,
   isOpen,
   onToggle,
@@ -1727,24 +1727,84 @@ function ReleasePayloadSectionList({
   return (
     <div className="mt-3 space-y-2">
       {sections.map((section) => (
-        <div key={section.cardId} className="rounded-md border border-border bg-surface px-3 py-2">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="text-sm font-semibold text-text">{section.title}</p>
-            <Badge tone={statusBadgeTone[section.status]}>{statusLabel[section.status]}</Badge>
-          </div>
-          <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            {section.labels.slice(0, 2).join("; ")}
-            {section.labels.length > 2 ? `; +${section.labels.length - 2} more` : ""}
-          </p>
-          {(section.confirmationNote || section.editNote) && (
-            <p className="mt-2 text-xs leading-relaxed text-text-subtle">
-              {section.confirmationNote ?? section.editNote}
-            </p>
-          )}
-        </div>
+        <ReleasePayloadSectionCard key={section.cardId} section={section} />
       ))}
     </div>
   );
+}
+
+function ReleasePayloadSectionCard({
+  section,
+}: {
+  section: VisitCompletionReleasePayload["includedSections"][number];
+}) {
+  const structuredDetails = structuredReleaseDetailsForSection(section);
+
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-semibold text-text">{section.title}</p>
+        <Badge tone={statusBadgeTone[section.status]}>{statusLabel[section.status]}</Badge>
+      </div>
+      <p className="mt-1 text-xs leading-relaxed text-text-muted">
+        {section.labels.slice(0, 2).join("; ")}
+        {section.labels.length > 2 ? `; +${section.labels.length - 2} more` : ""}
+      </p>
+      {structuredDetails.length > 0 && (
+        <div className="mt-3 rounded-md border border-accent/20 bg-accent-soft/35 px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-accent">
+            Physician-edited release details
+          </p>
+          <ul className="mt-2 space-y-1">
+            {structuredDetails.map((detail) => (
+              <li key={detail} className="text-xs leading-relaxed text-text-muted">
+                {detail}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {(section.confirmationNote || section.editNote) && (
+        <p className="mt-2 text-xs leading-relaxed text-text-subtle">
+          {section.confirmationNote ?? section.editNote}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function structuredReleaseDetailsForSection(
+  section: VisitCompletionReleasePayload["includedSections"][number],
+): string[] {
+  const edit = section.structuredEdit;
+  if (!edit) {
+    return [];
+  }
+
+  const details: string[] = [];
+  if (edit.selectedItemIds !== undefined) {
+    details.push(`${section.labels.length} reviewed action${section.labels.length === 1 ? "" : "s"}`);
+  }
+  if (edit.followUpInterval) {
+    details.push(`Interval: ${edit.followUpInterval}`);
+  }
+  if (edit.followUpRouting) {
+    details.push(`Handoff: ${followUpRoutingLabel[edit.followUpRouting]}`);
+  }
+  if (edit.patientMessageChannel) {
+    details.push(`Channel: ${patientMessageChannelLabel[edit.patientMessageChannel]}`);
+  }
+  if (edit.patientMessageDraft) {
+    details.push("Patient draft edited");
+  }
+  if (edit.practiceReadinessOwner) {
+    details.push(`Owner: ${practiceReadinessOwnerLabel[edit.practiceReadinessOwner]}`);
+  }
+  if (edit.physicianNote) {
+    details.push("Physician note captured");
+  }
+
+  return details;
 }
 
 function PayloadSafetyFlag({ label, value }: { label: string; value: boolean }) {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -225,6 +225,7 @@ export function VisitCompletionPanel({
   const [activeCardId, setActiveCardId] = React.useState<VisitCompletionCardId>(
     bundle.cards[0]?.id ?? "orders",
   );
+  const [detailsDrawerOpen, setDetailsDrawerOpen] = React.useState(false);
   const [editingCardId, setEditingCardId] = React.useState<VisitCompletionCardId | null>(null);
   const [editDraft, setEditDraft] = React.useState("");
   const [releasePayloadOpen, setReleasePayloadOpen] = React.useState(!releasedPayload);
@@ -260,6 +261,7 @@ export function VisitCompletionPanel({
       setSelectionState({ cardStates });
       setReleaseReviewOpen(false);
       setReleasePayloadOpen(false);
+      setDetailsDrawerOpen(false);
     }
   }, [releasedPayload]);
 
@@ -305,6 +307,7 @@ export function VisitCompletionPanel({
 
   function openCardDetails(cardId: VisitCompletionCardId) {
     setActiveCardId(cardId);
+    setDetailsDrawerOpen(true);
     setReleaseReviewOpen(true);
   }
 
@@ -314,11 +317,13 @@ export function VisitCompletionPanel({
       cardId: card.id,
       confirmationNote: detailCopy[card.id].confirmNote,
     });
+    setDetailsDrawerOpen(false);
     setReleaseReviewOpen(true);
   }
 
   function handleCardAction(card: VisitCompletionCard, action: VisitCompletionAction) {
-    openCardDetails(card.id);
+    setActiveCardId(card.id);
+    setReleaseReviewOpen(true);
 
     switch (action.proposedActionType) {
       case "approve":
@@ -336,12 +341,14 @@ export function VisitCompletionPanel({
         applyLocalAction({ type: "defer_card", cardId: card.id });
         return;
       case "edit":
+        setDetailsDrawerOpen(false);
         setEditingCardId(card.id);
         setEditDraft(selectionState.cardStates[card.id]?.editNote ?? "");
         return;
       case "order_review":
       case "coding_review":
       case "view_checks":
+        setDetailsDrawerOpen(true);
         return;
     }
   }
@@ -421,21 +428,26 @@ export function VisitCompletionPanel({
       </div>
 
       {activeCard && activeCardState && (
-        <VisitCompletionCardDetailPanel
+        <VisitCompletionDetailsDrawer
           card={activeCard}
           cardState={activeCardState}
+          isOpen={detailsDrawerOpen}
+          onClose={() => setDetailsDrawerOpen(false)}
           onConfirm={() => confirmCard(activeCard)}
           onEdit={() => {
-            openCardDetails(activeCard.id);
+            setDetailsDrawerOpen(false);
+            setActiveCardId(activeCard.id);
             setEditingCardId(activeCard.id);
             setEditDraft(selectionState.cardStates[activeCard.id]?.editNote ?? "");
           }}
           onRemove={() => {
-            openCardDetails(activeCard.id);
+            setDetailsDrawerOpen(false);
+            setActiveCardId(activeCard.id);
             applyLocalAction({ type: "remove_card", cardId: activeCard.id });
           }}
           onDefer={() => {
-            openCardDetails(activeCard.id);
+            setDetailsDrawerOpen(false);
+            setActiveCardId(activeCard.id);
             applyLocalAction({ type: "defer_card", cardId: activeCard.id });
           }}
           isReleased={isReleased}
@@ -643,9 +655,11 @@ function SuggestedActionCard({
   );
 }
 
-function VisitCompletionCardDetailPanel({
+export function VisitCompletionDetailsDrawer({
   card,
   cardState,
+  isOpen = true,
+  onClose,
   onConfirm,
   onEdit,
   onRemove,
@@ -654,6 +668,8 @@ function VisitCompletionCardDetailPanel({
 }: {
   card: VisitCompletionCard;
   cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
+  isOpen?: boolean;
+  onClose: () => void;
   onConfirm: () => void;
   onEdit: () => void;
   onRemove: () => void;
@@ -664,114 +680,145 @@ function VisitCompletionCardDetailPanel({
   const copy = detailCopy[card.id];
   const resolved = isResolvedStatus(cardState.status);
 
-  return (
-    <div className="mx-5 mb-5 rounded-lg border border-border bg-surface px-4 py-4 shadow-sm lg:mx-6 lg:px-5">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex gap-3">
-          <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-soft text-accent">
-            <Icon className="h-5 w-5" />
-          </span>
-          <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
-                Click in to confirm
-              </p>
-              <Badge tone={statusBadgeTone[cardState.status]}>{statusLabel[cardState.status]}</Badge>
-            </div>
-            <h3 className="mt-1 text-lg font-semibold text-text">{card.title} confirmation</h3>
-            <p className="mt-1 max-w-3xl text-sm leading-relaxed text-text-muted">
-              {copy.instruction}
-            </p>
-          </div>
-        </div>
+  if (!isOpen) {
+    return null;
+  }
 
-        {!isReleased && (
-          <div className="flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={onConfirm}
-              title="Confirm this card for release review"
-              leadingIcon={<Check className="h-3.5 w-3.5" />}
-            >
-              Confirm this card
-            </Button>
+  return (
+    <div className="fixed inset-0 z-50 bg-black/15">
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`visit-completion-drawer-${card.id}`}
+        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-xl flex-col border-l border-border bg-surface shadow-2xl"
+      >
+        <div className="border-b border-border bg-surface-muted/60 px-5 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex gap-3">
+              <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-soft text-accent">
+                <Icon className="h-5 w-5" />
+              </span>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
+                    Review details drawer
+                  </p>
+                  <Badge tone={statusBadgeTone[cardState.status]}>
+                    {statusLabel[cardState.status]}
+                  </Badge>
+                </div>
+                <h3
+                  id={`visit-completion-drawer-${card.id}`}
+                  className="mt-1 text-lg font-semibold text-text"
+                >
+                  {card.title} confirmation
+                </h3>
+                <p className="mt-1 text-sm leading-relaxed text-text-muted">
+                  {copy.instruction}
+                </p>
+              </div>
+            </div>
+
             <Button
               size="sm"
               variant="ghost"
-              onClick={onEdit}
-              title="Edit this card locally before release"
-              leadingIcon={<Pencil className="h-3.5 w-3.5" />}
-            >
-              Edit
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={onRemove}
-              title="Remove this card from the release review"
+              onClick={onClose}
+              title="Close details"
+              aria-label="Close details"
               leadingIcon={<X className="h-3.5 w-3.5" />}
             >
-              Remove
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={onDefer}
-              title="Defer this card without rejecting the concept"
-              leadingIcon={<Clock3 className="h-3.5 w-3.5" />}
-            >
-              Defer
+              Close details
             </Button>
           </div>
-        )}
-      </div>
-
-      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_0.9fr]">
-        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-          <p className="text-sm font-semibold text-text">{copy.question}</p>
-          <ul className="mt-3 space-y-2">
-            {card.items.map((item) => (
-              <VisitCompletionDetailItem key={item.id} item={item} />
-            ))}
-          </ul>
         </div>
 
-        <div className="space-y-3">
-          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
-              What release will do
-            </p>
-            <p className="mt-2 text-sm font-semibold text-text">{copy.releaseWillDo}</p>
-            <p className="mt-1 text-xs leading-relaxed text-text-muted">
-              {copy.releaseWillNotDo}
-            </p>
-          </div>
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {!isReleased && (
+            <div className="mb-4 flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={onConfirm}
+                title="Confirm this card for release review"
+                leadingIcon={<Check className="h-3.5 w-3.5" />}
+              >
+                Confirm this card
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onEdit}
+                title="Edit this card locally before release"
+                leadingIcon={<Pencil className="h-3.5 w-3.5" />}
+              >
+                Edit
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onRemove}
+                title="Remove this card from the release review"
+                leadingIcon={<X className="h-3.5 w-3.5" />}
+              >
+                Remove
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onDefer}
+                title="Defer this card without rejecting the concept"
+                leadingIcon={<Clock3 className="h-3.5 w-3.5" />}
+              >
+                Defer
+              </Button>
+            </div>
+          )}
 
-          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
-              Confirmation state
-            </p>
-            <p className="mt-2 text-sm font-semibold text-text">
-              {resolved ? "Resolved for release review" : "Confirmation required before release."}
-            </p>
-            <p className="mt-1 text-xs leading-relaxed text-text-muted">
-              Nothing is routed until the physician releases the care plan. Release creates only
-              the reviewed task, draft, and audit artifacts described above.
-            </p>
-            {cardState.confirmationNote && (
-              <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
-                Confirmation note: {cardState.confirmationNote}
+          <div className="space-y-3">
+            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+              <p className="text-sm font-semibold text-text">{copy.question}</p>
+              <ul className="mt-3 space-y-2">
+                {card.items.map((item) => (
+                  <VisitCompletionDetailItem key={item.id} item={item} />
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                What release will do
               </p>
-            )}
-            {cardState.editNote && (
-              <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
-                Edit note: {cardState.editNote}
+              <p className="mt-2 text-sm font-semibold text-text">{copy.releaseWillDo}</p>
+              <p className="mt-1 text-xs leading-relaxed text-text-muted">
+                {copy.releaseWillNotDo}
               </p>
-            )}
+            </div>
+
+            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                Confirmation state
+              </p>
+              <p className="mt-2 text-sm font-semibold text-text">
+                {resolved ? "Resolved for release review" : "Confirmation required before release."}
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-text-muted">
+                Nothing is routed until the physician releases the care plan. Release creates only
+                the reviewed task, draft, and audit artifacts described above.
+              </p>
+              {cardState.confirmationNote && (
+                <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
+                  Confirmation note: {cardState.confirmationNote}
+                </p>
+              )}
+              {cardState.editNote && (
+                <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
+                  Edit note: {cardState.editNote}
+                </p>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </aside>
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import {
   Check,
   ClipboardCheck,
@@ -39,9 +40,12 @@ import {
   type VisitCompletionSelectionAction,
   type VisitCompletionSelectionState,
 } from "@/lib/domain/visit-completion-selection";
+import { releaseVisitCompletion } from "./actions";
 
 interface VisitCompletionPanelProps {
   bundle: VisitCompletionBundle;
+  releasedPayload?: VisitCompletionReleasePayload | null;
+  noteId: string;
 }
 
 const cardIcons: Record<VisitCompletionCardId, React.ComponentType<{ className?: string }>> = {
@@ -138,17 +142,107 @@ function isResolvedStatus(status: VisitCompletionCardSelectionStatus): boolean {
   return ["confirmed", "edited", "removed", "deferred"].includes(status);
 }
 
-export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
-  const [selectionState, setSelectionState] = React.useState<VisitCompletionSelectionState>(() =>
-    initializeVisitCompletionSelection(bundle),
+export function VisitCompletionPanel({
+  bundle,
+  releasedPayload,
+  noteId,
+}: VisitCompletionPanelProps) {
+  const router = useRouter();
+  const [localReleasedPayload, setLocalReleasedPayload] = React.useState<VisitCompletionReleasePayload | null>(
+    releasedPayload ?? null
   );
-  const [releaseReviewOpen, setReleaseReviewOpen] = React.useState(true);
+
+  const [selectionState, setSelectionState] = React.useState<VisitCompletionSelectionState>(() => {
+    if (releasedPayload) {
+      const cardStates = {} as VisitCompletionSelectionState["cardStates"];
+      for (const section of releasedPayload.includedSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      for (const section of releasedPayload.heldOutSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      for (const section of releasedPayload.unresolvedSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      return { cardStates };
+    }
+    return initializeVisitCompletionSelection(bundle);
+  });
+
+  const [releaseReviewOpen, setReleaseReviewOpen] = React.useState(!releasedPayload);
   const [activeCardId, setActiveCardId] = React.useState<VisitCompletionCardId>(
     bundle.cards[0]?.id ?? "orders",
   );
   const [editingCardId, setEditingCardId] = React.useState<VisitCompletionCardId | null>(null);
   const [editDraft, setEditDraft] = React.useState("");
-  const [releasePayloadOpen, setReleasePayloadOpen] = React.useState(true);
+  const [releasePayloadOpen, setReleasePayloadOpen] = React.useState(!releasedPayload);
+
+  const [isReleasing, startReleaseTransition] = React.useTransition();
+  const [releaseError, setReleaseError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (releasedPayload) {
+      setLocalReleasedPayload(releasedPayload);
+      const cardStates = {} as VisitCompletionSelectionState["cardStates"];
+      for (const section of releasedPayload.includedSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      for (const section of releasedPayload.heldOutSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      for (const section of releasedPayload.unresolvedSections) {
+        cardStates[section.cardId] = {
+          status: section.status,
+          editNote: section.editNote,
+          confirmationNote: section.confirmationNote,
+        };
+      }
+      setSelectionState({ cardStates });
+      setReleaseReviewOpen(false);
+      setReleasePayloadOpen(false);
+    }
+  }, [releasedPayload]);
+
+  const handleRelease = () => {
+    setReleaseError(null);
+    startReleaseTransition(async () => {
+      try {
+        const result = await releaseVisitCompletion(noteId, releasePayload);
+        if (result.ok) {
+          setLocalReleasedPayload(releasePayload);
+          setReleasePayloadOpen(false);
+          setReleaseReviewOpen(false);
+          router.refresh();
+        } else {
+          setReleaseError(result.error);
+        }
+      } catch (err: any) {
+        setReleaseError(err?.message || "An unexpected error occurred during release.");
+      }
+    });
+  };
+
+  const isReleased = Boolean(localReleasedPayload);
 
   const review = React.useMemo(
     () => buildVisitCompletionReview(bundle, selectionState),
@@ -256,6 +350,7 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
           review={review}
           isOpen={releaseReviewOpen}
           onToggle={() => setReleaseReviewOpen((open) => !open)}
+          isReleased={isReleased}
         />
       </div>
 
@@ -288,6 +383,7 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
             }}
             onOpenDetails={() => openCardDetails(card.id)}
             onAction={(action) => handleCardAction(card, action)}
+            isReleased={isReleased}
           />
         ))}
       </div>
@@ -310,6 +406,7 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
             openCardDetails(activeCard.id);
             applyLocalAction({ type: "defer_card", cardId: activeCard.id });
           }}
+          isReleased={isReleased}
         />
       )}
 
@@ -325,21 +422,28 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
         payload={releasePayload}
         isOpen={releasePayloadOpen}
         onToggle={() => setReleasePayloadOpen((open) => !open)}
+        isReleasing={isReleasing}
+        releaseError={releaseError}
+        onRelease={handleRelease}
+        isReleased={isReleased}
       />
 
       <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
         <div>
-          <p className="text-sm font-semibold text-text">Physician remains in control.</p>
+          <p className="text-sm font-semibold text-text">
+            {isReleased ? "Care Plan released." : "Physician remains in control."}
+          </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
-            AI prepares the next actions; no clinical, billing, messaging, scheduling,
-            staffing, or chart action happens from this MVP panel.
+            {isReleased
+              ? "Audited physician actions have been durably saved and task handoffs are routed to queues."
+              : "AI prepares the next actions; no clinical, billing, messaging, scheduling, staffing, or chart action happens from this MVP panel."}
           </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
             Learns from approvals, edits, removals, and deferrals.
           </p>
         </div>
-        <Badge tone="highlight" className="shrink-0">
-          Review-only MVP
+        <Badge tone={isReleased ? "success" : "highlight"} className="shrink-0">
+          {isReleased ? "Released" : "Review-only MVP"}
         </Badge>
       </div>
     </section>
@@ -351,12 +455,37 @@ function ReleaseCarePlanButton({
   review,
   isOpen,
   onToggle,
+  isReleased,
 }: {
   bundle: VisitCompletionBundle;
   review: VisitCompletionReview;
   isOpen: boolean;
   onToggle: () => void;
+  isReleased: boolean;
 }) {
+  if (isReleased) {
+    return (
+      <div className="w-full lg:w-[320px]">
+        <Button
+          size="md"
+          className="w-full"
+          disabled
+          leadingIcon={<Check className="h-4 w-4" />}
+        >
+          Care Plan Released
+        </Button>
+        <div className="mt-3 rounded-lg border border-success/35 bg-success-soft px-4 py-3 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-text">Release status</p>
+            <Badge tone="success">Released</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Care actions have been durably saved and routed.
+          </p>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="w-full lg:w-[320px]">
       <Button
@@ -404,6 +533,7 @@ function SuggestedActionCard({
   onCancelEdit,
   onOpenDetails,
   onAction,
+  isReleased,
 }: {
   card: VisitCompletionCard;
   cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
@@ -415,6 +545,7 @@ function SuggestedActionCard({
   onCancelEdit: () => void;
   onOpenDetails: () => void;
   onAction: (action: VisitCompletionAction) => void;
+  isReleased: boolean;
 }) {
   const Icon = cardIcons[card.id];
   const needsReview = card.items.some((item) => item.tone !== "neutral");
@@ -510,7 +641,7 @@ function SuggestedActionCard({
         </Button>
       </div>
 
-      <VisitCompletionActionList actions={card.actions} onAction={onAction} />
+      {!isReleased && <VisitCompletionActionList actions={card.actions} onAction={onAction} />}
     </article>
   );
 }
@@ -522,6 +653,7 @@ function VisitCompletionCardDetailPanel({
   onEdit,
   onRemove,
   onDefer,
+  isReleased,
 }: {
   card: VisitCompletionCard;
   cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
@@ -529,6 +661,7 @@ function VisitCompletionCardDetailPanel({
   onEdit: () => void;
   onRemove: () => void;
   onDefer: () => void;
+  isReleased: boolean;
 }) {
   const Icon = cardIcons[card.id];
   const copy = detailCopy[card.id];
@@ -555,44 +688,46 @@ function VisitCompletionCardDetailPanel({
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={onConfirm}
-            title="Confirm this card for release review"
-            leadingIcon={<Check className="h-3.5 w-3.5" />}
-          >
-            Confirm this card
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onEdit}
-            title="Edit this card locally before release"
-            leadingIcon={<Pencil className="h-3.5 w-3.5" />}
-          >
-            Edit
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onRemove}
-            title="Remove this card from the release review"
-            leadingIcon={<X className="h-3.5 w-3.5" />}
-          >
-            Remove
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onDefer}
-            title="Defer this card without rejecting the concept"
-            leadingIcon={<Clock3 className="h-3.5 w-3.5" />}
-          >
-            Defer
-          </Button>
-        </div>
+        {!isReleased && (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={onConfirm}
+              title="Confirm this card for release review"
+              leadingIcon={<Check className="h-3.5 w-3.5" />}
+            >
+              Confirm this card
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onEdit}
+              title="Edit this card locally before release"
+              leadingIcon={<Pencil className="h-3.5 w-3.5" />}
+            >
+              Edit
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onRemove}
+              title="Remove this card from the release review"
+              leadingIcon={<X className="h-3.5 w-3.5" />}
+            >
+              Remove
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onDefer}
+              title="Defer this card without rejecting the concept"
+              leadingIcon={<Clock3 className="h-3.5 w-3.5" />}
+            >
+              Defer
+            </Button>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_0.9fr]">
@@ -783,10 +918,18 @@ function FinalReleaseReviewPanel({
   payload,
   isOpen,
   onToggle,
+  isReleasing,
+  releaseError,
+  onRelease,
+  isReleased,
 }: {
   payload: VisitCompletionReleasePayload;
   isOpen: boolean;
   onToggle: () => void;
+  isReleasing: boolean;
+  releaseError: string | null;
+  onRelease: () => void;
+  isReleased: boolean;
 }) {
   return (
     <div className="mx-5 mb-5 rounded-lg border border-border bg-surface px-4 py-4 shadow-sm lg:mx-6 lg:px-5">
@@ -812,15 +955,34 @@ function FinalReleaseReviewPanel({
           </p>
         </div>
 
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={onToggle}
-          title="Preview the structured release payload"
-          leadingIcon={<FileText className="h-3.5 w-3.5" />}
-        >
-          Preview release payload
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={onToggle}
+            title="Preview the structured release payload"
+            leadingIcon={<FileText className="h-3.5 w-3.5" />}
+          >
+            Preview release payload
+          </Button>
+          {!isReleased && (
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={!payload.canRelease || isReleasing}
+              onClick={onRelease}
+              title="Release Care Plan"
+              leadingIcon={isReleasing ? <span className="animate-spin mr-1">⌛</span> : <Check className="h-3.5 w-3.5" />}
+            >
+              {isReleasing ? "Releasing..." : "Release Care Plan"}
+            </Button>
+          )}
+        </div>
+        {releaseError && (
+          <div className="mt-3 w-full rounded-md border border-danger/30 bg-red-50/50 px-3 py-2 text-xs text-danger">
+            {releaseError}
+          </div>
+        )}
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-2 text-center md:grid-cols-4">

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -89,20 +89,52 @@ const statusBadgeTone: Record<
   VisitCompletionCardSelectionStatus,
   "neutral" | "success" | "warning" | "danger" | "info"
 > = {
-  selected: "info",
-  approved: "success",
+  selected: "warning",
+  approved: "warning",
+  confirmed: "success",
   edited: "warning",
   removed: "danger",
   deferred: "neutral",
 };
 
 const statusLabel: Record<VisitCompletionCardSelectionStatus, string> = {
-  selected: "Selected for release",
-  approved: "Approved locally",
-  edited: "Edited locally",
+  selected: "Confirmation required",
+  approved: "Approved; confirm",
+  confirmed: "Confirmed",
+  edited: "Edited; resolved",
   removed: "Removed",
   deferred: "Deferred",
 };
+
+const detailCopy: Record<
+  VisitCompletionCardId,
+  { instruction: string; question: string; confirmNote: string }
+> = {
+  orders: {
+    instruction: "Review proposed orders, screenings, and care-gap items before release.",
+    question: "Are these suggested orders and care actions appropriate for this visit?",
+    confirmNote: "Orders reviewed in the card detail panel.",
+  },
+  follow_up: {
+    instruction: "Confirm interval, routing, scheduling handoff, and any patient link.",
+    question: "Is this follow-up handoff clinically and operationally correct?",
+    confirmNote: "Follow-up plan reviewed in the card detail panel.",
+  },
+  patient_message: {
+    instruction: "Preview the patient-facing plan, channel, print needs, and translation needs.",
+    question: "Is this communication ready to include in the care plan release review?",
+    confirmNote: "Patient communication reviewed in the card detail panel.",
+  },
+  practice_readiness: {
+    instruction: "Confirm coding, documentation, prior authorization, and staff-task checks.",
+    question: "Are the practice readiness checks acceptable for release review?",
+    confirmNote: "Practice readiness reviewed in the card detail panel.",
+  },
+};
+
+function isResolvedStatus(status: VisitCompletionCardSelectionStatus): boolean {
+  return ["confirmed", "edited", "removed", "deferred"].includes(status);
+}
 
 export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
   const [selectionState, setSelectionState] = React.useState<VisitCompletionSelectionState>(() =>
@@ -121,13 +153,31 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
   );
 
   const activeCard = bundle.cards.find((card) => card.id === activeCardId) ?? bundle.cards[0];
+  const activeCardState =
+    activeCard !== undefined
+      ? (selectionState.cardStates[activeCard.id] ?? { status: "selected" })
+      : undefined;
 
   function applyLocalAction(action: VisitCompletionSelectionAction) {
     setSelectionState((current) => applyVisitCompletionAction(bundle, current, action));
   }
 
+  function openCardDetails(cardId: VisitCompletionCardId) {
+    setActiveCardId(cardId);
+    setReleaseReviewOpen(true);
+  }
+
+  function confirmCard(card: VisitCompletionCard) {
+    applyLocalAction({
+      type: "confirm_card",
+      cardId: card.id,
+      confirmationNote: detailCopy[card.id].confirmNote,
+    });
+    setReleaseReviewOpen(true);
+  }
+
   function handleCardAction(card: VisitCompletionCard, action: VisitCompletionAction) {
-    setActiveCardId(card.id);
+    openCardDetails(card.id);
 
     switch (action.proposedActionType) {
       case "approve":
@@ -137,15 +187,12 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
       case "print":
       case "create_staff_task":
         applyLocalAction({ type: "approve_card", cardId: card.id });
-        setReleaseReviewOpen(true);
         return;
       case "remove":
         applyLocalAction({ type: "remove_card", cardId: card.id });
-        setReleaseReviewOpen(true);
         return;
       case "defer":
         applyLocalAction({ type: "defer_card", cardId: card.id });
-        setReleaseReviewOpen(true);
         return;
       case "edit":
         setEditingCardId(card.id);
@@ -154,7 +201,6 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
       case "order_review":
       case "coding_review":
       case "view_checks":
-        setReleaseReviewOpen(true);
         return;
     }
   }
@@ -224,6 +270,7 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
             key={card.id}
             card={card}
             cardState={selectionState.cardStates[card.id] ?? { status: "selected" }}
+            isActive={activeCardId === card.id}
             isEditing={editingCardId === card.id}
             editDraft={editDraft}
             onEditDraftChange={setEditDraft}
@@ -232,10 +279,32 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
               setEditingCardId(null);
               setEditDraft("");
             }}
+            onOpenDetails={() => openCardDetails(card.id)}
             onAction={(action) => handleCardAction(card, action)}
           />
         ))}
       </div>
+
+      {activeCard && activeCardState && (
+        <VisitCompletionCardDetailPanel
+          card={activeCard}
+          cardState={activeCardState}
+          onConfirm={() => confirmCard(activeCard)}
+          onEdit={() => {
+            openCardDetails(activeCard.id);
+            setEditingCardId(activeCard.id);
+            setEditDraft(selectionState.cardStates[activeCard.id]?.editNote ?? "");
+          }}
+          onRemove={() => {
+            openCardDetails(activeCard.id);
+            applyLocalAction({ type: "remove_card", cardId: activeCard.id });
+          }}
+          onDefer={() => {
+            openCardDetails(activeCard.id);
+            applyLocalAction({ type: "defer_card", cardId: activeCard.id });
+          }}
+        />
+      )}
 
       {releaseReviewOpen && (
         <VisitCompletionReviewPanel
@@ -290,14 +359,21 @@ function ReleaseCarePlanButton({
       </Button>
       <div className="mt-3 rounded-lg border border-border bg-surface px-4 py-3 shadow-sm">
         <div className="flex items-center justify-between gap-3">
-          <p className="text-sm font-semibold text-text">No actions have been released.</p>
-          <Badge tone={isOpen ? "accent" : "neutral"}>
-            {isOpen ? "Review open" : "Review closed"}
+          <p className="text-sm font-semibold text-text">Release readiness</p>
+          <Badge tone={review.isReadyForRelease ? "success" : isOpen ? "warning" : "neutral"}>
+            {review.isReadyForRelease ? "Ready" : isOpen ? "Review open" : "Review closed"}
           </Badge>
         </div>
         <p className="mt-1 text-xs leading-relaxed text-text-muted">
-          {review.selectedCount} selected for release, {review.deferredCount} deferred,{" "}
-          {review.removedCount} removed.
+          {review.resolvedCardCount} of {review.totalCardCount} cards resolved.
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">
+          {review.isReadyForRelease
+            ? "Ready for physician release review."
+            : "Confirmation required before release."}
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">
+          No actions have been released.
         </p>
       </div>
     </div>
@@ -307,29 +383,35 @@ function ReleaseCarePlanButton({
 function SuggestedActionCard({
   card,
   cardState,
+  isActive,
   isEditing,
   editDraft,
   onEditDraftChange,
   onSaveEdit,
   onCancelEdit,
+  onOpenDetails,
   onAction,
 }: {
   card: VisitCompletionCard;
   cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
+  isActive: boolean;
   isEditing: boolean;
   editDraft: string;
   onEditDraftChange: (value: string) => void;
   onSaveEdit: () => void;
   onCancelEdit: () => void;
+  onOpenDetails: () => void;
   onAction: (action: VisitCompletionAction) => void;
 }) {
   const Icon = cardIcons[card.id];
   const needsReview = card.items.some((item) => item.tone !== "neutral");
+  const needsConfirmation = !isResolvedStatus(cardState.status);
 
   return (
     <article
       className={cn(
         "flex min-h-[300px] flex-col overflow-hidden rounded-lg border bg-surface transition",
+        isActive && "border-accent/45 shadow-sm ring-1 ring-accent/15",
         cardState.status === "removed"
           ? "border-danger/30 bg-red-50/30"
           : cardState.status === "deferred"
@@ -357,6 +439,11 @@ function SuggestedActionCard({
           </div>
         </div>
         <p className="mt-2 text-xs leading-relaxed text-text-muted">{card.subtitle}</p>
+        {needsConfirmation && (
+          <p className="mt-2 text-xs font-medium text-[color:var(--highlight-hover)]">
+            Click in to confirm before release.
+          </p>
+        )}
       </div>
 
       <ul className="flex-1 space-y-3 px-4 py-4">
@@ -394,8 +481,154 @@ function SuggestedActionCard({
         </div>
       )}
 
+      <div className="border-t border-border/60 px-4 py-3">
+        <Button
+          size="sm"
+          variant={isActive ? "secondary" : "ghost"}
+          className={cn(
+            "h-8 rounded-md px-2.5 text-xs",
+            isActive && "border-accent/25 bg-accent-soft text-accent hover:bg-accent-soft",
+          )}
+          onClick={onOpenDetails}
+          title={`Open ${card.title} details`}
+          leadingIcon={<Eye className="h-3.5 w-3.5" />}
+        >
+          Open details
+        </Button>
+      </div>
+
       <VisitCompletionActionList actions={card.actions} onAction={onAction} />
     </article>
+  );
+}
+
+function VisitCompletionCardDetailPanel({
+  card,
+  cardState,
+  onConfirm,
+  onEdit,
+  onRemove,
+  onDefer,
+}: {
+  card: VisitCompletionCard;
+  cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
+  onConfirm: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+  onDefer: () => void;
+}) {
+  const Icon = cardIcons[card.id];
+  const copy = detailCopy[card.id];
+  const resolved = isResolvedStatus(cardState.status);
+
+  return (
+    <div className="mx-5 mb-5 rounded-lg border border-border bg-surface px-4 py-4 shadow-sm lg:mx-6 lg:px-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex gap-3">
+          <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-soft text-accent">
+            <Icon className="h-5 w-5" />
+          </span>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
+                Click in to confirm
+              </p>
+              <Badge tone={statusBadgeTone[cardState.status]}>{statusLabel[cardState.status]}</Badge>
+            </div>
+            <h3 className="mt-1 text-lg font-semibold text-text">{card.title} confirmation</h3>
+            <p className="mt-1 max-w-3xl text-sm leading-relaxed text-text-muted">
+              {copy.instruction}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={onConfirm}
+            title="Confirm this card for release review"
+            leadingIcon={<Check className="h-3.5 w-3.5" />}
+          >
+            Confirm this card
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onEdit}
+            title="Edit this card locally before release"
+            leadingIcon={<Pencil className="h-3.5 w-3.5" />}
+          >
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onRemove}
+            title="Remove this card from the release review"
+            leadingIcon={<X className="h-3.5 w-3.5" />}
+          >
+            Remove
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onDefer}
+            title="Defer this card without rejecting the concept"
+            leadingIcon={<Clock3 className="h-3.5 w-3.5" />}
+          >
+            Defer
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_0.9fr]">
+        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+          <p className="text-sm font-semibold text-text">{copy.question}</p>
+          <ul className="mt-3 space-y-2">
+            {card.items.map((item) => (
+              <li key={item.id} className="flex gap-2 text-sm leading-relaxed text-text-muted">
+                <span
+                  className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", toneDot[item.tone])}
+                  aria-hidden="true"
+                />
+                <span>
+                  {item.label}
+                  {item.reason && (
+                    <span className="mt-1 block text-xs text-text-subtle">
+                      Source: {item.reason}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            Confirmation state
+          </p>
+          <p className="mt-2 text-sm font-semibold text-text">
+            {resolved ? "Resolved for release review" : "Confirmation required before release."}
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Confirmation stays local in this MVP. No order, message, billing, scheduling,
+            staff task, or chart write is sent from this panel.
+          </p>
+          {cardState.confirmationNote && (
+            <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
+              Confirmation note: {cardState.confirmationNote}
+            </p>
+          )}
+          {cardState.editNote && (
+            <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
+              Edit note: {cardState.editNote}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -469,6 +702,15 @@ function VisitCompletionReviewPanel({
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="text-sm font-semibold text-text">Review selected actions</p>
+          <p className="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            Release readiness
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            {review.resolvedCardCount} of {review.totalCardCount} cards resolved.{" "}
+            {review.isReadyForRelease
+              ? "Ready for physician release review."
+              : "Confirmation required before release."}
+          </p>
           <p className="mt-1 text-xs leading-relaxed text-text-muted">
             Release is staged for review only in this MVP.
           </p>
@@ -478,9 +720,9 @@ function VisitCompletionReviewPanel({
           </p>
         </div>
         <div className="grid grid-cols-3 gap-2 text-center">
-          <ReviewMetric label="Selected" value={review.selectedCount} />
-          <ReviewMetric label="Deferred" value={review.deferredCount} />
-          <ReviewMetric label="Removed" value={review.removedCount} />
+          <ReviewMetric label="Resolved" value={review.resolvedCardCount} />
+          <ReviewMetric label="Needs confirm" value={review.needsConfirmationCount} />
+          <ReviewMetric label="Held out" value={review.deferredSections.length + review.removedSections.length} />
         </div>
       </div>
 
@@ -504,7 +746,8 @@ function VisitCompletionReviewPanel({
               {activeCard?.title ?? "No action selected"}
             </p>
             <p className="mt-1 text-xs leading-relaxed text-text-muted">
-              Use the card controls to approve, edit, remove, or defer before release.
+              Open details to confirm, or use the card controls to edit, remove, or defer before
+              release.
             </p>
           </div>
           <div className="rounded-lg border border-border bg-surface px-4 py-3">

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -30,9 +30,11 @@ import type {
 } from "@/lib/domain/visit-completion";
 import {
   applyVisitCompletionAction,
+  buildVisitCompletionReleasePayload,
   buildVisitCompletionReview,
   initializeVisitCompletionSelection,
   type VisitCompletionCardSelectionStatus,
+  type VisitCompletionReleasePayload,
   type VisitCompletionReview,
   type VisitCompletionSelectionAction,
   type VisitCompletionSelectionState,
@@ -146,9 +148,14 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
   );
   const [editingCardId, setEditingCardId] = React.useState<VisitCompletionCardId | null>(null);
   const [editDraft, setEditDraft] = React.useState("");
+  const [releasePayloadOpen, setReleasePayloadOpen] = React.useState(true);
 
   const review = React.useMemo(
     () => buildVisitCompletionReview(bundle, selectionState),
+    [bundle, selectionState],
+  );
+  const releasePayload = React.useMemo(
+    () => buildVisitCompletionReleasePayload(bundle, selectionState),
     [bundle, selectionState],
   );
 
@@ -313,6 +320,12 @@ export function VisitCompletionPanel({ bundle }: VisitCompletionPanelProps) {
           onSelectCard={(cardId) => setActiveCardId(cardId)}
         />
       )}
+
+      <FinalReleaseReviewPanel
+        payload={releasePayload}
+        isOpen={releasePayloadOpen}
+        onToggle={() => setReleasePayloadOpen((open) => !open)}
+      />
 
       <div className="mx-5 mb-5 flex flex-col gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3 md:flex-row md:items-center md:justify-between">
         <div>
@@ -762,6 +775,147 @@ function VisitCompletionReviewPanel({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function FinalReleaseReviewPanel({
+  payload,
+  isOpen,
+  onToggle,
+}: {
+  payload: VisitCompletionReleasePayload;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="mx-5 mb-5 rounded-lg border border-border bg-surface px-4 py-4 shadow-sm lg:mx-6 lg:px-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-subtle">
+              Final release review
+            </p>
+            <Badge tone={payload.canRelease ? "success" : "warning"}>
+              {payload.canRelease ? "Ready" : "Blocked"}
+            </Badge>
+          </div>
+          <h3 className="mt-1 text-lg font-semibold text-text">Structured release payload</h3>
+          <p className="mt-1 max-w-3xl text-sm leading-relaxed text-text-muted">
+            {payload.canRelease
+              ? "Release Care Plan is staged for final physician review."
+              : "Release Care Plan is blocked until every card has an explicit physician disposition."}
+          </p>
+          <p className="mt-1 max-w-3xl text-xs leading-relaxed text-text-muted">
+            Payload is review-only and creates no clinical, billing, messaging, scheduling,
+            staff, or chart side effects.
+          </p>
+        </div>
+
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={onToggle}
+          title="Preview the structured release payload"
+          leadingIcon={<FileText className="h-3.5 w-3.5" />}
+        >
+          Preview release payload
+        </Button>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 text-center md:grid-cols-4">
+        <ReviewMetric label="Included" value={payload.summary.includedCards} />
+        <ReviewMetric label="Held out" value={payload.summary.heldOutCards} />
+        <ReviewMetric label="Unresolved" value={payload.summary.unresolvedCards} />
+        <ReviewMetric label="Audit events" value={payload.auditEvents.length} />
+      </div>
+
+      {isOpen && (
+        <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_1fr]">
+          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Ready cards
+            </p>
+            <ReleasePayloadSectionList
+              sections={payload.includedSections}
+              emptyCopy="No cards are ready for release yet."
+            />
+          </div>
+
+          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Held-out or unresolved cards
+            </p>
+            <ReleasePayloadSectionList
+              sections={[...payload.heldOutSections, ...payload.unresolvedSections]}
+              emptyCopy="No held-out or unresolved cards."
+            />
+          </div>
+
+          <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3 lg:col-span-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                Payload safety contract
+              </p>
+              <Badge tone="highlight">{payload.mode}</Badge>
+            </div>
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-text-muted md:grid-cols-3">
+              <PayloadSafetyFlag label="Clinical" value={payload.sideEffects.clinical} />
+              <PayloadSafetyFlag label="Billing" value={payload.sideEffects.billing} />
+              <PayloadSafetyFlag
+                label="Patient message"
+                value={payload.sideEffects.patientCommunication}
+              />
+              <PayloadSafetyFlag label="Scheduling" value={payload.sideEffects.scheduling} />
+              <PayloadSafetyFlag label="Staff task" value={payload.sideEffects.staffAssignment} />
+              <PayloadSafetyFlag label="Chart write" value={payload.sideEffects.chartWrite} />
+            </dl>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReleasePayloadSectionList({
+  sections,
+  emptyCopy,
+}: {
+  sections: VisitCompletionReleasePayload["includedSections"];
+  emptyCopy: string;
+}) {
+  if (sections.length === 0) {
+    return <p className="mt-3 text-sm text-text-muted">{emptyCopy}</p>;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {sections.map((section) => (
+        <div key={section.cardId} className="rounded-md border border-border bg-surface px-3 py-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-text">{section.title}</p>
+            <Badge tone={statusBadgeTone[section.status]}>{statusLabel[section.status]}</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            {section.labels.slice(0, 2).join("; ")}
+            {section.labels.length > 2 ? `; +${section.labels.length - 2} more` : ""}
+          </p>
+          {(section.confirmationNote || section.editNote) && (
+            <p className="mt-2 text-xs leading-relaxed text-text-subtle">
+              {section.confirmationNote ?? section.editNote}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PayloadSafetyFlag({ label, value }: { label: string; value: boolean }) {
+  return (
+    <div className="rounded-md border border-border bg-surface px-3 py-2">
+      <dt className="font-medium text-text">{label}</dt>
+      <dd className="mt-1">{value ? "Side effect enabled" : "No side effect"}</dd>
     </div>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -41,6 +41,7 @@ import {
   type VisitCompletionReview,
   type VisitCompletionSelectionAction,
   type VisitCompletionSelectionState,
+  type VisitCompletionStructuredEdit,
 } from "@/lib/domain/visit-completion-selection";
 import { releaseVisitCompletion } from "./actions";
 
@@ -182,6 +183,28 @@ function shouldOpenDetailsFromCardActivation(target: EventTarget | null): boolea
   );
 }
 
+type VisitCompletionDrawerMode = "review" | "edit";
+
+interface VisitCompletionDrawerEditSubmission {
+  note: string;
+  selectedItemIds: string[];
+  customLabels: string[];
+  structuredEdit: VisitCompletionStructuredEdit;
+}
+
+function cardStateFromReleaseSection(
+  section: VisitCompletionReleasePayload["includedSections"][number],
+): VisitCompletionSelectionState["cardStates"][VisitCompletionCardId] {
+  return {
+    status: section.status,
+    editNote: section.editNote,
+    confirmationNote: section.confirmationNote,
+    selectedItemIds: section.selectedItemIds,
+    customLabels: section.customLabels,
+    structuredEdit: section.structuredEdit,
+  };
+}
+
 export function VisitCompletionPanel({
   bundle,
   releasedPayload,
@@ -196,25 +219,13 @@ export function VisitCompletionPanel({
     if (releasedPayload) {
       const cardStates = {} as VisitCompletionSelectionState["cardStates"];
       for (const section of releasedPayload.includedSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       for (const section of releasedPayload.heldOutSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       for (const section of releasedPayload.unresolvedSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       return { cardStates };
     }
@@ -226,6 +237,7 @@ export function VisitCompletionPanel({
     bundle.cards[0]?.id ?? "orders",
   );
   const [detailsDrawerOpen, setDetailsDrawerOpen] = React.useState(false);
+  const [drawerMode, setDrawerMode] = React.useState<VisitCompletionDrawerMode>("review");
   const [editingCardId, setEditingCardId] = React.useState<VisitCompletionCardId | null>(null);
   const [editDraft, setEditDraft] = React.useState("");
   const [releasePayloadOpen, setReleasePayloadOpen] = React.useState(!releasedPayload);
@@ -238,30 +250,19 @@ export function VisitCompletionPanel({
       setLocalReleasedPayload(releasedPayload);
       const cardStates = {} as VisitCompletionSelectionState["cardStates"];
       for (const section of releasedPayload.includedSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       for (const section of releasedPayload.heldOutSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       for (const section of releasedPayload.unresolvedSections) {
-        cardStates[section.cardId] = {
-          status: section.status,
-          editNote: section.editNote,
-          confirmationNote: section.confirmationNote,
-        };
+        cardStates[section.cardId] = cardStateFromReleaseSection(section);
       }
       setSelectionState({ cardStates });
       setReleaseReviewOpen(false);
       setReleasePayloadOpen(false);
       setDetailsDrawerOpen(false);
+      setDrawerMode("review");
     }
   }, [releasedPayload]);
 
@@ -305,8 +306,12 @@ export function VisitCompletionPanel({
     setSelectionState((current) => applyVisitCompletionAction(bundle, current, action));
   }
 
-  function openCardDetails(cardId: VisitCompletionCardId) {
+  function openCardDetails(
+    cardId: VisitCompletionCardId,
+    mode: VisitCompletionDrawerMode = "review",
+  ) {
     setActiveCardId(cardId);
+    setDrawerMode(mode);
     setDetailsDrawerOpen(true);
     setReleaseReviewOpen(true);
   }
@@ -318,6 +323,7 @@ export function VisitCompletionPanel({
       confirmationNote: detailCopy[card.id].confirmNote,
     });
     setDetailsDrawerOpen(false);
+    setDrawerMode("review");
     setReleaseReviewOpen(true);
   }
 
@@ -341,16 +347,30 @@ export function VisitCompletionPanel({
         applyLocalAction({ type: "defer_card", cardId: card.id });
         return;
       case "edit":
-        setDetailsDrawerOpen(false);
-        setEditingCardId(card.id);
-        setEditDraft(selectionState.cardStates[card.id]?.editNote ?? "");
+        setEditingCardId(null);
+        setEditDraft("");
+        openCardDetails(card.id, "edit");
         return;
       case "order_review":
       case "coding_review":
       case "view_checks":
-        setDetailsDrawerOpen(true);
+        openCardDetails(card.id);
         return;
     }
+  }
+
+  function saveStructuredEdit(card: VisitCompletionCard, edit: VisitCompletionDrawerEditSubmission) {
+    applyLocalAction({
+      type: "edit_card",
+      cardId: card.id,
+      note: edit.note,
+      selectedItemIds: edit.selectedItemIds,
+      customLabels: edit.customLabels,
+      structuredEdit: edit.structuredEdit,
+    });
+    setDrawerMode("review");
+    setDetailsDrawerOpen(true);
+    setReleaseReviewOpen(true);
   }
 
   function saveEdit(cardId: VisitCompletionCardId) {
@@ -432,21 +452,29 @@ export function VisitCompletionPanel({
           card={activeCard}
           cardState={activeCardState}
           isOpen={detailsDrawerOpen}
-          onClose={() => setDetailsDrawerOpen(false)}
+          mode={drawerMode}
+          onClose={() => {
+            setDetailsDrawerOpen(false);
+            setDrawerMode("review");
+          }}
           onConfirm={() => confirmCard(activeCard)}
           onEdit={() => {
-            setDetailsDrawerOpen(false);
             setActiveCardId(activeCard.id);
-            setEditingCardId(activeCard.id);
-            setEditDraft(selectionState.cardStates[activeCard.id]?.editNote ?? "");
+            setEditingCardId(null);
+            setEditDraft("");
+            setDrawerMode("edit");
           }}
+          onSaveEdit={(edit) => saveStructuredEdit(activeCard, edit)}
+          onCancelEdit={() => setDrawerMode("review")}
           onRemove={() => {
             setDetailsDrawerOpen(false);
+            setDrawerMode("review");
             setActiveCardId(activeCard.id);
             applyLocalAction({ type: "remove_card", cardId: activeCard.id });
           }}
           onDefer={() => {
             setDetailsDrawerOpen(false);
+            setDrawerMode("review");
             setActiveCardId(activeCard.id);
             applyLocalAction({ type: "defer_card", cardId: activeCard.id });
           }}
@@ -659,9 +687,12 @@ export function VisitCompletionDetailsDrawer({
   card,
   cardState,
   isOpen = true,
+  mode = "review",
   onClose,
   onConfirm,
   onEdit,
+  onSaveEdit,
+  onCancelEdit,
   onRemove,
   onDefer,
   isReleased,
@@ -669,9 +700,12 @@ export function VisitCompletionDetailsDrawer({
   card: VisitCompletionCard;
   cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
   isOpen?: boolean;
+  mode?: VisitCompletionDrawerMode;
   onClose: () => void;
   onConfirm: () => void;
   onEdit: () => void;
+  onSaveEdit: (edit: VisitCompletionDrawerEditSubmission) => void;
+  onCancelEdit: () => void;
   onRemove: () => void;
   onDefer: () => void;
   isReleased: boolean;
@@ -679,6 +713,7 @@ export function VisitCompletionDetailsDrawer({
   const Icon = cardIcons[card.id];
   const copy = detailCopy[card.id];
   const resolved = isResolvedStatus(cardState.status);
+  const isEditing = mode === "edit" && !isReleased;
 
   if (!isOpen) {
     return null;
@@ -711,10 +746,12 @@ export function VisitCompletionDetailsDrawer({
                   id={`visit-completion-drawer-${card.id}`}
                   className="mt-1 text-lg font-semibold text-text"
                 >
-                  {card.title} confirmation
+                  {isEditing ? `Edit ${card.title}` : `${card.title} confirmation`}
                 </h3>
                 <p className="mt-1 text-sm leading-relaxed text-text-muted">
-                  {copy.instruction}
+                  {isEditing
+                    ? "Adjust the prepared action, keep only what belongs, then save it back into the release review."
+                    : copy.instruction}
                 </p>
               </div>
             </div>
@@ -733,7 +770,7 @@ export function VisitCompletionDetailsDrawer({
         </div>
 
         <div className="flex-1 overflow-y-auto px-5 py-4">
-          {!isReleased && (
+          {!isReleased && !isEditing && (
             <div className="mb-4 flex flex-wrap gap-2">
               <Button
                 size="sm"
@@ -774,54 +811,479 @@ export function VisitCompletionDetailsDrawer({
             </div>
           )}
 
-          <div className="space-y-3">
-            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-              <p className="text-sm font-semibold text-text">{copy.question}</p>
-              <ul className="mt-3 space-y-2">
-                {card.items.map((item) => (
-                  <VisitCompletionDetailItem key={item.id} item={item} />
-                ))}
-              </ul>
-            </div>
+          {isEditing ? (
+            <VisitCompletionStructuredEditForm
+              card={card}
+              cardState={cardState}
+              onSave={onSaveEdit}
+              onCancel={onCancelEdit}
+            />
+          ) : (
+            <div className="space-y-3">
+              <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+                <p className="text-sm font-semibold text-text">{copy.question}</p>
+                <ul className="mt-3 space-y-2">
+                  {card.items.map((item) => (
+                    <VisitCompletionDetailItem key={item.id} item={item} />
+                  ))}
+                </ul>
+              </div>
 
-            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
-                What release will do
-              </p>
-              <p className="mt-2 text-sm font-semibold text-text">{copy.releaseWillDo}</p>
-              <p className="mt-1 text-xs leading-relaxed text-text-muted">
-                {copy.releaseWillNotDo}
-              </p>
-            </div>
+              <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                  What release will do
+                </p>
+                <p className="mt-2 text-sm font-semibold text-text">{copy.releaseWillDo}</p>
+                <p className="mt-1 text-xs leading-relaxed text-text-muted">
+                  {copy.releaseWillNotDo}
+                </p>
+              </div>
 
-            <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
-                Confirmation state
-              </p>
-              <p className="mt-2 text-sm font-semibold text-text">
-                {resolved ? "Resolved for release review" : "Confirmation required before release."}
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-text-muted">
-                Nothing is routed until the physician releases the care plan. Release creates only
-                the reviewed task, draft, and audit artifacts described above.
-              </p>
-              {cardState.confirmationNote && (
-                <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
-                  Confirmation note: {cardState.confirmationNote}
+              <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                  Confirmation state
                 </p>
-              )}
-              {cardState.editNote && (
-                <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
-                  Edit note: {cardState.editNote}
+                <p className="mt-2 text-sm font-semibold text-text">
+                  {resolved
+                    ? "Resolved for release review"
+                    : "Confirmation required before release."}
                 </p>
-              )}
+                <p className="mt-1 text-xs leading-relaxed text-text-muted">
+                  Nothing is routed until the physician releases the care plan. Release creates only
+                  the reviewed task, draft, and audit artifacts described above.
+                </p>
+                {cardState.confirmationNote && (
+                  <p className="mt-3 rounded-md border border-accent/20 bg-accent-soft/45 px-3 py-2 text-xs leading-relaxed text-text-muted">
+                    Confirmation note: {cardState.confirmationNote}
+                  </p>
+                )}
+                {cardState.editNote && (
+                  <p className="mt-3 rounded-md border border-highlight/30 bg-highlight-soft px-3 py-2 text-xs leading-relaxed text-text-muted">
+                    Edit note: {cardState.editNote}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </aside>
     </div>
   );
 }
+
+interface VisitCompletionStructuredEditDraft {
+  selectedItemIds: string[];
+  customLabels: string[];
+  customLabelDraft: string;
+  physicianNote: string;
+  followUpInterval: string;
+  followUpRouting: NonNullable<VisitCompletionStructuredEdit["followUpRouting"]>;
+  patientMessageDraft: string;
+  patientMessageChannel: NonNullable<VisitCompletionStructuredEdit["patientMessageChannel"]>;
+  practiceReadinessOwner: NonNullable<VisitCompletionStructuredEdit["practiceReadinessOwner"]>;
+}
+
+function VisitCompletionStructuredEditForm({
+  card,
+  cardState,
+  onSave,
+  onCancel,
+}: {
+  card: VisitCompletionCard;
+  cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId];
+  onSave: (edit: VisitCompletionDrawerEditSubmission) => void;
+  onCancel: () => void;
+}) {
+  const initialDraft = React.useMemo(
+    () => buildStructuredEditDraft(card, cardState),
+    [card, cardState],
+  );
+  const [draft, setDraft] = React.useState(initialDraft);
+
+  React.useEffect(() => {
+    setDraft(buildStructuredEditDraft(card, cardState));
+  }, [card, cardState]);
+
+  function toggleItem(itemId: string) {
+    setDraft((current) => {
+      const selected = new Set(current.selectedItemIds);
+      if (selected.has(itemId)) {
+        selected.delete(itemId);
+      } else {
+        selected.add(itemId);
+      }
+      return { ...current, selectedItemIds: Array.from(selected) };
+    });
+  }
+
+  function addCustomLabel() {
+    const label = draft.customLabelDraft.trim();
+    if (!label) return;
+    setDraft((current) => ({
+      ...current,
+      customLabels: [...current.customLabels, label],
+      customLabelDraft: "",
+    }));
+  }
+
+  function removeCustomLabel(label: string) {
+    setDraft((current) => ({
+      ...current,
+      customLabels: current.customLabels.filter((existing) => existing !== label),
+    }));
+  }
+
+  const submission = buildStructuredEditSubmission(card, draft);
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-accent/20 bg-accent-soft/35 px-4 py-3">
+        <p className="text-sm font-semibold text-text">Included actions</p>
+        <p className="mt-1 text-xs leading-relaxed text-text-muted">
+          Keep the suggestions that belong in the release. Removed rows stay out of the released
+          staff task, draft, or readiness record.
+        </p>
+        <div className="mt-3 space-y-2">
+          {card.items.map((item) => (
+            <label
+              key={item.id}
+              className="flex gap-3 rounded-md border border-border bg-surface px-3 py-2 text-sm leading-relaxed text-text"
+            >
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-border text-accent focus:ring-accent"
+                checked={draft.selectedItemIds.includes(item.id)}
+                onChange={() => toggleItem(item.id)}
+              />
+              <span>
+                <span className="font-medium">{item.label}</span>
+                {item.reason && (
+                  <span className="mt-1 block text-xs text-text-subtle">{item.reason}</span>
+                )}
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {card.id === "follow_up" && (
+        <div className="grid gap-3 rounded-lg border border-border bg-surface-muted/35 px-4 py-3 md:grid-cols-2">
+          <label className="text-sm font-semibold text-text">
+            Follow-up interval
+            <input
+              className="mt-2 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.followUpInterval}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, followUpInterval: event.target.value }))
+              }
+              placeholder="6 weeks"
+            />
+          </label>
+          <label className="text-sm font-semibold text-text">
+            Scheduling handoff
+            <select
+              className="mt-2 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.followUpRouting}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  followUpRouting: event.target.value as VisitCompletionStructuredEditDraft["followUpRouting"],
+                }))
+              }
+            >
+              <option value="front_desk">Front desk scheduling task</option>
+              <option value="scheduling_link">Text scheduling link</option>
+              <option value="no_handoff">No scheduling handoff</option>
+            </select>
+          </label>
+        </div>
+      )}
+
+      {card.id === "patient_message" && (
+        <div className="space-y-3 rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+          <label className="text-sm font-semibold text-text">
+            Message channel
+            <select
+              className="mt-2 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.patientMessageChannel}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  patientMessageChannel:
+                    event.target.value as VisitCompletionStructuredEditDraft["patientMessageChannel"],
+                }))
+              }
+            >
+              <option value="portal">Portal draft</option>
+              <option value="print">Print summary</option>
+              <option value="sms">SMS scheduling note</option>
+              <option value="translation">Translation requested</option>
+            </select>
+          </label>
+          <label className="text-sm font-semibold text-text">
+            Patient message draft
+            <textarea
+              className="mt-2 min-h-36 w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal leading-relaxed text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.patientMessageDraft}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, patientMessageDraft: event.target.value }))
+              }
+            />
+          </label>
+        </div>
+      )}
+
+      {card.id === "practice_readiness" && (
+        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+          <label className="text-sm font-semibold text-text">
+            Practice readiness owner
+            <select
+              className="mt-2 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.practiceReadinessOwner}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  practiceReadinessOwner:
+                    event.target.value as VisitCompletionStructuredEditDraft["practiceReadinessOwner"],
+                }))
+              }
+            >
+              <option value="back_office">Back office</option>
+              <option value="front_office">Front office</option>
+              <option value="clinician">Clinician</option>
+              <option value="billing">Billing</option>
+            </select>
+          </label>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+        <label className="text-sm font-semibold text-text">
+          Add custom action
+          <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+            <input
+              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.customLabelDraft}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, customLabelDraft: event.target.value }))
+              }
+              placeholder="Add a reviewed action for staff or patient handoff"
+            />
+            <Button type="button" size="sm" variant="secondary" onClick={addCustomLabel}>
+              Add
+            </Button>
+          </div>
+        </label>
+        {draft.customLabels.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {draft.customLabels.map((label) => (
+              <button
+                key={label}
+                type="button"
+                className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2.5 py-1 text-xs font-medium text-text-muted hover:border-danger/40 hover:text-danger"
+                onClick={() => removeCustomLabel(label)}
+              >
+                {label}
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {card.id !== "patient_message" && (
+        <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-3">
+          <label className="text-sm font-semibold text-text">
+            Physician note
+            <textarea
+              className="mt-2 min-h-24 w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal leading-relaxed text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+              value={draft.physicianNote}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, physicianNote: event.target.value }))
+              }
+              placeholder="Add the physician-approved change or rationale."
+            />
+          </label>
+        </div>
+      )}
+
+      <div className="sticky bottom-0 -mx-5 -mb-4 border-t border-border bg-surface/95 px-5 py-4 backdrop-blur">
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel edit
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onSave(submission)}
+            leadingIcon={<Check className="h-3.5 w-3.5" />}
+          >
+            Save and confirm
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildStructuredEditDraft(
+  card: VisitCompletionCard,
+  cardState: VisitCompletionSelectionState["cardStates"][VisitCompletionCardId],
+): VisitCompletionStructuredEditDraft {
+  const structuredEdit = cardState.structuredEdit ?? {};
+
+  return {
+    selectedItemIds:
+      structuredEdit.selectedItemIds ?? cardState.selectedItemIds ?? card.items.map((item) => item.id),
+    customLabels: structuredEdit.customLabels ?? cardState.customLabels ?? [],
+    customLabelDraft: "",
+    physicianNote: structuredEdit.physicianNote ?? cardState.editNote ?? "",
+    followUpInterval: structuredEdit.followUpInterval ?? inferFollowUpInterval(card),
+    followUpRouting: structuredEdit.followUpRouting ?? "front_desk",
+    patientMessageDraft:
+      structuredEdit.patientMessageDraft ?? cardState.editNote ?? buildDefaultPatientMessage(card),
+    patientMessageChannel: structuredEdit.patientMessageChannel ?? "portal",
+    practiceReadinessOwner: structuredEdit.practiceReadinessOwner ?? "back_office",
+  };
+}
+
+function buildStructuredEditSubmission(
+  card: VisitCompletionCard,
+  draft: VisitCompletionStructuredEditDraft,
+): VisitCompletionDrawerEditSubmission {
+  const customLabels = normalizeDrawerLabels([
+    ...draft.customLabels,
+    ...derivedStructuredLabels(card, draft),
+    draft.customLabelDraft,
+  ]);
+  const selectedItemIds = draft.selectedItemIds.filter((itemId) =>
+    card.items.some((item) => item.id === itemId),
+  );
+  const structuredEdit: VisitCompletionStructuredEdit = {
+    selectedItemIds,
+    customLabels,
+    physicianNote: draft.physicianNote.trim() || undefined,
+  };
+
+  if (card.id === "follow_up") {
+    structuredEdit.followUpInterval = draft.followUpInterval.trim() || undefined;
+    structuredEdit.followUpRouting = draft.followUpRouting;
+  }
+
+  if (card.id === "patient_message") {
+    structuredEdit.patientMessageDraft = draft.patientMessageDraft.trim() || undefined;
+    structuredEdit.patientMessageChannel = draft.patientMessageChannel;
+  }
+
+  if (card.id === "practice_readiness") {
+    structuredEdit.practiceReadinessOwner = draft.practiceReadinessOwner;
+  }
+
+  return {
+    note: noteForStructuredEdit(card, draft),
+    selectedItemIds,
+    customLabels,
+    structuredEdit,
+  };
+}
+
+function derivedStructuredLabels(
+  card: VisitCompletionCard,
+  draft: VisitCompletionStructuredEditDraft,
+): string[] {
+  switch (card.id) {
+    case "follow_up":
+      return [
+        draft.followUpInterval.trim() ? `Follow-up interval: ${draft.followUpInterval.trim()}` : "",
+        `Scheduling handoff: ${followUpRoutingLabel[draft.followUpRouting]}`,
+      ];
+    case "patient_message":
+      return [`Patient message channel: ${patientMessageChannelLabel[draft.patientMessageChannel]}`];
+    case "practice_readiness":
+      return [`Practice readiness owner: ${practiceReadinessOwnerLabel[draft.practiceReadinessOwner]}`];
+    case "orders":
+      return [];
+  }
+}
+
+function noteForStructuredEdit(
+  card: VisitCompletionCard,
+  draft: VisitCompletionStructuredEditDraft,
+): string {
+  if (card.id === "patient_message") {
+    return draft.patientMessageDraft.trim() || "Patient message edited before release.";
+  }
+
+  const physicianNote = draft.physicianNote.trim();
+  if (physicianNote) {
+    return physicianNote;
+  }
+
+  if (card.id === "follow_up") {
+    return `Follow-up interval: ${draft.followUpInterval.trim() || "not specified"}; scheduling handoff: ${
+      followUpRoutingLabel[draft.followUpRouting]
+    }.`;
+  }
+
+  if (card.id === "practice_readiness") {
+    return `Practice readiness owner: ${practiceReadinessOwnerLabel[draft.practiceReadinessOwner]}.`;
+  }
+
+  return "Structured edits reviewed and confirmed before release.";
+}
+
+function normalizeDrawerLabels(labels: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const label of labels) {
+    const trimmed = label.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function inferFollowUpInterval(card: VisitCompletionCard): string {
+  const labelText = card.items.map((item) => item.label).join(" ");
+  return labelText.match(/\b(\d+\s*(?:day|days|week|weeks|month|months))\b/i)?.[1] ?? "6 weeks";
+}
+
+function buildDefaultPatientMessage(card: VisitCompletionCard): string {
+  const nextSteps = card.items.map((item) => `- ${item.label}`).join("\n");
+  return `Today we reviewed your care plan. Please review these next steps:\n\n${nextSteps}`;
+}
+
+const followUpRoutingLabel: Record<
+  NonNullable<VisitCompletionStructuredEdit["followUpRouting"]>,
+  string
+> = {
+  front_desk: "front desk scheduling task",
+  scheduling_link: "text scheduling link",
+  no_handoff: "no scheduling handoff",
+};
+
+const patientMessageChannelLabel: Record<
+  NonNullable<VisitCompletionStructuredEdit["patientMessageChannel"]>,
+  string
+> = {
+  portal: "portal draft",
+  print: "print summary",
+  sms: "SMS scheduling note",
+  translation: "translation requested",
+};
+
+const practiceReadinessOwnerLabel: Record<
+  NonNullable<VisitCompletionStructuredEdit["practiceReadinessOwner"]>,
+  string
+> = {
+  back_office: "back office",
+  front_office: "front office",
+  clinician: "clinician",
+  billing: "billing",
+};
 
 function VisitCompletionDetailItem({ item }: { item: VisitCompletionItem }) {
   return (

--- a/src/lib/domain/visit-completion-selection.test.ts
+++ b/src/lib/domain/visit-completion-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildVisitCompletionBundle } from "./visit-completion";
 import {
   applyVisitCompletionAction,
+  buildVisitCompletionReleasePayload,
   buildVisitCompletionReview,
   initializeVisitCompletionSelection,
 } from "./visit-completion-selection";
@@ -174,5 +175,95 @@ describe("visit completion selection state", () => {
     expect(finalReview.resolvedCardCount).toBe(4);
     expect(finalReview.needsConfirmationCount).toBe(0);
     expect(finalReview.isReadyForRelease).toBe(true);
+  });
+
+  it("builds a blocked release payload until every card has an explicit disposition", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const payload = buildVisitCompletionReleasePayload(bundle, initial);
+
+    expect(payload.version).toBe("visit-completion-release/v1");
+    expect(payload.releaseActionLabel).toBe("Release Care Plan");
+    expect(payload.mode).toBe("review_only_mvp");
+    expect(payload.canRelease).toBe(false);
+    expect(payload.status).toBe("blocked_needs_confirmation");
+    expect(payload.blockingCardIds).toEqual([
+      "orders",
+      "follow_up",
+      "patient_message",
+      "practice_readiness",
+    ]);
+    expect(payload.sideEffects).toEqual({
+      clinical: false,
+      billing: false,
+      patientCommunication: false,
+      staffAssignment: false,
+      chartWrite: false,
+      scheduling: false,
+    });
+    expect(payload.auditEvents).toHaveLength(4);
+    expect(payload.auditEvents.every((event) => event.requiresPhysicianApproval)).toBe(true);
+  });
+
+  it("builds a review-only release payload after all cards are resolved", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const confirmedOrders = applyVisitCompletionAction(bundle, initial, {
+      type: "confirm_card",
+      cardId: "orders",
+      confirmationNote: "Orders confirmed.",
+    });
+    const confirmedFollowUp = applyVisitCompletionAction(bundle, confirmedOrders, {
+      type: "confirm_card",
+      cardId: "follow_up",
+      confirmationNote: "Follow-up handoff confirmed.",
+    });
+    const editedPatientMessage = applyVisitCompletionAction(bundle, confirmedFollowUp, {
+      type: "edit_card",
+      cardId: "patient_message",
+      note: "Use simpler language.",
+    });
+    const deferredReadiness = applyVisitCompletionAction(bundle, editedPatientMessage, {
+      type: "defer_card",
+      cardId: "practice_readiness",
+    });
+
+    const payload = buildVisitCompletionReleasePayload(bundle, deferredReadiness);
+
+    expect(payload.canRelease).toBe(true);
+    expect(payload.status).toBe("ready_for_physician_release");
+    expect(payload.blockingCardIds).toEqual([]);
+    expect(payload.includedSections.map((section) => section.cardId)).toEqual([
+      "orders",
+      "follow_up",
+      "patient_message",
+    ]);
+    expect(payload.heldOutSections.map((section) => section.cardId)).toEqual([
+      "practice_readiness",
+    ]);
+    expect(payload.summary).toEqual({
+      totalCards: 4,
+      includedCards: 3,
+      heldOutCards: 1,
+      unresolvedCards: 0,
+    });
+    expect(payload.auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cardId: "orders",
+          eventType: "visit_completion.card_confirmed",
+          disposition: "include",
+        }),
+        expect.objectContaining({
+          cardId: "patient_message",
+          eventType: "visit_completion.card_edited",
+          disposition: "include",
+          note: "Use simpler language.",
+        }),
+        expect.objectContaining({
+          cardId: "practice_readiness",
+          eventType: "visit_completion.card_deferred",
+          disposition: "hold_out",
+        }),
+      ]),
+    );
   });
 });

--- a/src/lib/domain/visit-completion-selection.test.ts
+++ b/src/lib/domain/visit-completion-selection.test.ts
@@ -183,7 +183,7 @@ describe("visit completion selection state", () => {
 
     expect(payload.version).toBe("visit-completion-release/v1");
     expect(payload.releaseActionLabel).toBe("Release Care Plan");
-    expect(payload.mode).toBe("review_only_mvp");
+    expect(payload.mode).toBe("physician_release_v1");
     expect(payload.canRelease).toBe(false);
     expect(payload.status).toBe("blocked_needs_confirmation");
     expect(payload.blockingCardIds).toEqual([
@@ -204,7 +204,7 @@ describe("visit completion selection state", () => {
     expect(payload.auditEvents.every((event) => event.requiresPhysicianApproval)).toBe(true);
   });
 
-  it("builds a review-only release payload after all cards are resolved", () => {
+  it("builds a physician-release payload after all cards are resolved", () => {
     const initial = initializeVisitCompletionSelection(bundle);
     const confirmedOrders = applyVisitCompletionAction(bundle, initial, {
       type: "confirm_card",
@@ -229,6 +229,7 @@ describe("visit completion selection state", () => {
     const payload = buildVisitCompletionReleasePayload(bundle, deferredReadiness);
 
     expect(payload.canRelease).toBe(true);
+    expect(payload.mode).toBe("physician_release_v1");
     expect(payload.status).toBe("ready_for_physician_release");
     expect(payload.blockingCardIds).toEqual([]);
     expect(payload.includedSections.map((section) => section.cardId)).toEqual([
@@ -244,6 +245,14 @@ describe("visit completion selection state", () => {
       includedCards: 3,
       heldOutCards: 1,
       unresolvedCards: 0,
+    });
+    expect(payload.sideEffects).toEqual({
+      clinical: false,
+      billing: false,
+      patientCommunication: true,
+      staffAssignment: true,
+      chartWrite: false,
+      scheduling: true,
     });
     expect(payload.auditEvents).toEqual(
       expect.arrayContaining([

--- a/src/lib/domain/visit-completion-selection.test.ts
+++ b/src/lib/domain/visit-completion-selection.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { buildVisitCompletionBundle } from "./visit-completion";
+import {
+  applyVisitCompletionAction,
+  buildVisitCompletionReview,
+  initializeVisitCompletionSelection,
+} from "./visit-completion-selection";
+
+const bundle = buildVisitCompletionBundle({
+  patientFirstName: "Miguel",
+  hasFutureAppointment: false,
+  blocks: [
+    {
+      heading: "Assessment",
+      body: "Diabetes follow-up with worsening glycemic control.",
+    },
+    {
+      heading: "Plan",
+      body: "Repeat labs and return to clinic in 6 weeks to review A1C and medication response.",
+    },
+  ],
+  codingSuggestion: {
+    emLevel: "99214",
+    rationale: "Chronic condition management with medication adjustment.",
+    icd10: [{ code: "E11.9", label: "Diabetes mellitus", confidence: 0.91 }],
+  },
+});
+
+describe("visit completion selection state", () => {
+  it("starts every card selected for physician review without creating side effects", () => {
+    const state = initializeVisitCompletionSelection(bundle);
+    const review = buildVisitCompletionReview(bundle, state);
+
+    expect(Object.values(state.cardStates).map((card) => card.status)).toEqual([
+      "selected",
+      "selected",
+      "selected",
+      "selected",
+    ]);
+    expect(review.selectedCount).toBe(
+      bundle.cards.reduce((sum, card) => sum + card.items.length, 0),
+    );
+    expect(review.removedCount).toBe(0);
+    expect(review.deferredCount).toBe(0);
+    expect(review.hasClinicalSideEffects).toBe(false);
+    expect(review.hasBillingSideEffects).toBe(false);
+    expect(review.hasPatientCommunicationSideEffects).toBe(false);
+    expect(review.hasStaffAssignmentSideEffects).toBe(false);
+    expect(review.hasChartWriteSideEffects).toBe(false);
+  });
+
+  it("records approvals, removals, deferrals, and edits as learning feedback", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const approved = applyVisitCompletionAction(bundle, initial, {
+      type: "approve_card",
+      cardId: "orders",
+    });
+    const removed = applyVisitCompletionAction(bundle, approved, {
+      type: "remove_card",
+      cardId: "follow_up",
+    });
+    const deferred = applyVisitCompletionAction(bundle, removed, {
+      type: "defer_card",
+      cardId: "practice_readiness",
+    });
+    const edited = applyVisitCompletionAction(bundle, deferred, {
+      type: "edit_card",
+      cardId: "patient_message",
+      note: "Use simpler language and include pharmacy confirmation.",
+    });
+
+    const review = buildVisitCompletionReview(bundle, edited);
+
+    expect(edited.cardStates.orders.status).toBe("approved");
+    expect(edited.cardStates.follow_up.status).toBe("removed");
+    expect(edited.cardStates.practice_readiness.status).toBe("deferred");
+    expect(edited.cardStates.patient_message).toMatchObject({
+      status: "edited",
+      editNote: "Use simpler language and include pharmacy confirmation.",
+    });
+    expect(review.removedCount).toBe(
+      bundle.cards.find((card) => card.id === "follow_up")?.items.length,
+    );
+    expect(review.deferredCount).toBe(
+      bundle.cards.find((card) => card.id === "practice_readiness")?.items.length,
+    );
+    expect(review.feedbackSignals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ cardId: "orders", feedbackAction: "approved" }),
+        expect.objectContaining({ cardId: "follow_up", feedbackAction: "rejected" }),
+        expect.objectContaining({ cardId: "practice_readiness", feedbackAction: "dismissed" }),
+        expect.objectContaining({
+          cardId: "patient_message",
+          feedbackAction: "approved_with_edits",
+        }),
+      ]),
+    );
+  });
+
+  it("builds a release review that separates selected, removed, and deferred work", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const removed = applyVisitCompletionAction(bundle, initial, {
+      type: "remove_card",
+      cardId: "orders",
+    });
+    const deferred = applyVisitCompletionAction(bundle, removed, {
+      type: "defer_card",
+      cardId: "follow_up",
+    });
+
+    const review = buildVisitCompletionReview(bundle, deferred);
+
+    expect(review.selectedSections.map((section) => section.cardId)).toEqual([
+      "patient_message",
+      "practice_readiness",
+    ]);
+    expect(review.removedSections.map((section) => section.cardId)).toEqual(["orders"]);
+    expect(review.deferredSections.map((section) => section.cardId)).toEqual(["follow_up"]);
+    expect(review.selectedLabels).toEqual(
+      expect.arrayContaining([
+        "Portal summary drafted with lab instructions and follow-up timing.",
+        "Suggested E/M: 99214",
+      ]),
+    );
+    expect(review.removedLabels).toEqual(
+      expect.arrayContaining(["A1C", "Urine albumin/creatinine", "CMP/eGFR"]),
+    );
+    expect(review.deferredLabels).toEqual(
+      expect.arrayContaining(["RTC in 6 weeks recommended. No appointment currently scheduled."]),
+    );
+  });
+});

--- a/src/lib/domain/visit-completion-selection.test.ts
+++ b/src/lib/domain/visit-completion-selection.test.ts
@@ -275,4 +275,34 @@ describe("visit completion selection state", () => {
       ]),
     );
   });
+
+  it("carries structured drawer edits into the release payload", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const editedOrders = applyVisitCompletionAction(bundle, initial, {
+      type: "edit_card",
+      cardId: "orders",
+      note: "A1C only today; add retinal exam referral for staff follow-up.",
+      selectedItemIds: ["a1c-due"],
+      customLabels: ["Retinal exam referral"],
+      structuredEdit: {
+        physicianNote: "A1C only today; add retinal exam referral for staff follow-up.",
+        customLabels: ["Retinal exam referral"],
+        selectedItemIds: ["a1c-due"],
+      },
+    });
+
+    const payload = buildVisitCompletionReleasePayload(bundle, editedOrders);
+    const ordersSection = payload.includedSections.find((section) => section.cardId === "orders");
+
+    expect(ordersSection).toMatchObject({
+      status: "edited",
+      labels: ["A1C", "Retinal exam referral"],
+      editNote: "A1C only today; add retinal exam referral for staff follow-up.",
+      structuredEdit: {
+        physicianNote: "A1C only today; add retinal exam referral for staff follow-up.",
+        customLabels: ["Retinal exam referral"],
+        selectedItemIds: ["a1c-due"],
+      },
+    });
+  });
 });

--- a/src/lib/domain/visit-completion-selection.test.ts
+++ b/src/lib/domain/visit-completion-selection.test.ts
@@ -129,4 +129,50 @@ describe("visit completion selection state", () => {
       expect.arrayContaining(["RTC in 6 weeks recommended. No appointment currently scheduled."]),
     );
   });
+
+  it("requires every card to be clicked into and resolved before release readiness", () => {
+    const initial = initializeVisitCompletionSelection(bundle);
+    const initialReview = buildVisitCompletionReview(bundle, initial);
+
+    expect(initialReview.totalCardCount).toBe(4);
+    expect(initialReview.resolvedCardCount).toBe(0);
+    expect(initialReview.needsConfirmationCount).toBe(4);
+    expect(initialReview.isReadyForRelease).toBe(false);
+    expect(initialReview.needsConfirmationSections.map((section) => section.cardId)).toEqual([
+      "orders",
+      "follow_up",
+      "patient_message",
+      "practice_readiness",
+    ]);
+
+    const confirmedOrders = applyVisitCompletionAction(bundle, initial, {
+      type: "confirm_card",
+      cardId: "orders",
+      confirmationNote: "Orders reviewed in the detail panel.",
+    });
+    const removedFollowUp = applyVisitCompletionAction(bundle, confirmedOrders, {
+      type: "remove_card",
+      cardId: "follow_up",
+    });
+    const editedPatientMessage = applyVisitCompletionAction(bundle, removedFollowUp, {
+      type: "edit_card",
+      cardId: "patient_message",
+      note: "Tell Miguel to complete labs before the follow-up.",
+    });
+    const deferredReadiness = applyVisitCompletionAction(bundle, editedPatientMessage, {
+      type: "defer_card",
+      cardId: "practice_readiness",
+    });
+
+    const finalReview = buildVisitCompletionReview(bundle, deferredReadiness);
+
+    expect(deferredReadiness.cardStates.orders).toMatchObject({
+      status: "confirmed",
+      confirmationNote: "Orders reviewed in the detail panel.",
+    });
+    expect(finalReview.confirmedSections.map((section) => section.cardId)).toEqual(["orders"]);
+    expect(finalReview.resolvedCardCount).toBe(4);
+    expect(finalReview.needsConfirmationCount).toBe(0);
+    expect(finalReview.isReadyForRelease).toBe(true);
+  });
 });

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -17,6 +17,20 @@ export interface VisitCompletionCardSelectionState {
   status: VisitCompletionCardSelectionStatus;
   editNote?: string;
   confirmationNote?: string;
+  selectedItemIds?: string[];
+  customLabels?: string[];
+  structuredEdit?: VisitCompletionStructuredEdit;
+}
+
+export interface VisitCompletionStructuredEdit {
+  selectedItemIds?: string[];
+  customLabels?: string[];
+  physicianNote?: string;
+  followUpInterval?: string;
+  followUpRouting?: "front_desk" | "scheduling_link" | "no_handoff";
+  patientMessageDraft?: string;
+  patientMessageChannel?: "portal" | "print" | "sms" | "translation";
+  practiceReadinessOwner?: "back_office" | "front_office" | "clinician" | "billing";
 }
 
 export interface VisitCompletionSelectionState {
@@ -28,7 +42,14 @@ export type VisitCompletionSelectionAction =
   | { type: "confirm_card"; cardId: VisitCompletionCardId; confirmationNote?: string }
   | { type: "remove_card"; cardId: VisitCompletionCardId }
   | { type: "defer_card"; cardId: VisitCompletionCardId }
-  | { type: "edit_card"; cardId: VisitCompletionCardId; note: string };
+  | {
+      type: "edit_card";
+      cardId: VisitCompletionCardId;
+      note: string;
+      selectedItemIds?: string[];
+      customLabels?: string[];
+      structuredEdit?: VisitCompletionStructuredEdit;
+    };
 
 export interface VisitCompletionReviewSection {
   cardId: VisitCompletionCardId;
@@ -37,6 +58,9 @@ export interface VisitCompletionReviewSection {
   labels: string[];
   editNote?: string;
   confirmationNote?: string;
+  selectedItemIds?: string[];
+  customLabels?: string[];
+  structuredEdit?: VisitCompletionStructuredEdit;
 }
 
 export interface VisitCompletionReviewSignal {
@@ -87,6 +111,9 @@ export interface VisitCompletionReleaseSection {
   labels: string[];
   editNote?: string;
   confirmationNote?: string;
+  selectedItemIds?: string[];
+  customLabels?: string[];
+  structuredEdit?: VisitCompletionStructuredEdit;
   requiresPhysicianApproval: true;
 }
 
@@ -159,7 +186,13 @@ export function applyVisitCompletionAction(
 
   switch (action.type) {
     case "edit_card":
-      nextCardState = { status: "edited", editNote: action.note.trim() };
+      nextCardState = {
+        status: "edited",
+        editNote: action.note.trim(),
+        selectedItemIds: normalizeStringList(action.selectedItemIds),
+        customLabels: normalizeStringList(action.customLabels),
+        structuredEdit: normalizeStructuredEdit(action.structuredEdit),
+      };
       break;
     case "confirm_card":
       nextCardState = {
@@ -302,10 +335,29 @@ function sectionForCard(
     cardId: card.id,
     title: card.title,
     status: cardState.status,
-    labels: card.items.map((item) => item.label),
+    labels: labelsForCard(card, cardState),
     editNote: cardState.editNote,
     confirmationNote: cardState.confirmationNote,
+    selectedItemIds: cardState.selectedItemIds,
+    customLabels: cardState.customLabels,
+    structuredEdit: cardState.structuredEdit,
   };
+}
+
+function labelsForCard(
+  card: VisitCompletionCard,
+  cardState: VisitCompletionCardSelectionState,
+): string[] {
+  const selectedItemIds = cardState.selectedItemIds;
+  const includedItemIds =
+    selectedItemIds === undefined
+      ? new Set(card.items.map((item) => item.id))
+      : new Set(selectedItemIds);
+
+  return [
+    ...card.items.filter((item) => includedItemIds.has(item.id)).map((item) => item.label),
+    ...(normalizeStringList(cardState.customLabels) ?? []),
+  ];
 }
 
 function releaseSectionForCard(
@@ -382,6 +434,36 @@ function isResolvedCardStatus(status: VisitCompletionCardSelectionStatus): boole
 
 function countLabels(sections: VisitCompletionReviewSection[]): number {
   return sections.reduce((sum, section) => sum + section.labels.length, 0);
+}
+
+function normalizeStringList(values: string[] | undefined): string[] | undefined {
+  if (!values) {
+    return undefined;
+  }
+
+  const normalized = values.map((value) => value.trim()).filter(Boolean);
+  return normalized.length > 0 ? normalized : [];
+}
+
+function normalizeStructuredEdit(
+  structuredEdit: VisitCompletionStructuredEdit | undefined,
+): VisitCompletionStructuredEdit | undefined {
+  if (!structuredEdit) {
+    return undefined;
+  }
+
+  const normalized: VisitCompletionStructuredEdit = {
+    ...structuredEdit,
+    selectedItemIds: normalizeStringList(structuredEdit.selectedItemIds),
+    customLabels: normalizeStringList(structuredEdit.customLabels),
+    physicianNote: structuredEdit.physicianNote?.trim() || undefined,
+    followUpInterval: structuredEdit.followUpInterval?.trim() || undefined,
+    patientMessageDraft: structuredEdit.patientMessageDraft?.trim() || undefined,
+  };
+
+  return Object.fromEntries(
+    Object.entries(normalized).filter(([, value]) => value !== undefined),
+  ) as VisitCompletionStructuredEdit;
 }
 
 function feedbackSignalForSection(

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -69,6 +69,71 @@ export interface VisitCompletionReview {
   hasChartWriteSideEffects: false;
 }
 
+export type VisitCompletionReleasePayloadStatus =
+  | "blocked_needs_confirmation"
+  | "ready_for_physician_release";
+
+export type VisitCompletionReleaseDisposition =
+  | "include"
+  | "remove"
+  | "hold_out"
+  | "unresolved";
+
+export interface VisitCompletionReleaseSection {
+  cardId: VisitCompletionCardId;
+  title: string;
+  status: VisitCompletionCardSelectionStatus;
+  disposition: VisitCompletionReleaseDisposition;
+  labels: string[];
+  editNote?: string;
+  confirmationNote?: string;
+  requiresPhysicianApproval: true;
+}
+
+export interface VisitCompletionReleaseAuditEvent {
+  cardId: VisitCompletionCardId;
+  eventType:
+    | "visit_completion.card_needs_confirmation"
+    | "visit_completion.card_confirmed"
+    | "visit_completion.card_edited"
+    | "visit_completion.card_removed"
+    | "visit_completion.card_deferred";
+  disposition: VisitCompletionReleaseDisposition;
+  note?: string;
+  requiresPhysicianApproval: true;
+}
+
+export interface VisitCompletionReleaseSummary {
+  totalCards: number;
+  includedCards: number;
+  heldOutCards: number;
+  unresolvedCards: number;
+}
+
+export interface VisitCompletionReleasePayload {
+  version: "visit-completion-release/v1";
+  releaseActionLabel: "Release Care Plan";
+  mode: "review_only_mvp";
+  status: VisitCompletionReleasePayloadStatus;
+  canRelease: boolean;
+  summary: VisitCompletionReleaseSummary;
+  includedSections: VisitCompletionReleaseSection[];
+  heldOutSections: VisitCompletionReleaseSection[];
+  unresolvedSections: VisitCompletionReleaseSection[];
+  blockingCardIds: VisitCompletionCardId[];
+  auditEvents: VisitCompletionReleaseAuditEvent[];
+  feedbackSignals: VisitCompletionReviewSignal[];
+  safetyCopy: VisitCompletionBundle["safetyCopy"];
+  sideEffects: {
+    clinical: false;
+    billing: false;
+    patientCommunication: false;
+    staffAssignment: false;
+    chartWrite: false;
+    scheduling: false;
+  };
+}
+
 export function initializeVisitCompletionSelection(
   bundle: VisitCompletionBundle,
 ): VisitCompletionSelectionState {
@@ -160,6 +225,49 @@ export function buildVisitCompletionReview(
   };
 }
 
+export function buildVisitCompletionReleasePayload(
+  bundle: VisitCompletionBundle,
+  state: VisitCompletionSelectionState,
+): VisitCompletionReleasePayload {
+  const review = buildVisitCompletionReview(bundle, state);
+  const sections = bundle.cards.map((card) => releaseSectionForCard(card, state));
+  const includedSections = sections.filter((section) => section.disposition === "include");
+  const heldOutSections = sections.filter((section) =>
+    ["remove", "hold_out"].includes(section.disposition),
+  );
+  const unresolvedSections = sections.filter((section) => section.disposition === "unresolved");
+  const canRelease = unresolvedSections.length === 0;
+
+  return {
+    version: "visit-completion-release/v1",
+    releaseActionLabel: "Release Care Plan",
+    mode: "review_only_mvp",
+    status: canRelease ? "ready_for_physician_release" : "blocked_needs_confirmation",
+    canRelease,
+    summary: {
+      totalCards: sections.length,
+      includedCards: includedSections.length,
+      heldOutCards: heldOutSections.length,
+      unresolvedCards: unresolvedSections.length,
+    },
+    includedSections,
+    heldOutSections,
+    unresolvedSections,
+    blockingCardIds: unresolvedSections.map((section) => section.cardId),
+    auditEvents: sections.map((section) => auditEventForSection(section)),
+    feedbackSignals: review.feedbackSignals,
+    safetyCopy: bundle.safetyCopy,
+    sideEffects: {
+      clinical: false,
+      billing: false,
+      patientCommunication: false,
+      staffAssignment: false,
+      chartWrite: false,
+      scheduling: false,
+    },
+  };
+}
+
 function statusForAction(
   type: Exclude<VisitCompletionSelectionAction["type"], "edit_card" | "confirm_card">,
 ): VisitCompletionCardSelectionStatus {
@@ -187,6 +295,66 @@ function sectionForCard(
     editNote: cardState.editNote,
     confirmationNote: cardState.confirmationNote,
   };
+}
+
+function releaseSectionForCard(
+  card: VisitCompletionCard,
+  state: VisitCompletionSelectionState,
+): VisitCompletionReleaseSection {
+  const section = sectionForCard(card, state);
+
+  return {
+    ...section,
+    disposition: dispositionForStatus(section.status),
+    requiresPhysicianApproval: true,
+  };
+}
+
+function dispositionForStatus(
+  status: VisitCompletionCardSelectionStatus,
+): VisitCompletionReleaseDisposition {
+  switch (status) {
+    case "confirmed":
+    case "edited":
+      return "include";
+    case "removed":
+      return "remove";
+    case "deferred":
+      return "hold_out";
+    case "selected":
+    case "approved":
+      return "unresolved";
+  }
+}
+
+function auditEventForSection(
+  section: VisitCompletionReleaseSection,
+): VisitCompletionReleaseAuditEvent {
+  return {
+    cardId: section.cardId,
+    eventType: eventTypeForStatus(section.status),
+    disposition: section.disposition,
+    note: section.editNote ?? section.confirmationNote,
+    requiresPhysicianApproval: true,
+  };
+}
+
+function eventTypeForStatus(
+  status: VisitCompletionCardSelectionStatus,
+): VisitCompletionReleaseAuditEvent["eventType"] {
+  switch (status) {
+    case "confirmed":
+      return "visit_completion.card_confirmed";
+    case "edited":
+      return "visit_completion.card_edited";
+    case "removed":
+      return "visit_completion.card_removed";
+    case "deferred":
+      return "visit_completion.card_deferred";
+    case "selected":
+    case "approved":
+      return "visit_completion.card_needs_confirmation";
+  }
 }
 
 function isSelectedForReleaseStatus(status: VisitCompletionCardSelectionStatus): boolean {

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -1,0 +1,188 @@
+import type {
+  VisitCompletionBundle,
+  VisitCompletionCard,
+  VisitCompletionCardId,
+  VisitCompletionLearningSignal,
+} from "./visit-completion";
+
+export type VisitCompletionCardSelectionStatus =
+  | "selected"
+  | "approved"
+  | "edited"
+  | "removed"
+  | "deferred";
+
+export interface VisitCompletionCardSelectionState {
+  status: VisitCompletionCardSelectionStatus;
+  editNote?: string;
+}
+
+export interface VisitCompletionSelectionState {
+  cardStates: Record<VisitCompletionCardId, VisitCompletionCardSelectionState>;
+}
+
+export type VisitCompletionSelectionAction =
+  | { type: "approve_card"; cardId: VisitCompletionCardId }
+  | { type: "remove_card"; cardId: VisitCompletionCardId }
+  | { type: "defer_card"; cardId: VisitCompletionCardId }
+  | { type: "edit_card"; cardId: VisitCompletionCardId; note: string };
+
+export interface VisitCompletionReviewSection {
+  cardId: VisitCompletionCardId;
+  title: string;
+  status: VisitCompletionCardSelectionStatus;
+  labels: string[];
+  editNote?: string;
+}
+
+export interface VisitCompletionReviewSignal {
+  cardId: VisitCompletionCardId;
+  feedbackAction: VisitCompletionLearningSignal["feedbackAction"];
+  meaning: string;
+}
+
+export interface VisitCompletionReview {
+  selectedSections: VisitCompletionReviewSection[];
+  removedSections: VisitCompletionReviewSection[];
+  deferredSections: VisitCompletionReviewSection[];
+  selectedLabels: string[];
+  removedLabels: string[];
+  deferredLabels: string[];
+  selectedCount: number;
+  removedCount: number;
+  deferredCount: number;
+  feedbackSignals: VisitCompletionReviewSignal[];
+  hasClinicalSideEffects: false;
+  hasBillingSideEffects: false;
+  hasPatientCommunicationSideEffects: false;
+  hasStaffAssignmentSideEffects: false;
+  hasChartWriteSideEffects: false;
+}
+
+export function initializeVisitCompletionSelection(
+  bundle: VisitCompletionBundle,
+): VisitCompletionSelectionState {
+  const cardStates = {} as VisitCompletionSelectionState["cardStates"];
+
+  for (const card of bundle.cards) {
+    cardStates[card.id] = { status: "selected" };
+  }
+
+  return { cardStates };
+}
+
+export function applyVisitCompletionAction(
+  bundle: VisitCompletionBundle,
+  state: VisitCompletionSelectionState,
+  action: VisitCompletionSelectionAction,
+): VisitCompletionSelectionState {
+  if (!bundle.cards.some((card) => card.id === action.cardId)) {
+    return state;
+  }
+
+  const nextCardState: VisitCompletionCardSelectionState =
+    action.type === "edit_card"
+      ? { status: "edited", editNote: action.note.trim() }
+      : { status: statusForAction(action.type) };
+
+  return {
+    cardStates: {
+      ...state.cardStates,
+      [action.cardId]: nextCardState,
+    },
+  };
+}
+
+export function buildVisitCompletionReview(
+  bundle: VisitCompletionBundle,
+  state: VisitCompletionSelectionState,
+): VisitCompletionReview {
+  const sections = bundle.cards.map((card) => sectionForCard(card, state));
+  const selectedSections = sections.filter((section) =>
+    ["selected", "approved", "edited"].includes(section.status),
+  );
+  const removedSections = sections.filter((section) => section.status === "removed");
+  const deferredSections = sections.filter((section) => section.status === "deferred");
+
+  return {
+    selectedSections,
+    removedSections,
+    deferredSections,
+    selectedLabels: selectedSections.flatMap((section) => section.labels),
+    removedLabels: removedSections.flatMap((section) => section.labels),
+    deferredLabels: deferredSections.flatMap((section) => section.labels),
+    selectedCount: countLabels(selectedSections),
+    removedCount: countLabels(removedSections),
+    deferredCount: countLabels(deferredSections),
+    feedbackSignals: sections.map((section) => feedbackSignalForSection(section)),
+    hasClinicalSideEffects: false,
+    hasBillingSideEffects: false,
+    hasPatientCommunicationSideEffects: false,
+    hasStaffAssignmentSideEffects: false,
+    hasChartWriteSideEffects: false,
+  };
+}
+
+function statusForAction(
+  type: Exclude<VisitCompletionSelectionAction["type"], "edit_card">,
+): VisitCompletionCardSelectionStatus {
+  switch (type) {
+    case "approve_card":
+      return "approved";
+    case "remove_card":
+      return "removed";
+    case "defer_card":
+      return "deferred";
+  }
+}
+
+function sectionForCard(
+  card: VisitCompletionCard,
+  state: VisitCompletionSelectionState,
+): VisitCompletionReviewSection {
+  const cardState = state.cardStates[card.id] ?? { status: "selected" };
+
+  return {
+    cardId: card.id,
+    title: card.title,
+    status: cardState.status,
+    labels: card.items.map((item) => item.label),
+    editNote: cardState.editNote,
+  };
+}
+
+function countLabels(sections: VisitCompletionReviewSection[]): number {
+  return sections.reduce((sum, section) => sum + section.labels.length, 0);
+}
+
+function feedbackSignalForSection(
+  section: VisitCompletionReviewSection,
+): VisitCompletionReviewSignal {
+  switch (section.status) {
+    case "edited":
+      return {
+        cardId: section.cardId,
+        feedbackAction: "approved_with_edits",
+        meaning: "Physician kept the suggestion but changed details before release.",
+      };
+    case "removed":
+      return {
+        cardId: section.cardId,
+        feedbackAction: "rejected",
+        meaning: "Physician removed a suggested action as inappropriate for this visit.",
+      };
+    case "deferred":
+      return {
+        cardId: section.cardId,
+        feedbackAction: "dismissed",
+        meaning: "Physician deferred the suggestion without rejecting the concept.",
+      };
+    case "approved":
+    case "selected":
+      return {
+        cardId: section.cardId,
+        feedbackAction: "approved",
+        meaning: "Physician kept the suggested action in the release review.",
+      };
+  }
+}

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -8,6 +8,7 @@ import type {
 export type VisitCompletionCardSelectionStatus =
   | "selected"
   | "approved"
+  | "confirmed"
   | "edited"
   | "removed"
   | "deferred";
@@ -15,6 +16,7 @@ export type VisitCompletionCardSelectionStatus =
 export interface VisitCompletionCardSelectionState {
   status: VisitCompletionCardSelectionStatus;
   editNote?: string;
+  confirmationNote?: string;
 }
 
 export interface VisitCompletionSelectionState {
@@ -23,6 +25,7 @@ export interface VisitCompletionSelectionState {
 
 export type VisitCompletionSelectionAction =
   | { type: "approve_card"; cardId: VisitCompletionCardId }
+  | { type: "confirm_card"; cardId: VisitCompletionCardId; confirmationNote?: string }
   | { type: "remove_card"; cardId: VisitCompletionCardId }
   | { type: "defer_card"; cardId: VisitCompletionCardId }
   | { type: "edit_card"; cardId: VisitCompletionCardId; note: string };
@@ -33,6 +36,7 @@ export interface VisitCompletionReviewSection {
   status: VisitCompletionCardSelectionStatus;
   labels: string[];
   editNote?: string;
+  confirmationNote?: string;
 }
 
 export interface VisitCompletionReviewSignal {
@@ -43,14 +47,20 @@ export interface VisitCompletionReviewSignal {
 
 export interface VisitCompletionReview {
   selectedSections: VisitCompletionReviewSection[];
+  confirmedSections: VisitCompletionReviewSection[];
+  needsConfirmationSections: VisitCompletionReviewSection[];
   removedSections: VisitCompletionReviewSection[];
   deferredSections: VisitCompletionReviewSection[];
   selectedLabels: string[];
   removedLabels: string[];
   deferredLabels: string[];
   selectedCount: number;
+  totalCardCount: number;
+  resolvedCardCount: number;
+  needsConfirmationCount: number;
   removedCount: number;
   deferredCount: number;
+  isReadyForRelease: boolean;
   feedbackSignals: VisitCompletionReviewSignal[];
   hasClinicalSideEffects: false;
   hasBillingSideEffects: false;
@@ -80,10 +90,24 @@ export function applyVisitCompletionAction(
     return state;
   }
 
-  const nextCardState: VisitCompletionCardSelectionState =
-    action.type === "edit_card"
-      ? { status: "edited", editNote: action.note.trim() }
-      : { status: statusForAction(action.type) };
+  let nextCardState: VisitCompletionCardSelectionState;
+
+  switch (action.type) {
+    case "edit_card":
+      nextCardState = { status: "edited", editNote: action.note.trim() };
+      break;
+    case "confirm_card":
+      nextCardState = {
+        status: "confirmed",
+        confirmationNote: action.confirmationNote?.trim() || undefined,
+      };
+      break;
+    case "approve_card":
+    case "remove_card":
+    case "defer_card":
+      nextCardState = { status: statusForAction(action.type) };
+      break;
+  }
 
   return {
     cardStates: {
@@ -99,21 +123,34 @@ export function buildVisitCompletionReview(
 ): VisitCompletionReview {
   const sections = bundle.cards.map((card) => sectionForCard(card, state));
   const selectedSections = sections.filter((section) =>
-    ["selected", "approved", "edited"].includes(section.status),
+    isSelectedForReleaseStatus(section.status),
+  );
+  const confirmedSections = sections.filter((section) => section.status === "confirmed");
+  const needsConfirmationSections = sections.filter((section) =>
+    isNeedsConfirmationStatus(section.status),
   );
   const removedSections = sections.filter((section) => section.status === "removed");
   const deferredSections = sections.filter((section) => section.status === "deferred");
+  const resolvedCardCount = sections.filter((section) =>
+    isResolvedCardStatus(section.status),
+  ).length;
 
   return {
     selectedSections,
+    confirmedSections,
+    needsConfirmationSections,
     removedSections,
     deferredSections,
     selectedLabels: selectedSections.flatMap((section) => section.labels),
     removedLabels: removedSections.flatMap((section) => section.labels),
     deferredLabels: deferredSections.flatMap((section) => section.labels),
     selectedCount: countLabels(selectedSections),
+    totalCardCount: sections.length,
+    resolvedCardCount,
+    needsConfirmationCount: needsConfirmationSections.length,
     removedCount: countLabels(removedSections),
     deferredCount: countLabels(deferredSections),
+    isReadyForRelease: resolvedCardCount === sections.length,
     feedbackSignals: sections.map((section) => feedbackSignalForSection(section)),
     hasClinicalSideEffects: false,
     hasBillingSideEffects: false,
@@ -124,7 +161,7 @@ export function buildVisitCompletionReview(
 }
 
 function statusForAction(
-  type: Exclude<VisitCompletionSelectionAction["type"], "edit_card">,
+  type: Exclude<VisitCompletionSelectionAction["type"], "edit_card" | "confirm_card">,
 ): VisitCompletionCardSelectionStatus {
   switch (type) {
     case "approve_card":
@@ -148,7 +185,20 @@ function sectionForCard(
     status: cardState.status,
     labels: card.items.map((item) => item.label),
     editNote: cardState.editNote,
+    confirmationNote: cardState.confirmationNote,
   };
+}
+
+function isSelectedForReleaseStatus(status: VisitCompletionCardSelectionStatus): boolean {
+  return ["selected", "approved", "confirmed", "edited"].includes(status);
+}
+
+function isNeedsConfirmationStatus(status: VisitCompletionCardSelectionStatus): boolean {
+  return ["selected", "approved"].includes(status);
+}
+
+function isResolvedCardStatus(status: VisitCompletionCardSelectionStatus): boolean {
+  return ["confirmed", "edited", "removed", "deferred"].includes(status);
 }
 
 function countLabels(sections: VisitCompletionReviewSection[]): number {
@@ -178,6 +228,7 @@ function feedbackSignalForSection(
         meaning: "Physician deferred the suggestion without rejecting the concept.",
       };
     case "approved":
+    case "confirmed":
     case "selected":
       return {
         cardId: section.cardId,

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -113,7 +113,7 @@ export interface VisitCompletionReleaseSummary {
 export interface VisitCompletionReleasePayload {
   version: "visit-completion-release/v1";
   releaseActionLabel: "Release Care Plan";
-  mode: "review_only_mvp";
+  mode: "review_only_mvp" | "physician_release_v1";
   status: VisitCompletionReleasePayloadStatus;
   canRelease: boolean;
   summary: VisitCompletionReleaseSummary;
@@ -127,10 +127,10 @@ export interface VisitCompletionReleasePayload {
   sideEffects: {
     clinical: false;
     billing: false;
-    patientCommunication: false;
-    staffAssignment: false;
+    patientCommunication: boolean;
+    staffAssignment: boolean;
     chartWrite: false;
-    scheduling: false;
+    scheduling: boolean;
   };
 }
 
@@ -241,7 +241,7 @@ export function buildVisitCompletionReleasePayload(
   return {
     version: "visit-completion-release/v1",
     releaseActionLabel: "Release Care Plan",
-    mode: "review_only_mvp",
+    mode: "physician_release_v1",
     status: canRelease ? "ready_for_physician_release" : "blocked_needs_confirmation",
     canRelease,
     summary: {
@@ -257,14 +257,25 @@ export function buildVisitCompletionReleasePayload(
     auditEvents: sections.map((section) => auditEventForSection(section)),
     feedbackSignals: review.feedbackSignals,
     safetyCopy: bundle.safetyCopy,
-    sideEffects: {
-      clinical: false,
-      billing: false,
-      patientCommunication: false,
-      staffAssignment: false,
-      chartWrite: false,
-      scheduling: false,
-    },
+    sideEffects: releaseSideEffectsForSections(includedSections),
+  };
+}
+
+function releaseSideEffectsForSections(
+  includedSections: VisitCompletionReleaseSection[],
+): VisitCompletionReleasePayload["sideEffects"] {
+  const includedCardIds = new Set(includedSections.map((section) => section.cardId));
+  const includesOrders = includedCardIds.has("orders");
+  const includesFollowUp = includedCardIds.has("follow_up");
+  const includesPatientMessage = includedCardIds.has("patient_message");
+
+  return {
+    clinical: false,
+    billing: false,
+    patientCommunication: includesPatientMessage,
+    staffAssignment: includesOrders || includesFollowUp,
+    chartWrite: false,
+    scheduling: includesFollowUp,
   };
 }
 

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -161,7 +161,7 @@ export function buildVisitCompletionBundle(
     safetyCopy:
       "Nothing is ordered, sent, billed, scheduled, or assigned until the physician releases the care plan.",
     mockedDataNotice:
-      "Draft suggestions only. This MVP prepares the review surface without submitting orders, messages, billing, scheduling, staff assignments, or chart writes.",
+      "Draft suggestions only. Release creates reviewed staff tasks, draft patient communication, and an audit record; it does not place orders, send messages, submit billing, book appointments, or overwrite chart data.",
     summary: buildSummary(cards),
     releaseEnabled: cards.some((card) => card.items.length > 0),
     learningLoop,
@@ -490,6 +490,6 @@ function action(
     requiresPhysicianApproval: true,
     sideEffect: "none",
     placeholderCopy:
-      "Review-only MVP. This control records no orders, messages, billing, scheduling, staffing, or chart writes.",
+      "Physician review required. This control stages the card disposition; Release Care Plan is the only action that creates reviewed tasks, drafts, and audit records.",
   };
 }

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -370,11 +370,30 @@ function buildPracticeReadinessCard(
   const items: VisitCompletionItem[] = [
     item(
       "practice-readiness-overview",
-      "Coding support, prior auth risk, documentation gaps, and staff tasks.",
+      "Practice Readiness feedback: coding, documentation, prior auth, and staff routing checks.",
       "neutral",
       "heuristic",
       "mvp_mock",
       "view_checks",
+      "AI summarizes operational checks here so the physician can release intent without doing back-office translation.",
+    ),
+    item(
+      "documentation-gap",
+      "Documentation gap: add medication risk discussion if dose changes proceed",
+      "warning",
+      "heuristic",
+      "deterministic_heuristic",
+      "coding_review",
+      "This strengthens billing readiness and makes the clinical reasoning easier for staff to follow.",
+    ),
+    item(
+      "staff-routing",
+      "Staff task draft: confirm pharmacy and monitor prior-auth need before fulfillment",
+      "neutral",
+      "heuristic",
+      "deterministic_heuristic",
+      "create_staff_task",
+      "This turns the physician's plan into a reviewable staff handoff without silently assigning work.",
     ),
   ];
 


### PR DESCRIPTION
## Summary
* **VisitCompletion DB Model**: Added a new database model with relations to Notes, Patients, Users, and Organizations to durably store approved clinician intents.
* **releaseVisitCompletion Server Action**: Created a transaction-safe action that atomically registers completion records, generates tasks for orders and follow-ups, drafts patient messages, and records global audit logs.
* **Locked-Down UI State**: Integrated the note editor and completion panel to render in a read-only locked-down state with visual completion badges once released.
* **Seeded Kiosk User**: Seeded `kiosk@demo.health` in `prisma/seed.ts` and `scripts/sync-clerk-seed.ts` to support walk-in console testing.

## Test Plan
- Verified unit and integration test coverage for the server action via `npx vitest run src/app/\(clinician\)/clinic/patients/\[id\]/notes/\[noteId\]/actions.release.test.ts` (9 tests passed).
- Verified rendering and lockdown logic via `npx vitest run src/app/\(clinician\)/clinic/patients/\[id\]/notes/\[noteId\]/visit-completion-panel.test.tsx` (5 tests passed).
- Confirmed full project compilation and typecheck with `npm run typecheck` and `npm run build`.