### PR TITLE
feat: stabilize golden visit spine

### DIFF
--- a/src/app/(operator)/ops/queue/actions.test.ts
+++ b/src/app/(operator)/ops/queue/actions.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const now = new Date("2026-06-04T18:30:00.000Z");
+  const mockUser = {
+    id: "front-desk-1",
+    organizationId: "org-1",
+    roles: ["front_office"],
+  };
+  const mockPrisma = {
+    encounter: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    auditLog: {
+      create: vi.fn(),
+    },
+  };
+
+  return {
+    now,
+    mockUser,
+    mockPrisma,
+    requireUserMock: vi.fn(async () => mockUser),
+    revalidatePathMock: vi.fn((_path: string) => undefined),
+  };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUser: () => hoisted.requireUserMock(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (path: string) => hoisted.revalidatePathMock(path),
+}));
+
+import { moveQueueEncounter } from "./actions";
+
+describe("ops queue actions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(hoisted.now);
+    vi.clearAllMocks();
+
+    hoisted.mockPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc-1",
+      organizationId: "org-1",
+      patientId: "patient-1",
+      status: "wrap_up",
+      completedAt: null,
+    });
+    hoisted.mockPrisma.encounter.update.mockResolvedValue({
+      id: "enc-1",
+      status: "complete",
+    });
+    hoisted.mockPrisma.auditLog.create.mockResolvedValue({ id: "audit-1" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("allows front desk to complete a visit from wrap_up", async () => {
+    const result = await moveQueueEncounter({
+      encounterId: "enc-1",
+      target: "complete",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(hoisted.mockPrisma.encounter.findFirst).toHaveBeenCalledWith({
+      where: { id: "enc-1", organizationId: "org-1" },
+    });
+    expect(hoisted.mockPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc-1" },
+      data: {
+        status: "complete",
+        completedAt: hoisted.now,
+      },
+    });
+    expect(hoisted.mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org-1",
+        actorUserId: "front-desk-1",
+        action: "encounter.visit_state.updated",
+        subjectType: "Encounter",
+        subjectId: "enc-1",
+        metadata: { from: "wrap_up", to: "complete" },
+      }),
+    });
+    expect(hoisted.revalidatePathMock).toHaveBeenCalledWith("/ops/queue");
+  });
+
+  it("rejects users without a queue role before mutating state", async () => {
+    hoisted.requireUserMock.mockResolvedValue({
+      ...hoisted.mockUser,
+      roles: ["clinician"],
+    });
+
+    const result = await moveQueueEncounter({
+      encounterId: "enc-1",
+      target: "complete",
+    });
+
+    expect(result).toEqual({ ok: false, error: "Forbidden." });
+    expect(hoisted.mockPrisma.encounter.update).not.toHaveBeenCalled();
+    expect(hoisted.mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(operator)/ops/queue/actions.ts
+++ b/src/app/(operator)/ops/queue/actions.ts
@@ -25,6 +25,7 @@ const TransitionSchema = z.object({
     "rooming",
     "roomed",
     "wrap_up",
+    "complete",
     "cancelled",
     "no_show",
   ]),

--- a/src/app/(operator)/ops/queue/queue-board.tsx
+++ b/src/app/(operator)/ops/queue/queue-board.tsx
@@ -66,6 +66,7 @@ type QueueActionTarget =
   | "rooming"
   | "roomed"
   | "wrap_up"
+  | "complete"
   | "cancelled"
   | "no_show";
 
@@ -103,6 +104,8 @@ function canMoveVisit(entry: QueueEntry, target: QueueActionTarget): boolean {
       return status === "rooming" || status === "ready";
     case "wrap_up":
       return status === "roomed" || status === "in_visit";
+    case "complete":
+      return status === "wrap_up" || status === "in_visit";
     case "cancelled":
       return [
         "scheduled",
@@ -319,7 +322,7 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
       },
     },
     {
-      label: "Ready",
+      label: "Mark ready",
       icon: ContextMenuIcons.Check,
       disabled: mutating || !canMoveVisit(entry, "ready"),
       onSelect: (c) => {
@@ -346,11 +349,29 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
       },
     },
     {
-      label: "Send to checkout",
-      icon: ContextMenuIcons.Calendar,
+      label: "Start checkout",
+      icon: ContextMenuIcons.Check,
       disabled: mutating || !canMoveVisit(entry, "wrap_up"),
       onSelect: (c) => {
         runMove("wrap_up");
+        c();
+      },
+    },
+    {
+      label: "Complete visit",
+      icon: ContextMenuIcons.Check,
+      disabled: mutating || !canMoveVisit(entry, "complete"),
+      onSelect: (c) => {
+        runMove("complete");
+        c();
+      },
+    },
+    {
+      label: "Mark no-show",
+      icon: ContextMenuIcons.Archive,
+      disabled: mutating || !canMoveVisit(entry, "no_show"),
+      onSelect: (c) => {
+        runMove("no_show");
         c();
       },
     },
@@ -368,15 +389,6 @@ function QueueCard({ entry }: { entry: QueueEntry }) {
       },
     },
     { divider: true, label: "" },
-    {
-      label: "Mark no-show",
-      icon: ContextMenuIcons.Archive,
-      disabled: mutating || !canMoveVisit(entry, "no_show"),
-      onSelect: (c) => {
-        runMove("no_show");
-        c();
-      },
-    },
     {
       label: "Cancel visit",
       icon: ContextMenuIcons.Archive,


### PR DESCRIPTION
## Summary
- Add canonical same-day visit spine states and central transition helper.
- Link portal appointment booking to a scheduled encounter in the same transaction.
- Harden kiosk check-in to verify encounter/patient ownership and move to checked_in.
- Wire queue board staff transitions and map real visit states into queue columns.
- Make physician Start Visit claim the prepared same-day encounter and advance it to in_visit.

## Verification
- Focused Vitest bundle: 6 files, 25 tests passed.
- Prisma generate passed.
- Typecheck passed.

## Notes
- Linear ticket creation is blocked by connector reauthentication; backlog artifact is docs/pm/tickets/GOLDEN-VISIT-SPINE.md.
- Local nested-worktree lint is blocked by a Next/ESLint parent-config conflict; CI should lint from a normal checkout.
- Golden path E2E, dictation, coding/billing closeout, prescriptions/orders/follow-up closeout remain next slices.