### PR TITLE
EMR-1001: Add Golden Visit E2E harness

### DIFF
--- a/docs/superpowers/plans/2026-06-05-golden-visit-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-05-golden-visit-e2e-harness.md
@@ -1,0 +1,1002 @@
+# Golden Visit E2E Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic Golden Visit release gate that proves one scheduled patient can move from appointment booking through kiosk check-in, rooming, physician start, note finalization, and billing/closeout evidence without losing encounter continuity.
+
+**Architecture:** Keep hard business assertions in a Vitest integration harness that uses existing domain/server-action functions and an in-memory Prisma double. Add a small Playwright smoke spec for route crash detection only. Add package scripts so CI/CD and local operators can run the deterministic harness and optional browser smoke by name.
+
+**Tech Stack:** Next.js 14, TypeScript, Vitest, Playwright, Prisma mock doubles, existing LeafJourney visit-state/check-in/note/billing domain helpers.
+
+---
+
+## File Structure
+
+- Create: `src/lib/domain/golden-visit-harness.test.ts`
+  - Test-only deterministic Golden Visit harness.
+  - Owns in-memory fixture state, Prisma mock, auth mock, helper assertions, and the full scheduled-visit journey.
+  - Imports real workflow functions: `bookAppointment`, `ensureEncounterForAppointment`, `kioskVerifyDob`, `kioskCheckIn`, `moveQueueEncounter`, `saveRoomingHandoff`, `startVisit`, `saveAndFinalizeNote`, `buildVisitCompletionBundle`, `scrubClaim`, and `isClaimSubmittable`.
+- Create: `e2e/golden-visit-surfaces.spec.ts`
+  - Browser smoke spec for route health only.
+  - Skips authed surfaces unless `.auth/clerk.json` or `TEST_USER_EMAIL`/`TEST_USER_PASSWORD` is available.
+  - Fails on server-component error cards, HTTP 5xx, and obvious rendered crash text.
+- Modify: `package.json`
+  - Add `test:golden-visit`.
+  - Add `e2e:golden-visit`.
+- Optional after implementation exposes a real bug: modify the affected production file only after the failing Golden Visit test identifies the break.
+
+---
+
+## Task 1: Add Golden Visit Release-Gate Scripts
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Update package scripts**
+
+Add two scripts after the existing `test` script:
+
+```json
+"test": "vitest run",
+"test:golden-visit": "vitest run src/lib/domain/golden-visit-harness.test.ts",
+"e2e:golden-visit": "playwright test e2e/golden-visit-surfaces.spec.ts",
+"test:watch": "vitest",
+```
+
+- [ ] **Step 2: Verify package JSON parses**
+
+Run:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"
+```
+
+Expected:
+
+```text
+package.json ok
+```
+
+- [ ] **Step 3: Commit the script change**
+
+```bash
+git add package.json
+git commit -m "test: add golden visit release gate scripts"
+```
+
+---
+
+## Task 2: Create The Failing Golden Visit Harness Skeleton
+
+**Files:**
+- Create: `src/lib/domain/golden-visit-harness.test.ts`
+
+- [ ] **Step 1: Add the initial failing test**
+
+Create `src/lib/domain/golden-visit-harness.test.ts` with this content:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+describe("Golden Visit harness", () => {
+  it("walks one scheduled patient from booking to closeout without losing encounter continuity", async () => {
+    await expect(runGoldenVisit()).resolves.toMatchObject({
+      appointmentId: "appt_golden_1",
+      encounterId: "enc_golden_1",
+      finalEncounterStatus: "complete",
+      duplicateActiveEncounterCount: 0,
+      roomingHandoffVisibleToPhysician: true,
+      noteFinalizedDispatchCount: 1,
+      encounterCompletedDispatchCount: 1,
+      closeoutReady: true,
+    });
+  });
+});
+```
+
+This intentionally references `runGoldenVisit` before it exists.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+npm run test:golden-visit
+```
+
+Expected: FAIL with a TypeScript/runtime error that `runGoldenVisit` is not defined.
+
+- [ ] **Step 3: Commit the failing skeleton**
+
+```bash
+git add src/lib/domain/golden-visit-harness.test.ts
+git commit -m "test: sketch golden visit harness expectation"
+```
+
+---
+
+## Task 3: Implement The In-Memory Fixture And Prisma Double
+
+**Files:**
+- Modify: `src/lib/domain/golden-visit-harness.test.ts`
+
+- [ ] **Step 1: Add hoisted mocks and fixture state above the test**
+
+Replace the file with this structure. Keep the final `describe` block from Task 2 at the bottom.
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const FIXED_NOW = new Date("2099-06-05T16:00:00.000Z");
+const ORG_ID = "org_golden";
+const PATIENT_ID = "patient_golden";
+const PATIENT_USER_ID = "user_patient_golden";
+const PROVIDER_ID = "provider_golden";
+const PHYSICIAN_USER_ID = "user_physician_golden";
+const FRONT_DESK_USER_ID = "user_front_desk_golden";
+const MA_USER_ID = "user_ma_golden";
+const KIOSK_USER_ID = "user_kiosk_golden";
+const APPOINTMENT_ID = "appt_golden_1";
+const ENCOUNTER_ID = "enc_golden_1";
+const NOTE_ID = "note_golden_1";
+
+type RoleUser = {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  roles: string[];
+  organizationId: string;
+  organizationName: string;
+};
+
+type GoldenState = {
+  patients: any[];
+  providers: any[];
+  appointments: any[];
+  encounters: any[];
+  notes: any[];
+  auditLogs: any[];
+  financialEvents: any[];
+  dispatchEvents: any[];
+  user: RoleUser;
+};
+
+function user(id: string, roles: string[]): RoleUser {
+  return {
+    id,
+    email: `${id}@golden.local`,
+    firstName: id.includes("physician") ? "Golden" : "Test",
+    lastName: id.includes("physician") ? "Physician" : "User",
+    roles,
+    organizationId: ORG_ID,
+    organizationName: "Golden Clinic",
+  };
+}
+
+const h = vi.hoisted(() => {
+  const state: GoldenState = {
+    patients: [],
+    providers: [],
+    appointments: [],
+    encounters: [],
+    notes: [],
+    auditLogs: [],
+    financialEvents: [],
+    dispatchEvents: [],
+    user: user(PATIENT_USER_ID, ["patient"]),
+  };
+
+  const now = () => new Date(FIXED_NOW);
+  const clone = <T>(value: T): T => ({ ...(value as any) });
+
+  function dayRangeContains(value: Date | null | undefined, range: any): boolean {
+    if (!value) return false;
+    const t = value.getTime();
+    if (range?.gte && t < range.gte.getTime()) return false;
+    if (range?.lte && t > range.lte.getTime()) return false;
+    if (range?.lt && t >= range.lt.getTime()) return false;
+    if (range?.gt && t <= range.gt.getTime()) return false;
+    return true;
+  }
+
+  function patientMatches(row: any, where: any): boolean {
+    if (!where) return true;
+    if (where.id && row.id !== where.id) return false;
+    if (where.userId && row.userId !== where.userId) return false;
+    if (where.organizationId && row.organizationId !== where.organizationId) return false;
+    if (where.deletedAt === null && row.deletedAt !== null) return false;
+    return true;
+  }
+
+  function appointmentMatches(row: any, where: any): boolean {
+    if (!where) return true;
+    if (where.id && row.id !== where.id) return false;
+    if (where.patientId && row.patientId !== where.patientId) return false;
+    if (where.providerId && row.providerId !== where.providerId) return false;
+    if (where.status?.in && !where.status.in.includes(row.status)) return false;
+    if (typeof where.status === "string" && row.status !== where.status) return false;
+    if (where.startAt?.lt && !dayRangeContains(row.startAt, { lt: where.startAt.lt })) return false;
+    if (where.endAt?.gt && !dayRangeContains(row.endAt, { gt: where.endAt.gt })) return false;
+    if (where.startAt?.gte || where.startAt?.lte) {
+      if (!dayRangeContains(row.startAt, where.startAt)) return false;
+    }
+    if (where.encounter?.is === null && state.encounters.some((e) => e.appointmentId === row.id)) {
+      return false;
+    }
+    if (where.patient?.userId) {
+      const p = state.patients.find((x) => x.id === row.patientId);
+      if (!p || p.userId !== where.patient.userId) return false;
+    }
+    if (where.patient?.organizationId) {
+      const p = state.patients.find((x) => x.id === row.patientId);
+      if (!p || p.organizationId !== where.patient.organizationId) return false;
+    }
+    if (where.patient?.deletedAt === null) {
+      const p = state.patients.find((x) => x.id === row.patientId);
+      if (!p || p.deletedAt !== null) return false;
+    }
+    if (where.NOT?.notes?.startsWith && row.notes?.startsWith(where.NOT.notes.startsWith)) return false;
+    return true;
+  }
+
+  function encounterMatches(row: any, where: any): boolean {
+    if (!where) return true;
+    if (where.id && row.id !== where.id) return false;
+    if (where.patientId && row.patientId !== where.patientId) return false;
+    if (where.organizationId && row.organizationId !== where.organizationId) return false;
+    if (where.appointmentId && row.appointmentId !== where.appointmentId) return false;
+    if (where.status?.in && !where.status.in.includes(row.status)) return false;
+    if (typeof where.status === "string" && row.status !== where.status) return false;
+    if (where.OR) {
+      const ok = where.OR.some((clause: any) => {
+        if (clause.scheduledFor) return dayRangeContains(row.scheduledFor, clause.scheduledFor);
+        if (clause.createdAt) return dayRangeContains(row.createdAt, clause.createdAt);
+        return false;
+      });
+      if (!ok) return false;
+    }
+    if (where.chartingCompletedAt === null && row.chartingCompletedAt !== null) return false;
+    return true;
+  }
+
+  function includeAppointment(row: any, include: any) {
+    const result = clone(row);
+    if (include?.encounter) {
+      result.encounter = state.encounters.find((e) => e.appointmentId === row.id) ?? null;
+    }
+    if (include?.patient) {
+      const p = state.patients.find((x) => x.id === row.patientId) ?? null;
+      result.patient = p ? clone(p) : null;
+    }
+    return result;
+  }
+
+  function includeEncounter(row: any, include: any) {
+    const result = clone(row);
+    if (include?.provider) {
+      const provider = state.providers.find((p) => p.id === row.providerId) ?? null;
+      result.provider = provider
+        ? { ...provider, user: { firstName: "Golden", lastName: "Physician" } }
+        : null;
+    }
+    return result;
+  }
+
+  const prismaMock = {
+    patient: {
+      findFirst: vi.fn(async ({ where, select }: any) => {
+        const row = state.patients.find((p) => patientMatches(p, where));
+        if (!row) return null;
+        if (select) {
+          const selected: any = {};
+          for (const key of Object.keys(select)) selected[key] = row[key];
+          return selected;
+        }
+        return clone(row);
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = state.patients.find((p) => p.id === where.id);
+        Object.assign(row, data);
+        return clone(row);
+      }),
+    },
+    provider: {
+      findFirst: vi.fn(async ({ where, select }: any) => {
+        const row = state.providers.find(
+          (p) =>
+            (!where.id || p.id === where.id) &&
+            (!where.userId || p.userId === where.userId) &&
+            (!where.organizationId || p.organizationId === where.organizationId) &&
+            (where.active === undefined || p.active === where.active),
+        );
+        if (!row) return null;
+        if (select) {
+          const selected: any = {};
+          for (const key of Object.keys(select)) selected[key] = row[key];
+          return selected;
+        }
+        return clone(row);
+      }),
+    },
+    appointment: {
+      findFirst: vi.fn(async ({ where, orderBy }: any) => {
+        const rows = state.appointments.filter((a) => appointmentMatches(a, where));
+        if (orderBy?.startAt === "asc") rows.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+        return rows[0] ? clone(rows[0]) : null;
+      }),
+      findUnique: vi.fn(async ({ where, include }: any) => {
+        const row = state.appointments.find((a) => a.id === where.id);
+        return row ? includeAppointment(row, include) : null;
+      }),
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: APPOINTMENT_ID,
+          patientId: data.patientId,
+          providerId: data.providerId,
+          status: data.status,
+          startAt: data.startAt,
+          endAt: data.endAt,
+          modality: data.modality,
+          notes: data.notes ?? null,
+        };
+        state.appointments.push(row);
+        return clone(row);
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = state.appointments.find((a) => a.id === where.id);
+        Object.assign(row, data);
+        return clone(row);
+      }),
+    },
+    encounter: {
+      findFirst: vi.fn(async ({ where, orderBy, include }: any) => {
+        const rows = state.encounters.filter((e) => encounterMatches(e, where));
+        if (orderBy?.scheduledFor === "asc") {
+          rows.sort((a, b) => (a.scheduledFor?.getTime() ?? 0) - (b.scheduledFor?.getTime() ?? 0));
+        }
+        const row = rows[0];
+        return row ? includeEncounter(row, include) : null;
+      }),
+      findMany: vi.fn(async ({ where, orderBy }: any) => {
+        const rows = state.encounters.filter((e) => encounterMatches(e, where));
+        if (orderBy?.scheduledFor === "desc") {
+          rows.sort((a, b) => (b.scheduledFor?.getTime() ?? 0) - (a.scheduledFor?.getTime() ?? 0));
+        }
+        return rows.map(clone);
+      }),
+      findUnique: vi.fn(async ({ where }: any) => {
+        const row = where.appointmentId
+          ? state.encounters.find((e) => e.appointmentId === where.appointmentId)
+          : state.encounters.find((e) => e.id === where.id);
+        return row ? clone(row) : null;
+      }),
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: ENCOUNTER_ID,
+          organizationId: data.organizationId,
+          patientId: data.patientId,
+          providerId: data.providerId ?? null,
+          renderingProviderId: data.renderingProviderId ?? null,
+          appointmentId: data.appointmentId ?? null,
+          status: data.status,
+          scheduledFor: data.scheduledFor ?? now(),
+          modality: data.modality ?? "in_person",
+          reason: data.reason ?? null,
+          createdAt: now(),
+          startedAt: data.startedAt ?? null,
+          checkedInAt: null,
+          roomingStartedAt: null,
+          roomedAt: null,
+          completedAt: null,
+          chartingCompletedAt: null,
+          briefingContext: data.briefingContext ?? null,
+        };
+        state.encounters.push(row);
+        return clone(row);
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = state.encounters.find((e) => e.id === where.id);
+        Object.assign(row, data);
+        return clone(row);
+      }),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        let count = 0;
+        for (const row of state.encounters.filter((e) => encounterMatches(e, where))) {
+          Object.assign(row, data);
+          count += 1;
+        }
+        return { count };
+      }),
+    },
+    note: {
+      findFirst: vi.fn(async ({ where }: any) => {
+        const rows = state.notes.filter((n) => !where.encounterId || n.encounterId === where.encounterId);
+        return rows[0] ? clone(rows[0]) : null;
+      }),
+      findUnique: vi.fn(async ({ where, include }: any) => {
+        const row = state.notes.find((n) => n.id === where.id);
+        if (!row) return null;
+        const result = clone(row);
+        if (include?.encounter) result.encounter = clone(state.encounters.find((e) => e.id === row.encounterId));
+        return result;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = state.notes.find((n) => n.id === where.id);
+        Object.assign(row, data);
+        return clone(row);
+      }),
+      count: vi.fn(async ({ where }: any) =>
+        state.notes.filter((n) => n.encounterId === where.encounterId && n.status !== where.status.not).length,
+      ),
+    },
+    auditLog: {
+      create: vi.fn(async ({ data }: any) => {
+        const row = { id: `audit_${state.auditLogs.length + 1}`, ...data };
+        state.auditLogs.push(row);
+        return clone(row);
+      }),
+    },
+    agentJob: {
+      findMany: vi.fn(async () => []),
+    },
+  };
+
+  return {
+    state,
+    prismaMock,
+    requireUserMock: vi.fn(async () => state.user),
+    requireRoleMock: vi.fn(async () => state.user),
+    dispatchMock: vi.fn(async (event: any) => {
+      state.dispatchEvents.push(event);
+      if (event.name === "encounter.note.draft.requested") return ["job_golden_1"];
+      return [];
+    }),
+    runTickMock: vi.fn(async () => undefined),
+    runJobMock: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: h.prismaMock }));
+vi.mock("@/lib/auth/session", () => ({
+  requireUser: () => h.requireUserMock(),
+  requireRole: (role: string) => h.requireRoleMock(role),
+}));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: h.dispatchMock }));
+vi.mock("@/lib/orchestration/runner", () => ({
+  runTick: h.runTickMock,
+  runJob: h.runJobMock,
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+```
+
+- [ ] **Step 2: Add fixture reset before each test**
+
+Add this below the module mocks and imports:
+
+```ts
+import { bookAppointment } from "@/app/(patient)/portal/schedule/actions";
+import { kioskCheckIn, kioskVerifyDob } from "@/app/kiosk/(console)/actions";
+import { moveQueueEncounter, saveRoomingHandoff } from "@/app/(operator)/ops/queue/actions";
+import { startVisit } from "@/app/(clinician)/clinic/patients/[id]/actions";
+import { saveAndFinalizeNote } from "@/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions";
+import { ensureEncounterForAppointment } from "./ensure-encounter";
+import { buildVisitCompletionBundle } from "./visit-completion";
+import {
+  applyVisitCompletionAction,
+  buildVisitCompletionReleasePayload,
+  initializeVisitCompletionSelection,
+} from "./visit-completion-selection";
+import { scrubClaim, isClaimSubmittable } from "@/lib/billing/scrub";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.state.patients.length = 0;
+  h.state.providers.length = 0;
+  h.state.appointments.length = 0;
+  h.state.encounters.length = 0;
+  h.state.notes.length = 0;
+  h.state.auditLogs.length = 0;
+  h.state.financialEvents.length = 0;
+  h.state.dispatchEvents.length = 0;
+  h.state.user = user(PATIENT_USER_ID, ["patient"]);
+
+  h.state.patients.push({
+    id: PATIENT_ID,
+    userId: PATIENT_USER_ID,
+    firstName: "Golden",
+    lastName: "Patient",
+    dateOfBirth: new Date("1954-02-11T00:00:00.000Z"),
+    organizationId: ORG_ID,
+    deletedAt: null,
+    chartRestricted: false,
+    restrictedProviderIds: [],
+    chartRestrictedReason: null,
+    intakeAnswers: {
+      demographics: { confirmed: true },
+      insurance: { payerName: "Blue Cross", memberId: "GOLD123" },
+      signedForms: { consent: { signedAt: FIXED_NOW.toISOString() } },
+    },
+  });
+
+  h.state.providers.push({
+    id: PROVIDER_ID,
+    userId: PHYSICIAN_USER_ID,
+    organizationId: ORG_ID,
+    active: true,
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to identify the next missing implementation**
+
+Run:
+
+```bash
+npm run test:golden-visit
+```
+
+Expected: FAIL because `runGoldenVisit` still does not exist.
+
+---
+
+## Task 4: Implement The Golden Visit Driver
+
+**Files:**
+- Modify: `src/lib/domain/golden-visit-harness.test.ts`
+
+- [ ] **Step 1: Add helper assertions**
+
+Add this above the `describe` block:
+
+```ts
+function activeEncountersForPatient() {
+  return h.state.encounters.filter(
+    (e: any) =>
+      e.patientId === PATIENT_ID &&
+      !["complete", "cancelled", "no_show"].includes(e.status),
+  );
+}
+
+function expectSingleActiveEncounter(label: string) {
+  const active = activeEncountersForPatient();
+  expect(active, `${label}: duplicate active encounter count`).toHaveLength(1);
+  expect(active[0].id, `${label}: encounter id continuity`).toBe(ENCOUNTER_ID);
+  return active[0];
+}
+
+function dispatchCount(name: string) {
+  return h.state.dispatchEvents.filter((event: any) => event.name === name).length;
+}
+
+function noteBlocks() {
+  return [
+    {
+      heading: "Subjective",
+      body: "Golden Patient reports chronic pain, mild daytime somnolence with CBD dose changes, and good adherence.",
+    },
+    {
+      heading: "Objective",
+      body: "BP 142/88, weight 168 lb. MA handoff: BP a little high.",
+    },
+    {
+      heading: "Assessment",
+      body: "Chronic pain with medication management. No acute red flags.",
+    },
+    {
+      heading: "Plan",
+      body: "Adjust evening regimen, monitor somnolence, repeat labs, and return to clinic in 6 weeks.",
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Add `runGoldenVisit`**
+
+Add this above the `describe` block:
+
+```ts
+async function runGoldenVisit() {
+  vi.setSystemTime(FIXED_NOW);
+
+  const booked = await bookAppointment({
+    patientId: PATIENT_ID,
+    providerId: PROVIDER_ID,
+    slotDate: "2099-06-05",
+    slotStartTime: "09:00",
+    appointmentType: "follow_up",
+    modality: "in_person",
+    reason: "Golden Visit harness follow-up",
+  });
+  expect(booked).toEqual({ ok: true, id: APPOINTMENT_ID });
+
+  h.state.appointments[0].status = "confirmed";
+
+  const materialized = await ensureEncounterForAppointment(APPOINTMENT_ID);
+  expect(materialized?.id).toBe(ENCOUNTER_ID);
+  expectSingleActiveEncounter("after encounter materialization");
+
+  h.state.user = user(KIOSK_USER_ID, ["kiosk"]);
+  const verified = await kioskVerifyDob(PATIENT_ID, "1954-02-11");
+  expect(verified.ok).toBe(true);
+  expect(verified.context?.appointment?.encounterId).toBe(ENCOUNTER_ID);
+
+  const checkedIn = await kioskCheckIn(PATIENT_ID);
+  expect(checkedIn).toMatchObject({ ok: true, status: "checked_in", alreadyCheckedIn: false });
+  expect(expectSingleActiveEncounter("after kiosk check-in").status).toBe("checked_in");
+
+  const secondCheckIn = await kioskCheckIn(PATIENT_ID);
+  expect(secondCheckIn).toMatchObject({ ok: true, status: "checked_in", alreadyCheckedIn: true });
+
+  h.state.user = user(MA_USER_ID, ["back_office"]);
+  await expect(moveQueueEncounter({ encounterId: ENCOUNTER_ID, target: "rooming" })).resolves.toEqual({ ok: true });
+  expect(expectSingleActiveEncounter("after rooming start").status).toBe("rooming");
+
+  await expect(
+    saveRoomingHandoff({
+      encounterId: ENCOUNTER_ID,
+      room: "A3",
+      handoffNote: "BP a little high; patient anxious about new dose.",
+      readinessFlags: ["bp_recheck", "review_cbd_somnolence"],
+    }),
+  ).resolves.toEqual({ ok: true });
+
+  await expect(moveQueueEncounter({ encounterId: ENCOUNTER_ID, target: "roomed" })).resolves.toEqual({ ok: true });
+  const roomed = expectSingleActiveEncounter("after roomed");
+  expect(roomed.status).toBe("roomed");
+  expect(roomed.briefingContext.rooming).toMatchObject({
+    room: "A3",
+    handoffNote: "BP a little high; patient anxious about new dose.",
+    readinessFlags: ["bp_recheck", "review_cbd_somnolence"],
+  });
+
+  h.state.user = user(PHYSICIAN_USER_ID, ["clinician"]);
+  h.state.notes.push({
+    id: NOTE_ID,
+    encounterId: ENCOUNTER_ID,
+    status: "draft",
+    aiDrafted: false,
+    blocks: noteBlocks(),
+    authorUserId: null,
+    createdAt: FIXED_NOW,
+  });
+
+  await expect(startVisit(PATIENT_ID)).rejects.toThrow(`redirect:/clinic/patients/${PATIENT_ID}/notes/${NOTE_ID}`);
+  const inVisit = expectSingleActiveEncounter("after physician start");
+  expect(inVisit.status).toBe("in_progress");
+  expect(inVisit.providerId).toBe(PROVIDER_ID);
+  expect(inVisit.briefingContext.rooming.handoffNote).toContain("BP a little high");
+
+  await expect(startVisit(PATIENT_ID)).rejects.toThrow(`redirect:/clinic/patients/${PATIENT_ID}/notes/${NOTE_ID}`);
+  expectSingleActiveEncounter("after repeat physician start");
+
+  const finalized = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
+  expect(finalized).toEqual({ ok: true, status: "finalized" });
+  expect(h.state.encounters.find((e: any) => e.id === ENCOUNTER_ID)?.status).toBe("complete");
+
+  const repeatFinalize = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
+  expect(repeatFinalize).toEqual({ ok: true, status: "finalized" });
+
+  const completionBundle = buildVisitCompletionBundle({
+    patientFirstName: "Golden",
+    blocks: noteBlocks(),
+    hasFutureAppointment: false,
+    codingSuggestion: {
+      emLevel: "99214",
+      rationale: "Medication management with chronic pain and follow-up planning.",
+      icd10: [{ code: "G89.29", label: "Chronic pain", confidence: 0.91 }],
+    },
+  });
+
+  let selection = initializeVisitCompletionSelection(completionBundle);
+  for (const card of completionBundle.cards) {
+    selection = applyVisitCompletionAction(completionBundle, selection, {
+      type: "confirm_card",
+      cardId: card.id,
+      confirmationNote: `${card.title} reviewed in Golden Visit harness.`,
+    });
+  }
+  const releasePayload = buildVisitCompletionReleasePayload(completionBundle, selection);
+  expect(releasePayload.canRelease).toBe(true);
+
+  const scrubIssues = scrubClaim({
+    cptCodes: [{ code: "99214", label: "Established patient visit", chargeAmount: 18000 }],
+    icd10Codes: [{ code: "G89.29", label: "Chronic pain" }],
+    payerName: "Blue Cross",
+    serviceDate: FIXED_NOW,
+    providerId: PROVIDER_ID,
+    patientCoverage: { eligibilityStatus: "active", payerName: "Blue Cross" },
+  });
+  expect(isClaimSubmittable(scrubIssues)).toBe(true);
+
+  return {
+    appointmentId: APPOINTMENT_ID,
+    encounterId: ENCOUNTER_ID,
+    finalEncounterStatus: h.state.encounters.find((e: any) => e.id === ENCOUNTER_ID)?.status,
+    duplicateActiveEncounterCount: activeEncountersForPatient().filter((e: any) => e.id !== ENCOUNTER_ID).length,
+    roomingHandoffVisibleToPhysician: Boolean(
+      h.state.encounters.find((e: any) => e.id === ENCOUNTER_ID)?.briefingContext?.rooming?.handoffNote,
+    ),
+    noteFinalizedDispatchCount: dispatchCount("note.finalized"),
+    encounterCompletedDispatchCount: dispatchCount("encounter.completed"),
+    closeoutReady: releasePayload.canRelease && isClaimSubmittable(scrubIssues),
+  };
+}
+```
+
+- [ ] **Step 3: Add fake timers cleanup**
+
+Add this after `beforeEach`:
+
+```ts
+afterEach(() => {
+  vi.useRealTimers();
+});
+```
+
+Also update the Vitest import:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+```
+
+Inside `runGoldenVisit`, add before `vi.setSystemTime(FIXED_NOW);`:
+
+```ts
+vi.useFakeTimers();
+```
+
+- [ ] **Step 4: Run the harness**
+
+Run:
+
+```bash
+npm run test:golden-visit
+```
+
+Expected: PASS. If it fails because a production function has a real continuity bug, keep the failing assertion, fix the production bug in the smallest affected file, and re-run.
+
+- [ ] **Step 5: Commit the deterministic harness**
+
+```bash
+git add src/lib/domain/golden-visit-harness.test.ts
+git commit -m "test: add deterministic golden visit harness"
+```
+
+---
+
+## Task 5: Add Optional Playwright Route Smoke
+
+**Files:**
+- Create: `e2e/golden-visit-surfaces.spec.ts`
+
+- [ ] **Step 1: Add the browser smoke spec**
+
+Create `e2e/golden-visit-surfaces.spec.ts`:
+
+```ts
+import { test, expect, type Page } from "@playwright/test";
+import { existsSync } from "node:fs";
+
+const AUTH_FILE = ".auth/clerk.json";
+const PUBLIC_ROUTES = ["/kiosk"];
+const AUTHED_ROUTES = ["/portal", "/ops/queue", "/clinic"];
+
+async function assertNoServerCrash(page: Page) {
+  const body = await page.locator("body").innerText();
+  expect(body).not.toContain("Something went wrong");
+  expect(body).not.toContain("We couldn't load that");
+  expect(body).not.toContain("An error occurred in the Server Components render");
+  expect(body).not.toContain("[object Object]");
+}
+
+test.describe("Golden Visit route smoke", () => {
+  for (const route of PUBLIC_ROUTES) {
+    test(`public surface loads: ${route}`, async ({ page, request }) => {
+      const res = await request.get(route, { maxRedirects: 0 });
+      expect(res.status()).toBeLessThan(500);
+
+      const pageRes = await page.goto(route, { waitUntil: "domcontentloaded" });
+      expect(pageRes?.status() ?? 200).toBeLessThan(500);
+      await assertNoServerCrash(page);
+    });
+  }
+
+  test.describe("authenticated surfaces", () => {
+    test.skip(
+      !existsSync(AUTH_FILE) && (!process.env.TEST_USER_EMAIL || !process.env.TEST_USER_PASSWORD),
+      "Golden Visit authed smoke requires .auth/clerk.json or TEST_USER_EMAIL/TEST_USER_PASSWORD.",
+    );
+
+    for (const route of AUTHED_ROUTES) {
+      test(`authed surface loads: ${route}`, async ({ page, request }) => {
+        const res = await request.get(route, { maxRedirects: 2 });
+        expect(res.status()).toBeLessThan(500);
+
+        const pageRes = await page.goto(route, { waitUntil: "domcontentloaded" });
+        expect(pageRes?.status() ?? 200).toBeLessThan(500);
+        await assertNoServerCrash(page);
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the smoke spec only when a local server is running**
+
+Run:
+
+```bash
+npm run e2e:golden-visit
+```
+
+Expected with no dev server: FAIL in `e2e/global-setup.ts` with the existing actionable "dev server is not running" message.
+
+Expected with dev server and auth unavailable: public `/kiosk` check runs; authenticated checks skip.
+
+- [ ] **Step 3: Commit the smoke spec**
+
+```bash
+git add e2e/golden-visit-surfaces.spec.ts
+git commit -m "test: add golden visit route smoke"
+```
+
+---
+
+## Task 6: Verification Gate
+
+**Files:**
+- No new files unless a real bug fix was required.
+
+- [ ] **Step 1: Run the Golden Visit harness**
+
+```bash
+npm run test:golden-visit
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run adjacent regression tests**
+
+```bash
+npm test -- src/lib/domain/visit-journey.integration.test.ts src/lib/domain/ensure-encounter.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts src/app/\(operator\)/ops/queue/actions.test.ts src/app/\(clinician\)/clinic/patients/\[id\]/actions.start-visit.test.ts src/app/\(clinician\)/clinic/patients/\[id\]/notes/\[noteId\]/actions.finalize-idempotent.test.ts src/lib/domain/visit-completion.test.ts src/lib/domain/visit-completion-selection.test.ts src/lib/agents/billing/charge-integrity-agent.test.ts src/lib/agents/billing/clearinghouse-submission-agent.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: PASS, or report the exact pre-existing lint failure if the repo has a known lint baseline issue.
+
+- [ ] **Step 5: Run build when typecheck/lint pass**
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit any verification-only documentation if needed**
+
+If implementation exposed no production bug and only test/script files changed, no extra commit is needed beyond prior task commits.
+
+If a production bug was fixed, use `git status --short` to identify the exact changed production and test files, then commit those exact paths with a message that names the failed Golden Visit phase. For example, if the queue rooming transition was the failing phase:
+
+```bash
+git add src/app/\(operator\)/ops/queue/actions.ts src/lib/domain/golden-visit-harness.test.ts
+git commit -m "fix: preserve golden visit continuity during queue rooming"
+```
+
+---
+
+## Task 7: Publish And Update Linear
+
+**Files:**
+- No file changes expected.
+
+- [ ] **Step 1: Inspect final branch state**
+
+```bash
+git status -sb
+git log --oneline --decorate --max-count=8
+```
+
+Expected: clean working tree on `test/golden-visit-e2e`.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin test/golden-visit-e2e
+```
+
+Expected: branch pushed to origin.
+
+- [ ] **Step 3: Open PR**
+
+Use GitHub tooling or `gh pr create` with this title:
+
+```text
+EMR-1001: Add Golden Visit E2E harness
+```
+
+PR body:
+
+```markdown
+## Summary
+
+- adds deterministic Golden Visit Vitest harness from appointment booking through closeout evidence
+- adds optional Playwright route smoke for the critical visit surfaces
+- adds named release-gate scripts for CI/local execution
+
+## Verification
+
+- npm run test:golden-visit
+- npm test -- src/lib/domain/visit-journey.integration.test.ts src/lib/domain/ensure-encounter.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts src/app/(operator)/ops/queue/actions.test.ts src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts src/lib/domain/visit-completion.test.ts src/lib/domain/visit-completion-selection.test.ts src/lib/agents/billing/charge-integrity-agent.test.ts src/lib/agents/billing/clearinghouse-submission-agent.test.ts
+- npm run typecheck
+- npm run lint
+- npm run build
+
+Linear: EMR-1001
+```
+
+- [ ] **Step 4: Update Linear `EMR-1001`**
+
+Set state to `In Review` after the PR is open.
+
+Add a comment:
+
+```markdown
+Golden Visit E2E harness branch is pushed and in PR.
+
+Release gate added:
+- `npm run test:golden-visit`
+- optional browser smoke: `npm run e2e:golden-visit`
+
+Verification results:
+- paste exact command results from Task 6
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Scheduled synthetic patient journey: Task 4.
+- Kiosk check-in: Task 4 via `kioskVerifyDob` and `kioskCheckIn`.
+- MA rooming/vitals/handoff continuity: Task 4 via `saveRoomingHandoff` and assertions on `briefingContext.rooming`.
+- Physician start reduces cognitive load by preserving rooming handoff and reusing the same encounter: Task 4.
+- Dictation/documentation proxy: Task 4 uses structured note blocks and `saveAndFinalizeNote`; real audio is intentionally out of first-harness scope per design.
+- Coding/billing/RCM evidence: Task 4 uses `buildVisitCompletionBundle`, release payload generation, `scrubClaim`, and `isClaimSubmittable`.
+- Browser route crash coverage: Task 5.
+- CI/CD health: Task 6 and Task 7.
+
+Placeholder scan:
+
+- No plan step uses unresolved placeholders.
+
+Type consistency:
+
+- Encounter status expectations match the current `visit-state` bridge: physician visit maps to `in_progress`, closeout maps to `complete`.
+- Queue targets match `moveQueueEncounter` schema.
+- Visit completion payload fields match existing `visit-completion-selection` tests.

--- a/docs/superpowers/specs/2026-06-05-golden-visit-e2e-harness-design.md
+++ b/docs/superpowers/specs/2026-06-05-golden-visit-e2e-harness-design.md
@@ -1,0 +1,179 @@
+# Golden Visit E2E Harness Design
+
+## Purpose
+
+Build a deterministic Golden Visit harness for `EMR-1001` that proves the critical same-day patient journey cannot regress silently.
+
+The harness must verify one synthetic visit from appointment booking through kiosk check-in, queue/rooming, physician start, note finalization, and billing/closeout evidence. It should fail on broken workflow continuity, duplicate encounters, lost handoff data, or missing closeout outputs.
+
+## Problem
+
+LeafJourney already has focused unit and integration tests for individual workflow pieces:
+
+- appointment booking guardrails
+- kiosk check-in security and state movement
+- queue state transitions
+- active encounter selection
+- physician start visit reuse
+- note finalization idempotency
+- billing agent/unit behavior
+
+Those tests are valuable but fragmented. They do not yet provide one release gate that says: "a patient who booked today can move through the whole clinic visit without the system losing continuity."
+
+## Design Choice
+
+Use a layered harness:
+
+1. A deterministic integration harness owns the hard workflow assertions.
+2. One focused Playwright smoke spec verifies the major UI surfaces remain reachable and clickable.
+3. CI runs the deterministic harness by default; browser smoke can run when an authenticated local/staging environment is available.
+
+This avoids a brittle browser-only test while still catching broken user-facing routes.
+
+## Scope
+
+In scope:
+
+- Create a Golden Visit test data fixture for one organization, one patient, one provider, one kiosk/front-desk user, one MA/extender user, and one physician user.
+- Exercise the visit spine from appointment booking to final closeout.
+- Assert encounter continuity at every phase.
+- Assert the rooming handoff survives physician start.
+- Assert finalization is idempotent.
+- Assert billing/closeout returns either a generated result or explicit blocker state.
+- Produce a single obvious test command for the release gate.
+
+Out of scope for this first harness:
+
+- Full production Clerk login coverage for every role.
+- Full browser-only patient portal/kiosk/ops/clinician/billing journey.
+- Real clearinghouse submission.
+- Real dictation audio transcription.
+- Production data mutation.
+
+## Architecture
+
+### Golden Visit Fixture
+
+Add a small test fixture module that creates the synthetic visit state in memory or against mocked Prisma doubles, matching existing Vitest patterns in the repo.
+
+The fixture should expose stable IDs and helpers:
+
+- `orgId`
+- `patientId`
+- `providerId`
+- `frontDeskUser`
+- `maUser`
+- `physicianUser`
+- `appointmentId`
+- `encounterId`
+- date/time helpers pinned to a fixed clock
+
+The fixture should keep the test deterministic and avoid depending on current wall-clock time except where the code under test requires `new Date()`. Where possible, the harness should inject a fixed `now`.
+
+### Golden Visit Driver
+
+Add a focused driver that performs the journey in named phases:
+
+1. `bookAppointment`
+2. `materializeEncounter`
+3. `kioskCheckIn`
+4. `moveToRooming`
+5. `saveRoomingHandoff`
+6. `roomPatient`
+7. `startPhysicianVisit`
+8. `saveAndFinalizeDocumentation`
+9. `assertBillingCloseout`
+
+Each phase should return the current encounter snapshot and fail with a clear message if the expected state is not present.
+
+### Deterministic Integration Test
+
+Add a Vitest file for the Golden Visit harness. It should assert:
+
+- booking produces or links one appointment-backed encounter
+- kiosk check-in moves the same encounter to `checked_in`
+- queue movement advances the same encounter to `rooming` and `roomed`
+- rooming handoff is preserved in `briefingContext.rooming`
+- physician start reuses the roomed encounter instead of creating another one
+- repeat physician start does not create a duplicate
+- finalizing the note completes the same encounter
+- repeat finalization does not dispatch duplicate completion work
+- billing/closeout evidence is present, or a structured blocker is returned
+
+The duplicate encounter check is mandatory after every major phase.
+
+### Playwright Smoke Spec
+
+Add one browser smoke spec only after the deterministic harness is in place.
+
+The smoke spec should not carry the hard business assertions. It should verify:
+
+- `/portal` or scheduling surface loads in an authenticated test context when credentials/storage state are available
+- `/kiosk` surface loads
+- `/ops/queue` loads
+- `/clinic/patients/[id]` or the note route loads for the synthetic patient when the environment provides valid auth
+- no page shows the production server-component error card
+
+If auth is unavailable, the smoke spec should skip with an explicit message rather than failing the release gate for missing credentials.
+
+## Data Flow
+
+The harness should prove this continuity:
+
+`Appointment.confirmed`
+-> linked `Encounter.scheduled`
+-> `Encounter.checked_in`
+-> `Encounter.rooming`
+-> `Encounter.roomed`
+-> `Encounter.in_progress`
+-> `Encounter.complete`
+-> closeout/billing evidence
+
+The same encounter ID must remain attached to the journey unless the test is deliberately exercising walk-in creation. The first harness should use a scheduled appointment, not a walk-in.
+
+## Error Handling
+
+Failures should be specific. The test should distinguish:
+
+- missing appointment-backed encounter
+- kiosk could not find today's encounter
+- invalid queue transition
+- duplicate active encounter
+- lost rooming handoff
+- physician start created a new encounter
+- finalization was not idempotent
+- billing/closeout evidence missing
+
+The Playwright smoke spec should fail on user-visible broken pages, server-component error cards, and route-level crashes.
+
+## CI And Release Gate
+
+The primary release gate should be a targeted Vitest command for the deterministic harness plus existing health checks:
+
+- `npm test -- <golden-visit-test-file>`
+- `npm run typecheck`
+- existing lint/build checks when the branch is ready for PR
+
+The Playwright smoke spec should be configured so CI can run it only when the required auth/storage-state environment is present.
+
+## Acceptance Criteria
+
+- A single Golden Visit integration test walks the same synthetic visit from booking to closeout.
+- The test fails if any phase creates a duplicate active encounter.
+- The test fails if the MA handoff is unavailable to physician start.
+- The test fails if note finalization is not idempotent.
+- The test fails if billing/closeout has neither generated evidence nor an explicit structured blocker.
+- A browser smoke spec verifies core surfaces load without route crashes when auth is available.
+- The implementation has a clear command that can be added to CI/CD as a quarantine/release gate.
+
+## Implementation Notes
+
+Follow existing local patterns:
+
+- `src/lib/domain/visit-journey.integration.test.ts` for in-memory encounter mutation.
+- `src/app/(operator)/ops/queue/actions.test.ts` for queue action mocking.
+- `src/app/api/mobile/kiosk/check-in/route.test.ts` for kiosk check-in behavior.
+- `src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts` for physician start behavior.
+- `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.finalize-idempotent.test.ts` for finalization behavior.
+
+Avoid broad rewrites. The first pass should add the harness and only change production code if the harness exposes a real continuity bug.

--- a/e2e/golden-visit-surfaces.spec.ts
+++ b/e2e/golden-visit-surfaces.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from "@playwright/test";
 import { existsSync } from "node:fs";
 
 const AUTH_FILE = ".auth/clerk.json";
+const hasAuthState = existsSync(AUTH_FILE);
 const PUBLIC_ROUTES = ["/kiosk"];
 const AUTHED_ROUTES = ["/portal", "/ops/queue", "/clinic"];
 
@@ -27,9 +28,10 @@ test.describe("Golden Visit route smoke", () => {
 
   test.describe("authenticated surfaces", () => {
     test.skip(
-      !existsSync(AUTH_FILE) && (!process.env.TEST_USER_EMAIL || !process.env.TEST_USER_PASSWORD),
-      "Golden Visit authed smoke requires .auth/clerk.json or TEST_USER_EMAIL/TEST_USER_PASSWORD.",
+      !hasAuthState,
+      "Golden Visit authed smoke requires .auth/clerk.json. Run e2e/auth.setup.ts or capture auth first.",
     );
+    test.use({ storageState: AUTH_FILE });
 
     for (const route of AUTHED_ROUTES) {
       test(`authed surface loads: ${route}`, async ({ page, request }) => {

--- a/e2e/golden-visit-surfaces.spec.ts
+++ b/e2e/golden-visit-surfaces.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect, type Page } from "@playwright/test";
+import { existsSync } from "node:fs";
+
+const AUTH_FILE = ".auth/clerk.json";
+const PUBLIC_ROUTES = ["/kiosk"];
+const AUTHED_ROUTES = ["/portal", "/ops/queue", "/clinic"];
+
+async function assertNoServerCrash(page: Page) {
+  const body = await page.locator("body").innerText();
+  expect(body).not.toContain("Something went wrong");
+  expect(body).not.toContain("We couldn't load that");
+  expect(body).not.toContain("An error occurred in the Server Components render");
+  expect(body).not.toContain("[object Object]");
+}
+
+test.describe("Golden Visit route smoke", () => {
+  for (const route of PUBLIC_ROUTES) {
+    test(`public surface loads: ${route}`, async ({ page, request }) => {
+      const res = await request.get(route, { maxRedirects: 0 });
+      expect(res.status()).toBeLessThan(500);
+
+      const pageRes = await page.goto(route, { waitUntil: "domcontentloaded" });
+      expect(pageRes?.status() ?? 200).toBeLessThan(500);
+      await assertNoServerCrash(page);
+    });
+  }
+
+  test.describe("authenticated surfaces", () => {
+    test.skip(
+      !existsSync(AUTH_FILE) && (!process.env.TEST_USER_EMAIL || !process.env.TEST_USER_PASSWORD),
+      "Golden Visit authed smoke requires .auth/clerk.json or TEST_USER_EMAIL/TEST_USER_PASSWORD.",
+    );
+
+    for (const route of AUTHED_ROUTES) {
+      test(`authed surface loads: ${route}`, async ({ page, request }) => {
+        const res = await request.get(route, { maxRedirects: 2 });
+        expect(res.status()).toBeLessThan(500);
+
+        const pageRes = await page.goto(route, { waitUntil: "domcontentloaded" });
+        expect(pageRes?.status() ?? 200).toBeLessThan(500);
+        await assertNoServerCrash(page);
+      });
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "db:seed-cfo": "tsx --conditions=react-server scripts/seed-cfo.ts",
     "db:studio": "prisma studio",
     "test": "vitest run",
+    "test:golden-visit": "vitest run src/lib/domain/golden-visit-harness.test.ts",
+    "e2e:golden-visit": "playwright test e2e/golden-visit-surfaces.spec.ts",
     "test:watch": "vitest",
     "test:smoke": "tsx --conditions=react-server scripts/smoke-test.ts",
     "pm": "tsx --conditions=react-server scripts/pm-agent.ts",

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -1,4 +1,652 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => {
+  const FIXED_NOW = new Date("2099-06-05T16:00:00.000Z");
+  const ORG_ID = "org_golden";
+  const PATIENT_ID = "patient_golden";
+  const PATIENT_USER_ID = "user_patient_golden";
+  const PROVIDER_ID = "provider_golden";
+  const PHYSICIAN_USER_ID = "user_physician_golden";
+  const FRONT_DESK_USER_ID = "user_front_desk_golden";
+  const MA_USER_ID = "user_ma_golden";
+  const KIOSK_USER_ID = "user_kiosk_golden";
+  const APPOINTMENT_ID = "appt_golden_1";
+  const ENCOUNTER_ID = "enc_golden_1";
+  const NOTE_ID = "note_golden_1";
+
+  const users = {
+    patient: {
+      id: PATIENT_USER_ID,
+      email: "golden.patient@example.test",
+      firstName: "Goldie",
+      lastName: "Patient",
+      roles: ["patient"],
+      organizationId: ORG_ID,
+      organizationName: "Golden Care",
+    },
+    physician: {
+      id: PHYSICIAN_USER_ID,
+      email: "golden.physician@example.test",
+      firstName: "Ada",
+      lastName: "Physician",
+      roles: ["clinician"],
+      organizationId: ORG_ID,
+      organizationName: "Golden Care",
+    },
+    frontDesk: {
+      id: FRONT_DESK_USER_ID,
+      email: "golden.frontdesk@example.test",
+      firstName: "Fran",
+      lastName: "Desk",
+      roles: ["front_office"],
+      organizationId: ORG_ID,
+      organizationName: "Golden Care",
+    },
+    ma: {
+      id: MA_USER_ID,
+      email: "golden.ma@example.test",
+      firstName: "Mara",
+      lastName: "Assistant",
+      roles: ["back_office"],
+      organizationId: ORG_ID,
+      organizationName: "Golden Care",
+    },
+    kiosk: {
+      id: KIOSK_USER_ID,
+      email: "golden.kiosk@example.test",
+      firstName: "Golden",
+      lastName: "Kiosk",
+      roles: ["kiosk"],
+      organizationId: ORG_ID,
+      organizationName: "Golden Care",
+    },
+  };
+
+  const db = {
+    patients: [] as any[],
+    providers: [] as any[],
+    appointments: [] as any[],
+    encounters: [] as any[],
+    notes: [] as any[],
+    auditLogs: [] as any[],
+    agentJobs: [] as any[],
+  };
+
+  const fixture = {
+    db,
+    users,
+    dispatchEvents: [] as any[],
+    session: { currentUser: users.patient as any },
+  };
+
+  function clone<T>(value: T): T {
+    return value == null ? value : structuredClone(value);
+  }
+
+  function userForId(userId: string | null | undefined) {
+    return Object.values(users).find((user) => user.id === userId) ?? null;
+  }
+
+  function isPlainObject(value: unknown): value is Record<string, any> {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    );
+  }
+
+  function compareValues(actual: any, expected: any): boolean {
+    if (actual instanceof Date && expected instanceof Date) {
+      return actual.getTime() === expected.getTime();
+    }
+    return actual === expected;
+  }
+
+  function relationFor(row: any, relation: string): any {
+    if (relation === "patient") {
+      return db.patients.find((patient) => patient.id === row.patientId) ?? null;
+    }
+    if (relation === "provider") {
+      return db.providers.find((provider) => provider.id === row.providerId) ?? null;
+    }
+    if (relation === "encounter") {
+      if (row.appointmentId) {
+        return db.encounters.find((encounter) => encounter.appointmentId === row.id) ?? null;
+      }
+      if (row.encounterId) {
+        return db.encounters.find((encounter) => encounter.id === row.encounterId) ?? null;
+      }
+    }
+    return null;
+  }
+
+  function matchesOperator(actual: any, expected: Record<string, any>): boolean {
+    for (const [op, value] of Object.entries(expected)) {
+      if (op === "in") {
+        if (!Array.isArray(value) || !value.includes(actual)) return false;
+      } else if (op === "not") {
+        if (compareValues(actual, value)) return false;
+      } else if (op === "lt") {
+        if (!(actual < value)) return false;
+      } else if (op === "lte") {
+        if (!(actual <= value)) return false;
+      } else if (op === "gt") {
+        if (!(actual > value)) return false;
+      } else if (op === "gte") {
+        if (!(actual >= value)) return false;
+      } else if (op === "startsWith") {
+        if (typeof actual !== "string" || !actual.startsWith(String(value))) return false;
+      } else if (op === "is") {
+        if (value === null && actual !== null) return false;
+        if (value !== null && !matchesWhere(actual, value)) return false;
+      } else if (!compareValues(actual?.[op], value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function matchesWhere(row: any, where: Record<string, any> = {}): boolean {
+    if (!row) return false;
+
+    for (const [key, expected] of Object.entries(where)) {
+      if (key === "OR") {
+        if (!Array.isArray(expected) || !expected.some((branch) => matchesWhere(row, branch))) {
+          return false;
+        }
+        continue;
+      }
+      if (key === "AND") {
+        if (!Array.isArray(expected) || !expected.every((branch) => matchesWhere(row, branch))) {
+          return false;
+        }
+        continue;
+      }
+      if (key === "NOT") {
+        if (matchesWhere(row, expected)) return false;
+        continue;
+      }
+
+      const relation = ["patient", "provider", "encounter"].includes(key)
+        ? relationFor(row, key)
+        : undefined;
+      if (relation !== undefined) {
+        if (isPlainObject(expected) && "is" in expected) {
+          if (expected.is === null) {
+            if (relation !== null) return false;
+          } else if (!matchesWhere(relation, expected.is)) {
+            return false;
+          }
+        } else if (!matchesWhere(relation, expected)) {
+          return false;
+        }
+        continue;
+      }
+
+      const actual = row[key];
+      if (isPlainObject(expected)) {
+        if (!matchesOperator(actual, expected)) return false;
+      } else if (!compareValues(actual, expected)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function orderRows(rows: any[], orderBy: Record<string, "asc" | "desc"> | undefined) {
+    if (!orderBy) return rows;
+    const [[field, direction]] = Object.entries(orderBy);
+    return [...rows].sort((a, b) => {
+      const av = a[field] instanceof Date ? a[field].getTime() : (a[field] ?? Infinity);
+      const bv = b[field] instanceof Date ? b[field].getTime() : (b[field] ?? Infinity);
+      return direction === "desc" ? bv - av : av - bv;
+    });
+  }
+
+  function selectRow(row: any, select: Record<string, any> | undefined): any {
+    if (!select) return row;
+    const out: Record<string, any> = {};
+    for (const [field, selection] of Object.entries(select)) {
+      if (selection === true) {
+        out[field] = row[field];
+      } else if (field === "user" && row.userId) {
+        out.user = materializeProviderUser(userForId(row.userId), selection as any);
+      }
+    }
+    return out;
+  }
+
+  function materializeProviderUser(user: any, selection: any): any {
+    if (!user) return null;
+    const selected = selection?.select;
+    return selected ? selectRow(user, selected) : clone(user);
+  }
+
+  function materializePatient(row: any, args: any = {}) {
+    return clone(selectRow(row, args.select));
+  }
+
+  function materializeProvider(row: any, args: any = {}) {
+    const provider = clone(selectRow(row, args.select));
+    if (args.include?.user) {
+      provider.user = materializeProviderUser(userForId(row.userId), args.include.user);
+    }
+    return provider;
+  }
+
+  function materializeAppointment(row: any, args: any = {}) {
+    const appointment = clone(selectRow(row, args.select));
+    if (args.include?.patient) {
+      const patient = db.patients.find((candidate) => candidate.id === row.patientId) ?? null;
+      appointment.patient = patient ? materializePatient(patient, args.include.patient) : null;
+    }
+    if (args.include?.encounter) {
+      const encounter =
+        db.encounters.find((candidate) => candidate.appointmentId === row.id) ?? null;
+      appointment.encounter = encounter ? materializeEncounter(encounter, args.include.encounter) : null;
+    }
+    return appointment;
+  }
+
+  function materializeEncounter(row: any, args: any = {}) {
+    const encounter = clone(selectRow(row, args.select));
+    if (args.include?.provider) {
+      const provider = db.providers.find((candidate) => candidate.id === row.providerId) ?? null;
+      encounter.provider = provider ? materializeProvider(provider, args.include.provider) : null;
+    }
+    if (args.include?.patient) {
+      const patient = db.patients.find((candidate) => candidate.id === row.patientId) ?? null;
+      encounter.patient = patient ? materializePatient(patient, args.include.patient) : null;
+    }
+    return encounter;
+  }
+
+  function materializeNote(row: any, args: any = {}) {
+    const note = clone(selectRow(row, args.select));
+    if (args.include?.encounter) {
+      const encounter = db.encounters.find((candidate) => candidate.id === row.encounterId) ?? null;
+      note.encounter = encounter ? materializeEncounter(encounter, args.include.encounter) : null;
+    }
+    return note;
+  }
+
+  function firstFrom(rows: any[], args: any, materialize: (row: any, args?: any) => any) {
+    const matches = rows.filter((row) => matchesWhere(row, args?.where));
+    const ordered = orderRows(matches, args?.orderBy);
+    const row = typeof args?.take === "number" ? ordered.slice(0, args.take)[0] : ordered[0];
+    return row ? materialize(row, args) : null;
+  }
+
+  function manyFrom(rows: any[], args: any, materialize: (row: any, args?: any) => any) {
+    const matches = rows.filter((row) => matchesWhere(row, args?.where));
+    const ordered = orderRows(matches, args?.orderBy);
+    const limited = typeof args?.take === "number" ? ordered.slice(0, args.take) : ordered;
+    return limited.map((row) => materialize(row, args));
+  }
+
+  function updateRow(
+    rows: any[],
+    where: Record<string, any>,
+    data: Record<string, any>,
+    materialize: (row: any, args?: any) => any,
+  ) {
+    const row = rows.find((candidate) => matchesWhere(candidate, where));
+    if (!row) throw new Error("Fixture row not found");
+    Object.assign(row, clone(data), { updatedAt: data.updatedAt ?? row.updatedAt });
+    return materialize(row);
+  }
+
+  function createAppointment(data: Record<string, any>) {
+    const row = {
+      id: data.id ?? (db.appointments.length === 0 ? APPOINTMENT_ID : `appt_golden_${db.appointments.length + 1}`),
+      status: "requested",
+      modality: "video",
+      createdAt: new Date(),
+      ...clone(data),
+    };
+    db.appointments.push(row);
+    return materializeAppointment(row);
+  }
+
+  function createEncounter(data: Record<string, any>) {
+    const row = {
+      id: data.id ?? (db.encounters.length === 0 ? ENCOUNTER_ID : `enc_golden_${db.encounters.length + 1}`),
+      status: "scheduled",
+      scheduledFor: null,
+      checkedInAt: null,
+      roomingStartedAt: null,
+      roomedAt: null,
+      startedAt: null,
+      wrapUpAt: null,
+      completedAt: null,
+      cancelledAt: null,
+      noShowAt: null,
+      chartingCompletedAt: null,
+      modality: "in_person",
+      placeOfService: null,
+      renderingProviderId: null,
+      reason: null,
+      briefingContext: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...clone(data),
+    };
+    db.encounters.push(row);
+    return materializeEncounter(row);
+  }
+
+  function createNote(data: Record<string, any>) {
+    const row = {
+      id: data.id ?? (db.notes.length === 0 ? NOTE_ID : `note_golden_${db.notes.length + 1}`),
+      authorUserId: null,
+      status: "draft",
+      blocks: [],
+      narrative: null,
+      aiDrafted: false,
+      aiConfidence: null,
+      finalizedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...clone(data),
+    };
+    db.notes.push(row);
+    return materializeNote(row);
+  }
+
+  const prisma = {
+    patient: {
+      findFirst: vi.fn(async (args?: any) => firstFrom(db.patients, args, materializePatient)),
+      findMany: vi.fn(async (args?: any) => manyFrom(db.patients, args, materializePatient)),
+      update: vi.fn(async ({ where, data }: any) =>
+        updateRow(db.patients, where, data, materializePatient),
+      ),
+    },
+    provider: {
+      findFirst: vi.fn(async (args?: any) => firstFrom(db.providers, args, materializeProvider)),
+      findMany: vi.fn(async (args?: any) => manyFrom(db.providers, args, materializeProvider)),
+    },
+    appointment: {
+      findFirst: vi.fn(async (args?: any) => firstFrom(db.appointments, args, materializeAppointment)),
+      findMany: vi.fn(async (args?: any) => manyFrom(db.appointments, args, materializeAppointment)),
+      findUnique: vi.fn(async (args?: any) => firstFrom(db.appointments, args, materializeAppointment)),
+      create: vi.fn(async ({ data }: any) => createAppointment(data)),
+      update: vi.fn(async ({ where, data }: any) =>
+        updateRow(db.appointments, where, data, materializeAppointment),
+      ),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        const rows = db.appointments.filter((row) => matchesWhere(row, where));
+        rows.forEach((row) => Object.assign(row, clone(data)));
+        return { count: rows.length };
+      }),
+    },
+    encounter: {
+      findFirst: vi.fn(async (args?: any) => firstFrom(db.encounters, args, materializeEncounter)),
+      findMany: vi.fn(async (args?: any) => manyFrom(db.encounters, args, materializeEncounter)),
+      findUnique: vi.fn(async (args?: any) => firstFrom(db.encounters, args, materializeEncounter)),
+      create: vi.fn(async ({ data }: any) => createEncounter(data)),
+      update: vi.fn(async ({ where, data }: any) =>
+        updateRow(db.encounters, where, data, materializeEncounter),
+      ),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        const rows = db.encounters.filter((row) => matchesWhere(row, where));
+        rows.forEach((row) => Object.assign(row, clone(data)));
+        return { count: rows.length };
+      }),
+    },
+    note: {
+      findFirst: vi.fn(async (args?: any) => firstFrom(db.notes, args, materializeNote)),
+      findMany: vi.fn(async (args?: any) => manyFrom(db.notes, args, materializeNote)),
+      findUnique: vi.fn(async (args?: any) => firstFrom(db.notes, args, materializeNote)),
+      create: vi.fn(async ({ data }: any) => createNote(data)),
+      update: vi.fn(async ({ where, data }: any) =>
+        updateRow(db.notes, where, data, materializeNote),
+      ),
+      count: vi.fn(async (args?: any) => db.notes.filter((row) => matchesWhere(row, args?.where)).length),
+    },
+    auditLog: {
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: `audit_golden_${db.auditLogs.length + 1}`,
+          createdAt: new Date(),
+          ...clone(data),
+        };
+        db.auditLogs.push(row);
+        return clone(row);
+      }),
+    },
+    agentJob: {
+      findMany: vi.fn(async (args?: any) => manyFrom(db.agentJobs, args, (row) => clone(row))),
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: data.id ?? `job_golden_${db.agentJobs.length + 1}`,
+          status: "pending",
+          attempts: 0,
+          maxAttempts: 3,
+          logs: [],
+          createdAt: new Date(),
+          runAfter: new Date(),
+          ...clone(data),
+        };
+        db.agentJobs.push(row);
+        return clone(row);
+      }),
+    },
+    $transaction: vi.fn(async (callback: any) => callback(prisma)),
+  };
+
+  const revalidatePath = vi.fn();
+  const redirect = vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  });
+  const requireUser = vi.fn(async () => fixture.session.currentUser);
+  const requireRole = vi.fn(async () => fixture.session.currentUser);
+  const dispatch = vi.fn(async (event: any) => {
+    fixture.dispatchEvents.push(clone(event));
+    if (event.name !== "encounter.note.draft.requested") return [];
+    const id = "job_golden_1";
+    if (!db.agentJobs.some((job) => job.id === id)) {
+      db.agentJobs.push({
+        id,
+        organizationId: ORG_ID,
+        workflowName: "encounter-note-draft",
+        agentName: "scribe",
+        eventName: event.name,
+        input: clone(event),
+        output: null,
+        status: "pending",
+        attempts: 0,
+        maxAttempts: 3,
+        lastError: null,
+        logs: [],
+        requiresApproval: false,
+        approvalRequiredAt: null,
+        approvedById: null,
+        approvedAt: null,
+        claimedAt: null,
+        claimedBy: null,
+        runAfter: new Date(),
+        startedAt: null,
+        completedAt: null,
+        createdAt: new Date(),
+      });
+    }
+    return [id];
+  });
+  const runTick = vi.fn(async () => undefined);
+  const runJob = vi.fn(async () => undefined);
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    with: vi.fn(() => logger),
+  };
+
+  function resetFixture() {
+    db.patients.splice(0);
+    db.providers.splice(0);
+    db.appointments.splice(0);
+    db.encounters.splice(0);
+    db.notes.splice(0);
+    db.auditLogs.splice(0);
+    db.agentJobs.splice(0);
+    fixture.dispatchEvents.splice(0);
+    fixture.session.currentUser = users.patient;
+
+    db.patients.push({
+      id: PATIENT_ID,
+      userId: PATIENT_USER_ID,
+      organizationId: ORG_ID,
+      status: "active",
+      firstName: "Goldie",
+      lastName: "Patient",
+      dateOfBirth: new Date("1954-02-11T00:00:00.000Z"),
+      ageVerifiedAt: FIXED_NOW,
+      email: "goldie.patient@example.test",
+      phone: "555-0100",
+      addressLine1: "100 Golden Way",
+      addressLine2: null,
+      city: "Los Angeles",
+      state: "CA",
+      postalCode: "90001",
+      intakeAnswers: {
+        demographics: {
+          firstName: "Goldie",
+          lastName: "Patient",
+          dateOfBirth: "1954-02-11",
+          phone: "555-0100",
+          address: {
+            line1: "100 Golden Way",
+            city: "Los Angeles",
+            state: "CA",
+            postalCode: "90001",
+          },
+        },
+        insurance: {
+          payerName: "Golden Health",
+          memberId: "GOLDEN-123",
+          eligibilityStatus: "active",
+        },
+        signedConsent: {
+          signed: true,
+          signedAt: FIXED_NOW.toISOString(),
+          consentVersion: "golden-visit-e2e/v1",
+        },
+      },
+      cannabisHistory: {
+        priorUse: "topical CBD",
+        benefits: ["pain relief"],
+        sideEffects: [],
+      },
+      presentingConcerns: "Chronic arthritic pain with daytime stiffness.",
+      treatmentGoals: "Improve pain control while avoiding daytime somnolence.",
+      allergies: [],
+      contraindications: [],
+      allergiesScreenedAt: FIXED_NOW,
+      qualificationStatus: "qualified",
+      qualificationExpiresAt: new Date("2100-06-05T16:00:00.000Z"),
+      chartRestricted: false,
+      restrictedProviderIds: [],
+      chartRestrictedReason: null,
+      chartRestrictedAt: null,
+      deletedAt: null,
+      createdAt: FIXED_NOW,
+      updatedAt: FIXED_NOW,
+    });
+
+    db.providers.push({
+      id: PROVIDER_ID,
+      userId: PHYSICIAN_USER_ID,
+      organizationId: ORG_ID,
+      title: "MD",
+      specialties: ["Cannabis medicine"],
+      bio: "Golden visit fixture physician",
+      active: true,
+      npi: "1234567893",
+      taxonomyCode: "207Q00000X",
+      practiceAddress: "100 Golden Way, Los Angeles, CA 90001",
+      hospitalAffiliations: [],
+      createdAt: FIXED_NOW,
+    });
+  }
+
+  return {
+    FIXED_NOW,
+    ORG_ID,
+    PATIENT_ID,
+    PATIENT_USER_ID,
+    PROVIDER_ID,
+    PHYSICIAN_USER_ID,
+    FRONT_DESK_USER_ID,
+    MA_USER_ID,
+    KIOSK_USER_ID,
+    APPOINTMENT_ID,
+    ENCOUNTER_ID,
+    NOTE_ID,
+    fixture,
+    prisma,
+    revalidatePath,
+    redirect,
+    requireUser,
+    requireRole,
+    dispatch,
+    runTick,
+    runJob,
+    logger,
+    resetFixture,
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: h.revalidatePath }));
+vi.mock("next/navigation", () => ({ redirect: h.redirect }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: h.prisma }));
+vi.mock("@/lib/auth/session", () => ({
+  requireUser: h.requireUser,
+  requireRole: h.requireRole,
+}));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: h.dispatch }));
+vi.mock("@/lib/orchestration/runner", () => ({
+  runTick: h.runTick,
+  runJob: h.runJob,
+}));
+vi.mock("@/lib/observability/log", () => ({ logger: h.logger }));
+
+import { bookAppointment } from "@/app/(patient)/portal/schedule/actions";
+import { kioskCheckIn, kioskVerifyDob } from "@/app/kiosk/(console)/actions";
+import { moveQueueEncounter, saveRoomingHandoff } from "@/app/(operator)/ops/queue/actions";
+import { startVisit } from "@/app/(clinician)/clinic/patients/[id]/actions";
+import { saveAndFinalizeNote } from "@/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions";
+import { ensureEncounterForAppointment } from "./ensure-encounter";
+import { buildVisitCompletionBundle } from "./visit-completion";
+import {
+  applyVisitCompletionAction,
+  buildVisitCompletionReleasePayload,
+  initializeVisitCompletionSelection,
+} from "./visit-completion-selection";
+import { scrubClaim, isClaimSubmittable } from "@/lib/billing/scrub";
+
+const FIXED_NOW = h.FIXED_NOW;
+const ORG_ID = h.ORG_ID;
+const PATIENT_ID = h.PATIENT_ID;
+const PATIENT_USER_ID = h.PATIENT_USER_ID;
+const PROVIDER_ID = h.PROVIDER_ID;
+const PHYSICIAN_USER_ID = h.PHYSICIAN_USER_ID;
+const FRONT_DESK_USER_ID = h.FRONT_DESK_USER_ID;
+const MA_USER_ID = h.MA_USER_ID;
+const KIOSK_USER_ID = h.KIOSK_USER_ID;
+const APPOINTMENT_ID = h.APPOINTMENT_ID;
+const ENCOUNTER_ID = h.ENCOUNTER_ID;
+const NOTE_ID = h.NOTE_ID;
+const fixture = h.fixture;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+  h.resetFixture();
+});
 
 describe("Golden Visit harness", () => {
   it("walks one scheduled patient from booking to closeout without losing encounter continuity", async () => {

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => {
-  const FIXED_NOW = new Date("2099-06-05T16:00:00.000Z");
+  // Keep this local-time based because bookAppointment parses slotDate +
+  // slotStartTime in the process timezone. 08:00 local keeps the 09:00 slot in
+  // the future under UTC, Pacific, and CI timezones.
+  const FIXED_NOW = new Date(2099, 5, 5, 8, 0, 0, 0);
   const ORG_ID = "org_golden";
   const PATIENT_ID = "patient_golden";
   const PATIENT_USER_ID = "user_patient_golden";

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -111,7 +111,7 @@ const h = vi.hoisted(() => {
       return db.providers.find((provider) => provider.id === row.providerId) ?? null;
     }
     if (relation === "encounter") {
-      if (row.appointmentId) {
+      if ("startAt" in row && "endAt" in row) {
         return db.encounters.find((encounter) => encounter.appointmentId === row.id) ?? null;
       }
       if (row.encounterId) {
@@ -441,7 +441,11 @@ const h = vi.hoisted(() => {
     throw new Error(`redirect:${href}`);
   });
   const requireUser = vi.fn(async () => fixture.session.currentUser);
-  const requireRole = vi.fn(async () => fixture.session.currentUser);
+  const requireRole = vi.fn(async (role: string) => {
+    const user = fixture.session.currentUser;
+    if (!user.roles.includes(role)) throw new Error("FORBIDDEN");
+    return user;
+  });
   const dispatch = vi.fn(async (event: any) => {
     fixture.dispatchEvents.push(clone(event));
     if (event.name !== "encounter.note.draft.requested") return [];

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+describe("Golden Visit harness", () => {
+  it("walks one scheduled patient from booking to closeout without losing encounter continuity", async () => {
+    await expect(runGoldenVisit()).resolves.toMatchObject({
+      appointmentId: "appt_golden_1",
+      encounterId: "enc_golden_1",
+      finalEncounterStatus: "complete",
+      duplicateActiveEncounterCount: 0,
+      roomingHandoffVisibleToPhysician: true,
+      noteFinalizedDispatchCount: 1,
+      encounterCompletedDispatchCount: 1,
+      closeoutReady: true,
+    });
+  });
+});

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => {
   const FIXED_NOW = new Date("2099-06-05T16:00:00.000Z");
@@ -651,6 +651,229 @@ beforeEach(() => {
   vi.setSystemTime(FIXED_NOW);
   h.resetFixture();
 });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function activeEncountersForPatient() {
+  return fixture.db.encounters.filter(
+    (encounter) =>
+      encounter.patientId === PATIENT_ID &&
+      !["complete", "cancelled", "no_show"].includes(encounter.status),
+  );
+}
+
+function expectSingleActiveEncounter(label: string) {
+  const activeEncounters = activeEncountersForPatient();
+  expect(activeEncounters, label).toHaveLength(1);
+  expect(activeEncounters[0].id, label).toBe(ENCOUNTER_ID);
+  return activeEncounters[0];
+}
+
+function dispatchCount(name: string) {
+  return fixture.dispatchEvents.filter((event) => event.name === name).length;
+}
+
+function noteBlocks() {
+  return [
+    {
+      heading: "Subjective",
+      body:
+        "Golden reports chronic arthritic pain with morning stiffness. Topical CBD helps pain, but the new evening CBD dose caused daytime somnolence.",
+    },
+    {
+      heading: "Objective",
+      body:
+        "Vitals reviewed. BP 148/86 on arrival and 142/84 on recheck; HR 78. Patient appears alert, mildly anxious, and in no acute distress.",
+    },
+    {
+      heading: "Assessment",
+      body:
+        "Chronic pain, ICD-10 G89.29, partially responsive to CBD therapy. Daytime somnolence is likely related to recent dose timing change.",
+    },
+    {
+      heading: "Plan",
+      body:
+        "Reduce evening CBD dose and avoid daytime use while monitoring somnolence. Order labs including CMP and renal function panel. RTC in 6 weeks for BP and pain reassessment.",
+    },
+  ];
+}
+
+async function runGoldenVisit() {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+
+  fixture.session.currentUser = fixture.users.patient;
+  const booked = await bookAppointment({
+    patientId: PATIENT_ID,
+    providerId: PROVIDER_ID,
+    slotDate: "2099-06-05",
+    slotStartTime: "09:00",
+    appointmentType: "follow_up",
+    modality: "in_person",
+    reason: "Golden Visit harness follow-up",
+  });
+  expect(booked).toEqual({ ok: true, id: APPOINTMENT_ID });
+
+  const appointment = fixture.db.appointments.find((row) => row.id === APPOINTMENT_ID);
+  expect(appointment).toBeDefined();
+  if (!appointment) throw new Error("Golden Visit appointment was not created.");
+  appointment.status = "confirmed";
+
+  const ensuredEncounter = await ensureEncounterForAppointment(APPOINTMENT_ID);
+  expect(ensuredEncounter?.id).toBe(ENCOUNTER_ID);
+  expectSingleActiveEncounter("after appointment encounter materialization");
+
+  fixture.session.currentUser = fixture.users.kiosk;
+  const verified = await kioskVerifyDob(PATIENT_ID, "1954-02-11");
+  expect(verified.ok).toBe(true);
+  expect(verified.context?.appointment?.encounterId).toBe(ENCOUNTER_ID);
+
+  const firstCheckIn = await kioskCheckIn(PATIENT_ID);
+  expect(firstCheckIn).toMatchObject({
+    ok: true,
+    status: "checked_in",
+    alreadyCheckedIn: false,
+  });
+  expectSingleActiveEncounter("after first kiosk check-in");
+
+  const secondCheckIn = await kioskCheckIn(PATIENT_ID);
+  expect(secondCheckIn).toMatchObject({
+    ok: true,
+    status: "checked_in",
+    alreadyCheckedIn: true,
+  });
+  expectSingleActiveEncounter("after idempotent kiosk check-in");
+
+  fixture.session.currentUser = fixture.users.ma;
+  expect(
+    await moveQueueEncounter({ encounterId: ENCOUNTER_ID, target: "rooming" }),
+  ).toEqual({ ok: true });
+  expect(fixture.db.encounters.find((row) => row.id === ENCOUNTER_ID)?.status).toBe(
+    "rooming",
+  );
+
+  expect(
+    await saveRoomingHandoff({
+      encounterId: ENCOUNTER_ID,
+      room: "A3",
+      handoffNote: "BP a little high; patient anxious about new dose.",
+      readinessFlags: ["bp_recheck", "review_cbd_somnolence"],
+    }),
+  ).toEqual({ ok: true });
+
+  expect(
+    await moveQueueEncounter({ encounterId: ENCOUNTER_ID, target: "roomed" }),
+  ).toEqual({ ok: true });
+  const roomedEncounter = expectSingleActiveEncounter("after roomed transition");
+  expect(roomedEncounter.status).toBe("roomed");
+  expect(roomedEncounter.briefingContext?.rooming).toMatchObject({
+    room: "A3",
+    handoffNote: "BP a little high; patient anxious about new dose.",
+    readinessFlags: ["bp_recheck", "review_cbd_somnolence"],
+  });
+
+  fixture.session.currentUser = fixture.users.physician;
+  await h.prisma.note.create({
+    data: {
+      id: NOTE_ID,
+      encounterId: ENCOUNTER_ID,
+      status: "draft",
+      aiDrafted: false,
+      blocks: noteBlocks(),
+      createdAt: FIXED_NOW,
+    },
+  });
+
+  await expect(startVisit(PATIENT_ID)).rejects.toThrow(
+    `redirect:/clinic/patients/${PATIENT_ID}/notes/${NOTE_ID}`,
+  );
+  const inProgressEncounter = expectSingleActiveEncounter("after physician starts visit");
+  expect(inProgressEncounter.status).toBe("in_progress");
+  expect(inProgressEncounter.providerId).toBe(PROVIDER_ID);
+  const roomingHandoffVisibleToPhysician = Boolean(
+    inProgressEncounter.briefingContext?.rooming?.room === "A3" &&
+      inProgressEncounter.briefingContext?.rooming?.handoffNote ===
+        "BP a little high; patient anxious about new dose." &&
+      inProgressEncounter.briefingContext?.rooming?.readinessFlags?.includes("bp_recheck") &&
+      inProgressEncounter.briefingContext?.rooming?.readinessFlags?.includes(
+        "review_cbd_somnolence",
+      ),
+  );
+  expect(roomingHandoffVisibleToPhysician).toBe(true);
+
+  await expect(startVisit(PATIENT_ID)).rejects.toThrow(
+    `redirect:/clinic/patients/${PATIENT_ID}/notes/${NOTE_ID}`,
+  );
+  expectSingleActiveEncounter("after idempotent physician start visit");
+
+  const finalized = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
+  expect(finalized).toEqual({ ok: true, status: "finalized" });
+  expect(fixture.db.encounters.find((row) => row.id === ENCOUNTER_ID)?.status).toBe(
+    "complete",
+  );
+
+  const finalizedAgain = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
+  expect(finalizedAgain).toEqual({ ok: true, status: "finalized" });
+
+  const bundle = buildVisitCompletionBundle({
+    patientFirstName: "Golden",
+    blocks: noteBlocks(),
+    hasFutureAppointment: false,
+    codingSuggestion: {
+      emLevel: "99214",
+      icd10: [{ code: "G89.29", label: "Other chronic pain", confidence: 0.95 }],
+      rationale: "Established follow-up with chronic pain management and medication adjustment.",
+    },
+  });
+  let selection = initializeVisitCompletionSelection(bundle);
+  for (const card of bundle.cards) {
+    selection = applyVisitCompletionAction(bundle, selection, {
+      type: "confirm_card",
+      cardId: card.id,
+      confirmationNote: `Confirmed ${card.title} for Golden Visit closeout.`,
+    });
+  }
+  const releasePayload = buildVisitCompletionReleasePayload(bundle, selection);
+  expect(releasePayload.canRelease).toBe(true);
+
+  const scrubIssues = scrubClaim({
+    cptCodes: [
+      {
+        code: "99214",
+        label: "Established patient office visit",
+        units: 1,
+        chargeAmount: 235,
+        modifiers: [],
+      },
+    ],
+    icd10Codes: [{ code: "G89.29", label: "Other chronic pain" }],
+    payerName: "Blue Cross",
+    payerId: "bcbs",
+    serviceDate: FIXED_NOW,
+    providerId: PROVIDER_ID,
+    patientCoverage: {
+      payerName: "Blue Cross",
+      eligibilityStatus: "active",
+    },
+  });
+  expect(isClaimSubmittable(scrubIssues)).toBe(true);
+
+  return {
+    appointmentId: APPOINTMENT_ID,
+    encounterId: ENCOUNTER_ID,
+    finalEncounterStatus: fixture.db.encounters.find((row) => row.id === ENCOUNTER_ID)
+      ?.status,
+    duplicateActiveEncounterCount: activeEncountersForPatient().filter(
+      (encounter) => encounter.id !== ENCOUNTER_ID,
+    ).length,
+    roomingHandoffVisibleToPhysician,
+    noteFinalizedDispatchCount: dispatchCount("note.finalized"),
+    encounterCompletedDispatchCount: dispatchCount("encounter.completed"),
+    closeoutReady: releasePayload.canRelease && isClaimSubmittable(scrubIssues),
+  };
+}
 
 describe("Golden Visit harness", () => {
   it("walks one scheduled patient from booking to closeout without losing encounter continuity", async () => {

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -671,6 +671,13 @@ function expectSingleActiveEncounter(label: string) {
   return activeEncounters[0];
 }
 
+function expectOnlyGoldenEncounter(label: string) {
+  expect(
+    fixture.db.encounters.map((encounter) => encounter.id),
+    label,
+  ).toEqual([ENCOUNTER_ID]);
+}
+
 function dispatchCount(name: string) {
   return fixture.dispatchEvents.filter((event) => event.name === name).length;
 }
@@ -724,6 +731,7 @@ async function runGoldenVisit() {
   const ensuredEncounter = await ensureEncounterForAppointment(APPOINTMENT_ID);
   expect(ensuredEncounter?.id).toBe(ENCOUNTER_ID);
   expectSingleActiveEncounter("after appointment encounter materialization");
+  expectOnlyGoldenEncounter("after appointment encounter materialization");
 
   fixture.session.currentUser = fixture.users.kiosk;
   const verified = await kioskVerifyDob(PATIENT_ID, "1954-02-11");
@@ -745,6 +753,7 @@ async function runGoldenVisit() {
     alreadyCheckedIn: true,
   });
   expectSingleActiveEncounter("after idempotent kiosk check-in");
+  expectOnlyGoldenEncounter("after idempotent kiosk check-in");
 
   fixture.session.currentUser = fixture.users.ma;
   expect(
@@ -807,6 +816,9 @@ async function runGoldenVisit() {
     `redirect:/clinic/patients/${PATIENT_ID}/notes/${NOTE_ID}`,
   );
   expectSingleActiveEncounter("after idempotent physician start visit");
+  expectOnlyGoldenEncounter("after idempotent physician start visit");
+  expect(dispatchCount("encounter.note.draft.requested")).toBe(0);
+  expect(fixture.db.agentJobs).toHaveLength(0);
 
   const finalized = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
   expect(finalized).toEqual({ ok: true, status: "finalized" });
@@ -816,6 +828,8 @@ async function runGoldenVisit() {
 
   const finalizedAgain = await saveAndFinalizeNote(NOTE_ID, noteBlocks());
   expect(finalizedAgain).toEqual({ ok: true, status: "finalized" });
+  expectOnlyGoldenEncounter("after final closeout");
+  expect(activeEncountersForPatient()).toHaveLength(0);
 
   const bundle = buildVisitCompletionBundle({
     patientFirstName: "Golden",


### PR DESCRIPTION
## Summary

- adds deterministic Golden Visit Vitest harness from appointment booking through closeout evidence
- adds optional Playwright route smoke for the critical visit surfaces
- adds named release-gate scripts for CI/local execution

## Verification

- npm run test:golden-visit — PASS
- TZ=UTC npm run test:golden-visit — PASS
- npm test -- src/lib/domain/visit-journey.integration.test.ts src/lib/domain/ensure-encounter.test.ts src/app/api/mobile/kiosk/check-in/route.test.ts src/app/\(operator\)/ops/queue/actions.test.ts src/app/\(clinician\)/clinic/patients/\[id\]/actions.start-visit.test.ts src/app/\(clinician\)/clinic/patients/\[id\]/notes/\[noteId\]/actions.finalize-idempotent.test.ts src/lib/domain/visit-completion.test.ts src/lib/domain/visit-completion-selection.test.ts src/lib/agents/billing/charge-integrity-agent.test.ts src/lib/agents/billing/clearinghouse-submission-agent.test.ts — PASS, 111 tests
- npm run db:generate — PASS
- npm run typecheck — PASS after prisma generate
- npm run lint — PASS with existing warnings only
- npm run build — PASS with existing warnings / DB fallback noise during static generation
- npm run e2e:golden-visit — expected no-dev-server global setup failure locally; spec is optional and auth-state gated

Linear: EMR-1001