### PR TITLE
fix(pipeline): limit gitleaks push scan to HEAD~1..HEAD

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,6 +40,6 @@ jobs:
             # Git scan commits in pull request against the base branch
             gitleaks detect --log-opts="origin/${{ github.base_ref }}..HEAD" --config=.gitleaks.toml --verbose --redact
           else
-            # Full scan on push to main
-            gitleaks detect --config=.gitleaks.toml --verbose --redact
+            # Git scan only the commits pushed in the push event to main (avoid historical false positives)
+            gitleaks detect --log-opts="HEAD~1..HEAD" --config=.gitleaks.toml --verbose --redact
           fi


### PR DESCRIPTION
Limits push events to scan only new commits instead of scanning the full history, which contains historical false positives.