### PR TITLE
EMR-653: Pre-visit checklist leaf indicators

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/telehealth/video-room.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/telehealth/video-room.tsx
@@ -195,12 +195,7 @@ export function VideoRoom({
                           : "bg-surface border-border hover:bg-surface-muted",
                       )}
                     >
-                      <div className={cn(
-                        "mt-0.5 flex h-5 w-5 items-center justify-center rounded border transition-colors",
-                        checkedItems.has(item.id) ? "border-accent bg-accent text-white" : "border-border-strong text-transparent"
-                      )}>
-                        <LeafSprig size={12} className="text-current" />
-                      </div>
+                      <ChecklistLeaf checked={checkedItems.has(item.id)} />
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
                           <span className="text-sm font-medium text-text">
@@ -768,5 +763,18 @@ export function VideoRoom({
         )}
       </div>
     </div>
+  );
+}
+
+function ChecklistLeaf({ checked }: { checked: boolean }) {
+  return (
+    <span
+      className={cn(
+        "mt-0.5 shrink-0 transition-all duration-200",
+        checked ? "text-success scale-110" : "text-text-subtle",
+      )}
+    >
+      <LeafSprig size={14} className="text-current" />
+    </span>
   );
 }


### PR DESCRIPTION
Implements EMR-653.

## What changed
- Replaced the generic box-checkbox (an outlined box with an invisible leaf when unchecked) in the VideoRoom pre-visit checklist (`video-room.tsx`) with a standalone `ChecklistLeaf` indicator component
- Unchecked items show a muted (`text-text-subtle`) leaf; checked items show a green (`text-success`) leaf with a subtle `scale-110` pop
- This brings the manual patient pre-visit checklist in line with the `LeafIndicator` pattern already used in the provider-side pre-visit checklist (`pre-visit-checklist-client.tsx`)
- No new imports needed — `LeafSprig` and `cn` were already in scope

## How to verify
1. Navigate to `/clinic/patients/<any-patient-id>/telehealth`
2. On the "Pre-visit checklist" screen, verify each item renders a muted leaf icon to its left
3. Click any item — the leaf should turn green and the row should show the `bg-accent/5 border-accent/30` highlight
4. Confirm all required items checked enables the "Start video visit" button

## Notes
- `ChecklistLeaf` is a file-local helper (same pattern as `LeafIndicator` in `pre-visit-checklist-client.tsx`); extracting to a shared component is a follow-up if a third callsite appears

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pny5e3uUHXZDiEPHZCoDiu)_