### PR TITLE
EMR-669: /clinic/research ChatCB conversational AI + citations

### DIFF
--- a/src/app/(clinician)/clinic/research/chat-cb-panel.tsx
+++ b/src/app/(clinician)/clinic/research/chat-cb-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
   Card,
   CardHeader,
@@ -29,6 +29,13 @@ export function ChatCBPanel() {
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
 
   async function send() {
     const question = input.trim();
@@ -47,11 +54,18 @@ export function ChatCBPanel() {
     const abort = new AbortController();
     abortRef.current = abort;
 
+    // Build a history snapshot before appending the new user message.
+    // Include only settled (non-loading) Q+A pairs, capped at last 3 pairs.
+    const history = messages
+      .filter((m) => !m.loading)
+      .slice(-6)
+      .map((m) => ({ role: m.role, text: m.text }));
+
     try {
       const res = await fetch("/api/agents/chat-cb", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question }),
+        body: JSON.stringify({ question, history }),
         signal: abort.signal,
       });
 
@@ -154,17 +168,36 @@ export function ChatCBPanel() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-sm">
-          <span className="text-base">🌿</span>
-          ChatCB
-        </CardTitle>
-        <CardDescription className="text-xs">
-          Ask about cannabinoids, conditions, or evidence.
-        </CardDescription>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <span className="text-base">🌿</span>
+              ChatCB
+            </CardTitle>
+            <CardDescription className="text-xs">
+              Ask about cannabinoids, conditions, or evidence.
+            </CardDescription>
+          </div>
+          {messages.length > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                abortRef.current?.abort();
+                setMessages([]);
+                setInput("");
+                setBusy(false);
+              }}
+              className="shrink-0 text-[10px] text-text-subtle hover:text-text transition-colors mt-0.5 px-1.5 py-0.5 rounded hover:bg-surface-muted"
+              aria-label="Clear conversation"
+            >
+              Clear
+            </button>
+          )}
+        </div>
       </CardHeader>
       <CardContent className="space-y-3">
         {messages.length > 0 && (
-          <div className="space-y-3 max-h-72 overflow-y-auto pr-1">
+          <div ref={scrollRef} className="space-y-3 max-h-72 overflow-y-auto pr-1">
             {messages.map((msg, i) => (
               <div key={i}>
                 {msg.role === "user" ? (

--- a/src/app/api/agents/chat-cb/route.ts
+++ b/src/app/api/agents/chat-cb/route.ts
@@ -58,7 +58,11 @@ export async function POST(request: Request) {
   });
   if (gate.error) return gate.error;
 
-  let body: { question?: unknown; message?: unknown };
+  let body: {
+    question?: unknown;
+    message?: unknown;
+    history?: unknown;
+  };
   try {
     body = (await request.json()) as typeof body;
   } catch {
@@ -73,6 +77,24 @@ export async function POST(request: Request) {
     typeof rawQuestion === "string" && rawQuestion.trim().length > 0
       ? rawQuestion.trim().slice(0, 400)
       : null;
+
+  // Validated prior turns for multi-turn context. We accept at most 6 turns
+  // (3 Q+A pairs) to keep the prompt size bounded.
+  type HistoryTurn = { role: "user" | "assistant"; text: string };
+  const history: HistoryTurn[] = (() => {
+    if (!Array.isArray(body.history)) return [];
+    return (body.history as unknown[])
+      .filter((t) => {
+        if (typeof t !== "object" || t === null) return false;
+        const role = (t as Record<string, unknown>).role;
+        return role === "user" || role === "assistant";
+      })
+      .slice(-6)
+      .map((t) => ({
+        role: (t as Record<string, unknown>).role as "user" | "assistant",
+        text: String((t as Record<string, unknown>).text ?? "").slice(0, 600),
+      }));
+  })();
 
   if (!question) {
     return new Response(JSON.stringify({ error: "missing_question" }), {
@@ -130,8 +152,16 @@ export async function POST(request: Request) {
           .join("\n")
       : "";
 
+  const historyContext =
+    history.length > 0
+      ? "\n\nPrior conversation (use for context only — do not re-answer):\n" +
+        history
+          .map((t) => `${t.role === "user" ? "Clinician" : "ChatCB"}: ${t.text}`)
+          .join("\n")
+      : "";
+
   const systemPrompt = buildChatCBSystemPrompt();
-  const userPrompt = `${systemPrompt}${kbContext}${pubmedContext}\n\nClinician question: ${question}`;
+  const userPrompt = `${systemPrompt}${historyContext}${kbContext}${pubmedContext}\n\nClinician question: ${question}`;
 
   const model = resolveModelClient();
 
@@ -237,4 +267,3 @@ export async function POST(request: Request) {
     },
   });
 }
-


### PR DESCRIPTION
Implements EMR-669.

## What changed
- **Multi-turn conversation context** (`route.ts`): The API now accepts an optional `history` array of prior Q+A turns. Up to 6 turns are validated, sanitized (600-char cap per message), and encoded as a labelled transcript block inserted between the system prompt and the current question — so the AI can resolve follow-ups like "what about CBD for that?" without losing context.
- **History passed from panel** (`chat-cb-panel.tsx`): Before each request, the panel snapshots settled (non-loading) messages and sends them as `history`. Only the last 6 turns are included to keep payload size bounded.
- **Auto-scroll**: A `scrollRef` + `useEffect` anchors the message list to the bottom on every new message so the clinician always sees the latest response without manual scrolling.
- **Clear button**: A lightweight "Clear" button appears in the panel header once a conversation starts. It aborts any in-flight request and resets state to empty — useful when switching topics without leaving the page.

## How to verify
1. Open `/clinic/research` on a cannabis-medicine org (ChatCBPanel is cannabis-gated).
2. Ask a first question (e.g. "CBD for anxiety — evidence?") and wait for the answer.
3. Ask a follow-up that requires context (e.g. "What's the dose range for that?") — the AI should answer in context rather than starting fresh.
4. Confirm the message list auto-scrolls as the streamed answer arrives.
5. Click **Clear** — conversation resets to the empty hints state.
6. Confirm non-cannabis orgs still see no ChatCBPanel (modality gate unchanged).

## Notes
- No schema changes. No new dependencies. No new routes.
- The JSON fallback path (`message` field) also benefits from history context.
- Follow-up: inline citation bracket linkification (`[1]`, `[2]`) in streamed text — left for a dedicated ticket since it requires post-process parsing of the accumulated answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATHJAJvqdRe5mRXJmxqtpi)_