### PR TITLE
EMR-645: /clinic top-ribbon Threads count as link to messages

### DIFF
--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -651,8 +651,10 @@ export default async function ClinicHomePage() {
             />
             <StatusDot
               color="var(--text-subtle)"
+              pulse={activeThreads > 0}
               count={activeThreads}
               label="Threads"
+              href="/clinic/messages"
             />
           </div>
 


### PR DESCRIPTION
Implements EMR-645.

## What changed
- Added `href="/clinic/messages"` to the `Threads` `StatusDot` in the `/clinic` command-strip ribbon — it now navigates to the Smart Inbox on click, matching the behaviour of the other three counts (Patients today → `/clinic/schedule`, Notes to sign → `/clinic/sign-off`, Approvals → `/clinic/approvals`)
- Added `pulse={activeThreads > 0}` so the dot animates when there are active threads, consistent with the Notes and Approvals dots

## How to verify
1. Open `/clinic` (Mission Control)
2. Confirm the **Threads** count in the top ribbon is now a hover-highlighted link (same hover ring as the other three counts)
3. Click it — should navigate to `/clinic/messages` (Smart Inbox)
4. Open the Smart Inbox — confirm thread rows still expand in the right panel on click; they are **not** navigation links (unchanged behaviour)

## Notes
- 2-line change, no new deps, no schema touch
- Thread rows in `smart-inbox.tsx` remain `motion.button` elements with `onClick={onSelect}` — the ticket explicitly calls for threads to stay non-navigating

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHjypUEpUgP9t79BQ8PqPo)_