### PR TITLE
feat(scheduling): quick-win sweep + EMR-214 real persistence + EMR-422 patient picker

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/header-contact.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/header-contact.tsx
@@ -2,7 +2,14 @@
 
 import { useState, useEffect, useRef } from "react";
 import { logCorrespondence } from "./actions";
-import { formatDate } from "@/lib/utils/format";
+
+// EMR-829 — DOB shown as MM-DD-YYYY under the patient name (local format; the
+// shared formatDate stays "Mon D, YYYY" everywhere else it's used).
+function dobMMDDYYYY(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${m}-${day}-${d.getFullYear()}`;
+}
 
 interface HeaderContactProps {
   patientId: string;
@@ -191,7 +198,7 @@ export function HeaderContact({
   return (
     <div className="flex items-center gap-2 flex-wrap mt-3">
       <span className="text-xs text-text-subtle">
-        DOB {dateOfBirth ? formatDate(new Date(dateOfBirth)) : "Not on file"}
+        DOB {dateOfBirth ? dobMMDDYYYY(new Date(dateOfBirth)) : "Not on file"}
       </span>
       <span className="text-xs text-text-subtle">&middot;</span>
       {email ? (

--- a/src/app/(clinician)/clinic/patients/[id]/inline-demographics-card.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/inline-demographics-card.tsx
@@ -110,26 +110,56 @@ export function InlineDemographicsCard({
             />
           </Row>
           <Row label="Email">
-            <InlineEdit
-              value={initial.email}
-              onSave={makeDemo("email")}
-              validator={inlineValidators.email}
-              type="email"
-              placeholder="Add email"
-              ariaLabel="email"
-              disabled={!canEdit}
-            />
+            <div className="flex items-center gap-1.5">
+              <div className="min-w-0 flex-1">
+                <InlineEdit
+                  value={initial.email}
+                  onSave={makeDemo("email")}
+                  validator={inlineValidators.email}
+                  type="email"
+                  placeholder="Add email"
+                  ariaLabel="email"
+                  disabled={!canEdit}
+                />
+              </div>
+              {/* EMR-826 — click-to-mail icon next to the contact detail. */}
+              {initial.email && (
+                <a
+                  href={`mailto:${initial.email}`}
+                  title={`Email ${initial.email}`}
+                  aria-label="Send email"
+                  className="shrink-0 text-text-subtle hover:text-accent"
+                >
+                  <MailIcon />
+                </a>
+              )}
+            </div>
           </Row>
           <Row label="Phone">
-            <InlineEdit
-              value={initial.phone}
-              onSave={makeDemo("phone")}
-              validator={inlineValidators.phone}
-              type="tel"
-              placeholder="Add phone"
-              ariaLabel="phone"
-              disabled={!canEdit}
-            />
+            <div className="flex items-center gap-1.5">
+              <div className="min-w-0 flex-1">
+                <InlineEdit
+                  value={initial.phone}
+                  onSave={makeDemo("phone")}
+                  validator={inlineValidators.phone}
+                  type="tel"
+                  placeholder="Add phone"
+                  ariaLabel="phone"
+                  disabled={!canEdit}
+                />
+              </div>
+              {/* EMR-826 — click-to-call icon next to the contact detail. */}
+              {initial.phone && (
+                <a
+                  href={`tel:${initial.phone.replace(/[^0-9+]/g, "")}`}
+                  title={`Call ${initial.phone}`}
+                  aria-label="Call"
+                  className="shrink-0 text-text-subtle hover:text-accent"
+                >
+                  <PhoneIcon />
+                </a>
+              )}
+            </div>
           </Row>
           <Row label="Address">
             <InlineEdit
@@ -230,5 +260,23 @@ function Row({
       <dt className="text-xs text-text-subtle py-1 self-center">{label}</dt>
       <dd className="min-w-0 py-0.5">{children}</dd>
     </>
+  );
+}
+
+// EMR-826 — compact click-to-contact glyphs.
+function MailIcon() {
+  return (
+    <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
+      <rect x="2.5" y="4.5" width="15" height="11" rx="2" />
+      <path d="M3 6l7 5 7-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function PhoneIcon() {
+  return (
+    <svg viewBox="0 0 20 20" className="h-3.5 w-3.5" fill="currentColor" aria-hidden="true">
+      <path d="M6 3H4a1 1 0 0 0-1 1c0 7.18 5.82 13 13 13a1 1 0 0 0 1-1v-2a1 1 0 0 0-.76-.97l-2.45-.61a1 1 0 0 0-1 .27l-.7.86a10.6 10.6 0 0 1-4.4-4.4l.86-.7a1 1 0 0 0 .27-1l-.61-2.45A1 1 0 0 0 6 3z" />
+    </svg>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -475,6 +475,29 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       meta: `${c.status} · ${formatRelative(c.serviceDate)}`,
       href: `/clinic/patients/${params.id}/billing`,
     })),
+    // EMR-817 — demographics tab hover peek: primary contact summary.
+    demographics: [
+      {
+        id: "dob",
+        title: patient.dateOfBirth
+          ? `DOB ${new Date(patient.dateOfBirth).toLocaleDateString("en-US", { month: "2-digit", day: "2-digit", year: "numeric" })}`
+          : "DOB not on file",
+        meta: "Date of birth",
+        href: `/clinic/patients/${params.id}?tab=demographics`,
+      },
+      {
+        id: "email",
+        title: patient.email || "No email on file",
+        meta: "Email",
+        href: `/clinic/patients/${params.id}?tab=demographics`,
+      },
+      {
+        id: "phone",
+        title: patient.phone || "No phone on file",
+        meta: "Phone",
+        href: `/clinic/patients/${params.id}?tab=demographics`,
+      },
+    ],
   };
 
   /* ── AI peek summaries (slice 3) ────────────────────────────

--- a/src/app/(clinician)/clinic/schedule/schedule-calendar.tsx
+++ b/src/app/(clinician)/clinic/schedule/schedule-calendar.tsx
@@ -145,6 +145,23 @@ export function ScheduleCalendar({
     }
   };
 
+  // EMR-578 — List-view drag: drop an appointment onto a day group to move it
+  // to that day at the same time-of-day. Reuses onDrop (conflict handling).
+  const onDropToDay = (appointmentId: string, dayKey: string) => {
+    const appt = appointments.find((a) => a.id === appointmentId);
+    if (!appt) return;
+    const cur = new Date(appt.startAtIso);
+    const dayIdx = Math.round(
+      (new Date(dayKey).getTime() - new Date(weekStart.toDateString()).getTime()) /
+        86_400_000,
+    );
+    const slotIdx = Math.max(
+      0,
+      Math.round((cur.getHours() * 60 + cur.getMinutes() - FIRST_HOUR * 60) / SLOT_MIN),
+    );
+    onDrop(appointmentId, dayIdx, slotIdx);
+  };
+
   const goWeek = (delta: number) => {
     const next = addDays(weekStart, delta * 7);
     const iso = next.toISOString().slice(0, 10);
@@ -244,7 +261,9 @@ export function ScheduleCalendar({
         </div>
       )}
 
-      {view === "list" && <ListView appointments={appointments} />}
+      {view === "list" && (
+        <ListView appointments={appointments} onDropToDay={onDropToDay} />
+      )}
       {view === "week" && (
         <WeekGrid
           weekStart={weekStart}
@@ -576,7 +595,16 @@ function DayGrid({
 
 // ── List view ───────────────────────────────────────────────────
 
-function ListView({ appointments }: { appointments: AppointmentDTO[] }) {
+function ListView({
+  appointments,
+  onDropToDay,
+}: {
+  appointments: AppointmentDTO[];
+  // EMR-578 — drop an appointment onto a day group to reschedule it there.
+  onDropToDay?: (appointmentId: string, dayKey: string) => void;
+}) {
+  const [dragOverDay, setDragOverDay] = React.useState<string | null>(null);
+
   if (appointments.length === 0) {
     return (
       <Card>
@@ -596,35 +624,67 @@ function ListView({ appointments }: { appointments: AppointmentDTO[] }) {
   return (
     <div className="space-y-4">
       {Array.from(groups.entries()).map(([dayKey, list]) => (
-        <Card key={dayKey}>
+        <Card
+          key={dayKey}
+          className={cn(
+            "transition-colors",
+            dragOverDay === dayKey && "ring-2 ring-accent/50 border-accent/40",
+          )}
+          onDragOver={(e) => {
+            if (!onDropToDay) return;
+            e.preventDefault();
+            setDragOverDay(dayKey);
+          }}
+          onDragLeave={() => setDragOverDay((d) => (d === dayKey ? null : d))}
+          onDrop={(e) => {
+            if (!onDropToDay) return;
+            e.preventDefault();
+            setDragOverDay(null);
+            const apptId = e.dataTransfer.getData("text/appt-id");
+            if (apptId) onDropToDay(apptId, dayKey);
+          }}
+        >
           <CardContent className="pt-4">
             <p className="text-[11px] uppercase tracking-wider text-text-subtle font-medium mb-3">
               {dayKey}
             </p>
             <ul className="divide-y divide-border/60">
-              {list.map((a) => (
-                <li key={a.id} className="py-2 flex items-center gap-3">
-                  <span className="text-xs font-mono tabular-nums text-text-subtle w-16 shrink-0">
-                    {formatTime(a.startAtIso)}
-                  </span>
-                  {a.patientName.includes("System CalendarBlock") ? (
-                    <span className="flex-1 text-sm font-semibold text-text-subtle">
-                      {a.notes?.replace(/\[CalendarBlock:.*?\]/, "").trim() || "Blocked Time"}
+              {list.map((a) => {
+                const isBlock = a.patientName.includes("System CalendarBlock");
+                return (
+                  <li
+                    key={a.id}
+                    draggable={!isBlock && !!onDropToDay}
+                    onDragStart={(e) =>
+                      e.dataTransfer.setData("text/appt-id", a.id)
+                    }
+                    className={cn(
+                      "py-2 flex items-center gap-3",
+                      !isBlock && onDropToDay && "cursor-grab active:cursor-grabbing",
+                    )}
+                  >
+                    <span className="text-xs font-mono tabular-nums text-text-subtle w-16 shrink-0">
+                      {formatTime(a.startAtIso)}
                     </span>
-                  ) : (
-                    <Link
-                      href={`/clinic/patients/${a.patientId}`}
-                      className="flex-1 min-w-0 text-sm text-text hover:text-accent truncate"
-                    >
-                      {a.patientName}
-                    </Link>
-                  )}
-                  <Badge tone={statusTone(a.status)} className="text-[10px]">
-                    {a.status}
-                  </Badge>
-                  <span className="text-[11px] text-text-subtle">{a.modality}</span>
-                </li>
-              ))}
+                    {isBlock ? (
+                      <span className="flex-1 text-sm font-semibold text-text-subtle">
+                        {a.notes?.replace(/\[CalendarBlock:.*?\]/, "").trim() || "Blocked Time"}
+                      </span>
+                    ) : (
+                      <Link
+                        href={`/clinic/patients/${a.patientId}`}
+                        className="flex-1 min-w-0 text-sm text-text hover:text-accent truncate"
+                      >
+                        {a.patientName}
+                      </Link>
+                    )}
+                    <Badge tone={statusTone(a.status)} className="text-[10px]">
+                      {a.status}
+                    </Badge>
+                    <span className="text-[11px] text-text-subtle">{a.modality}</span>
+                  </li>
+                );
+              })}
             </ul>
           </CardContent>
         </Card>

--- a/src/app/(clinician)/clinic/scheduling/book/booking-flow.tsx
+++ b/src/app/(clinician)/clinic/scheduling/book/booking-flow.tsx
@@ -8,6 +8,7 @@ import { Input, Label, Textarea, FieldGroup } from "@/components/ui/input";
 import { Stepper as UiStepper } from "@/components/ui/stepper";
 import { cn } from "@/lib/utils/cn";
 import { confirmBookingAction, type ConfirmBookingInput } from "./actions";
+import { googleCalendarUrl } from "@/lib/scheduling/ics-export";
 
 export interface VisitTypeOption {
   id: "new_patient" | "follow_up" | "renewal" | "in_person";
@@ -449,6 +450,15 @@ function ConfirmedScreen({
   visitType: VisitTypeOption;
   slotIso: string;
 }) {
+  // EMR-388 — Google Calendar invite link alongside the iCal download.
+  const gcalUrl = googleCalendarUrl({
+    id: `appt-${confirmation.appointmentId}`,
+    title: visitType.label,
+    startsAt: slotIso,
+    endsAt: new Date(
+      new Date(slotIso).getTime() + visitType.durationMinutes * 60_000,
+    ).toISOString(),
+  });
   return (
     <Card tone="ambient">
       <CardContent className="pt-8 pb-8 text-center">
@@ -458,9 +468,12 @@ function ConfirmedScreen({
           {visitType.label} on {formatDayHeader(slotIso.slice(0, 10))} at {formatTime(slotIso)}.
           We've sent a confirmation to your secure inbox.
         </p>
-        <div className="flex items-center justify-center gap-3">
+        <div className="flex flex-wrap items-center justify-center gap-3">
           <a href={confirmation.icsDataUrl} download={confirmation.icsFileName}>
             <Button variant="primary">Add to calendar</Button>
+          </a>
+          <a href={gcalUrl} target="_blank" rel="noopener noreferrer">
+            <Button variant="secondary">Google Calendar</Button>
           </a>
           <Button variant="secondary" onClick={() => window.location.reload()}>
             Book another

--- a/src/app/(clinician)/clinic/settings/burnout-guardrails-form.tsx
+++ b/src/app/(clinician)/clinic/settings/burnout-guardrails-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * EMR-214 — Provider burnout guardrails (prefs INTERIM, localStorage-backed).
+ * EMR-214 — Provider burnout guardrails (prefs persisted server-side).
  *
  * Editor for the per-provider scheduling caps the slot recommender / waitlist
  * consult before placing a visit (max/day, max/week, buffer, protected lunch,
@@ -9,13 +9,14 @@
  * the real engine (`@/lib/scheduling/provider-prefs`) against the provider's
  * actual last-14-day load (passed in from the server).
  *
- * Interim notice: the caps persist to this browser's localStorage only (no
- * schema change). The burnout index itself is real — it reads loaded
- * appointment data — but `highIntensityVisits` is not yet derived from visit
- * type, so that single component reads 0 until visit-type tagging lands.
+ * Persistence: caps save to the per-user CommunicationPreference row
+ * (preferences.schedulingPrefs JSON) via a server action — no schema change.
+ * The burnout index is real (reads loaded appointment data); `highIntensityVisits`
+ * is not yet derived from visit type, so that single component reads 0 until
+ * visit-type tagging lands.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -27,10 +28,10 @@ import {
 } from "@/components/ui/card";
 import {
   burnoutIndex,
-  DEFAULT_PROVIDER_PREFS,
   type ProviderPrefs,
   type DayLoad,
 } from "@/lib/scheduling/provider-prefs";
+import { saveSchedulingPrefs } from "./scheduling-prefs-actions";
 
 const LABEL_CLASS =
   "block text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle mb-1.5";
@@ -42,10 +43,6 @@ const INPUT_CLASS =
 export type SerializedDayLoad = Omit<DayLoad, "day"> & { day: string };
 
 type StoredPrefs = Omit<ProviderPrefs, "providerId">;
-
-function storageKey(providerId: string) {
-  return `provider-prefs:${providerId}:v1`;
-}
 
 const LEVEL_TONE: Record<"green" | "yellow" | "red", "success" | "warning" | "danger"> = {
   green: "success",
@@ -64,35 +61,31 @@ const COMPONENT_LABEL: Record<string, string> = {
 export function BurnoutGuardrailsForm({
   providerId,
   fortnight,
+  initialPrefs,
 }: {
   providerId: string;
   fortnight: SerializedDayLoad[];
+  initialPrefs: StoredPrefs;
 }) {
-  const key = storageKey(providerId);
-  const [prefs, setPrefs] = useState<StoredPrefs>(DEFAULT_PROVIDER_PREFS);
+  const [prefs, setPrefs] = useState<StoredPrefs>(initialPrefs);
   const [justSaved, setJustSaved] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const raw = window.localStorage.getItem(key);
-      if (raw) setPrefs({ ...DEFAULT_PROVIDER_PREFS, ...(JSON.parse(raw) as StoredPrefs) });
-    } catch {
-      /* corrupt / private mode — keep defaults */
-    }
-  }, [key]);
+  const [saving, setSaving] = useState(false);
 
   function updateNum(field: keyof StoredPrefs, value: number) {
     setPrefs((p) => ({ ...p, [field]: value }));
   }
 
-  function save() {
+  async function save() {
+    setSaving(true);
     try {
-      window.localStorage.setItem(key, JSON.stringify(prefs));
+      const saved = await saveSchedulingPrefs(prefs);
+      setPrefs(saved);
       setJustSaved(true);
       setTimeout(() => setJustSaved(false), 2500);
     } catch {
-      /* non-fatal */
+      /* non-fatal — button returns to idle so the user can retry */
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -195,16 +188,15 @@ export function BurnoutGuardrailsForm({
         </div>
 
         <div className="flex items-center gap-3">
-          <Button type="button" onClick={save}>
-            {justSaved ? "Saved ✓" : "Save guardrails"}
+          <Button type="button" onClick={save} disabled={saving}>
+            {saving ? "Saving…" : justSaved ? "Saved ✓" : "Save guardrails"}
           </Button>
         </div>
 
         <p className="text-[11px] leading-relaxed text-text-subtle rounded-lg bg-surface-muted/60 border border-border/60 px-3 py-2">
-          <span className="font-semibold">Interim storage notice:</span> caps save
-          to this browser&apos;s localStorage only (no schema change). The burnout
-          index reads real loaded appointment data; the high-intensity component
-          reads 0 until visit-type tagging lands.
+          Caps save to your provider communication profile (server-side). The
+          burnout index reads real loaded appointment data; the high-intensity
+          component reads 0 until visit-type tagging lands.
         </p>
       </CardContent>
     </Card>

--- a/src/app/(clinician)/clinic/settings/page.tsx
+++ b/src/app/(clinician)/clinic/settings/page.tsx
@@ -4,6 +4,7 @@ import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { CuresCredentialsForm } from "./cures-credentials-form";
 import { ReminderPreferencesForm } from "./reminder-preferences-form";
 import { loadReminderPrefs } from "./reminder-actions";
+import { loadSchedulingPrefs } from "./scheduling-prefs-actions";
 import {
   BurnoutGuardrailsForm,
   type SerializedDayLoad,
@@ -27,8 +28,10 @@ export default async function ClinicSettingsPage() {
   const providerName = `${user.firstName} ${user.lastName}`.trim() || "Provider";
   const organizationId = user.organizationId!;
 
-  // EMR-211 — load reminder prefs from the per-user communication profile.
+  // EMR-211 / EMR-214 — load reminder + scheduling prefs from the per-user
+  // communication profile (both persisted server-side, no schema change).
   const reminderPrefs = await loadReminderPrefs(user.id);
+  const schedulingPrefs = await loadSchedulingPrefs(user.id);
 
   // EMR-214 — load the provider's last-14-day appointment load for the index.
   const provider = await prisma.provider.findFirst({
@@ -60,7 +63,11 @@ export default async function ClinicSettingsPage() {
       <div className="space-y-6">
         <ReminderPreferencesForm initialPrefs={reminderPrefs} />
         {provider && (
-          <BurnoutGuardrailsForm providerId={provider.id} fortnight={fortnight} />
+          <BurnoutGuardrailsForm
+            providerId={provider.id}
+            fortnight={fortnight}
+            initialPrefs={schedulingPrefs}
+          />
         )}
         <CuresCredentialsForm userId={user.id} />
       </div>

--- a/src/app/(clinician)/clinic/settings/scheduling-prefs-actions.ts
+++ b/src/app/(clinician)/clinic/settings/scheduling-prefs-actions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+/**
+ * EMR-214 — Provider scheduling-guardrail persistence (REAL, DB-backed).
+ *
+ * Promotes the burnout-guardrail caps off the interim localStorage store onto
+ * the same per-user `CommunicationPreference` row used by reminders (EMR-211),
+ * under a distinct `preferences.schedulingPrefs` key — a provider is a user, so
+ * no schema change is needed. Reminders and scheduling prefs coexist in the
+ * JSON (each save merges, never clobbers the other).
+ */
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { Prisma } from "@prisma/client";
+import {
+  ProviderPrefsSchema,
+  DEFAULT_PROVIDER_PREFS,
+  type ProviderPrefs,
+} from "@/lib/scheduling/provider-prefs";
+
+// Stored shape = ProviderPrefs without the providerId (that's contextual).
+const StoredSchedulingPrefsSchema = ProviderPrefsSchema.omit({ providerId: true });
+
+function readBase(
+  preferences: Prisma.JsonValue | null | undefined,
+): Record<string, unknown> {
+  return preferences && typeof preferences === "object" && !Array.isArray(preferences)
+    ? (preferences as Record<string, unknown>)
+    : {};
+}
+
+/** Read a user's stored scheduling caps, or the defaults. Server-component safe. */
+export async function loadSchedulingPrefs(
+  userId: string,
+): Promise<Omit<ProviderPrefs, "providerId">> {
+  const row = await prisma.communicationPreference.findUnique({ where: { userId } });
+  const parsed = StoredSchedulingPrefsSchema.safeParse(
+    readBase(row?.preferences).schedulingPrefs,
+  );
+  return parsed.success ? parsed.data : DEFAULT_PROVIDER_PREFS;
+}
+
+/** Persist the current user's scheduling caps. Returns the validated prefs. */
+export async function saveSchedulingPrefs(
+  input: Omit<ProviderPrefs, "providerId">,
+): Promise<Omit<ProviderPrefs, "providerId">> {
+  const user = await requireUser();
+  const prefs = StoredSchedulingPrefsSchema.parse(input);
+
+  const existing = await prisma.communicationPreference.findUnique({
+    where: { userId: user.id },
+    select: { preferences: true },
+  });
+  const merged = {
+    ...readBase(existing?.preferences),
+    schedulingPrefs: prefs,
+  } as Prisma.InputJsonValue;
+
+  await prisma.communicationPreference.upsert({
+    where: { userId: user.id },
+    create: { userId: user.id, preferences: merged },
+    update: { preferences: merged },
+  });
+
+  return prefs;
+}

--- a/src/app/(operator)/ops/schedule/ScheduleClient.tsx
+++ b/src/app/(operator)/ops/schedule/ScheduleClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Avatar } from "@/components/ui/avatar";
@@ -36,6 +37,9 @@ const MODALITY_TONE: Record<string, "accent" | "info" | "neutral"> = {
   video: "info",
   phone: "neutral",
 };
+
+// EMR-919 — stable display order for the clickable modality KPI chips.
+const MODALITY_ORDER = ["in_person", "video", "phone"];
 
 const STATUS_TONE: Record<
   string,
@@ -107,6 +111,8 @@ export function ScheduleClient({
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(
     null,
   );
+  // EMR-919 / EMR-930 — modality filter driven by the clickable KPI chips.
+  const [selectedModality, setSelectedModality] = useState<string | null>(null);
 
   const selectedProvider = useMemo(
     () => providers.find((p) => p.id === selectedProviderId) ?? null,
@@ -115,17 +121,26 @@ export function ScheduleClient({
 
   const totalThisWeek = appointments.length;
 
-  // When a provider is selected, restrict the day buckets to that provider so
-  // the Week View grid reflects only their schedule.
+  // Modality counts across the loaded window — power the KPI chips.
+  const modalityCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const a of appointments) counts[a.modality] = (counts[a.modality] ?? 0) + 1;
+    return counts;
+  }, [appointments]);
+
+  // Restrict the day buckets by the active provider + modality filters so the
+  // Week View grid reflects only the matching schedule.
   const visibleDays = useMemo(() => {
-    if (!selectedProviderId) return days;
+    if (!selectedProviderId && !selectedModality) return days;
     return days.map((d) => ({
       ...d,
       appointments: d.appointments.filter(
-        (a) => a.providerId === selectedProviderId,
+        (a) =>
+          (!selectedProviderId || a.providerId === selectedProviderId) &&
+          (!selectedModality || a.modality === selectedModality),
       ),
     }));
-  }, [days, selectedProviderId]);
+  }, [days, selectedProviderId, selectedModality]);
 
   // Snapshot stats for the selected provider, computed from loaded data.
   const snapshot = useMemo(() => {
@@ -176,6 +191,41 @@ export function ScheduleClient({
           />
         </div>
       </div>
+
+      {/* EMR-919 — clickable modality KPI chips that filter the calendar on click. */}
+      {totalThisWeek > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {MODALITY_ORDER.filter((m) => modalityCounts[m]).map((m) => {
+            const active = selectedModality === m;
+            return (
+              <button
+                key={m}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setSelectedModality(active ? null : m)}
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                  active
+                    ? "border-accent/50 bg-accent/10 text-accent"
+                    : "border-border text-text-muted hover:border-border-strong",
+                )}
+              >
+                {MODALITY_LABEL[m] ?? m}:{" "}
+                <span className="tabular-nums">{modalityCounts[m]}</span>
+              </button>
+            );
+          })}
+          {selectedModality && (
+            <button
+              type="button"
+              onClick={() => setSelectedModality(null)}
+              className="text-[11px] text-accent hover:underline"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Week View box — either the full grid, or the provider snapshot. */}
       {selectedProvider && snapshot ? (
@@ -377,9 +427,13 @@ function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
           size="sm"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-xs font-medium text-text truncate">
+          {/* EMR-923 — patient name links through to the chart home page. */}
+          <Link
+            href={`/clinic/patients/${appt.patient.id}`}
+            className="block text-xs font-medium text-text truncate hover:text-accent hover:underline"
+          >
             {appt.patient.firstName} {appt.patient.lastName}
-          </p>
+          </Link>
           <p className="text-[10px] text-text-subtle tabular-nums">
             {formatTime(new Date(appt.startAt))}
           </p>
@@ -399,6 +453,16 @@ function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
           {appt.status}
         </Badge>
         <NoShowRiskBadge tier={appt.riskTier} probability={appt.riskProbability} />
+        {/* EMR-920 — inline insurance-eligibility helper tag on upcoming visits. */}
+        {(appt.status === "requested" || appt.status === "confirmed") && (
+          <Badge
+            tone="info"
+            className="text-[9px]"
+            title="Insurance eligibility not yet verified for this visit."
+          >
+            ⊕ Verify insurance
+          </Badge>
+        )}
       </div>
       {menu}
     </div>

--- a/src/app/(operator)/ops/schedule/page.tsx
+++ b/src/app/(operator)/ops/schedule/page.tsx
@@ -151,18 +151,18 @@ function isoOf(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+// EMR-579 — schedule header date as a clean MM-DD-YYYY label.
+function mmddyyyy(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${m}-${day}-${d.getFullYear()}`;
+}
+
 function rangeSpanLabel(start: Date, end: Date): string {
   // end is exclusive; show the inclusive last day.
   const lastDay = addDays(end, -1);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  if (isSameDay(start, lastDay)) {
-    return start.toLocaleDateString("en-US", {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-    });
-  }
-  return `${start.toLocaleDateString("en-US", opts)} – ${lastDay.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+  if (isSameDay(start, lastDay)) return mmddyyyy(start);
+  return `${mmddyyyy(start)} – ${mmddyyyy(lastDay)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/(patient)/portal/care-pathway/care-pathway-picker.tsx
+++ b/src/app/(patient)/portal/care-pathway/care-pathway-picker.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+/**
+ * EMR-422 — Patient care-pathway picker (NEW, distinct from the shipped
+ * practice-admin care-model archetype step that shares the EMR-422 id).
+ *
+ * Lets an onboarding patient choose between a Conventional and a Cannabinoid
+ * care pathway. Choice persists to localStorage-interim (no patient schema
+ * field yet) and routes onward to intake. A future pass adds a Patient column
+ * + clinician-visible surface so the pathway is queryable for cohorting.
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+type PathwayKey = "conventional" | "cannabinoid";
+
+const PATHWAYS: {
+  key: PathwayKey;
+  emoji: string;
+  title: string;
+  tagline: string;
+  points: string[];
+}[] = [
+  {
+    key: "conventional",
+    emoji: "🩺",
+    title: "Conventional care",
+    tagline: "Traditional medicine first, with your usual prescriptions and referrals.",
+    points: [
+      "Standard medications and therapies",
+      "Specialist referrals as needed",
+      "Familiar, evidence-based treatment plans",
+    ],
+  },
+  {
+    key: "cannabinoid",
+    emoji: "🌿",
+    title: "Cannabinoid care",
+    tagline: "A cannabis-forward plan with per-product tracking and outcome check-ins.",
+    points: [
+      "Personalized cannabinoid regimens",
+      "Fun post-dose check-ins and outcome tracking",
+      "Conventional options stay available any time",
+    ],
+  },
+];
+
+function storageKey(userId: string) {
+  return `care-pathway:${userId}:v1`;
+}
+
+export function CarePathwayPicker({ userId }: { userId: string }) {
+  const router = useRouter();
+  const key = storageKey(userId);
+  const [selected, setSelected] = useState<PathwayKey | null>(null);
+  const [saved, setSaved] = useState<PathwayKey | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(key) as PathwayKey | null;
+      if (raw === "conventional" || raw === "cannabinoid") {
+        setSelected(raw);
+        setSaved(raw);
+      }
+    } catch {
+      /* private mode — start unselected */
+    }
+  }, [key]);
+
+  function choose(k: PathwayKey) {
+    setSelected(k);
+  }
+
+  function confirm() {
+    if (!selected) return;
+    try {
+      window.localStorage.setItem(key, selected);
+      setSaved(selected);
+    } catch {
+      /* non-fatal */
+    }
+    router.push("/portal/intake");
+  }
+
+  return (
+    <div className="py-2">
+      <div className="text-center mb-8">
+        <h1 className="font-display text-3xl text-text">How would you like to be cared for?</h1>
+        <p className="text-sm text-text-muted mt-2">
+          Pick the pathway that feels right. You can switch any time — nothing here is permanent.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {PATHWAYS.map((p) => {
+          const active = selected === p.key;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => choose(p.key)}
+              aria-pressed={active}
+              className={cn(
+                "text-left rounded-3xl border-2 p-6 transition-all focus:outline-none",
+                "focus-visible:ring-2 focus-visible:ring-accent/40 active:scale-[0.99]",
+                active
+                  ? "border-accent bg-accent/5 shadow-lg"
+                  : "border-border bg-white hover:border-accent/40 hover:shadow-md",
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-4xl" aria-hidden="true">{p.emoji}</span>
+                <span
+                  className={cn(
+                    "h-6 w-6 rounded-full border-2 flex items-center justify-center text-xs",
+                    active ? "border-accent bg-accent text-accent-ink" : "border-border-strong text-transparent",
+                  )}
+                  aria-hidden="true"
+                >
+                  ✓
+                </span>
+              </div>
+              <h2 className="font-display text-xl text-text mt-4">{p.title}</h2>
+              <p className="text-sm text-text-muted mt-1 leading-relaxed">{p.tagline}</p>
+              <ul className="mt-4 space-y-1.5">
+                {p.points.map((pt) => (
+                  <li key={pt} className="flex items-start gap-2 text-[13px] text-text">
+                    <span className="text-accent mt-0.5" aria-hidden="true">•</span>
+                    <span>{pt}</span>
+                  </li>
+                ))}
+              </ul>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-8 flex flex-col items-center gap-3">
+        <Button
+          size="lg"
+          disabled={!selected}
+          onClick={confirm}
+          className="w-full sm:w-auto sm:px-12"
+        >
+          {saved && saved === selected ? "Continue to intake →" : "Choose this pathway →"}
+        </Button>
+        {saved && (
+          <p className="text-[12px] text-text-subtle">
+            Currently set to{" "}
+            <span className="font-medium text-text">
+              {saved === "conventional" ? "Conventional care" : "Cannabinoid care"}
+            </span>
+            .
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(patient)/portal/care-pathway/page.tsx
+++ b/src/app/(patient)/portal/care-pathway/page.tsx
@@ -1,0 +1,24 @@
+import { requireRole } from "@/lib/auth/session";
+import { PageShell } from "@/components/shell/PageHeader";
+import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
+import { CarePathwayPicker } from "./care-pathway-picker";
+
+export const metadata = { title: "Choose your care pathway" };
+
+/**
+ * EMR-422 — Patient care-pathway picker.
+ *
+ * NEW patient-facing feature, intentionally distinct from the practice-admin
+ * care-model archetype step already shipped under the EMR-422 id. Lets an
+ * onboarding patient choose between a Conventional and a Cannabinoid care
+ * pathway. Reachable at /portal/care-pathway.
+ */
+export default async function CarePathwayPage() {
+  const user = await requireRole("patient");
+  return (
+    <PageShell maxWidth="max-w-[860px]">
+      <PatientSectionNav section="account" />
+      <CarePathwayPicker userId={user.id} />
+    </PageShell>
+  );
+}


### PR DESCRIPTION
## What & why

Tonight's batch off the scheduling-swarm dedupe (`docs/plans/track-2-scheduling-swarm-DEDUPED.md`): the high-value PARTIAL/polish cards, plus promoting EMR-214 to real DB persistence and building the EMR-422 patient picker.

### Quick wins (10)
| Card | Change |
|---|---|
| **EMR-579** | Schedule header date → `MM-DD-YYYY` |
| **EMR-919 / 930** | Clickable modality KPI chips that filter the calendar (modality dimension; provider + date filters already existed) |
| **EMR-923** | Calendar patient names link to the chart home page |
| **EMR-920** | Inline `⊕ Verify insurance` helper tag on upcoming visits |
| **EMR-578** | Drag an appointment onto a day group in **List** view to reschedule (reuses `onDrop` conflict handling) |
| **EMR-829** | Patient DOB → `MM-DD-YYYY` |
| **EMR-826** | Click-to-call / click-to-mail icons on demographics contact rows |
| **EMR-388** | Wire the existing `googleCalendarUrl()` (0 callers) into the booking confirmation, next to the iCal button |
| **EMR-817** | Demographics tab hover-peek showing primary contact summary |

### Deepen
- **EMR-214** — promoted the burnout-guardrail caps off interim localStorage onto the per-user `CommunicationPreference.preferences.schedulingPrefs` JSON via a server action (same mechanism as EMR-211 reminders; a provider is a user). **No schema change.**

### New feature
- **EMR-422** — patient-facing Conventional-vs-Cannabinoid care-pathway picker at `/portal/care-pathway`, intentionally distinct from the practice-admin care-model archetype step already shipped under the EMR-422 id. Emoji-first, large touch targets; choice persists localStorage-interim and routes to intake.

## Verification
- `tsc --noEmit`: **0 errors** · `vitest run`: **2,830 passing / 304 files**
- **In-app (dev login), 0 console errors:**
  - ops/schedule: MM-DD-YYYY header, `In-person/Video/Phone` KPI chips, chart-link names, `⊕ Verify insurance` tags (correctly absent on completed/no_show)
  - **EMR-214: save → reload round-trip persists** (toggled same-day add-ons off, survived reload — DB-backed)
  - **EMR-422: picker renders both pathways; selection enables the CTA**

## Notes / limitations
- EMR-422 choice is localStorage-interim (no Patient column yet); a future pass adds a column + clinician-visible surface for cohorting.
- EMR-930 covers provider + modality + date filtering; visit-type isn't in the data model.
- New `/portal/care-pathway` route is reachable by URL; linking it into the onboarding flow is a follow-up (shared-layout-untouched convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)