### PR TITLE
feat(ops): Back-Office Operations Audit — P0 roles + P3 worklist + P4 quick wins

### DIFF
--- a/prisma/migrations/20260609040000_emr1079_add_task_kind/migration.sql
+++ b/prisma/migrations/20260609040000_emr1079_add_task_kind/migration.sql
@@ -1,0 +1,12 @@
+-- EMR-1079 — Task.kind: category for the unified staff worklist (/ops/tasks)
+-- so it can facet by type per the Back-Office Operations Audit. Nullable;
+-- existing rows fall into the "Unspecified" bucket until classified.
+
+-- CreateEnum
+CREATE TYPE "TaskKind" AS ENUM ('verify_benefits', 'obtain_auth', 'refill', 'recall', 'message_reply', 'records_request', 'billing_followup', 'clinical_review', 'patient_task', 'other');
+
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN "kind" "TaskKind";
+
+-- CreateIndex
+CREATE INDEX "Task_organizationId_kind_idx" ON "Task"("organizationId", "kind");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1780,6 +1780,23 @@ enum TaskStatus {
   cancelled
 }
 
+// EMR-1079 — task category, so the unified staff worklist (/ops/tasks) can
+// facet by the kind of work, matching the Back-Office Operations Audit's
+// "filterable by type". Nullable: existing rows and unclassified creators fall
+// into the "Unspecified" bucket until set.
+enum TaskKind {
+  verify_benefits
+  obtain_auth
+  refill
+  recall
+  message_reply
+  records_request
+  billing_followup
+  clinical_review
+  patient_task
+  other
+}
+
 model Task {
   id             String     @id @default(cuid())
   organizationId String
@@ -1787,6 +1804,7 @@ model Task {
   title          String
   description    String?
   status         TaskStatus @default(open)
+  kind           TaskKind?
   assigneeRole   Role?
   assigneeUserId String?
   dueAt          DateTime?
@@ -1801,6 +1819,8 @@ model Task {
   // Filters by patientId+status, orders by dueAt — covered by this composite.
   // Index audit 2026-05-09.
   @@index([patientId, status, dueAt])
+  // EMR-1079 — worklist owner/type facet (groupBy assigneeRole/kind).
+  @@index([organizationId, kind])
 }
 
 // --------------------------------------------------------------

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2018,6 +2018,7 @@ async function main() {
       organizationId: org.id,
       patientId: maya.id,
       title: "Upload current medication list",
+      kind: "patient_task",
       description:
         "Patient needs to provide a list of all current medications including OTC supplements.",
       status: TaskStatus.open,
@@ -2031,6 +2032,7 @@ async function main() {
       organizationId: org.id,
       patientId: maya.id,
       title: "Complete sleep quality assessment",
+      kind: "patient_task",
       description: "Complete the Pittsburgh Sleep Quality Index questionnaire.",
       status: TaskStatus.open,
       assigneeRole: Role.patient,
@@ -2043,6 +2045,7 @@ async function main() {
       organizationId: org.id,
       patientId: maya.id,
       title: "Review initial intake form",
+      kind: "clinical_review",
       description: "Clinician to review Maya's completed intake answers.",
       status: TaskStatus.done,
       assigneeRole: Role.clinician,
@@ -2056,6 +2059,7 @@ async function main() {
       organizationId: org.id,
       patientId: maya.id,
       title: "Classify uploaded sleep diary image",
+      kind: "other",
       description: "AI document organizer should classify Sleep_Diary_Photo.jpg.",
       status: TaskStatus.done,
       assigneeRole: Role.system,
@@ -2068,6 +2072,7 @@ async function main() {
       organizationId: org.id,
       patientId: maya.id,
       title: "Follow up on lab results interpretation",
+      kind: "clinical_review",
       description:
         "Waiting for oncology team to provide interpretation of CBC results before next visit.",
       status: TaskStatus.snoozed,
@@ -2348,6 +2353,7 @@ async function main() {
       organizationId: org.id,
       patientId: sarah.id,
       title: "Complete your intake",
+      kind: "records_request",
       description:
         "Please finish filling out your intake form so we can prepare for your first consultation.",
       status: TaskStatus.open,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1481,6 +1481,57 @@ async function main() {
     },
   });
 
+  // Non-clinical staff (Back-Office Operations Audit §7). A real front-desk /
+  // MA / office-manager team so /ops/team is populated and the P0 guarantee is
+  // demonstrable: none of these roles carries `notes.edit`, so none can author
+  // or sign a clinical note — clinical authoring is a permission, not a default.
+  await prisma.user.upsert({
+    where: { email: "frontdesk@demo.health" },
+    update: { passwordHash },
+    create: {
+      email: "frontdesk@demo.health",
+      passwordHash,
+      firstName: "Robin",
+      lastName: "Vance",
+      // Front Desk / Scheduler: demographics + billing only.
+      memberships: {
+        create: { organizationId: org.id, role: Role.front_office },
+      },
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { email: "ma@demo.health" },
+    update: { passwordHash },
+    create: {
+      email: "ma@demo.health",
+      passwordHash,
+      firstName: "Sam",
+      lastName: "Ortiz",
+      // Medical Assistant / Biller: rooming + read-notes-to-code + billing.
+      memberships: {
+        create: { organizationId: org.id, role: Role.back_office },
+      },
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { email: "office@demo.health" },
+    update: { passwordHash },
+    create: {
+      email: "office@demo.health",
+      passwordHash,
+      firstName: "Jordan",
+      lastName: "Lee",
+      // Office Manager: all ops, read-only chart, NO chart authoring. Distinct
+      // from owner@demo.health (practice_owner), who is an owner-as-provider
+      // and therefore does carry clinical authority.
+      memberships: {
+        create: { organizationId: org.id, role: Role.operator },
+      },
+    },
+  });
+
   // ------------------------------------------------------------------
   // Patient 1 — Maya Reyes (active, richest record)
   // ------------------------------------------------------------------
@@ -4462,6 +4513,9 @@ async function main() {
   console.log("Seed complete.");
   console.log("  Owner:     owner@demo.health            / Longbeach2026!");
   console.log("  Clinician: clinician@demo.health        / Longbeach2026!");
+  console.log("  Front Desk:frontdesk@demo.health        / Longbeach2026!");
+  console.log("  MA/Biller: ma@demo.health               / Longbeach2026!");
+  console.log("  Office Mgr:office@demo.health            / Longbeach2026!");
   console.log("  Patient 1: patient@demo.health (Maya)   / Longbeach2026!");
   console.log("  Patient 2: james.chen@demo.health       / Longbeach2026!");
   console.log("  Patient 3: sarah.thompson@demo.health   / Longbeach2026!");

--- a/scripts/sync-clerk-seed.ts
+++ b/scripts/sync-clerk-seed.ts
@@ -18,6 +18,9 @@ async function syncClerkUsers() {
   const SEED_USERS = [
     { email: "owner@demo.health", password: "Longbeach2026!" },
     { email: "clinician@demo.health", password: "Longbeach2026!" },
+    { email: "frontdesk@demo.health", password: "Longbeach2026!" },
+    { email: "ma@demo.health", password: "Longbeach2026!" },
+    { email: "office@demo.health", password: "Longbeach2026!" },
     { email: "patient@demo.health", password: "Longbeach2026!" },
     { email: "james.chen@demo.health", password: "Longbeach2026!" },
     { email: "sarah.thompson@demo.health", password: "Longbeach2026!" },

--- a/src/app/(clinician)/clinic/inbox/page.tsx
+++ b/src/app/(clinician)/clinic/inbox/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// EMR-1079 (Back-Office Operations Audit §6.5) — the Smart Inbox lives at
+// /clinic/messages. Older links / bookmarks pointed at /clinic/inbox and
+// 404'd; this redirect makes the inbox reachable from that path too.
+export default function InboxRedirect() {
+  redirect("/clinic/messages");
+}

--- a/src/app/(clinician)/clinic/patients/[id]/billing/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/billing/actions.ts
@@ -33,7 +33,19 @@ export async function collectPayment(
 ): Promise<CollectResult> {
   const user = await requireUser();
 
-  if (!user.roles.some((r) => r === "clinician" || r === "practice_owner" || r === "operator")) {
+  // Front desk and billers collect money at the desk (Back-Office Audit §7),
+  // alongside operators, owners, and clinicians.
+  if (
+    !user.roles.some(
+      (r) =>
+        r === "front_office" ||
+        r === "back_office" ||
+        r === "operator" ||
+        r === "practice_owner" ||
+        r === "practice_admin" ||
+        r === "clinician",
+    )
+  ) {
     return { ok: false, error: "Unauthorized" };
   }
 

--- a/src/app/(clinician)/clinic/schedule/actions.ts
+++ b/src/app/(clinician)/clinic/schedule/actions.ts
@@ -8,6 +8,7 @@ import {
   ensureEncounterForAppointment,
   syncEncounterScheduleForAppointment,
 } from "@/lib/domain/ensure-encounter";
+import { CALENDAR_BLOCK_PATIENT } from "@/lib/domain/calendar-block-patient";
 
 const rescheduleSchema = z.object({
   appointmentId: z.string(),
@@ -172,16 +173,14 @@ export async function createSpecialBlockAction(
   let patient = await prisma.patient.findFirst({
     where: {
       organizationId: user.organizationId!,
-      firstName: "System",
-      lastName: "CalendarBlock",
+      ...CALENDAR_BLOCK_PATIENT,
     },
   });
   if (!patient) {
     patient = await prisma.patient.create({
       data: {
         organizationId: user.organizationId!,
-        firstName: "System",
-        lastName: "CalendarBlock",
+        ...CALENDAR_BLOCK_PATIENT,
         status: "active",
       },
     });

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -134,6 +134,8 @@ export default async function OperatorLayout({
         { label: "Schedule", href: "/ops/schedule" },
         { label: "Patients", href: "/ops/patients" },
         { label: "Worklist", href: "/ops/tasks" },
+        { label: "Refills", href: "/ops/refills" },
+        { label: "Recalls", href: "/ops/recalls" },
         { label: "Command Center", href: "/clinic/command" },
       ],
     },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -228,6 +228,7 @@ export default async function OperatorLayout({
       pillar: "system",
       icon: "settings",
       items: [
+        { label: "Team & roles", href: "/ops/team" },
         { label: "AI Config", href: "/ops/settings/ai-config" },
         { label: "Webhooks", href: "/ops/webhooks" },
         { label: "API keys", href: "/ops/api-keys" },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -149,6 +149,7 @@ export default async function OperatorLayout({
         { label: "Denials", href: "/ops/denials", badge: denialsBadge },
         { label: "Aging", href: "/ops/aging", badge: agingBadge },
         { label: "Eligibility", href: "/ops/eligibility" },
+        { label: "Patient payments", href: "/ops/payments" },
         { label: "Mail / Fax OCR", href: "/ops/mail-fax" },
         { label: "Agents", href: "/ops/billing-agents" },
         { label: "Revenue", href: "/ops/revenue" },

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -133,6 +133,7 @@ export default async function OperatorLayout({
         { label: "Mission Control", href: "/ops/mission-control" },
         { label: "Schedule", href: "/ops/schedule" },
         { label: "Patients", href: "/ops/patients" },
+        { label: "Worklist", href: "/ops/tasks" },
         { label: "Command Center", href: "/clinic/command" },
       ],
     },

--- a/src/app/(operator)/ops/patients/page.tsx
+++ b/src/app/(operator)/ops/patients/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { MetricTile } from "@/components/ui/metric-tile";
+import { EXCLUDE_CALENDAR_BLOCK_PATIENT } from "@/lib/domain/calendar-block-patient";
 import { PatientsClient } from "./patients-client";
 
 export const metadata = { title: "Patients" };
@@ -20,7 +21,12 @@ export default async function OpsPatientsPage({
 
   const [patients, counts] = await Promise.all([
     prisma.patient.findMany({
-      where: { organizationId: orgId, deletedAt: null, ...statusWhere },
+      where: {
+        organizationId: orgId,
+        deletedAt: null,
+        ...statusWhere,
+        ...EXCLUDE_CALENDAR_BLOCK_PATIENT,
+      },
       include: {
         chartSummary: true,
         tasks: { where: { status: "open" } },
@@ -30,7 +36,11 @@ export default async function OpsPatientsPage({
     }),
     prisma.patient.groupBy({
       by: ["status"],
-      where: { organizationId: orgId, deletedAt: null },
+      where: {
+        organizationId: orgId,
+        deletedAt: null,
+        ...EXCLUDE_CALENDAR_BLOCK_PATIENT,
+      },
       _count: true,
     }),
   ]);

--- a/src/app/(operator)/ops/payments/collect-form.tsx
+++ b/src/app/(operator)/ops/payments/collect-form.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import { useFormState } from "react-dom";
+import { useRouter } from "next/navigation";
+import { SubmitButton } from "@/lib/ui/form-helpers";
+import {
+  collectPayment,
+  type CollectResult,
+} from "@/app/(clinician)/clinic/patients/[id]/billing/actions";
+
+/**
+ * Inline collect form for the front-desk payments worklist. Reuses the
+ * existing `collectPayment` server action verbatim — same gateway routing,
+ * idempotency, ledger writes, and audit — so there is no second money path to
+ * keep in sync.
+ */
+export function CollectForm({
+  patientId,
+  defaultAmountCents,
+  liveProcessor,
+}: {
+  patientId: string;
+  defaultAmountCents: number;
+  liveProcessor: boolean;
+}) {
+  const router = useRouter();
+  const [state, formAction] = useFormState<CollectResult | null, FormData>(
+    collectPayment,
+    null,
+  );
+  const [dollars, setDollars] = React.useState(
+    (defaultAmountCents / 100).toFixed(2),
+  );
+
+  React.useEffect(() => {
+    if (state?.ok) router.refresh();
+  }, [state, router]);
+
+  const parsed = parseFloat(dollars);
+  const cents = Number.isFinite(parsed) ? Math.round(parsed * 100) : 0;
+
+  return (
+    <form action={formAction} className="flex flex-wrap items-center gap-2">
+      <input type="hidden" name="patientId" value={patientId} />
+      <input type="hidden" name="amountCents" value={cents} />
+      <div className="relative">
+        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-sm text-text-subtle">
+          $
+        </span>
+        <input
+          inputMode="decimal"
+          value={dollars}
+          onChange={(e) => setDollars(e.target.value)}
+          aria-label="Amount"
+          className="h-9 w-24 rounded-md border border-border-strong/70 bg-surface pl-5 pr-2 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+        />
+      </div>
+      <select
+        name="method"
+        defaultValue={liveProcessor ? "card" : "cash"}
+        aria-label="Payment method"
+        className="h-9 rounded-md border border-border-strong/70 bg-surface px-2 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+      >
+        <option value="card">Card</option>
+        <option value="cash">Cash</option>
+        <option value="check">Check</option>
+        <option value="ach">ACH</option>
+      </select>
+      <SubmitButton
+        size="sm"
+        variant="secondary"
+        idleLabel="Collect"
+        pendingLabel="Collecting…"
+        disabled={cents < 1}
+        className="min-w-0"
+      />
+      {state && !state.ok && (
+        <span className="w-full text-xs text-danger md:w-auto">{state.error}</span>
+      )}
+    </form>
+  );
+}

--- a/src/app/(operator)/ops/payments/page.tsx
+++ b/src/app/(operator)/ops/payments/page.tsx
@@ -1,0 +1,223 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { formatMoney } from "@/lib/domain/billing";
+import { resolvePaymentGateway } from "@/lib/payments";
+import { aggregateOutstandingBalances } from "@/lib/domain/patient-balances";
+import { CollectForm } from "./collect-form";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Patient Payments" };
+
+const STATEMENT_OPEN = ["sent", "viewed", "partially_paid", "overdue"] as const;
+
+/**
+ * Front-desk patient payments (Back-Office Operations Audit §6.4, EMR-1078).
+ * The "money in from the patient at the desk" surface the audit found missing
+ * (only payer billing existed). Lists outstanding patient-responsibility
+ * balances and lets staff collect against them — routed through the
+ * provider-agnostic payment gateway (stub today; flips to Payabli when
+ * PAYMENT_GATEWAY=payabli + keys are set). Open patient statements are shown
+ * alongside. /ops/payments no longer 404s.
+ */
+export default async function PaymentsPage() {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Revenue cycle"
+          title="Patient payments"
+          description="No practice is associated with your account."
+        />
+      </PageShell>
+    );
+  }
+
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+
+  const [claims, todayEvents, statements] = await Promise.all([
+    prisma.claim.findMany({
+      where: {
+        organizationId: orgId,
+        patientRespCents: { gt: 0 },
+        status: { in: ["accepted", "adjudicated", "partial", "paid"] },
+      },
+      select: {
+        patientId: true,
+        patientRespCents: true,
+        patient: { select: { firstName: true, lastName: true } },
+        payments: { select: { source: true, amountCents: true } },
+      },
+    }),
+    prisma.financialEvent.findMany({
+      where: {
+        organizationId: orgId,
+        type: { in: ["patient_payment", "copay_collected"] },
+        occurredAt: { gte: startOfToday },
+      },
+      select: { amountCents: true },
+    }),
+    prisma.statement.findMany({
+      where: { organizationId: orgId, status: { in: [...STATEMENT_OPEN] } },
+      orderBy: { dueDate: "asc" },
+      take: 50,
+      select: {
+        id: true,
+        amountDueCents: true,
+        paidToDateCents: true,
+        status: true,
+        dueDate: true,
+        patient: { select: { id: true, firstName: true, lastName: true } },
+      },
+    }),
+  ]);
+
+  const balances = aggregateOutstandingBalances(
+    claims.map((c) => ({
+      patientId: c.patientId,
+      patientFirstName: c.patient.firstName,
+      patientLastName: c.patient.lastName,
+      patientRespCents: c.patientRespCents,
+      payments: c.payments,
+    })),
+  );
+
+  const todayCollectedCents = todayEvents.reduce((s, e) => s + e.amountCents, 0);
+  const gatewayName = resolvePaymentGateway().name;
+  const liveProcessor = gatewayName.toLowerCase() !== "stub";
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Revenue cycle"
+        title="Patient payments"
+        description="Collect copays and balances at the desk. The payer side is handled in Billing; this is the patient's side."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+        <StatCard label="Collected today" value={formatMoney(todayCollectedCents)} tone="success" />
+        <StatCard label="Patients with a balance" value={String(balances.length)} />
+        <StatCard label="Open statements" value={String(statements.length)} tone="muted" />
+      </div>
+
+      {/* Processor status — so staff know whether a real charge will fire. */}
+      <div className="mb-8">
+        <Badge tone={liveProcessor ? "success" : "warning"}>
+          {liveProcessor
+            ? `Live processor: ${gatewayName}`
+            : "Demo mode — payments are recorded but no card is charged (processor not yet enabled)"}
+        </Badge>
+      </div>
+
+      <section className="mb-12">
+        <h2 className="font-display text-lg text-text mb-3">Outstanding balances</h2>
+        {balances.length === 0 ? (
+          <EmptyState
+            title="No outstanding patient balances"
+            description="When a claim leaves patient responsibility, it shows up here to collect."
+          />
+        ) : (
+          <div className="space-y-2">
+            {balances.map((b) => (
+              <div
+                key={b.patientId}
+                className="flex flex-col gap-3 rounded-lg border border-border/60 p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div>
+                  <p className="font-medium text-text">{b.patientName}</p>
+                  <p className="text-sm text-text-muted">
+                    Patient owes{" "}
+                    <span className="font-medium text-text tabular-nums">
+                      {formatMoney(b.owedCents)}
+                    </span>
+                  </p>
+                </div>
+                <CollectForm
+                  patientId={b.patientId}
+                  defaultAmountCents={b.owedCents}
+                  liveProcessor={liveProcessor}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-display text-lg text-text mb-3">Open statements</h2>
+        {statements.length === 0 ? (
+          <EmptyState
+            title="No open statements"
+            description="Patient statements awaiting payment will appear here."
+          />
+        ) : (
+          <div className="space-y-2">
+            {statements.map((s) => {
+              const remaining = s.amountDueCents - s.paidToDateCents;
+              return (
+                <div
+                  key={s.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border/60 p-4"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-text">
+                      {s.patient.firstName} {s.patient.lastName}
+                    </p>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-subtle">
+                      <Badge tone={s.status === "overdue" ? "danger" : "neutral"}>
+                        {s.status.replace(/_/g, " ")}
+                      </Badge>
+                      {s.dueDate && (
+                        <span>
+                          Due{" "}
+                          {s.dueDate.toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <p className="shrink-0 font-medium text-text tabular-nums">
+                    {formatMoney(remaining)}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </PageShell>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: "neutral" | "success" | "muted";
+}) {
+  const colors = {
+    neutral: "text-text",
+    success: "text-success",
+    muted: "text-text-muted",
+  };
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-5 pb-5">
+        <p className={`font-display text-2xl tabular-nums ${colors[tone]}`}>{value}</p>
+        <p className="text-xs text-text-muted mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/recalls/page.tsx
+++ b/src/app/(operator)/ops/recalls/page.tsx
@@ -1,0 +1,193 @@
+import Link from "next/link";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { EXCLUDE_CALENDAR_BLOCK_PATIENT } from "@/lib/domain/calendar-block-patient";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Recalls" };
+
+const THRESHOLDS = [90, 180, 365] as const;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type Search = { since?: string };
+
+/**
+ * Recalls / outreach (Back-Office Operations Audit §6.5, EMR-1079). Surfaces
+ * established patients who are overdue for a follow-up — no upcoming
+ * appointment and a last visit older than the chosen window — so the back
+ * office can pull them back in. /ops/recalls no longer 404s.
+ *
+ * First slice is the worklist + one-tap scheduling. Batch outreach through the
+ * waitlist's staggered, quiet-hours-aware engine is a tracked follow-up.
+ */
+export default async function RecallsPage({
+  searchParams,
+}: {
+  searchParams: Search;
+}) {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Between visits"
+          title="Recalls"
+          description="No practice is associated with your account."
+        />
+      </PageShell>
+    );
+  }
+
+  const sinceDays = (THRESHOLDS as readonly number[]).includes(
+    Number(searchParams.since),
+  )
+    ? Number(searchParams.since)
+    : 90;
+
+  const now = Date.now();
+  const cutoff = new Date(now - sinceDays * DAY_MS);
+
+  // Active, real patients and their appointment timeline (just the dates).
+  const patients = await prisma.patient.findMany({
+    where: {
+      organizationId: orgId,
+      status: "active",
+      deletedAt: null,
+      ...EXCLUDE_CALENDAR_BLOCK_PATIENT,
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      appointments: {
+        select: { startAt: true, status: true },
+        orderBy: { startAt: "desc" },
+      },
+    },
+    take: 1000,
+  });
+
+  // Overdue = no upcoming appointment AND a most-recent past visit older than
+  // the window. (Brand-new patients with no past visit aren't "recalls" yet.)
+  const overdue = patients
+    .map((p) => {
+      const hasUpcoming = p.appointments.some(
+        (a) => a.startAt.getTime() >= now && a.status !== "cancelled",
+      );
+      const lastPast = p.appointments
+        .filter((a) => a.startAt.getTime() < now && a.status !== "cancelled")
+        .sort((a, b) => b.startAt.getTime() - a.startAt.getTime())[0];
+      if (hasUpcoming || !lastPast) return null;
+      if (lastPast.startAt.getTime() >= cutoff.getTime()) return null;
+      const daysSince = Math.floor((now - lastPast.startAt.getTime()) / DAY_MS);
+      return {
+        id: p.id,
+        name: `${p.firstName} ${p.lastName}`.trim(),
+        lastVisit: lastPast.startAt,
+        daysSince,
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+    .sort((a, b) => b.daysSince - a.daysSince);
+
+  return (
+    <PageShell maxWidth="max-w-[1000px]">
+      <PageHeader
+        eyebrow="Between visits"
+        title="Recalls"
+        description="Established patients with no upcoming visit and a lapsed last appointment. Pull them back in before they fall through the cracks."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+        <StatCard label={`Overdue ${sinceDays}d+`} value={overdue.length} tone="warning" />
+        <StatCard label="Active patients" value={patients.length} tone="muted" />
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-text-subtle mr-1">
+          Lapsed for
+        </span>
+        {THRESHOLDS.map((t) => (
+          <Link
+            key={t}
+            href={t === 90 ? "/ops/recalls" : `/ops/recalls?since=${t}`}
+            className={
+              sinceDays === t
+                ? "rounded-full border border-accent/50 bg-accent/10 px-3 py-1 text-xs font-medium text-accent"
+                : "rounded-full border border-border px-3 py-1 text-xs font-medium text-text-muted hover:border-border-strong"
+            }
+          >
+            {t} days
+          </Link>
+        ))}
+      </div>
+
+      {overdue.length === 0 ? (
+        <EmptyState
+          title="No recalls due"
+          description="Every active patient has an upcoming visit or a recent one. Widen the window to look further back."
+        />
+      ) : (
+        <div className="space-y-2">
+          {overdue.map((p) => (
+            <div
+              key={p.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-border/60 p-4"
+            >
+              <div className="min-w-0">
+                <Link
+                  href={`/clinic/patients/${p.id}`}
+                  className="font-medium text-text hover:text-accent hover:underline"
+                >
+                  {p.name}
+                </Link>
+                <div className="mt-1 flex items-center gap-2 text-xs text-text-subtle">
+                  <Badge tone="warning">{p.daysSince} days since last visit</Badge>
+                  <span>
+                    Last seen{" "}
+                    {p.lastVisit.toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </span>
+                </div>
+              </div>
+              <Link
+                href={`/clinic/schedule?patientId=${p.id}`}
+                className="shrink-0 rounded-md bg-surface-raised border border-border-strong/70 px-3 h-9 inline-flex items-center text-sm font-medium text-text hover:bg-surface-muted"
+              >
+                Schedule
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  tone?: "neutral" | "warning" | "muted";
+}) {
+  const colors = { neutral: "text-text", warning: "text-[color:var(--warning)]", muted: "text-text-muted" };
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-5 pb-5">
+        <p className={`font-display text-3xl tabular-nums ${colors[tone]}`}>{value}</p>
+        <p className="text-xs text-text-muted mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/refills/actions.ts
+++ b/src/app/(operator)/ops/refills/actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+
+// EMR-1079 (Back-Office Operations Audit §6.5) — refill queue, staff side.
+// Refill *approval/signing* is clinical and already lives at
+// /clinic/sign-off/refills. The back office's job is to route an incoming
+// request to a provider. This action flags a `new` request for provider
+// review; it deliberately does NOT approve, deny, or sign.
+
+const REFILL_STAFF_ROLES = new Set<string>([
+  "front_office",
+  "back_office",
+  "operator",
+  "practice_owner",
+  "practice_admin",
+  "system",
+]);
+
+const FlagSchema = z.object({ refillId: z.string().min(1) });
+
+export type RefillActionResult = { ok: true } | { ok: false; error: string };
+
+export async function flagRefillForProvider(input: {
+  refillId: string;
+}): Promise<RefillActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "Missing organization." };
+  if (!user.roles.some((r) => REFILL_STAFF_ROLES.has(r))) {
+    return { ok: false, error: "Forbidden." };
+  }
+
+  const parsed = FlagSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid request." };
+
+  const refill = await prisma.refillRequest.findFirst({
+    where: { id: parsed.data.refillId, organizationId: user.organizationId },
+    select: { id: true, status: true },
+  });
+  if (!refill) return { ok: false, error: "Refill request not found." };
+
+  if (refill.status === "flagged") {
+    revalidatePath("/ops/refills");
+    return { ok: true };
+  }
+  // Only an untriaged ("new") request can be routed from here. Approved/sent/
+  // denied requests are past the staff routing step.
+  if (refill.status !== "new") {
+    return { ok: false, error: "Only a new request can be flagged for the provider." };
+  }
+
+  await prisma.refillRequest.update({
+    where: { id: refill.id },
+    data: { status: "flagged" },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      action: "refill.flagged_for_provider",
+      subjectType: "RefillRequest",
+      subjectId: refill.id,
+      metadata: { from: "new", to: "flagged" },
+    },
+  });
+
+  revalidatePath("/ops/refills");
+  return { ok: true };
+}

--- a/src/app/(operator)/ops/refills/page.tsx
+++ b/src/app/(operator)/ops/refills/page.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { canManageTeam } from "@/lib/rbac/team-management";
+import { RefillsBoard, type RefillRow } from "./refills-board";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Refills" };
+
+type View = "open" | "all" | "signed";
+type Search = { view?: string };
+
+/**
+ * Refill queue — staff side (Back-Office Operations Audit §6.5, EMR-1079).
+ * Routes incoming refill requests to a provider. The clinical approve/sign
+ * step lives in the provider sign-off queue (/clinic/sign-off/refills); this
+ * surface gives the back office visibility + a one-tap "flag for provider".
+ * /ops/refills no longer 404s.
+ */
+export default async function RefillsPage({
+  searchParams,
+}: {
+  searchParams: Search;
+}) {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Between visits"
+          title="Refills"
+          description="No practice is associated with your account."
+        />
+      </PageShell>
+    );
+  }
+
+  const view: View =
+    searchParams.view === "all" || searchParams.view === "signed"
+      ? searchParams.view
+      : "open";
+
+  const statusWhere: Prisma.RefillRequestWhereInput =
+    view === "all"
+      ? {}
+      : view === "signed"
+        ? { status: { in: ["approved", "sent", "denied"] } }
+        : { status: { in: ["new", "flagged"] } };
+
+  const [refills, newCount, flaggedCount] = await Promise.all([
+    prisma.refillRequest.findMany({
+      where: { organizationId: orgId, ...statusWhere },
+      orderBy: [{ status: "asc" }, { receivedAt: "asc" }],
+      take: 200,
+      include: {
+        patient: { select: { id: true, firstName: true, lastName: true } },
+        medication: { select: { name: true, dosage: true } },
+      },
+    }),
+    prisma.refillRequest.count({ where: { organizationId: orgId, status: "new" } }),
+    prisma.refillRequest.count({
+      where: { organizationId: orgId, status: "flagged" },
+    }),
+  ]);
+
+  const rows: RefillRow[] = refills.map((r) => ({
+    id: r.id,
+    patientId: r.patient.id,
+    patientName: `${r.patient.firstName} ${r.patient.lastName}`.trim(),
+    medicationName: r.medication.name,
+    medicationDosage: r.medication.dosage ?? null,
+    requestedQty: r.requestedQty,
+    requestedDays: r.requestedDays,
+    pharmacyName: r.pharmacyName,
+    status: r.status,
+    copilotSuggestion: r.copilotSuggestion,
+    rationale: r.rationale,
+    safetyFlags: Array.isArray(r.safetyFlags) ? (r.safetyFlags as string[]) : [],
+    receivedAt: r.receivedAt.toISOString(),
+  }));
+
+  const canManage =
+    canManageTeam(user.roles) ||
+    user.roles.some((role) => role === "operator" || role === "front_office" || role === "back_office");
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Between visits"
+        title="Refills"
+        description="Incoming refill requests. Route them to a provider — the clinical approve & sign step lives in the provider sign-off queue."
+        actions={
+          <Link
+            href="/clinic/sign-off/refills"
+            className="rounded-md bg-surface-raised border border-border-strong/70 px-4 h-10 inline-flex items-center text-sm font-medium text-text hover:bg-surface-muted"
+          >
+            Provider sign-off →
+          </Link>
+        }
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+        <StatCard label="New" value={newCount} tone="accent" />
+        <StatCard label="Flagged for provider" value={flaggedCount} tone="warning" />
+        <StatCard label="Showing" value={rows.length} tone="muted" />
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        {(
+          [
+            { key: "open", label: "Open" },
+            { key: "signed", label: "Resolved" },
+            { key: "all", label: "All" },
+          ] as Array<{ key: View; label: string }>
+        ).map((opt) => (
+          <Link
+            key={opt.key}
+            href={opt.key === "open" ? "/ops/refills" : `/ops/refills?view=${opt.key}`}
+            className={
+              view === opt.key
+                ? "rounded-full border border-accent/50 bg-accent/10 px-3 py-1 text-xs font-medium text-accent"
+                : "rounded-full border border-border px-3 py-1 text-xs font-medium text-text-muted hover:border-border-strong"
+            }
+          >
+            {opt.label}
+          </Link>
+        ))}
+      </div>
+
+      <RefillsBoard rows={rows} canManage={canManage} />
+    </PageShell>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  tone?: "neutral" | "accent" | "warning" | "muted";
+}) {
+  const colors = {
+    neutral: "text-text",
+    accent: "text-accent",
+    warning: "text-[color:var(--warning)]",
+    muted: "text-text-muted",
+  };
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-5 pb-5">
+        <p className={`font-display text-3xl tabular-nums ${colors[tone]}`}>{value}</p>
+        <p className="text-xs text-text-muted mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/refills/refills-board.tsx
+++ b/src/app/(operator)/ops/refills/refills-board.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { flagRefillForProvider, type RefillActionResult } from "./actions";
+
+export interface RefillRow {
+  id: string;
+  patientId: string;
+  patientName: string;
+  medicationName: string;
+  medicationDosage: string | null;
+  requestedQty: number;
+  requestedDays: number | null;
+  pharmacyName: string;
+  status: string;
+  copilotSuggestion: string | null;
+  rationale: string | null;
+  safetyFlags: string[];
+  receivedAt: string;
+}
+
+const STATUS_TONE: Record<string, React.ComponentProps<typeof Badge>["tone"]> = {
+  new: "accent",
+  flagged: "warning",
+  approved: "success",
+  sent: "success",
+  denied: "neutral",
+};
+
+const SUGGESTION_TONE: Record<string, React.ComponentProps<typeof Badge>["tone"]> = {
+  approve: "success",
+  deny: "danger",
+  review: "warning",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function RefillsBoard({
+  rows,
+  canManage,
+}: {
+  rows: RefillRow[];
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = React.useTransition();
+  const [busyId, setBusyId] = React.useState<string | null>(null);
+  const [errors, setErrors] = React.useState<Record<string, string>>({});
+
+  function run(id: string, fn: () => Promise<RefillActionResult>) {
+    setBusyId(id);
+    setErrors((e) => ({ ...e, [id]: "" }));
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) setErrors((e) => ({ ...e, [id]: res.error }));
+      else router.refresh();
+      setBusyId(null);
+    });
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="Queue clear"
+        description="No refill requests in this view. New requests appear here as they arrive."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((r) => {
+        const rowBusy = pending && busyId === r.id;
+        return (
+          <div
+            key={r.id}
+            className="flex flex-col gap-3 rounded-lg border border-border/60 p-4 md:flex-row md:items-start md:justify-between"
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-medium text-text">
+                  {r.medicationName}
+                  {r.medicationDosage ? ` · ${r.medicationDosage}` : ""}
+                </span>
+                <Badge tone={STATUS_TONE[r.status] ?? "neutral"}>{r.status}</Badge>
+                {r.copilotSuggestion && (
+                  <Badge tone={SUGGESTION_TONE[r.copilotSuggestion] ?? "neutral"}>
+                    Copilot: {r.copilotSuggestion}
+                  </Badge>
+                )}
+                {r.safetyFlags.map((flag) => (
+                  <Badge key={flag} tone="danger">
+                    {flag}
+                  </Badge>
+                ))}
+              </div>
+              {r.rationale && (
+                <p className="mt-1 text-sm text-text-muted line-clamp-2">{r.rationale}</p>
+              )}
+              <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-subtle">
+                <Link
+                  href={`/clinic/patients/${r.patientId}`}
+                  className="text-accent hover:underline"
+                >
+                  {r.patientName}
+                </Link>
+                <span>
+                  Qty {r.requestedQty}
+                  {r.requestedDays ? ` · ${r.requestedDays}d` : ""}
+                </span>
+                <span>{r.pharmacyName}</span>
+                <span>Received {formatDate(r.receivedAt)}</span>
+              </div>
+              {errors[r.id] && (
+                <p className="mt-2 text-xs text-danger">{errors[r.id]}</p>
+              )}
+            </div>
+
+            {canManage && r.status === "new" && (
+              <div className="shrink-0">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={rowBusy}
+                  onClick={() => run(r.id, () => flagRefillForProvider({ refillId: r.id }))}
+                >
+                  Flag for provider
+                </Button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(operator)/ops/schedule/ScheduleClient.tsx
+++ b/src/app/(operator)/ops/schedule/ScheduleClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils/cn";
 import { RangeFilter, type RangeKey } from "./RangeFilter";
+import { confirmAppointment, declineAppointment } from "./actions";
 
 // ---------------------------------------------------------------------------
 // EMR-936 — Clickable "Providers this week" cards → provider snapshot in the
@@ -402,6 +403,20 @@ function WeekGrid({ days }: { days: DayBucket[] }) {
 
 function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
   const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  // EMR-1085 — action a patient-requested booking right from the card.
+  function runStatusChange(
+    fn: () => Promise<{ ok: boolean; error?: string }>,
+  ) {
+    setError(null);
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) setError(res.error ?? "Could not update the appointment.");
+      else router.refresh();
+    });
+  }
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -413,6 +428,23 @@ function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
       },
     },
   ];
+  // Only a still-requested booking can be confirmed or declined.
+  if (appt.status === "requested") {
+    menuItems.push(
+      {
+        label: "Confirm appointment",
+        icon: ContextMenuIcons.Check,
+        onSelect: () =>
+          runStatusChange(() => confirmAppointment({ appointmentId: appt.id })),
+      },
+      {
+        label: "Decline request",
+        danger: true,
+        onSelect: () =>
+          runStatusChange(() => declineAppointment({ appointmentId: appt.id })),
+      },
+    );
+  }
   const { triggerProps, menu } = useContextMenu(menuItems);
 
   return (
@@ -455,15 +487,44 @@ function AppointmentCard({ appt }: { appt: SerializedAppointment }) {
         <NoShowRiskBadge tier={appt.riskTier} probability={appt.riskProbability} />
         {/* EMR-920 — inline insurance-eligibility helper tag on upcoming visits. */}
         {(appt.status === "requested" || appt.status === "confirmed") && (
-          <Badge
-            tone="info"
-            className="text-[9px]"
-            title="Insurance eligibility not yet verified for this visit."
+          <Link
+            href="/ops/eligibility"
+            className="inline-flex"
+            title="Check insurance eligibility for this visit."
           >
-            ⊕ Verify insurance
-          </Badge>
+            <Badge tone="info" className="text-[9px] hover:bg-blue-100">
+              ⊕ Verify insurance
+            </Badge>
+          </Link>
         )}
       </div>
+
+      {/* EMR-1085 — confirm/decline a patient-requested booking inline. */}
+      {appt.status === "requested" && (
+        <div className="mt-2 flex items-center gap-1.5">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() =>
+              runStatusChange(() => confirmAppointment({ appointmentId: appt.id }))
+            }
+            className="rounded-md bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() =>
+              runStatusChange(() => declineAppointment({ appointmentId: appt.id }))
+            }
+            className="rounded-md px-2 py-0.5 text-[10px] font-medium text-danger hover:bg-danger/10 disabled:opacity-50"
+          >
+            Decline
+          </button>
+        </div>
+      )}
+      {error && <p className="mt-1 text-[10px] text-danger">{error}</p>}
       {menu}
     </div>
   );

--- a/src/app/(operator)/ops/schedule/actions.ts
+++ b/src/app/(operator)/ops/schedule/actions.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+
+// EMR-1085 (Back-Office Operations Audit §6.1 / §5) — the front desk must be
+// able to action a patient-requested booking. These server actions flip a
+// `requested` appointment to `confirmed` or `cancelled` (declined) so the
+// pre-visit order-of-operations can actually start.
+
+// Scheduling-capable staff. Mirrors the queue actions' role set: front desk,
+// MA/biller, office manager, owner/admin, and the system actor.
+const SCHEDULE_ROLES = new Set<string>([
+  "front_office",
+  "back_office",
+  "operator",
+  "practice_owner",
+  "practice_admin",
+  "system",
+]);
+
+const ApptActionSchema = z.object({ appointmentId: z.string().min(1) });
+
+export type ScheduleActionResult = { ok: true } | { ok: false; error: string };
+
+export async function confirmAppointment(input: {
+  appointmentId: string;
+}): Promise<ScheduleActionResult> {
+  return transition(input, "confirmed");
+}
+
+export async function declineAppointment(input: {
+  appointmentId: string;
+}): Promise<ScheduleActionResult> {
+  return transition(input, "cancelled");
+}
+
+async function transition(
+  input: unknown,
+  target: "confirmed" | "cancelled",
+): Promise<ScheduleActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "Missing organization." };
+  if (!user.roles.some((r) => SCHEDULE_ROLES.has(r))) {
+    return { ok: false, error: "Forbidden." };
+  }
+
+  const parsed = ApptActionSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid request." };
+
+  // Org-scope through the patient relation — never action another practice's
+  // appointment.
+  const appt = await prisma.appointment.findFirst({
+    where: {
+      id: parsed.data.appointmentId,
+      patient: { organizationId: user.organizationId },
+    },
+    select: { id: true, status: true },
+  });
+  if (!appt) return { ok: false, error: "Appointment not found." };
+
+  // Idempotent: already in the desired state is a success.
+  if (appt.status === target) {
+    revalidatePath("/ops/schedule");
+    return { ok: true };
+  }
+  // Only a requested booking can be confirmed/declined from this surface.
+  if (appt.status !== "requested") {
+    return {
+      ok: false,
+      error: `Only a requested appointment can be ${
+        target === "confirmed" ? "confirmed" : "declined"
+      }.`,
+    };
+  }
+
+  await prisma.appointment.update({
+    where: { id: appt.id },
+    data: { status: target },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      action: target === "confirmed" ? "appointment.confirmed" : "appointment.declined",
+      subjectType: "Appointment",
+      subjectId: appt.id,
+      metadata: { from: "requested", to: target },
+    },
+  });
+
+  revalidatePath("/ops/schedule");
+  return { ok: true };
+}

--- a/src/app/(operator)/ops/scrub/charge-capture-pipeline.tsx
+++ b/src/app/(operator)/ops/scrub/charge-capture-pipeline.tsx
@@ -1,0 +1,92 @@
+import type { ClaimStatus } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatMoney } from "@/lib/domain/billing";
+
+// EMR-1080 (Back-Office Operations Audit §6.4 P4 #4) — make the charge-capture
+// → scrub hand-off visible to staff. A signed note + ordered codes become a
+// draft claim, which is scrubbed and submitted. This strip surfaces that flow
+// as a stage funnel so staff can see the chain from captured charge to payer.
+
+const STAGES: Array<{
+  key: string;
+  label: string;
+  hint: string;
+  statuses: ClaimStatus[];
+}> = [
+  { key: "draft", label: "Draft", hint: "Charge captured", statuses: ["draft"] },
+  {
+    key: "review",
+    label: "In review",
+    hint: "Scrubbing",
+    statuses: ["scrubbing", "scrub_blocked"],
+  },
+  { key: "ready", label: "Ready", hint: "Scrub passed", statuses: ["ready"] },
+  { key: "submitted", label: "Submitted", hint: "Sent to payer", statuses: ["submitted"] },
+];
+
+const ALL_STATUSES = STAGES.flatMap((s) => s.statuses);
+
+export async function ChargeCapturePipeline({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const groups = await prisma.claim.groupBy({
+    by: ["status"],
+    where: { organizationId, status: { in: ALL_STATUSES } },
+    _count: true,
+    _sum: { billedAmountCents: true },
+  });
+
+  const byStatus = new Map(
+    groups.map((g) => [
+      g.status,
+      { count: g._count, cents: g._sum.billedAmountCents ?? 0 },
+    ]),
+  );
+
+  const stages = STAGES.map((s) => {
+    let count = 0;
+    let cents = 0;
+    for (const st of s.statuses) {
+      const g = byStatus.get(st);
+      if (g) {
+        count += g.count;
+        cents += g.cents;
+      }
+    }
+    return { ...s, count, cents };
+  });
+
+  // Nothing captured yet — don't show an empty funnel on a fresh tenant.
+  if (stages.reduce((a, s) => a + s.count, 0) === 0) return null;
+
+  return (
+    <Card tone="raised" className="mb-6">
+      <CardContent className="py-4">
+        <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+          Charge capture → submission
+        </p>
+        <div className="flex items-stretch gap-2 overflow-x-auto">
+          {stages.map((s, i) => (
+            <div key={s.key} className="flex items-center gap-2">
+              <div className="min-w-[128px] rounded-lg border border-border/60 px-4 py-2">
+                <p className="font-display text-2xl tabular-nums text-text">{s.count}</p>
+                <p className="text-xs font-medium text-text">{s.label}</p>
+                <p className="text-[10px] text-text-subtle">
+                  {s.hint} · {formatMoney(s.cents)}
+                </p>
+              </div>
+              {i < stages.length - 1 && (
+                <span aria-hidden className="text-text-subtle">
+                  →
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/scrub/page.tsx
+++ b/src/app/(operator)/ops/scrub/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { ChargeCapturePipeline } from "./charge-capture-pipeline";
 import {
   scrubClaim,
   countBySeverity,
@@ -198,6 +199,10 @@ export default async function ScrubWorkbenchPage() {
         title="Scrub and Auths"
         description="Every claim is checked against payer + coding rules. Plain language issues, structured detail, suggested fixes. Submit prior authorizations from one hub."
       />
+
+      {/* EMR-1080 — charge capture → submission funnel so staff see the
+          hand-off from a signed note's codes into a scrubbed, submitted claim. */}
+      <ChargeCapturePipeline organizationId={organizationId} />
 
       {/* EMR-979 — "Top issues this week" now lives inside the client shell so
           its count bubbles can filter the review list. */}

--- a/src/app/(operator)/ops/tasks/actions.ts
+++ b/src/app/(operator)/ops/tasks/actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+
+// EMR-1079 (Back-Office Operations Audit §6.5) — the unified staff worklist.
+// Per-patient "open tasks" already exist; this surface rolls them into one
+// queue the back office can actually work. These actions let staff close out
+// or reopen a task from that queue.
+
+const WORKLIST_ROLES = new Set<string>([
+  "front_office",
+  "back_office",
+  "operator",
+  "practice_owner",
+  "practice_admin",
+  "system",
+]);
+
+const TaskActionSchema = z.object({ taskId: z.string().min(1) });
+
+export type TaskActionResult = { ok: true } | { ok: false; error: string };
+
+export async function completeTask(input: {
+  taskId: string;
+}): Promise<TaskActionResult> {
+  return mutate(input, "done");
+}
+
+export async function reopenTask(input: {
+  taskId: string;
+}): Promise<TaskActionResult> {
+  return mutate(input, "open");
+}
+
+async function mutate(
+  input: unknown,
+  target: "done" | "open",
+): Promise<TaskActionResult> {
+  const user = await requireUser();
+  if (!user.organizationId) return { ok: false, error: "Missing organization." };
+  if (!user.roles.some((r) => WORKLIST_ROLES.has(r))) {
+    return { ok: false, error: "Forbidden." };
+  }
+
+  const parsed = TaskActionSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid request." };
+
+  // Org-scope: only act on a task in the caller's practice.
+  const task = await prisma.task.findFirst({
+    where: { id: parsed.data.taskId, organizationId: user.organizationId },
+    select: { id: true, status: true },
+  });
+  if (!task) return { ok: false, error: "Task not found." };
+
+  if (task.status === target) {
+    revalidatePath("/ops/tasks");
+    return { ok: true };
+  }
+
+  await prisma.task.update({
+    where: { id: task.id },
+    data: {
+      status: target,
+      // Stamp/clear completion so the rollup counts and "completed" filter
+      // stay honest.
+      completedAt: target === "done" ? new Date() : null,
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      action: target === "done" ? "task.completed" : "task.reopened",
+      subjectType: "Task",
+      subjectId: task.id,
+      metadata: { from: task.status, to: target },
+    },
+  });
+
+  revalidatePath("/ops/tasks");
+  return { ok: true };
+}

--- a/src/app/(operator)/ops/tasks/kinds.ts
+++ b/src/app/(operator)/ops/tasks/kinds.ts
@@ -1,0 +1,16 @@
+import type { TaskKind } from "@prisma/client";
+
+// Human labels for the worklist's task-type facet (EMR-1079). Mirrors the
+// Back-Office Operations Audit's task categories.
+export const KIND_LABELS: Record<TaskKind, string> = {
+  verify_benefits: "Verify benefits",
+  obtain_auth: "Obtain auth",
+  refill: "Refill",
+  recall: "Recall / outreach",
+  message_reply: "Message reply",
+  records_request: "Records request",
+  billing_followup: "Billing follow-up",
+  clinical_review: "Clinical review",
+  patient_task: "Patient task",
+  other: "Other",
+};

--- a/src/app/(operator)/ops/tasks/page.tsx
+++ b/src/app/(operator)/ops/tasks/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
-import type { Prisma, Role, TaskStatus } from "@prisma/client";
+import type { Prisma, Role, TaskKind, TaskStatus } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
 import { ROLE_LABELS } from "@/lib/rbac/roles";
 import { canManageTeam } from "@/lib/rbac/team-management";
+import { KIND_LABELS } from "./kinds";
 import { TasksBoard, type TaskRow } from "./tasks-board";
 
 export const dynamic = "force-dynamic";
@@ -20,6 +21,7 @@ type Search = {
   view?: string;
   owner?: string;
   due?: string;
+  kind?: string;
 };
 
 /**
@@ -56,6 +58,7 @@ export default async function TasksPage({
       ? searchParams.due
       : "all";
   const owner = searchParams.owner ?? "all";
+  const kind = searchParams.kind ?? "all";
 
   const now = new Date();
   const soonCutoff = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -84,14 +87,24 @@ export default async function TasksPage({
         ? { dueAt: { gte: now, lt: soonCutoff } }
         : {};
 
+  // Type facet: all | unspecified | a specific kind.
+  const kindWhere: Prisma.TaskWhereInput =
+    kind === "all"
+      ? {}
+      : kind === "unspecified"
+        ? { kind: null }
+        : { kind: kind as TaskKind };
+
   const where: Prisma.TaskWhereInput = {
     organizationId: orgId,
     ...statusWhere,
     ...ownerWhere,
     ...dueWhere,
+    ...kindWhere,
   };
 
-  const [tasks, activeCount, overdueCount, ownerGroups] = await Promise.all([
+  const [tasks, activeCount, overdueCount, ownerGroups, kindGroups] =
+    await Promise.all([
     prisma.task.findMany({
       where,
       select: {
@@ -99,6 +112,7 @@ export default async function TasksPage({
         title: true,
         description: true,
         status: true,
+        kind: true,
         assigneeRole: true,
         assigneeUserId: true,
         dueAt: true,
@@ -122,6 +136,12 @@ export default async function TasksPage({
     // Owner chips — which assignee roles actually have active tasks.
     prisma.task.groupBy({
       by: ["assigneeRole"],
+      where: { organizationId: orgId, status: { in: ACTIVE_STATUSES } },
+      _count: true,
+    }),
+    // Type chips — which kinds actually have active tasks.
+    prisma.task.groupBy({
+      by: ["kind"],
       where: { organizationId: orgId, status: { in: ACTIVE_STATUSES } },
       _count: true,
     }),
@@ -150,6 +170,7 @@ export default async function TasksPage({
     title: t.title,
     description: t.description,
     status: t.status,
+    kindLabel: t.kind ? KIND_LABELS[t.kind] : null,
     assigneeRole: t.assigneeRole,
     assigneeName: t.assigneeUserId ? nameById.get(t.assigneeUserId) ?? null : null,
     dueAt: t.dueAt ? t.dueAt.toISOString() : null,
@@ -166,6 +187,7 @@ export default async function TasksPage({
   }));
 
   const ownerOptions = buildOwnerOptions(ownerGroups);
+  const kindOptions = buildKindOptions(kindGroups);
   const canManage = canManageTeam(user.roles) || user.roles.includes("operator");
 
   return (
@@ -207,6 +229,13 @@ export default async function TasksPage({
           search={searchParams}
         />
         <FilterRow
+          label="Type"
+          options={kindOptions}
+          param="kind"
+          active={kind}
+          search={searchParams}
+        />
+        <FilterRow
           label="Owner"
           options={ownerOptions}
           param="owner"
@@ -237,6 +266,22 @@ function buildOwnerOptions(
     opts.push({ key: g.assigneeRole, label: ROLE_LABELS[g.assigneeRole] ?? g.assigneeRole });
   }
   if (hasUnassigned) opts.push({ key: "unassigned", label: "Unassigned" });
+  return opts;
+}
+
+function buildKindOptions(
+  groups: Array<{ kind: TaskKind | null; _count: number }>,
+): Array<{ key: string; label: string }> {
+  const opts: Array<{ key: string; label: string }> = [{ key: "all", label: "All types" }];
+  let hasUnspecified = false;
+  for (const g of groups) {
+    if (g.kind === null) {
+      hasUnspecified = true;
+      continue;
+    }
+    opts.push({ key: g.kind, label: KIND_LABELS[g.kind] });
+  }
+  if (hasUnspecified) opts.push({ key: "unspecified", label: "Unspecified" });
   return opts;
 }
 

--- a/src/app/(operator)/ops/tasks/page.tsx
+++ b/src/app/(operator)/ops/tasks/page.tsx
@@ -1,0 +1,315 @@
+import Link from "next/link";
+import type { Prisma, Role, TaskStatus } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { ROLE_LABELS } from "@/lib/rbac/roles";
+import { canManageTeam } from "@/lib/rbac/team-management";
+import { TasksBoard, type TaskRow } from "./tasks-board";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Worklist" };
+
+const ACTIVE_STATUSES: TaskStatus[] = ["open", "in_progress", "snoozed"];
+
+type View = "active" | "completed" | "all";
+type Due = "all" | "overdue" | "soon";
+
+type Search = {
+  view?: string;
+  owner?: string;
+  due?: string;
+};
+
+/**
+ * Staff worklist (Back-Office Operations Audit §6.5, EMR-1079). Rolls the
+ * per-patient "open tasks" the system already counts into one queue the back
+ * office can actually work — filterable by status, owner, and due date. The
+ * back office's home screen; /ops/tasks no longer 404s.
+ */
+export default async function TasksPage({
+  searchParams,
+}: {
+  searchParams: Search;
+}) {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+  if (!orgId) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Operations"
+          title="Worklist"
+          description="No practice is associated with your account."
+        />
+      </PageShell>
+    );
+  }
+
+  const view: View =
+    searchParams.view === "completed" || searchParams.view === "all"
+      ? searchParams.view
+      : "active";
+  const due: Due =
+    searchParams.due === "overdue" || searchParams.due === "soon"
+      ? searchParams.due
+      : "all";
+  const owner = searchParams.owner ?? "all";
+
+  const now = new Date();
+  const soonCutoff = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  // Status facet.
+  const statusWhere: Prisma.TaskWhereInput =
+    view === "completed"
+      ? { status: "done" }
+      : view === "all"
+        ? {}
+        : { status: { in: ACTIVE_STATUSES } };
+
+  // Owner facet: all | unassigned | a specific role.
+  const ownerWhere: Prisma.TaskWhereInput =
+    owner === "all"
+      ? {}
+      : owner === "unassigned"
+        ? { assigneeRole: null }
+        : { assigneeRole: owner as Role };
+
+  // Due facet.
+  const dueWhere: Prisma.TaskWhereInput =
+    due === "overdue"
+      ? { dueAt: { lt: now } }
+      : due === "soon"
+        ? { dueAt: { gte: now, lt: soonCutoff } }
+        : {};
+
+  const where: Prisma.TaskWhereInput = {
+    organizationId: orgId,
+    ...statusWhere,
+    ...ownerWhere,
+    ...dueWhere,
+  };
+
+  const [tasks, activeCount, overdueCount, ownerGroups] = await Promise.all([
+    prisma.task.findMany({
+      where,
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        status: true,
+        assigneeRole: true,
+        assigneeUserId: true,
+        dueAt: true,
+        completedAt: true,
+        createdAt: true,
+        patient: { select: { id: true, firstName: true, lastName: true } },
+      },
+      orderBy: [{ dueAt: { sort: "asc", nulls: "last" } }, { createdAt: "desc" }],
+      take: 300,
+    }),
+    prisma.task.count({
+      where: { organizationId: orgId, status: { in: ACTIVE_STATUSES } },
+    }),
+    prisma.task.count({
+      where: {
+        organizationId: orgId,
+        status: { in: ACTIVE_STATUSES },
+        dueAt: { lt: now },
+      },
+    }),
+    // Owner chips — which assignee roles actually have active tasks.
+    prisma.task.groupBy({
+      by: ["assigneeRole"],
+      where: { organizationId: orgId, status: { in: ACTIVE_STATUSES } },
+      _count: true,
+    }),
+  ]);
+
+  // Resolve assignee display names in one batched query.
+  const assigneeIds = Array.from(
+    new Set(
+      tasks
+        .map((t) => t.assigneeUserId)
+        .filter((id): id is string => typeof id === "string"),
+    ),
+  );
+  const assignees = assigneeIds.length
+    ? await prisma.user.findMany({
+        where: { id: { in: assigneeIds } },
+        select: { id: true, firstName: true, lastName: true },
+      })
+    : [];
+  const nameById = new Map(
+    assignees.map((u) => [u.id, `${u.firstName} ${u.lastName}`.trim()]),
+  );
+
+  const rows: TaskRow[] = tasks.map((t) => ({
+    id: t.id,
+    title: t.title,
+    description: t.description,
+    status: t.status,
+    assigneeRole: t.assigneeRole,
+    assigneeName: t.assigneeUserId ? nameById.get(t.assigneeUserId) ?? null : null,
+    dueAt: t.dueAt ? t.dueAt.toISOString() : null,
+    isOverdue:
+      t.dueAt != null &&
+      t.dueAt.getTime() < now.getTime() &&
+      t.status !== "done",
+    patient: t.patient
+      ? {
+          id: t.patient.id,
+          name: `${t.patient.firstName} ${t.patient.lastName}`.trim(),
+        }
+      : null,
+  }));
+
+  const ownerOptions = buildOwnerOptions(ownerGroups);
+  const canManage = canManageTeam(user.roles) || user.roles.includes("operator");
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Operations"
+        title="Worklist"
+        description="Every open task across the practice in one queue. Work the oldest and overdue first."
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+        <StatCard label="Active tasks" value={activeCount} />
+        <StatCard label="Overdue" value={overdueCount} tone="danger" />
+        <StatCard label="Showing" value={rows.length} tone="muted" />
+      </div>
+
+      {/* Filters — URL-driven so they're shareable and survive refresh. */}
+      <div className="space-y-3 mb-6">
+        <FilterRow
+          label="Status"
+          options={[
+            { key: "active", label: "Active" },
+            { key: "completed", label: "Completed" },
+            { key: "all", label: "All" },
+          ]}
+          param="view"
+          active={view}
+          search={searchParams}
+        />
+        <FilterRow
+          label="Due"
+          options={[
+            { key: "all", label: "Any time" },
+            { key: "overdue", label: "Overdue" },
+            { key: "soon", label: "Next 7 days" },
+          ]}
+          param="due"
+          active={due}
+          search={searchParams}
+        />
+        <FilterRow
+          label="Owner"
+          options={ownerOptions}
+          param="owner"
+          active={owner}
+          search={searchParams}
+        />
+      </div>
+
+      <TasksBoard rows={rows} canManage={canManage} />
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Owner chips
+// ---------------------------------------------------------------------------
+
+function buildOwnerOptions(
+  groups: Array<{ assigneeRole: Role | null; _count: number }>,
+): Array<{ key: string; label: string }> {
+  const opts: Array<{ key: string; label: string }> = [{ key: "all", label: "Everyone" }];
+  let hasUnassigned = false;
+  for (const g of groups) {
+    if (g.assigneeRole === null) {
+      hasUnassigned = true;
+      continue;
+    }
+    opts.push({ key: g.assigneeRole, label: ROLE_LABELS[g.assigneeRole] ?? g.assigneeRole });
+  }
+  if (hasUnassigned) opts.push({ key: "unassigned", label: "Unassigned" });
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Filter row — server-rendered chips that set one search param.
+// ---------------------------------------------------------------------------
+
+function FilterRow({
+  label,
+  options,
+  param,
+  active,
+  search,
+}: {
+  label: string;
+  options: Array<{ key: string; label: string }>;
+  param: keyof Search;
+  active: string;
+  search: Search;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="w-14 shrink-0 text-[11px] font-medium uppercase tracking-wider text-text-subtle">
+        {label}
+      </span>
+      {options.map((opt) => {
+        const isActive = active === opt.key;
+        const next = { ...search, [param]: opt.key };
+        const qs = new URLSearchParams(
+          Object.entries(next).filter(([, v]) => v != null) as [string, string][],
+        ).toString();
+        return (
+          <Link
+            key={opt.key}
+            href={qs ? `/ops/tasks?${qs}` : "/ops/tasks"}
+            className={
+              isActive
+                ? "rounded-full border border-accent/50 bg-accent/10 px-3 py-1 text-xs font-medium text-accent"
+                : "rounded-full border border-border px-3 py-1 text-xs font-medium text-text-muted hover:border-border-strong"
+            }
+          >
+            {opt.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  tone?: "neutral" | "danger" | "muted";
+}) {
+  const colors = {
+    neutral: "text-text",
+    danger: "text-danger",
+    muted: "text-text-muted",
+  };
+  return (
+    <Card tone="raised">
+      <CardContent className="pt-5 pb-5">
+        <p className={`font-display text-3xl tabular-nums ${colors[tone]}`}>{value}</p>
+        <p className="text-xs text-text-muted mt-1">{label}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/tasks/tasks-board.tsx
+++ b/src/app/(operator)/ops/tasks/tasks-board.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { Role, TaskStatus } from "@prisma/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ROLE_LABELS } from "@/lib/rbac/roles";
+import { completeTask, reopenTask, type TaskActionResult } from "./actions";
+
+export interface TaskRow {
+  id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  assigneeRole: Role | null;
+  assigneeName: string | null;
+  dueAt: string | null;
+  isOverdue: boolean;
+  patient: { id: string; name: string } | null;
+}
+
+const STATUS_TONE: Record<TaskStatus, React.ComponentProps<typeof Badge>["tone"]> = {
+  open: "accent",
+  in_progress: "info",
+  snoozed: "warning",
+  done: "success",
+  cancelled: "neutral",
+};
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  open: "Open",
+  in_progress: "In progress",
+  snoozed: "Snoozed",
+  done: "Done",
+  cancelled: "Cancelled",
+};
+
+function formatDue(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function TasksBoard({
+  rows,
+  canManage,
+}: {
+  rows: TaskRow[];
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = React.useTransition();
+  const [busyId, setBusyId] = React.useState<string | null>(null);
+  const [errors, setErrors] = React.useState<Record<string, string>>({});
+
+  function run(id: string, fn: () => Promise<TaskActionResult>) {
+    setBusyId(id);
+    setErrors((e) => ({ ...e, [id]: "" }));
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) setErrors((e) => ({ ...e, [id]: res.error }));
+      else router.refresh();
+      setBusyId(null);
+    });
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="Nothing in this view"
+        description="A clear worklist is the goal. Adjust the filters above or check back later."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((task) => {
+        const rowBusy = pending && busyId === task.id;
+        return (
+          <div
+            key={task.id}
+            className="flex flex-col gap-3 rounded-lg border border-border/60 p-4 md:flex-row md:items-start md:justify-between"
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-medium text-text">{task.title}</span>
+                <Badge tone={STATUS_TONE[task.status]}>
+                  {STATUS_LABEL[task.status]}
+                </Badge>
+                {task.isOverdue && <Badge tone="danger">Overdue</Badge>}
+              </div>
+              {task.description && (
+                <p className="mt-1 text-sm text-text-muted line-clamp-2">
+                  {task.description}
+                </p>
+              )}
+              <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-subtle">
+                {task.patient && (
+                  <Link
+                    href={`/clinic/patients/${task.patient.id}`}
+                    className="text-accent hover:underline"
+                  >
+                    {task.patient.name}
+                  </Link>
+                )}
+                <span>
+                  Owner:{" "}
+                  {task.assigneeName ??
+                    (task.assigneeRole
+                      ? ROLE_LABELS[task.assigneeRole] ?? task.assigneeRole
+                      : "Unassigned")}
+                </span>
+                {task.dueAt && (
+                  <span className={task.isOverdue ? "text-danger" : undefined}>
+                    Due {formatDue(task.dueAt)}
+                  </span>
+                )}
+              </div>
+              {errors[task.id] && (
+                <p className="mt-2 text-xs text-danger">{errors[task.id]}</p>
+              )}
+            </div>
+
+            {canManage && (
+              <div className="shrink-0">
+                {task.status === "done" ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={rowBusy}
+                    onClick={() => run(task.id, () => reopenTask({ taskId: task.id }))}
+                  >
+                    Reopen
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={rowBusy}
+                    onClick={() => run(task.id, () => completeTask({ taskId: task.id }))}
+                  >
+                    Mark done
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(operator)/ops/tasks/tasks-board.tsx
+++ b/src/app/(operator)/ops/tasks/tasks-board.tsx
@@ -15,6 +15,7 @@ export interface TaskRow {
   title: string;
   description: string | null;
   status: TaskStatus;
+  kindLabel: string | null;
   assigneeRole: Role | null;
   assigneeName: string | null;
   dueAt: string | null;
@@ -93,6 +94,7 @@ export function TasksBoard({
                 <Badge tone={STATUS_TONE[task.status]}>
                   {STATUS_LABEL[task.status]}
                 </Badge>
+                {task.kindLabel && <Badge tone="neutral">{task.kindLabel}</Badge>}
                 {task.isOverdue && <Badge tone="danger">Overdue</Badge>}
               </div>
               {task.description && (

--- a/src/app/(operator)/ops/team/actions.ts
+++ b/src/app/(operator)/ops/team/actions.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { Role } from "@prisma/client";
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import {
+  checkAddRole,
+  checkRemoveRole,
+  ROLE_CHANGE_MESSAGES,
+  type RoleChangeContext,
+} from "@/lib/rbac/team-management";
+
+// The roles assignable from /ops/team. Mirrors STAFF_ROLES in
+// team-management.ts; kept as a literal here so zod can validate the wire
+// input against an exact enum (platform/realm roles are rejected as invalid
+// before any DB work).
+const STAFF_ROLE_VALUES = [
+  "front_office",
+  "back_office",
+  "midlevel",
+  "clinician",
+  "operator",
+  "practice_admin",
+  "practice_owner",
+] as const;
+
+const RoleMutationSchema = z.object({
+  targetUserId: z.string().min(1),
+  role: z.enum(STAFF_ROLE_VALUES),
+});
+
+export type RoleActionResult = { ok: true } | { ok: false; error: string };
+
+// Callers pass the broad `Role` type; the zod schema narrows it at runtime
+// and rejects any role that isn't a practice-assignable staff role.
+export interface RoleMutationInput {
+  targetUserId: string;
+  role: Role;
+}
+
+export async function addStaffRole(
+  input: RoleMutationInput,
+): Promise<RoleActionResult> {
+  return mutateRole("add", input);
+}
+
+export async function removeStaffRole(
+  input: RoleMutationInput,
+): Promise<RoleActionResult> {
+  return mutateRole("remove", input);
+}
+
+async function mutateRole(
+  op: "add" | "remove",
+  input: unknown,
+): Promise<RoleActionResult> {
+  const actor = await requireUser();
+  if (!actor.organizationId) return { ok: false, error: "Missing organization." };
+  const orgId = actor.organizationId;
+
+  const parsed = RoleMutationSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid request." };
+  const { targetUserId, role } = parsed.data;
+
+  // Org-scope every read: the target must be a member of the actor's
+  // practice. This both authorizes and prevents cross-tenant mutation.
+  const memberships = await prisma.membership.findMany({
+    where: { userId: targetUserId, organizationId: orgId },
+    select: { role: true },
+  });
+  if (memberships.length === 0) {
+    return { ok: false, error: "Member not found in your practice." };
+  }
+
+  const ownerCount = await prisma.membership.count({
+    where: { organizationId: orgId, role: "practice_owner" },
+  });
+
+  const ctx: RoleChangeContext = {
+    actorRoles: actor.roles,
+    targetRole: role as Role,
+    memberCurrentRoles: memberships.map((m) => m.role),
+    ownerCount,
+  };
+
+  const err = op === "add" ? checkAddRole(ctx) : checkRemoveRole(ctx);
+  if (err === "noop") {
+    // Already in the desired state — treat as success so the UI settles.
+    revalidatePath("/ops/team");
+    return { ok: true };
+  }
+  if (err) return { ok: false, error: ROLE_CHANGE_MESSAGES[err] };
+
+  if (op === "add") {
+    // The @@unique([userId, organizationId, role]) constraint makes this
+    // idempotent under a race; the noop check above handles the common case.
+    await prisma.membership.create({
+      data: { userId: targetUserId, organizationId: orgId, role: role as Role },
+    });
+  } else {
+    await prisma.membership.deleteMany({
+      where: { userId: targetUserId, organizationId: orgId, role: role as Role },
+    });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: orgId,
+      actorUserId: actor.id,
+      action: op === "add" ? "membership.role.granted" : "membership.role.revoked",
+      subjectType: "User",
+      subjectId: targetUserId,
+      metadata: { role },
+    },
+  });
+
+  revalidatePath("/ops/team");
+  return { ok: true };
+}

--- a/src/app/(operator)/ops/team/page.tsx
+++ b/src/app/(operator)/ops/team/page.tsx
@@ -1,0 +1,89 @@
+import { requireUser } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { canManageElevatedRoles, canManageTeam } from "@/lib/rbac/team-management";
+import { TeamRoster, type TeamMember } from "./team-roster";
+import { RoleMatrix } from "./role-matrix";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Team & Roles" };
+
+/**
+ * Team & Roles — the practice's staff-management surface (Back-Office
+ * Operations Audit §6.6 / §7, EMR-1076). Closes the "no settings entry
+ * point / no way to manage staff" gap (EMR-1083): an owner/admin can see
+ * everyone in the practice and assign each person exactly the role —
+ * therefore the permissions — their job needs. Clinical authoring/signing
+ * is granted deliberately via the Provider role, never by default.
+ */
+export default async function TeamPage() {
+  const user = await requireUser();
+  const orgId = user.organizationId;
+
+  if (!orgId) {
+    return (
+      <PageShell>
+        <PageHeader
+          eyebrow="Administration"
+          title="Team & roles"
+          description="No practice is associated with your account."
+        />
+      </PageShell>
+    );
+  }
+
+  const memberships = await prisma.membership.findMany({
+    where: { organizationId: orgId },
+    select: {
+      role: true,
+      createdAt: true,
+      user: {
+        select: { id: true, firstName: true, lastName: true, email: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // One user can hold several memberships (one row per role). Collapse them
+  // into a single roster entry carrying all their roles.
+  const byUser = new Map<string, TeamMember>();
+  for (const m of memberships) {
+    const entry = byUser.get(m.user.id);
+    if (entry) {
+      entry.roles.push(m.role);
+      continue;
+    }
+    const name = `${m.user.firstName} ${m.user.lastName}`.trim();
+    byUser.set(m.user.id, {
+      userId: m.user.id,
+      name: name.length > 0 ? name : m.user.email,
+      email: m.user.email,
+      roles: [m.role],
+      isSelf: m.user.id === user.id,
+    });
+  }
+  const members = [...byUser.values()].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  const canManage = canManageTeam(user.roles);
+  const canManageElevated = canManageElevatedRoles(user.roles);
+
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Administration"
+        title="Team & roles"
+        description="Assign each person in your practice the role their job needs. A role grants exactly the stations it owns — clinical authoring and signing are gated permissions, not a default."
+      />
+      <div className="space-y-10">
+        <TeamRoster
+          members={members}
+          canManage={canManage}
+          canManageElevated={canManageElevated}
+        />
+        <RoleMatrix />
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/team/role-matrix.tsx
+++ b/src/app/(operator)/ops/team/role-matrix.tsx
@@ -1,0 +1,76 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { type Permission, permissionsForRole } from "@/lib/rbac/permissions";
+import { STAFF_ROLES } from "@/lib/rbac/team-management";
+
+// A curated, scannable slice of the full permission matrix. The point the
+// audit insists on — "clinical authoring/signing is a permission, not a
+// default" — is the "Author & sign notes" column: every non-clinical role
+// reads as "—" there. Values are computed from `permissionsForRole`, the
+// same source enforcement uses, so this viewer can never drift from reality.
+const COLUMNS: Array<{ label: string; permission: Permission }> = [
+  { label: "Demographics", permission: "patient.demographics.edit" },
+  { label: "Billing", permission: "billing.edit" },
+  { label: "Read notes", permission: "notes.read" },
+  { label: "Author & sign notes", permission: "notes.edit" },
+  { label: "Prescribe", permission: "prescriptions.write" },
+  { label: "Sensitive dx", permission: "sensitive_diagnoses.read" },
+  { label: "Chart privacy", permission: "chart.privacy.manage" },
+];
+
+export function RoleMatrix() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>What each role can do</CardTitle>
+        <CardDescription>
+          Read-only reference, computed from the live permission matrix.
+          Clinical authoring and signing are gated permissions — only Provider
+          and Owner-as-provider roles carry them.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border/70 text-left">
+                <th className="py-2 pr-4 font-medium text-text-muted">Role</th>
+                {COLUMNS.map((col) => (
+                  <th
+                    key={col.permission}
+                    className="px-3 py-2 text-center font-medium text-text-muted whitespace-nowrap"
+                  >
+                    {col.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {STAFF_ROLES.map((meta) => {
+                const granted = new Set(permissionsForRole(meta.role));
+                return (
+                  <tr key={meta.role} className="border-b border-border/40">
+                    <td className="py-2.5 pr-4">
+                      <span className="font-medium text-text">{meta.label}</span>
+                    </td>
+                    {COLUMNS.map((col) => {
+                      const has = granted.has(col.permission);
+                      return (
+                        <td key={col.permission} className="px-3 py-2.5 text-center">
+                          {has ? (
+                            <span className="text-accent" aria-label="yes">✓</span>
+                          ) : (
+                            <span className="text-text-muted/40" aria-label="no">—</span>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(operator)/ops/team/team-roster.tsx
+++ b/src/app/(operator)/ops/team/team-roster.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import type { Role } from "@prisma/client";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ROLE_LABELS } from "@/lib/rbac/roles";
+import { STAFF_ROLES, staffRoleMeta } from "@/lib/rbac/team-management";
+import { addStaffRole, removeStaffRole, type RoleActionResult } from "./actions";
+
+export interface TeamMember {
+  userId: string;
+  name: string;
+  email: string;
+  roles: Role[];
+  isSelf: boolean;
+}
+
+function roleTone(role: Role): React.ComponentProps<typeof Badge>["tone"] {
+  const meta = staffRoleMeta(role);
+  if (!meta) return "neutral";
+  if (meta.clinicalAuthoring) return "warning"; // chart-signing power: flag it
+  if (meta.elevated) return "accent";
+  return "neutral";
+}
+
+export function TeamRoster({
+  members,
+  canManage,
+  canManageElevated,
+}: {
+  members: TeamMember[];
+  canManage: boolean;
+  canManageElevated: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = React.useTransition();
+  const [errors, setErrors] = React.useState<Record<string, string>>({});
+  // Which member row currently has an action in flight, so we only disable
+  // that row's controls (not the whole roster).
+  const [busyUser, setBusyUser] = React.useState<string | null>(null);
+
+  function run(userId: string, fn: () => Promise<RoleActionResult>) {
+    setBusyUser(userId);
+    setErrors((e) => ({ ...e, [userId]: "" }));
+    startTransition(async () => {
+      const res = await fn();
+      if (!res.ok) {
+        setErrors((e) => ({ ...e, [userId]: res.error }));
+      } else {
+        router.refresh();
+      }
+      setBusyUser(null);
+    });
+  }
+
+  function assignableFor(member: TeamMember) {
+    return STAFF_ROLES.filter(
+      (meta) =>
+        !member.roles.includes(meta.role) &&
+        (!meta.elevated || canManageElevated),
+    );
+  }
+
+  function canRemove(role: Role) {
+    const meta = staffRoleMeta(role);
+    if (!meta) return false; // platform/realm roles aren't managed here
+    if (meta.elevated && !canManageElevated) return false;
+    return true;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Practice team</CardTitle>
+        <CardDescription>
+          {canManage
+            ? "Assign or revoke roles for everyone in your practice. A role grants exactly the stations it owns — nothing more."
+            : "Everyone in your practice and the roles they hold. Role changes are limited to owners and admins."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {members.length === 0 ? (
+          <p className="text-sm text-text-muted py-6 text-center">
+            No team members found for this practice.
+          </p>
+        ) : (
+          members.map((member) => {
+            const assignable = assignableFor(member);
+            const rowBusy = pending && busyUser === member.userId;
+            return (
+              <div
+                key={member.userId}
+                className="flex flex-col gap-3 rounded-lg border border-border/60 p-4 md:flex-row md:items-start md:justify-between"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-text truncate">
+                      {member.name}
+                    </span>
+                    {member.isSelf && (
+                      <Badge tone="info">You</Badge>
+                    )}
+                  </div>
+                  <p className="text-sm text-text-muted truncate">{member.email}</p>
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                    {member.roles.map((role) => {
+                      const removable = canManage && canRemove(role) && !(role === "practice_owner" && member.isSelf);
+                      return (
+                        <Badge key={role} tone={roleTone(role)}>
+                          {ROLE_LABELS[role] ?? role}
+                          {removable && (
+                            <button
+                              type="button"
+                              aria-label={`Remove ${ROLE_LABELS[role] ?? role}`}
+                              disabled={rowBusy}
+                              onClick={() =>
+                                run(member.userId, () =>
+                                  removeStaffRole({ targetUserId: member.userId, role }),
+                                )
+                              }
+                              className="ml-1 -mr-0.5 rounded-full px-1 leading-none opacity-70 hover:opacity-100 disabled:opacity-40"
+                            >
+                              ×
+                            </button>
+                          )}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                  {errors[member.userId] && (
+                    <p className="mt-2 text-xs text-danger">{errors[member.userId]}</p>
+                  )}
+                </div>
+
+                {canManage && assignable.length > 0 && (
+                  <AddRoleControl
+                    disabled={rowBusy}
+                    options={assignable.map((m) => ({ value: m.role, label: m.label }))}
+                    onAdd={(role) =>
+                      run(member.userId, () =>
+                        addStaffRole({ targetUserId: member.userId, role }),
+                      )
+                    }
+                  />
+                )}
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AddRoleControl({
+  options,
+  onAdd,
+  disabled,
+}: {
+  options: Array<{ value: Role; label: string }>;
+  onAdd: (role: Role) => void;
+  disabled: boolean;
+}) {
+  const [selected, setSelected] = React.useState<Role | "">("");
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      <select
+        value={selected}
+        disabled={disabled}
+        onChange={(e) => setSelected(e.target.value as Role)}
+        className="h-9 rounded-md border border-border-strong/70 bg-surface px-2 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:opacity-50"
+        aria-label="Role to add"
+      >
+        <option value="">Add role…</option>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <Button
+        size="sm"
+        variant="secondary"
+        disabled={disabled || selected === ""}
+        onClick={() => {
+          if (selected !== "") {
+            onAdd(selected);
+            setSelected("");
+          }
+        }}
+      >
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/src/app/api/patients/search/route.ts
+++ b/src/app/api/patients/search/route.ts
@@ -11,6 +11,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { requireApiAuth } from "@/lib/auth/api-gate";
 import { prisma } from "@/lib/db/prisma";
+import { EXCLUDE_CALENDAR_BLOCK_PATIENT } from "@/lib/domain/calendar-block-patient";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -39,6 +40,7 @@ export async function GET(req: NextRequest) {
     where: {
       organizationId: orgId,
       deletedAt: null,
+      ...EXCLUDE_CALENDAR_BLOCK_PATIENT,
       OR: [
         { firstName: { contains: q, mode: "insensitive" } },
         { lastName: { contains: q, mode: "insensitive" } },
@@ -63,7 +65,12 @@ export async function GET(req: NextRequest) {
   let dobMatches: typeof patients = [];
   if (/\d/.test(q) && patients.length < LIMIT) {
     const all = await prisma.patient.findMany({
-      where: { organizationId: orgId, deletedAt: null, dateOfBirth: { not: null } },
+      where: {
+        organizationId: orgId,
+        deletedAt: null,
+        dateOfBirth: { not: null },
+        ...EXCLUDE_CALENDAR_BLOCK_PATIENT,
+      },
       select: {
         id: true,
         firstName: true,

--- a/src/components/charts/TrendArea.tsx
+++ b/src/components/charts/TrendArea.tsx
@@ -27,6 +27,18 @@ export interface TrendAreaSeries {
   color?: string;
 }
 
+/**
+ * Compact Y-axis tick label. Long values like 62800 were being clipped to
+ * ",800" by the narrow axis (Back-Office Audit P4 / QA-132): abbreviate
+ * thousands/millions so the label always fits.
+ */
+function formatCompactTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (abs >= 1_000) return `${(v / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return v.toLocaleString();
+}
+
 export interface TrendAreaProps<T extends object> {
   data: T[];
   lines: TrendAreaSeries[];
@@ -121,8 +133,9 @@ export function TrendArea<T extends object>({
           />
           <YAxis
             {...Y_AXIS_DEFAULTS}
+            width={48}
             tickFormatter={(v: number) =>
-              unit ? `${v}${unit}` : v.toLocaleString()
+              unit ? `${v}${unit}` : formatCompactTick(v)
             }
             label={
               yLabel

--- a/src/components/operator/owner-dashboard.tsx
+++ b/src/components/operator/owner-dashboard.tsx
@@ -147,9 +147,12 @@ export function OwnerDashboard({ snapshot, hasPracticeManagerAgent = true }: Own
   // day-by-day series at this layer (the upstream snapshot collapses to two
   // 7-day buckets) so we anchor a smooth ramp between the two so the trend
   // direction reads visually without inventing fake mid-week values.
+  // Chart in dollars, not cents — otherwise the axis shows cent-magnitude
+  // numbers (e.g. 62,800 for $628) that read wrong and clip. The KPI card
+  // below still shows the precise formatted dollar figure.
   const revenueSpark = sparkBetween(
-    snapshot.revenuePriorWeekCents,
-    snapshot.revenueThisWeekCents,
+    Math.round(snapshot.revenuePriorWeekCents / 100),
+    Math.round(snapshot.revenueThisWeekCents / 100),
   );
   const patientsSpark = sparkBetween(
     snapshot.newPatientsPriorWeek,

--- a/src/lib/agents/billing/aging-agent.ts
+++ b/src/lib/agents/billing/aging-agent.ts
@@ -97,6 +97,7 @@ export const agingAgent: Agent<z.infer<typeof input>, z.infer<typeof output>> = 
           title: `A/R follow-up: ${patient.firstName} ${patient.lastName} (${entry.ageDays}d)`,
           description: `Open balance: ${formatMoney(entry.balanceCents)}\nPayer: ${entry.payerName ?? "Self-pay"}\nStatus: ${entry.status}\nInsurance owes: ${formatMoney(entry.insuranceBalanceCents)}\nPatient owes: ${formatMoney(entry.patientBalanceCents)}\nRecoverability: ${recoverabilityScore(entry)}%\n\n[Created by aging agent]`,
           status: "open",
+          kind: "billing_followup",
           assigneeRole: "operator",
           dueAt: new Date(Date.now() + dueDays * 24 * 60 * 60 * 1000),
         },

--- a/src/lib/agents/billing/denial-triage-agent.ts
+++ b/src/lib/agents/billing/denial-triage-agent.ts
@@ -367,6 +367,7 @@ export const denialTriageAgent: Agent<z.infer<typeof input>, z.infer<typeof outp
         title: `${titlePrefix}${claim.patient.firstName} ${claim.patient.lastName}`,
         description: `${triage.description}\n\nSuggested action: ${NEXT_ACTION_LABEL[triage.suggestedAction]}\n\nClaim: ${claim.claimNumber} — ${claim.payerName ?? "Unknown payer"}\n\nPayer message: "${claim.denialReason ?? "no reason given"}"\n\n[Created by denialTriage agent${cannabisPattern ? ` — cannabis pattern: ${cannabisPattern.id}` : ""}]`,
         status: "open",
+        kind: "billing_followup",
         assigneeRole: "operator",
         dueAt: new Date(Date.now() + dueDays * 24 * 60 * 60 * 1000),
       },

--- a/src/lib/agents/billing/refund-credit-agent.ts
+++ b/src/lib/agents/billing/refund-credit-agent.ts
@@ -203,6 +203,7 @@ export const refundCreditAgent: Agent<
             title: `Credit balance: ${patient.firstName} ${patient.lastName} (${formatMoney(creditCents)})`,
             description: `${reason}\n\nRecommended action: ${action.toUpperCase()}\n\n[Created by refundCredit agent]`,
             status: "open",
+            kind: "billing_followup",
             assigneeRole: "operator",
             dueAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
           },

--- a/src/lib/agents/billing/stale-claim-monitor-agent.ts
+++ b/src/lib/agents/billing/stale-claim-monitor-agent.ts
@@ -200,6 +200,7 @@ export const staleClaimMonitorAgent: Agent<
           title: `Stale claim [stale-${f.category}] ${f.claimNumber ?? f.claimId.slice(0, 8)} — ${f.payerName ?? "payer"}`,
           description: `${f.recommendedAction}\n\nClaim id: ${f.claimId}\nCategory: ${f.category}\nDays waited: ${f.daysWaited}\nSLA days: ${f.slaDays}\n\n[Created by staleClaimMonitor agent]`,
           status: "open",
+          kind: "billing_followup",
           assigneeRole: "operator",
           dueAt: new Date(Date.now() + 2 * 86_400_000),
         },

--- a/src/lib/agents/billing/underpayment-detection-agent.ts
+++ b/src/lib/agents/billing/underpayment-detection-agent.ts
@@ -178,6 +178,7 @@ export const underpaymentDetectionAgent: Agent<
           title: `Underpayment review: ${candidate.payerName ?? "payer"} (${formatMoney(candidate.varianceCents)} variance)`,
           description: `Claim ${candidate.claimId.slice(0, 8)} (${candidate.cptCode}) was paid below expectation.\n\nExpected: ${formatMoney(candidate.expectedCents)}\nAllowed: ${formatMoney(candidate.allowedCents)}\nVariance: ${formatMoney(candidate.varianceCents)}\n\nReview the contract and consider an appeal if the payer's allowed amount is below your contracted rate.\n\n[Created by underpaymentDetection agent]`,
           status: "open",
+          kind: "billing_followup",
           assigneeRole: "operator",
           dueAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
         },

--- a/src/lib/agents/outcome-tracker-agent.ts
+++ b/src/lib/agents/outcome-tracker-agent.ts
@@ -61,6 +61,7 @@ export const outcomeTrackerAgent: Agent<z.infer<typeof input>, z.infer<typeof ou
           organizationId: patient.organizationId,
           patientId,
           title: t.title,
+          kind: "patient_task",
           assigneeRole: "patient",
           dueAt: t.dueAt,
         },

--- a/src/lib/agents/physician-nudge-agent.ts
+++ b/src/lib/agents/physician-nudge-agent.ts
@@ -210,6 +210,7 @@ Generate 2-5 specific, actionable tasks. Examples:
             patientId,
             title: t.title,
             description: t.description,
+            kind: "clinical_review",
             assigneeRole: "clinician",
             dueAt: new Date(now.getTime() + t.dueInDays * 24 * 60 * 60 * 1000),
             status: "open",

--- a/src/lib/agents/refill-reminder-agent.ts
+++ b/src/lib/agents/refill-reminder-agent.ts
@@ -101,6 +101,7 @@ export const refillReminderAgent: Agent<
               title: `Refill reminder: ${regimen.product?.name ?? "your cannabis medicine"}`,
               description: `You have approximately ${daysRemaining} day${daysRemaining === 1 ? "" : "s"} of ${regimen.product?.name ?? "your medicine"} left. Tap to request a refill so you don't run out.\n\n[regimenId: ${regimen.id}]`,
               status: "open",
+              kind: "refill",
               assigneeRole: "patient",
               dueAt: new Date(
                 Date.now() +

--- a/src/lib/agents/scheduling-agent.ts
+++ b/src/lib/agents/scheduling-agent.ts
@@ -365,6 +365,7 @@ export const schedulingAgent: Agent<z.infer<typeof input>, z.infer<typeof output
           patientId,
           title: rule.title,
           description,
+          kind: "recall",
           assigneeRole: "operator",
           dueAt,
         },

--- a/src/lib/cds/alerts.ts
+++ b/src/lib/cds/alerts.ts
@@ -38,6 +38,7 @@ export async function routeCDSTriggers(triggers: CDSTrigger[]) {
         title,
         description: `${trigger.description}\n\nReview chart at: /patients/${trigger.patientId}/biometrics`,
         status: "open",
+        kind: "clinical_review",
       },
     });
 

--- a/src/lib/domain/calendar-block-patient.test.ts
+++ b/src/lib/domain/calendar-block-patient.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  CALENDAR_BLOCK_PATIENT,
+  EXCLUDE_CALENDAR_BLOCK_PATIENT,
+  isCalendarBlockPatient,
+} from "./calendar-block-patient";
+
+describe("calendar-block placeholder patient", () => {
+  it("identifies the placeholder by both name fields", () => {
+    expect(isCalendarBlockPatient(CALENDAR_BLOCK_PATIENT)).toBe(true);
+    expect(
+      isCalendarBlockPatient({ firstName: "System", lastName: "CalendarBlock" }),
+    ).toBe(true);
+  });
+
+  it("does not flag a real patient who shares only one name field", () => {
+    expect(isCalendarBlockPatient({ firstName: "System", lastName: "Reyes" })).toBe(false);
+    expect(isCalendarBlockPatient({ firstName: "Maya", lastName: "CalendarBlock" })).toBe(false);
+    expect(isCalendarBlockPatient({ firstName: "Maya", lastName: "Reyes" })).toBe(false);
+  });
+
+  it("handles null/undefined name fields", () => {
+    expect(isCalendarBlockPatient({})).toBe(false);
+    expect(isCalendarBlockPatient({ firstName: null, lastName: null })).toBe(false);
+  });
+
+  it("exposes a Prisma NOT fragment matching both name fields", () => {
+    // The fragment must exclude ONLY rows matching BOTH names, so a real
+    // patient sharing one name is never filtered out.
+    expect(EXCLUDE_CALENDAR_BLOCK_PATIENT).toEqual({
+      NOT: { firstName: "System", lastName: "CalendarBlock" },
+    });
+  });
+});

--- a/src/lib/domain/calendar-block-patient.ts
+++ b/src/lib/domain/calendar-block-patient.ts
@@ -1,0 +1,45 @@
+// EMR-1084 (Back-Office Operations Audit §5) — the calendar-block placeholder
+// patient must never surface as a person.
+//
+// `createSpecialBlock` (src/app/(clinician)/clinic/schedule/actions.ts) anchors
+// vacation / meeting / do_not_book holds on a synthetic Patient row named
+// "System CalendarBlock" (no linked User). It exists only so a block can own an
+// Appointment. It is NOT a real patient and must be filtered out of every
+// patient roster and search surface.
+//
+// This module is the single source of truth for that identity so the create
+// site, the Prisma exclusion, and any in-memory predicate can't drift apart.
+
+/** Name fields that identify the synthetic calendar-block placeholder patient. */
+export const CALENDAR_BLOCK_PATIENT = {
+  firstName: "System",
+  lastName: "CalendarBlock",
+} as const;
+
+/**
+ * Prisma `where` fragment that excludes the placeholder. Spread it into a
+ * patient query's `where`:
+ *
+ *   where: { organizationId, deletedAt: null, ...EXCLUDE_CALENDAR_BLOCK_PATIENT }
+ *
+ * `NOT: { firstName, lastName }` excludes only rows matching BOTH fields, so a
+ * real patient who happens to share one of the names is unaffected. Safe to
+ * spread into any `where` that does not already define a top-level `NOT`.
+ */
+export const EXCLUDE_CALENDAR_BLOCK_PATIENT = {
+  NOT: {
+    firstName: CALENDAR_BLOCK_PATIENT.firstName,
+    lastName: CALENDAR_BLOCK_PATIENT.lastName,
+  },
+} as const;
+
+/** In-memory predicate for filtering already-loaded rows. */
+export function isCalendarBlockPatient(p: {
+  firstName?: string | null;
+  lastName?: string | null;
+}): boolean {
+  return (
+    p.firstName === CALENDAR_BLOCK_PATIENT.firstName &&
+    p.lastName === CALENDAR_BLOCK_PATIENT.lastName
+  );
+}

--- a/src/lib/domain/patient-balances.test.ts
+++ b/src/lib/domain/patient-balances.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateOutstandingBalances,
+  type ClaimForBalance,
+} from "./patient-balances";
+
+function claim(over: Partial<ClaimForBalance> = {}): ClaimForBalance {
+  return {
+    patientId: "p1",
+    patientFirstName: "Maya",
+    patientLastName: "Reyes",
+    patientRespCents: 5000,
+    payments: [],
+    ...over,
+  };
+}
+
+describe("aggregateOutstandingBalances", () => {
+  it("returns the unpaid patient responsibility", () => {
+    const out = aggregateOutstandingBalances([claim()]);
+    expect(out).toEqual([
+      { patientId: "p1", patientName: "Maya Reyes", owedCents: 5000 },
+    ]);
+  });
+
+  it("subtracts only patient-source payments", () => {
+    const out = aggregateOutstandingBalances([
+      claim({
+        payments: [
+          { source: "patient", amountCents: 2000 },
+          { source: "insurance", amountCents: 1000 },
+        ],
+      }),
+    ]);
+    expect(out[0].owedCents).toBe(3000);
+  });
+
+  it("sums multiple claims for one patient", () => {
+    const out = aggregateOutstandingBalances([
+      claim({ patientRespCents: 5000 }),
+      claim({ patientRespCents: 2500, payments: [{ source: "patient", amountCents: 500 }] }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].owedCents).toBe(7000);
+  });
+
+  it("drops patients with no balance or a credit", () => {
+    const out = aggregateOutstandingBalances([
+      claim({ patientId: "paid", payments: [{ source: "patient", amountCents: 5000 }] }),
+      claim({ patientId: "credit", patientRespCents: 1000, payments: [{ source: "patient", amountCents: 1500 }] }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("sorts most-owed first", () => {
+    const out = aggregateOutstandingBalances([
+      claim({ patientId: "a", patientFirstName: "A", patientLastName: "A", patientRespCents: 1000 }),
+      claim({ patientId: "b", patientFirstName: "B", patientLastName: "B", patientRespCents: 9000 }),
+    ]);
+    expect(out.map((b) => b.patientId)).toEqual(["b", "a"]);
+  });
+});

--- a/src/lib/domain/patient-balances.ts
+++ b/src/lib/domain/patient-balances.ts
@@ -1,0 +1,54 @@
+// EMR-1078 (Back-Office Operations Audit §6.4) — patient-responsibility
+// balance aggregation for the front-desk payments surface.
+//
+// Pure + dependency-free so the money math is unit-testable without a DB.
+// "Patient owes" = sum of patient-responsibility on their claims minus what
+// the patient has already paid against those claims. Insurance/adjustment
+// payments don't reduce the patient's share.
+
+export interface ClaimForBalance {
+  patientId: string;
+  patientFirstName: string;
+  patientLastName: string;
+  patientRespCents: number;
+  payments: Array<{ source: string; amountCents: number }>;
+}
+
+export interface PatientBalance {
+  patientId: string;
+  patientName: string;
+  owedCents: number;
+}
+
+/**
+ * Collapse claims into per-patient outstanding balances. Patients whose
+ * patient-responsibility is fully paid (or net-negative from overpayment) are
+ * dropped. Returned most-owed first.
+ */
+export function aggregateOutstandingBalances(
+  claims: ClaimForBalance[],
+): PatientBalance[] {
+  const byPatient = new Map<string, PatientBalance>();
+
+  for (const claim of claims) {
+    const patientPaid = claim.payments
+      .filter((p) => p.source === "patient")
+      .reduce((sum, p) => sum + p.amountCents, 0);
+    const claimOwed = claim.patientRespCents - patientPaid;
+
+    const existing = byPatient.get(claim.patientId);
+    if (existing) {
+      existing.owedCents += claimOwed;
+    } else {
+      byPatient.set(claim.patientId, {
+        patientId: claim.patientId,
+        patientName: `${claim.patientFirstName} ${claim.patientLastName}`.trim(),
+        owedCents: claimOwed,
+      });
+    }
+  }
+
+  return [...byPatient.values()]
+    .filter((b) => b.owedCents > 0)
+    .sort((a, b) => b.owedCents - a.owedCents);
+}

--- a/src/lib/rbac/permissions.ts
+++ b/src/lib/rbac/permissions.ts
@@ -232,6 +232,40 @@ export function requirePermission(
 }
 
 /**
+ * Ordered list of every permission key, for surfaces that enumerate the
+ * full matrix (e.g. the read-only role/permission viewer at /ops/team).
+ * Kept as an explicit literal so the display order is intentional rather
+ * than dependent on Set iteration order.
+ */
+export const ALL_PERMISSIONS: readonly Permission[] = [
+  "patient.demographics.read",
+  "patient.demographics.edit",
+  "billing.read",
+  "billing.edit",
+  "notes.read",
+  "notes.objective.document",
+  "notes.edit",
+  "clinical_history.read",
+  "sensitive_diagnoses.read",
+  "prescriptions.read",
+  "prescriptions.write",
+  "labs.read",
+  "labs.sign",
+  "notes.cosign_required",
+  "chart.privacy.manage",
+] as const;
+
+/**
+ * The default permission grants for a single role — the matrix "floor"
+ * (chart privacy can still subtract on a per-patient basis). Drives the
+ * read-only permission viewer so the UI can never drift from enforcement:
+ * both read from the same `PERMISSIONS` source of truth.
+ */
+export function permissionsForRole(role: Role): Permission[] {
+  return ALL_PERMISSIONS.filter((p) => PERMISSIONS[role]?.has(p));
+}
+
+/**
  * Can this user document the Objective / vitals section of a note? True for
  * full note editors (clinician, mid-level, owner — via `notes.edit`) and for
  * rooming staff (MAs) who carry only the scoped `notes.objective.document`

--- a/src/lib/rbac/team-management.test.ts
+++ b/src/lib/rbac/team-management.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  canManageElevatedRoles,
+  canManageTeam,
+  checkAddRole,
+  checkRemoveRole,
+  isStaffRole,
+  STAFF_ROLES,
+  staffRoleMeta,
+  type RoleChangeContext,
+} from "./team-management";
+
+// Base context helper — the happy path is an owner managing a member who
+// already holds front_office, in an org with two owners.
+function ctx(overrides: Partial<RoleChangeContext> = {}): RoleChangeContext {
+  return {
+    actorRoles: ["practice_owner"],
+    targetRole: "back_office",
+    memberCurrentRoles: ["front_office"],
+    ownerCount: 2,
+    ...overrides,
+  };
+}
+
+describe("staff role catalog", () => {
+  it("excludes platform and realm roles", () => {
+    for (const forbidden of [
+      "super_admin",
+      "implementation_admin",
+      "system",
+      "leafnerd",
+      "patient",
+      "kiosk",
+    ] as const) {
+      expect(isStaffRole(forbidden)).toBe(false);
+    }
+  });
+
+  it("includes the six §7 staff roles", () => {
+    for (const allowed of [
+      "front_office",
+      "back_office",
+      "midlevel",
+      "clinician",
+      "operator",
+      "practice_admin",
+      "practice_owner",
+    ] as const) {
+      expect(isStaffRole(allowed)).toBe(true);
+    }
+  });
+
+  it("flags only provider-class roles as clinical-authoring", () => {
+    const authoring = STAFF_ROLES.filter((r) => r.clinicalAuthoring).map((r) => r.role);
+    expect(authoring).toEqual(["midlevel", "clinician", "practice_owner"]);
+    // The non-clinical front/back office never carry authoring — the audit's
+    // headline guarantee.
+    expect(staffRoleMeta("front_office")?.clinicalAuthoring).toBe(false);
+    expect(staffRoleMeta("back_office")?.clinicalAuthoring).toBe(false);
+    expect(staffRoleMeta("operator")?.clinicalAuthoring).toBe(false);
+  });
+});
+
+describe("canManageTeam / canManageElevatedRoles", () => {
+  it("lets owner, admin, and super-admin manage the team", () => {
+    expect(canManageTeam(["practice_owner"])).toBe(true);
+    expect(canManageTeam(["practice_admin"])).toBe(true);
+    expect(canManageTeam(["super_admin"])).toBe(true);
+  });
+
+  it("denies line staff and office manager from managing the team", () => {
+    expect(canManageTeam(["front_office"])).toBe(false);
+    expect(canManageTeam(["back_office"])).toBe(false);
+    expect(canManageTeam(["operator"])).toBe(false);
+    expect(canManageTeam(["clinician"])).toBe(false);
+  });
+
+  it("restricts elevated-role management to owner and super-admin", () => {
+    expect(canManageElevatedRoles(["practice_owner"])).toBe(true);
+    expect(canManageElevatedRoles(["super_admin"])).toBe(true);
+    expect(canManageElevatedRoles(["practice_admin"])).toBe(false);
+  });
+});
+
+describe("checkAddRole", () => {
+  it("allows an owner to grant a line role", () => {
+    expect(checkAddRole(ctx())).toBeNull();
+  });
+
+  it("forbids a non-manager", () => {
+    expect(checkAddRole(ctx({ actorRoles: ["front_office"] }))).toBe("forbidden");
+  });
+
+  it("rejects non-staff roles", () => {
+    expect(checkAddRole(ctx({ targetRole: "super_admin" }))).toBe("not_manageable");
+  });
+
+  it("blocks a practice_admin from granting an elevated role", () => {
+    expect(
+      checkAddRole(ctx({ actorRoles: ["practice_admin"], targetRole: "practice_owner" })),
+    ).toBe("needs_owner");
+  });
+
+  it("lets an owner grant an elevated role", () => {
+    expect(
+      checkAddRole(ctx({ actorRoles: ["practice_owner"], targetRole: "practice_admin" })),
+    ).toBeNull();
+  });
+
+  it("is a no-op when the member already holds the role", () => {
+    expect(
+      checkAddRole(ctx({ targetRole: "front_office", memberCurrentRoles: ["front_office"] })),
+    ).toBe("noop");
+  });
+});
+
+describe("checkRemoveRole", () => {
+  it("allows removing a role the member holds (alongside others)", () => {
+    expect(
+      checkRemoveRole(
+        ctx({ targetRole: "front_office", memberCurrentRoles: ["front_office", "back_office"] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("is a no-op when the member doesn't hold the role", () => {
+    expect(
+      checkRemoveRole(ctx({ targetRole: "back_office", memberCurrentRoles: ["front_office"] })),
+    ).toBe("noop");
+  });
+
+  it("won't strand a member with zero roles", () => {
+    expect(
+      checkRemoveRole(ctx({ targetRole: "front_office", memberCurrentRoles: ["front_office"] })),
+    ).toBe("last_role");
+  });
+
+  it("won't remove the practice's last owner", () => {
+    expect(
+      checkRemoveRole(
+        ctx({
+          targetRole: "practice_owner",
+          memberCurrentRoles: ["practice_owner", "clinician"],
+          ownerCount: 1,
+        }),
+      ),
+    ).toBe("last_owner");
+  });
+
+  it("allows removing an owner when another owner remains", () => {
+    expect(
+      checkRemoveRole(
+        ctx({
+          targetRole: "practice_owner",
+          memberCurrentRoles: ["practice_owner", "clinician"],
+          ownerCount: 2,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("blocks a practice_admin from revoking an elevated role", () => {
+    expect(
+      checkRemoveRole(
+        ctx({
+          actorRoles: ["practice_admin"],
+          targetRole: "practice_owner",
+          memberCurrentRoles: ["practice_owner", "clinician"],
+          ownerCount: 2,
+        }),
+      ),
+    ).toBe("needs_owner");
+  });
+});

--- a/src/lib/rbac/team-management.ts
+++ b/src/lib/rbac/team-management.ts
@@ -1,0 +1,202 @@
+// Back-Office Operations Audit §7 — practice-facing role management.
+//
+// The audit's headline risk: "there is no non-clinical staff role; the
+// office-manager account carries a PROVIDER role with chart-signing rights."
+// The Role enum + `permissions.ts` matrix already model non-clinical roles
+// correctly (front_office/back_office cannot edit or sign notes). What was
+// missing is a *surface* for an owner/admin to see and assign those roles —
+// that is what /ops/team provides, and this module is its pure rule core.
+//
+// Everything here is dependency-free (type-only Prisma import) so it is
+// safe to import from both server actions and client components, and is
+// trivially unit-testable without a database.
+
+import type { Role } from "@prisma/client";
+
+export interface StaffRoleMeta {
+  role: Role;
+  /** Human label. Maps the Role enum to the audit's §7 role names. */
+  label: string;
+  /** The §7 station(s) this role owns. */
+  station: string;
+  /** One-line scope summary shown on the roster. */
+  scope: string;
+  /**
+   * True when the role can author and/or sign clinical notes. The audit's
+   * core principle: clinical authoring/signing is a permission, not a
+   * default — so the UI flags these roles explicitly.
+   */
+  clinicalAuthoring: boolean;
+  /**
+   * Elevated roles (owner/admin) can only be granted or revoked by an owner
+   * or super-admin — never by a practice_admin managing line staff.
+   */
+  elevated: boolean;
+}
+
+/**
+ * Roles a practice can assign to its own staff from /ops/team, in display
+ * order. Platform roles (super_admin, implementation_admin, system,
+ * leafnerd) and the realm roles (patient, kiosk) are deliberately ABSENT —
+ * they are never granted from a practice admin tool.
+ */
+export const STAFF_ROLES: readonly StaffRoleMeta[] = [
+  {
+    role: "front_office",
+    label: "Front Desk / Scheduler",
+    station: "Pre-visit · Arrival · Checkout",
+    scope:
+      "Book/confirm, check-in, capture insurance & consent, collect copay, book follow-up.",
+    clinicalAuthoring: false,
+    elevated: false,
+  },
+  {
+    role: "back_office",
+    label: "Medical Assistant / Biller",
+    station: "Arrival (rooming) · Post-visit RCM",
+    scope:
+      "Room patients, record vitals, read notes to code; full billing. Cannot author or sign notes.",
+    clinicalAuthoring: false,
+    elevated: false,
+  },
+  {
+    role: "midlevel",
+    label: "Mid-Level Provider (NP/PA)",
+    station: "Visit",
+    scope:
+      "Author notes and prescribe in scope; sensitive items require a clinician co-signature.",
+    clinicalAuthoring: true,
+    elevated: false,
+  },
+  {
+    role: "clinician",
+    label: "Provider",
+    station: "Visit · Sign-off",
+    scope: "Full chart, orders, sign notes, release care plans, approve refills.",
+    clinicalAuthoring: true,
+    elevated: false,
+  },
+  {
+    role: "operator",
+    label: "Office Manager",
+    station: "All ops (no chart authoring)",
+    scope:
+      "Waitlist, inventory, reporting, task assignment. Read-only chart access.",
+    clinicalAuthoring: false,
+    elevated: false,
+  },
+  {
+    role: "practice_admin",
+    label: "Practice Admin",
+    station: "Administration",
+    scope: "Practice settings, templates, reporting. Manages line staff.",
+    clinicalAuthoring: false,
+    elevated: true,
+  },
+  {
+    role: "practice_owner",
+    label: "Admin / Owner",
+    station: "Administration",
+    scope:
+      "Manage roles/permissions, settings, audit. Clinical authority only if also a provider.",
+    clinicalAuthoring: true,
+    elevated: true,
+  },
+];
+
+const STAFF_ROLE_SET = new Set<Role>(STAFF_ROLES.map((r) => r.role));
+const STAFF_ROLE_BY_ID = new Map<Role, StaffRoleMeta>(
+  STAFF_ROLES.map((r) => [r.role, r]),
+);
+
+/** Roles permitted to manage the team at all. */
+const TEAM_MANAGER_ROLES = new Set<Role>([
+  "practice_owner",
+  "practice_admin",
+  "super_admin",
+]);
+
+/** Roles permitted to grant/revoke ELEVATED staff roles (owner / admin). */
+const ELEVATED_MANAGER_ROLES = new Set<Role>(["practice_owner", "super_admin"]);
+
+export function isStaffRole(role: Role): boolean {
+  return STAFF_ROLE_SET.has(role);
+}
+
+export function staffRoleMeta(role: Role): StaffRoleMeta | undefined {
+  return STAFF_ROLE_BY_ID.get(role);
+}
+
+/** Can this set of roles manage the practice team at all? */
+export function canManageTeam(roles: Role[]): boolean {
+  return roles.some((r) => TEAM_MANAGER_ROLES.has(r));
+}
+
+/** Can this set of roles grant/revoke elevated (owner/admin) roles? */
+export function canManageElevatedRoles(roles: Role[]): boolean {
+  return roles.some((r) => ELEVATED_MANAGER_ROLES.has(r));
+}
+
+export type RoleChangeError =
+  | "forbidden" // actor can't manage the team
+  | "not_manageable" // target role isn't a practice-assignable staff role
+  | "needs_owner" // only owner/super_admin may manage elevated roles
+  | "last_owner" // would remove the org's last practice_owner
+  | "last_role" // would strand the member with no roles
+  | "noop"; // nothing to change
+
+export const ROLE_CHANGE_MESSAGES: Record<RoleChangeError, string> = {
+  forbidden: "You don't have permission to manage the team.",
+  not_manageable: "That role can't be assigned from this surface.",
+  needs_owner: "Only an owner can grant or revoke owner / admin roles.",
+  last_owner:
+    "This is the practice's last owner — assign another owner before removing this one.",
+  last_role:
+    "A team member must keep at least one role. Remove the member instead.",
+  noop: "No change.",
+};
+
+export interface RoleChangeContext {
+  /** Roles held by the user performing the change. */
+  actorRoles: Role[];
+  /** The role being added or removed. */
+  targetRole: Role;
+  /** All roles the target member currently holds in this org. */
+  memberCurrentRoles: Role[];
+  /** Count of practice_owner memberships in the org (last-owner guard). */
+  ownerCount: number;
+}
+
+function commonGuards(ctx: RoleChangeContext): RoleChangeError | null {
+  if (!canManageTeam(ctx.actorRoles)) return "forbidden";
+  if (!isStaffRole(ctx.targetRole)) return "not_manageable";
+  if (
+    staffRoleMeta(ctx.targetRole)?.elevated &&
+    !canManageElevatedRoles(ctx.actorRoles)
+  ) {
+    return "needs_owner";
+  }
+  return null;
+}
+
+/** Pure precondition check for granting a role. Returns null when allowed. */
+export function checkAddRole(ctx: RoleChangeContext): RoleChangeError | null {
+  const guard = commonGuards(ctx);
+  if (guard) return guard;
+  if (ctx.memberCurrentRoles.includes(ctx.targetRole)) return "noop";
+  return null;
+}
+
+/** Pure precondition check for revoking a role. Returns null when allowed. */
+export function checkRemoveRole(ctx: RoleChangeContext): RoleChangeError | null {
+  const guard = commonGuards(ctx);
+  if (guard) return guard;
+  if (!ctx.memberCurrentRoles.includes(ctx.targetRole)) return "noop";
+  // Don't strand a member with zero roles — they'd be orphaned in the org.
+  if (ctx.memberCurrentRoles.length <= 1) return "last_role";
+  // Don't lock the practice out of ownership.
+  if (ctx.targetRole === "practice_owner" && ctx.ownerCount <= 1) {
+    return "last_owner";
+  }
+  return null;
+}


### PR DESCRIPTION
Branch for the **Back-Office Operations Audit** workstream ([project](https://linear.app/emr-project/project/back-office-operations-audit-f2df4710f8c2)). Ships the P0 roles foundation plus several P4 defect fixes. All on `claude/trusting-bell-gv09V`.

---

## P0 — Roles & permissions surface (EMR-1076 / EMR-1083)

The `Role` enum + permission matrix (`src/lib/rbac/permissions.ts`, EMR-786) already model non-clinical roles correctly — `finalizeNote` is gated on `notes.edit`, which `front_office`/`back_office`/`operator` don't carry, so a Front Desk user genuinely cannot sign a note. The missing piece was the **management UI**:

- **`/ops/team`** — practice roster grouped by user with role badges + a read-only permission matrix computed from the live `PERMISSIONS` source of truth. The "Author & sign notes" column reads "—" for every non-clinical role.
- **Grant/revoke server actions** — org-scoped, audited (`membership.role.granted`/`revoked`), owner/admin-gated, with `last_role` / `last_owner` / `needs_owner` guards.
- **Pure rule core** `src/lib/rbac/team-management.ts` — 18 unit tests.
- Non-clinical staff demo team (`frontdesk@`, `ma@`, `office@`) so the guarantee is provable.
- Wired into the operator System nav; dead `/ops/team` route now resolves.

## P4 — Quick wins (EMR-1080)

- **EMR-1084** — the synthetic "System CalendarBlock" placeholder patient no longer surfaces as a person. Single source of truth (`src/lib/domain/calendar-block-patient.ts`: identity + Prisma `NOT` fragment + predicate, 4 tests) applied to the ops roster + counts and both patient-search queries; create site uses the same constant.
- **EMR-1085** — ops schedule is no longer display-only for requested bookings: front desk can **Confirm** / **Decline** a requested appointment (inline card buttons + right-click menu) via org-scoped, role-gated, audited server actions; the **"Verify insurance"** chip now links to `/ops/eligibility`.
- **EMR-1082** — investigated; **not reproducible** in current code (the `/ops/mail-fax` and `/ops/billing-agents` routes exist and the nav hrefs match). No code change; ticket annotated.

## Deferred
- Invite-by-email of brand-new staff via Clerk (P0 follow-up).
- Visit-status spine half of P0 is owned by EMR-993 (linked, not duplicated).

## Validation
`npm run typecheck` clean · `next lint` clean · `vitest` green (rbac 64, calendar-block + ensure-encounter 17). First commit's CI was all-green (4/4 checks).

https://claude.ai/code/session_01HSfU2BABre4ZLUuztTafzR