### PR TITLE
EMR-668: research-agent v2.1 — supplement corpus with live PubMed

### DIFF
--- a/src/lib/agents/research-agent.ts
+++ b/src/lib/agents/research-agent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import type { Agent } from "@/lib/orchestration/types";
 import { writeAgentAudit } from "@/lib/orchestration/context";
+import { searchPubMed } from "@/lib/domain/pubmed";
 import corpus from "../../../data/cannabis-research-corpus.json";
 
 // ---------------------------------------------------------------------------
@@ -114,11 +115,13 @@ const output = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Research Synthesizer Agent v2
- * -----------------------------
+ * Research Synthesizer Agent v2.1
+ * --------------------------------
  * Searches Justin Kander's curated cannabis research corpus (50+ peer-reviewed
- * studies with PMIDs and structured dosing data). Matches by keyword across
- * symptom categories, cannabinoids, delivery methods, and outcomes.
+ * studies with PMIDs and structured dosing data) then supplements with live
+ * PubMed E-utilities results (4 s timeout, fail-open). Corpus hits come first
+ * since they carry dose/outcome data; live PubMed fills the remaining slots up
+ * to MAX_RESULTS=10 with deduplication by PMID.
  *
  * When OpenRouter is configured, the agent uses the LLM to generate a
  * synthesized summary of the matching studies. Otherwise falls back to a
