### PR TITLE
EMR-664: refills e-sign — auto-submit PIN, paste support, remove stub notice

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/refills/refills-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/refills/refills-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useTransition } from "react";
-import type { KeyboardEvent } from "react";
+import type { ClipboardEvent, KeyboardEvent } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/ui/avatar";
@@ -198,7 +198,7 @@ function RxDetailPane({
   onDone: (id: string) => void;
 }) {
   const [phase, setPhase] = useState<"idle" | "approve-pin" | "deny-reason">("idle");
-  const [pin, setPin] = useState<string[]>(["", "", "", ""]);
+  const [pin, setPin] = useState<string[]>(["" , "", "", ""]);
   const [denyReason, setDenyReason] = useState("");
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -206,18 +206,42 @@ function RxDetailPane({
 
   const pinFilled = pin.every((d) => d !== "");
 
+  const submitApprove = (digits: string[]) => {
+    if (!digits.every((d) => d !== "")) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await approveRefillAction(row.id);
+      if (!res.ok) setError(res.error);
+      else onDone(row.id);
+    });
+  };
+
   const handlePinChange = (i: number, val: string) => {
     const digit = val.replace(/\D/g, "").slice(-1);
     const next = [...pin];
     next[i] = digit;
     setPin(next);
-    if (digit && i < 3) pinRefs.current[i + 1]?.focus();
+    if (digit && i < 3) {
+      pinRefs.current[i + 1]?.focus();
+    } else if (digit && i === 3 && next.every((d) => d !== "")) {
+      submitApprove(next);
+    }
   };
 
   const handlePinKeyDown = (i: number, e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Backspace" && pin[i] === "" && i > 0) {
       pinRefs.current[i - 1]?.focus();
     }
+  };
+
+  const handlePinPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const digits = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, 4);
+    if (digits.length === 0) return;
+    e.preventDefault();
+    const next = (["", "", "", ""] as string[]).map((_, idx) => digits[idx] ?? "");
+    setPin(next);
+    pinRefs.current[Math.min(digits.length, 3)]?.focus();
+    if (digits.length === 4) submitApprove(next);
   };
 
   const resetPhase = () => {
@@ -227,15 +251,7 @@ function RxDetailPane({
     setError(null);
   };
 
-  const confirmApprove = () => {
-    if (!pinFilled) return;
-    setError(null);
-    startTransition(async () => {
-      const res = await approveRefillAction(row.id);
-      if (!res.ok) setError(res.error);
-      else onDone(row.id);
-    });
-  };
+  const confirmApprove = () => submitApprove(pin);
 
   const confirmDeny = () => {
     if (!denyReason.trim()) return;
@@ -412,6 +428,7 @@ function RxDetailPane({
                   autoFocus={i === 0}
                   onChange={(e) => handlePinChange(i, e.target.value)}
                   onKeyDown={(e) => handlePinKeyDown(i, e)}
+                  onPaste={handlePinPaste}
                   className="w-12 h-12 rounded-xl border-2 border-border text-center text-lg font-mono text-text bg-surface focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20 transition-colors"
                   aria-label={`PIN digit ${i + 1}`}
                 />
@@ -435,11 +452,6 @@ function RxDetailPane({
                 {pending ? "Signing…" : "Complete sign-off"}
               </Button>
             </div>
-
-            <p className="text-[11px] text-text-subtle">
-              Phase 1 stub — PIN is recorded for audit intent; server-side PIN
-              hashing ships in Phase 2 (MALLIK-012).
-            </p>
           </div>
         )}
 


### PR DESCRIPTION
Implements EMR-664.

## What changed

**`refills-view.tsx`** (single file, ~28 net lines)

- **`submitApprove(digits)`** — extracted the approve action into a helper that takes the digit array directly, so it can be called both from the button click and from the auto-submit path without reading stale state.
- **PIN auto-submit** — `handlePinChange` now calls `submitApprove(next)` immediately when the 4th digit is entered and all four slots are filled. The clinician never has to reach for "Complete sign-off" in the happy path.
- **Paste support** — `handlePinPaste` strips non-digits from clipboard text, distributes up to 4 digits across the inputs, focuses the last filled slot, and auto-submits if all 4 arrive in one paste. Handles partial pastes gracefully.
- **Removed user-visible stub notice** — the `<p>` that read "Phase 1 stub — PIN is recorded for audit intent; server-side PIN hashing ships in Phase 2 (MALLIK-012)" was leaking an internal implementation note into the production clinician UI. Removed. The note still exists as a code comment in `actions.ts`.

## How to verify

1. Navigate to `/clinic/sign-off/refills` with a pending refill in the queue.
2. Click **Approve & e-sign** — the 4-digit PIN inputs appear.
3. Type digits 1–4; after the 4th digit auto-advances and all four are filled, the action should fire without pressing "Complete sign-off."
4. Reset, re-enter the PIN phase, and paste a 4-digit string (e.g. `1234`) — all four inputs should fill and the action should fire immediately.
5. Paste a 2-digit string — inputs fill partially, no auto-submit, "Complete sign-off" button remains disabled until the remaining digits are typed.
6. Confirm the "Phase 1 stub…" notice no longer appears anywhere in the PIN flow.

## Notes

- The existing `overnight/emr-664-refills-split-pane` branch has the original EMR-664 implementation (created May 22 from an older base). That work landed in main via #541. This PR adds the production-polish layer on top of what's in main today.
- Follow-up (MALLIK-012): server-side PIN hashing / verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAw7xJzFpQ8AUt1mgeEw2v)_