### PR TITLE
EMR-673: /clinic/communications clickable summary boxes + detail modals

### DIFF
--- a/src/app/(clinician)/clinic/communications/comms-summary-modals.client.tsx
+++ b/src/app/(clinician)/clinic/communications/comms-summary-modals.client.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+// EMR-673 — MetricTile summary grid wired to inline detail modals for
+// channels where the server already fetches recent-activity data.
+// Tiles without pre-fetched data (Beam, Voicemail, Transcripts) keep
+// their Link → full-page navigation so the modal approach is additive.
+
+import { useState } from "react";
+import Link from "next/link";
+import { MetricTile } from "@/components/ui/metric-tile";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { formatRelative } from "@/lib/utils/format";
+import type { CallRow, FaxRow, BroadcastRow } from "./comms-recent-client";
+
+type ModalKey = "calls" | "faxes" | "broadcasts";
+
+function badgeTone(status: string): "success" | "warning" | "danger" | "neutral" | "info" {
+  switch (status) {
+    case "completed":
+    case "delivered":
+    case "received":
+      return "success";
+    case "in_progress":
+    case "ringing":
+    case "initiated":
+    case "queued":
+    case "sending":
+    case "scheduled":
+      return "info";
+    case "missed":
+    case "cancelled":
+      return "warning";
+    case "failed":
+      return "danger";
+    default:
+      return "neutral";
+  }
+}
+
+export function CommsSummaryModals({
+  callsThisWeek,
+  upcomingBeam,
+  newVoicemails,
+  pendingTranscripts,
+  pendingFaxes,
+  activeCampaigns,
+  recentCalls,
+  recentFaxes,
+  recentBroadcasts,
+}: {
+  callsThisWeek: number;
+  upcomingBeam: number;
+  newVoicemails: number;
+  pendingTranscripts: number;
+  pendingFaxes: number;
+  activeCampaigns: number;
+  recentCalls: CallRow[];
+  recentFaxes: FaxRow[];
+  recentBroadcasts: BroadcastRow[];
+}) {
+  const [open, setOpen] = useState<ModalKey | null>(null);
+  const close = () => setOpen(null);
+
+  return (
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+        <button
+          type="button"
+          className="block text-left group"
+          onClick={() => setOpen("calls")}
+          aria-label="View recent calls"
+        >
+          <MetricTile
+            label="CALLS (7 DAYS)"
+            value={callsThisWeek}
+            accent="forest"
+            hint="Click to preview recent sessions"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow cursor-pointer"
+          />
+        </button>
+
+        <Link href="/clinic/communications/beam" className="block group">
+          <MetricTile
+            label="BEAM UPCOMING"
+            value={upcomingBeam}
+            accent={upcomingBeam > 0 ? "forest" : "none"}
+            hint="HIPAA-compliant Beam visits"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
+          />
+        </Link>
+
+        <Link href="/clinic/communications/voicemail" className="block group">
+          <MetricTile
+            label="NEW VOICEMAILS"
+            value={newVoicemails}
+            accent={newVoicemails > 0 ? "amber" : "none"}
+            hint="Awaiting clinician review"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
+          />
+        </Link>
+
+        <Link href="/clinic/communications/transcripts" className="block group">
+          <MetricTile
+            label="TRANSCRIPTS TO REVIEW"
+            value={pendingTranscripts}
+            accent={pendingTranscripts > 0 ? "amber" : "none"}
+            hint="Pertinent-info-only summaries"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
+          />
+        </Link>
+
+        <button
+          type="button"
+          className="block text-left group"
+          onClick={() => setOpen("faxes")}
+          aria-label="View recent faxes"
+        >
+          <MetricTile
+            label="FAXES IN FLIGHT"
+            value={pendingFaxes}
+            accent={pendingFaxes > 0 ? "amber" : "none"}
+            hint="Click to preview recent faxes"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow cursor-pointer"
+          />
+        </button>
+
+        <button
+          type="button"
+          className="block text-left group"
+          onClick={() => setOpen("broadcasts")}
+          aria-label="View recent broadcasts"
+        >
+          <MetricTile
+            label="ACTIVE OUTREACH"
+            value={activeCampaigns}
+            accent="forest"
+            hint="Click to preview recent campaigns"
+            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow cursor-pointer"
+          />
+        </button>
+      </div>
+
+      {/* Calls detail modal */}
+      <Dialog open={open === "calls"} onOpenChange={(v) => !v && close()}>
+        <DialogContent className="max-w-md">
+          <DialogTitle>Recent calls (7 days)</DialogTitle>
+          <div className="mt-4 space-y-1 max-h-72 overflow-y-auto">
+            {recentCalls.length === 0 ? (
+              <p className="text-sm text-text-subtle py-6 text-center">No calls this week.</p>
+            ) : (
+              recentCalls.map((call) => (
+                <div
+                  key={call.id}
+                  className="flex items-center justify-between rounded-lg px-3 py-2 bg-surface-muted"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm text-text truncate">{call.counterparty}</p>
+                    <p className="text-[11px] text-text-subtle">
+                      {call.channel} · {call.direction} · {formatRelative(call.startedAt)}
+                    </p>
+                  </div>
+                  <Badge tone={badgeTone(call.status)}>{call.status.replace("_", " ")}</Badge>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex gap-2 mt-5">
+            <Link href="/clinic/communications/transcripts" onClick={close}>
+              <Button size="sm" variant="secondary">All transcripts</Button>
+            </Link>
+            <Button size="sm" variant="ghost" onClick={close}>Close</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Faxes detail modal */}
+      <Dialog open={open === "faxes"} onOpenChange={(v) => !v && close()}>
+        <DialogContent className="max-w-md">
+          <DialogTitle>Recent faxes</DialogTitle>
+          <div className="mt-4 space-y-1 max-h-72 overflow-y-auto">
+            {recentFaxes.length === 0 ? (
+              <p className="text-sm text-text-subtle py-6 text-center">No fax activity.</p>
+            ) : (
+              recentFaxes.map((fax) => (
+                <div
+                  key={fax.id}
+                  className="flex items-center justify-between rounded-lg px-3 py-2 bg-surface-muted"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm text-text truncate">
+                      {fax.direction === "outbound" ? "→ " : "← "}
+                      {fax.toNumber}
+                      {fax.patientName && (
+                        <span className="text-text-subtle"> · {fax.patientName}</span>
+                      )}
+                    </p>
+                    <p className="text-[11px] text-text-subtle">
+                      {fax.pageCount ?? "?"} pages · {formatRelative(fax.createdAt)}
+                    </p>
+                  </div>
+                  <Badge tone={badgeTone(fax.status)}>{fax.status}</Badge>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex gap-2 mt-5">
+            <Link href="/clinic/communications/fax" onClick={close}>
+              <Button size="sm" variant="secondary">Open fax center</Button>
+            </Link>
+            <Button size="sm" variant="ghost" onClick={close}>Close</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Broadcasts detail modal */}
+      <Dialog open={open === "broadcasts"} onOpenChange={(v) => !v && close()}>
+        <DialogContent className="max-w-md">
+          <DialogTitle>Recent broadcasts</DialogTitle>
+          <div className="mt-4 space-y-1 max-h-72 overflow-y-auto">
+            {recentBroadcasts.length === 0 ? (
+              <p className="text-sm text-text-subtle py-6 text-center">No broadcasts yet.</p>
+            ) : (
+              recentBroadcasts.map((b) => (
+                <div
+                  key={b.id}
+                  className="flex items-center justify-between rounded-lg px-3 py-2 bg-surface-muted"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm text-text truncate">{b.name}</p>
+                    <p className="text-[11px] text-text-subtle">
+                      {b.channel.toUpperCase()} · {b.recipientCount} recipients ·{" "}
+                      {formatRelative(b.createdAt)}
+                    </p>
+                  </div>
+                  <Badge tone={badgeTone(b.status)}>{b.status}</Badge>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex gap-2 mt-5">
+            <Link href="/clinic/communications/broadcasts" onClick={close}>
+              <Button size="sm" variant="secondary">Open broadcasts</Button>
+            </Link>
+            <Button size="sm" variant="ghost" onClick={close}>Close</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/(clinician)/clinic/communications/page.tsx
+++ b/src/app/(clinician)/clinic/communications/page.tsx
@@ -13,10 +13,9 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { MetricTile } from "@/components/ui/metric-tile";
 import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { CommsRecentClient } from "./comms-recent-client";
+import { CommsSummaryModals } from "./comms-summary-modals.client";
 import { ChannelsDensityFrame } from "./channels-density-frame";
 import { OverlayWorkspace } from "./overlay-workspace.client";
 
@@ -117,64 +116,49 @@ export default async function CommunicationsPage() {
           and recent activity below are the original hub surface. */}
       <OverlayWorkspace />
 
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
-        {/* EMR-673 — each tile is a Link to its detail surface.
-            EMR-690 — labels use the all-caps spec; Zoom is now Beam. */}
-        <Link href="/clinic/communications/transcripts" className="block group">
-          <MetricTile
-            label="CALLS (7 DAYS)"
-            value={callsThisWeek}
-            accent="forest"
-            hint="Phone + video sessions logged"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-        <Link href="/clinic/communications/beam" className="block group">
-          <MetricTile
-            label="BEAM UPCOMING"
-            value={upcomingBeam}
-            accent={upcomingBeam > 0 ? "forest" : "none"}
-            hint="HIPAA-compliant Beam visits"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-        <Link href="/clinic/communications/voicemail" className="block group">
-          <MetricTile
-            label="NEW VOICEMAILS"
-            value={newVoicemails}
-            accent={newVoicemails > 0 ? "amber" : "none"}
-            hint="Awaiting clinician review"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-        <Link href="/clinic/communications/transcripts" className="block group">
-          <MetricTile
-            label="TRANSCRIPTS TO REVIEW"
-            value={pendingTranscripts}
-            accent={pendingTranscripts > 0 ? "amber" : "none"}
-            hint="Pertinent-info-only summaries"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-        <Link href="/clinic/communications/fax" className="block group">
-          <MetricTile
-            label="FAXES IN FLIGHT"
-            value={pendingFaxes}
-            accent={pendingFaxes > 0 ? "amber" : "none"}
-            hint="Queued or sending"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-        <Link href="/clinic/communications/broadcasts" className="block group">
-          <MetricTile
-            label="ACTIVE OUTREACH"
-            value={activeCampaigns}
-            accent="forest"
-            hint="SMS + email campaigns"
-            className="group-hover:ring-1 group-hover:ring-accent/30 transition-shadow"
-          />
-        </Link>
-      </div>
+      {/* EMR-673 — tiles with pre-fetched data open inline detail modals;
+          tiles without (Beam, Voicemail, Transcripts) navigate to their page. */}
+      <CommsSummaryModals
+        callsThisWeek={callsThisWeek}
+        upcomingBeam={upcomingBeam}
+        newVoicemails={newVoicemails}
+        pendingTranscripts={pendingTranscripts}
+        pendingFaxes={pendingFaxes}
+        activeCampaigns={activeCampaigns}
+        recentCalls={recentCalls.map((call) => ({
+          id: call.id,
+          counterparty: call.patient
+            ? `${call.patient.firstName} ${call.patient.lastName}`
+            : call.providerUser
+              ? `${call.providerUser.firstName} ${call.providerUser.lastName}`
+              : call.externalNumber ?? "Unknown",
+          patientId: call.patient?.id,
+          channel: call.channel,
+          direction: call.direction,
+          startedAt: call.startedAt.toISOString(),
+          status: call.status,
+        }))}
+        recentFaxes={recentFaxes.map((fax) => ({
+          id: fax.id,
+          toNumber: fax.toNumber,
+          patientId: fax.patient?.id,
+          patientName: fax.patient
+            ? `${fax.patient.firstName} ${fax.patient.lastName}`
+            : undefined,
+          direction: fax.direction,
+          pageCount: fax.pageCount,
+          createdAt: fax.createdAt.toISOString(),
+          status: fax.status,
+        }))}
+        recentBroadcasts={recentCampaigns.map((c) => ({
+          id: c.id,
+          name: c.name,
+          channel: c.channel,
+          recipientCount: c._count.recipients,
+          createdAt: c.createdAt.toISOString(),
+          status: c.status,
+        }))}
+      />
 
       <ChannelsDensityFrame>
         <ChannelCard
@@ -277,25 +261,30 @@ function ChannelCard({
   cta: string;
   highlight?: boolean;
 }) {
-  // When mounted inside `.density-dense`, collapse the default Card
-  // header/content padding so more channel tiles fit above the fold.
+  // EMR-673 — entire card is now the clickable region; the CTA pill is
+  // decorative (pointer-events handled by the outer Link).
   return (
-    <Card
-      tone={highlight ? "raised" : "default"}
-      className="[.density-dense_&]:[&_>div]:py-2 [.density-dense_&]:[&_>div]:px-4"
-    >
-      <CardHeader>
-        <CardTitle className="text-base">{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Link href={href}>
-          <Button variant={highlight ? "primary" : "secondary"} size="sm">
+    <Link href={href} className="block group h-full">
+      <Card
+        tone={highlight ? "raised" : "default"}
+        className="h-full transition-shadow group-hover:ring-1 group-hover:ring-accent/30 [.density-dense_&]:[&_>div]:py-2 [.density-dense_&]:[&_>div]:px-4"
+      >
+        <CardHeader>
+          <CardTitle className="text-base">{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <span
+            className={
+              highlight
+                ? "inline-flex items-center rounded-md bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent"
+                : "inline-flex items-center rounded-md border border-border bg-surface-muted px-3 py-1.5 text-xs font-medium text-text-subtle"
+            }
+          >
             {cta}
-          </Button>
-        </Link>
-      </CardContent>
-    </Card>
+          </span>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
-


### PR DESCRIPTION
Implements EMR-673.

## What changed
- **New `comms-summary-modals.client.tsx`** — client component that renders the MetricTile grid. The three tiles where the server already pre-fetches recent rows (Calls, Faxes, Broadcasts) now open inline detail modals instead of navigating away. The remaining three (Beam, Voicemail, Transcripts) keep their Link → full-page navigation since no per-item data is pre-fetched for them.
- **`page.tsx`** — swapped the static MetricTile+Link grid for `<CommsSummaryModals>`, passing the already-fetched `recentCalls`, `recentFaxes`, `recentCampaigns` arrays down to the client component. Removed unused `Button` and `MetricTile` imports.
- **`ChannelCard`** — entire card is now wrapped in a `<Link>`; the internal `Link`+`Button` was replaced with a decorative `<span>` pill so there are no nested anchor tags. Hover ring added to match the MetricTile affordance.

## How to verify
1. Navigate to `/clinic/communications`.
2. Click the **CALLS (7 DAYS)** tile — a modal listing the last 8 calls should appear with channel, direction, relative time, and status badge.
3. Click **FAXES IN FLIGHT** — modal shows recent faxes with direction arrows, page count, and patient name where available.
4. Click **ACTIVE OUTREACH** — modal shows recent broadcast campaigns.
5. Click **BEAM UPCOMING**, **NEW VOICEMAILS**, or **TRANSCRIPTS TO REVIEW** — these navigate to their full pages (no modal).
6. Click anywhere on a ChannelCard body (not just the CTA pill) — should navigate to the channel's page.
7. All modals dismiss via the ✕ button, Escape, or the backdrop click.

## Notes
- Follow-up: Beam, Voicemail, and Transcript tiles could get modals once their per-item data is plumbed through (requires fetching additional rows in the server component).

---
_Generated by [Claude Code](https://claude.ai/code/session_011QemqcqJNYfY4RA58Gq5TN)_