@@ -126,8 +129,8 @@ const output = z.object({
  */
 export const researchAgent: Agent<z.infer<typeof input>, z.infer<typeof output>> = {
   name: "researchSynthesizer",
-  version: "2.0.0",
-  description: "Searches the cannabis research corpus and synthesizes evidence.",
+  version: "2.1.0",
+  description: "Searches the internal cannabis corpus then supplements with live PubMed results.",
   inputSchema: input,
   outputSchema: output,
   allowedActions: ["read.research", "read.patient"],
@@ -168,9 +171,52 @@ export const researchAgent: Agent<z.infer<typeof input>, z.infer<typeof output>>
       .sort((a, b) => b.score - a.score)
       .slice(0, 8);
 
-    const hits = scored.map((s) => s.entry);
+    const corpusHits = scored.map((s) => s.entry);
 
-    ctx.log("info", `Corpus search for "${query}": ${hits.length} hits from ${CORPUS.length} entries`);
+    ctx.log("info", `Corpus search for "${query}": ${corpusHits.length} hits from ${CORPUS.length} entries`);
+
+    // Supplement with live PubMed — general biomedical search, 4 s timeout.
+    // scopeToCannabis:false so non-cannabis practices get useful results too.
+    // Fail-open: any network or parse error is swallowed; corpus results
+    // are returned as-is.
+    // Live hits are normalized to CorpusEntry so the rest of the function
+    // (citations build, persist) doesn't need to branch on source type.
+    const corpusPmids = new Set(corpusHits.map((h) => h.pmid).filter(Boolean));
+    let liveHits: CorpusEntry[] = [];
+
+    try {
+      const liveResult = await Promise.race([
+        searchPubMed(query, 5, { scopeToCannabis: false }),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 4000)),
+      ]);
+      if (liveResult) {
+        liveHits = liveResult.articles
+          .filter((a) => !corpusPmids.has(a.pmid))
+          .map((a) => ({
+            title: a.title,
+            source: `PubMed PMID: ${a.pmid}`,
+            year: a.year || null,
+            pmid: a.pmid,
+            url: a.url,
+            category: "PubMed",
+            cannabinoids: [],
+            delivery: null,
+            outcome: null,
+            doseInfo: "",
+            tags: [],
+            summary: a.abstract
+              ? a.abstract.slice(0, 400)
+              : `Published in ${a.journal}${a.year ? `, ${a.year}` : ""}. Open the PubMed link for the full abstract.`,
+          }));
+        ctx.log("info", `Live PubMed: ${liveHits.length} new articles for "${query}" (${liveResult.totalResults} total)`);
+      }
+    } catch {
+      // supplemental only — swallow errors
+    }
+
+    // Corpus results first (richer dose data); live PubMed fills remaining slots
+    const MAX_RESULTS = 10;
+    const hits = [...corpusHits.slice(0, MAX_RESULTS), ...liveHits].slice(0, MAX_RESULTS);
 
     // Build citations
     const citations = hits.map((h) => ({
@@ -191,7 +237,7 @@ export const researchAgent: Agent<z.infer<typeof input>, z.infer<typeof output>>
     // Generate summary — try LLM first, fall back to concatenation
     let summary: string;
     if (hits.length === 0) {
-      summary = `No matching studies found for "${query}" in the indexed corpus of ${CORPUS.length} studies. Try broader terms like "pain", "sleep", "anxiety", "nausea", "appetite", "fatigue", or specific cannabinoids like "CBD", "THC".`;
+      summary = `No matching studies found for "${query}" in the indexed corpus of ${CORPUS.length} studies or in the live PubMed search. Try broader terms like "pain", "sleep", "anxiety", "nausea", "appetite", "fatigue", or specific cannabinoids like "CBD", "THC".`;
     } else {
       try {
         const studyList = hits
@@ -201,14 +247,7 @@ export const researchAgent: Agent<z.infer<typeof input>, z.infer<typeof output>>
           )
           .join("\n");
 
-        const prompt = `Synthesize these ${hits.length} cannabis research studies into a concise clinical summary for a physician. Focus on dosing recommendations and clinical outcomes. Keep it under 200 words.
-
-Query: "${query}"
-
-Studies:
-${studyList}
-
-Write a brief, evidence-based synthesis paragraph.`;
+        const prompt = `Synthesize these ${hits.length} cannabis research studies into a concise clinical summary for a physician. Focus on dosing recommendations and clinical outcomes. Keep it under 200 words.\n\nQuery: "${query}"\n\nStudies:\n${studyList}\n\nWrite a brief, evidence-based synthesis paragraph.`;
 
         const modelSummary = await ctx.model.complete(prompt, {
           maxTokens: 512,
@@ -251,11 +290,11 @@ Write a brief, evidence-based synthesis paragraph.`;
 
     await writeAgentAudit(
       "researchSynthesizer",
-      "2.0.0",
+      "2.1.0",
       null,
       "research.query.answered",
       { type: "ResearchQuery", id: queryId },
-      { hitCount: hits.length, corpusSize: CORPUS.length }
+      { hitCount: hits.length, corpusHits: corpusHits.length, liveHits: liveHits.length, corpusSize: CORPUS.length }
     );
 
     ctx.log("info", "Research query answered", { hitCount: hits.length });

--- a/src/lib/domain/pubmed.ts
+++ b/src/lib/domain/pubmed.ts
@@ -22,18 +22,31 @@ export interface PubMedSearchResult {
 
 const EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils";
 
+export interface SearchPubMedOptions {
+  /**
+   * When true (default), appends a cannabis/cannabinoid AND clause so results
+   * stay within the therapeutic-cannabis literature — useful for ChatCB.
+   * Set to false for general biomedical search (e.g. the research-agent
+   * supplemental lookup which must work for non-cannabis practices too).
+   */
+  scopeToCannabis?: boolean;
+}
+
 /**
- * Search PubMed for cannabis-related articles.
+ * Search PubMed for articles matching `query`.
  * Uses NCBI E-utilities (free, no API key needed for <3 req/sec).
  */
 export async function searchPubMed(
   query: string,
-  maxResults: number = 10
+  maxResults: number = 10,
+  options: SearchPubMedOptions = {},
 ): Promise<PubMedSearchResult> {
+  const { scopeToCannabis = true } = options;
   const start = Date.now();
 
-  // Always scope to cannabis/cannabinoid research
-  const scopedQuery = `(${query}) AND (cannabis OR cannabinoid OR THC OR CBD OR marijuana OR hemp)`;
+  const scopedQuery = scopeToCannabis
+    ? `(${query}) AND (cannabis OR cannabinoid OR THC OR CBD OR marijuana OR hemp)`
+    : query;
 
   // Step 1: ESearch — get PMIDs
   const searchUrl = `${EUTILS_BASE}/esearch.fcgi?db=pubmed&term=${encodeURIComponent(scopedQuery)}&retmax=${maxResults}&sort=relevance&retmode=json`;


### PR DESCRIPTION
Implements EMR-668.

## What changed

- **`src/lib/domain/pubmed.ts`** — Added `SearchPubMedOptions` interface with a `scopeToCannabis` flag (default `true`, fully backwards-compatible). When `false`, the query is sent to NCBI E-utilities without the cannabis AND-clause, enabling general biomedical lookup for non-cannabis practices.

- **`src/lib/agents/research-agent.ts`** — Bumped to v2.1.0. After scoring the internal corpus the agent now calls `searchPubMed(..., { scopeToCannabis: false })` with a 4 s `Promise.race` timeout. Live PubMed articles are normalized to the `CorpusEntry` shape (empty cannabinoids/doseInfo/delivery), deduplicated against corpus PMIDs, and appended to fill up to 10 total results. Any network or parse error is swallowed (fail-open) so the agent always returns corpus results. Audit log now tracks `corpusHits` and `liveHits` counts separately.

## How to verify

1. Open `/clinic/research` and search for a general term like `"nausea"` or `"neuropathic pain"`.
2. Results should include up to 10 items; the last several (when corpus has < 10 matches) will show `source: PubMed PMID: …` and link out to PubMed.
3. Search for a term with no corpus match (e.g. `"metformin"`) — results should show live PubMed articles.
4. Simulate a network failure (block `eutils.ncbi.nlm.nih.gov` in DevTools) — search should still return corpus results without error.
5. ChatCB (sidebar, cannabis practices only) continues to scope to cannabis — no change in behaviour.

## Notes

- `scopeToCannabis` defaults to `true` so all existing callers (`fetchPubMedCitations` in `pubmed-citation-service.ts`) are unaffected.
- The 4 s timeout means worst-case adds 4 s to agent run time in production when NCBI is slow; in dev the queue runs inline and the timeout fires before the PubMed response if NCBI is unreachable.
- Follow-up: wire `includeAbstracts: true` via `pubmed-citation-service.ts` so live hits carry full abstracts rather than the ESummary-only fallback string (currently abstract field is `""` from ESummary; the enrichment path in `pubmed-citation-service.ts` is not yet called from here).
- Follow-up (EMR-669): ChatCB conversational AI + citations (separate ticket).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeuM226yc4t8fgAk1dsFFx)_