### PR TITLE
fix(portal): scope patient records to the signed-in patient, drop demo PHI fallbacks (EMR-806)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/imaging/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/imaging/page.tsx
@@ -22,7 +22,6 @@ import {
   listStudies,
 } from "@/lib/domain/medical-imaging-store";
 import {
-  DEMO_PATIENT_ID,
   type ImagingAnnotation,
   type RadiologyReport,
 } from "@/lib/domain/medical-imaging";
@@ -52,13 +51,12 @@ export default async function PatientImagingChartPage({ params }: PageProps) {
 
   if (!patient) notFound();
 
-  // The imaging store is process-local and seeded against DEMO_PATIENT_ID.
-  // We look up the patient's real studies first; if there are none we fall
-  // back to the demo so the workspace never renders empty during the
-  // pilot. This branch is the seam where a real PACS adapter slots in.
-  const realStudies = listStudies(patient.id);
-  const studies =
-    realStudies.length > 0 ? realStudies : listStudies(DEMO_PATIENT_ID);
+  // Scope strictly to this patient's studies (EMR-806). Previously this fell
+  // back to the DEMO_PATIENT_ID seed when a patient had none, which rendered
+  // demo CT/MR studies attributed to a real patient — fabricated clinical
+  // data in a doctor-live route. An empty list now renders an honest empty
+  // workspace. This is the seam where a real PACS adapter slots in.
+  const studies = listStudies(patient.id);
 
   const annotationsByStudy: Record<string, ImagingAnnotation[]> =
     Object.fromEntries(studies.map((s) => [s.id, listAnnotations(s.id)]));

--- a/src/app/(patient)/portal/imaging/page.tsx
+++ b/src/app/(patient)/portal/imaging/page.tsx
@@ -11,7 +11,9 @@
  * provider.
  */
 
+import { redirect } from "next/navigation";
 import { requireRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import {
   getReportForStudy,
@@ -19,7 +21,6 @@ import {
   listStudies,
 } from "@/lib/domain/medical-imaging-store";
 import {
-  DEMO_PATIENT_ID,
   type ImagingAnnotation,
   type RadiologyReport,
 } from "@/lib/domain/medical-imaging";
@@ -28,12 +29,19 @@ import { PatientImagingGallery } from "@/components/imaging/patient-imaging-gall
 export const metadata = { title: "My Imaging" };
 
 export default async function PatientImagingPage() {
-  await requireRole("patient");
+  const user = await requireRole("patient");
 
-  // The demo store is keyed off DEMO_PATIENT_ID so every authenticated
-  // patient sees the same seeded studies. When this rolls into production
-  // the store swap-in will scope by `user.patientId`.
-  const studies = listStudies(DEMO_PATIENT_ID);
+  // Scope to the signed-in patient only (EMR-806). Previously this read the
+  // shared demo store via DEMO_PATIENT_ID, so every patient saw the same
+  // seeded studies — a cross-patient PHI bleed. A patient with no imaging now
+  // gets an honest empty state from the gallery.
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) redirect("/portal/intake");
+
+  const studies = listStudies(patient.id);
 
   const annotationsByStudy: Record<string, ImagingAnnotation[]> =
     Object.fromEntries(

--- a/src/app/(patient)/portal/labs/lab-results-view.tsx
+++ b/src/app/(patient)/portal/labs/lab-results-view.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import {
-  generateDemoLabPanels,
   STATUS_COLORS,
   type LabPanel,
   type LabResult,
@@ -14,10 +13,9 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
 import { cn } from "@/lib/utils/cn";
 import { LabTooltip } from "@/components/ui/lab-tooltip";
-
-const panels = generateDemoLabPanels();
 
 function panelStatusBadgeTone(status: LabPanel["status"]) {
   if (status === "complete") return "success" as const;
@@ -37,9 +35,9 @@ function formatDate(iso: string): string {
   });
 }
 
-export function LabResultsView() {
+export function LabResultsView({ panels }: { panels: LabPanel[] }) {
   const [expandedPanels, setExpandedPanels] = useState<Set<string>>(
-    new Set([panels[0]?.id])
+    () => new Set(panels[0] ? [panels[0].id] : [])
   );
   const [selectedResult, setSelectedResult] = useState<LabResult | null>(null);
 
@@ -50,6 +48,15 @@ export function LabResultsView() {
       else next.add(id);
       return next;
     });
+  }
+
+  if (panels.length === 0) {
+    return (
+      <EmptyState
+        title="No lab results yet"
+        description="Your lab results will appear here once your care team releases them."
+      />
+    );
   }
 
   return (
@@ -170,8 +177,9 @@ export function LabResultsView() {
                               {result.unit}
                             </td>
                             <td className="px-6 py-3 text-text-subtle tabular-nums">
-                              {result.referenceRange.low} &ndash;{" "}
-                              {result.referenceRange.high}
+                              {result.referenceRange
+                                ? `${result.referenceRange.low} – ${result.referenceRange.high}`
+                                : "—"}
                             </td>
                             <td className="px-6 py-3 text-center">
                               <Badge

--- a/src/app/(patient)/portal/labs/page.tsx
+++ b/src/app/(patient)/portal/labs/page.tsx
@@ -1,12 +1,25 @@
+import { redirect } from "next/navigation";
 import { requireRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
+import { getPatientLabPanels } from "@/lib/domain/lab-results-loader";
 import { LabResultsView } from "./lab-results-view";
 
 export const metadata = { title: "Lab Results" };
 
 export default async function LabsPage() {
-  await requireRole("patient");
+  const user = await requireRole("patient");
+
+  // Real, patient-scoped labs only (EMR-806). The view used to render shared
+  // demo panels for every patient.
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) redirect("/portal/intake");
+
+  const panels = await getPatientLabPanels(patient.id);
 
   return (
     <PageShell maxWidth="max-w-[960px]">
@@ -16,7 +29,7 @@ export default async function LabsPage() {
         description="View your laboratory results, reference ranges, and cannabis-relevant interpretations."
       />
       <PatientSectionNav section="health" />
-      <LabResultsView />
+      <LabResultsView panels={panels} />
     </PageShell>
   );
 }

--- a/src/app/(patient)/portal/notifications/notification-center.tsx
+++ b/src/app/(patient)/portal/notifications/notification-center.tsx
@@ -16,124 +16,6 @@ import {
   getDefaultPreferences,
 } from "@/lib/domain/notifications";
 
-// ── Demo notifications ──────────────────────────────────
-
-const DEMO_NOTIFICATIONS: Notification[] = [
-  {
-    id: "n-1",
-    userId: "u-1",
-    type: "appointment_reminder",
-    priority: "normal",
-    title: "Upcoming appointment tomorrow",
-    body: "You have a telehealth visit with Dr. Rivera tomorrow at 2:00 PM. Make sure your camera and microphone are working.",
-    href: "/portal/schedule",
-    read: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
-  },
-  {
-    id: "n-2",
-    userId: "u-1",
-    type: "message_received",
-    priority: "normal",
-    title: "New message from Dr. Rivera",
-    body: "Your provider has responded to your question about adjusting your evening dose. Check your messages to read the full response.",
-    href: "/portal/messages",
-    read: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
-  },
-  {
-    id: "n-3",
-    userId: "u-1",
-    type: "lab_results",
-    priority: "normal",
-    title: "Lab results are ready",
-    body: "Your blood work results from April 10th are now available. Your care team has reviewed them.",
-    href: "/portal/records",
-    read: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
-  },
-  {
-    id: "n-4",
-    userId: "u-1",
-    type: "prescription_ready",
-    priority: "normal",
-    title: "Prescription ready for pickup",
-    body: "Your CBD tincture (30mL, 25mg/mL) is ready at Green Leaf Dispensary. Remember to bring your medical card.",
-    href: "/portal/medications",
-    read: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
-  },
-  {
-    id: "n-5",
-    userId: "u-1",
-    type: "care_plan_update",
-    priority: "normal",
-    title: "Care plan updated",
-    body: "Dr. Rivera has made adjustments to your treatment plan based on your latest assessment. Review the changes in your care plan.",
-    href: "/portal/care-plan",
-    read: true,
-    readAt: new Date(Date.now() - 1000 * 60 * 60 * 20).toISOString(),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-  },
-  {
-    id: "n-6",
-    userId: "u-1",
-    type: "assessment_due",
-    priority: "normal",
-    title: "Weekly symptom check-in due",
-    body: "It's time for your weekly symptom assessment. This helps your care team track your progress and adjust your treatment.",
-    href: "/portal/assessments",
-    read: true,
-    readAt: new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString(),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
-  },
-  {
-    id: "n-7",
-    userId: "u-1",
-    type: "dosing_reminder",
-    priority: "low",
-    title: "Evening dose reminder",
-    body: "Time for your evening CBD dose (10mg sublingual). Remember to hold under your tongue for 60 seconds.",
-    read: true,
-    readAt: new Date(Date.now() - 1000 * 60 * 60 * 36).toISOString(),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 72).toISOString(),
-  },
-  {
-    id: "n-8",
-    userId: "u-1",
-    type: "billing_statement",
-    priority: "normal",
-    title: "New billing statement available",
-    body: "Your statement for March 2026 is ready. Your insurance covered $145.00 of the total charges. View the full breakdown.",
-    href: "/portal/billing",
-    read: true,
-    readAt: new Date(Date.now() - 1000 * 60 * 60 * 100).toISOString(),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 120).toISOString(),
-  },
-  {
-    id: "n-9",
-    userId: "u-1",
-    type: "system",
-    priority: "low",
-    title: "Portal maintenance scheduled",
-    body: "The patient portal will be briefly unavailable on Saturday, April 18th from 2:00-4:00 AM for scheduled maintenance.",
-    read: true,
-    readAt: new Date(Date.now() - 1000 * 60 * 60 * 140).toISOString(),
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 168).toISOString(),
-  },
-  {
-    id: "n-10",
-    userId: "u-1",
-    type: "agent_approval",
-    priority: "urgent",
-    title: "Nurse Nora needs your input",
-    body: "Nora has a follow-up question about the side effects you reported. Please respond so your provider can review your case.",
-    href: "/portal/messages",
-    read: false,
-    createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-  },
-];
-
 // ── Helpers ────────────────────────────────────────────
 
 function timeAgo(dateStr: string): string {
@@ -182,7 +64,10 @@ const FILTER_TABS: { label: string; value: FilterValue }[] = [
 // ── Main component ────────────────────────────────────
 
 export function NotificationCenter() {
-  const [notifications, setNotifications] = useState<Notification[]>(DEMO_NOTIFICATIONS);
+  // EMR-806: no fabricated demo notifications. There is no real per-patient
+  // notification feed wired yet, so start empty and render the honest
+  // "all caught up" empty state rather than the same demo list for everyone.
+  const [notifications, setNotifications] = useState<Notification[]>([]);
   const [activeFilter, setActiveFilter] = useState<FilterValue>("all");
   const [preferences, setPreferences] = useState<NotificationPreference[]>(
     getDefaultPreferences()

--- a/src/app/(patient)/portal/results/page.tsx
+++ b/src/app/(patient)/portal/results/page.tsx
@@ -1,8 +1,9 @@
+import { redirect } from "next/navigation";
 import { requireRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import {
-  DEMO_PATIENT_ID,
   type ImagingStudy,
   type RadiologyReport,
 } from "@/lib/domain/medical-imaging";
@@ -10,10 +11,8 @@ import {
   getReportForStudy,
   listStudies,
 } from "@/lib/domain/medical-imaging-store";
-import {
-  generateDemoLabPanels,
-  type LabPanel,
-} from "@/lib/domain/lab-results";
+import { type LabPanel } from "@/lib/domain/lab-results";
+import { getPatientLabPanels } from "@/lib/domain/lab-results-loader";
 import { ResultsView } from "./results-view";
 
 export const metadata = { title: "My Results" };
@@ -39,10 +38,19 @@ export const metadata = { title: "My Results" };
 // hand back, so we keep the boundary stable.
 
 export default async function ResultsPage() {
-  await requireRole("patient");
+  const user = await requireRole("patient");
 
-  const labPanels: LabPanel[] = generateDemoLabPanels();
-  const studies: ImagingStudy[] = listStudies(DEMO_PATIENT_ID);
+  // Scope labs and imaging to the signed-in patient (EMR-806). Both feeds
+  // were previously shared demo fixtures (generateDemoLabPanels +
+  // DEMO_PATIENT_ID), shown identically to every patient.
+  const patient = await prisma.patient.findFirst({
+    where: { userId: user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!patient) redirect("/portal/intake");
+
+  const labPanels: LabPanel[] = await getPatientLabPanels(patient.id);
+  const studies: ImagingStudy[] = listStudies(patient.id);
   // Imaging reports keyed by study; null when nothing has been released
   // to the patient yet (preliminary reads stay provider-side).
   const reports: Record<string, RadiologyReport | null> = Object.fromEntries(

--- a/src/app/(patient)/portal/results/results-view.tsx
+++ b/src/app/(patient)/portal/results/results-view.tsx
@@ -324,7 +324,9 @@ function LabRow({
         {result.value} <span className="text-xs text-text-subtle">{result.unit}</span>
       </td>
       <td className="px-6 py-3 text-text-subtle tabular-nums">
-        {result.referenceRange.low} – {result.referenceRange.high}
+        {result.referenceRange
+          ? `${result.referenceRange.low} – ${result.referenceRange.high}`
+          : "—"}
       </td>
       <td className="px-6 py-3">
         <Badge

--- a/src/lib/domain/lab-results-loader.test.ts
+++ b/src/lib/domain/lab-results-loader.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { mapLabResultRow, type LabResultRow } from "./lab-results";
+
+function row(overrides: Partial<LabResultRow> = {}): LabResultRow {
+  return {
+    id: "lab-1",
+    panelName: "Comprehensive Metabolic Panel",
+    receivedAt: new Date("2026-05-20T12:00:00.000Z"),
+    signedAt: null,
+    results: {
+      Glucose: { value: 95, unit: "mg/dL", refLow: 70, refHigh: 100, abnormal: false },
+      ALT: { value: 62, unit: "U/L", refLow: 7, refHigh: 55, abnormal: true },
+    },
+    ...overrides,
+  };
+}
+
+describe("mapLabResultRow", () => {
+  it("maps markers and classifies status from the reference range", () => {
+    const panel = mapLabResultRow(row());
+    expect(panel.id).toBe("lab-1");
+    expect(panel.name).toBe("Comprehensive Metabolic Panel");
+    expect(panel.results).toHaveLength(2);
+
+    const glucose = panel.results.find((r) => r.name === "Glucose")!;
+    expect(glucose.value).toBe(95);
+    expect(glucose.referenceRange).toEqual({ low: 70, high: 100 });
+    expect(glucose.status).toBe("normal");
+
+    const alt = panel.results.find((r) => r.name === "ALT")!;
+    // 62 > refHigh 55 → high (classified from the range, not the flag).
+    expect(alt.status).toBe("high");
+  });
+
+  it("marks unsigned panels partial and signed panels complete", () => {
+    expect(mapLabResultRow(row()).status).toBe("partial");
+    expect(
+      mapLabResultRow(row({ signedAt: new Date("2026-05-21T09:00:00.000Z") }))
+        .status,
+    ).toBe("complete");
+  });
+
+  it("omits the reference range when the marker has none, falling back to the abnormal flag", () => {
+    const panel = mapLabResultRow(
+      row({
+        results: {
+          "Vitamin D": { value: 18, unit: "ng/mL", abnormal: true },
+          TSH: { value: 2.1, unit: "mIU/L", abnormal: false },
+        },
+      }),
+    );
+    const vitD = panel.results.find((r) => r.name === "Vitamin D")!;
+    expect(vitD.referenceRange).toBeUndefined();
+    expect(vitD.status).toBe("high"); // abnormal flag, direction unknown
+    const tsh = panel.results.find((r) => r.name === "TSH")!;
+    expect(tsh.referenceRange).toBeUndefined();
+    expect(tsh.status).toBe("normal");
+  });
+
+  it("drops malformed markers and tolerates non-object JSON", () => {
+    const panel = mapLabResultRow(
+      row({
+        results: {
+          Good: { value: 5, unit: "x", refLow: 1, refHigh: 10, abnormal: false },
+          Bad: { unit: "x", abnormal: false }, // no numeric value
+          AlsoBad: "not-an-object",
+        },
+      }),
+    );
+    expect(panel.results.map((r) => r.name)).toEqual(["Good"]);
+    expect(mapLabResultRow(row({ results: null })).results).toEqual([]);
+    expect(mapLabResultRow(row({ results: "nope" })).results).toEqual([]);
+  });
+});

--- a/src/lib/domain/lab-results-loader.ts
+++ b/src/lib/domain/lab-results-loader.ts
@@ -1,0 +1,31 @@
+/**
+ * Patient-scoped lab loader (EMR-806).
+ *
+ * The patient portal previously rendered `generateDemoLabPanels()` — the same
+ * fabricated panels for every authenticated patient. That is a demo-PHI
+ * fallback: it shows lab data that does not belong to the signed-in patient
+ * and implies a successful data load when none happened. This loader reads the
+ * real `LabResult` rows for one patient. The pure row→panel mapping lives in
+ * `lab-results.ts` (`mapLabResultRow`) and is unit tested without a database.
+ */
+
+import { prisma } from "@/lib/db/prisma";
+import { mapLabResultRow, type LabPanel } from "./lab-results";
+
+/** Load a single patient's real lab panels, newest first. */
+export async function getPatientLabPanels(
+  patientId: string,
+): Promise<LabPanel[]> {
+  const rows = await prisma.labResult.findMany({
+    where: { patientId },
+    orderBy: { receivedAt: "desc" },
+    select: {
+      id: true,
+      panelName: true,
+      receivedAt: true,
+      results: true,
+      signedAt: true,
+    },
+  });
+  return rows.map(mapLabResultRow);
+}

--- a/src/lib/domain/lab-results.ts
+++ b/src/lib/domain/lab-results.ts
@@ -8,7 +8,9 @@ export interface LabResult {
   name: string;
   value: number;
   unit: string;
-  referenceRange: { low: number; high: number };
+  // Optional: real lab feeds may omit a reference range for a marker, in
+  // which case the UI renders a dash rather than a fabricated "0 – 0" range.
+  referenceRange?: { low: number; high: number };
   criticalRange?: { low: number; high: number };
   status: LabStatus;
   collectedAt: string;
@@ -46,6 +48,95 @@ export const STATUS_COLORS: Record<LabStatus, { bg: string; text: string; label:
   critical_low: { bg: "bg-red-50", text: "text-red-700", label: "Critical Low" },
   critical_high: { bg: "bg-red-50", text: "text-red-700", label: "Critical High" },
 };
+
+// ── Real LabResult → view-model mapping (EMR-806) ───────
+//
+// Pure helpers (no Prisma) so the patient portal's lab loader can be unit
+// tested without a database. The DB query lives in `lab-results-loader.ts`.
+
+interface RawMarker {
+  value: number;
+  unit: string;
+  refLow?: number;
+  refHigh?: number;
+  abnormal: boolean;
+}
+
+export interface LabResultRow {
+  id: string;
+  panelName: string;
+  receivedAt: Date;
+  results: unknown;
+  signedAt: Date | null;
+}
+
+/**
+ * Parse the `LabResult.results` JSON, whose documented shape is
+ * `{ markerName: { value, unit, refLow?, refHigh?, abnormal } }`. Markers that
+ * are malformed (missing a numeric value) are dropped rather than rendered as
+ * bogus rows.
+ */
+function parseMarkers(raw: unknown): Array<[string, RawMarker]> {
+  if (!raw || typeof raw !== "object") return [];
+  const out: Array<[string, RawMarker]> = [];
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const m = value as Record<string, unknown>;
+    if (typeof m.value !== "number") continue;
+    out.push([
+      name,
+      {
+        value: m.value,
+        unit: typeof m.unit === "string" ? m.unit : "",
+        refLow: typeof m.refLow === "number" ? m.refLow : undefined,
+        refHigh: typeof m.refHigh === "number" ? m.refHigh : undefined,
+        abnormal: m.abnormal === true,
+      },
+    ]);
+  }
+  return out;
+}
+
+/** Map one real `LabResult` row into the portal's `LabPanel` view model. */
+export function mapLabResultRow(row: LabResultRow): LabPanel {
+  const iso = row.receivedAt.toISOString();
+  const results: LabResult[] = parseMarkers(row.results).map(([name, m]) => {
+    const referenceRange =
+      m.refLow != null && m.refHigh != null
+        ? { low: m.refLow, high: m.refHigh }
+        : undefined;
+    // Prefer a precise classification when we have a reference range; fall
+    // back to the row's denormalized `abnormal` flag (direction unknown, so
+    // surface it as out-of-range rather than inventing critical bounds).
+    const status: LabStatus = referenceRange
+      ? classifyLabValue(m.value, referenceRange)
+      : m.abnormal
+        ? "high"
+        : "normal";
+    return {
+      id: `${row.id}:${name}`,
+      name,
+      value: m.value,
+      unit: m.unit,
+      referenceRange,
+      status,
+      collectedAt: iso,
+      resultedAt: iso,
+    };
+  });
+
+  return {
+    id: row.id,
+    name: row.panelName,
+    orderedAt: iso,
+    collectedAt: iso,
+    resultedAt: iso,
+    // A received-but-unsigned result is real but still awaiting clinician
+    // sign-off — surface that honestly rather than claiming "complete".
+    status: row.signedAt ? "complete" : "partial",
+    results,
+  };
+}
 
 // ── Demo lab panels ────────────────────────────────────
 

--- a/src/lib/domain/medical-imaging-store.test.ts
+++ b/src/lib/domain/medical-imaging-store.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { listStudies, upsertStudy } from "./medical-imaging-store";
+import type { ImagingStudy } from "./medical-imaging";
+
+function study(id: string, patientId: string): ImagingStudy {
+  return {
+    id,
+    patientId,
+    modality: "CT",
+    description: `Study ${id}`,
+    bodyPart: "Chest",
+    studyDate: "2026-05-20",
+    status: "final",
+    series: [],
+  };
+}
+
+// EMR-806: the patient portal must only ever show studies belonging to the
+// signed-in patient. `listStudies(patientId)` is the scoping primitive the
+// portal pages now rely on, so guard its filtering directly.
+describe("listStudies patient scoping", () => {
+  it("returns only the requested patient's studies", () => {
+    upsertStudy(study("scope-a1", "patient-A"));
+    upsertStudy(study("scope-a2", "patient-A"));
+    upsertStudy(study("scope-b1", "patient-B"));
+
+    const a = listStudies("patient-A");
+    expect(a.map((s) => s.id).sort()).toEqual(["scope-a1", "scope-a2"]);
+    expect(a.every((s) => s.patientId === "patient-A")).toBe(true);
+  });
+
+  it("never leaks another patient's studies", () => {
+    upsertStudy(study("scope-a1", "patient-A"));
+    const b = listStudies("patient-B");
+    expect(b.some((s) => s.patientId === "patient-A")).toBe(false);
+  });
+
+  it("returns an empty list for a patient with no studies", () => {
+    expect(listStudies("patient-with-nothing")).toEqual([]);
+  });
+});


### PR DESCRIPTION
The patient portal rendered shared demo fixtures to every authenticated patient — a cross-patient PHI bleed and a "fake success" (it implied a real data load when none happened):

- Imaging (portal/imaging, portal/results) read the imaging store via DEMO_PATIENT_ID, so every patient saw the same seeded studies.
- Labs (portal/labs, portal/results) rendered generateDemoLabPanels() — identical fabricated panels for everyone.
- The clinician patient-imaging chart fell back to DEMO_PATIENT_ID studies whenever a real patient had none, attributing demo CT/MR to that patient.
- The notification center initialized state from a hardcoded DEMO list ("Dr. Rivera", specific labs) shown to every patient.

Changes:
- Resolve the real patient (prisma.patient.findFirst by userId, redirect to /portal/intake if none) and scope imaging via listStudies(patient.id).
- Source labs from the real LabResult model (new getPatientLabPanels + pure mapLabResultRow mapper in lab-results.ts), newest first.
- Make LabResult.referenceRange optional; both lab renderers show "—" when a marker has no range instead of a fabricated "0 – 0".
- LabResultsView now takes panels as a prop and renders an honest empty state.
- Clinician patient-imaging scopes strictly to the patient (honest empty workspace instead of demo fallback).
- Notification center starts empty and shows the existing "all caught up" empty state; remove the demo array.