### PR TITLE
EMR-640: whisper FAB — success toast names Scott & Neal explicitly

### DIFF
--- a/src/components/feedback/UniversalFeedbackFab.tsx
+++ b/src/components/feedback/UniversalFeedbackFab.tsx
@@ -87,7 +87,7 @@ export function UniversalFeedbackFab() {
       setState("thanks");
       toast({
         title: "Thanks for the whisper",
-        description: "We'll route it to the right team.",
+        description: "On its way to Scott & Neal.",
         variant: "success",
       });
       setTimeout(close, 2500);


### PR DESCRIPTION
Implements EMR-640.

## What changed
- `UniversalFeedbackFab.tsx`: success toast description changed from `"We'll route it to the right team."` → `"On its way to Scott & Neal."`, consistent with the modal header copy `"Goes straight to Scott & Neal. No bots in between."`

## Context
The backend routing for EMR-640 was already shipped to `main` (route always fans out to `scott@leafjourney.com` + `neal@leafjourney.com` as `To:`, with area-specialised inboxes demoted to `Cc:`). This PR closes the UX gap: the submit confirmation toast now matches the promise shown in the modal header, so the full submit journey ("goes to Scott & Neal" → submit → "on its way to Scott & Neal") is internally consistent.

## How to verify
1. Open any page in the app.
2. Click the green 🌱 FAB in the bottom-right corner.
3. Select a topic, enter ≥ 5 characters, click **Send whisper**.
4. Confirm the toast says **"On its way to Scott & Neal."** (previously said "We'll route it to the right team.").

## Notes
- No backend changes — `src/app/api/feedback/whisper/route.ts` already implements unconditional founder routing with rate-limiting and structured logging.
- Follow-up: wire up multipart support so screenshot attachments actually upload (noted as TODO in the FAB; separate ticket scope).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbWP7qqbipR75eM7GHNTbn)_