### PR TITLE
feat(scheduling): per-org pre-visit portal URL override (EMR-916)

### DIFF
--- a/prisma/migrations/20260601020000_org_previsit_portal_url/migration.sql
+++ b/prisma/migrations/20260601020000_org_previsit_portal_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add per-org pre-visit portal URL override (EMR-916)
+ALTER TABLE "Organization" ADD COLUMN "previsitPortalUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,12 @@ model Organization {
   supplies     Supply[]
   suppliers    Supplier[]
   supplyOrders SupplyOrder[]
+
+  // EMR-916 — Per-org pre-visit portal URL override.
+  // When set, pre-visit nudges for patients in this org link here instead of
+  // the global PREVISIT_PORTAL_URL env. Must be a bare HTTPS origin (no path/
+  // query/hash) — validated by normalizePrevisitPortalOrigin before use.
+  previsitPortalUrl String?
 }
 
 // EMR-420 — A Practice is a single clinical location/group under an

--- a/src/lib/scheduling/previsit-reminders.test.ts
+++ b/src/lib/scheduling/previsit-reminders.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => {
   const prisma = {
     appointment: { findMany: vi.fn() },
+    organization: { findMany: vi.fn() },
     auditLog: { findMany: vi.fn(), create: vi.fn() },
     communicationPreference: { findUnique: vi.fn() },
     notification: { create: vi.fn() },
@@ -67,6 +68,8 @@ beforeEach(() => {
   prisma.communicationPreference.findUnique.mockResolvedValue(null);
   prisma.notification.create.mockResolvedValue({ id: "note_1" });
   sendEmail.mockResolvedValue({ ok: true, id: "email_1" });
+  // Default: no org-level portal URL override.
+  prisma.organization.findMany.mockResolvedValue([]);
 });
 
 describe("pickPrevisitMilestone", () => {
@@ -257,6 +260,66 @@ describe("sendDuePrevisitCompletionReminders — multi-channel (EMR-914)", () =>
   });
 });
 
+describe("sendDuePrevisitCompletionReminders — per-org portal URL (EMR-916)", () => {
+  const ORG_PORTAL = "https://org1.portal.example.com";
+
+  it("uses the org's custom previsitPortalUrl when set, ignoring the global fallback", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    prisma.organization.findMany.mockResolvedValue([
+      { id: "org_1", previsitPortalUrl: ORG_PORTAL },
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1);
+    const sms = getMockSmsAdapter().getSent();
+    expect(sms[0].body).toContain(ORG_PORTAL);
+    expect(sms[0].body).not.toContain(PORTAL);
+  });
+
+  it("falls back to the global env URL when the org has no previsitPortalUrl", async () => {
+    prisma.appointment.findMany.mockResolvedValue([makeAppt()]);
+    prisma.organization.findMany.mockResolvedValue([
+      { id: "org_1", previsitPortalUrl: null },
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1);
+    expect(getMockSmsAdapter().getSent()[0].body).toContain(PORTAL);
+  });
+
+  it("quarantines appointments for an org with an invalid custom URL; other orgs still send", async () => {
+    const apptOrg1 = makeAppt({
+      id: "appt_valid",
+      patient: { id: "pat_1", phone: "+15551234567", email: null, userId: null, organizationId: "org_1" },
+    });
+    const apptOrg2 = makeAppt({
+      id: "appt_invalid",
+      patient: { id: "pat_2", phone: "+15557654321", email: null, userId: null, organizationId: "org_2" },
+    });
+    prisma.appointment.findMany.mockResolvedValue([apptOrg1, apptOrg2]);
+    prisma.organization.findMany.mockResolvedValue([
+      { id: "org_1", previsitPortalUrl: null },               // falls back to global
+      { id: "org_2", previsitPortalUrl: "http://insecure.org" }, // invalid: HTTP not HTTPS
+    ]);
+    vi.mocked(getAppointmentReadiness).mockResolvedValue(incomplete as any);
+
+    const res = await sendDuePrevisitCompletionReminders({ now: NOW, portalUrl: PORTAL });
+
+    expect(res.sent).toBe(1);
+    expect(res.details.find((d) => d.appointmentId === "appt_valid")?.result).toBe("sent");
+    expect(res.details.find((d) => d.appointmentId === "appt_invalid")?.result).toBe(
+      "skipped:portal-url-invalid",
+    );
+    // The quarantined org's appointment never reaches readiness check.
+    const readinessCalls = vi.mocked(getAppointmentReadiness).mock.calls.map((c) => c[0]);
+    expect(readinessCalls).not.toContain("appt_invalid");
+  });
+});
+
 describe("sendDueVisitReminders", () => {
   it("runs appointment reminders and pre-visit completion reminders in one scheduler tick", async () => {
     prisma.appointment.findMany
@@ -267,23 +330,27 @@ describe("sendDueVisitReminders", () => {
     const res = await sendDueVisitReminders({ now: NOW, portalUrl: PORTAL });
 
     expect(res.appointment.sent).toBe(1);
-    expect(res.previsit?.sent).toBe(1);
+    expect(res.previsit.sent).toBe(1);
     expect(getMockSmsAdapter().getSent()).toHaveLength(2);
   });
 
-  it("quarantines pre-visit nudges when no portal origin is configured", async () => {
-    prisma.appointment.findMany.mockResolvedValueOnce([dueAppointmentReminder()]);
+  it("quarantines per-appointment when no portal origin is configured (no org override, no env)", async () => {
+    prisma.appointment.findMany
+      .mockResolvedValueOnce([dueAppointmentReminder()])
+      .mockResolvedValueOnce([makeAppt()]);
 
     const res = await sendDueVisitReminders({ now: NOW });
 
     expect(res.appointment.sent).toBe(1);
-    expect(res.previsit).toBeNull();
-    expect(res.previsitSkippedReason).toBe("portal-url-missing");
+    expect(res.previsit.sent).toBe(0);
+    expect(res.previsit.details[0].result).toBe("skipped:portal-url-missing");
     expect(getAppointmentReadiness).not.toHaveBeenCalled();
   });
 
-  it("quarantines pre-visit nudges when the portal origin is not a bare HTTPS origin", async () => {
-    prisma.appointment.findMany.mockResolvedValueOnce([dueAppointmentReminder()]);
+  it("quarantines per-appointment when the portal origin is not a bare HTTPS origin", async () => {
+    prisma.appointment.findMany
+      .mockResolvedValueOnce([dueAppointmentReminder()])
+      .mockResolvedValueOnce([makeAppt()]);
 
     const res = await sendDueVisitReminders({
       now: NOW,
@@ -291,8 +358,8 @@ describe("sendDueVisitReminders", () => {
     });
 
     expect(res.appointment.sent).toBe(1);
-    expect(res.previsit).toBeNull();
-    expect(res.previsitSkippedReason).toBe("portal-url-invalid");
+    expect(res.previsit.sent).toBe(0);
+    expect(res.previsit.details[0].result).toBe("skipped:portal-url-invalid");
     expect(getAppointmentReadiness).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/scheduling/send-reminders.ts
+++ b/src/lib/scheduling/send-reminders.ts
@@ -245,8 +245,8 @@ export function pickPrevisitMilestone(
 
 export interface SendPrevisitRemindersInput {
   now: Date;
-  /** Generic portal origin; no PHI/path/query (validated by the renderer). */
-  portalUrl: string;
+  /** Global fallback portal origin from env; null when not configured. */
+  portalUrl: string | null;
 }
 
 export type PrevisitReminderResult =
@@ -256,6 +256,8 @@ export type PrevisitReminderResult =
   | "skipped:already-sent"
   | "skipped:no-channel"
   | "skipped:channel-unconfigured"
+  | "skipped:portal-url-missing"
+  | "skipped:portal-url-invalid"
   | "failed";
 
 export interface PrevisitReminderOutcome {
@@ -284,8 +286,7 @@ export interface SendDueVisitRemindersInput extends SendDueRemindersInput {
 
 export interface SendDueVisitRemindersResult {
   appointment: SendDueRemindersResult;
-  previsit: SendPrevisitRemindersResult | null;
-  previsitSkippedReason?: PrevisitReminderSkippedReason;
+  previsit: SendPrevisitRemindersResult;
 }
 
 export async function sendDuePrevisitCompletionReminders(
@@ -306,6 +307,17 @@ export async function sendDuePrevisitCompletionReminders(
     },
   });
 
+  // Batch-load per-org portal URL overrides to avoid N+1.
+  const orgIds = [...new Set(appointments.map((a) => a.patient.organizationId))];
+  const orgPortalUrlMap = new Map<string, string | null>();
+  if (orgIds.length > 0) {
+    const orgs = await prisma.organization.findMany({
+      where: { id: { in: orgIds } },
+      select: { id: true, previsitPortalUrl: true },
+    });
+    for (const o of orgs) orgPortalUrlMap.set(o.id, o.previsitPortalUrl);
+  }
+
   const details: PrevisitReminderOutcome[] = [];
   let sent = 0;
   let skipped = 0;
@@ -317,6 +329,22 @@ export async function sendDuePrevisitCompletionReminders(
       skipped += 1;
       continue;
     }
+
+    // Resolve per-org portal URL: org override → global env fallback.
+    // An explicitly-set but invalid org URL is quarantined rather than
+    // silently falling back to global (configuration error, not absence).
+    const orgRawUrl = orgPortalUrlMap.get(appt.patient.organizationId) ?? null;
+    const resolvedPortal = normalizePrevisitPortalOrigin(orgRawUrl ?? input.portalUrl);
+    if (!resolvedPortal.ok) {
+      const result =
+        resolvedPortal.reason === "portal-url-missing"
+          ? ("skipped:portal-url-missing" as const)
+          : ("skipped:portal-url-invalid" as const);
+      details.push({ appointmentId: appt.id, milestone, result });
+      skipped += 1;
+      continue;
+    }
+    const resolvedPortalUrl = resolvedPortal.portalUrl;
 
     // Only nudge patients with outstanding required items.
     const readiness = await getAppointmentReadiness(appt.id, now);
@@ -366,7 +394,7 @@ export async function sendDuePrevisitCompletionReminders(
       const send = await sendPrevisitChannel({
         channel,
         milestone,
-        portalUrl: input.portalUrl,
+        portalUrl: resolvedPortalUrl,
         phone,
         email: appt.patient.email,
         userId: appt.patient.userId,
@@ -484,25 +512,14 @@ export async function sendDueVisitReminders(
   input: SendDueVisitRemindersInput,
 ): Promise<SendDueVisitRemindersResult> {
   const appointment = await sendDueAppointmentReminders(input);
-  const portal = normalizePrevisitPortalOrigin(input.portalUrl);
-
-  if (!portal.ok) {
-    return {
-      appointment,
-      previsit: null,
-      previsitSkippedReason: portal.reason,
-    };
-  }
-
   const previsit = await sendDuePrevisitCompletionReminders({
     now: input.now,
-    portalUrl: portal.portalUrl,
+    portalUrl: input.portalUrl ?? null,
   });
-
   return { appointment, previsit };
 }
 
-function normalizePrevisitPortalOrigin(
+export function normalizePrevisitPortalOrigin(
   portalUrl: string | null | undefined,
 ):
   | { ok: true; portalUrl: string }

--- a/src/workers/scheduler.ts
+++ b/src/workers/scheduler.ts
@@ -121,22 +121,21 @@ async function main() {
     cfoEnqueued += orgs.length;
   }
 
-  // 6. Visit SMS reminders. Appointment reminders always run; pre-visit
-  //    completion nudges only run when a bare HTTPS portal origin is configured.
+  // 6. Visit SMS reminders. Appointment and pre-visit completion nudges always
+  //    run; per-org URL overrides are resolved inside sendDueVisitReminders with
+  //    the global env value as a fallback. Appointments whose orgs have no valid
+  //    portal URL are quarantined per-appointment in previsit.details.
   const reminderResult = await sendDueVisitReminders({
     now,
     portalUrl: resolvePrevisitPortalUrl(process.env),
   });
-  const previsitSent = reminderResult.previsit?.sent ?? 0;
-  const previsitSkipped = reminderResult.previsit?.skipped ?? 0;
-  const previsitQuarantine = reminderResult.previsitSkippedReason
-    ? ` quarantine=${reminderResult.previsitSkippedReason}`
-    : "";
+  const previsitSent = reminderResult.previsit.sent;
+  const previsitSkipped = reminderResult.previsit.skipped;
 
   console.log(
     `[scheduler] enqueued outcome=${patients.length} stalled=${stalled.length} adherence=${adherenceEnqueued} cfo=${cfoEnqueued} ` +
       `sms=${reminderResult.appointment.sent} (skipped=${reminderResult.appointment.skipped}) ` +
-      `previsit=${previsitSent} (skipped=${previsitSkipped}${previsitQuarantine})`,
+      `previsit=${previsitSent} (skipped=${previsitSkipped})`,
   );
 
   // 6. Clearinghouse functional/payer acknowledgment polling


### PR DESCRIPTION
## Summary

EMR-916 · Phase 3 hardening follow-on to EMR-914 multi-channel pre-visit reminders.

Today every org's pre-visit nudges link to the same global portal origin (`PREVISIT_PORTAL_URL` → `NEXT_PUBLIC_APP_URL` → `APP_URL`). This PR adds a nullable `previsitPortalUrl` column to `Organization` so each org can override that origin.

### What changed

| File | Change |
|------|--------|
| `prisma/schema.prisma` | `Organization.previsitPortalUrl String?` |
| `prisma/migrations/20260601020000_org_previsit_portal_url/migration.sql` | `ALTER TABLE "Organization" ADD COLUMN "previsitPortalUrl" TEXT` |
| `src/lib/scheduling/send-reminders.ts` | Per-appointment URL resolution; export `normalizePrevisitPortalOrigin`; two new `PrevisitReminderResult` values; `SendDueVisitRemindersResult.previsit` is always non-null |
| `src/workers/scheduler.ts` | Remove now-deleted `previsitSkippedReason` reference |
| `src/lib/scheduling/previsit-reminders.test.ts` | Add `organization.findMany` mock; 3 new EMR-916 tests; update quarantine tests to reflect per-appointment semantics |

### Resolution order (per appointment)

```
org.previsitPortalUrl (when set + valid)
  └─ falls back to → global env (PREVISIT_PORTAL_URL / NEXT_PUBLIC_APP_URL / APP_URL)
                        └─ if missing/invalid → skipped:portal-url-missing / skipped:portal-url-invalid
```

**Explicit-but-invalid org URL is quarantined** — it does *not* silently fall back to global. An invalid configured value is a configuration error that should surface, not be papered over.

### Behavior changes

- The global pre-validation gate in `sendDueVisitReminders` (which returned `previsit: null` when the env URL was bad) is **removed**. Quarantine is now per-appointment, so a misconfigured org never blocks other orgs from sending.
- `SendDueVisitRemindersResult.previsit` is always `SendPrevisitRemindersResult` (never `null`). Callers using `?.sent` still compile; `previsitSkippedReason` is removed (per-appointment skip reason is in `previsit.details[n].result`).
- `normalizePrevisitPortalOrigin` is now exported for reuse.

### PHI-safety preserved

- Org URL is validated to a bare HTTPS origin (no path/query/hash) by the same `normalizePrevisitPortalOrigin` guard used for the global URL.
- Skip reasons recorded in audit metadata are `portal-url-missing` / `portal-url-invalid` — no PHI.
- All channel-aware idempotency and PHI-free copy guarantees from EMR-914 are unchanged.

### Deferred

- **Quiet-hours timezone handling** stays deferred (needs a patient-timezone decision before implementation) — tracked under EMR-916.

### CI results (run locally before push)

```
npx vitest run src/lib/scheduling
  Test Files  13 passed (13)
  Tests       129 passed (129)

npx tsc --noEmit
  (no output — clean)

npx eslint src/lib/scheduling/send-reminders.ts \
           src/lib/scheduling/previsit-reminders.test.ts \
           src/workers/scheduler.ts
  (no output — clean)

npx prisma generate
  ✔ Generated Prisma Client (v5.22.0) in 2.45s
```

> **Migration note:** The migration SQL is committed but unapplied. Run `npx prisma migrate deploy` (or `migrate dev` locally) against a live DB before deploying. `DATABASE_URL` (Supabase connection pool) is already configured in the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTqh6FXa3wRVPpXmRJHx7Y)_