### PR TITLE
EMR-615: gate ChatCBPanel on cannabis modality; remove duplicate ChatCB widget

### DIFF
--- a/src/app/(clinician)/clinic/research/page.tsx
+++ b/src/app/(clinician)/clinic/research/page.tsx
@@ -8,7 +8,6 @@ import { LeafSprig } from "@/components/ui/ornament";
 import { ResearchSearchForm } from "./research-form";
 import { ChatCBPanel } from "./chat-cb-panel";
 import { formatRelative } from "@/lib/utils/format";
-import { ChatCB } from "./chat-cb";
 import { EvidenceSourcesCard } from "./evidence-sources-card";
 import { getCurrentUser } from "@/lib/auth/session";
 import { isModalityEnabled } from "@/lib/modality/server";
@@ -198,10 +197,6 @@ export default async function ResearchConsolePage({
 
         {/* Sidebar */}
         <div className="space-y-6">
-          {/* ChatCB is the cannabis conversational search — gated on
-              cannabis-medicine modality (EMR-668). */}
-          {cannabisEnabled && <ChatCB />}
-
           <Card>
             <CardHeader>
               <CardTitle>Recent queries</CardTitle>
@@ -249,7 +244,9 @@ export default async function ResearchConsolePage({
             </CardContent>
           </Card>
 
-          <ChatCBPanel />
+          {/* ChatCBPanel — streaming ChatCB with citations. Cannabis-only
+              (EMR-615): non-cannabis practices don't use the chat-cb API. */}
+          {cannabisEnabled && <ChatCBPanel />}
 
           {/* Cannabis opt-out button — only meaningful when the practice
               does cannabis (EMR-668). */}


### PR DESCRIPTION
Implements EMR-615.

## What changed
- Removed the unguarded `<ChatCBPanel />` render in the `/clinic/research` sidebar — it was calling the cannabis-specific `/api/agents/chat-cb` endpoint for every practice, including non-cannabis clinics
- Wrapped `ChatCBPanel` in `{cannabisEnabled && ...}` (same guard already used for the Combo Wheel card and opt-out button)
- Removed the redundant `<ChatCB />` block that was also in the sidebar under its own `cannabisEnabled` guard — `ChatCBPanel` is the streaming SSE successor with full citation rendering and supersedes it; `chat-cb.tsx` itself is left in place since `/clinic/library` still imports it

## How to verify
- Log in as a **cannabis-medicine** org: sidebar on `/clinic/research` should show exactly one ChatCB panel (with streaming citations and quick-prompt hints)
- Log in as a **non-cannabis** org (e.g. pain-mgmt): sidebar should show only Recent Queries and About the research database — no ChatCB widget
- Cannabis opt-out flow (`?optout=1`) and Combo Wheel link are unaffected

## Notes
- EMR-615 multi-word search and opt-out UI were already present on `main` (shipped with EMR-668 work); this PR addresses the residual gating bug — the ChatCBPanel appearing for all practices
- Follow-up: `chat-cb.tsx` (legacy JSON-only chat) could be replaced by `ChatCBPanel` in `/clinic/library` too, but that is out of scope for this ticket

---
_Generated by [Claude Code](https://claude.ai/code/session_01217Js3aoLtBodZSSNL5dyx)_