### PR TITLE
EMR-617: /education Drug Mix — PMID references, severity labels, CBN fix

### DIFF
--- a/src/components/education/DrugMixChecker.tsx
+++ b/src/components/education/DrugMixChecker.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, CheckCircle, ShieldAlert } from "lucide-react";
 import {
   checkInteractions,
+  getSeverityLabel,
   type DrugInteraction,
 } from "@/lib/domain/drug-interactions";
 
@@ -27,7 +28,8 @@ export function parseMedicationInput(input: string): string[] {
     .filter(Boolean);
 }
 
-const DEFAULT_CANNABINOIDS = ["THC", "CBD", "CBN"];
+// CBN omitted — the bundled database has no CBN entries yet.
+const DEFAULT_CANNABINOIDS = ["THC", "CBD"];
 
 export interface DrugMixCheckerProps {
   /**
@@ -206,7 +208,7 @@ export function DrugMixChecker({
                             tone={isRed ? "danger" : isYellow ? "warning" : "success"}
                             className="uppercase tracking-widest text-[10px] font-bold"
                           >
-                            {ix.severity} Severity
+                            {getSeverityLabel(ix.severity)}
                           </Badge>
                         </div>
 
@@ -229,6 +231,36 @@ export function DrugMixChecker({
                         >
                           <span>Action:</span> {ix.recommendation}
                         </p>
+
+                        {ix.references.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {ix.references.map((ref) => {
+                              const pmidMatch = ref.match(/PMID:\s*(\d+)/i);
+                              const href = pmidMatch
+                                ? `https://pubmed.ncbi.nlm.nih.gov/${pmidMatch[1]}/`
+                                : null;
+                              return href ? (
+                                <a
+                                  key={ref}
+                                  href={href}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="inline-flex items-center gap-1 text-[10px] font-semibold text-slate-500 hover:text-accent bg-slate-100 hover:bg-accent/10 px-2.5 py-1 rounded-full transition-colors"
+                                >
+                                  {ref}
+                                  <span aria-hidden="true">↗</span>
+                                </a>
+                              ) : (
+                                <span
+                                  key={ref}
+                                  className="inline-flex items-center text-[10px] font-semibold text-slate-500 bg-slate-100 px-2.5 py-1 rounded-full"
+                                >
+                                  {ref}
+                                </span>
+                              );
+                            })}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </CardContent>

--- a/src/lib/domain/drug-interactions.ts
+++ b/src/lib/domain/drug-interactions.ts
@@ -8,6 +8,8 @@ export interface DrugInteraction {
   severity: Severity;
   mechanism: string;
   recommendation: string;
+  /** Raw reference strings from the database (e.g. "PMID: 12345678"). */
+  references: string[];
 }
 
 interface InteractionEntry {
@@ -63,6 +65,7 @@ export function checkInteractions(
           severity: entry.severity as Severity,
           mechanism: entry.mechanism,
           recommendation: entry.recommendation,
+          references: entry.references ?? [],
         });
         break; // Avoid duplicate matches for same med against same entry
       }
@@ -93,6 +96,7 @@ export function getAllInteractions(): DrugInteraction[] {
       severity: e.severity as Severity,
       mechanism: e.mechanism,
       recommendation: e.recommendation,
+      references: e.references ?? [],
     }))
     .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
 }


### PR DESCRIPTION
Implements EMR-617.

## What changed

- **`DrugMixChecker.tsx`** — Each interaction result card now renders its PMID references as clickable pill badges that deep-link to `pubmed.ncbi.nlm.nih.gov`. Non-PMID references (e.g. "Epidiolex FDA label") render as inert text pills.
- **`DrugMixChecker.tsx`** — Severity badge now uses `getSeverityLabel()` ("Contraindicated" / "Use with caution" / "No known interaction") instead of the raw enum value ("red Severity" etc.).
- **`DrugMixChecker.tsx`** — Removed CBN from `DEFAULT_CANNABINOIDS`. The bundled `data/drug-interactions.json` has zero CBN entries, so including it was silently returning no results for any CBN query.
- **`drug-interactions.ts`** — Added `references: string[]` to the `DrugInteraction` interface and threaded it through `checkInteractions()` and `getAllInteractions()` so callers can display provenance.

## How to verify

1. Navigate to `/education/drug-mix` (or the Drug Mix tab on `/education`)
2. Enter `Warfarin` → click **Check Interactions**
3. Confirm the result card shows:
   - Badge reads "Contraindicated" (was "red Severity")
   - A "PMID: 32456789 ↗" pill appears beneath the Action line — clicking opens the PubMed article in a new tab
4. Enter `Metformin` → confirm "No known interactions found" (Metformin has no entries)
5. Verify the same checker in the embedded `/education#drugmix` tab behaves identically

## Notes

- The Drug Mix standalone page (`/education/drug-mix/page.tsx`) and tab wrapper (`DrugMixTab.tsx`) required no changes — they already use `<DrugMixChecker />` and inherit these fixes automatically.
- Follow-up: expand `data/drug-interactions.json` with CBG, CBN, and THCV entries so the cannabinoid list can be widened.
- Follow-up: add a cannabinoid selector (checkboxes) so patients on CBD-only products can narrow results.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V99cD38dWbTfym2UJX4jXX)_