### PR TITLE
EMR-644: /clinic top-ribbon RELAX mindfulness button

### DIFF
--- a/src/components/clinic/RelaxPopup.tsx
+++ b/src/components/clinic/RelaxPopup.tsx
@@ -1,20 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { LeafSprig } from "@/components/ui/ornament";
 
 export function RelaxPopup() {
   const [open, setOpen] = useState(false);
-
-  // Randomly show the relax popup for clinician wellness
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      // Show once per session randomly after 1-2 hours, for demo we just won't auto-show it
-      // but we expose it for manual triggers.
-    }, 1000 * 60 * 60);
-    return () => clearTimeout(timer);
-  }, []);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -25,7 +24,9 @@ export function RelaxPopup() {
       </DialogTrigger>
       <DialogContent className="sm:max-w-[400px] text-center">
         <DialogHeader>
-          <DialogTitle className="text-center font-display text-2xl text-accent">Take a Breath</DialogTitle>
+          <DialogTitle className="text-center font-display text-2xl text-accent">
+            Take a Breath
+          </DialogTitle>
         </DialogHeader>
         <div className="py-8 flex flex-col items-center">
           <div className="relative w-32 h-32 flex items-center justify-center">
@@ -35,9 +36,24 @@ export function RelaxPopup() {
               <LeafSprig size={24} />
             </div>
           </div>
-          <p className="mt-8 text-text-muted text-sm">
-            You've been working hard. Take 3 deep breaths before your next patient.
+          <p className="mt-8 text-text-muted text-sm leading-relaxed max-w-[280px]">
+            You&apos;ve been working hard. Take a guided breathing break before
+            your next patient.
           </p>
+        </div>
+        <div className="flex flex-col gap-2 pb-2">
+          <Link href="/clinic/mindful/breathe" onClick={() => setOpen(false)}>
+            <Button size="md" className="w-full">
+              🌬️ Start breathing session
+            </Button>
+          </Link>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="text-sm text-text-subtle hover:text-text transition-colors py-2"
+          >
+            Maybe later
+          </button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Implements EMR-644.

## What changed
- `RelaxPopup.tsx`: Added a **"🌬️ Start breathing session"** primary button that navigates to `/clinic/mindful/breathe` and closes the dialog
- Added a **"Maybe later"** plain text dismiss button so the clinician can close without navigating away
- Updated copy: "Take 3 deep breaths" → "Take a guided breathing break before your next patient" (more inviting, links intention to the full breathing tool)
- Removed the no-op `useEffect` placeholder (1-hour timer with empty callback — dead code)
- The ribbon already has two RELAX entry points: the `RelaxPopup` pill button inline with the clinician greeting, and a `🍃 Relax` ghost button on the right side linking to `/clinic/mindful`. This PR completes the popup so it's no longer a dead-end.

## How to verify
1. Navigate to `/clinic`
2. Click the **"Relax"** pill button next to the clinician's name in the top ribbon
3. Confirm dialog opens with pulsing breathing animation
4. Click **"🌬️ Start breathing session"** → should navigate to `/clinic/mindful/breathe`
5. Re-open the dialog and click **"Maybe later"** → dialog should close and stay on `/clinic`
6. Also verify the **"🍃 Relax"** ghost button on the right side of the ribbon still navigates to `/clinic/mindful` hub

## Notes
- Follow-up: the `RelaxPopup` is also used as a `primaryAction` prop lower on the clinic page (around line 847); that usage is unchanged and still works correctly
- Move and Inspire cards on `/clinic/mindful` are still marked "Soon" — out of scope for this ticket

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFKjPKKxkJaET1q67AXns)_