### PR TITLE
EMR-657: thread list rows — avatar + meds tooltip + name links to chart

### DIFF
--- a/src/app/(clinician)/clinic/messages/smart-inbox.tsx
+++ b/src/app/(clinician)/clinic/messages/smart-inbox.tsx
@@ -845,6 +845,8 @@ interface ThreadRowProps {
   isSelected: boolean;
   isPinned: boolean;
   childVariants: ReturnType<typeof listStaggerChild>;
+  /** EMR-657 — active meds for the hover tooltip on the patient avatar. */
+  meds: PatientMed[];
   onSelect: () => void;
   onTogglePin: () => void;
   onMarkRead: () => void;
@@ -858,6 +860,7 @@ function ThreadInboxRow({
   isSelected,
   isPinned,
   childVariants,
+  meds,
   onSelect,
   onTogglePin,
   onMarkRead,
@@ -905,6 +908,20 @@ function ThreadInboxRow({
         )}
       >
         <div className="flex items-start gap-3">
+          {/* EMR-657 — avatar with meds tooltip; click navigates to chart */}
+          <MedsTooltip meds={meds}>
+            <Link
+              href={`/clinic/patients/${t.patientId}`}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Open chart for ${t.patientName}`}
+            >
+              <Avatar
+                firstName={t.patientName.split(" ")[0] ?? ""}
+                lastName={t.patientName.split(" ")[1] ?? ""}
+                size="sm"
+              />
+            </Link>
+          </MedsTooltip>
           <div className="flex-1 min-w-0">
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0">
@@ -940,10 +957,15 @@ function ThreadInboxRow({
                     <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .013 2.371c-.125.612-.413 1.27-.978 1.834a.5.5 0 0 1-.707 0L5.95 11.756 1.854 15.85a.5.5 0 1 1-.708-.707L5.243 11.05 2.475 8.28a.5.5 0 0 1 0-.706c.565-.565 1.222-.853 1.834-.978a5.93 5.93 0 0 1 2.372.013l3.134-3.134a2.97 2.97 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
                   </svg>
                 </span>
+                {/* EMR-657 — clicking name opens the patient chart */}
                 <PatientHoverCard patientId={t.patientId}>
-                  <p className="text-sm font-semibold text-text truncate cursor-default">
+                  <Link
+                    href={`/clinic/patients/${t.patientId}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-sm font-semibold text-text truncate hover:text-accent hover:underline transition-colors"
+                  >
                     {t.patientName}
-                  </p>
+                  </Link>
                 </PatientHoverCard>
               </div>
               <div className="flex items-center gap-1.5 shrink-0">
@@ -1525,6 +1547,7 @@ export function SmartInboxView({
                       isSelected={isSelected}
                       isPinned={isPinned}
                       childVariants={childVariants}
+                      meds={patientMeds[t.patientId] ?? []}
                       onSelect={() => setSelectedThreadId(t.threadId)}
                       onTogglePin={() => togglePinned(t.threadId)}
                       onMarkRead={() => {


### PR DESCRIPTION
Implements EMR-657.

## What changed
- Added patient `Avatar` (initials circle) to every thread-list row in the left panel, wrapped in the existing `MedsTooltip` component — hovering the avatar shows the patient's active medications (pre-fetched server-side in `page.tsx`, already landed)
- Made the patient name in each thread-list row a `<Link>` navigating to `/clinic/patients/:id`, replacing the old `<p cursor-default>` non-interactive text. Both the avatar link and the name link call `e.stopPropagation()` so clicking them navigates to the chart rather than selecting the thread
- Added a `meds: PatientMed[]` prop to `ThreadRowProps` / `ThreadInboxRow`; passed down as `patientMeds[t.patientId] ?? []` at the call site in `SmartInboxView`
- The right-panel (detail view) already had these two features from a previous iteration; this PR adds them symmetrically to the left-panel thread list

**Already shipped in prior work (not re-implemented here):**
- Auto-save drafts — `localStorage` draft persistence in `InlineReplyCompose` (DRAFT_KEY pattern)
- Smart sort — `smartScore()` + pin-first comparator in the `filtered` memo

## How to verify
1. Navigate to `/clinic/messages`
2. In the left thread list, each row should now show a patient initials avatar on the left
3. Hover the avatar — a "Current Meds" tooltip should appear listing the patient's active medications (empty tooltip if patient has no active meds)
4. Click the avatar or the patient name — should navigate to `/clinic/patients/:id` without also selecting/changing the active thread

## Notes
- No schema changes; meds are fetched via an existing query in `page.tsx`
- The local git proxy returned 503 on every push attempt; file was pushed via the GitHub MCP `push_files` tool instead — content is identical to the local commit `a48d20c2`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM44C2fG8JgH9KXrWCpZUM)_