### PR TITLE
Megasprint P2 Track 2 — intake-gate pipeline + registration packet (EMR-212, EMR-489)

### DIFF
--- a/src/app/(operator)/ops/schedule/intake-gate/page.tsx
+++ b/src/app/(operator)/ops/schedule/intake-gate/page.tsx
@@ -1,0 +1,269 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatDate } from "@/lib/utils/format";
+import {
+  evaluateIntakeGate,
+  type IntakeGateInput,
+  type IntakeGateResult,
+} from "@/lib/scheduling";
+
+export const metadata = { title: "Intake-to-Visit Gate" };
+
+// ---------------------------------------------------------------------------
+// EMR-212 — New-Patient Intake-to-Visit Gate Pipeline.
+//
+// Operator view of every *requested* appointment and whether it has cleared the
+// intake artifacts needed to confirm (demographics, ID/age, allergy screen,
+// cannabis history, reason, consent, insurance). The gate logic itself lives in
+// src/lib/scheduling/intake-gate.ts — this page is a thin rendering layer that
+// builds the engine input from real patient data and shows the checklist.
+// ---------------------------------------------------------------------------
+
+function isVirtualModality(modality: string): boolean {
+  return !["in_person", "in-office", "office", "in_office"].includes(modality);
+}
+
+export default async function IntakeGatePage() {
+  const user = await requireUser();
+  const orgId = user.organizationId!;
+
+  const appts = await prisma.appointment.findMany({
+    where: { status: "requested", patient: { organizationId: orgId, deletedAt: null } },
+    orderBy: { startAt: "asc" },
+    take: 100,
+    include: {
+      patient: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          status: true,
+          dateOfBirth: true,
+          ageVerifiedAt: true,
+          addressLine1: true,
+          state: true,
+          allergiesScreenedAt: true,
+          cannabisHistory: true,
+          presentingConcerns: true,
+          intakeAnswers: true,
+          signedConsents: {
+            orderBy: { signedAt: "desc" },
+            select: { templateName: true, signedAt: true },
+          },
+        },
+      },
+    },
+  });
+
+  // Primary-coverage eligibility per patient (insurance gate input).
+  const patientIds = [...new Set(appts.map((a) => a.patient.id))];
+  const coverages = await prisma.patientCoverage.findMany({
+    where: { patientId: { in: patientIds }, type: "primary", active: true },
+    select: { patientId: true, eligibilityStatus: true },
+  });
+  const coverageByPatient = new Map(coverages.map((c) => [c.patientId, c.eligibilityStatus]));
+
+  const rows = appts.map((a) => {
+    const p = a.patient;
+    // No visitType column on Appointment — a prospect is a new patient, anyone
+    // else is a follow-up. (treatmentPhase left null; the titration outcome-log
+    // requirement only fires for titration/tapering follow-ups.)
+    const visitType: IntakeGateInput["visitType"] =
+      p.status === "prospect" ? "new_patient" : "follow_up";
+    const consents = p.signedConsents;
+    const input: IntakeGateInput = {
+      visitType,
+      treatmentPhase: null,
+      patient: {
+        dateOfBirth: p.dateOfBirth,
+        addressLine1: p.addressLine1,
+        state: p.state,
+        allergiesScreenedAt: p.allergiesScreenedAt,
+        cannabisHistory: p.cannabisHistory,
+        presentingConcerns: p.presentingConcerns,
+        intakeAnswers: p.intakeAnswers,
+        ageVerifiedAt: p.ageVerifiedAt,
+      },
+      consent: {
+        visitConsentSignedAt: consents[0]?.signedAt ?? null,
+        telehealthConsentSignedAt:
+          consents.find((c) => /telehealth/i.test(c.templateName))?.signedAt ?? null,
+      },
+      insurance: {
+        coverageVerified: coverageByPatient.get(p.id) === "active",
+        selfPayAttested: false,
+      },
+      outcomeLogsSinceLastVisit: 0,
+      isVirtual: isVirtualModality(a.modality),
+    };
+    return {
+      apptId: a.id,
+      startAt: a.startAt,
+      modality: a.modality,
+      patient: { id: p.id, firstName: p.firstName, lastName: p.lastName },
+      visitType,
+      gate: evaluateIntakeGate(input),
+    };
+  });
+
+  const cleared = rows.filter((r) => r.gate.allowConfirm).length;
+  const blocked = rows.length - cleared;
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        title="Intake-to-Visit Gate"
+        description="Requested visits and whether they've cleared the intake steps needed to confirm. Gate logic is shared with booking, waitlist fill, and the slot recommender."
+      />
+
+      {/* Summary */}
+      <div className="grid grid-cols-3 gap-3 mb-8">
+        <SummaryTile label="Requested" value={rows.length} tone="neutral" />
+        <SummaryTile label="Ready to confirm" value={cleared} tone="success" />
+        <SummaryTile label="Blocked" value={blocked} tone={blocked > 0 ? "warning" : "neutral"} />
+      </div>
+
+      {rows.length === 0 ? (
+        <Card tone="raised">
+          <CardContent className="py-12 text-center text-text-muted text-sm">
+            No requested visits awaiting intake. New booking requests will appear here.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((r) => (
+            <GateCard key={r.apptId} row={r} />
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+interface GateRow {
+  apptId: string;
+  startAt: Date;
+  modality: string;
+  patient: { id: string; firstName: string; lastName: string };
+  visitType: IntakeGateInput["visitType"];
+  gate: IntakeGateResult;
+}
+
+function GateCard({ row }: { row: GateRow }) {
+  const { gate } = row;
+  const pct = Math.round(gate.completionPct * 100);
+  return (
+    <Card
+      tone="raised"
+      className={`border-l-4 ${gate.allowConfirm ? "border-l-success" : "border-l-[color:var(--warning)]"}`}
+    >
+      <CardContent className="pt-5 pb-5">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <div className="min-w-0">
+            <Link
+              href={`/clinic/patients/${row.patient.id}`}
+              className="text-sm font-semibold text-text hover:text-accent transition-colors"
+            >
+              {row.patient.firstName} {row.patient.lastName}
+            </Link>
+            <p className="text-[11px] text-text-subtle mt-0.5">
+              {formatDate(row.startAt)} ·{" "}
+              {new Date(row.startAt).toLocaleTimeString(undefined, {
+                hour: "numeric",
+                minute: "2-digit",
+              })}{" "}
+              · {row.visitType.replace(/_/g, " ")} · {row.modality}
+            </p>
+          </div>
+          <Badge tone={gate.allowConfirm ? "success" : "warning"} className="shrink-0 text-[10px]">
+            {gate.allowConfirm ? "Ready to confirm" : "Blocked"}
+          </Badge>
+        </div>
+
+        {/* Completion bar */}
+        <div className="flex items-center gap-2 mb-3">
+          <div className="h-1.5 flex-1 bg-surface-muted rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full ${gate.allowConfirm ? "bg-success" : "bg-accent"}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="text-[11px] tabular-nums text-text-subtle shrink-0">{pct}%</span>
+        </div>
+
+        {gate.blockReason && (
+          <p className="text-[11px] text-[color:var(--warning)] mb-3">{gate.blockReason}</p>
+        )}
+
+        {/* Requirements checklist */}
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1.5">
+          {gate.requirements.map((req) => (
+            <li key={req.id} className="flex items-center gap-2 text-xs">
+              <span
+                className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${
+                  req.satisfied
+                    ? "bg-success/15 text-success"
+                    : req.blocking
+                      ? "bg-[color:var(--warning)]/15 text-[color:var(--warning)]"
+                      : "bg-surface-muted text-text-subtle"
+                }`}
+                aria-hidden
+              >
+                {req.satisfied ? (
+                  <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M3.5 7L6 9.5L10.5 4.5"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                ) : (
+                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                )}
+              </span>
+              <span className={req.satisfied ? "text-text-muted" : "text-text"}>{req.label}</span>
+              {!req.satisfied && !req.blocking && (
+                <span className="text-[9px] uppercase tracking-wider text-text-subtle">advisory</span>
+              )}
+              {!req.satisfied && req.resolveHref && (
+                <Link
+                  href={req.resolveHref}
+                  className="text-[10px] font-medium text-accent hover:underline ml-auto shrink-0"
+                >
+                  Resolve
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "neutral" | "success" | "warning";
+}) {
+  const color =
+    tone === "success" ? "text-success" : tone === "warning" ? "text-[color:var(--warning)]" : "text-text";
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-4 pb-4">
+        <p className={`font-display text-2xl tabular-nums ${color}`}>{value}</p>
+        <p className="text-[11px] text-text-subtle uppercase tracking-wider mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(patient)/portal/registration/actions.ts
+++ b/src/app/(patient)/portal/registration/actions.ts
@@ -1,0 +1,136 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireRole } from "@/lib/auth/session";
+
+// EMR-489 — submit the new-patient digital registration packet.
+const schema = z.object({
+  firstName: z.string().min(1, "First name is required").max(100),
+  lastName: z.string().min(1, "Last name is required").max(100),
+  dateOfBirth: z.string().optional(),
+  email: z.string().email("Invalid email").optional().or(z.literal("")),
+  phone: z.string().max(30).optional(),
+  addressLine1: z.string().max(200).optional(),
+  city: z.string().max(100).optional(),
+  state: z.string().max(50).optional(),
+  postalCode: z.string().max(20).optional(),
+  insurancePayer: z.string().max(120).optional(),
+  memberId: z.string().max(80).optional(),
+  selfPay: z.string().optional(),
+  treatmentConsent: z.string().optional(),
+  telehealthConsent: z.string().optional(),
+  privacyConsent: z.string().optional(),
+});
+
+const FIELDS = [
+  "firstName",
+  "lastName",
+  "dateOfBirth",
+  "email",
+  "phone",
+  "addressLine1",
+  "city",
+  "state",
+  "postalCode",
+  "insurancePayer",
+  "memberId",
+  "selfPay",
+  "treatmentConsent",
+  "telehealthConsent",
+  "privacyConsent",
+] as const;
+
+export type RegistrationResult = { ok: true } | { ok: false; error: string };
+
+export async function submitRegistrationPacket(
+  _prev: RegistrationResult | null,
+  formData: FormData,
+): Promise<RegistrationResult> {
+  const user = await requireRole("patient");
+
+  const raw: Record<string, string> = {};
+  for (const k of FIELDS) raw[k] = (formData.get(k) as string) ?? "";
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.errors[0]?.message ?? "Invalid input." };
+  }
+  const d = parsed.data;
+
+  // Consent + insurance gates.
+  if (d.treatmentConsent !== "true" || d.privacyConsent !== "true") {
+    return {
+      ok: false,
+      error: "Treatment and privacy consents are required to complete registration.",
+    };
+  }
+  const isSelfPay = d.selfPay === "true";
+  if (!isSelfPay && (!d.insurancePayer || !d.memberId)) {
+    return { ok: false, error: "Enter insurance details or choose self-pay." };
+  }
+
+  const patient = await prisma.patient.findUnique({ where: { userId: user.id } });
+  if (!patient) return { ok: false, error: "No patient profile found." };
+
+  const existingIntake = (patient.intakeAnswers as Record<string, unknown>) ?? {};
+  const updatedIntake = {
+    ...existingIntake,
+    insurancePayer: isSelfPay ? undefined : d.insurancePayer,
+    insuranceMemberId: isSelfPay ? undefined : d.memberId,
+    selfPay: isSelfPay,
+    registrationCompletedAt: new Date().toISOString(),
+  };
+
+  const consents: Array<{ id: string; name: string }> = [
+    { id: "reg-treatment", name: "Treatment Consent" },
+    { id: "reg-privacy", name: "Notice of Privacy Practices" },
+  ];
+  if (d.telehealthConsent === "true") {
+    consents.push({ id: "reg-telehealth", name: "Telehealth Consent" });
+  }
+
+  await prisma.$transaction([
+    prisma.patient.update({
+      where: { id: patient.id },
+      data: {
+        firstName: d.firstName,
+        lastName: d.lastName,
+        dateOfBirth: d.dateOfBirth ? new Date(d.dateOfBirth) : undefined,
+        email: d.email || null,
+        phone: d.phone || null,
+        addressLine1: d.addressLine1 || null,
+        city: d.city || null,
+        state: d.state || null,
+        postalCode: d.postalCode || null,
+        intakeAnswers: updatedIntake as unknown as object,
+      },
+    }),
+    ...consents.map((c) =>
+      prisma.signedConsent.create({
+        data: {
+          patientId: patient.id,
+          templateId: c.id,
+          templateName: c.name,
+          version: "1.0",
+          responses: { acknowledged: true, via: "registration_packet" } as unknown as object,
+        },
+      }),
+    ),
+    prisma.auditLog.create({
+      data: {
+        organizationId: patient.organizationId,
+        actorUserId: user.id,
+        action: "patient.registration.completed",
+        subjectType: "Patient",
+        subjectId: patient.id,
+        metadata: { selfPay: isSelfPay, consents: consents.map((c) => c.id) },
+      },
+    }),
+  ]);
+
+  revalidatePath("/portal");
+  revalidatePath("/portal/registration");
+  return { ok: true };
+}

--- a/src/app/(patient)/portal/registration/page.tsx
+++ b/src/app/(patient)/portal/registration/page.tsx
@@ -1,0 +1,58 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireRole } from "@/lib/auth/session";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Eyebrow } from "@/components/ui/ornament";
+import { RegistrationPacket, type RegistrationPrefill } from "./registration-packet";
+
+export const metadata = { title: "Registration" };
+
+// EMR-489 — patient-facing digital registration packet.
+export default async function RegistrationPage() {
+  const user = await requireRole("patient");
+  const patient = await prisma.patient.findUnique({
+    where: { userId: user.id },
+    select: {
+      firstName: true,
+      lastName: true,
+      dateOfBirth: true,
+      email: true,
+      phone: true,
+      addressLine1: true,
+      city: true,
+      state: true,
+      postalCode: true,
+    },
+  });
+
+  const prefill: RegistrationPrefill = {
+    firstName: patient?.firstName ?? "",
+    lastName: patient?.lastName ?? "",
+    dateOfBirth: patient?.dateOfBirth ? patient.dateOfBirth.toISOString().slice(0, 10) : "",
+    email: patient?.email ?? "",
+    phone: patient?.phone ?? "",
+    addressLine1: patient?.addressLine1 ?? "",
+    city: patient?.city ?? "",
+    state: patient?.state ?? "",
+    postalCode: patient?.postalCode ?? "",
+  };
+
+  return (
+    <PageShell maxWidth="max-w-[720px]">
+      <div className="mb-6">
+        <Eyebrow className="mb-2">Welcome</Eyebrow>
+        <h1 className="font-display text-2xl text-text tracking-tight">
+          Complete your registration
+        </h1>
+        <p className="text-sm text-text-muted mt-1">
+          A few quick steps so your care team is ready for your first visit.
+        </p>
+      </div>
+      <Card tone="raised">
+        <CardContent className="pt-6 pb-6">
+          <RegistrationPacket prefill={prefill} />
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/src/app/(patient)/portal/registration/registration-packet.tsx
+++ b/src/app/(patient)/portal/registration/registration-packet.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { submitRegistrationPacket, type RegistrationResult } from "./actions";
+import { Button } from "@/components/ui/button";
+
+// EMR-489 — New-patient digital registration packet: a guided multi-step flow
+// (personal → insurance → consents → review) that writes to the patient record
+// + creates SignedConsent rows via submitRegistrationPacket.
+
+export interface RegistrationPrefill {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string; // yyyy-mm-dd or ""
+  email: string;
+  phone: string;
+  addressLine1: string;
+  city: string;
+  state: string;
+  postalCode: string;
+}
+
+const STEPS = ["Personal", "Insurance", "Consents", "Review"] as const;
+
+export function RegistrationPacket({ prefill }: { prefill: RegistrationPrefill }) {
+  const [state, formAction] = useFormState<RegistrationResult | null, FormData>(
+    submitRegistrationPacket,
+    null,
+  );
+  const [step, setStep] = useState(0);
+
+  const [f, setF] = useState({ ...prefill });
+  const [selfPay, setSelfPay] = useState(false);
+  const [insurancePayer, setInsurancePayer] = useState("");
+  const [memberId, setMemberId] = useState("");
+  const [treatmentConsent, setTreatmentConsent] = useState(false);
+  const [telehealthConsent, setTelehealthConsent] = useState(false);
+  const [privacyConsent, setPrivacyConsent] = useState(false);
+
+  const set = (k: keyof RegistrationPrefill, v: string) => setF((prev) => ({ ...prev, [k]: v }));
+
+  const stepValid = (() => {
+    if (step === 0) return f.firstName.trim() && f.lastName.trim();
+    if (step === 1) return selfPay || (insurancePayer.trim() && memberId.trim());
+    if (step === 2) return treatmentConsent && privacyConsent;
+    return true;
+  })();
+
+  if (state?.ok) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-4xl mb-3">🌱</div>
+        <h2 className="font-display text-2xl text-text mb-2">You're all set.</h2>
+        <p className="text-sm text-text-muted">
+          Your registration is complete. Your care team has everything they need for your first
+          visit.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form action={formAction}>
+      {/* All state mirrored as hidden inputs so the final submit carries it. */}
+      <input type="hidden" name="firstName" value={f.firstName} />
+      <input type="hidden" name="lastName" value={f.lastName} />
+      <input type="hidden" name="dateOfBirth" value={f.dateOfBirth} />
+      <input type="hidden" name="email" value={f.email} />
+      <input type="hidden" name="phone" value={f.phone} />
+      <input type="hidden" name="addressLine1" value={f.addressLine1} />
+      <input type="hidden" name="city" value={f.city} />
+      <input type="hidden" name="state" value={f.state} />
+      <input type="hidden" name="postalCode" value={f.postalCode} />
+      <input type="hidden" name="selfPay" value={String(selfPay)} />
+      <input type="hidden" name="insurancePayer" value={selfPay ? "" : insurancePayer} />
+      <input type="hidden" name="memberId" value={selfPay ? "" : memberId} />
+      <input type="hidden" name="treatmentConsent" value={String(treatmentConsent)} />
+      <input type="hidden" name="telehealthConsent" value={String(telehealthConsent)} />
+      <input type="hidden" name="privacyConsent" value={String(privacyConsent)} />
+
+      {/* Progress */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-2">
+          {STEPS.map((label, i) => (
+            <span
+              key={label}
+              className={`text-[11px] font-medium ${
+                i === step ? "text-accent" : i < step ? "text-text-muted" : "text-text-subtle"
+              }`}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className="h-1.5 bg-surface-muted rounded-full overflow-hidden">
+          <div
+            className="h-full bg-accent rounded-full transition-all"
+            style={{ width: `${((step + 1) / STEPS.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Step bodies */}
+      {step === 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Field label="First name" required>
+            <Input value={f.firstName} onChange={(v) => set("firstName", v)} />
+          </Field>
+          <Field label="Last name" required>
+            <Input value={f.lastName} onChange={(v) => set("lastName", v)} />
+          </Field>
+          <Field label="Date of birth">
+            <Input type="date" value={f.dateOfBirth} onChange={(v) => set("dateOfBirth", v)} />
+          </Field>
+          <Field label="Phone">
+            <Input value={f.phone} onChange={(v) => set("phone", v)} />
+          </Field>
+          <Field label="Email">
+            <Input type="email" value={f.email} onChange={(v) => set("email", v)} />
+          </Field>
+          <Field label="Address">
+            <Input value={f.addressLine1} onChange={(v) => set("addressLine1", v)} />
+          </Field>
+          <Field label="City">
+            <Input value={f.city} onChange={(v) => set("city", v)} />
+          </Field>
+          <Field label="State">
+            <Input value={f.state} onChange={(v) => set("state", v)} />
+          </Field>
+          <Field label="ZIP">
+            <Input value={f.postalCode} onChange={(v) => set("postalCode", v)} />
+          </Field>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setSelfPay(false)}
+              className={`flex-1 py-2 rounded-md text-sm font-medium border transition-colors ${
+                !selfPay ? "bg-accent text-accent-ink border-accent" : "bg-surface-muted text-text-muted border-border"
+              }`}
+            >
+              I have insurance
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelfPay(true)}
+              className={`flex-1 py-2 rounded-md text-sm font-medium border transition-colors ${
+                selfPay ? "bg-accent text-accent-ink border-accent" : "bg-surface-muted text-text-muted border-border"
+              }`}
+            >
+              Self-pay
+            </button>
+          </div>
+          {!selfPay && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Field label="Insurance payer" required>
+                <Input value={insurancePayer} onChange={setInsurancePayer} />
+              </Field>
+              <Field label="Member ID" required>
+                <Input value={memberId} onChange={setMemberId} />
+              </Field>
+            </div>
+          )}
+          {selfPay && (
+            <p className="text-sm text-text-muted">
+              No problem — you can add insurance later from your profile.
+            </p>
+          )}
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-3">
+          <Consent
+            checked={treatmentConsent}
+            onChange={setTreatmentConsent}
+            title="Consent to Treatment"
+            body="I consent to evaluation and treatment by this practice's clinicians."
+            required
+          />
+          <Consent
+            checked={privacyConsent}
+            onChange={setPrivacyConsent}
+            title="Notice of Privacy Practices"
+            body="I acknowledge I've received the Notice of Privacy Practices (HIPAA)."
+            required
+          />
+          <Consent
+            checked={telehealthConsent}
+            onChange={setTelehealthConsent}
+            title="Telehealth Consent"
+            body="I consent to receiving care via secure video visits (optional)."
+          />
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-2 text-sm">
+          <Review label="Name" value={`${f.firstName} ${f.lastName}`.trim() || "—"} />
+          <Review label="Date of birth" value={f.dateOfBirth || "—"} />
+          <Review label="Contact" value={[f.phone, f.email].filter(Boolean).join(" · ") || "—"} />
+          <Review
+            label="Address"
+            value={[f.addressLine1, f.city, f.state, f.postalCode].filter(Boolean).join(", ") || "—"}
+          />
+          <Review
+            label="Coverage"
+            value={selfPay ? "Self-pay" : `${insurancePayer} · ${memberId}`}
+          />
+          <Review
+            label="Consents"
+            value={[
+              treatmentConsent && "Treatment",
+              privacyConsent && "Privacy",
+              telehealthConsent && "Telehealth",
+            ]
+              .filter(Boolean)
+              .join(", ")}
+          />
+        </div>
+      )}
+
+      {state?.ok === false && <p className="text-xs text-danger mt-4">{state.error}</p>}
+
+      {/* Nav */}
+      <div className="flex items-center justify-between mt-6">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => setStep((s) => Math.max(0, s - 1))}
+          disabled={step === 0}
+        >
+          Back
+        </Button>
+        {step < STEPS.length - 1 ? (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setStep((s) => s + 1)}
+            disabled={!stepValid}
+          >
+            Continue
+          </Button>
+        ) : (
+          <SubmitButton />
+        )}
+      </div>
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="sm" disabled={pending}>
+      {pending ? "Submitting…" : "Complete registration"}
+    </Button>
+  );
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="text-[10px] font-medium uppercase tracking-wider text-text-subtle block mb-1">
+        {label}
+        {required && <span className="text-danger"> *</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function Input({
+  value,
+  onChange,
+  type = "text",
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full px-3 py-2 rounded-md border border-border bg-surface text-sm text-text focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50"
+    />
+  );
+}
+
+function Consent({
+  checked,
+  onChange,
+  title,
+  body,
+  required,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  title: string;
+  body: string;
+  required?: boolean;
+}) {
+  return (
+    <label className="flex items-start gap-3 p-3 rounded-lg border border-border bg-surface cursor-pointer hover:border-accent/40 transition-colors">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-border text-accent focus:ring-accent/40"
+      />
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-text">
+          {title}
+          {required && <span className="text-danger"> *</span>}
+        </span>
+        <span className="block text-xs text-text-muted mt-0.5">{body}</span>
+      </span>
+    </label>
+  );
+}
+
+function Review({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-border/60 pb-2">
+      <span className="text-[10px] uppercase tracking-wider text-text-subtle">{label}</span>
+      <span className="text-sm text-text text-right">{value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Megasprint P2 Track 2 — Scheduling (stream 2: the two larger gaps)

Follow-on to #624, building the two heavier net-new pages from the Track-2 audit.

### Shipped
- **EMR-212 — Intake-to-Visit Gate Pipeline UI** — new operator page `/ops/schedule/intake-gate` listing every *requested* appointment and whether it has cleared the intake artifacts needed to confirm. Thin render layer over the existing `evaluateIntakeGate` engine: builds the input from real patient data (demographics, ID/age, allergy screen, cannabis history, reason, signed consents, primary-coverage eligibility) and shows per-visit completion %, ready/blocked status, block reason, and a per-requirement checklist with Resolve deep-links. (`visitType` derived from patient status; engine reused, no new logic.)
- **EMR-489 — New-patient digital registration packet** — patient-facing `/portal/registration`: a guided multi-step flow (personal → insurance → consents → review) with progress + prefill + self-pay path. `submitRegistrationPacket` persists demographics, merges insurance into `intakeAnswers`, creates `SignedConsent` rows for acknowledged consents, writes an audit row, and stamps `registrationCompletedAt`.

### Verification (cumulative branch)
- `npm run typecheck` — clean (each commit) · `npm run lint` — 0 errors (11 pre-existing warnings, 0 introduced) · `npx vitest run` — 304 files / 2830 tests pass.

### Still open (heaviest Track-2 items)
Week-view drag-to-reschedule (EMR-921/578/577), KPI-driven schedule filters (919), address autocomplete (399), 23:59 metrics cron (816), plus smaller polish (817/926/487/564/573/579/829).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
