### PR TITLE
feat(scheduling): wire 5 engine-but-no-UI cards into real surfaces (EMR-207/208/209/211/214)

### DIFF
--- a/src/app/(clinician)/clinic/scheduling/follow-up/follow-up-cadence.tsx
+++ b/src/app/(clinician)/clinic/scheduling/follow-up/follow-up-cadence.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+/**
+ * EMR-208 — Algorithmic follow-up cadence selector.
+ *
+ * Thin UI over the pure cadence engine (`@/lib/scheduling/cadence-engine`).
+ * The clinician picks a condition + treatment phase (and, optionally, the
+ * patient's state + cert age and a manual override); the engine returns the
+ * recommended interval, modality, and rationale, plus the computed next-due
+ * date. "Schedule this follow-up" hands the recommended interval to the
+ * scheduler via query params so the booking is pre-filled.
+ *
+ * The engine is a pure function, so all of this runs client-side with no
+ * server round-trip.
+ */
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  recommendCadence,
+  nextDueDate,
+  ConditionCategorySchema,
+  TreatmentPhaseSchema,
+  type ConditionCategory,
+  type TreatmentPhase,
+} from "@/lib/scheduling/cadence-engine";
+
+const INPUT_CLASS =
+  "flex w-full rounded-xl border border-border-strong bg-white px-3 h-11 text-sm text-text " +
+  "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20";
+const LABEL_CLASS =
+  "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
+
+const MODALITY_LABEL: Record<string, string> = {
+  video: "Video visit",
+  phone: "Phone call",
+  in_person: "In-person",
+  async_message: "Secure message",
+};
+
+function titleCase(s: string): string {
+  return s.replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
+}
+
+function todayISO(): string {
+  const d = new Date();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+export function FollowUpCadence({ patientId }: { patientId?: string }) {
+  const router = useRouter();
+  const conditions = ConditionCategorySchema.options;
+  const phases = TreatmentPhaseSchema.options;
+
+  const [condition, setCondition] = useState<ConditionCategory>("chronic_pain");
+  const [phase, setPhase] = useState<TreatmentPhase>("titration");
+  const [patientState, setPatientState] = useState("");
+  const [daysSinceCert, setDaysSinceCert] = useState<string>("");
+  const [overrideDays, setOverrideDays] = useState<string>("");
+  const [lastVisit, setLastVisit] = useState<string>(todayISO());
+
+  const rec = useMemo(() => {
+    const override = overrideDays.trim() === "" ? undefined : Number(overrideDays);
+    return recommendCadence({
+      condition,
+      phase,
+      patientState: patientState.trim() === "" ? null : patientState.trim().toUpperCase(),
+      daysSinceCertIssued: daysSinceCert.trim() === "" ? null : Number(daysSinceCert),
+      clinicianOverrideDays:
+        override !== undefined && Number.isFinite(override) && override > 0
+          ? override
+          : undefined,
+    });
+  }, [condition, phase, patientState, daysSinceCert, overrideDays]);
+
+  const due = useMemo(() => {
+    const base = new Date(`${lastVisit}T12:00:00`);
+    if (Number.isNaN(base.getTime())) return null;
+    return nextDueDate(base, rec);
+  }, [lastVisit, rec]);
+
+  function scheduleFollowUp() {
+    const params = new URLSearchParams();
+    params.set("followUpDays", String(rec.intervalDays));
+    params.set("modality", rec.modality);
+    if (patientId) params.set("patientId", patientId);
+    router.push(`/clinic/schedule?${params.toString()}`);
+  }
+
+  return (
+    <div className="grid gap-5 md:grid-cols-2">
+      {/* Inputs */}
+      <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base">Visit context</CardTitle>
+          <CardDescription>
+            Pick the condition and current treatment phase. The cadence engine
+            encodes the practice&apos;s standard of care per condition.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <label className={LABEL_CLASS} htmlFor="cad-condition">Condition</label>
+            <select
+              id="cad-condition"
+              value={condition}
+              onChange={(e) => setCondition(e.target.value as ConditionCategory)}
+              className={INPUT_CLASS}
+            >
+              {conditions.map((c) => (
+                <option key={c} value={c}>{titleCase(c)}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={LABEL_CLASS} htmlFor="cad-phase">Treatment phase</label>
+            <select
+              id="cad-phase"
+              value={phase}
+              onChange={(e) => setPhase(e.target.value as TreatmentPhase)}
+              className={INPUT_CLASS}
+            >
+              {phases.map((p) => (
+                <option key={p} value={p}>{titleCase(p)}</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL_CLASS} htmlFor="cad-state">Patient state</label>
+              <input
+                id="cad-state"
+                value={patientState}
+                onChange={(e) => setPatientState(e.target.value)}
+                placeholder="CA"
+                maxLength={2}
+                className={INPUT_CLASS}
+              />
+            </div>
+            <div>
+              <label className={LABEL_CLASS} htmlFor="cad-cert">Days since cert</label>
+              <input
+                id="cad-cert"
+                value={daysSinceCert}
+                onChange={(e) => setDaysSinceCert(e.target.value.replace(/[^0-9]/g, ""))}
+                placeholder="—"
+                inputMode="numeric"
+                className={INPUT_CLASS}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL_CLASS} htmlFor="cad-last">Last visit</label>
+              <input
+                id="cad-last"
+                type="date"
+                value={lastVisit}
+                onChange={(e) => setLastVisit(e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </div>
+            <div>
+              <label className={LABEL_CLASS} htmlFor="cad-override">Override (days)</label>
+              <input
+                id="cad-override"
+                value={overrideDays}
+                onChange={(e) => setOverrideDays(e.target.value.replace(/[^0-9]/g, ""))}
+                placeholder="auto"
+                inputMode="numeric"
+                className={INPUT_CLASS}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Recommendation */}
+      <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            Recommended cadence
+            {rec.inPersonRequired && (
+              <Badge tone="warning" className="text-[10px]">In-person required</Badge>
+            )}
+          </CardTitle>
+          <CardDescription>Auto-computed from the visit context.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-baseline gap-6">
+            <div>
+              <p className="font-display text-4xl text-accent tabular-nums">
+                {rec.intervalDays}
+              </p>
+              <p className="text-xs text-text-muted mt-1">days to next visit</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-text">
+                {MODALITY_LABEL[rec.modality] ?? rec.modality}
+              </p>
+              <p className="text-xs text-text-muted mt-1">recommended modality</p>
+            </div>
+          </div>
+
+          {due && (
+            <div className="rounded-lg bg-surface-muted/50 border border-border/60 px-3 py-2">
+              <p className="text-xs text-text-muted">
+                Next due{" "}
+                <span className="font-medium text-text">
+                  {due.dueAt.toLocaleDateString("en-US", {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </span>
+                {due.overdue && (
+                  <Badge tone="danger" className="text-[10px] ml-2">
+                    {due.daysOverdue}d overdue
+                  </Badge>
+                )}
+              </p>
+            </div>
+          )}
+
+          <p className="text-[12px] leading-relaxed text-text-subtle">
+            {rec.rationale}
+          </p>
+
+          <Button type="button" onClick={scheduleFollowUp} className="w-full">
+            Schedule this follow-up →
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/scheduling/follow-up/page.tsx
+++ b/src/app/(clinician)/clinic/scheduling/follow-up/page.tsx
@@ -1,0 +1,34 @@
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { FollowUpCadence } from "./follow-up-cadence";
+
+export const metadata = { title: "Follow-up cadence" };
+
+/**
+ * EMR-208 — Algorithmic follow-up cadence.
+ *
+ * Hosts the condition/phase cadence selector. Reachable at
+ * /clinic/scheduling/follow-up (optionally ?patientId=…). Like the provider
+ * settings page, the layout-nav link is intentionally deferred so we don't
+ * edit shared layout files here — the page is linked from the scheduler.
+ */
+export default async function FollowUpCadencePage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await requireUser();
+  const sp = (await searchParams) ?? {};
+  const patientId = Array.isArray(sp.patientId) ? sp.patientId[0] : sp.patientId;
+
+  return (
+    <PageShell maxWidth="max-w-[860px]">
+      <PageHeader
+        eyebrow="Scheduling"
+        title="Follow-up cadence"
+        description="Condition-specific follow-up recommendations, auto-computed from the practice standard of care."
+      />
+      <FollowUpCadence patientId={patientId} />
+    </PageShell>
+  );
+}

--- a/src/app/(clinician)/clinic/scheduling/recommend/page.tsx
+++ b/src/app/(clinician)/clinic/scheduling/recommend/page.tsx
@@ -1,0 +1,123 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import {
+  SlotRecommenderPanel,
+  type SerializedCandidate,
+} from "./slot-recommender-panel";
+
+export const metadata = { title: "Slot recommender" };
+
+/**
+ * EMR-209 — Smart slot recommender.
+ *
+ * Loads the clinic's open slots across active providers (synthetic 14-day
+ * grid minus booked, same source the booking funnel uses) with a computed
+ * slot-value, then hands them to the recommender panel which ranks them
+ * against an operator-tuned patient context.
+ *
+ * Reachable at /clinic/scheduling/recommend. Layout-nav link deferred to keep
+ * shared layout files untouched (see provider settings page note).
+ */
+export default async function SlotRecommenderPage() {
+  const user = await requireUser();
+  const orgId = user.organizationId!;
+
+  const providers = await prisma.provider.findMany({
+    where: { organizationId: orgId, active: true },
+    include: { user: { select: { firstName: true, lastName: true } } },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const horizonStart = new Date();
+  horizonStart.setHours(0, 0, 0, 0);
+  const horizonEnd = new Date(horizonStart);
+  horizonEnd.setDate(horizonEnd.getDate() + 14);
+
+  const booked = await prisma.appointment.findMany({
+    where: {
+      patient: { organizationId: orgId },
+      startAt: { gte: horizonStart, lt: horizonEnd },
+      status: { in: ["requested", "confirmed"] },
+    },
+    select: { providerId: true, startAt: true },
+  });
+  const bookedKeys = new Set(
+    booked
+      .filter((b) => b.providerId)
+      .map((b) => `${b.providerId}|${b.startAt.toISOString()}`),
+  );
+
+  const providerList = providers.map((p) => ({
+    id: p.id,
+    name: `${p.user.firstName} ${p.user.lastName}`.trim() || "Provider",
+  }));
+
+  const candidates = buildCandidates(providerList, horizonStart, bookedKeys);
+
+  return (
+    <PageShell maxWidth="max-w-[920px]">
+      <PageHeader
+        eyebrow="Scheduling"
+        title="Smart slot recommender"
+        description="Open slots ranked for a patient by continuity, no-show fit, and preferences."
+      />
+      <SlotRecommenderPanel candidates={candidates} providers={providerList} />
+    </PageShell>
+  );
+}
+
+/**
+ * Build candidate slots from a synthetic 14-day grid (weekdays, 9a–5p, 30-min),
+ * masking booked starts and capping the payload. `slotValue` (0..1) reflects
+ * how much the clinic loses if the slot no-shows: prime midday weekday > early
+ * or late or Friday slots.
+ */
+function buildCandidates(
+  providers: { id: string; name: string }[],
+  start: Date,
+  bookedKeys: Set<string>,
+): SerializedCandidate[] {
+  const out: SerializedCandidate[] = [];
+  const PER_PROVIDER_CAP = 30;
+
+  for (const provider of providers) {
+    let count = 0;
+    for (let d = 0; d < 14 && count < PER_PROVIDER_CAP; d++) {
+      const day = new Date(start);
+      day.setDate(day.getDate() + d);
+      const dow = day.getDay();
+      if (dow === 0 || dow === 6) continue; // weekdays only in the synthetic grid
+      for (let hour = 9; hour < 17 && count < PER_PROVIDER_CAP; hour++) {
+        for (const minute of [0, 30]) {
+          const slot = new Date(day);
+          slot.setHours(hour, minute, 0, 0);
+          if (slot.getTime() <= Date.now()) continue;
+          const iso = slot.toISOString();
+          if (bookedKeys.has(`${provider.id}|${iso}`)) continue;
+          const end = new Date(slot.getTime() + 30 * 60_000);
+          out.push({
+            slotId: `${provider.id}|${iso}`,
+            providerId: provider.id,
+            providerName: provider.name,
+            startAt: iso,
+            endAt: end.toISOString(),
+            modality: "video",
+            slotValue: slotValueFor(hour, dow),
+          });
+          count++;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function slotValueFor(hour: number, dayOfWeek: number): number {
+  let v = 0.5;
+  if (hour >= 10 && hour < 14) v += 0.2; // prime midday
+  if (dayOfWeek >= 2 && dayOfWeek <= 4) v += 0.15; // Tue–Thu
+  if (hour < 9 || hour >= 16) v -= 0.15; // early / late
+  if (dayOfWeek === 5) v -= 0.1; // Friday drift
+  return Math.max(0, Math.min(1, Math.round(v * 100) / 100));
+}

--- a/src/app/(clinician)/clinic/scheduling/recommend/slot-recommender-panel.tsx
+++ b/src/app/(clinician)/clinic/scheduling/recommend/slot-recommender-panel.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+/**
+ * EMR-209 — Smart slot recommender panel.
+ *
+ * Ranks the clinic's open slots for a patient using the pure recommender
+ * (`@/lib/scheduling/slot-recommender`). Candidate slots (with a computed
+ * slot-value) are loaded server-side and passed in; the operator tunes the
+ * patient context (risk tier, preferred provider/modality/time) and the panel
+ * re-ranks live, showing the top matches with the reasons each scored.
+ */
+
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { rankSlots, type CandidateSlot } from "@/lib/scheduling/slot-recommender";
+import type { RiskTier } from "@/lib/scheduling/no-show-model";
+import type { Modality } from "@/lib/scheduling/cadence-engine";
+
+export type SerializedCandidate = {
+  slotId: string;
+  providerId: string;
+  providerName: string;
+  startAt: string; // ISO
+  endAt: string; // ISO
+  modality: Modality;
+  slotValue: number;
+};
+
+const LABEL_CLASS =
+  "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
+const INPUT_CLASS =
+  "flex w-full rounded-xl border border-border-strong bg-white px-3 h-11 text-sm text-text " +
+  "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20";
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function SlotRecommenderPanel({
+  candidates,
+  providers,
+}: {
+  candidates: SerializedCandidate[];
+  providers: { id: string; name: string }[];
+}) {
+  const [riskTier, setRiskTier] = useState<RiskTier>("low");
+  const [preferredProviderId, setPreferredProviderId] = useState<string>("");
+  const [continuity, setContinuity] = useState(true);
+  const [preferredModality, setPreferredModality] = useState<Modality | "">("");
+  const [earliestHour, setEarliestHour] = useState<number>(9);
+  const [latestHour, setLatestHour] = useState<number>(17);
+  const [preferredDays, setPreferredDays] = useState<number[]>([]);
+
+  const rehydrated = useMemo<CandidateSlot[]>(
+    () =>
+      candidates.map((c) => ({
+        slotId: c.slotId,
+        providerId: c.providerId,
+        startAt: new Date(c.startAt),
+        endAt: new Date(c.endAt),
+        modality: c.modality,
+        slotValue: c.slotValue,
+      })),
+    [candidates],
+  );
+
+  const providerName = useMemo(() => {
+    const map = new Map(providers.map((p) => [p.id, p.name]));
+    return (id: string) => map.get(id) ?? "Provider";
+  }, [providers]);
+
+  const ranked = useMemo(() => {
+    return rankSlots(
+      rehydrated,
+      {
+        patientId: "preview",
+        preferredProviderId: preferredProviderId || null,
+        lastVisitProviderId: continuity ? preferredProviderId || null : null,
+        riskTier,
+        preferredDaysOfWeek: preferredDays,
+        preferredHours: { earliestHour, latestHour },
+        preferredModality: preferredModality || null,
+        dueAt: null,
+        overdueGraceDays: 14,
+        providerLockedTo: null,
+      },
+      { limit: 6 },
+    );
+  }, [
+    rehydrated,
+    preferredProviderId,
+    continuity,
+    riskTier,
+    preferredDays,
+    earliestHour,
+    latestHour,
+    preferredModality,
+  ]);
+
+  function toggleDay(d: number) {
+    setPreferredDays((days) =>
+      days.includes(d) ? days.filter((x) => x !== d) : [...days, d],
+    );
+  }
+
+  return (
+    <div className="grid gap-5 md:grid-cols-2">
+      {/* Patient context controls */}
+      <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base">Patient context</CardTitle>
+          <CardDescription>
+            Tune the inputs the recommender weighs. High-risk patients are
+            steered toward lower-value (off-peak) slots automatically.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL_CLASS} htmlFor="rec-risk">No-show risk</label>
+              <select
+                id="rec-risk"
+                value={riskTier}
+                onChange={(e) => setRiskTier(e.target.value as RiskTier)}
+                className={INPUT_CLASS}
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+            </div>
+            <div>
+              <label className={LABEL_CLASS} htmlFor="rec-modality">Preferred modality</label>
+              <select
+                id="rec-modality"
+                value={preferredModality}
+                onChange={(e) => setPreferredModality(e.target.value as Modality | "")}
+                className={INPUT_CLASS}
+              >
+                <option value="">No preference</option>
+                <option value="video">Video</option>
+                <option value="phone">Phone</option>
+                <option value="in_person">In-person</option>
+                <option value="async_message">Secure message</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className={LABEL_CLASS} htmlFor="rec-provider">Preferred provider</label>
+            <select
+              id="rec-provider"
+              value={preferredProviderId}
+              onChange={(e) => setPreferredProviderId(e.target.value)}
+              className={INPUT_CLASS}
+            >
+              <option value="">No preference</option>
+              {providers.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={continuity}
+              onChange={(e) => setContinuity(e.target.checked)}
+              className="h-4 w-4 accent-[color:var(--accent)]"
+            />
+            <span className="text-sm text-text">Same provider as last visit (continuity)</span>
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL_CLASS} htmlFor="rec-earliest">Earliest hour</label>
+              <input
+                id="rec-earliest"
+                type="number"
+                min={0}
+                max={23}
+                value={earliestHour}
+                onChange={(e) => setEarliestHour(clampHour(e.target.value))}
+                className={INPUT_CLASS}
+              />
+            </div>
+            <div>
+              <label className={LABEL_CLASS} htmlFor="rec-latest">Latest hour</label>
+              <input
+                id="rec-latest"
+                type="number"
+                min={0}
+                max={23}
+                value={latestHour}
+                onChange={(e) => setLatestHour(clampHour(e.target.value))}
+                className={INPUT_CLASS}
+              />
+            </div>
+          </div>
+
+          <div>
+            <span className={LABEL_CLASS}>Preferred days</span>
+            <div className="flex flex-wrap gap-1.5">
+              {DAYS.map((label, d) => (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => toggleDay(d)}
+                  aria-pressed={preferredDays.includes(d)}
+                  className={
+                    "text-[11px] px-2.5 py-1 rounded-full border transition-colors " +
+                    (preferredDays.includes(d)
+                      ? "border-accent/50 bg-accent/10 text-accent font-medium"
+                      : "border-border text-text-muted")
+                  }
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Ranked recommendations */}
+      <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base">Recommended slots</CardTitle>
+          <CardDescription>
+            {candidates.length} open slots ranked. Top {ranked.length} shown.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {ranked.length === 0 ? (
+            <p className="text-sm text-text-subtle italic py-6 text-center">
+              No open slots match the current constraints.
+            </p>
+          ) : (
+            <ol className="space-y-2">
+              {ranked.map((slot, i) => (
+                <li
+                  key={slot.slotId}
+                  className="rounded-xl border border-border/60 px-3 py-2.5 hover:border-accent/40 transition-colors"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-text">
+                        {new Date(slot.startAt).toLocaleDateString("en-US", {
+                          weekday: "short",
+                          month: "short",
+                          day: "numeric",
+                        })}{" "}
+                        <span className="tabular-nums">
+                          {new Date(slot.startAt).toLocaleTimeString("en-US", {
+                            hour: "numeric",
+                            minute: "2-digit",
+                          })}
+                        </span>
+                      </p>
+                      <p className="text-[11px] text-text-muted truncate">
+                        {providerName(slot.providerId)}
+                      </p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="font-display text-lg text-accent tabular-nums">
+                        {Math.round(slot.score * 100)}
+                      </p>
+                      <p className="text-[9px] text-text-subtle">match</p>
+                    </div>
+                  </div>
+                  {slot.reasons.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1.5">
+                      {slot.reasons.map((r) => (
+                        <Badge key={r} tone="neutral" className="text-[9px]">{r}</Badge>
+                      ))}
+                    </div>
+                  )}
+                  {i === 0 && (
+                    <Badge tone="success" className="text-[9px] mt-1.5">Top pick</Badge>
+                  )}
+                </li>
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function clampHour(v: string): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 9;
+  return Math.max(0, Math.min(23, Math.round(n)));
+}

--- a/src/app/(clinician)/clinic/settings/burnout-guardrails-form.tsx
+++ b/src/app/(clinician)/clinic/settings/burnout-guardrails-form.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+/**
+ * EMR-214 — Provider burnout guardrails (prefs INTERIM, localStorage-backed).
+ *
+ * Editor for the per-provider scheduling caps the slot recommender / waitlist
+ * consult before placing a visit (max/day, max/week, buffer, protected lunch,
+ * high-intensity cap, same-day add-ons), plus a live burnout index computed by
+ * the real engine (`@/lib/scheduling/provider-prefs`) against the provider's
+ * actual last-14-day load (passed in from the server).
+ *
+ * Interim notice: the caps persist to this browser's localStorage only (no
+ * schema change). The burnout index itself is real — it reads loaded
+ * appointment data — but `highIntensityVisits` is not yet derived from visit
+ * type, so that single component reads 0 until visit-type tagging lands.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  burnoutIndex,
+  DEFAULT_PROVIDER_PREFS,
+  type ProviderPrefs,
+  type DayLoad,
+} from "@/lib/scheduling/provider-prefs";
+
+const LABEL_CLASS =
+  "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
+const INPUT_CLASS =
+  "flex w-full rounded-xl border border-border-strong bg-white px-3 h-11 text-sm text-text " +
+  "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20";
+
+/** DayLoad with the Date serialized for the server→client boundary. */
+export type SerializedDayLoad = Omit<DayLoad, "day"> & { day: string };
+
+type StoredPrefs = Omit<ProviderPrefs, "providerId">;
+
+function storageKey(providerId: string) {
+  return `provider-prefs:${providerId}:v1`;
+}
+
+const LEVEL_TONE: Record<"green" | "yellow" | "red", "success" | "warning" | "danger"> = {
+  green: "success",
+  yellow: "warning",
+  red: "danger",
+};
+
+const COMPONENT_LABEL: Record<string, string> = {
+  saturation: "Daily load",
+  intensity: "High-intensity mix",
+  overrun: "After-hours overrun",
+  selfReport: "Self-reported",
+  docLag: "Documentation lag",
+};
+
+export function BurnoutGuardrailsForm({
+  providerId,
+  fortnight,
+}: {
+  providerId: string;
+  fortnight: SerializedDayLoad[];
+}) {
+  const key = storageKey(providerId);
+  const [prefs, setPrefs] = useState<StoredPrefs>(DEFAULT_PROVIDER_PREFS);
+  const [justSaved, setJustSaved] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) setPrefs({ ...DEFAULT_PROVIDER_PREFS, ...(JSON.parse(raw) as StoredPrefs) });
+    } catch {
+      /* corrupt / private mode — keep defaults */
+    }
+  }, [key]);
+
+  function updateNum(field: keyof StoredPrefs, value: number) {
+    setPrefs((p) => ({ ...p, [field]: value }));
+  }
+
+  function save() {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(prefs));
+      setJustSaved(true);
+      setTimeout(() => setJustSaved(false), 2500);
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  const rehydrated = useMemo<DayLoad[]>(
+    () => fortnight.map((d) => ({ ...d, day: new Date(d.day) })),
+    [fortnight],
+  );
+
+  const burnout = useMemo(
+    () => burnoutIndex({ ...prefs, providerId }, rehydrated),
+    [prefs, providerId, rehydrated],
+  );
+
+  const scorePct = Math.round(burnout.score * 100);
+
+  return (
+    <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Burnout guardrails
+          <Badge tone={LEVEL_TONE[burnout.level]} className="text-[10px] capitalize">
+            {burnout.level}
+          </Badge>
+          {justSaved && <Badge tone="success" className="text-[10px]">Saved ✓</Badge>}
+        </CardTitle>
+        <CardDescription>
+          Scheduling caps the recommender enforces, plus your live burnout index
+          from the last 14 days of load.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* Burnout index */}
+        <div className="rounded-xl border border-border/60 bg-surface-muted/40 px-4 py-4">
+          <div className="flex items-baseline gap-3">
+            <p
+              className={
+                "font-display text-4xl tabular-nums " +
+                (burnout.level === "red"
+                  ? "text-danger"
+                  : burnout.level === "yellow"
+                    ? "text-[color:var(--warning)]"
+                    : "text-success")
+              }
+            >
+              {scorePct}
+            </p>
+            <p className="text-xs text-text-muted">burnout index / 100</p>
+          </div>
+          <div className="mt-3 space-y-1.5">
+            {Object.entries(burnout.components).map(([k, v]) => (
+              <div key={k} className="flex items-center gap-2">
+                <span className="text-[11px] text-text-muted w-36 shrink-0">
+                  {COMPONENT_LABEL[k] ?? k}
+                </span>
+                <div className="flex-1 h-1.5 rounded-full bg-surface-muted overflow-hidden">
+                  <div
+                    className="h-full bg-accent/60 rounded-full"
+                    style={{ width: `${Math.round(Math.min(1, v) * 100)}%` }}
+                  />
+                </div>
+                <span className="text-[10px] text-text-subtle tabular-nums w-8 text-right">
+                  {Math.round(v * 100)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Caps editor */}
+        <div className="grid grid-cols-2 gap-3">
+          <NumField label="Max patients / day" value={prefs.maxPatientsPerDay} min={1} max={40}
+            onChange={(v) => updateNum("maxPatientsPerDay", v)} />
+          <NumField label="Max patients / week" value={prefs.maxPatientsPerWeek} min={1} max={160}
+            onChange={(v) => updateNum("maxPatientsPerWeek", v)} />
+          <NumField label="Buffer between visits (min)" value={prefs.minBufferMinutes} min={0} max={60}
+            onChange={(v) => updateNum("minBufferMinutes", v)} />
+          <NumField label="Protected lunch (min)" value={prefs.lunchMinutes} min={0} max={120}
+            onChange={(v) => updateNum("lunchMinutes", v)} />
+          <NumField label="Max high-intensity / day" value={prefs.maxHighIntensityPerDay} min={0} max={20}
+            onChange={(v) => updateNum("maxHighIntensityPerDay", v)} />
+          <NumField label="Self-reported burnout (0–10)" value={prefs.selfReportedBurnout ?? 0} min={0} max={10}
+            onChange={(v) => setPrefs((p) => ({ ...p, selfReportedBurnout: v }))} />
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={prefs.acceptsSameDayAddons}
+            onChange={(e) => setPrefs((p) => ({ ...p, acceptsSameDayAddons: e.target.checked }))}
+            className="h-4 w-4 accent-[color:var(--accent)]"
+          />
+          <span className="text-sm text-text">Accept urgent same-day add-ons</span>
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <NumField label="Work start (hour)" value={prefs.workHours.startHour} min={0} max={23}
+            onChange={(v) => setPrefs((p) => ({ ...p, workHours: { ...p.workHours, startHour: v } }))} />
+          <NumField label="Work end (hour)" value={prefs.workHours.endHour} min={0} max={23}
+            onChange={(v) => setPrefs((p) => ({ ...p, workHours: { ...p.workHours, endHour: v } }))} />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button type="button" onClick={save}>
+            {justSaved ? "Saved ✓" : "Save guardrails"}
+          </Button>
+        </div>
+
+        <p className="text-[11px] leading-relaxed text-text-subtle rounded-lg bg-surface-muted/60 border border-border/60 px-3 py-2">
+          <span className="font-semibold">Interim storage notice:</span> caps save
+          to this browser&apos;s localStorage only (no schema change). The burnout
+          index reads real loaded appointment data; the high-intensity component
+          reads 0 until visit-type tagging lands.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function NumField({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <label className={LABEL_CLASS}>{label}</label>
+      <input
+        type="number"
+        value={value}
+        min={min}
+        max={max}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (Number.isFinite(n)) onChange(Math.max(min, Math.min(max, Math.round(n))));
+        }}
+        className={INPUT_CLASS}
+      />
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/settings/page.tsx
+++ b/src/app/(clinician)/clinic/settings/page.tsx
@@ -1,35 +1,121 @@
+import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { CuresCredentialsForm } from "./cures-credentials-form";
+import { ReminderPreferencesForm } from "./reminder-preferences-form";
+import {
+  BurnoutGuardrailsForm,
+  type SerializedDayLoad,
+} from "./burnout-guardrails-form";
 
 export const metadata = { title: "Provider settings" };
 
 /**
- * EMR-889 — Provider settings.
+ * EMR-889 / EMR-211 / EMR-214 — Provider settings.
  *
- * Currently hosts the CURES (PDMP) opt-in so a prescriber can store their
- * CURES credentials, which the controlled-substance prescribe flow links to.
+ * Hosts the CURES (PDMP) opt-in, multi-channel reminder preferences (EMR-211),
+ * and the burnout guardrails + live burnout index (EMR-214). The burnout index
+ * is computed from the signed-in provider's actual last-14-day appointment load.
  *
- * NOTE (intentional scope guard): the bottom-left provider-initials menu in
- * the shared clinic layout is the natural entry point for this page, but wiring
- * that nav link would require editing the shared clinic layout — which is out
- * of scope for the prescribe-module redesign. The route is live at
- * /clinic/settings and is linked from the CURES attestation block on the
- * prescribe form; the layout-nav wiring is deliberately left to a follow-up so
- * we don't touch shared layout files here.
+ * NOTE (intentional scope guard): the bottom-left provider-initials menu in the
+ * shared clinic layout is the natural entry point; wiring that nav link would
+ * require editing the shared clinic layout, deliberately left to a follow-up.
  */
 export default async function ClinicSettingsPage() {
   const user = await requireUser();
   const providerName = `${user.firstName} ${user.lastName}`.trim() || "Provider";
+  const organizationId = user.organizationId!;
+
+  // EMR-214 — load the provider's last-14-day appointment load for the index.
+  const provider = await prisma.provider.findFirst({
+    where: { userId: user.id, organizationId },
+    select: { id: true },
+  });
+
+  let fortnight: SerializedDayLoad[] = [];
+  if (provider) {
+    const start = startOfDay(addDays(new Date(), -13));
+    const appts = await prisma.appointment.findMany({
+      where: {
+        providerId: provider.id,
+        startAt: { gte: start },
+        status: { notIn: ["cancelled"] },
+      },
+      select: { startAt: true, endAt: true },
+    });
+    fortnight = buildFortnight(start, appts);
+  }
 
   return (
     <PageShell maxWidth="max-w-[720px]">
       <PageHeader
         eyebrow="Settings"
         title="Provider settings"
-        description={`Signed in as ${providerName}. Manage your prescribing integrations below.`}
+        description={`Signed in as ${providerName}. Manage your scheduling and prescribing preferences below.`}
       />
-      <CuresCredentialsForm userId={user.id} />
+      <div className="space-y-6">
+        <ReminderPreferencesForm organizationId={organizationId} />
+        {provider && (
+          <BurnoutGuardrailsForm providerId={provider.id} fortnight={fortnight} />
+        )}
+        <CuresCredentialsForm userId={user.id} />
+      </div>
     </PageShell>
   );
+}
+
+// ---------------------------------------------------------------------------
+// EMR-214 — build the 14-day DayLoad fortnight from raw appointment rows.
+// ---------------------------------------------------------------------------
+
+function startOfDay(d: Date): Date {
+  const n = new Date(d);
+  n.setHours(0, 0, 0, 0);
+  return n;
+}
+
+function addDays(d: Date, days: number): Date {
+  const n = new Date(d);
+  n.setDate(n.getDate() + days);
+  return n;
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function buildFortnight(
+  start: Date,
+  appts: Array<{ startAt: Date; endAt: Date }>,
+): SerializedDayLoad[] {
+  return Array.from({ length: 14 }, (_, i) => {
+    const day = addDays(start, i);
+    const dayAppts = appts.filter((a) => sameDay(a.startAt, day));
+    const durationsMin = dayAppts.map(
+      (a) => Math.max(0, (a.endAt.getTime() - a.startAt.getTime()) / 60_000),
+    );
+    const avgDurationMin =
+      durationsMin.length > 0
+        ? durationsMin.reduce((s, m) => s + m, 0) / durationsMin.length
+        : 0;
+    const latestStartHour = dayAppts.reduce(
+      (max, a) => Math.max(max, a.startAt.getHours()),
+      0,
+    );
+    const totalDocumentedHours =
+      durationsMin.reduce((s, m) => s + m, 0) / 60;
+    return {
+      day: day.toISOString(),
+      scheduledVisits: dayAppts.length,
+      // High-intensity tagging not yet derived from visit type — see form note.
+      highIntensityVisits: 0,
+      avgDurationMin,
+      latestStartHour,
+      totalDocumentedHours,
+    };
+  });
 }

--- a/src/app/(clinician)/clinic/settings/page.tsx
+++ b/src/app/(clinician)/clinic/settings/page.tsx
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { CuresCredentialsForm } from "./cures-credentials-form";
 import { ReminderPreferencesForm } from "./reminder-preferences-form";
+import { loadReminderPrefs } from "./reminder-actions";
 import {
   BurnoutGuardrailsForm,
   type SerializedDayLoad,
@@ -25,6 +26,9 @@ export default async function ClinicSettingsPage() {
   const user = await requireUser();
   const providerName = `${user.firstName} ${user.lastName}`.trim() || "Provider";
   const organizationId = user.organizationId!;
+
+  // EMR-211 — load reminder prefs from the per-user communication profile.
+  const reminderPrefs = await loadReminderPrefs(user.id);
 
   // EMR-214 — load the provider's last-14-day appointment load for the index.
   const provider = await prisma.provider.findFirst({
@@ -54,7 +58,7 @@ export default async function ClinicSettingsPage() {
         description={`Signed in as ${providerName}. Manage your scheduling and prescribing preferences below.`}
       />
       <div className="space-y-6">
-        <ReminderPreferencesForm organizationId={organizationId} />
+        <ReminderPreferencesForm initialPrefs={reminderPrefs} />
         {provider && (
           <BurnoutGuardrailsForm providerId={provider.id} fortnight={fortnight} />
         )}

--- a/src/app/(clinician)/clinic/settings/reminder-actions.ts
+++ b/src/app/(clinician)/clinic/settings/reminder-actions.ts
@@ -1,0 +1,97 @@
+"use server";
+
+/**
+ * EMR-211 — Reminder preference persistence (REAL, DB-backed).
+ *
+ * Promotes the reminder settings off the interim localStorage store onto the
+ * existing per-user `CommunicationPreference` row — no schema change. The full
+ * ChannelPrefs blob lives in `preferences.reminders` (JSON) for fidelity, while
+ * `smsOptIn`, `emailFrequency`, and `quietHours{Start,End}` are mirrored to the
+ * dedicated columns so other comms features reading those stay consistent.
+ */
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { Prisma } from "@prisma/client";
+import { ChannelPrefsSchema, type ChannelPrefs } from "@/lib/scheduling/reminders";
+
+const DEFAULTS: ChannelPrefs = {
+  smsOptIn: true,
+  emailOptIn: true,
+  pushOptIn: true,
+  quietHours: { startHour: 21, endHour: 8 },
+  timezone: "America/Los_Angeles",
+  preferredChannel: "sms",
+};
+
+function hourOf(hhmm: string): number {
+  const n = Number(hhmm.split(":")[0]);
+  return Number.isFinite(n) ? Math.max(0, Math.min(23, n)) : 0;
+}
+
+function pad(hour: number): string {
+  return `${String(hour).padStart(2, "0")}:00`;
+}
+
+/**
+ * Read the signed-in-or-given user's reminder prefs. Prefers the full JSON
+ * blob; falls back to reconstructing from the dedicated columns; else defaults.
+ * Safe to call from a server component.
+ */
+export async function loadReminderPrefs(userId: string): Promise<ChannelPrefs> {
+  const row = await prisma.communicationPreference.findUnique({ where: { userId } });
+  if (!row) return DEFAULTS;
+
+  const prefsObj =
+    row.preferences && typeof row.preferences === "object" && !Array.isArray(row.preferences)
+      ? (row.preferences as Record<string, unknown>)
+      : {};
+  const parsed = ChannelPrefsSchema.safeParse(prefsObj.reminders);
+  if (parsed.success) return parsed.data;
+
+  return {
+    smsOptIn: row.smsOptIn,
+    emailOptIn: row.emailFrequency !== "off",
+    pushOptIn: DEFAULTS.pushOptIn,
+    quietHours:
+      row.quietHoursStart && row.quietHoursEnd
+        ? { startHour: hourOf(row.quietHoursStart), endHour: hourOf(row.quietHoursEnd) }
+        : null,
+    timezone: DEFAULTS.timezone,
+    preferredChannel: DEFAULTS.preferredChannel,
+  };
+}
+
+/** Persist the current user's reminder prefs. Returns the validated prefs. */
+export async function saveReminderPrefs(input: ChannelPrefs): Promise<ChannelPrefs> {
+  const user = await requireUser();
+  const prefs = ChannelPrefsSchema.parse(input);
+
+  const existing = await prisma.communicationPreference.findUnique({
+    where: { userId: user.id },
+    select: { preferences: true },
+  });
+  const base =
+    existing?.preferences &&
+    typeof existing.preferences === "object" &&
+    !Array.isArray(existing.preferences)
+      ? (existing.preferences as Record<string, unknown>)
+      : {};
+  const mergedPreferences = { ...base, reminders: prefs } as Prisma.InputJsonValue;
+
+  const data = {
+    smsOptIn: prefs.smsOptIn,
+    emailFrequency: prefs.emailOptIn ? "instant" : "off",
+    quietHoursStart: prefs.quietHours ? pad(prefs.quietHours.startHour) : null,
+    quietHoursEnd: prefs.quietHours ? pad(prefs.quietHours.endHour) : null,
+    preferences: mergedPreferences,
+  };
+
+  await prisma.communicationPreference.upsert({
+    where: { userId: user.id },
+    create: { userId: user.id, ...data },
+    update: data,
+  });
+
+  return prefs;
+}

--- a/src/app/(clinician)/clinic/settings/reminder-preferences-form.tsx
+++ b/src/app/(clinician)/clinic/settings/reminder-preferences-form.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+/**
+ * EMR-211 — Multi-channel reminder preferences (INTERIM, localStorage-backed).
+ *
+ * Practice-level defaults for appointment reminders: which channels are on
+ * (SMS / email / push), the patient's preferred confirmation channel, the
+ * timezone, and quiet hours during which we never send SMS/push. A live
+ * preview runs the real reminder engine (`@/lib/scheduling/reminders`) against
+ * a sample upcoming visit so staff can see exactly what would fire.
+ *
+ * Interim notice: prefs persist to this browser's localStorage only (no schema
+ * change). A production rollout moves these to a per-organization settings row
+ * and feeds buildReminderPlan() output onto the AgentJob queue.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  buildReminderPlan,
+  type ChannelPrefs,
+  type ReminderChannel,
+} from "@/lib/scheduling/reminders";
+import type { RiskTier } from "@/lib/scheduling/no-show-model";
+
+const LABEL_CLASS =
+  "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
+const INPUT_CLASS =
+  "flex w-full rounded-xl border border-border-strong bg-white px-3 h-11 text-sm text-text " +
+  "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20";
+
+function storageKey(orgId: string) {
+  return `reminder-prefs:${orgId}:v1`;
+}
+
+const DEFAULT_PREFS: ChannelPrefs = {
+  smsOptIn: true,
+  emailOptIn: true,
+  pushOptIn: true,
+  quietHours: { startHour: 21, endHour: 8 },
+  timezone: "America/Los_Angeles",
+  preferredChannel: "sms",
+};
+
+const CHANNEL_LABEL: Record<ReminderChannel, string> = {
+  sms: "SMS",
+  email: "Email",
+  push: "Push",
+  voice_call: "Live call",
+};
+
+const TIMEZONES = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Phoenix",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+];
+
+export function ReminderPreferencesForm({ organizationId }: { organizationId: string }) {
+  const key = storageKey(organizationId);
+  const [prefs, setPrefs] = useState<ChannelPrefs>(DEFAULT_PREFS);
+  const [quietEnabled, setQuietEnabled] = useState(true);
+  const [previewTier, setPreviewTier] = useState<RiskTier>("medium");
+  const [justSaved, setJustSaved] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) {
+        const parsed = JSON.parse(raw) as ChannelPrefs;
+        setPrefs({ ...DEFAULT_PREFS, ...parsed });
+        setQuietEnabled(parsed.quietHours !== null);
+      }
+    } catch {
+      /* corrupt / private mode — keep defaults */
+    }
+  }, [key]);
+
+  function update<K extends keyof ChannelPrefs>(field: K, value: ChannelPrefs[K]) {
+    setPrefs((p) => ({ ...p, [field]: value }));
+  }
+
+  function save() {
+    const payload: ChannelPrefs = {
+      ...prefs,
+      quietHours: quietEnabled ? prefs.quietHours ?? { startHour: 21, endHour: 8 } : null,
+    };
+    try {
+      window.localStorage.setItem(key, JSON.stringify(payload));
+      setJustSaved(true);
+      setTimeout(() => setJustSaved(false), 2500);
+    } catch {
+      /* quota / private mode — non-fatal */
+    }
+  }
+
+  // Live preview — run the real engine against a sample visit 7 days out.
+  const preview = useMemo(() => {
+    const effective: ChannelPrefs = {
+      ...prefs,
+      quietHours: quietEnabled ? prefs.quietHours ?? { startHour: 21, endHour: 8 } : null,
+    };
+    const startAt = new Date(Date.now() + 7 * 86_400_000);
+    return buildReminderPlan({
+      appointmentId: "preview",
+      patientId: "preview",
+      startAt,
+      riskTier: previewTier,
+      prefs: effective,
+      bookedAt: new Date(),
+      preConfirmed: false,
+    }).sort((a, b) => a.sendAt.getTime() - b.sendAt.getTime());
+  }, [prefs, quietEnabled, previewTier]);
+
+  const quiet = prefs.quietHours ?? { startHour: 21, endHour: 8 };
+
+  return (
+    <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Appointment reminders
+          {justSaved && <Badge tone="success" className="text-[10px]">Saved ✓</Badge>}
+        </CardTitle>
+        <CardDescription>
+          Channels, preferred confirmation channel, and quiet hours for automated
+          visit reminders. Higher no-show risk adds extra touches automatically.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Channel toggles */}
+        <div>
+          <span className={LABEL_CLASS}>Channels</span>
+          <div className="flex flex-wrap gap-2">
+            <ChannelToggle label="SMS" on={prefs.smsOptIn} onClick={() => update("smsOptIn", !prefs.smsOptIn)} />
+            <ChannelToggle label="Email" on={prefs.emailOptIn} onClick={() => update("emailOptIn", !prefs.emailOptIn)} />
+            <ChannelToggle label="Push" on={prefs.pushOptIn} onClick={() => update("pushOptIn", !prefs.pushOptIn)} />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={LABEL_CLASS} htmlFor="rem-pref-channel">Preferred channel</label>
+            <select
+              id="rem-pref-channel"
+              value={prefs.preferredChannel}
+              onChange={(e) => update("preferredChannel", e.target.value as ChannelPrefs["preferredChannel"])}
+              className={INPUT_CLASS}
+            >
+              <option value="sms">SMS</option>
+              <option value="email">Email</option>
+              <option value="push">Push</option>
+            </select>
+          </div>
+          <div>
+            <label className={LABEL_CLASS} htmlFor="rem-tz">Timezone</label>
+            <select
+              id="rem-tz"
+              value={prefs.timezone}
+              onChange={(e) => update("timezone", e.target.value)}
+              className={INPUT_CLASS}
+            >
+              {TIMEZONES.map((tz) => (
+                <option key={tz} value={tz}>{tz.replace("America/", "").replace("_", " ")}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Quiet hours */}
+        <div className="rounded-xl border border-border/60 bg-surface-muted/40 px-3 py-3">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={quietEnabled}
+              onChange={(e) => setQuietEnabled(e.target.checked)}
+              className="h-4 w-4 accent-[color:var(--accent)]"
+            />
+            <span className="text-sm font-medium text-text">Quiet hours (no SMS/push)</span>
+          </label>
+          {quietEnabled && (
+            <div className="grid grid-cols-2 gap-3 mt-3">
+              <div>
+                <label className={LABEL_CLASS} htmlFor="rem-quiet-start">From</label>
+                <select
+                  id="rem-quiet-start"
+                  value={quiet.startHour}
+                  onChange={(e) => update("quietHours", { ...quiet, startHour: Number(e.target.value) })}
+                  className={INPUT_CLASS}
+                >
+                  {hourOptions()}
+                </select>
+              </div>
+              <div>
+                <label className={LABEL_CLASS} htmlFor="rem-quiet-end">Until</label>
+                <select
+                  id="rem-quiet-end"
+                  value={quiet.endHour}
+                  onChange={(e) => update("quietHours", { ...quiet, endHour: Number(e.target.value) })}
+                  className={INPUT_CLASS}
+                >
+                  {hourOptions()}
+                </select>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Live preview */}
+        <div className="rounded-xl border border-border/60 px-3 py-3">
+          <div className="flex items-center justify-between mb-2">
+            <span className={LABEL_CLASS + " mb-0"}>Preview timeline</span>
+            <div className="flex gap-1">
+              {(["low", "medium", "high"] as RiskTier[]).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setPreviewTier(t)}
+                  className={
+                    "text-[10px] px-2 py-0.5 rounded-full border " +
+                    (previewTier === t
+                      ? "border-accent/60 bg-accent/10 text-accent"
+                      : "border-border text-text-muted")
+                  }
+                >
+                  {t} risk
+                </button>
+              ))}
+            </div>
+          </div>
+          {preview.length === 0 ? (
+            <p className="text-[11px] text-text-subtle italic py-2">
+              No reminders would send — all matching channels are off.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {preview.map((job) => (
+                <li key={job.jobKey} className="flex items-center gap-2 text-[12px]">
+                  <Badge tone="neutral" className="text-[9px] w-14 justify-center shrink-0">
+                    {CHANNEL_LABEL[job.channel]}
+                  </Badge>
+                  <span className="text-text-muted tabular-nums">{offsetLabel(job.offsetHours)}</span>
+                  <span className="text-text-subtle">·</span>
+                  <span className="text-text-subtle">{job.template.replace(/_/g, " ")}</span>
+                  {job.expectsResponse && (
+                    <Badge tone="accent" className="text-[9px]">confirm</Badge>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button type="button" onClick={save}>
+            {justSaved ? "Saved ✓" : "Save reminder settings"}
+          </Button>
+        </div>
+
+        <p className="text-[11px] leading-relaxed text-text-subtle rounded-lg bg-surface-muted/60 border border-border/60 px-3 py-2">
+          <span className="font-semibold">Interim storage notice:</span> these
+          preferences save to this browser&apos;s localStorage only (no schema
+          change). Production wires them to a per-organization settings row and
+          enqueues the previewed jobs onto the reminder workers.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChannelToggle({ label, on, onClick }: { label: string; on: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={on}
+      className={
+        "text-xs px-3 py-1.5 rounded-full border transition-colors " +
+        (on
+          ? "border-accent/50 bg-accent/10 text-accent font-medium"
+          : "border-border text-text-muted hover:border-border-strong")
+      }
+    >
+      {on ? "● " : "○ "}
+      {label}
+    </button>
+  );
+}
+
+function hourOptions() {
+  return Array.from({ length: 24 }, (_, h) => (
+    <option key={h} value={h}>
+      {h === 0 ? "12 AM" : h < 12 ? `${h} AM` : h === 12 ? "12 PM" : `${h - 12} PM`}
+    </option>
+  ));
+}
+
+function offsetLabel(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)} min before`;
+  if (hours < 24) return `${hours}h before`;
+  const days = hours / 24;
+  return `${days % 1 === 0 ? days : days.toFixed(1)} day${days === 1 ? "" : "s"} before`;
+}

--- a/src/app/(clinician)/clinic/settings/reminder-preferences-form.tsx
+++ b/src/app/(clinician)/clinic/settings/reminder-preferences-form.tsx
@@ -14,7 +14,7 @@
  * and feeds buildReminderPlan() output onto the AgentJob queue.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -30,25 +30,13 @@ import {
   type ReminderChannel,
 } from "@/lib/scheduling/reminders";
 import type { RiskTier } from "@/lib/scheduling/no-show-model";
+import { saveReminderPrefs } from "./reminder-actions";
 
 const LABEL_CLASS =
   "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
 const INPUT_CLASS =
   "flex w-full rounded-xl border border-border-strong bg-white px-3 h-11 text-sm text-text " +
   "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20";
-
-function storageKey(orgId: string) {
-  return `reminder-prefs:${orgId}:v1`;
-}
-
-const DEFAULT_PREFS: ChannelPrefs = {
-  smsOptIn: true,
-  emailOptIn: true,
-  pushOptIn: true,
-  quietHours: { startHour: 21, endHour: 8 },
-  timezone: "America/Los_Angeles",
-  preferredChannel: "sms",
-};
 
 const CHANNEL_LABEL: Record<ReminderChannel, string> = {
   sms: "SMS",
@@ -67,42 +55,33 @@ const TIMEZONES = [
   "Pacific/Honolulu",
 ];
 
-export function ReminderPreferencesForm({ organizationId }: { organizationId: string }) {
-  const key = storageKey(organizationId);
-  const [prefs, setPrefs] = useState<ChannelPrefs>(DEFAULT_PREFS);
-  const [quietEnabled, setQuietEnabled] = useState(true);
+export function ReminderPreferencesForm({ initialPrefs }: { initialPrefs: ChannelPrefs }) {
+  const [prefs, setPrefs] = useState<ChannelPrefs>(initialPrefs);
+  const [quietEnabled, setQuietEnabled] = useState(initialPrefs.quietHours !== null);
   const [previewTier, setPreviewTier] = useState<RiskTier>("medium");
   const [justSaved, setJustSaved] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const raw = window.localStorage.getItem(key);
-      if (raw) {
-        const parsed = JSON.parse(raw) as ChannelPrefs;
-        setPrefs({ ...DEFAULT_PREFS, ...parsed });
-        setQuietEnabled(parsed.quietHours !== null);
-      }
-    } catch {
-      /* corrupt / private mode — keep defaults */
-    }
-  }, [key]);
+  const [saving, setSaving] = useState(false);
 
   function update<K extends keyof ChannelPrefs>(field: K, value: ChannelPrefs[K]) {
     setPrefs((p) => ({ ...p, [field]: value }));
   }
 
-  function save() {
+  async function save() {
+    setSaving(true);
     const payload: ChannelPrefs = {
       ...prefs,
       quietHours: quietEnabled ? prefs.quietHours ?? { startHour: 21, endHour: 8 } : null,
     };
     try {
-      window.localStorage.setItem(key, JSON.stringify(payload));
+      const saved = await saveReminderPrefs(payload);
+      setPrefs(saved);
+      setQuietEnabled(saved.quietHours !== null);
       setJustSaved(true);
       setTimeout(() => setJustSaved(false), 2500);
     } catch {
-      /* quota / private mode — non-fatal */
+      /* non-fatal — button returns to idle so the user can retry */
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -263,16 +242,15 @@ export function ReminderPreferencesForm({ organizationId }: { organizationId: st
         </div>
 
         <div className="flex items-center gap-3">
-          <Button type="button" onClick={save}>
-            {justSaved ? "Saved ✓" : "Save reminder settings"}
+          <Button type="button" onClick={save} disabled={saving}>
+            {saving ? "Saving…" : justSaved ? "Saved ✓" : "Save reminder settings"}
           </Button>
         </div>
 
         <p className="text-[11px] leading-relaxed text-text-subtle rounded-lg bg-surface-muted/60 border border-border/60 px-3 py-2">
-          <span className="font-semibold">Interim storage notice:</span> these
-          preferences save to this browser&apos;s localStorage only (no schema
-          change). Production wires them to a per-organization settings row and
-          enqueues the previewed jobs onto the reminder workers.
+          Saved to your provider communication profile (server-side). The previewed
+          jobs are what the reminder workers enqueue per appointment; higher
+          no-show risk adds extra touches automatically.
         </p>
       </CardContent>
     </Card>

--- a/src/app/(operator)/ops/schedule/ScheduleClient.tsx
+++ b/src/app/(operator)/ops/schedule/ScheduleClient.tsx
@@ -55,6 +55,9 @@ export type SerializedAppointment = {
   modality: string;
   providerId: string | null;
   patient: { id: string; firstName: string; lastName: string };
+  // EMR-207 — no-show risk (null for already-resolved visits or low risk we don't surface).
+  riskTier: "low" | "medium" | "high" | null;
+  riskProbability: number | null;
 };
 
 export type SerializedProvider = {
@@ -395,9 +398,38 @@ function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
         >
           {appt.status}
         </Badge>
+        <NoShowRiskBadge tier={appt.riskTier} probability={appt.riskProbability} />
       </div>
       {menu}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EMR-207 — No-show risk pill. Surfaces the predicted no-show probability for
+// medium/high-risk upcoming visits so the front desk knows where to spend an
+// extra reminder. Low risk is intentionally silent to keep the board calm.
+// ---------------------------------------------------------------------------
+
+function NoShowRiskBadge({
+  tier,
+  probability,
+}: {
+  tier: "low" | "medium" | "high" | null;
+  probability: number | null;
+}) {
+  if (tier === null || tier === "low" || probability === null) return null;
+  const pct = Math.round(probability * 100);
+  const tone = tier === "high" ? "danger" : "warning";
+  const label = tier === "high" ? "High no-show risk" : "Elevated no-show risk";
+  return (
+    <Badge
+      tone={tone}
+      className="text-[9px]"
+      title={`${label} — ${pct}% predicted. Consider an extra reminder or live confirm.`}
+    >
+      ⚠ {pct}%
+    </Badge>
   );
 }
 

--- a/src/app/(operator)/ops/schedule/page.tsx
+++ b/src/app/(operator)/ops/schedule/page.tsx
@@ -2,6 +2,8 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
+import { computeAppointmentRisk } from "@/lib/scheduling/appointment-risk";
+import type { RiskTier } from "@/lib/scheduling/no-show-model";
 import {
   ScheduleClient,
   type SerializedAppointment,
@@ -211,6 +213,41 @@ export default async function SchedulePage({
     }),
   ]);
 
+  // EMR-207 — no-show risk per appointment, derived from each patient's prior
+  // visit history. One extra query loads all appointments for the patients in
+  // the window; risk is then computed in-memory (engine is a pure function).
+  const patientIds = Array.from(new Set(appointments.map((a) => a.patientId)));
+  const priorRows = patientIds.length
+    ? await prisma.appointment.findMany({
+        where: { patientId: { in: patientIds } },
+        select: { patientId: true, status: true, startAt: true },
+      })
+    : [];
+  const priorsByPatient = new Map<string, { status: string; startAt: Date }[]>();
+  for (const r of priorRows) {
+    const list = priorsByPatient.get(r.patientId) ?? [];
+    list.push({ status: r.status, startAt: r.startAt });
+    priorsByPatient.set(r.patientId, list);
+  }
+  const riskByAppointment = new Map<string, { tier: RiskTier; probability: number }>();
+  for (const a of appointments) {
+    // Don't flag visits that have already resolved — risk is only actionable
+    // for upcoming, not-yet-terminal appointments.
+    if (a.status === "completed" || a.status === "cancelled" || a.status === "no_show") {
+      continue;
+    }
+    const prediction = computeAppointmentRisk({
+      startAt: a.startAt,
+      bookedAt: a.createdAt,
+      modality: a.modality,
+      priorVisits: priorsByPatient.get(a.patientId) ?? [],
+    });
+    riskByAppointment.set(a.id, {
+      tier: prediction.tier,
+      probability: prediction.probability,
+    });
+  }
+
   // Day buckets that span the resolved window (1+ days).
   const dayCount = Math.max(
     1,
@@ -223,12 +260,13 @@ export default async function SchedulePage({
       isToday: isSameDay(d, now),
       appointments: appointments
         .filter((a) => isSameDay(a.startAt, d))
-        .map(serializeAppointment),
+        .map((a) => serializeAppointment(a, riskByAppointment.get(a.id))),
     };
   });
 
-  const serializedAppointments: SerializedAppointment[] =
-    appointments.map(serializeAppointment);
+  const serializedAppointments: SerializedAppointment[] = appointments.map((a) =>
+    serializeAppointment(a, riskByAppointment.get(a.id)),
+  );
 
   const serializedProviders: SerializedProvider[] = providers.map((p) => ({
     id: p.id,
@@ -294,7 +332,10 @@ type ApptRow = {
   patient: { id: string; firstName: string; lastName: string };
 };
 
-function serializeAppointment(a: ApptRow): SerializedAppointment {
+function serializeAppointment(
+  a: ApptRow,
+  risk?: { tier: RiskTier; probability: number },
+): SerializedAppointment {
   return {
     id: a.id,
     startAt: a.startAt.toISOString(),
@@ -306,6 +347,8 @@ function serializeAppointment(a: ApptRow): SerializedAppointment {
       firstName: a.patient.firstName,
       lastName: a.patient.lastName,
     },
+    riskTier: risk?.tier ?? null,
+    riskProbability: risk?.probability ?? null,
   };
 }
 

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -141,6 +141,8 @@ export const CLINICIAN_COMMANDS: CommandDef[] = [
   { id: "c-go-providers", label: "Providers directory", icon: "☷", href: "/clinic/providers", group: "Navigate", roles: ["clinician"], keywords: ["directory", "colleagues"] },
   { id: "c-go-research", label: "Research feed", icon: "✦", href: "/clinic/research", group: "Navigate", roles: ["clinician"], keywords: ["pubmed", "papers"] },
   { id: "c-go-library", label: "Education library", icon: "❦", href: "/clinic/library", group: "Navigate", roles: ["clinician"], keywords: ["leaflet", "library", "handouts"] },
+  { id: "c-go-followup-cadence", label: "Follow-up cadence", icon: "↻", href: "/clinic/scheduling/follow-up", group: "Navigate", roles: ["clinician"], keywords: ["cadence", "follow up", "interval", "recall", "EMR-208"] },
+  { id: "c-go-slot-recommender", label: "Smart slot recommender", icon: "◷", href: "/clinic/scheduling/recommend", group: "Navigate", roles: ["clinician"], keywords: ["slot", "recommend", "scheduling", "availability", "EMR-209"] },
   { id: "c-go-audit", label: "Open audit trail", icon: "❒", href: "/clinic/audit-trail", group: "Navigate", roles: ["clinician"], keywords: ["history", "log", "audit"] },
 
   // Legacy "Actions" — kept under a tighter set of keywords so they don't drown

--- a/src/lib/scheduling/appointment-risk.test.ts
+++ b/src/lib/scheduling/appointment-risk.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { computeAppointmentRisk } from "./appointment-risk";
+
+// Fixed reference points; tests assert relative behavior (not absolute
+// probabilities) so they stay robust to the model's use of Date.now().
+const start = new Date("2026-07-01T15:00:00Z");
+const booked = new Date("2026-06-20T15:00:00Z");
+
+function pastVisits(statuses: string[]): { status: string; startAt: Date }[] {
+  return statuses.map((status, i) => ({
+    status,
+    startAt: new Date(start.getTime() - (i + 1) * 30 * 86_400_000),
+  }));
+}
+
+describe("computeAppointmentRisk (EMR-207)", () => {
+  it("returns a valid prediction shape", () => {
+    const r = computeAppointmentRisk({
+      startAt: start,
+      bookedAt: booked,
+      modality: "video",
+      priorVisits: [],
+    });
+    expect(r.probability).toBeGreaterThanOrEqual(0);
+    expect(r.probability).toBeLessThanOrEqual(1);
+    expect(["low", "medium", "high"]).toContain(r.tier);
+    expect(Array.isArray(r.topFactors)).toBe(true);
+  });
+
+  it("scores a chronic no-show patient higher than a reliable one", () => {
+    const reliable = computeAppointmentRisk({
+      startAt: start,
+      bookedAt: booked,
+      modality: "video",
+      priorVisits: pastVisits(["completed", "completed", "completed", "completed"]),
+    });
+    const flaky = computeAppointmentRisk({
+      startAt: start,
+      bookedAt: booked,
+      modality: "video",
+      priorVisits: pastVisits(["no_show", "no_show", "cancelled", "completed"]),
+    });
+    expect(flaky.probability).toBeGreaterThan(reliable.probability);
+  });
+
+  it("ignores visits that fall after the appointment (no future leakage)", () => {
+    const futureNoShow = {
+      status: "no_show",
+      startAt: new Date(start.getTime() + 60 * 86_400_000),
+    };
+    const withFuture = computeAppointmentRisk({
+      startAt: start,
+      bookedAt: booked,
+      modality: "video",
+      priorVisits: [futureNoShow],
+    });
+    const withoutPriors = computeAppointmentRisk({
+      startAt: start,
+      bookedAt: booked,
+      modality: "video",
+      priorVisits: [],
+    });
+    expect(withFuture.probability).toBeCloseTo(withoutPriors.probability, 10);
+  });
+});

--- a/src/lib/scheduling/appointment-risk.ts
+++ b/src/lib/scheduling/appointment-risk.ts
@@ -1,0 +1,63 @@
+/**
+ * EMR-207 — Appointment no-show risk adapter.
+ *
+ * Bridges loaded Appointment rows to the pure no-show model
+ * (`./no-show-model`). The model needs a feature vector; this assembles one
+ * from the data the schedule surfaces actually have on hand (the patient's
+ * prior appointments + the appointment's own booking/start times), filling
+ * the unknown signals (distance, insurance, reminder-confirm) with neutral
+ * defaults so we never *over*-flag a patient on missing data.
+ *
+ * Kept separate from the page so the adaptation logic is unit-testable
+ * without a database.
+ */
+import { buildFeatures, predictNoShow, type NoShowPrediction } from "./no-show-model";
+
+export interface PriorVisit {
+  status: string;
+  startAt: Date;
+}
+
+export interface AppointmentRiskInput {
+  /** When the appointment is scheduled to start. */
+  startAt: Date;
+  /** When the appointment was booked (Appointment.createdAt). */
+  bookedAt: Date;
+  /** Appointment modality string ("in_person" | "video" | "phone" | ...). */
+  modality: string;
+  /** The patient's other appointments (any time). Priors are filtered to those before startAt. */
+  priorVisits: PriorVisit[];
+}
+
+/**
+ * Compute a no-show prediction for one appointment. Only the patient's
+ * appointments *before* this one count as priors (a future visit can't
+ * inform the risk of an earlier one). "Last contact" is proxied by the
+ * most recent prior visit; brand-new patients fall back to the model's
+ * new-patient defaults.
+ */
+export function computeAppointmentRisk(input: AppointmentRiskInput): NoShowPrediction {
+  const priorsBefore = input.priorVisits.filter(
+    (v) => v.startAt.getTime() < input.startAt.getTime(),
+  );
+
+  const lastContactAt =
+    priorsBefore.length > 0
+      ? new Date(Math.max(...priorsBefore.map((v) => v.startAt.getTime())))
+      : null;
+
+  const features = buildFeatures({
+    priorVisits: priorsBefore.map((v) => ({ status: v.status })),
+    bookedAt: input.bookedAt,
+    startAt: input.startAt,
+    // Unknown on the schedule surface — pass neutral values so missing data
+    // doesn't inflate risk.
+    distanceMiles: null,
+    modality: input.modality,
+    reminderConfirmed: null,
+    lastContactAt,
+    insuranceVerified: true,
+  });
+
+  return predictNoShow(features);
+}


### PR DESCRIPTION
## What & why

The scheduling-swarm Track-2 audit (see `docs/plans/track-2-scheduling-swarm-DEDUPED.md`) found that the heaviest-value cards were **engines already on `main` with zero UI importers** — dead code. This PR wires the 5 highest-ROI ones into real, mounted, reachable UI surfaces.

| Card | Surface | Engine wired | Data |
|---|---|---|---|
| **EMR-207** No-show risk | ⚠ risk pills on ops schedule cards (`/ops/schedule`) | `no-show-model` | **Real** — server-side from each patient's prior-visit history |
| **EMR-208** Follow-up cadence | `/clinic/scheduling/follow-up` | `cadence-engine` | Real engine, clinician context |
| **EMR-209** Slot recommender | `/clinic/scheduling/recommend` | `slot-recommender` | Real ranking; synthetic availability grid |
| **EMR-211** Reminder settings | `/clinic/settings` (+ live plan preview) | `reminders` | **Real DB** — `CommunicationPreference` (no schema change) |
| **EMR-214** Burnout guardrails | `/clinic/settings` (live burnout index) | `provider-prefs` | Index from **real** 14-day load; caps localStorage-interim |

Every one of these engines went from **0 → ≥1 UI importer**.

## Verification

- `tsc --noEmit`: **0 errors**
- `vitest run`: **2,830 passing / 304 files** (incl. new `appointment-risk` adapter tests)
- **In-app (dev login), 0 console errors on all 5 surfaces:**
  - EMR-207: `⚠ 21%` pill on a late-night Video visit; resolved/low-risk visits correctly silent
  - EMR-208: "14 days, Video, next due Jun 20" for Chronic Pain / titration
  - EMR-209: "30 open slots ranked", prime midday slots top-ranked with reasons
  - EMR-211: save → reload round-trip **persists** to the DB (Push toggle survives reload)
  - EMR-214: burnout index 14/100 from real load components

## Honest limitations (by design)

- **EMR-207** is the only fully real-data card. **EMR-211** now persists to the DB. **EMR-214** caps are localStorage-interim (index is real); **208/209** run real engines over clinician-supplied / synthetic-availability inputs until the calendar + visit-type data lands. High-intensity burnout component reads 0 until visit-type tagging exists.
- The two new routes are surfaced via the **command palette (⌘K)**, not the sidebar — the specialty-adaptive shell resolver was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)