### PR TITLE
EMR-647: include observation summary in queue urgency select

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -313,7 +313,7 @@ export default async function ClinicHomePage() {
             chartSummary: true,
             observations: {
               where: { acknowledgedAt: null },
-              select: { severity: true },
+              select: { severity: true, summary: true, category: true },
             },
             documents: {
               where: { deletedAt: null },


### PR DESCRIPTION
Implements EMR-647.

## What changed
- Extended the `ClinicalObservation` Prisma select in the today's-queue encounter fan-out (`src/app/(clinician)/clinic/page.tsx` line 316) to include `summary` and `category` alongside `severity`.
- Previously only `severity: true` was selected, so `o.summary` was always `null` when mapped into `categorizeQueueItem`. The urgency reason text always fell back to the generic string ("Patient has an urgent unacknowledged observation.") even when a specific clinical summary existed.
- With this fix the "Why:" line on each queue card now surfaces the actual observation text — e.g. "Urgent observation: Hypertensive crisis, BP 180/110" — matching what the unit tests in `queue-urgency.test.ts` assert.

## How to verify
1. Seed a patient with an unacknowledged `ClinicalObservation` that has `severity = "urgent"` and a non-empty `summary`.
2. Schedule an encounter for that patient today.
3. Open `/clinic`. The queue card should show the AI: Urgent badge and the "Why:" line should display the observation summary, not the generic fallback.
4. Run the existing unit tests: `npx vitest run src/lib/domain/queue-urgency.test.ts` — all 7 cases pass unchanged.

## Notes
- 1-line change, no schema migration, no new dependencies.
- `category` is selected for forward-compatibility (the triage function has a `category?` field on `QueueObservationInput`) but is not yet used in sort/display logic.
- Follow-up: consider passing `category` through the mapping at line 875 if future triage rules need it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqDBktPeCMVmBSsdJrCs2g)_