### PR TITLE
Harden the same-day care journey (no duplicate encounters, appointment→encounter bridge, booking + note-signing guards)

### DIFF
--- a/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
+++ b/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
@@ -30,7 +30,7 @@ Queue board (`/ops/queue`, kiosk) persists the intermediate flow states via `com
 | Step / required scenario | Status | Evidence |
 |---|---|---|
 | Patient books through portal | **fixed** | `bookAppointment` now guards conflicts/past/invalid + preserves modality; `actions.book.test.ts` |
-| Same patient checks in on appt day | pass | `api/mobile/kiosk/check-in/route.ts` + `computeQueueTransition`; existing route test |
+| Same patient checks in on appt day | **⚠ gap** | check-in transition works (`api/mobile/kiosk/check-in`, `kioskCheckIn`, `computeQueueTransition`) **but only if an Encounter already exists** — booked appointments are never materialized into encounters (see Risk #1), so a booked-but-no-encounter patient hits "No appointment found" |
 | Missing required intake detected/surfaced | pass | `intake-gate` + `previsit-readiness` (existing suites) |
 | QR/OTP rescue (no portal password for older adult) | pass | `kiosk-handoff` → OTP → lobby session; existing `check-in/*` suites |
 | Front desk marks readiness / sees blockers | pass | `getAppointmentReadiness`, `MissingRequirement[]` deep links |
@@ -80,9 +80,43 @@ server didn't enforce it; `saveObjectiveDocumentation` already did).
 - Fix: reject block saves on finalized/amended notes.
 - Tests: `actions.save-note-lock.test.ts`. Commit `886e495b`.
 
+### D. Two more duplicate-encounter siblings (round 2)  — **MED**
+An audit of EVERY `prisma.encounter.find*` selector for the same status-drift class found
+two more find-or-create paths that missed queue-state encounters:
+- `startVoiceEncounter` (`voice-chart/actions.ts`) matched `status:"in_progress"` only →
+  voice charting on a checked-in/roomed patient minted a duplicate. Now uses
+  `selectActiveVisitEncounter`.
+- `startOverlayTelehealthVisit` (`communications/actions.ts`) filtered
+  `["scheduled","in_progress"]` → broadened to `ACTIVE_VISIT_STATUSES`.
+- Tests: `actions.start-voice.test.ts`, `actions.overlay-telehealth.test.ts`. Commit `8a0f3619`.
+- (The `/ops/queue` board query was audited and is correct — no status filter, loads the full day.)
+
+### E. Booking trusted an arbitrary providerId (round 2)  — **MED**
+`bookAppointment` never validated `providerId`, so the portal could create a dangling
+appointment against a missing, inactive, or cross-org provider.
+- Fix: look the provider up by id + patient's `organizationId` + `active` before booking.
+- Tests: extended `actions.book.test.ts`. Commit `61735a21`.
+
 ---
 
 ## 4. Residual risks (do NOT mark fully shipped without these)
+
+0. **★ Appointments are never materialized into Encounters (SYSTEMIC — needs a product decision).**
+   `Encounter.appointmentId` is `@unique` in the schema but is **never set anywhere in app
+   code** — confirmed by auditing every `encounter.create` site. Booking creates only an
+   `Appointment`; encounters are created solely at visit-start (`startVisit` /
+   `startVisitWithBriefing` / `startVoiceEncounter`) or walk-in, all as `in_progress`. The
+   readiness/intake side runs off Appointments; the check-in → rooming → visit side runs off
+   Encounters; **nothing bridges them.** Consequence: a patient who books and shows up has no
+   Encounter, so `kioskCheckIn` returns *"No appointment found for today"* and the queue board
+   never shows them. The seeded demo hides this because it creates encounters directly.
+   - **Recommended fix (team decision required — timing/semantics):** an idempotent
+     `ensureEncounterForAppointment(appointmentId)` that creates a `scheduled` Encounter from a
+     confirmed Appointment (copying `scheduledFor`/`providerId`/`modality`, linking
+     `appointmentId` — the `@unique` makes it race-safe). Wire it at ONE agreed trigger: at
+     appointment confirmation, a day-of cron, or lazily on first check-in / queue-board load.
+     This affects what the queue/dashboards/billing count, so it's a workflow-semantics call,
+     not a silent fix — deliberately left for you.
 
 1. **Concurrent walk-in duplicate** — `selectActiveVisitEncounter`+`create` is not atomic.
    The deterministic roomed-miss is fixed and repeat-clicks reuse, but two *simultaneous*
@@ -108,10 +142,10 @@ Baseline before changes: 269 test files / 2566 tests, all passing.
 
 | Gate | Command | Result |
 |------|---------|--------|
-| Unit + integration | `npx vitest run` | **273 files / 2601 tests passing** (+4 files, +35 tests) |
-| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) |
+| Unit + integration | `npx vitest run` | **275 files / 2613 tests passing** (+6 files, +47 tests over baseline) |
+| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after round 2 |
 | Lint | `npm run lint` (`next lint`) | pass (exit 0); only a pre-existing `no-img-element` warning in `ShareDialog.tsx` (untouched) |
-| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0); full production build incl. `/telehealth`, portal schedule, clinic notes |
+| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) at round 1; round-2 changes are typecheck+lint+test clean (build not re-run) |
 
 New / changed tests:
 - `src/lib/domain/visit-state.select-active.test.ts` (new, 13) — drives the real
@@ -121,6 +155,9 @@ New / changed tests:
 - `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.save-note-lock.test.ts` (new, 5).
 - `actions.start-visit.test.ts` (+6 queue-state reuse / terminal-create cases).
 - `visit-state.test.ts` (updated contract assertions to the corrected non-terminal set).
+- Round 2: `voice-chart/actions.start-voice.test.ts` (new, 7),
+  `communications/actions.overlay-telehealth.test.ts` (new, 3),
+  `actions.book.test.ts` (+2 provider-validation cases).
 
 Playwright e2e was **not executed**: the authed care-journey UI needs a running
 dev server + seeded DB + Clerk auth, which can't be stood up with synthetic-only,
@@ -136,4 +173,7 @@ specs (public/authed surfaces) remain unchanged.
 886e495b fix(notes): block saveNoteBlocks from silently mutating a signed note
 ad2084b0 test(visit): end-to-end same-day care-journey integration spine
 61121004 test(visit): align ACTIVE_VISIT_STATUSES contract test with the non-terminal fix
+8a0f3619 fix(visit): close two more duplicate-encounter siblings (voice charting, telehealth overlay)
+61735a21 fix(portal): validate provider exists, is active, and shares the patient's org on booking
+docs(audit): round-2 update — siblings, provider validation, appointment↔encounter finding
 ```

--- a/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
+++ b/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
@@ -141,7 +141,7 @@ Baseline before changes: 269 test files / 2566 tests, all passing.
 | Unit + integration | `npx vitest run` | **276 files / 2622 tests passing** (+7 files, +56 tests over baseline) |
 | Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after the bridge; Prisma relation-filter types check out |
 | Lint | `npm run lint` (`next lint`) | pass (exit 0); only a pre-existing `no-img-element` warning in `ShareDialog.tsx` (untouched) |
-| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) at round 1; later rounds are typecheck+lint+test clean (build not re-run) |
+| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) — re-run after the bridge; full production build |
 
 New / changed tests:
 - `src/lib/domain/visit-state.select-active.test.ts` (new, 13) — drives the real

--- a/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
+++ b/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
@@ -30,7 +30,7 @@ Queue board (`/ops/queue`, kiosk) persists the intermediate flow states via `com
 | Step / required scenario | Status | Evidence |
 |---|---|---|
 | Patient books through portal | **fixed** | `bookAppointment` now guards conflicts/past/invalid + preserves modality; `actions.book.test.ts` |
-| Same patient checks in on appt day | **⚠ gap** | check-in transition works (`api/mobile/kiosk/check-in`, `kioskCheckIn`, `computeQueueTransition`) **but only if an Encounter already exists** — booked appointments are never materialized into encounters (see Risk #1), so a booked-but-no-encounter patient hits "No appointment found" |
+| Same patient checks in on appt day | **fixed** | confirmed appointments now materialize a `scheduled` Encounter (`ensureEncounterForAppointment` at confirm + `ensureTodayEncounters` day-of on the queue board), so the patient is checkinable and appears on `/ops/queue`; then `kioskCheckIn`/`computeQueueTransition` advance it |
 | Missing required intake detected/surfaced | pass | `intake-gate` + `previsit-readiness` (existing suites) |
 | QR/OTP rescue (no portal password for older adult) | pass | `kiosk-handoff` → OTP → lobby session; existing `check-in/*` suites |
 | Front desk marks readiness / sees blockers | pass | `getAppointmentReadiness`, `MissingRequirement[]` deep links |
@@ -101,22 +101,18 @@ appointment against a missing, inactive, or cross-org provider.
 
 ## 4. Residual risks (do NOT mark fully shipped without these)
 
-0. **★ Appointments are never materialized into Encounters (SYSTEMIC — needs a product decision).**
-   `Encounter.appointmentId` is `@unique` in the schema but is **never set anywhere in app
-   code** — confirmed by auditing every `encounter.create` site. Booking creates only an
-   `Appointment`; encounters are created solely at visit-start (`startVisit` /
-   `startVisitWithBriefing` / `startVoiceEncounter`) or walk-in, all as `in_progress`. The
-   readiness/intake side runs off Appointments; the check-in → rooming → visit side runs off
-   Encounters; **nothing bridges them.** Consequence: a patient who books and shows up has no
-   Encounter, so `kioskCheckIn` returns *"No appointment found for today"* and the queue board
-   never shows them. The seeded demo hides this because it creates encounters directly.
-   - **Recommended fix (team decision required — timing/semantics):** an idempotent
-     `ensureEncounterForAppointment(appointmentId)` that creates a `scheduled` Encounter from a
-     confirmed Appointment (copying `scheduledFor`/`providerId`/`modality`, linking
-     `appointmentId` — the `@unique` makes it race-safe). Wire it at ONE agreed trigger: at
-     appointment confirmation, a day-of cron, or lazily on first check-in / queue-board load.
-     This affects what the queue/dashboards/billing count, so it's a workflow-semantics call,
-     not a silent fix — deliberately left for you.
+0. **✅ FIXED — Appointment→Encounter bridge.** Previously `Encounter.appointmentId` was
+   `@unique` but never set in app code, so booked appointments never became encounters and a
+   booked patient couldn't be checked in ("No appointment found"). Now `ensureEncounterForAppointment`
+   materializes a `scheduled` Encounter from a **confirmed** appointment (idempotent via the
+   `@unique appointmentId`, race-safe, skips `[CalendarBlock:…]` holds), wired **eagerly** per
+   product decision: at appointment confirmation (`createPatientAppointmentAction`) and as a
+   day-of backstop on the `/ops/queue` board (`ensureTodayEncounters`). Commit `a52f9a17`,
+   9 unit tests. Residual: the kiosk console (`loadTodayEncounter`) does not itself run the
+   backstop — it relies on the board having been opened (clinic open) or the appointment having
+   been confirmed via the clinician path; a patient self-booking that is auto-confirmed by some
+   other path before any board load would still need staff to open the queue first. Patient
+   self-bookings remain `requested` until confirmed (no encounter until then — by design).
 
 1. **Concurrent walk-in duplicate** — `selectActiveVisitEncounter`+`create` is not atomic.
    The deterministic roomed-miss is fixed and repeat-clicks reuse, but two *simultaneous*
@@ -142,10 +138,10 @@ Baseline before changes: 269 test files / 2566 tests, all passing.
 
 | Gate | Command | Result |
 |------|---------|--------|
-| Unit + integration | `npx vitest run` | **275 files / 2613 tests passing** (+6 files, +47 tests over baseline) |
-| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after round 2 |
+| Unit + integration | `npx vitest run` | **276 files / 2622 tests passing** (+7 files, +56 tests over baseline) |
+| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after the bridge; Prisma relation-filter types check out |
 | Lint | `npm run lint` (`next lint`) | pass (exit 0); only a pre-existing `no-img-element` warning in `ShareDialog.tsx` (untouched) |
-| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) at round 1; round-2 changes are typecheck+lint+test clean (build not re-run) |
+| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) at round 1; later rounds are typecheck+lint+test clean (build not re-run) |
 
 New / changed tests:
 - `src/lib/domain/visit-state.select-active.test.ts` (new, 13) — drives the real
@@ -175,5 +171,13 @@ ad2084b0 test(visit): end-to-end same-day care-journey integration spine
 61121004 test(visit): align ACTIVE_VISIT_STATUSES contract test with the non-terminal fix
 8a0f3619 fix(visit): close two more duplicate-encounter siblings (voice charting, telehealth overlay)
 61735a21 fix(portal): validate provider exists, is active, and shares the patient's org on booking
-docs(audit): round-2 update — siblings, provider validation, appointment↔encounter finding
+4615b128 docs(audit): round-2 update — siblings, provider validation, appointment↔encounter finding
+a52f9a17 feat(visit): materialize Encounter from confirmed Appointment (check-in/queue bridge)
 ```
+
+### F. Appointment→Encounter bridge (round 3)  — **HIGH (systemic)**
+See Risk #0 (now ✅ fixed). Booked appointments never became encounters, so the
+documented "check in on appointment day" scenario was broken end-to-end. Added
+`ensureEncounterForAppointment` / `ensureTodayEncounters`
+(`src/lib/domain/ensure-encounter.ts`), wired at confirm + the queue day-of view.
+- Tests: `ensure-encounter.test.ts` (9). Commit `a52f9a17`.

--- a/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
+++ b/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
@@ -107,12 +107,18 @@ appointment against a missing, inactive, or cross-org provider.
    materializes a `scheduled` Encounter from a **confirmed** appointment (idempotent via the
    `@unique appointmentId`, race-safe, skips `[CalendarBlock:…]` holds), wired **eagerly** per
    product decision: at appointment confirmation (`createPatientAppointmentAction`) and as a
-   day-of backstop on the `/ops/queue` board (`ensureTodayEncounters`). Commit `a52f9a17`,
-   9 unit tests. Residual: the kiosk console (`loadTodayEncounter`) does not itself run the
-   backstop — it relies on the board having been opened (clinic open) or the appointment having
-   been confirmed via the clinician path; a patient self-booking that is auto-confirmed by some
-   other path before any board load would still need staff to open the queue first. Patient
-   self-bookings remain `requested` until confirmed (no encounter until then — by design).
+   day-of backstop on the `/ops/queue` board (`ensureTodayEncounters`). Commits `a52f9a17`,
+   `5289d234`, 13 unit tests. The kiosk console now also self-serves
+   (`ensureTodayEncounterForPatient` inside `loadTodayEncounter`), so a booked patient can
+   check in even before the board is opened. Appointment lifecycle is kept consistent:
+   cancel → `cancelEncounterForAppointment` (no ghost board card), reschedule (all 3 paths) →
+   `syncEncounterScheduleForAppointment` (no stale time). Patient self-bookings remain
+   `requested` until confirmed (no encounter until then — by design).
+   **Blast-radius verified:** the crons that iterate `status:"scheduled"` encounters
+   (`cron/reminders`, `integrations/eligibility-check`) are unscheduled (no `vercel.json`) and
+   are logging/simulation mocks, so the now-plentiful scheduled encounters don't trigger real
+   sends. Forward note: if real cron scheduling + sending is wired later, dedupe the
+   encounter-based reminders against the appointment-based `sendDueReminders`.
 
 1. **Concurrent walk-in duplicate** — `selectActiveVisitEncounter`+`create` is not atomic.
    The deterministic roomed-miss is fixed and repeat-clicks reuse, but two *simultaneous*
@@ -138,10 +144,10 @@ Baseline before changes: 269 test files / 2566 tests, all passing.
 
 | Gate | Command | Result |
 |------|---------|--------|
-| Unit + integration | `npx vitest run` | **276 files / 2622 tests passing** (+7 files, +56 tests over baseline) |
-| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after the bridge; Prisma relation-filter types check out |
+| Unit + integration | `npx vitest run` | **276 files / 2626 tests passing** (+7 files, +60 tests over baseline) |
+| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) — re-run after the lifecycle round; Prisma relation-filter types check out |
 | Lint | `npm run lint` (`next lint`) | pass (exit 0); only a pre-existing `no-img-element` warning in `ShareDialog.tsx` (untouched) |
-| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) — re-run after the bridge; full production build |
+| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0) — re-run after the lifecycle round; full production build |
 
 New / changed tests:
 - `src/lib/domain/visit-state.select-active.test.ts` (new, 13) — drives the real
@@ -173,6 +179,7 @@ ad2084b0 test(visit): end-to-end same-day care-journey integration spine
 61735a21 fix(portal): validate provider exists, is active, and shares the patient's org on booking
 4615b128 docs(audit): round-2 update — siblings, provider validation, appointment↔encounter finding
 a52f9a17 feat(visit): materialize Encounter from confirmed Appointment (check-in/queue bridge)
+5289d234 fix(visit): keep materialized Encounter in sync across appointment cancel/reschedule + kiosk self-serve
 ```
 
 ### F. Appointment→Encounter bridge (round 3)  — **HIGH (systemic)**
@@ -181,3 +188,13 @@ documented "check in on appointment day" scenario was broken end-to-end. Added
 `ensureEncounterForAppointment` / `ensureTodayEncounters`
 (`src/lib/domain/ensure-encounter.ts`), wired at confirm + the queue day-of view.
 - Tests: `ensure-encounter.test.ts` (9). Commit `a52f9a17`.
+
+### G. Bridge lifecycle consistency + kiosk self-serve (round 4)  — **MED**
+Direct follow-through on F: a materialized encounter has to track its appointment,
+or the bridge leaves ghost "Scheduled" cards / stale times. Added (guarded to a
+still-`scheduled` encounter, idempotent): `cancelEncounterForAppointment`,
+`syncEncounterScheduleForAppointment`, `ensureTodayEncounterForPatient`. Wired into
+portal cancel/reschedule, both clinician drag-reschedule actions, and the kiosk
+`loadTodayEncounter`. Audited the blast radius (more scheduled encounters now exist):
+the scheduled-encounter crons are unscheduled mocks — no real double-sends.
+- Tests: `ensure-encounter.test.ts` (→13). Commit `5289d234`.

--- a/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
+++ b/docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md
@@ -1,0 +1,139 @@
+# Core Care-Journey Hardening — 2026-06-03
+
+Overnight hardening of the end-to-end same-day patient care workflow.
+Branch: `worktree-care-journey-hardening` (isolated git worktree).
+Synthetic data only; no production secrets, claims, emails/SMS, or prod mutations.
+
+---
+
+## 1. Workflow map
+
+| # | Step | Surface (route / module) | Server action / fn | State written |
+|---|------|--------------------------|--------------------|---------------|
+| 1 | Patient books | `/(patient)/portal/schedule` + `booking-calendar.tsx` | `bookAppointment` (`portal/schedule/actions.ts`) | `Appointment(status=requested)` |
+| 2 | Check-in (kiosk/QR rescue) | `/kiosk/(console)`, `/kiosk/lobby/[token]`, `src/lib/check-in/*` | `issueHandoffToken`→OTP→`createKioskLobbySession`; `POST /api/mobile/kiosk/check-in`; queue `moveQueueEncounter` | `Encounter.checkedInAt`, `status=checked_in`; staged `KioskLobbySubmission` |
+| 3 | Front-desk readiness | `/clinic` (`UpcomingVisitsMissingInfo`), `/ops/queue` | `getAppointmentReadiness` / `evaluatePrevisitReadiness`, `intake-gate` | derived (PHI-free requirement ids) |
+| 4 | MA rooming + vitals | `/ops/queue` (`queue-board.tsx`), staff objective editor | `moveQueueEncounter` (rooming→roomed), `saveRoomingHandoff`, `saveObjectiveDocumentation` | `roomingStartedAt`, `roomedAt`, `briefingContext.rooming`, Note `findings` block |
+| 5 | Physician Start Visit | `/clinic/patients/[id]` | `startVisit` / `startVisitWithBriefing` → `selectActiveVisitEncounter` + `advanceVisitState` + `assignVisitProvider` | reuse encounter → `status=in_progress`, `startedAt`, `providerId`/`renderingProviderId` |
+| 6 | Dictation / documentation | `/clinic/patients/[id]/notes/[noteId]` (`note-editor.tsx`) | `routeDictationToBlocks`, `saveNoteBlocks` | `Note.blocks` (APSO/SOAP) |
+| 7 | Finalize / sign / co-sign | same | `finalizeNote` / `saveAndFinalizeNote` (mid-levels → `pending_cosign`) | `Note.status=finalized`, `finalizedAt`; `Encounter.status=complete`, `completedAt`, `chartingCompletedAt` |
+| 8 | Billing / charge capture | coding agent + visit completion | `note.finalized` → Coding Readiness Agent → `CodingSuggestion`/`Charge`; `releaseVisitCompletion` (gated on finalized) | `CodingSuggestion`, `Charge(pending)`, `VisitCompletion` |
+
+**Encounter state machine** (12-value `EncounterStatus`):
+`scheduled → checked_in → info_incomplete/ready → rooming → roomed → in_progress (in_visit) → (wrap_up) → complete`; terminal: `complete | cancelled | no_show`.
+Queue board (`/ops/queue`, kiosk) persists the intermediate flow states via `computeQueueTransition`; the physician spine (`advanceVisitState`) maps `in_visit → in_progress` and `complete`.
+
+---
+
+## 2. Step-by-step status
+
+| Step / required scenario | Status | Evidence |
+|---|---|---|
+| Patient books through portal | **fixed** | `bookAppointment` now guards conflicts/past/invalid + preserves modality; `actions.book.test.ts` |
+| Same patient checks in on appt day | pass | `api/mobile/kiosk/check-in/route.ts` + `computeQueueTransition`; existing route test |
+| Missing required intake detected/surfaced | pass | `intake-gate` + `previsit-readiness` (existing suites) |
+| QR/OTP rescue (no portal password for older adult) | pass | `kiosk-handoff` → OTP → lobby session; existing `check-in/*` suites |
+| Front desk marks readiness / sees blockers | pass | `getAppointmentReadiness`, `MissingRequirement[]` deep links |
+| MA enters vitals + rooms patient | pass | `saveObjectiveDocumentation` (findings block, blocked once signed), `saveRoomingHandoff` |
+| Roomed patient appears for physician | **fixed** | was invisible (status filter bug); `visit-state.select-active.test.ts`, journey test |
+| Start Visit reuses correct same-day encounter | **fixed** | `selectActiveVisitEncounter` non-terminal set; start-visit + journey tests |
+| No duplicate active encounters (repeat click/refresh) | **fixed** | reuse + idempotent advance; journey test (repeat-click, walk-in) |
+| Provider/rendering attribution correct | pass | `assignVisitProvider`; existing start-visit attribution tests |
+| Dictation lands in intended section | pass | `routeDictationToBlocks`; `dictation-routing.test.ts` |
+| Docs edited/saved/finalized/reopened safely | **fixed** | `saveNoteBlocks` now blocks edits to signed notes; `actions.save-note-lock.test.ts` |
+| Finalization idempotent | pass | `finalizeNote` short-circuits; `actions.finalize-idempotent.test.ts` |
+| Billing only after clinical complete | pass | coding agent on `note.finalized`; `releaseVisitCompletion` gated on finalized + unique-noteId idempotency |
+| Completed visit leaves queues correctly | pass (covered) | terminal excluded from `selectActiveVisitEncounter`; `mapEncounterStatusToQueueStatus`→`completed`; journey test |
+
+---
+
+## 3. Blockers found & fixed (with regression tests)
+
+### A. Duplicate encounter + orphaned MA handoff at Start Visit  — **HIGH**
+`selectActiveVisitEncounter` filtered `status IN (scheduled, in_progress)` only, but the
+front-desk queue/kiosk persist `checked_in/ready/rooming/roomed/wrap_up` onto the row.
+A checked-in/roomed patient was invisible to the physician → Start Visit minted a
+**second** encounter and orphaned the rooming vitals + handoff stored in the first
+encounter's `briefingContext`. (The kiosk console had its own work-around set,
+`KIOSK_VISIBLE_STATUSES`; the physician path never got the fix.) Same drift in the
+telehealth page (`["scheduled","in_progress"]`) → a roomed video visit fell back to a
+bogus `patientId`-as-`encounterId` room URL.
+- Fix: `ACTIVE_VISIT_STATUSES` = all non-terminal statuses + `TERMINAL_VISIT_STATUSES`;
+  used in `selectActiveVisitEncounter` and telehealth (now org-scoped).
+- Tests: `visit-state.select-active.test.ts` (drives the real WHERE clause — fails on
+  old filter), `actions.start-visit.test.ts` (+queue-state reuse / terminal-create),
+  `visit-journey.integration.test.ts`.
+- Commit `4d922df3`.
+
+### B. Portal double-booking / silent failure  — **MED**
+`bookAppointment` created an Appointment unconditionally: no conflict guard (reschedule
+had one), no future/validity check, silently collapsed `phone`→`video`, and returned a
+bare `{id}` so the UI showed a fake "booked" even on (now-possible) failure.
+- Fix: overlap conflict guard, past/invalid rejection, modality preserved, discriminated
+  `{ok}` result; `booking-calendar.tsx` surfaces the error.
+- Tests: `actions.book.test.ts`. Commit `0304dda3`.
+
+### C. Signed note silently mutable  — **MED**
+`saveNoteBlocks` had no status guard, so a `finalized`/`amended` (signed legal) note could
+be rewritten via a direct action call with no audit trail (the editor hides Save, but the
+server didn't enforce it; `saveObjectiveDocumentation` already did).
+- Fix: reject block saves on finalized/amended notes.
+- Tests: `actions.save-note-lock.test.ts`. Commit `886e495b`.
+
+---
+
+## 4. Residual risks (do NOT mark fully shipped without these)
+
+1. **Concurrent walk-in duplicate** — `selectActiveVisitEncounter`+`create` is not atomic.
+   The deterministic roomed-miss is fixed and repeat-clicks reuse, but two *simultaneous*
+   Start Visits for a patient with NO existing encounter can still both create. A true fix
+   needs a DB-level guard (partial unique index on active encounter per patient/day);
+   deferred — requires a migration on the shared dev DB (which has known `migrate deploy`
+   drift). Low likelihood (single physician per patient), surfaced here intentionally.
+2. **Concurrent provider double-book at booking** — the new conflict check closes the
+   sequential/repeat case; a true concurrent race needs a DB exclusion constraint (same
+   migration caveat).
+3. **No formal amend/reopen workflow** — `amended` status exists but nothing transitions
+   into it; signed notes are now correctly locked. A clinician-facing amendment flow
+   (new addendum + audit) is a product decision, not in scope.
+4. **Co-sign author identity** — `pending_cosign` overwrites `authorUserId` with the
+   finalizing clinician; the originating mid-level is not separately retained. Pre-existing;
+   flagged for product/clinical review (semantic decision).
+
+---
+
+## 5. Verification
+
+Baseline before changes: 269 test files / 2566 tests, all passing.
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Unit + integration | `npx vitest run` | **273 files / 2601 tests passing** (+4 files, +35 tests) |
+| Typecheck | `npm run typecheck` (`tsc --noEmit`) | pass (exit 0) |
+| Lint | `npm run lint` (`next lint`) | pass (exit 0); only a pre-existing `no-img-element` warning in `ShareDialog.tsx` (untouched) |
+| Build | `npm run build` (`prisma generate && next build`) | pass (exit 0); full production build incl. `/telehealth`, portal schedule, clinic notes |
+
+New / changed tests:
+- `src/lib/domain/visit-state.select-active.test.ts` (new, 13) — drives the real
+  WHERE clause; **verified to fail on the pre-fix filter** (8 failures) then pass.
+- `src/lib/domain/visit-journey.integration.test.ts` (new, 4) — end-to-end spine.
+- `src/app/(patient)/portal/schedule/actions.book.test.ts` (new, 7).
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.save-note-lock.test.ts` (new, 5).
+- `actions.start-visit.test.ts` (+6 queue-state reuse / terminal-create cases).
+- `visit-state.test.ts` (updated contract assertions to the corrected non-terminal set).
+
+Playwright e2e was **not executed**: the authed care-journey UI needs a running
+dev server + seeded DB + Clerk auth, which can't be stood up with synthetic-only,
+no-prod-credential constraints in this sandbox. The journey is instead proven by
+the integration spine + server-action unit tests above. The existing `e2e/`
+specs (public/authed surfaces) remain unchanged.
+
+## 6. Commits (branch `worktree-care-journey-hardening`, off `main`)
+
+```
+4d922df3 fix(visit): reuse checked-in/roomed encounter on Start Visit — no duplicate encounters
+0304dda3 fix(portal): guard bookAppointment against double-booking, past/invalid times, modality loss
+886e495b fix(notes): block saveNoteBlocks from silently mutating a signed note
+ad2084b0 test(visit): end-to-end same-day care-journey integration spine
+61121004 test(visit): align ACTIVE_VISIT_STATUSES contract test with the non-terminal fix
+```

--- a/src/app/(clinician)/clinic/communications/actions.overlay-telehealth.test.ts
+++ b/src/app/(clinician)/clinic/communications/actions.overlay-telehealth.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * startOverlayTelehealthVisit must reuse an existing non-terminal video
+ * encounter (including one the front desk already checked in / roomed) before
+ * minting a new one. The old query filtered status IN (scheduled, in_progress),
+ * which duplicated the encounter when a patient pivoted to telehealth mid-flow.
+ */
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    patient: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn(), create: vi.fn() },
+  },
+  requireUserMock: vi.fn(),
+  startTelehealthMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("../patients/[id]/telehealth/actions", () => ({
+  startTelehealthVisit: (...args: unknown[]) => hoisted.startTelehealthMock(...args),
+  endTelehealthVisit: vi.fn(),
+}));
+
+import { startOverlayTelehealthVisit } from "./actions";
+import { ACTIVE_VISIT_STATUSES } from "@/lib/domain/visit-state";
+
+const { mockPrisma, requireUserMock, startTelehealthMock } = hoisted;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue({
+    id: "u1",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+  });
+  mockPrisma.patient.findFirst.mockResolvedValue({
+    id: "patient_1",
+    firstName: "Pat",
+    lastName: "Ient",
+    presentingConcerns: null,
+    medications: [],
+  });
+  mockPrisma.encounter.findFirst.mockResolvedValue(null);
+  mockPrisma.encounter.create.mockResolvedValue({ id: "new_video_enc" });
+  startTelehealthMock.mockResolvedValue({ roomUrl: "https://room" });
+});
+
+describe("startOverlayTelehealthVisit", () => {
+  it("queries for any non-terminal video encounter (not just scheduled/in_progress)", async () => {
+    await startOverlayTelehealthVisit();
+    const where = mockPrisma.encounter.findFirst.mock.calls[0][0].where;
+    expect(where.modality).toBe("video");
+    expect(new Set(where.status.in)).toEqual(new Set(ACTIVE_VISIT_STATUSES));
+  });
+
+  it("reuses a roomed video encounter instead of creating a duplicate", async () => {
+    mockPrisma.encounter.findFirst.mockResolvedValue({ id: "roomed_video", status: "roomed" });
+    const r = await startOverlayTelehealthVisit();
+    expect(r.encounterId).toBe("roomed_video");
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a video encounter when none is active", async () => {
+    const r = await startOverlayTelehealthVisit();
+    expect(r.encounterId).toBe("new_video_enc");
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/(clinician)/clinic/communications/actions.ts
+++ b/src/app/(clinician)/clinic/communications/actions.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { ACTIVE_VISIT_STATUSES } from "@/lib/domain/visit-state";
 import {
   startTelehealthVisit,
   endTelehealthVisit,
@@ -49,13 +50,16 @@ export async function startOverlayTelehealthVisit(): Promise<OverlayTelehealthVi
     throw new Error("No active patients found in the database to start a visit with.");
   }
 
-  // Get or create a scheduled/in-progress video encounter
+  // Reuse any non-terminal video encounter for this patient (incl. ones the
+  // front desk already checked in / roomed) before minting a new one — the old
+  // scheduled/in_progress-only filter duplicated the encounter when a patient
+  // pivoted to telehealth mid-flow.
   let encounter = await prisma.encounter.findFirst({
     where: {
       patientId: patient.id,
       organizationId: user.organizationId,
       modality: "video",
-      status: { in: ["scheduled", "in_progress"] },
+      status: { in: [...ACTIVE_VISIT_STATUSES] },
     },
     orderBy: { scheduledFor: "desc" },
   });

--- a/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
@@ -140,6 +140,45 @@ describe("startVisit — encounter selection", () => {
   });
 });
 
+describe("startVisit — reuses front-desk queue-state encounters (duplicate-encounter regression)", () => {
+  // Replicate Prisma's `status { in }` filter so the production WHERE clause in
+  // selectActiveVisitEncounter is exercised end-to-end, not just the mock's
+  // canned return. A patient checked-in / roomed by the front desk sits in a
+  // queue flow status; Start Visit must reuse that row, not mint a duplicate.
+  function withFilteringFindMany(rows: Array<Record<string, unknown>>) {
+    mockPrisma.encounter.findMany.mockImplementation(async ({ where }: any) =>
+      rows.filter((e: any) => where.status.in.includes(e.status)),
+    );
+  }
+
+  for (const status of ["checked_in", "ready", "rooming", "roomed", "wrap_up"]) {
+    it(`reuses today's ${status} encounter and advances it in-place`, async () => {
+      withFilteringFindMany([scheduledEncounter({ id: "live_1", status })]);
+
+      await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+      // No duplicate encounter minted...
+      expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+      // ...and the existing row (carrying the MA rooming handoff) is advanced
+      // into the visit rather than abandoned.
+      expect(mockPrisma.encounter.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "live_1" },
+          data: expect.objectContaining({ status: "in_progress" }),
+        }),
+      );
+    });
+  }
+
+  it("mints a fresh encounter when today's only encounter is terminal (complete)", async () => {
+    withFilteringFindMany([scheduledEncounter({ id: "done_1", status: "complete" })]);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("startVisit — provider attribution", () => {
   it("Dr B starting Dr A's scheduled encounter preserves ownership and stamps rendering provider", async () => {
     // Dr A owns today's scheduled encounter; Dr B (current user) starts the visit.

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.save-note-lock.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.save-note-lock.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Signed-note integrity — saveNoteBlocks must not silently mutate a finalized
+ * (or amended) note. The editor hides the Save button once a note is signed,
+ * but the server action must enforce the lock too; otherwise a direct action
+ * call or a stale client could rewrite a signed legal record with no audit
+ * trail. saveObjectiveDocumentation already enforces this; saveNoteBlocks did
+ * not. Draft / needs_review notes remain freely editable.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn() },
+    note: { findUnique: vi.fn(), update: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: vi.fn() }));
+vi.mock("@/lib/orchestration/runner", () => ({ runTick: vi.fn(), runJob: vi.fn() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { saveNoteBlocks } from "./actions";
+
+const { mockPrisma, requireUserMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function note(over: Record<string, unknown> = {}) {
+  return {
+    id: "note_1",
+    encounterId: "enc_1",
+    status: "draft",
+    aiDrafted: false,
+    blocks: [],
+    authorUserId: null,
+    encounter: { id: "enc_1", patientId: "patient_1", status: "in_progress" },
+    ...over,
+  };
+}
+
+const BLOCKS = [{ heading: "Subjective", body: "edited body" }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.note.findUnique.mockResolvedValue(note());
+  mockPrisma.encounter.findFirst.mockResolvedValue({
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+  });
+  // assertChartAccess (real RBAC) reads the patient's privacy flags.
+  mockPrisma.patient.findFirst.mockResolvedValue({
+    id: "patient_1",
+    organizationId: "org_1",
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+  });
+  mockPrisma.note.update.mockResolvedValue(note());
+});
+
+describe("saveNoteBlocks — signed-note lock", () => {
+  it("saves a draft note", async () => {
+    const res = await saveNoteBlocks("note_1", BLOCKS);
+    expect(res.ok).toBe(true);
+    expect(mockPrisma.note.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves a needs_review note", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "needs_review" }));
+    const res = await saveNoteBlocks("note_1", BLOCKS);
+    expect(res.ok).toBe(true);
+    expect(mockPrisma.note.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to edit a finalized note and does NOT write", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "finalized" }));
+    const res = await saveNoteBlocks("note_1", BLOCKS);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/signed/i);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to edit an amended note and does NOT write", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "amended" }));
+    const res = await saveNoteBlocks("note_1", BLOCKS);
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+
+  it("denies a read-only (no notes.edit) user", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    const res = await saveNoteBlocks("note_1", BLOCKS);
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.note.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -89,6 +89,17 @@ export async function saveNoteBlocks(
     }
     throw err;
   }
+
+  // A signed note (finalized or amended) is a locked legal record. The editor
+  // hides the Save button once a note leaves draft/needs_review, but the server
+  // must enforce it too: a direct action call (or a stale client) must not
+  // silently mutate a signed note. Mirrors the guard saveObjectiveDocumentation
+  // already applies. Amending a signed note is a deliberate, audited flow — not
+  // a plain block save.
+  if (note.status === "finalized" || note.status === "amended") {
+    return { ok: false, error: "This note is signed and can no longer be edited." };
+  }
+
   // EMR-784: AI-drafted notes (voice/ambient scribe) must keep the
   // patient verbal-consent disclaimer even if the clinician edited the
   // draft. Re-inject if it was stripped.

--- a/src/app/(clinician)/clinic/patients/[id]/telehealth/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/telehealth/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
 import { generateRoomUrl, PATIENT_CHECKLIST } from "@/lib/domain/telehealth";
+import { ACTIVE_VISIT_STATUSES } from "@/lib/domain/visit-state";
 import { VideoRoom } from "./video-room";
 
 interface PageProps {
@@ -30,12 +31,16 @@ export default async function TelehealthPage({ params }: PageProps) {
 
   if (!patient) notFound();
 
-  // Get or create an encounter for this telehealth visit
+  // Find the active telehealth encounter for this patient. Must include every
+  // non-terminal status — a video visit the front desk already checked in or
+  // roomed sits in checked_in/rooming/roomed, and the old scheduled/in_progress
+  // filter missed it, falling back to a bogus patientId-as-encounterId room URL.
   const encounter = await prisma.encounter.findFirst({
     where: {
       patientId: params.id,
+      organizationId: user.organizationId!,
       modality: "video",
-      status: { in: ["scheduled", "in_progress"] },
+      status: { in: [...ACTIVE_VISIT_STATUSES] },
     },
     orderBy: { scheduledFor: "desc" },
   });

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.start-voice.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.start-voice.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Voice charting must reuse today's active encounter, not mint a duplicate.
+ * startVoiceEncounter used to match status="in_progress" only, so a patient the
+ * front desk had checked in or roomed (checked_in/rooming/roomed) was missed and
+ * voice charting spun up a SECOND encounter — orphaning the rooming handoff. It
+ * now goes through selectActiveVisitEncounter (all non-terminal statuses).
+ */
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    patient: { findFirst: vi.fn() },
+    encounter: { findMany: vi.fn(), create: vi.fn() },
+  },
+  requireUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { startVoiceEncounter } from "./actions";
+
+const { mockPrisma, requireUserMock } = hoisted;
+
+// Replicate Prisma's status `in` filter so selectActiveVisitEncounter's real
+// WHERE clause is exercised end-to-end.
+function withFilteringFindMany(rows: Array<Record<string, unknown>>) {
+  mockPrisma.encounter.findMany.mockImplementation(async ({ where }: any) =>
+    rows.filter((e: any) => where.status.in.includes(e.status)),
+  );
+}
+
+function enc(over: Record<string, unknown> = {}) {
+  return {
+    id: "live",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    scheduledFor: new Date(),
+    createdAt: new Date(),
+    startedAt: null,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue({ id: "u1", organizationId: "org_1" });
+  mockPrisma.patient.findFirst.mockResolvedValue({ id: "patient_1", organizationId: "org_1" });
+  mockPrisma.encounter.findMany.mockResolvedValue([]);
+  mockPrisma.encounter.create.mockResolvedValue({ id: "new_voice_enc" });
+});
+
+describe("startVoiceEncounter", () => {
+  it.each(["checked_in", "rooming", "roomed", "scheduled", "in_progress"])(
+    "reuses today's %s encounter instead of creating a duplicate",
+    async (status) => {
+      withFilteringFindMany([enc({ status })]);
+      const r = await startVoiceEncounter("patient_1");
+      expect(r.encounterId).toBe("live");
+      expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+    },
+  );
+
+  it("creates a new encounter only when none is active today (terminal-only)", async () => {
+    withFilteringFindMany([enc({ id: "done", status: "complete" })]);
+    const r = await startVoiceEncounter("patient_1");
+    expect(r.encounterId).toBe("new_voice_enc");
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the patient is not found / not in the user's org", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(null);
+    await expect(startVoiceEncounter("patient_x")).rejects.toThrow(/not found/i);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/voice-chart/actions.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { selectActiveVisitEncounter } from "@/lib/domain/visit-state";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
 import {
   buildExtractionPrompt,
@@ -574,20 +575,12 @@ export async function startVoiceEncounter(
     throw new Error("Patient not found.");
   }
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
-
-  // Reuse an existing in-progress encounter for today if one exists
-  let encounter = await prisma.encounter.findFirst({
-    where: {
-      patientId,
-      organizationId: user.organizationId!,
-      status: "in_progress",
-      createdAt: { gte: todayStart, lte: todayEnd },
-    },
-  });
+  // Reuse today's active encounter before minting a new one. The old query
+  // matched status="in_progress" only, so a patient the front desk had already
+  // checked in or roomed (status checked_in/rooming/roomed) was missed and voice
+  // charting spun up a DUPLICATE encounter. selectActiveVisitEncounter covers
+  // every non-terminal status and prefers an already-started visit.
+  let encounter = await selectActiveVisitEncounter(patientId, user.organizationId!);
 
   if (!encounter) {
     encounter = await prisma.encounter.create({

--- a/src/app/(clinician)/clinic/schedule/actions.ts
+++ b/src/app/(clinician)/clinic/schedule/actions.ts
@@ -4,7 +4,10 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
-import { ensureEncounterForAppointment } from "@/lib/domain/ensure-encounter";
+import {
+  ensureEncounterForAppointment,
+  syncEncounterScheduleForAppointment,
+} from "@/lib/domain/ensure-encounter";
 
 const rescheduleSchema = z.object({
   appointmentId: z.string(),
@@ -64,6 +67,9 @@ export async function rescheduleAppointmentAction(
     where: { id: appt.id },
     data: { startAt: newStart, endAt: newEnd },
   });
+
+  // Keep a materialized (still-scheduled) Encounter aligned with the new slot.
+  await syncEncounterScheduleForAppointment(appt.id, newStart);
 
   revalidatePath("/clinic/schedule");
   return { ok: true };

--- a/src/app/(clinician)/clinic/schedule/actions.ts
+++ b/src/app/(clinician)/clinic/schedule/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { ensureEncounterForAppointment } from "@/lib/domain/ensure-encounter";
 
 const rescheduleSchema = z.object({
   appointmentId: z.string(),
@@ -117,7 +118,7 @@ export async function createPatientAppointmentAction(
     }
   }
 
-  await prisma.appointment.create({
+  const appointment = await prisma.appointment.create({
     data: {
       patientId,
       providerId: provider.id,
@@ -128,6 +129,11 @@ export async function createPatientAppointmentAction(
       status: "confirmed",
     },
   });
+
+  // Materialize the visit Encounter now so the patient is immediately
+  // checkinable and shows on the queue board (idempotent via the @unique
+  // appointmentId; the queue's day-of backstop also covers this).
+  await ensureEncounterForAppointment(appointment.id);
 
   revalidatePath("/clinic/schedule");
   return { ok: true };

--- a/src/app/(clinician)/clinic/schedule/calendar/actions.ts
+++ b/src/app/(clinician)/clinic/schedule/calendar/actions.ts
@@ -8,6 +8,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { syncEncounterScheduleForAppointment } from "@/lib/domain/ensure-encounter";
 
 const ALLOWED_MODALITIES = ["video", "in_person", "phone"] as const;
 
@@ -135,6 +136,9 @@ export async function rescheduleAppointmentAction(
     where: { id: appt.id },
     data: { startAt: newStart, endAt: newEnd },
   });
+
+  // Keep a materialized (still-scheduled) Encounter aligned with the new slot.
+  await syncEncounterScheduleForAppointment(appt.id, newStart);
 
   revalidatePath("/clinic/schedule/calendar");
   return { ok: true };

--- a/src/app/(operator)/ops/queue/page.tsx
+++ b/src/app/(operator)/ops/queue/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import { ensureTodayEncounters } from "@/lib/domain/ensure-encounter";
 import { PageShell } from "@/components/shell/PageHeader";
 import { QueueBoard } from "./queue-board";
 import {
@@ -27,6 +28,12 @@ type RoomingContext = {
 export default async function QueueBoardPage() {
   const user = await requireUser();
   const orgId = user.organizationId!;
+
+  // Day-of backstop: make sure every confirmed appointment for today has its
+  // Encounter materialized so booked patients appear on the board (as
+  // "Scheduled") and are checkinable, even if they were confirmed before the
+  // encounter bridge existed. Idempotent and bounded to today's org.
+  await ensureTodayEncounters(orgId);
 
   const today = new Date();
   const startOfDay = new Date(

--- a/src/app/(patient)/portal/schedule/actions.book.test.ts
+++ b/src/app/(patient)/portal/schedule/actions.book.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => ({
   mockPrisma: {
     patient: { findFirst: vi.fn() },
+    provider: { findFirst: vi.fn() },
     appointment: { findFirst: vi.fn(), create: vi.fn() },
   },
   requireUserMock: vi.fn(),
@@ -46,7 +47,8 @@ function base(over: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   requireUserMock.mockResolvedValue({ id: "user_1" });
-  mockPrisma.patient.findFirst.mockResolvedValue({ id: "patient_1" });
+  mockPrisma.patient.findFirst.mockResolvedValue({ id: "patient_1", organizationId: "org_1" });
+  mockPrisma.provider.findFirst.mockResolvedValue({ id: "prov_1" });
   mockPrisma.appointment.findFirst.mockResolvedValue(null);
   mockPrisma.appointment.create.mockResolvedValue({ id: "appt_new" });
 });
@@ -73,6 +75,22 @@ describe("bookAppointment", () => {
     expect(where.status.in).toEqual(["requested", "confirmed"]);
     expect(where.startAt.lt).toBeInstanceOf(Date);
     expect(where.endAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("rejects an unknown / inactive / cross-org provider without booking", async () => {
+    mockPrisma.provider.findFirst.mockResolvedValue(null);
+    const res = await bookAppointment(base());
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/provider/i);
+    expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+  });
+
+  it("scopes the provider lookup to the patient's org and active providers", async () => {
+    await bookAppointment(base());
+    const where = mockPrisma.provider.findFirst.mock.calls[0][0].where;
+    expect(where.id).toBe("prov_1");
+    expect(where.organizationId).toBe("org_1");
+    expect(where.active).toBe(true);
   });
 
   it("rejects a time in the past without touching the DB", async () => {

--- a/src/app/(patient)/portal/schedule/actions.book.test.ts
+++ b/src/app/(patient)/portal/schedule/actions.book.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Portal booking guardrails (bookAppointment).
+ *
+ * Regression cover for the hardening sprint: the patient-portal booking action
+ * used to create an Appointment unconditionally — no double-booking guard
+ * (rescheduleAppointment had one, bookAppointment did not), no future/validity
+ * check, and it silently collapsed a "phone" modality into "video". It also
+ * returned a bare { id }, so the caller couldn't tell a conflict from success.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    patient: { findFirst: vi.fn() },
+    appointment: { findFirst: vi.fn(), create: vi.fn() },
+  },
+  requireUserMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({
+  requireUser: () => hoisted.requireUserMock(),
+}));
+
+import { bookAppointment } from "./actions";
+
+const { mockPrisma, requireUserMock } = hoisted;
+
+const FUTURE = "2099-03-01";
+const TIME = "09:00";
+
+function base(over: Record<string, unknown> = {}) {
+  return {
+    patientId: "patient_1",
+    providerId: "prov_1",
+    slotDate: FUTURE,
+    slotStartTime: TIME,
+    appointmentType: "follow_up",
+    modality: "in_person",
+    ...over,
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue({ id: "user_1" });
+  mockPrisma.patient.findFirst.mockResolvedValue({ id: "patient_1" });
+  mockPrisma.appointment.findFirst.mockResolvedValue(null);
+  mockPrisma.appointment.create.mockResolvedValue({ id: "appt_new" });
+});
+
+describe("bookAppointment", () => {
+  it("books a free slot and returns the new id", async () => {
+    const res = await bookAppointment(base());
+    expect(res).toEqual({ ok: true, id: "appt_new" });
+    expect(mockPrisma.appointment.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to double-book an overlapping provider slot", async () => {
+    mockPrisma.appointment.findFirst.mockResolvedValue({ id: "existing" });
+    const res = await bookAppointment(base());
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe("CONFLICT");
+    expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+  });
+
+  it("checks for conflicts on the overlap window (lt end / gt start)", async () => {
+    await bookAppointment(base());
+    const where = mockPrisma.appointment.findFirst.mock.calls[0][0].where;
+    expect(where.providerId).toBe("prov_1");
+    expect(where.status.in).toEqual(["requested", "confirmed"]);
+    expect(where.startAt.lt).toBeInstanceOf(Date);
+    expect(where.endAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("rejects a time in the past without touching the DB", async () => {
+    const res = await bookAppointment(base({ slotDate: "2020-01-01" }));
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.appointment.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unparseable time", async () => {
+    const res = await bookAppointment(base({ slotDate: "not-a-date" }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/invalid/i);
+    expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves the phone modality instead of collapsing it to video", async () => {
+    await bookAppointment(base({ modality: "phone" }));
+    expect(mockPrisma.appointment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ modality: "phone" }),
+      }),
+    );
+  });
+
+  it("rejects booking for a patient the user does not own", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(null);
+    await expect(bookAppointment(base())).rejects.toThrow(/unauthorized|not found/i);
+    expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(patient)/portal/schedule/actions.ts
+++ b/src/app/(patient)/portal/schedule/actions.ts
@@ -4,6 +4,10 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
+import {
+  cancelEncounterForAppointment,
+  syncEncounterScheduleForAppointment,
+} from "@/lib/domain/ensure-encounter";
 import type { AppointmentType } from "@/lib/domain/scheduling";
 
 interface BookAppointmentInput {
@@ -137,6 +141,10 @@ export async function cancelAppointment(
     data: { status: "cancelled" },
   });
 
+  // If this appointment had already materialized a (still-scheduled) Encounter,
+  // cancel it too so it doesn't linger as a ghost card on the queue board.
+  await cancelEncounterForAppointment(appt.id);
+
   revalidatePath("/portal/schedule");
   return { ok: true };
 }
@@ -206,6 +214,10 @@ export async function rescheduleAppointment(
       status: "requested",
     },
   });
+
+  // Keep a materialized (still-scheduled) Encounter pointed at the new time so
+  // the queue board doesn't show the old slot.
+  await syncEncounterScheduleForAppointment(appt.id, newStart);
 
   revalidatePath("/portal/schedule");
   return { ok: true, id: appt.id };

--- a/src/app/(patient)/portal/schedule/actions.ts
+++ b/src/app/(patient)/portal/schedule/actions.ts
@@ -20,6 +20,12 @@ function durationMinutesFor(t: AppointmentType): number {
   return t === "new_patient" ? 60 : t === "urgent" ? 15 : 30;
 }
 
+const BOOK_MODALITIES = new Set(["in_person", "video", "phone"]);
+
+export type BookAppointmentResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string; code?: string };
+
 async function getOwnedPatient(userId: string, patientId: string) {
   const patient = await prisma.patient.findFirst({
     where: { id: patientId, userId, deletedAt: null },
@@ -28,14 +34,49 @@ async function getOwnedPatient(userId: string, patientId: string) {
   return patient;
 }
 
-export async function bookAppointment(input: BookAppointmentInput) {
+export async function bookAppointment(
+  input: BookAppointmentInput,
+): Promise<BookAppointmentResult> {
   const user = await requireUser();
   await getOwnedPatient(user.id, input.patientId);
 
   const startAt = new Date(`${input.slotDate}T${input.slotStartTime}:00`);
+  if (Number.isNaN(startAt.getTime())) {
+    return { ok: false, error: "Invalid appointment time." };
+  }
+  if (startAt.getTime() < Date.now()) {
+    return { ok: false, error: "Choose a time in the future." };
+  }
+
   const endAt = new Date(
     startAt.getTime() + durationMinutesFor(input.appointmentType) * 60_000,
   );
+
+  // Don't let the portal double-book a provider's slot. rescheduleAppointment
+  // already enforces this guard; bookAppointment skipped it, so two patients
+  // (or one patient clicking twice) could create overlapping "requested"
+  // appointments on the same provider.
+  if (input.providerId) {
+    const conflict = await prisma.appointment.findFirst({
+      where: {
+        providerId: input.providerId,
+        status: { in: ["requested", "confirmed"] },
+        startAt: { lt: endAt },
+        endAt: { gt: startAt },
+      },
+    });
+    if (conflict) {
+      return {
+        ok: false,
+        error: "That time was just taken. Please pick another slot.",
+        code: "CONFLICT",
+      };
+    }
+  }
+
+  // Preserve the requested modality (in_person | video | phone). The old code
+  // silently collapsed "phone" into "video".
+  const modality = BOOK_MODALITIES.has(input.modality) ? input.modality : "video";
 
   const appointment = await prisma.appointment.create({
     data: {
@@ -44,13 +85,13 @@ export async function bookAppointment(input: BookAppointmentInput) {
       status: "requested",
       startAt,
       endAt,
-      modality: input.modality === "in_person" ? "in_person" : "video",
+      modality,
       notes: input.reason ?? null,
     },
   });
 
   revalidatePath("/portal/schedule");
-  return { id: appointment.id };
+  return { ok: true, id: appointment.id };
 }
 
 const cancelSchema = z.object({ appointmentId: z.string().min(1) });

--- a/src/app/(patient)/portal/schedule/actions.ts
+++ b/src/app/(patient)/portal/schedule/actions.ts
@@ -38,7 +38,7 @@ export async function bookAppointment(
   input: BookAppointmentInput,
 ): Promise<BookAppointmentResult> {
   const user = await requireUser();
-  await getOwnedPatient(user.id, input.patientId);
+  const patient = await getOwnedPatient(user.id, input.patientId);
 
   const startAt = new Date(`${input.slotDate}T${input.slotStartTime}:00`);
   if (Number.isNaN(startAt.getTime())) {
@@ -52,26 +52,39 @@ export async function bookAppointment(
     startAt.getTime() + durationMinutesFor(input.appointmentType) * 60_000,
   );
 
+  // The provider must exist, be active, and belong to the patient's org —
+  // bookAppointment previously trusted an arbitrary providerId, so the portal
+  // could create a dangling appointment against a missing or cross-org provider.
+  const provider = await prisma.provider.findFirst({
+    where: {
+      id: input.providerId,
+      organizationId: patient.organizationId,
+      active: true,
+    },
+    select: { id: true },
+  });
+  if (!provider) {
+    return { ok: false, error: "That provider isn't available for booking." };
+  }
+
   // Don't let the portal double-book a provider's slot. rescheduleAppointment
   // already enforces this guard; bookAppointment skipped it, so two patients
   // (or one patient clicking twice) could create overlapping "requested"
   // appointments on the same provider.
-  if (input.providerId) {
-    const conflict = await prisma.appointment.findFirst({
-      where: {
-        providerId: input.providerId,
-        status: { in: ["requested", "confirmed"] },
-        startAt: { lt: endAt },
-        endAt: { gt: startAt },
-      },
-    });
-    if (conflict) {
-      return {
-        ok: false,
-        error: "That time was just taken. Please pick another slot.",
-        code: "CONFLICT",
-      };
-    }
+  const conflict = await prisma.appointment.findFirst({
+    where: {
+      providerId: provider.id,
+      status: { in: ["requested", "confirmed"] },
+      startAt: { lt: endAt },
+      endAt: { gt: startAt },
+    },
+  });
+  if (conflict) {
+    return {
+      ok: false,
+      error: "That time was just taken. Please pick another slot.",
+      code: "CONFLICT",
+    };
   }
 
   // Preserve the requested modality (in_person | video | phone). The old code

--- a/src/app/(patient)/portal/schedule/booking-calendar.tsx
+++ b/src/app/(patient)/portal/schedule/booking-calendar.tsx
@@ -184,7 +184,7 @@ export function BookingCalendar({ providers, patientId, upcoming }: BookingCalen
           action: "rescheduled",
         });
       } else {
-        await bookAppointment({
+        const res = await bookAppointment({
           patientId,
           providerId: selectedProviderId,
           slotDate: selectedDate,
@@ -192,6 +192,10 @@ export function BookingCalendar({ providers, patientId, upcoming }: BookingCalen
           appointmentType,
           modality: appointmentType === "telehealth" ? "video" : "in_person",
         });
+        if (!res.ok) {
+          setSubmitError(res.error);
+          return;
+        }
         setBookedDetails({
           date: formatDateLabel(selectedDate),
           time: `${selectedSlot.startTime} - ${selectedSlot.endTime}`,

--- a/src/app/kiosk/(console)/actions.ts
+++ b/src/app/kiosk/(console)/actions.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireRole } from "@/lib/auth/session";
 import { patientMatchesQuery } from "@/lib/search/patient-search";
 import { computeQueueTransition } from "@/lib/domain/visit-state";
+import { ensureTodayEncounterForPatient } from "@/lib/domain/ensure-encounter";
 import { logger } from "@/lib/observability/log";
 import { appOrigin, issueHandoffToken } from "@/lib/check-in/kiosk-handoff";
 
@@ -106,6 +107,11 @@ function dayBounds(now: Date): { start: Date; end: Date } {
  * "you're already checked in" instead of "no appointment".
  */
 async function loadTodayEncounter(orgId: string, patientId: string) {
+  // Self-sufficiency: a booked patient may have no Encounter yet if no staff has
+  // opened the queue board today. Materialize it here (idempotent) so the kiosk
+  // can find and check them in without depending on the board's day-of backstop.
+  await ensureTodayEncounterForPatient(orgId, patientId);
+
   const { start, end } = dayBounds(new Date());
   return prisma.encounter.findFirst({
     where: {

--- a/src/lib/domain/ensure-encounter.test.ts
+++ b/src/lib/domain/ensure-encounter.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Appointment → Encounter bridge. Booking only creates an Appointment; check-in /
+ * rooming / the queue board run off Encounters. ensureEncounterForAppointment
+ * materializes a scheduled Encounter from a confirmed appointment — idempotently
+ * (via the @unique appointmentId), skipping calendar blocks and non-confirmed
+ * appointments, and race-safe against concurrent creates.
+ */
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    appointment: { findUnique: vi.fn(), findMany: vi.fn() },
+    encounter: { create: vi.fn(), findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+
+import {
+  ensureEncounterForAppointment,
+  ensureTodayEncounters,
+  isCalendarBlockAppointment,
+} from "./ensure-encounter";
+
+const { mockPrisma } = hoisted;
+
+const START = new Date("2026-06-04T15:00:00.000Z");
+
+function appt(over: Record<string, unknown> = {}) {
+  return {
+    id: "appt_1",
+    patientId: "patient_1",
+    providerId: "prov_1",
+    status: "confirmed",
+    startAt: START,
+    modality: "in_person",
+    notes: null,
+    encounter: null,
+    patient: { organizationId: "org_1", deletedAt: null },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.appointment.findUnique.mockResolvedValue(appt());
+  mockPrisma.encounter.create.mockImplementation(async ({ data }: any) => ({ id: "enc_new", ...data }));
+  mockPrisma.encounter.findUnique.mockResolvedValue(null);
+});
+
+describe("ensureEncounterForAppointment", () => {
+  it("creates a scheduled encounter from a confirmed appointment", async () => {
+    const enc = await ensureEncounterForAppointment("appt_1");
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.encounter.create.mock.calls[0][0].data).toMatchObject({
+      organizationId: "org_1",
+      patientId: "patient_1",
+      providerId: "prov_1",
+      appointmentId: "appt_1",
+      status: "scheduled",
+      scheduledFor: START,
+      modality: "in_person",
+    });
+    expect(enc?.id).toBe("enc_new");
+  });
+
+  it("is idempotent — returns the already-linked encounter without creating", async () => {
+    mockPrisma.appointment.findUnique.mockResolvedValue(appt({ encounter: { id: "enc_existing" } }));
+    const enc = await ensureEncounterForAppointment("appt_1");
+    expect(enc?.id).toBe("enc_existing");
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("does NOT materialize a calendar block", async () => {
+    mockPrisma.appointment.findUnique.mockResolvedValue(
+      appt({ notes: "[CalendarBlock:VACATION] out of office" }),
+    );
+    const enc = await ensureEncounterForAppointment("appt_1");
+    expect(enc).toBeNull();
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("does NOT materialize a non-confirmed (requested) appointment", async () => {
+    mockPrisma.appointment.findUnique.mockResolvedValue(appt({ status: "requested" }));
+    expect(await ensureEncounterForAppointment("appt_1")).toBeNull();
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a deleted or missing patient/appointment", async () => {
+    mockPrisma.appointment.findUnique.mockResolvedValue(
+      appt({ patient: { organizationId: "org_1", deletedAt: new Date() } }),
+    );
+    expect(await ensureEncounterForAppointment("appt_1")).toBeNull();
+
+    mockPrisma.appointment.findUnique.mockResolvedValue(null);
+    expect(await ensureEncounterForAppointment("missing")).toBeNull();
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+
+  it("is race-safe — a P2002 on create falls back to the winning row", async () => {
+    mockPrisma.encounter.create.mockRejectedValue({ code: "P2002" });
+    mockPrisma.encounter.findUnique.mockResolvedValue({ id: "enc_winner" });
+    const enc = await ensureEncounterForAppointment("appt_1");
+    expect(enc?.id).toBe("enc_winner");
+  });
+});
+
+describe("ensureTodayEncounters", () => {
+  it("materializes today's confirmed, non-block appointments lacking an encounter", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
+    mockPrisma.appointment.findUnique.mockImplementation(async ({ where }: any) => appt({ id: where.id }));
+
+    const created = await ensureTodayEncounters("org_1", new Date("2026-06-04T12:00:00Z"));
+    expect(created).toBe(2);
+    expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(2);
+
+    const where = mockPrisma.appointment.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe("confirmed");
+    expect(where.encounter).toEqual({ is: null });
+    expect(where.patient).toMatchObject({ organizationId: "org_1", deletedAt: null });
+    expect(where.NOT).toEqual({ notes: { startsWith: "[CalendarBlock:" } });
+  });
+
+  it("returns 0 (and writes nothing) when there's nothing to materialize", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([]);
+    expect(await ensureTodayEncounters("org_1")).toBe(0);
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("isCalendarBlockAppointment", () => {
+  it("flags only the [CalendarBlock:…] prefix", () => {
+    expect(isCalendarBlockAppointment("[CalendarBlock:MEETING] standup")).toBe(true);
+    expect(isCalendarBlockAppointment("Follow-up visit")).toBe(false);
+    expect(isCalendarBlockAppointment(null)).toBe(false);
+    expect(isCalendarBlockAppointment(undefined)).toBe(false);
+  });
+});

--- a/src/lib/domain/ensure-encounter.test.ts
+++ b/src/lib/domain/ensure-encounter.test.ts
@@ -9,8 +9,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 const hoisted = vi.hoisted(() => ({
   mockPrisma: {
-    appointment: { findUnique: vi.fn(), findMany: vi.fn() },
-    encounter: { create: vi.fn(), findUnique: vi.fn() },
+    appointment: { findUnique: vi.fn(), findMany: vi.fn(), findFirst: vi.fn() },
+    encounter: { create: vi.fn(), findUnique: vi.fn(), updateMany: vi.fn() },
   },
 }));
 
@@ -19,6 +19,9 @@ vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
 import {
   ensureEncounterForAppointment,
   ensureTodayEncounters,
+  ensureTodayEncounterForPatient,
+  syncEncounterScheduleForAppointment,
+  cancelEncounterForAppointment,
   isCalendarBlockAppointment,
 } from "./ensure-encounter";
 
@@ -44,8 +47,10 @@ function appt(over: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockPrisma.appointment.findUnique.mockResolvedValue(appt());
+  mockPrisma.appointment.findFirst.mockResolvedValue({ id: "appt_1" });
   mockPrisma.encounter.create.mockImplementation(async ({ data }: any) => ({ id: "enc_new", ...data }));
   mockPrisma.encounter.findUnique.mockResolvedValue(null);
+  mockPrisma.encounter.updateMany.mockResolvedValue({ count: 1 });
 });
 
 describe("ensureEncounterForAppointment", () => {
@@ -125,6 +130,46 @@ describe("ensureTodayEncounters", () => {
     mockPrisma.appointment.findMany.mockResolvedValue([]);
     expect(await ensureTodayEncounters("org_1")).toBe(0);
     expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureTodayEncounterForPatient", () => {
+  it("materializes this patient's confirmed appointment for today", async () => {
+    const enc = await ensureTodayEncounterForPatient("org_1", "patient_1", new Date("2026-06-04T12:00:00Z"));
+    const where = mockPrisma.appointment.findFirst.mock.calls[0][0].where;
+    expect(where.patientId).toBe("patient_1");
+    expect(where.status).toBe("confirmed");
+    expect(where.encounter).toEqual({ is: null });
+    expect(where.NOT).toEqual({ notes: { startsWith: "[CalendarBlock:" } });
+    expect(enc?.id).toBe("enc_new");
+  });
+
+  it("returns null when the patient has no eligible appointment today", async () => {
+    mockPrisma.appointment.findFirst.mockResolvedValue(null);
+    expect(await ensureTodayEncounterForPatient("org_1", "patient_1")).toBeNull();
+    expect(mockPrisma.encounter.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncEncounterScheduleForAppointment", () => {
+  it("moves only a still-scheduled encounter to the new time", async () => {
+    const when = new Date("2026-06-05T18:00:00Z");
+    await syncEncounterScheduleForAppointment("appt_1", when);
+    expect(mockPrisma.encounter.updateMany).toHaveBeenCalledWith({
+      where: { appointmentId: "appt_1", status: "scheduled" },
+      data: { scheduledFor: when },
+    });
+  });
+});
+
+describe("cancelEncounterForAppointment", () => {
+  it("cancels only a still-scheduled encounter (no ghost board card)", async () => {
+    const now = new Date("2026-06-04T10:00:00Z");
+    await cancelEncounterForAppointment("appt_1", now);
+    expect(mockPrisma.encounter.updateMany).toHaveBeenCalledWith({
+      where: { appointmentId: "appt_1", status: "scheduled" },
+      data: { status: "cancelled", cancelledAt: now },
+    });
   });
 });
 

--- a/src/lib/domain/ensure-encounter.ts
+++ b/src/lib/domain/ensure-encounter.ts
@@ -1,0 +1,119 @@
+import { prisma } from "@/lib/db/prisma";
+import type { Encounter } from "@prisma/client";
+
+/**
+ * ensure-encounter — bridge confirmed Appointments into Encounters.
+ *
+ * Booking creates only an Appointment; the check-in → rooming → visit spine runs
+ * off Encounters. Without a bridge, a booked patient has no Encounter, so kiosk
+ * check-in reports "no appointment" and the queue board never shows them. These
+ * helpers materialize a `scheduled` Encounter from a confirmed Appointment,
+ * linked via the @unique `appointmentId` (which makes the create race-safe).
+ *
+ * NOT materialized: calendar blocks (vacation / meeting / do_not_book — created
+ * by createSpecialBlockAction with a "[CalendarBlock:…]" notes prefix on the
+ * System/CalendarBlock placeholder patient) and any non-confirmed appointment.
+ */
+
+/** Vacation / meeting / do-not-book holds are confirmed appointments but never visits. */
+export function isCalendarBlockAppointment(notes: string | null | undefined): boolean {
+  return typeof notes === "string" && notes.startsWith("[CalendarBlock:");
+}
+
+function isUniqueConstraintError(err: unknown): boolean {
+  const code =
+    typeof err === "object" && err !== null && "code" in err ? (err as { code?: unknown }).code : null;
+  return code === "P2002";
+}
+
+function dayBounds(now: Date): { start: Date; end: Date } {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+/**
+ * Idempotently materialize the Encounter for one Appointment.
+ *  - Returns the already-linked Encounter if present (the @unique appointmentId
+ *    guarantees at most one), so this is safe to call repeatedly.
+ *  - Creates a `scheduled` Encounter (copying scheduledFor / providerId /
+ *    modality) only for a `confirmed`, non-calendar-block, live-patient appointment.
+ *  - Returns null when there's nothing to (or we shouldn't) materialize.
+ *  - Race-safe: a concurrent create that loses the @unique(appointmentId) race
+ *    (P2002) falls back to re-reading the winning row.
+ */
+export async function ensureEncounterForAppointment(
+  appointmentId: string,
+): Promise<Encounter | null> {
+  const appt = await prisma.appointment.findUnique({
+    where: { id: appointmentId },
+    include: {
+      encounter: true,
+      patient: { select: { organizationId: true, deletedAt: true } },
+    },
+  });
+  if (!appt || !appt.patient || appt.patient.deletedAt) return null;
+
+  // Already materialized — idempotent no-op.
+  if (appt.encounter) return appt.encounter;
+
+  // Only confirmed real-patient visits get an encounter.
+  if (appt.status !== "confirmed") return null;
+  if (isCalendarBlockAppointment(appt.notes)) return null;
+
+  try {
+    return await prisma.encounter.create({
+      data: {
+        organizationId: appt.patient.organizationId,
+        patientId: appt.patientId,
+        providerId: appt.providerId ?? undefined,
+        appointmentId: appt.id,
+        status: "scheduled",
+        scheduledFor: appt.startAt,
+        modality: appt.modality,
+        reason: appt.notes ?? undefined,
+      },
+    });
+  } catch (err) {
+    if (isUniqueConstraintError(err)) {
+      // A concurrent caller won the appointmentId race — return their row.
+      return prisma.encounter.findUnique({ where: { appointmentId: appt.id } });
+    }
+    throw err;
+  }
+}
+
+/**
+ * Day-of backstop: materialize encounters for every confirmed, non-block
+ * appointment scheduled today (in `organizationId`) that doesn't already have
+ * one, so booked patients appear on the queue board as "Scheduled" before they
+ * arrive. Idempotent — after the first run the `encounter is null` filter
+ * returns nothing, so repeat calls (the board polls every 30s) are cheap.
+ * Returns the number of encounters created.
+ */
+export async function ensureTodayEncounters(
+  organizationId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const { start, end } = dayBounds(now);
+
+  const appts = await prisma.appointment.findMany({
+    where: {
+      status: "confirmed",
+      startAt: { gte: start, lte: end },
+      encounter: { is: null },
+      patient: { organizationId, deletedAt: null },
+      NOT: { notes: { startsWith: "[CalendarBlock:" } },
+    },
+    select: { id: true },
+  });
+
+  let created = 0;
+  for (const appt of appts) {
+    const enc = await ensureEncounterForAppointment(appt.id);
+    if (enc) created += 1;
+  }
+  return created;
+}

--- a/src/lib/domain/ensure-encounter.ts
+++ b/src/lib/domain/ensure-encounter.ts
@@ -117,3 +117,64 @@ export async function ensureTodayEncounters(
   }
   return created;
 }
+
+/**
+ * Kiosk self-sufficiency: ensure THIS patient's confirmed appointment for today
+ * has its Encounter before the kiosk looks it up, so a booked patient can check
+ * in even if no one has opened the queue board yet. Returns the (existing or new)
+ * encounter, or null if there's no eligible appointment.
+ */
+export async function ensureTodayEncounterForPatient(
+  organizationId: string,
+  patientId: string,
+  now: Date = new Date(),
+): Promise<Encounter | null> {
+  const { start, end } = dayBounds(now);
+
+  const appt = await prisma.appointment.findFirst({
+    where: {
+      patientId,
+      status: "confirmed",
+      startAt: { gte: start, lte: end },
+      encounter: { is: null },
+      NOT: { notes: { startsWith: "[CalendarBlock:" } },
+      patient: { organizationId, deletedAt: null },
+    },
+    select: { id: true },
+    orderBy: { startAt: "asc" },
+  });
+  if (!appt) return null;
+  return ensureEncounterForAppointment(appt.id);
+}
+
+/**
+ * Keep a materialized Encounter's scheduledFor in step with its Appointment when
+ * the appointment is moved. Only touches an encounter still in `scheduled`
+ * (untouched) state — never a checked-in / roomed / started visit. Idempotent.
+ */
+export async function syncEncounterScheduleForAppointment(
+  appointmentId: string,
+  newStartAt: Date,
+): Promise<void> {
+  await prisma.encounter.updateMany({
+    where: { appointmentId, status: "scheduled" },
+    data: { scheduledFor: newStartAt },
+  });
+}
+
+/**
+ * Cancel the Encounter materialized for an Appointment when that appointment is
+ * cancelled, so it doesn't linger as a ghost "Scheduled" card on the queue board
+ * (and isn't reused by selectActiveVisitEncounter). Only cancels an encounter
+ * still in `scheduled` state — a patient who already checked in, or a started
+ * visit, is left for staff to resolve on the queue. Idempotent.
+ */
+export async function cancelEncounterForAppointment(
+  appointmentId: string,
+  now: Date = new Date(),
+): Promise<void> {
+  await prisma.encounter.updateMany({
+    where: { appointmentId, status: "scheduled" },
+    data: { status: "cancelled", cancelledAt: now },
+  });
+}

--- a/src/lib/domain/visit-journey.integration.test.ts
+++ b/src/lib/domain/visit-journey.integration.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Same-day care-journey integration spine.
+ *
+ * Drives the REAL visit-state functions (computeQueueTransition,
+ * selectActiveVisitEncounter, advanceVisitState, assignVisitProvider) against an
+ * in-memory Encounter table that mutates like Prisma would, then walks one
+ * patient through the whole journey:
+ *
+ *   scheduled → checked_in (front desk) → rooming → roomed (MA + handoff)
+ *            → Start Visit (physician REUSES the roomed encounter)
+ *            → in_progress → complete (note finalized)
+ *
+ * The crux: at Start Visit the physician must reuse the encounter the front
+ * desk/MA already advanced — not mint a second one — and the MA's rooming
+ * handoff (briefingContext) must survive onto the started visit. This is the
+ * end-to-end guard for the duplicate-encounter / orphaned-handoff class of bug.
+ */
+
+// Hoisted so the vi.mock factory (which is itself hoisted) can reach the
+// in-memory store + prisma double before visit-state.ts is imported.
+const h = vi.hoisted(() => {
+  const store: any[] = [];
+
+  const inRange = (d: Date | null, r: any): boolean => {
+    if (d == null) return false;
+    const t = d.getTime();
+    if (r.gte && t < r.gte.getTime()) return false;
+    if (r.lte && t > r.lte.getTime()) return false;
+    return true;
+  };
+
+  const matchWhere = (e: any, where: any): boolean => {
+    if (!where) return true;
+    if (where.id && e.id !== where.id) return false;
+    if (where.patientId && e.patientId !== where.patientId) return false;
+    if (where.organizationId && e.organizationId !== where.organizationId) return false;
+    if (where.status?.in && !where.status.in.includes(e.status)) return false;
+    if (typeof where.status === "string" && e.status !== where.status) return false;
+    if (where.OR) {
+      const ok = where.OR.some((clause: any) =>
+        clause.scheduledFor
+          ? inRange(e.scheduledFor, clause.scheduledFor)
+          : inRange(e.createdAt, clause.createdAt),
+      );
+      if (!ok) return false;
+    }
+    return true;
+  };
+
+  const selectRows = (where: any, orderBy?: any): any[] => {
+    let rows = store.filter((e) => matchWhere(e, where));
+    if (orderBy?.scheduledFor) {
+      const dir = orderBy.scheduledFor === "desc" ? -1 : 1;
+      rows = rows.sort(
+        (a, b) =>
+          dir * ((a.scheduledFor?.getTime() ?? 0) - (b.scheduledFor?.getTime() ?? 0)),
+      );
+    }
+    return rows.map((e) => ({ ...e }));
+  };
+
+  const prismaMock = {
+    encounter: {
+      findMany: vi.fn(async ({ where, orderBy }: any) => selectRows(where, orderBy)),
+      findFirst: vi.fn(async ({ where, orderBy }: any) => selectRows(where, orderBy)[0] ?? null),
+      update: vi.fn(async ({ where, data }: any) => {
+        const e = store.find((x) => x.id === where.id);
+        if (!e) throw new Error(`no encounter ${where.id}`);
+        Object.assign(e, data);
+        return { ...e };
+      }),
+      create: vi.fn(async ({ data }: any) => {
+        const e = { id: `enc_${store.length + 1}`, ...data };
+        store.push(e);
+        return { ...e };
+      }),
+    },
+  };
+
+  return { store, prismaMock };
+});
+
+const { store, prismaMock } = h;
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: h.prismaMock }));
+
+import {
+  computeQueueTransition,
+  selectActiveVisitEncounter,
+  advanceVisitState,
+  assignVisitProvider,
+  type VisitSpineStatus,
+} from "./visit-state";
+import { mapEncounterStatusToQueueStatus } from "./queue-board";
+
+const NOW = new Date("2026-06-03T16:00:00.000Z");
+const ORG = "org_1";
+const PATIENT = "patient_1";
+
+async function queueMove(id: string, target: VisitSpineStatus) {
+  const enc = await prismaMock.encounter.findFirst({ where: { id } });
+  const t = computeQueueTransition(enc, target, NOW);
+  if (!t.ok) throw new Error(t.error);
+  await prismaMock.encounter.update({ where: { id }, data: t.data });
+}
+
+function seedScheduled() {
+  const enc = {
+    id: "enc_1",
+    organizationId: ORG,
+    patientId: PATIENT,
+    providerId: null,
+    renderingProviderId: null,
+    status: "scheduled",
+    scheduledFor: NOW,
+    createdAt: NOW,
+    startedAt: null,
+    completedAt: null,
+    briefingContext: null,
+  };
+  store.push(enc);
+  return enc;
+}
+
+beforeEach(() => {
+  store.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("same-day care journey", () => {
+  it("walks scheduled → checked_in → roomed → Start Visit (reuse) → complete with no duplicate encounter", async () => {
+    seedScheduled();
+
+    // Front desk checks the patient in.
+    await queueMove("enc_1", "checked_in");
+    // MA rooms the patient and leaves a handoff (vitals + note) in briefingContext.
+    await queueMove("enc_1", "rooming");
+    await queueMove("enc_1", "roomed");
+    await prismaMock.encounter.update({
+      where: { id: "enc_1" },
+      data: {
+        briefingContext: {
+          rooming: { room: "A3", handoffNote: "BP a little high", vitals: { systolic: 142 } },
+        },
+      },
+    });
+
+    // Physician Start Visit — must find the roomed encounter, not mint a new one.
+    const selected = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    expect(selected).not.toBeNull();
+    expect(selected!.id).toBe("enc_1");
+
+    const advanced = (await advanceVisitState(selected!, "in_visit", "doc_1")).encounter;
+    const withProvider = await assignVisitProvider(advanced, "prov_1");
+
+    // Exactly one encounter exists — no duplicate.
+    expect(store).toHaveLength(1);
+    const enc = store[0];
+    expect(enc.status).toBe("in_progress");
+    expect(enc.startedAt).toBeInstanceOf(Date);
+    expect(enc.providerId).toBe("prov_1");
+    // The MA handoff survived onto the started visit.
+    expect(enc.briefingContext.rooming.handoffNote).toBe("BP a little high");
+    expect(withProvider.id).toBe("enc_1");
+
+    // Every flow-state timestamp was stamped along the way.
+    expect(enc.checkedInAt).toBeInstanceOf(Date);
+    expect(enc.roomingStartedAt).toBeInstanceOf(Date);
+    expect(enc.roomedAt).toBeInstanceOf(Date);
+
+    // Finalizing the note completes the encounter.
+    const completion = await advanceVisitState(enc, "complete", "doc_1", { at: NOW });
+    expect(completion.transitioned).toBe(true);
+    expect(store[0].status).toBe("complete");
+    expect(store[0].completedAt).toBeInstanceOf(Date);
+
+    // A completed visit drops off the active selector and shows "Done" on the board.
+    const afterComplete = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    expect(afterComplete).toBeNull();
+    expect(mapEncounterStatusToQueueStatus(store[0].status)).toBe("completed");
+  });
+
+  it("repeat Start Visit clicks reuse the in-progress encounter (no duplicate)", async () => {
+    seedScheduled();
+    await queueMove("enc_1", "checked_in");
+    await queueMove("enc_1", "rooming");
+    await queueMove("enc_1", "roomed");
+
+    // First click.
+    const first = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    const a = (await advanceVisitState(first!, "in_visit", "doc_1")).encounter;
+    expect(a.status).toBe("in_progress");
+
+    // Second click (double-submit / refresh-then-click).
+    const second = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    expect(second!.id).toBe("enc_1");
+    const b = await advanceVisitState(second!, "in_visit", "doc_1");
+    // Already in-progress → idempotent, no state change.
+    expect(b.transitioned).toBe(false);
+
+    expect(store).toHaveLength(1);
+  });
+
+  it("Start Visit for a walk-in (no prior encounter) mints exactly one and reuses it on the next click", async () => {
+    // No seed — walk-in with nothing scheduled.
+    let encounter = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    expect(encounter).toBeNull();
+
+    // Caller mints the encounter (as startVisit does when selection is null).
+    encounter = await prismaMock.encounter.create({
+      data: {
+        organizationId: ORG,
+        patientId: PATIENT,
+        status: "in_progress",
+        scheduledFor: NOW,
+        createdAt: NOW,
+        startedAt: NOW,
+        providerId: "prov_1",
+      },
+    });
+    expect(store).toHaveLength(1);
+
+    // A second click now finds the just-created encounter instead of duplicating.
+    const again = await selectActiveVisitEncounter(PATIENT, ORG, { now: NOW });
+    expect(again!.id).toBe(encounter!.id);
+    expect(store).toHaveLength(1);
+  });
+
+  it("does not reuse another patient's roomed encounter", async () => {
+    seedScheduled();
+    await queueMove("enc_1", "checked_in");
+    await queueMove("enc_1", "rooming");
+    await queueMove("enc_1", "roomed");
+
+    const other = await selectActiveVisitEncounter("patient_2", ORG, { now: NOW });
+    expect(other).toBeNull();
+  });
+});

--- a/src/lib/domain/visit-state.select-active.test.ts
+++ b/src/lib/domain/visit-state.select-active.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Duplicate-encounter regression — physician visit spine.
+ *
+ * The front-desk queue board PERSISTS intermediate flow states
+ * (checked_in / info_incomplete / ready / rooming / roomed / wrap_up) directly
+ * onto the Encounter row via computeQueueTransition. `selectActiveVisitEncounter`
+ * is what Start Visit / the briefing / readiness use to find today's encounter
+ * BEFORE minting a new one. If its status filter omits those queue states, a
+ * checked-in or roomed patient is invisible to the physician → Start Visit
+ * creates a SECOND encounter, duplicating the visit and orphaning the rooming
+ * vitals + MA handoff stored in the first encounter's briefingContext.
+ *
+ * These tests drive the *real* WHERE clause: the prisma mock replicates Prisma's
+ * `status { in }` + today-bounds filtering, so a too-narrow filter makes the
+ * roomed/checked-in cases return null and the assertions fail.
+ */
+
+const hoisted = vi.hoisted(() => ({ findMany: vi.fn() }));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { encounter: { findMany: hoisted.findMany } },
+}));
+
+import {
+  selectActiveVisitEncounter,
+  ACTIVE_VISIT_STATUSES,
+  TERMINAL_VISIT_STATUSES,
+} from "./visit-state";
+
+const NOW = new Date("2026-06-03T17:00:00.000Z");
+
+function enc(over: Record<string, unknown> = {}) {
+  return {
+    id: "e1",
+    organizationId: "org_1",
+    patientId: "pat_1",
+    status: "scheduled",
+    scheduledFor: NOW,
+    createdAt: NOW,
+    startedAt: null,
+    ...over,
+  };
+}
+
+// Replicate the parts of Prisma's WHERE that selectActiveVisitEncounter relies
+// on so the test exercises the production filter, not the mock's canned return:
+//   - patientId / organizationId equality
+//   - status { in: [...] }
+//   - OR [{ scheduledFor in day }, { createdAt in day }]
+//   - orderBy scheduledFor asc
+function applyFilter(rows: any[], where: any) {
+  const allowed: string[] = where.status.in;
+  const within = (d: Date | null, range: any) =>
+    d != null && d >= range.gte && d <= range.lte;
+  return rows
+    .filter(
+      (e) =>
+        e.patientId === where.patientId &&
+        e.organizationId === where.organizationId &&
+        allowed.includes(e.status) &&
+        where.OR.some((clause: any) =>
+          clause.scheduledFor
+            ? within(e.scheduledFor, clause.scheduledFor)
+            : within(e.createdAt, clause.createdAt),
+        ),
+    )
+    .sort(
+      (a, b) =>
+        (a.scheduledFor?.getTime() ?? 0) - (b.scheduledFor?.getTime() ?? 0),
+    );
+}
+
+function mockStore(rows: any[]) {
+  hoisted.findMany.mockImplementation(async ({ where }: any) =>
+    applyFilter(rows, where),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("selectActiveVisitEncounter — reuses front-desk queue states", () => {
+  it.each(["checked_in", "info_incomplete", "ready", "rooming", "roomed", "wrap_up"])(
+    "reuses today's %s encounter (front desk already advanced it past scheduled)",
+    async (status) => {
+      mockStore([enc({ id: "live", status })]);
+      const got = await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+      expect(got?.id).toBe("live");
+    },
+  );
+
+  it("reuses a walk-in encounter created today even with no scheduledFor", async () => {
+    mockStore([enc({ id: "walkin", status: "checked_in", scheduledFor: null })]);
+    const got = await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+    expect(got?.id).toBe("walkin");
+  });
+
+  it.each([...TERMINAL_VISIT_STATUSES])(
+    "does NOT resume a terminal %s encounter (caller mints a fresh one)",
+    async (status) => {
+      mockStore([enc({ id: "done", status })]);
+      const got = await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+      expect(got).toBeNull();
+    },
+  );
+
+  it("prefers an already in-progress encounter over a separate scheduled one", async () => {
+    mockStore([
+      enc({ id: "sched", status: "scheduled", scheduledFor: new Date("2026-06-03T16:00:00Z") }),
+      enc({ id: "live", status: "in_progress", scheduledFor: new Date("2026-06-03T18:00:00Z") }),
+    ]);
+    const got = await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+    expect(got?.id).toBe("live");
+  });
+
+  it("ignores another patient's / another org's encounter", async () => {
+    mockStore([
+      enc({ id: "other_pat", patientId: "pat_2", status: "roomed" }),
+      enc({ id: "other_org", organizationId: "org_2", status: "roomed" }),
+    ]);
+    const got = await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+    expect(got).toBeNull();
+  });
+
+  it("queries with the full non-terminal status set (guards against re-narrowing)", async () => {
+    mockStore([]);
+    await selectActiveVisitEncounter("pat_1", "org_1", { now: NOW });
+    const where = hoisted.findMany.mock.calls[0][0].where;
+    for (const s of ["checked_in", "info_incomplete", "ready", "rooming", "roomed", "wrap_up"]) {
+      expect(where.status.in).toContain(s);
+    }
+    for (const t of TERMINAL_VISIT_STATUSES) {
+      expect(where.status.in).not.toContain(t);
+    }
+    // The exported constant and the executed query must stay in agreement.
+    expect(new Set(where.status.in)).toEqual(new Set(ACTIVE_VISIT_STATUSES));
+  });
+});

--- a/src/lib/domain/visit-state.test.ts
+++ b/src/lib/domain/visit-state.test.ts
@@ -61,8 +61,10 @@ describe("selectActiveVisitEncounter", () => {
     const arg = mockPrisma.encounter.findMany.mock.calls[0][0];
     expect(arg.where.patientId).toBe("patient_1");
     expect(arg.where.organizationId).toBe("org_1");
-    // Only scheduled + in_progress are candidates (never complete/cancelled).
-    expect(arg.where.status).toEqual({ in: ["scheduled", "in_progress"] });
+    // Every non-terminal status is a candidate — including the front-desk queue
+    // flow states (checked_in / rooming / roomed) the patient may already be in
+    // — never complete / cancelled / no_show.
+    expect(arg.where.status).toEqual({ in: [...ACTIVE_VISIT_STATUSES] });
   });
 
   it("returns null when there is no active encounter today", async () => {
@@ -210,7 +212,22 @@ describe("assignVisitProvider", () => {
 });
 
 describe("ACTIVE_VISIT_STATUSES", () => {
-  it("only includes non-terminal persisted statuses", () => {
-    expect([...ACTIVE_VISIT_STATUSES]).toEqual(["scheduled", "in_progress"]);
+  it("covers every non-terminal persisted status and excludes terminal ones", () => {
+    // The front-desk queue board persists checked_in..roomed/wrap_up onto the
+    // encounter row, so a reusable "active" encounter can be in any of these.
+    expect([...ACTIVE_VISIT_STATUSES]).toEqual([
+      "scheduled",
+      "checked_in",
+      "info_incomplete",
+      "ready",
+      "rooming",
+      "roomed",
+      "in_visit",
+      "wrap_up",
+      "in_progress",
+    ]);
+    for (const terminal of ["complete", "cancelled", "no_show"]) {
+      expect(ACTIVE_VISIT_STATUSES).not.toContain(terminal);
+    }
   });
 });

--- a/src/lib/domain/visit-state.ts
+++ b/src/lib/domain/visit-state.ts
@@ -11,15 +11,41 @@ import type { Encounter, EncounterStatus } from "@prisma/client";
  * to preserve; the physician-workflow callers (startVisit, startVisitWithBriefing,
  * finalizeNote) only depend on these signatures, not the internals.
  *
- * Reality check: EncounterStatus is a 4-value Prisma enum
- * (scheduled | in_progress | complete | cancelled). "roomed / ready / checked_in"
- * are queue-board *view* states (src/lib/domain/queue-board.ts) that map onto a
- * persisted `scheduled` (or `in_progress`) encounter — they are NOT distinct DB
- * statuses today. Selection therefore reuses today's non-terminal encounter.
+ * Reality check: EncounterStatus is a 12-value Prisma enum. Besides the
+ * terminal states (complete | cancelled | no_show) and the bookend
+ * scheduled/in_progress, the front-desk queue board PERSISTS the intermediate
+ * flow states (checked_in | info_incomplete | ready | rooming | roomed |
+ * in_visit | wrap_up) directly onto the encounter row via
+ * `computeQueueTransition`. The physician's visit therefore must reuse ANY
+ * non-terminal encounter for today: a patient who was checked in or roomed by
+ * staff already has a live encounter (carrying rooming vitals + the MA handoff
+ * in briefingContext), so minting a new one on Start Visit would create a
+ * duplicate active encounter and orphan that handoff. (EMR — duplicate-encounter
+ * regression: the old filter was scheduled/in_progress only and silently missed
+ * every checked-in/roomed patient.)
  */
 
-/** Non-terminal encounter statuses representing an active/pending visit today. */
-export const ACTIVE_VISIT_STATUSES = ["scheduled", "in_progress"] as const;
+/** Terminal encounter statuses — a visit that is over and must NOT be resumed. */
+export const TERMINAL_VISIT_STATUSES = ["complete", "cancelled", "no_show"] as const;
+
+/**
+ * Non-terminal encounter statuses representing an active/pending visit today —
+ * every EncounterStatus that is NOT terminal. Includes the front-desk queue
+ * flow states (checked_in … roomed / wrap_up) that `computeQueueTransition`
+ * persists, so `selectActiveVisitEncounter` reuses a checked-in/roomed
+ * encounter instead of minting a duplicate when the physician starts the visit.
+ */
+export const ACTIVE_VISIT_STATUSES = [
+  "scheduled",
+  "checked_in",
+  "info_incomplete",
+  "ready",
+  "rooming",
+  "roomed",
+  "in_visit",
+  "wrap_up",
+  "in_progress",
+] as const;
 
 /** Logical visit phases callers can advance an encounter into. */
 export type VisitPhase = "in_visit" | "wrap_up" | "complete";
@@ -148,7 +174,7 @@ export async function selectActiveVisitEncounter(
     where: {
       patientId,
       organizationId,
-      status: { in: ["scheduled", "in_progress"] },
+      status: { in: [...ACTIVE_VISIT_STATUSES] },
       // "today" by either the scheduled time or the row's creation — a
       // walk-in has no scheduledFor; a pre-booked visit has no same-day
       // createdAt.
@@ -162,9 +188,11 @@ export async function selectActiveVisitEncounter(
 
   if (candidates.length === 0) return null;
 
-  // An already-started visit is THE active encounter; otherwise the earliest
-  // scheduled one for today.
-  return candidates.find((e) => e.status === "in_progress") ?? candidates[0];
+  // An already-started visit (in the physician's hands) is THE active
+  // encounter; otherwise reuse the earliest one for today regardless of which
+  // front-desk flow state it currently sits in (checked_in / rooming / roomed …).
+  const started = new Set<string>(["in_progress", "in_visit"]);
+  return candidates.find((e) => started.has(e.status)) ?? candidates[0];
 }
 
 const PHASE_TO_STATUS: Record<VisitPhase, EncounterStatus> = {


### PR DESCRIPTION
## Overnight care-journey hardening

Makes the end-to-end **same-day patient care workflow** (book → check-in → front-desk readiness → MA rooming/vitals → physician visit → documentation/signing → billing) reliable, test-covered, and shippable. Synthetic data only; no prod secrets/claims/messages touched.

14 commits, all small and logical. Baseline before this work: 269 test files / 2566 tests. Now **276 files / 2626 tests**, typecheck/lint/build all green.

### Blockers fixed (each with a regression test)

1. **Duplicate encounter + orphaned MA handoff on Start Visit** (HIGH) — `selectActiveVisitEncounter` filtered `status IN (scheduled, in_progress)` only, but the front-desk queue/kiosk persist `checked_in/ready/rooming/roomed/wrap_up` onto the encounter row. A checked-in/roomed patient was invisible to the physician → Start Visit minted a **second** encounter and orphaned the rooming vitals/handoff. Fixed via `ACTIVE_VISIT_STATUSES` (all non-terminal) + `TERMINAL_VISIT_STATUSES`; same drift fixed in the telehealth page, voice charting (`startVoiceEncounter`), and the telehealth overlay.
2. **Portal double-booking / silent failure** (MED) — `bookAppointment` had no conflict guard, no future/validity check, silently dropped the `phone` modality, didn't validate the provider, and returned a bare `{id}` so the UI faked a "booked" confirmation on failure. Now: overlap conflict guard, past/invalid rejection, modality preserved, provider validated (exists + active + same org), discriminated `{ok}` result surfaced by the UI.
3. **Signed note silently mutable** (MED) — `saveNoteBlocks` had no status guard, so a finalized/amended (legally signed) note could be rewritten via a direct action call with no audit trail. Now rejected server-side (matching `saveObjectiveDocumentation`).
4. **Appointment→Encounter bridge** (HIGH, systemic) — `Encounter.appointmentId` was `@unique` but **never set in app code**: booking created only an Appointment, so a booked patient had no Encounter and `kioskCheckIn` returned "No appointment found." Added `ensureEncounterForAppointment` / `ensureTodayEncounters` / `ensureTodayEncounterForPatient` (`src/lib/domain/ensure-encounter.ts`) — idempotent (via the `@unique` appointmentId), race-safe, skips calendar blocks. Wired **eagerly**: at appointment confirmation, on the `/ops/queue` day-of view, and in the kiosk loader.
5. **Bridge lifecycle consistency** (MED) — cancel → cancel the linked scheduled encounter (no ghost board cards); reschedule (all 3 paths) → sync the encounter's `scheduledFor`. Guarded to a still-`scheduled` encounter. Audited the cron blast radius (more scheduled encounters now exist): the scheduled-encounter crons are unscheduled logging mocks, so no real double-sends.

### Tests
- `visit-state.select-active.test.ts` — drives the real WHERE clause; **proven to fail on the pre-fix filter** then pass.
- `visit-journey.integration.test.ts` — end-to-end spine (scheduled → checked-in → roomed → Start Visit reuse → complete), asserting exactly one encounter and surviving handoff.
- `ensure-encounter.test.ts` (13), `actions.book.test.ts` (9), `actions.save-note-lock.test.ts`, `actions.start-voice.test.ts`, `actions.overlay-telehealth.test.ts`, plus extensions to `actions.start-visit.test.ts` and `visit-state.test.ts`.

### Verification
- `npx vitest run` → **276 files / 2626 tests pass**
- `npm run typecheck` → exit 0
- `npm run lint` → exit 0 (only a pre-existing `no-img-element` warning in an untouched file)
- `npm run build` → exit 0 (full production build)

### Known residual risks (not blocking; see `docs/audit/CARE_JOURNEY_HARDENING_2026-06-03.md`)
- **Concurrent** walk-in / provider-booking races — sequential/repeat-click cases are closed and the bridge means almost every patient now reuses an encounter; the last true-concurrent walk-in race needs a DB constraint or advisory lock (deferred — couldn't be concurrency-verified here).
- **Co-sign author identity** — `pending_cosign` overwrites the mid-level's `authorUserId`; flagged for a clinical/records decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
