### PR TITLE
EMR-667: /clinic/providers slash-commands + Ancillary Services directory

### DIFF
--- a/src/app/(clinician)/clinic/providers/ancillary-services-directory.tsx
+++ b/src/app/(clinician)/clinic/providers/ancillary-services-directory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -149,6 +149,18 @@ const ALL_CATEGORIES = Object.keys(CATEGORY_LABELS) as ServiceCategory[];
 export function AncillaryServicesDirectory() {
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<ServiceCategory | null>(null);
+
+  // Listen for "ancillary:filter" events dispatched by the provider-directory
+  // slash-command handler (e.g. /ancillary lab) so the two sibling client
+  // components stay decoupled without lifting state to the server page.
+  useEffect(() => {
+    function handleFilter(e: Event) {
+      const cat = (e as CustomEvent<{ category: string }>).detail.category;
+      setActiveCategory(ALL_CATEGORIES.includes(cat as ServiceCategory) ? (cat as ServiceCategory) : null);
+    }
+    document.addEventListener("ancillary:filter", handleFilter);
+    return () => document.removeEventListener("ancillary:filter", handleFilter);
+  }, []);
 
   const categoryCounts = useMemo(() => {
     const counts = {} as Record<ServiceCategory, number>;

--- a/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
+++ b/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
@@ -43,6 +43,17 @@ function parseSlashCommand(raw: string): { mode: SlashMode; term: string } {
   return { mode: null, term: body };
 }
 
+// Category labels mirrored here so the provider-directory component can build
+// autocomplete suggestions without importing from ancillary-services-directory.
+const ANCILLARY_CATEGORY_LABELS: Record<string, string> = {
+  lab: "Lab",
+  imaging: "Imaging",
+  pharmacy: "Pharmacy",
+  dispensary: "Dispensary",
+  rehab: "Rehab / PT",
+};
+const ANCILLARY_CATEGORY_KEYS = Object.keys(ANCILLARY_CATEGORY_LABELS);
+
 function applyFilter(providers: ProviderRow[], search: string): ProviderRow[] {
   const { mode, term } = parseSlashCommand(search);
   if (!search.trim()) return providers;
@@ -66,9 +77,23 @@ function getSuggestions(raw: string, providers: ProviderRow[]): string[] {
   if (!raw.startsWith("/")) return [];
   const body = raw.slice(1);
 
-  if (!body || (!body.startsWith("specialty") && !body.startsWith("hospital"))) {
+  if (
+    !body ||
+    (!body.startsWith("specialty") &&
+      !body.startsWith("hospital") &&
+      !body.startsWith("ancillary"))
+  ) {
     const top = ["/specialty", "/hospital", "/ancillary"];
     return body ? top.filter((s) => s.slice(1).startsWith(body)) : top;
+  }
+  if (body.startsWith("ancillary")) {
+    const term = body.slice("ancillary".length).trimStart().toLowerCase();
+    return ANCILLARY_CATEGORY_KEYS.filter(
+      (c) =>
+        !term ||
+        c.startsWith(term) ||
+        ANCILLARY_CATEGORY_LABELS[c].toLowerCase().startsWith(term),
+    ).map((c) => `/ancillary ${c}`);
   }
   if (body.startsWith("specialty ")) {
     const term = body.slice(10).toLowerCase();
@@ -120,7 +145,13 @@ export function ProvidersDirectoryClient({ providers }: Props) {
   const { mode } = parseSlashCommand(search);
 
   function applySuggestion(s: string) {
-    if (s === "/ancillary") {
+    if (s === "/ancillary" || s.startsWith("/ancillary ")) {
+      const cat = s.startsWith("/ancillary ") ? s.slice("/ancillary ".length).trim() : null;
+      if (cat) {
+        document.dispatchEvent(
+          new CustomEvent("ancillary:filter", { detail: { category: cat } }),
+        );
+      }
       document.getElementById("ancillary")?.scrollIntoView({ behavior: "smooth" });
       setSearch("");
       setShowDropdown(false);


### PR DESCRIPTION
Implements EMR-667.

## What changed

- **`providers-directory-client.tsx`** — Extended `/ancillary` slash-command to accept a category argument. Typing `/ancillary` now shows autocomplete suggestions for all five service categories (`lab`, `imaging`, `pharmacy`, `dispensary`, `rehab`). Selecting one dispatches a `"ancillary:filter"` CustomEvent on `document` and smooth-scrolls to the section. Added `ANCILLARY_CATEGORY_LABELS` / `ANCILLARY_CATEGORY_KEYS` constants so the provider-directory component can build suggestions without a cross-component import.

- **`ancillary-services-directory.tsx`** — Added a `useEffect` listener for `"ancillary:filter"` CustomEvents. When fired, it updates the active category pill — same UX as clicking the pill manually. The two client components remain fully decoupled (no shared ref, no lifted state, no URL params) because they live in a server-rendered page with no shared parent state.

## How to verify

1. Navigate to `/clinic/providers`
2. Click the search box and type `/` — dropdown shows `/specialty`, `/hospital`, `/ancillary`
3. Arrow down to `/ancillary` and press Enter — page scrolls to Ancillary Services section
4. Type `/ancillary ` (with space) — dropdown shows all five category options
5. Select `/ancillary lab` — page scrolls to Ancillary Services AND "Lab" filter pill activates, showing only Quest Diagnostics and LabCorp
6. Clicking any category pill still works independently as before

## Notes

- The `ANCILLARY_CATEGORY_LABELS` map in `providers-directory-client.tsx` is a deliberate mirror of `CATEGORY_LABELS` in `ancillary-services-directory.tsx`. This avoids a cross-component import while keeping the two files independently testable. If categories change in future, both must be updated.
- No DB schema changes, no Prisma migrations, no new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_014xjvJsABYn95LS7QY1grRG)_