### PR TITLE
EMR-642: modal close pattern — LabOverlay migrated to ModalShell

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar } from "@/components/ui/avatar";
+import { ModalShell } from "@/components/ui/modal-shell";
 import { Printer } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { explainLabValue } from "@/lib/domain/lab-explainer";
@@ -426,61 +427,33 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
-      onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Lab review for ${row.patientFirstName} ${row.patientLastName}`}
+    <ModalShell
+      open
+      onClose={onClose}
+      title={`${row.patientFirstName} ${row.patientLastName}`}
+      eyebrow={row.panelName}
+      description={`Received ${fmtDate(row.receivedAt)}${row.prior ? ` · compared against ${fmtDate(row.prior.receivedAt)}` : ""}`}
+      placement="center"
+      maxWidth="max-w-3xl"
+      headerActions={
+        /* ux/print-stylesheets-clinical — open a server-rendered print view
+           in a new tab so the page lands as a clean clinical document with no
+           modal chrome. */
+        <Tooltip content="Print / Save as PDF">
+          <a
+            href={`/clinic/sign-off/labs/${row.id}/print`}
+            target="_blank"
+            rel="noopener"
+            className="text-text-subtle hover:text-text p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
+            aria-label="Print / Save as PDF"
+          >
+            <Printer className="h-4 w-4" aria-hidden="true" />
+          </a>
+        </Tooltip>
+      }
     >
-      <div
-        className="bg-bg rounded-2xl shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto border border-border"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="px-6 py-5 border-b border-border flex items-start justify-between gap-4 sticky top-0 bg-bg z-10">
-          <div>
-            <p className="text-xs uppercase tracking-wider text-text-subtle font-medium">
-              {row.panelName}
-            </p>
-            <h2 className="font-display text-2xl text-text tracking-tight mt-1">
-              {row.patientFirstName} {row.patientLastName}
-            </h2>
-            <p className="text-sm text-text-muted mt-1">
-              Received {fmtDate(row.receivedAt)}
-              {row.prior && ` · compared against ${fmtDate(row.prior.receivedAt)}`}
-            </p>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            {/* ux/print-stylesheets-clinical — open a server-rendered
-                print view in a new tab instead of printing the live overlay.
-                The dedicated route uses the shared PrintDocument frame so
-                the page lands on the printer as a clean clinical document
-                (no modal chrome, no batch tray, no glass blur). */}
-            <Tooltip content="Print / Save as PDF">
-              <a
-                href={`/clinic/sign-off/labs/${row.id}/print`}
-                target="_blank"
-                rel="noopener"
-                className="text-text-subtle hover:text-text p-1.5 rounded-lg hover:bg-surface-muted transition-colors"
-                aria-label="Print / Save as PDF"
-              >
-                <Printer className="h-4 w-4" aria-hidden="true" />
-              </a>
-            </Tooltip>
-            <button
-              onClick={onClose}
-              className="text-text-subtle hover:text-text text-xl leading-none px-2"
-              aria-label="Close"
-            >
-              &times;
-            </button>
-          </div>
-        </div>
-
-        {/* Body */}
-        <div className="px-6 py-5 space-y-6">
-          {/* Values table */}
+      <div className="px-6 py-5 space-y-6">
+        {/* Values table */}
           <section>
             <h3 className="text-sm font-semibold text-text mb-3">Results</h3>
             <div className="rounded-xl border border-border overflow-hidden">
@@ -719,8 +692,7 @@ function LabOverlay({ row, onClose }: { row: LabRow; onClose: () => void }) {
             />
           </section>
         </div>
-      </div>
-    </div>
+    </ModalShell>
   );
 }
 

--- a/src/components/ui/modal-shell.tsx
+++ b/src/components/ui/modal-shell.tsx
@@ -35,6 +35,8 @@ export interface ModalShellProps {
   className?: string;
   /** Optional sticky footer rendered below the scrollable body. */
   footer?: React.ReactNode;
+  /** Optional actions placed between the title block and the X button. */
+  headerActions?: React.ReactNode;
   children?: React.ReactNode;
 }
 
@@ -49,6 +51,7 @@ export function ModalShell({
   maxWidth = "max-w-lg",
   className,
   footer,
+  headerActions,
   children,
 }: ModalShellProps) {
   const titleId = useId();
@@ -136,19 +139,22 @@ export function ModalShell({
             )}
           </div>
 
-          {/* Visible X close button — EMR-642 */}
-          <button
-            type="button"
-            onClick={requestClose}
-            aria-label="Close"
-            className={cn(
-              "shrink-0 h-8 w-8 rounded-full flex items-center justify-center",
-              "bg-surface-muted hover:bg-surface-raised text-text-muted hover:text-text",
-              "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
-            )}
-          >
-            <X className="w-4 h-4" aria-hidden="true" />
-          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            {headerActions}
+            {/* Visible X close button — EMR-642 */}
+            <button
+              type="button"
+              onClick={requestClose}
+              aria-label="Close"
+              className={cn(
+                "h-8 w-8 rounded-full flex items-center justify-center",
+                "bg-surface-muted hover:bg-surface-raised text-text-muted hover:text-text",
+                "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
+              )}
+            >
+              <X className="w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
         </div>
 
         {/* ── Discard confirmation bar — shown when isDirty + requestClose ─ */}


### PR DESCRIPTION
Implements EMR-642.

## What changed

- **`src/components/ui/modal-shell.tsx`** — Added a `headerActions?: React.ReactNode` slot between the title block and the canonical X close button. This lets callers (like the lab overlay) place icon-button actions in the header without breaking the guaranteed X-always-visible invariant.

- **`src/app/(clinician)/clinic/sign-off/labs/labs-review-view.tsx`** — Migrated `LabOverlay` from the old ad-hoc pattern (raw `div` backdrop + `&times;` character button) to `ModalShell`. The overlay now gets:
  - Proper `<X>` icon close button (lucide) instead of the `&times;` character
  - Escape-key dismiss (handled by ModalShell's `useEffect`)
  - `body-overflow: hidden` scroll lock while open
  - `isDirty` guard ready to wire up if editable draft state needs a "Discard?" confirmation
  - Print link preserved via `headerActions`

Net: −22 LOC (47 added, 69 removed across 2 files).

## How to verify

1. Go to `/clinic/sign-off/labs` and click **Review** on any lab row.
2. Confirm the overlay opens with a visible circular **X** button in the top-right (not a bare `×` glyph).
3. Click the printer icon — should open the print route in a new tab.
4. Press **Escape** — overlay should close.
5. Click outside the modal card — overlay should close.
6. No visual regression on the rest of the labs-review list or batch-sign tray.

## Notes

- `ModalShell` was already shipping in main (also from EMR-642 work). This PR adds the `headerActions` extension and applies the pattern to the one surface that still had the old `&times;` close glyph.
- Follow-up: other raw-div modals (`ContraindicationWarning`, `FeedbackWidget`, `DosingGuideDisclaimer`) can be migrated in a subsequent sweep once the pattern is validated here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfWc8kVycC2fs1k9tNCuVS)_