### PR TITLE
EMR-660: filter resolved threads from Smart Inbox on page load

### DIFF
--- a/src/app/(clinician)/clinic/messages/page.tsx
+++ b/src/app/(clinician)/clinic/messages/page.tsx
@@ -10,6 +10,7 @@ import {
   type MessagePriority,
   type MessageCategory,
 } from "@/lib/domain/smart-inbox";
+import { isResolvedMarker } from "./resolve-marker";
 import { SmartInboxView } from "./smart-inbox";
 import { MorningBriefView } from "./brief-view";
 
@@ -210,6 +211,29 @@ export default async function ClinicMessagesPage({
     })),
   }));
 
+  // EMR-660 — Hide resolved threads from the inbox until the patient sends
+  // a new reply (which lands after the [[RESOLVED]] sentinel, making it
+  // no longer the last message). The resolveThread action deliberately
+  // skips bumping lastMessageAt for the same reason; this is the
+  // server-side complement that actually removes them from the feed.
+  //
+  // We cast to a narrow interface for the detection loop only; the final
+  // filtered arrays keep the `any[]` inference so they stay assignable to
+  // the ThreadMessageData[] prop expected by SmartInboxView.
+  type ThrSlice = { threadId: string; messages: { body: string; createdAt: string }[] };
+  const resolvedThreadIds = new Set<string>();
+  for (const t of threadMessages as ThrSlice[]) {
+    const msgs = [...t.messages].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    const last = msgs[msgs.length - 1];
+    if (last && isResolvedMarker(last.body)) resolvedThreadIds.add(t.threadId);
+  }
+
+  const activeTriaged = triaged.filter((t) => !resolvedThreadIds.has(t.threadId));
+  const activeThreadMessages: typeof threadMessages = [];
+  for (const t of threadMessages as ThrSlice[]) {
+    if (!resolvedThreadIds.has(t.threadId)) activeThreadMessages.push(t);
+  }
+
   return (
     <PageShell maxWidth="max-w-[1400px]">
       <PageHeader
@@ -230,8 +254,8 @@ export default async function ClinicMessagesPage({
         </Link>
       </div>
       <SmartInboxView
-        triaged={triaged}
-        threadMessages={threadMessages}
+        triaged={activeTriaged}
+        threadMessages={activeThreadMessages}
         currentUserId={user.id}
         initialThreadId={searchParams?.thread}
         initialFilter={searchParams?.filter}

--- a/src/app/(clinician)/clinic/messages/page.tsx
+++ b/src/app/(clinician)/clinic/messages/page.tsx
@@ -220,9 +220,8 @@ export default async function ClinicMessagesPage({
   // We cast to a narrow interface for the detection loop only; the final
   // filtered arrays keep the `any[]` inference so they stay assignable to
   // the ThreadMessageData[] prop expected by SmartInboxView.
-  type ThrSlice = { threadId: string; messages: { body: string; createdAt: string }[] };
   const resolvedThreadIds = new Set<string>();
-  for (const t of threadMessages as ThrSlice[]) {
+  for (const t of threadMessages) {
     const msgs = [...t.messages].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
     const last = msgs[msgs.length - 1];
     if (last && isResolvedMarker(last.body)) resolvedThreadIds.add(t.threadId);
@@ -230,7 +229,7 @@ export default async function ClinicMessagesPage({
 
   const activeTriaged = triaged.filter((t) => !resolvedThreadIds.has(t.threadId));
   const activeThreadMessages: typeof threadMessages = [];
-  for (const t of threadMessages as ThrSlice[]) {
+  for (const t of threadMessages) {
     if (!resolvedThreadIds.has(t.threadId)) activeThreadMessages.push(t);
   }
 


### PR DESCRIPTION
Implements EMR-660.

## What changed
- Added `import { isResolvedMarker } from "./resolve-marker"` to `page.tsx`
- After serializing `threadMessages`, detect which thread IDs have a `[[RESOLVED]]` sentinel as their chronologically-last message
- Filter both `triaged` → `activeTriaged` and `threadMessages` → `activeThreadMessages` before passing to `SmartInboxView`
- Resolved threads are completely absent from the inbox feed; they re-appear automatically when the patient sends a new reply (which lands after the sentinel, so the sentinel is no longer the last message)

## Context
The `resolveThread` server action (already in `actions.ts`) intentionally skips bumping `lastMessageAt` with this comment:
> "Do NOT bump lastMessageAt — that would defeat the 'hide until new patient message' filter."

This PR adds that filter. Without it, the Resolve button marked a thread resolved in the DB but the thread stayed visible in the inbox — making the action feel broken.

The sibling files (`resolve-button.tsx`, `export-modal.tsx`, `resolve-marker.ts`) and the UI integration in `smart-inbox.tsx` (Resolve button, Export button, continuous patient thread link) were already shipped to main.

## How to verify
1. Open `/clinic/messages` — note a thread
2. Click **Resolve** in the thread header, confirm the dialog
3. Refresh — the resolved thread should disappear from the inbox list
4. Simulate a patient reply (add a `Message` record with a non-`[[RESOLVED]]` body and a fresh `createdAt` after the sentinel) — the thread should reappear on next page load

## Notes
- No schema change; sentinel-based approach is a documented interim strategy pending a `MessageThread.status` column
- The `daytime/emr-660-messages-resolved-export` branch exists on remote with no PR — this PR covers the missing server-side filter; the export modal and resolve button UI were already merged via the megasprint integration PR (#613)
- Follow-up: add a `MessageThread.resolvedAt` column to avoid the sentinel body-scan on every page load

---
_Generated by [Claude Code](https://claude.ai/code/session_0122DYNVxPqr2mZLYF8RdzPD)_