### PR TITLE
EMR-666: /clinic/providers/messages iMessage split pane + directory deep-link

### DIFF
--- a/src/app/(clinician)/clinic/providers/messages/page.tsx
+++ b/src/app/(clinician)/clinic/providers/messages/page.tsx
@@ -19,9 +19,14 @@ import {
 
 export const metadata = { title: "Provider Messages" };
 
-export default async function ProviderMessagesPage() {
+export default async function ProviderMessagesPage({
+  searchParams,
+}: {
+  searchParams: { userId?: string };
+}) {
   const user = await requireUser();
   const orgId = user.organizationId;
+  const initialUserId = searchParams.userId ?? null;
 
   if (!orgId) {
     return (
@@ -134,6 +139,7 @@ export default async function ProviderMessagesPage() {
         threads={decrypted}
         currentUserId={user.id}
         directory={directory}
+        initialUserId={initialUserId}
       />
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/providers/messages/view.tsx
+++ b/src/app/(clinician)/clinic/providers/messages/view.tsx
@@ -59,6 +59,7 @@ interface Props {
   threads: DecryptedThread[];
   currentUserId: string;
   directory: DirectoryProvider[];
+  initialUserId?: string | null;
 }
 
 // One row in the left pane — either an existing thread (preferred) or
@@ -72,11 +73,18 @@ type RightPane =
   | { kind: "compose"; prefillUserId: string | null }
   | { kind: "empty" };
 
-export function ProviderInboxView({ threads, currentUserId, directory }: Props) {
+export function ProviderInboxView({ threads, currentUserId, directory, initialUserId }: Props) {
   const [search, setSearch] = useState("");
-  const [right, setRight] = useState<RightPane>(
-    threads[0] ? { kind: "thread", threadId: threads[0].id } : { kind: "empty" },
-  );
+  const [right, setRight] = useState<RightPane>(() => {
+    if (initialUserId) {
+      const existing = threads.find(
+        (t) => t.participants[0]?.userId === initialUserId,
+      );
+      if (existing) return { kind: "thread", threadId: existing.id };
+      return { kind: "compose", prefillUserId: initialUserId };
+    }
+    return threads[0] ? { kind: "thread", threadId: threads[0].id } : { kind: "empty" };
+  });
   const [popupUserId, setPopupUserId] = useState<string | null>(null);
 
   // Build merged left-pane list: every existing thread first (in chat

--- a/src/app/(clinician)/clinic/providers/page.tsx
+++ b/src/app/(clinician)/clinic/providers/page.tsx
@@ -26,7 +26,7 @@ export default async function ProvidersPage() {
     },
     include: {
       user: {
-        select: { firstName: true, lastName: true, email: true },
+        select: { id: true, firstName: true, lastName: true, email: true },
       },
     },
     orderBy: { createdAt: "asc" },
@@ -45,6 +45,7 @@ export default async function ProvidersPage() {
 
   const rows: ProviderRow[] = providers.map((p) => ({
     id: p.id,
+    userId: p.user.id,
     firstName: p.user.firstName,
     lastName: p.user.lastName,
     title: p.title,

--- a/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
+++ b/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
@@ -23,6 +23,7 @@ import {
 
 export interface ProviderRow extends SearchableProvider {
   id: string;
+  userId: string;
   bio: string | null;
 }
 
@@ -283,7 +284,7 @@ export function ProvidersDirectoryClient({ providers }: Props) {
 
                 <div className="mt-4 pt-3 border-t border-border/60">
                   <a
-                    href="/clinic/providers/messages"
+                    href={`/clinic/providers/messages?userId=${provider.userId}`}
                     className="flex items-center justify-center gap-2 w-full text-sm font-medium text-accent py-2 rounded-md border border-accent/30 bg-accent/5 hover:bg-accent/10 transition-colors"
                   >
                     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="text-accent">


### PR DESCRIPTION
Implements EMR-666.

## What changed
- **`providers/providers-directory-client.tsx`** — Added `userId: string` to the `ProviderRow` interface and updated the "Secure message" button href from a static `/clinic/providers/messages` to `/clinic/providers/messages?userId=${provider.userId}`. Clicking the button now deep-links to the exact thread or opens compose pre-filled for that provider.
- **`providers/page.tsx`** — Adds `id: true` to the Prisma user select and passes `userId: p.user.id` when building `ProviderRow`, so the client has the User ID (not just the Provider record ID) needed to match threads.
- **`providers/messages/page.tsx`** — Accepts `searchParams: { userId?: string }` and forwards `initialUserId` to `ProviderInboxView`.
- **`providers/messages/view.tsx`** — Accepts optional `initialUserId` prop; the `right` state now uses a lazy initializer: if `initialUserId` is provided it finds an existing thread with that peer (opens it) or falls back to compose mode pre-filled with that provider. No-arg behaviour is unchanged.

The iMessage-style split pane layout, directory search, encrypted thread actions, and unread indicators were already in place from the earlier EMR-033 implementation; this PR completes the UX loop by wiring the provider directory card directly into the messaging pane.

## How to verify
- Go to `/clinic/providers` — confirm provider cards show "Secure message" button.
- Click "Secure message" on a provider you've previously messaged → should land on `/clinic/providers/messages?userId=<id>` with that thread open in the right pane.
- Click "Secure message" on a provider you've never messaged → should land in compose mode with that provider pre-checked in the recipients list.
- Without a `userId` param (`/clinic/providers/messages` directly) → existing behaviour: most recent thread selected, or empty state if no threads.
- Search box in the left pane should filter by name, specialty, address, and hospital affiliation (existing).

## Notes
- No schema changes, no new dependencies, no protected files touched.
- Follow-up: the `userId` param is the User record ID (opaque to the URL), not a slug — if a public-facing directory is ever added, consider an opaque token.

---
_Generated by [Claude Code](https://claude.ai/code/session_0174F4okfydQ4RoBBCCt6fDS)_