### PR TITLE
EMR-670: /clinic/library — ChatCBPanel upgrade, terpene expansion, PDF print fix

### DIFF
--- a/src/app/(clinician)/clinic/library/page.tsx
+++ b/src/app/(clinician)/clinic/library/page.tsx
@@ -8,7 +8,7 @@ import { PdfExportButton } from "./pdf-export-button";
 import { InteractionBubbles } from "./interaction-bubbles";
 import { getCurrentUser } from "@/lib/auth/session";
 import { isModalityEnabled } from "@/lib/modality/server";
-import { ChatCB } from "../research/chat-cb";
+import { ChatCBPanel } from "../research/chat-cb-panel";
 
 export const metadata = { title: "Clinical Library" };
 
@@ -121,6 +121,21 @@ export default async function LibraryPage() {
                   <td className="py-3 pr-4 text-text-muted">Pepper, spicy, woody</td>
                   <td className="py-3 text-text-muted">CB2 agonist, anti-inflammatory, analgesic, gastroprotective</td>
                 </tr>
+                <tr>
+                  <td className="py-3 pr-4 font-medium text-text">Ocimene</td>
+                  <td className="py-3 pr-4 text-text-muted">Sweet, herbal, woody</td>
+                  <td className="py-3 text-text-muted">Antiviral, decongestant, mild anti-inflammatory; often found in energetic/uplifting cultivars</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 font-medium text-text">Terpinolene</td>
+                  <td className="py-3 pr-4 text-text-muted">Fresh, piney, floral, herbaceous</td>
+                  <td className="py-3 text-text-muted">Mildly sedating, antifungal, antioxidant; associated with cerebral/creative effects at low doses</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4 font-medium text-text">Humulene</td>
+                  <td className="py-3 pr-4 text-text-muted">Earthy, hoppy, woody</td>
+                  <td className="py-3 text-text-muted">Anti-inflammatory, appetite suppressant, antibacterial; shares terpene backbone with beta-caryophyllene</td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -213,10 +228,7 @@ export default async function LibraryPage() {
       {/* ChatCB — AI evidence assistant, cannabis-modality only */}
       {cannabisEnabled && (
         <div className="mb-6">
-          <p className="text-xs font-medium text-text-subtle uppercase tracking-wide mb-3">
-            AI evidence assistant
-          </p>
-          <ChatCB />
+          <ChatCBPanel />
         </div>
       )}
 

--- a/src/app/(clinician)/clinic/library/pdf-export-button.tsx
+++ b/src/app/(clinician)/clinic/library/pdf-export-button.tsx
@@ -2,14 +2,15 @@
 
 export function PdfExportButton() {
   return (
-    <button 
+    <button
+      data-print-hide=""
       className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border border-border rounded-md hover:bg-surface-muted transition-colors"
       onClick={() => {
         if (typeof window !== "undefined") window.print();
       }}
     >
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" /></svg>
-      Export to PDF
+      Export PDF
     </button>
   );
 }


### PR DESCRIPTION
Implements EMR-670.

## What changed
- **ChatCB upgrade**: replaced the legacy `ChatCB` component (non-streaming, no citations) with `ChatCBPanel` — the same streaming SSE widget used in the `/clinic/research` sidebar. Library clinicians now get real-time token streaming, rich citation cards with PMID links, evidence-level badges, and hint prompts when the conversation is empty. Gated on the `cannabis-medicine` modality as before.
- **Terpene table expansion**: added Ocimene, Terpinolene, and Humulene to the pharmacology reference. Table now covers 8 of the most clinically relevant cannabis terpenes.
- **PDF export fix**: added `data-print-hide=""` to `PdfExportButton` so the button is hidden by the global `@media print` rule in `globals.css` — it no longer prints itself onto the page when a clinician exports.

## How to verify
1. Navigate to `/clinic/library` with a cannabis-medicine org
2. Confirm the ChatCB widget streams responses and shows citation cards with PMID links
3. Confirm the terpene table has 8 rows (Myrcene → Humulene)
4. Cmd-P / browser print — confirm "Export PDF" button is not visible in the print preview

## Notes
- No schema changes, no new dependencies, no middleware touches.
- Follow-up (EMR-671): `/clinic/library` drug interaction leaf clicks — separate ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_017eEcjuvsSmLsPBmvSzD8NZ)_