### PR TITLE
Physician workflow: audit fixes, coding-approval charge gating, and Phase 2 workstreams (EMR-1094–1107)

### DIFF
--- a/PHYSICIAN_WORKFLOW_AUDIT.md
+++ b/PHYSICIAN_WORKFLOW_AUDIT.md
@@ -1,0 +1,98 @@
+# Physician Workflow — Happy-Path Audit
+
+**Date:** 2026-06-09
+**Scope:** End-to-end physician happy path: sign-in → schedule → chart review → encounter documentation → clinical decisions (recommendation / Rx / orders / compliance) → note finalization → post-visit wrap-up & billing handoff.
+**Method:** Code-level trace of every route, server action, and orchestration event on the path, with claims spot-verified against source. Lens: eliminate documentation waste, keep the physician in control, zero dead ends.
+
+---
+
+## Verdict
+
+**The documentation core is excellent. The clinical-decision and billing-control edges are where the workflow breaks.**
+
+- ✅ **Sign-in → schedule → chart → start visit → scribe draft → note edit → finalize → visit-completion release** works end-to-end, is idempotent, permission-gated, and covered by tests (`actions.finalize-idempotent.test.ts`, `actions.save-note-lock.test.ts`, `actions.release.test.ts`). No blockers on this spine.
+- ❌ **Orders, compliance e-signature, and the recommendation→prescription handoff are stubs or lose data.** The physician completes work that is never persisted or never transmitted.
+- ❌ **Charges are auto-created before the physician ever sees coding suggestions, with no approval checkpoint.** This violates "physician in control" of billing intent.
+
+---
+
+## Verified happy path (works today)
+
+1. **Sign-in → landing.** Clerk → `/post-sign-in` → `resolveHomePath()` → `/clinic` Mission Control (today's encounters, queue, messages).
+2. **Schedule → chart.** `/clinic/schedule` appointment chip links to `/clinic/patients/{id}` (`schedule-calendar.tsx:679,745`).
+3. **Start visit.** Chart header "Start visit" → `startVisit()` (`patients/[id]/actions.ts:33-150`): permission + chart-access checks, reuses today's active encounter (no duplicates), dispatches `encounter.note.draft.requested`, runs scribe inline with 15s timeout, redirects to the note editor (graceful fallback to `?tab=notes&scribe=processing`).
+4. **Document.** Note editor with APSO blocks, AI refine, dictation; save via `saveNoteBlocks`; finalize via `saveAndFinalizeNote` (`notes/[noteId]/actions.ts:275-402`) — idempotent, single shared timestamp, emits `note.finalized` + `encounter.completed`, revalidates the chart.
+5. **Wrap up.** Visit-completion panel (orders / follow-up / patient message / readiness cards) → `releaseVisitCompletion` creates back-office and front-office tasks, a draft patient message, and audit log entries. Coding suggestions render in the finalized note; outreach + outcome-tracker agents fire; AI drafts queue in `/clinic/approvals`.
+
+---
+
+## Blockers (happy path silently breaks)
+
+### B1. Lab & imaging orders are simulation-only — nothing is saved or transmitted
+`orders/labs/lab-order-form.tsx:83`, `orders/imaging/imaging-order-form.tsx:72`
+"Submit Order" `console.log`s the payload and shows a success state. No server action, no DB row, no order in the chart, no results tracking. The UI does disclose "simulated in this sandbox environment," but the workflow dead-ends: an order placed during a visit leaves zero trace in the record.
+**Fix:** real server action persisting an `Order` row + surface in chart/results; keep transmission stubbed behind an integration flag if needed.
+
+### B2. Compliance form e-signature and submission are UI state only
+`compliance/compliance-form.tsx:135-136,167,189`
+"Sign electronically" and "Submit form" mutate local `useState` only — reload and the signature, status, and generated form are gone. Nothing is written to the DB; no signed document artifact exists. For a cannabis EMR, the certification signature is *the* legal artifact of the visit.
+**Fix:** server action persisting signature event (who/when/what payload hash) + immutable document record, with audit log.
+
+### B3. State registry submission returns fake confirmations
+`lib/integrations/state-registries/ca.ts:12-16`, `client.ts:33-46`
+For CA/CO/MI, "Submit to registry" instantly fabricates a confirmation number via `buildManualSuccess`/`buildStubSuccess` unless `STATE_REGISTRY_<CODE>_API_URL/KEY` env vars are set. The physician sees a green success screen; the state has no record — and per B2 the "confirmation" isn't persisted either.
+**Fix:** label stub mode explicitly in the UI ("manual submission required — print packet"), persist the submission attempt, and gate the success UI on a real response.
+
+### B4. Charges are auto-created before the physician reviews coding — no approval checkpoint
+`lib/orchestration/workflows.ts` (encounter-charge-extraction on `encounter.completed`), `lib/agents/billing/encounter-intelligence-agent.ts`
+On finalize, `encounter.completed` fires and the encounter-intelligence agent creates charges immediately (`requiresApproval: false`) — before the coding-readiness suggestions even render. Coding suggestions are read-only in the note (`note-editor.tsx:675-736`): no accept/modify action, no `coding.approved` event, and `releaseVisitCompletion` never forwards coding decisions to billing. The physician's "approval" of codes is recorded nowhere.
+**Fix:** add a Review & Approve Codes step in the visit-completion panel wired to `codingSuggestion`, emit `coding.approved`, and gate (or reconcile) charge creation on it.
+
+---
+
+## Major issues
+
+| # | Issue | Where | Physician experience |
+|---|-------|-------|----------------------|
+| M1 | **Recommendation never persisted.** Generated recommendation lives only in React state; reload = gone. No audit trail of decision support used. | `recommend/actions.ts` (reads prisma, never writes) | Regenerates the same recommendation every time; can't compare or cite it later. |
+| M2 | **Recommendation → prescription handoff carries no data.** "Apply to prescription" is a bare `<Link>` to `/prescribe`. | `recommend-form.tsx:121` | Re-types product type, dose, frequency they were just shown. Pure documentation waste. |
+| M3 | **Pharmacy selection silently dropped.** Form posts `pharmacyId`/`pharmacyName` hidden inputs; server schema has no such fields. Submission also isn't blocked when pharmacy is empty. | `prescribe-form-v2.tsx:476,511-515`; `prescribe/actions.ts:13-41` | Picks a pharmacy, signs, Rx saves with no routing info. |
+| M4 | **Diagnosis codes not captured on Rx.** Server accepts optional `diagnosisCodes`, but the form never serializes them — no ICD-10 linkage on the prescription. | `prescribe-form-v2.tsx`, `prescribe/actions.ts:214-224` | Rx lacks the indication; downstream reimbursement documentation weakened. |
+| M5 | **Practice Readiness card is a mock.** Items are `mvp_mock`/heuristic placeholders; "coding_review" action opens a drawer, not a real coding flow; never reads actual `codingSuggestion` data. | `lib/domain/visit-completion.ts:367-395`, `visit-completion-panel.tsx:152-158` | Clicks "coding review," gets the same mock text — trust erosion. |
+| M6 | **Duplicate post-visit patient messages.** Visit-completion release creates a draft message AND the patient-outreach agent creates a second one on `encounter.completed`; no deconfliction. | `notes/[noteId]/actions.ts:816-848`; `lib/agents/patient-outreach-agent.ts` | Two competing drafts to the same patient thread in the approvals queue. |
+| M7 | **Compliance form validation is alert()-only, client-only.** Required-field check doesn't block state transitions; no server-side validation exists (there's no server submit at all — see B2). | `compliance-form.tsx:172-187` | Can "generate" a certification missing the ICD-10 code. |
+
+---
+
+## Minor issues / polish
+
+1. **No note autosave.** Only the manual "Save draft" persists; a crashed tab loses the whole encounter's documentation. Add debounced autosave. (`note-editor.tsx:267-273`)
+2. **Modality hard-coded.** `startVisit` creates ad-hoc encounters as `in_person` even when the appointment is telehealth. (`patients/[id]/actions.ts:94-105`)
+3. **Misleading finalize message for mid-levels.** Cosign path shows "Note finalized and signed" while status is `pending_cosign`. (`note-editor.tsx:312`, `actions.ts:328`)
+4. **"Open to edit" on signed notes** opens read-only view; label should be "View." (`notes-tab.tsx:135-139`)
+5. **Unreachable `needs_review` note status** — defined, filtered on, never set anywhere. Remove or implement. (`scribe-agent.ts:592`, `note-editor.tsx:184`)
+6. **No agent feedback after finalize.** Coding/outreach/outcome agents run invisibly; failures are silent. A small "agents running ✓" strip post-finalize closes the loop.
+7. **Follow-up isn't one-click.** Release creates a free-text front-desk task; no "book in 3 weeks" pre-filled booking from the note. (`notes/[noteId]/actions.ts:799-814`)
+8. **Leaflet (AVS) is off-path.** Useful AI-drafted after-visit summary exists but requires separate navigation; offer it inside the release flow. (`patients/[id]/leaflet/`)
+9. **Server doesn't re-check drug interactions for custom (non-formulary) products.** (`prescribe/actions.ts:139-163`)
+10. **Recommendation corpus load has no fallback** — missing `data/cannabis-research-corpus.json` throws a generic error. (`recommend/actions.ts:58-60`)
+11. **"Draft a note" button** on the Notes tab actually starts a visit; relabel "Start visit." (`notes-tab.tsx:70-72`)
+12. **Saved-message inconsistency:** save toast auto-clears, finalize toast persists forever. (`note-editor.tsx:295-318`)
+13. **Demographics don't pre-fill from intake answers** (insurance/email re-typed). (`patients/[id]/page.tsx:1234-1335`)
+14. **Messaging-assistant workflow is dead code** — `message.draft.requested` is never emitted on this path. (`workflows.ts`)
+
+**Audited and cleared (false positives ruled out):** referrals *do* persist — `referral-form.tsx:178` calls `createReferralAction`, which writes a `Referral` row and supports packet generation (`referrals/actions.ts:51,278`).
+
+---
+
+## Recommended fix order
+
+1. **B2 + B3** — persist compliance signature/submission; honest registry stub UX. (Legal artifact of the practice.)
+2. **B4 + M5** — coding approval checkpoint before/with charge creation; wire Practice Readiness to real `codingSuggestion` data. (Physician control of billing.)
+3. **B1** — persist lab/imaging orders. (Orders must leave a trace in the record.)
+4. **M1–M4** — persist recommendations, pre-fill prescribe from recommendation, save pharmacy + diagnosis codes on Rx. (Kills the worst re-typing waste.)
+5. **M6/M7 + minors** — message deconfliction, autosave, labels, agent-status feedback.
+
+---
+
+*Produced by a code-level audit; every blocker and major finding was verified against source before inclusion. Line numbers reflect the state of the repo on the audit date.*

--- a/WORKSTREAMS_PHASE_2.md
+++ b/WORKSTREAMS_PHASE_2.md
@@ -1,0 +1,171 @@
+# Tech-Debt Workstreams — Physician Workflow Phase 2
+
+Four parallel agent briefs. Each is self-contained: paste one brief into a fresh agent session.
+They burn down the remaining items from `PHYSICIAN_WORKFLOW_AUDIT.md` (EMR-1103 rollup) plus
+the loose ends left by the Phase 1 blocker/major fixes (commits `0186db9`, `7d40dd3`, `b33eb9d`, `d554500`).
+
+## Shared rules (apply to every workstream)
+
+- **Base branch:** branch off `claude/pensive-cerf-79lzwn` (it has the new Prisma models and the
+  Phase 1 fixes). Name your branch `claude/ws-<letter>-<short-desc>`. Commit per task, push when green.
+- **Read first:** `PHYSICIAN_WORKFLOW_AUDIT.md`, then the files in your territory. Follow existing
+  conventions exactly (server actions: `requireUser` → permission check → org-scoped lookup →
+  audit log → `revalidatePath`; structured `{ ok, error }` results; vitest with hoisted prisma mocks).
+- **Territory discipline:** edit only inside your listed territory. If a fix genuinely requires an
+  out-of-territory change, make the smallest possible edit and call it out in your report.
+- **Definition of done per task:** code + test (where a sibling test pattern exists) + `npm run
+  typecheck` clean + targeted `npx vitest run <files>` green. Run the full `npm test` before final push.
+- **No new dependencies. No `prisma migrate` against live DBs** — schema/codegen only (`npx prisma
+  generate` is fine; WS-D owns migration artifacts).
+- Update your Linear epic (WS-A…D) as you complete tasks; move it to In Review when pushed.
+
+---
+
+## WS-A — Documentation Cockpit (note editor reliability & speed)
+
+**Mission:** the note editor is where physicians live; make it lossless and honest. Zero wasted
+keystrokes, zero misleading states.
+
+**Linear:** epic WS-A; items 1, 3, 4, 5, 11, 12 of EMR-1103.
+
+**Territory:** `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/**` *except*
+`visit-completion-panel.tsx` (WS-B owns it; inside `actions.ts` stay out of the
+`releaseVisitCompletion` region), plus `src/app/(clinician)/clinic/patients/[id]/notes-tab.tsx`.
+
+**Tasks:**
+1. **Autosave** (`note-editor.tsx`): debounced autosave (~3s after last block edit) via the existing
+   `saveNoteBlocks` action; dirty-state indicator ("Unsaved changes…" → "Saved 12:04"); `beforeunload`
+   guard while dirty. Respect the existing save-lock semantics (`actions.save-note-lock.test.ts`).
+2. **Cosign-aware finalize messaging**: when the signer requires cosignature (`pending_cosign` path,
+   `actions.ts` ~328), the success message must read "Note routed for physician co-signature", not
+   "finalized and signed"; render a distinct "Awaiting co-signature" badge state in the editor.
+3. **Status visibility**: surface the note status badge (draft / awaiting co-sign / signed / amended)
+   in the note page header (`page.tsx`), not only below the fold.
+4. **Honest labels**: notes-tab "Open to edit" → "View" for finalized/amended notes; "Draft a note"
+   → "Start visit" (it creates an encounter).
+5. **Toast consistency**: finalize success message auto-clears like the save toast does.
+6. **Post-finalize agent strip**: after finalize, show a small strip listing the downstream agent jobs
+   for this encounter (coding readiness, patient outreach, outcome tracker) with live status from
+   `AgentJob` (pending/running/succeeded/failed + failure reason). Server-fetch on the note page;
+   no polling infrastructure — a refresh button is fine.
+7. **Cleanup**: remove the two `as any`/typed casts left in `actions.ts`/`page.tsx` pending prisma
+   regeneration (client is now regenerated). Remove `needs_review` from the editor's editable-status
+   set and notes filtering *within your territory only*; if references exist elsewhere, list them in
+   your report — do not edit them.
+
+---
+
+## WS-B — Visit Wrap-Up & Follow-Through
+
+**Mission:** the 60 seconds after "Sign" should finish the visit completely: follow-up booked,
+patient summary out the door, no zombie queue entries.
+
+**Linear:** epic WS-B; items 2, 6 (panel part), 7, 8, 14 of EMR-1103; outreach no-op queue entries
+(Phase 1 leftover).
+
+**Territory:** `src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx`
+(+ its test), the `releaseVisitCompletion` region of `notes/[noteId]/actions.ts`,
+`src/lib/domain/visit-completion.ts` (+ test), `src/app/(clinician)/clinic/patients/[id]/leaflet/**`,
+`src/app/(clinician)/clinic/scheduling/follow-up/**`, `src/lib/agents/patient-outreach-agent.ts`,
+`src/lib/agents/messaging-assistant-agent.ts`, `src/lib/orchestration/workflows.ts` (messaging
+workflow entry only), the approvals/sign-off queue page, and the `startVisit` function in
+`src/app/(clinician)/clinic/patients/[id]/actions.ts`.
+
+**Tasks:**
+1. **One-click follow-up booking**: the Follow-Up card in the visit-completion panel gets a real
+   "Book follow-up" action — derive the interval from the note/cadence config (follow-up cadence
+   page logic), propose the slot, create the `Appointment` on release (provider, modality, patient
+   pre-filled). Keep "Send to front desk" as the fallback for complex scheduling.
+2. **Leaflet in the release flow**: add a "Patient leaflet" card/affordance to the completion panel —
+   generate + preview without leaving the flow (link-out to the leaflet editor for edits is fine).
+3. **Modality fidelity**: `startVisit` reads modality from the day's appointment when creating an
+   ad-hoc encounter instead of hard-coding `in_person`.
+4. **Queue hygiene**: outreach agent runs that skip (M6 dedup) currently complete as visible no-op
+   jobs in the approvals queue — suppress or label them so the physician's inbox only shows
+   actionable items.
+5. **Messaging-assistant decision**: `message.draft.requested` is never emitted. Wire it from one
+   real surface (e.g., a "Draft reply with AI" button in the comms/inbox thread view) OR delete the
+   workflow + agent registration and document the removal. Pick based on how complete the agent is —
+   justify in your report.
+
+---
+
+## WS-C — Prescribing Safety & Compliance Hardening
+
+**Mission:** every safety check happens server-side, every compliance path ends in a real artifact.
+The client is a convenience, never the enforcement point.
+
+**Linear:** epic WS-C; items 9, 10 of EMR-1103; pharmacy server-enforcement + CURES coverage
+(Phase 1 leftovers); compliance print packet.
+
+**Territory:** `src/app/(clinician)/clinic/patients/[id]/prescribe/**`,
+`src/app/(clinician)/clinic/patients/[id]/recommend/**`,
+`src/app/(clinician)/clinic/patients/[id]/compliance/**`,
+`src/lib/integrations/state-registries/**`, `src/lib/domain/state-registry.ts`,
+and the pharmacology/interactions lib it already imports.
+
+**Tasks:**
+1. **Server-side pharmacy enforcement**: `pharmacyId`/`pharmacyName` were added optional-server-side
+   (commit `b33eb9d`) to protect the legacy v1 form and batch flow. Make the v2 path require pharmacy
+   server-side (reject with a structured error), and either bring the v1/batch flows up to the same
+   contract or annotate precisely why they're exempt.
+2. **Server-side interaction re-check for custom products**: `prescribe/actions.ts` (~139-163) only
+   re-checks interactions when a formulary product is matched. Run the interaction check server-side
+   for custom/free-text products too (best-effort match on cannabinoid profile/name); block on
+   unacknowledged red interactions regardless of product source.
+3. **High-risk attestation coverage**: the CURES attestation only renders for controlled substances.
+   Extend the attestation gate to high-risk non-controlled scenarios (high-dose THC, age ≥65,
+   documented psychiatric comorbidity — use whatever risk flags the safety-check engine already
+   computes). Server validates the acknowledgment, not just the client.
+4. **Corpus fallback**: `recommend/actions.ts` (~58-60) throws raw on missing
+   `data/cannabis-research-corpus.json`. Add graceful fallback (clear user-facing error +
+   template-path recommendation still works) and a startup-time log.
+5. **Compliance print packet**: the manual_stub registry path tells the physician to "print the
+   packet for manual filing" — make sure a print-ready view of the signed `StateComplianceForm`
+   exists (follow the `notes/[noteId]/print/page.tsx` pattern) and link it from the amber notice.
+6. **Cleanup**: `src/lib/domain/state-registry.ts#submitToRegistry` is now unused by the UI — remove
+   it (or repoint remaining callers to `submitToStateRegistry`), keeping `getRegistryForState`.
+
+---
+
+## WS-D — Chart Data Reuse & Platform Plumbing
+
+**Mission:** data entered once is data never re-typed; the new Phase 1 models become first-class
+citizens (visible on the chart, seeded, migrated, e2e-covered).
+
+**Linear:** epic WS-D; item 13 of EMR-1103; orders chart surfacing + imaging priority + lab
+attachment honesty (Phase 1 leftovers); migration + e2e coverage.
+
+**Territory:** `src/app/(clinician)/clinic/patients/[id]/page.tsx` and its tab components
+(`*-tab.tsx` in that directory, excluding `notes-tab.tsx` which WS-A owns),
+`src/app/(clinician)/clinic/patients/[id]/orders/**`,
+`src/app/(clinician)/clinic/patients/[id]/demographics/**`, `prisma/` (migrations, `seed.ts`),
+`e2e/**`, `src/lib/domain/golden-visit-harness*`.
+
+**Tasks:**
+1. **Orders on the chart**: surface `ClinicalOrder` rows on the patient chart (page.tsx) — an Orders
+   tab or card consistent with the existing tab pattern (count + hover peek + link to the order
+   pages). Pending orders should be visible during pre-visit chart review.
+2. **Intake → demographics prefill**: demographics inline-edit fields and the insurance section
+   pre-fill from `intakeAnswers` where the structured field is empty (audit minor 13). One-way,
+   physician-editable, with a subtle "from intake" hint on prefilled values.
+3. **Orders polish**: add the missing priority selector to the imaging form; make the lab form's
+   attachment upload stub honest (either persist attachments using the existing Document upload
+   pattern, or clearly label it not-yet-saved — prefer persisting if the Document flow supports it).
+4. **Migration + seed**: create the Prisma migration artifacts for the Phase 1 schema additions
+   (`ClinicalOrder`, `CannabisRecommendation`, `DosingRegimen.pharmacy*`, `CodingSuggestion`
+   approval fields) consistent with how this repo manages migrations (`db:push` vs `migrate` — check
+   and follow), and extend `prisma/seed.ts` with sample rows for each so demo orgs exercise the new
+   surfaces.
+5. **E2E coverage**: extend the golden-visit harness/e2e to cover the new control point: finalize →
+   coding suggestions → approve codes → charge created (and NOT before approval). Follow
+   `e2e/golden-visit-surfaces.spec.ts` + `golden-visit-harness.test.ts` patterns.
+
+---
+
+## Merge order & conflict notes
+
+- WS-A and WS-B both touch `notes/[noteId]/actions.ts` in disjoint regions (casts/messaging vs
+  release flow) — merge either order, trivial conflicts at worst.
+- WS-D's chart page work is isolated from everyone else by design (nobody else may touch `page.tsx`).
+- Suggested merge order: C → A → B → D (D rebases last so its migration + seed capture the final schema).

--- a/prisma/migrations/20260609180000_emr1103_clinical_orders_and_coding_approval/migration.sql
+++ b/prisma/migrations/20260609180000_emr1103_clinical_orders_and_coding_approval/migration.sql
@@ -1,0 +1,72 @@
+-- EMR-1103 (WS-D) — Physician Workflow Phase 1 schema additions, captured as a
+-- migration artifact. These models/columns were introduced into schema.prisma
+-- by the Phase 1 fixes (commits 0186db9, b33eb9d, d554500) and applied to dev
+-- via `db push`; this migration records them for fresh databases and deploys.
+--
+-- Everything is additive + idempotent (IF NOT EXISTS / guarded constraints) so
+-- it also applies cleanly over a db-push-drifted database where the tables and
+-- columns may already exist.
+
+-- ── B1: ClinicalOrder — persisted lab + imaging orders ──────────────────────
+CREATE TABLE IF NOT EXISTS "ClinicalOrder" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "encounterId" TEXT,
+    "orderType" TEXT NOT NULL,
+    "orderCode" TEXT NOT NULL,
+    "orderName" TEXT NOT NULL,
+    "priority" TEXT NOT NULL DEFAULT 'routine',
+    "diagnosisCodes" JSONB NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'placed',
+    "transmissionMode" TEXT NOT NULL DEFAULT 'simulated',
+    "orderedById" TEXT NOT NULL,
+    "orderedByName" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ClinicalOrder_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "ClinicalOrder_patientId_orderType_idx" ON "ClinicalOrder"("patientId", "orderType");
+CREATE INDEX IF NOT EXISTS "ClinicalOrder_organizationId_status_idx" ON "ClinicalOrder"("organizationId", "status");
+
+DO $$ BEGIN
+  ALTER TABLE "ClinicalOrder" ADD CONSTRAINT "ClinicalOrder_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ClinicalOrder" ADD CONSTRAINT "ClinicalOrder_patientId_fkey"
+    FOREIGN KEY ("patientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- ── M1: CannabisRecommendation — persisted AI treatment recommendations ─────
+-- Standalone (plain-string ids, no @relation), so no foreign keys.
+CREATE TABLE IF NOT EXISTS "CannabisRecommendation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdByName" TEXT NOT NULL,
+    "inputContext" JSONB NOT NULL,
+    "recommendation" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CannabisRecommendation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "CannabisRecommendation_patientId_idx" ON "CannabisRecommendation"("patientId");
+
+-- ── M3: DosingRegimen pharmacy routing ──────────────────────────────────────
+ALTER TABLE "DosingRegimen" ADD COLUMN IF NOT EXISTS "pharmacyId" TEXT;
+ALTER TABLE "DosingRegimen" ADD COLUMN IF NOT EXISTS "pharmacyName" TEXT;
+
+-- ── B4: CodingSuggestion physician approval fields ──────────────────────────
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'suggested';
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "approvedById" TEXT;
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "approvedByName" TEXT;
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "approvedAt" TIMESTAMP(3);
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "approvedIcd10" JSONB;
+ALTER TABLE "CodingSuggestion" ADD COLUMN IF NOT EXISTS "approvedEmLevel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,7 @@ model Organization {
   feeSchedule              FeeScheduleEntry[]
   referrals                Referral[]
   complianceForms          StateComplianceForm[]
+  clinicalOrders           ClinicalOrder[]
   intakeTemplates          IntakeFormTemplate[]
   products                 Product[]
   orders                   Order[]
@@ -374,6 +375,7 @@ model Patient {
   referrals                Referral[]
   signedConsents           SignedConsent[]
   complianceForms          StateComplianceForm[]
+  clinicalOrders           ClinicalOrder[]
   caregiverInvites         CaregiverInvite[]
   surveySubmissions        SurveySubmission[]
   // Marketplace
@@ -652,6 +654,15 @@ model CodingSuggestion {
   emLevel     String?
   rationale   String?
   generatedAt DateTime @default(now())
+
+  // EMR-1097 — physician coding decision. Charges are extracted only after
+  // the physician approves (or modifies) the suggested codes.
+  status          String    @default("suggested") // suggested, approved, modified, dismissed
+  approvedById    String?
+  approvedByName  String?
+  approvedAt      DateTime?
+  approvedIcd10   Json? // [{ code, label }] as approved/edited by the physician
+  approvedEmLevel String?
 
   note Note @relation(fields: [noteId], references: [id], onDelete: Cascade)
 }
@@ -2305,6 +2316,11 @@ model DosingRegimen {
   // a flagged contraindication. Contains: { contraindicationIds, reason,
   // overriddenByUserId, overriddenAt }
   contraindicationOverride Json?
+  // EMR-1099 (M3): pharmacy routing — where the signed Rx is sent. Optional
+  // at the schema level so legacy rows stay valid; the v2 prescribe form
+  // gates "Sign & send" on a pharmacy selection.
+  pharmacyId               String?
+  pharmacyName             String?
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
@@ -2375,6 +2391,27 @@ model PatientMedication {
 // --------------------------------------------------------------
 // Research (stubbed for V1)
 // --------------------------------------------------------------
+
+// EMR-1098 (M1) — persisted AI treatment recommendations. Every generation
+// from clinic/patients/[id]/recommend is saved here so there is a durable
+// record of the decision support the physician saw, and so a saved
+// recommendation can be applied to a prescription (/prescribe?rec={id}).
+model CannabisRecommendation {
+  id             String   @id @default(cuid())
+  organizationId String
+  patientId      String
+  createdById    String // provider user id
+  createdByName  String
+  /// Input context used to generate: { concerns, goals, outcomeSummary, assessmentSummary }
+  inputContext   Json
+  /// Full generated payload (`Recommendation` in recommend/actions.ts):
+  /// { productType, cannabinoidRatio, startingDoseMg, deliveryMethod,
+  ///   frequency, citations, confidence, rationale }
+  recommendation Json
+  createdAt      DateTime @default(now())
+
+  @@index([patientId])
+}
 
 model ResearchQuery {
   id        String   @id @default(cuid())
@@ -2930,6 +2967,35 @@ model StateComplianceForm {
   patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId, stateCode])
+  @@index([organizationId, status])
+}
+
+// --------------------------------------------------------------
+// Clinical Orders (labs + imaging) — EMR-1094
+// --------------------------------------------------------------
+
+model ClinicalOrder {
+  id               String   @id @default(cuid())
+  organizationId   String
+  patientId        String
+  encounterId      String?
+  orderType        String // "lab" | "imaging"
+  orderCode        String
+  orderName        String
+  priority         String   @default("routine") // routine, stat
+  diagnosisCodes   Json // array of ICD-10 codes supporting the order
+  payload          Json // full structured order as built by the order form
+  status           String   @default("placed") // placed, transmitted, resulted, cancelled
+  transmissionMode String   @default("simulated") // "simulated" until an external lab/imaging interface is wired
+  orderedById      String
+  orderedByName    String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+
+  @@index([patientId, orderType])
   @@index([organizationId, status])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -110,6 +110,13 @@ async function cleanIdempotent() {
   await prisma.codingSuggestion.deleteMany({
     where: { note: { encounter: { organizationId: org.id } } },
   });
+  // EMR-1103 (WS-D) — Phase 1 clinical-decision tables. No relation cascades
+  // reach these from the rows above, so clean them explicitly to keep the
+  // seed idempotent (both are cuid-keyed and would otherwise accumulate).
+  await prisma.clinicalOrder.deleteMany({ where: { organizationId: org.id } });
+  await prisma.cannabisRecommendation.deleteMany({
+    where: { organizationId: org.id },
+  });
   await prisma.note.deleteMany({
     where: { encounter: { organizationId: org.id } },
   });
@@ -1666,7 +1673,7 @@ async function main() {
   });
 
   // Maya — Finalized note on the completed encounter
-  await prisma.note.create({
+  const mayaNote = await prisma.note.create({
     data: {
       encounterId: mayaCompletedEncounter.id,
       authorUserId: clinicianUser.id,
@@ -1702,6 +1709,119 @@ async function main() {
         },
       ],
       narrative: null,
+    },
+  });
+
+  // EMR-1103 (WS-D) — Phase 1 clinical-decision sample data so demo orgs
+  // exercise the new chart surfaces: a physician-approved coding suggestion
+  // (drives the billing checkpoint), placed lab + imaging orders (Orders
+  // tab), and a persisted AI recommendation.
+
+  // Maya — coding suggestion, approved by the clinician on the signed note.
+  await prisma.codingSuggestion.create({
+    data: {
+      noteId: mayaNote.id,
+      icd10: [
+        { code: "G89.29", label: "Other chronic pain", confidence: 0.93 },
+        { code: "G47.00", label: "Insomnia, unspecified", confidence: 0.84 },
+      ],
+      emLevel: "99204",
+      rationale:
+        "New patient, moderate-complexity cannabis therapy initiation for chronic pain with secondary insomnia.",
+      generatedAt: daysAgo(7),
+      status: "approved",
+      approvedById: clinicianUser.id,
+      approvedByName: "Dr. Lena Okafor",
+      approvedAt: daysAgo(7),
+      approvedIcd10: [
+        { code: "G89.29", label: "Other chronic pain" },
+        { code: "G47.00", label: "Insomnia, unspecified" },
+      ],
+      approvedEmLevel: "99204",
+    },
+  });
+
+  // Maya — placed lab order (saved to the chart; transmission simulated).
+  await prisma.clinicalOrder.create({
+    data: {
+      organizationId: org.id,
+      patientId: maya.id,
+      encounterId: mayaCompletedEncounter.id,
+      orderType: "lab",
+      orderCode: "CBC,CMP",
+      orderName: "Complete Blood Count, Comprehensive Metabolic Panel",
+      priority: "routine",
+      diagnosisCodes: ["G89.29"],
+      payload: {
+        labs: ["CBC", "CMP"],
+        reason: "Baseline labs before cannabis therapy titration.",
+        diagnoses: ["G89.29"],
+        priority: "routine",
+      },
+      status: "placed",
+      transmissionMode: "simulated",
+      orderedById: clinicianUser.id,
+      orderedByName: "Dr. Lena Okafor",
+      createdAt: daysAgo(7),
+    },
+  });
+
+  // Maya — placed imaging order (STAT, to exercise the priority surface).
+  await prisma.clinicalOrder.create({
+    data: {
+      organizationId: org.id,
+      patientId: maya.id,
+      encounterId: mayaCompletedEncounter.id,
+      orderType: "imaging",
+      orderCode: "72148",
+      orderName: "MRI — Lumbar spine without contrast",
+      priority: "stat",
+      diagnosisCodes: ["G89.29"],
+      payload: {
+        modality: "MRI",
+        studyCode: "72148",
+        studyName: "MRI Lumbar spine without contrast",
+        indication: "Chronic low back pain, evaluate for structural cause.",
+        diagnoses: ["G89.29"],
+        priority: "stat",
+        priorAuth: true,
+      },
+      status: "placed",
+      transmissionMode: "simulated",
+      orderedById: clinicianUser.id,
+      orderedByName: "Dr. Lena Okafor",
+      createdAt: daysAgo(6),
+    },
+  });
+
+  // Maya — persisted AI treatment recommendation (decision-support record).
+  await prisma.cannabisRecommendation.create({
+    data: {
+      organizationId: org.id,
+      patientId: maya.id,
+      createdById: clinicianUser.id,
+      createdByName: "Dr. Lena Okafor",
+      inputContext: {
+        concerns: ["chronic neuropathic pain", "sleep disturbance"],
+        goals: ["improve sleep quality", "reduce daytime pain"],
+        outcomeSummary: "Pain 7/10, sleep 4/10 on intake.",
+        assessmentSummary:
+          "Chronic neuropathic pain with secondary insomnia; prior positive response to tinctures.",
+      },
+      recommendation: {
+        productType: "tincture",
+        cannabinoidRatio: "1:1 THC:CBD",
+        startingDoseMg: 5,
+        deliveryMethod: "sublingual",
+        frequency: "twice daily",
+        citations: [
+          "Whiting et al. (2015) JAMA — cannabinoids for chronic pain",
+        ],
+        confidence: 0.78,
+        rationale:
+          "Balanced 1:1 sublingual tincture at a low starting dose balances analgesia and sleep benefit while limiting daytime somnolence.",
+      },
+      createdAt: daysAgo(7),
     },
   });
 
@@ -2546,6 +2666,9 @@ async function main() {
         "Take 0.5 mL (half a dropper) under the tongue twice daily — once in the morning and once before bed. Hold under tongue for 60 seconds before swallowing. This equals 2.5 mg THC + 2.5 mg CBD per dose (5 mg each per day).",
       clinicianNotes:
         "Starting low dose 1:1 for sleep and pain. Reassess in 2 weeks. May titrate up to 1 mL if tolerated.",
+      // EMR-1099 (M3 / WS-D) — pharmacy routing for the signed Rx.
+      pharmacyId: "pharmacy-green-leaf-lb",
+      pharmacyName: "Green Leaf Pharmacy — Long Beach",
       startDate: daysAgo(3),
     },
   });

--- a/src/app/(clinician)/clinic/messages/actions.ai-draft.test.ts
+++ b/src/app/(clinician)/clinic/messages/actions.ai-draft.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * WS-B Task 5 (EMR-1103 audit #14) — the Messaging Assistant agent was dead
+ * code because `message.draft.requested` was never emitted. requestAiDraftAction
+ * is the real surface that emits it. These tests pin the wiring: the correct
+ * event is dispatched (org-scoped, with the thread's patient + intent), and the
+ * standing workflow table routes that event to the messagingAssistant agent.
+ */
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    messageThread: { findFirst: vi.fn() },
+    agentJob: { findMany: vi.fn() },
+  },
+  requireUserMock: vi.fn(),
+  dispatchMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+// Deliver/email/sms are imported by the module but unused on this path.
+vi.mock("@/lib/messaging/deliver", () => ({ deliverMessage: vi.fn() }));
+vi.mock("@/lib/email/resend", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/sms/adapter", () => ({ getSmsAdapter: vi.fn(), normalizePhone: vi.fn() }));
+
+import { requestAiDraftAction } from "./actions";
+import { matchWorkflows } from "@/lib/orchestration/workflows";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.messageThread.findFirst.mockResolvedValue({ patient: { id: "patient_9" } });
+  mockPrisma.agentJob.findMany.mockResolvedValue([]); // no inline run
+  dispatchMock.mockResolvedValue([]); // no enqueued jobs to run inline
+});
+
+describe("requestAiDraftAction", () => {
+  it("dispatches message.draft.requested for the thread's patient, org-scoped", async () => {
+    const result = await requestAiDraftAction("thread_1");
+
+    expect(result).toEqual({ ok: true });
+    expect(dispatchMock).toHaveBeenCalledWith({
+      name: "message.draft.requested",
+      patientId: "patient_9",
+      intent: "follow_up",
+      organizationId: "org_1",
+    });
+  });
+
+  it("forwards a caller-chosen intent", async () => {
+    await requestAiDraftAction("thread_1", "appointment_confirm");
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: "appointment_confirm" }),
+    );
+  });
+
+  it("rejects non-clinician roles without dispatching", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+    const result = await requestAiDraftAction("thread_1");
+    expect(result.ok).toBe(false);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a thread outside the caller's org without dispatching", async () => {
+    mockPrisma.messageThread.findFirst.mockResolvedValue(null);
+    const result = await requestAiDraftAction("thread_1");
+    expect(result).toEqual({ ok: false, error: "Thread not found." });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("the workflow table routes message.draft.requested to messagingAssistant", () => {
+    const matches = matchWorkflows({
+      name: "message.draft.requested",
+      patientId: "patient_9",
+      intent: "follow_up",
+      organizationId: "org_1",
+    });
+    expect(matches.map((m) => m.step.agent)).toContain("messagingAssistant");
+  });
+});

--- a/src/app/(clinician)/clinic/messages/actions.ts
+++ b/src/app/(clinician)/clinic/messages/actions.ts
@@ -7,6 +7,8 @@ import { requireUser } from "@/lib/auth/session";
 import { deliverMessage } from "@/lib/messaging/deliver";
 import { sendEmail } from "@/lib/email/resend";
 import { getSmsAdapter, normalizePhone } from "@/lib/sms/adapter";
+import { dispatch } from "@/lib/orchestration/dispatch";
+import { logger } from "@/lib/observability/log";
 
 // ---------- Reply to a thread ----------
 
@@ -52,6 +54,74 @@ export async function sendClinicReplyAction(
     body: parsed.data.body,
     senderUserId: user.id,
   });
+
+  revalidatePath("/clinic/messages");
+  return { ok: true };
+}
+
+// ---------- Request an AI-drafted reply (EMR-1103 audit #14) ----------
+//
+// Wires the previously-dead Messaging Assistant agent to a real surface. The
+// `message.draft.requested` domain event was defined and mapped to the
+// messagingAssistant workflow, but nothing ever emitted it — so the agent was
+// unreachable. The "Draft with AI" control in the thread view emits it here.
+//
+// The agent loads the patient's chart + longitudinal memory, drafts an
+// approval-gated `draft` Message, and that draft surfaces both inline in this
+// thread and in the clinician Approvals inbox for sign-off (it is NEVER sent
+// automatically). We best-effort run the enqueued job inline (mirroring
+// startVisit) so the draft appears promptly; on timeout the worker finishes it.
+
+const aiDraftSchema = z.object({
+  threadId: z.string().min(1),
+  intent: z.string().min(1).max(40).optional(),
+});
+
+export type AiDraftResult = { ok: true } | { ok: false; error: string };
+
+export async function requestAiDraftAction(
+  threadId: string,
+  intent: string = "follow_up",
+): Promise<AiDraftResult> {
+  const user = await requireUser();
+
+  if (!user.roles.some((r) => r === "clinician" || r === "practice_owner")) {
+    return { ok: false, error: "Unauthorized — clinician role required." };
+  }
+
+  const parsed = aiDraftSchema.safeParse({ threadId, intent });
+  if (!parsed.success) return { ok: false, error: "Invalid request." };
+
+  const thread = await prisma.messageThread.findFirst({
+    where: {
+      id: parsed.data.threadId,
+      patient: { organizationId: user.organizationId! },
+    },
+    select: { patient: { select: { id: true } } },
+  });
+  if (!thread) return { ok: false, error: "Thread not found." };
+
+  const jobs = await dispatch({
+    name: "message.draft.requested",
+    patientId: thread.patient.id,
+    intent: parsed.data.intent ?? "follow_up",
+    organizationId: user.organizationId!,
+  });
+
+  // Best-effort inline run so the draft shows up without waiting on the worker.
+  try {
+    if (jobs.length > 0) {
+      const jobRows = await prisma.agentJob.findMany({ where: { id: { in: jobs } } });
+      const { runJob } = await import("@/lib/orchestration/runner");
+      await Promise.race([
+        Promise.all(jobRows.map((job) => runJob(job, "inline-message-draft"))),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 15000)),
+      ]);
+    }
+  } catch (err) {
+    // Timeout or error — the job stays queued for the worker to finish.
+    logger.error({ event: "clinic.messages.ai_draft.inline_failed", err });
+  }
 
   revalidatePath("/clinic/messages");
   return { ok: true };

--- a/src/app/(clinician)/clinic/messages/brief-view.tsx
+++ b/src/app/(clinician)/clinic/messages/brief-view.tsx
@@ -49,7 +49,7 @@ export async function MorningBriefView() {
   ] = await Promise.all([
     prisma.note.findMany({
       where: {
-        status: { in: ["draft", "needs_review"] },
+        status: { in: ["draft", "pending_cosign"] },
         encounter: { organizationId: orgId },
         updatedAt: { lt: today },
       },
@@ -200,7 +200,7 @@ export async function MorningBriefView() {
       id: `note-${note.id}`,
       category: "unsigned",
       title: `Unsigned note for ${note.encounter.patient.firstName} ${note.encounter.patient.lastName}`,
-      detail: `${note.status === "needs_review" ? "Needs review" : "Draft"} · updated ${formatRelative(note.updatedAt)}`,
+      detail: `${note.status === "pending_cosign" ? "Awaiting co-signature" : "Draft"} · updated ${formatRelative(note.updatedAt)}`,
       href: `/clinic/patients/${note.encounter.patient.id}/notes/${note.id}`,
       urgency: "high",
     });

--- a/src/app/(clinician)/clinic/messages/compose.tsx
+++ b/src/app/(clinician)/clinic/messages/compose.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useFormState, useFormStatus } from "react-dom";
-import { useEffect, useRef, useState } from "react";
-import { sendClinicReplyAction } from "./actions";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { sendClinicReplyAction, requestAiDraftAction } from "./actions";
 import type { ReplyResult } from "./actions";
 import { Button } from "@/components/ui/button";
 import { DictationTextarea } from "@/components/ui/dictation-input";
@@ -20,6 +21,49 @@ function ClinicReplySubmitButton() {
   return (
     <Button type="submit" size="sm" disabled={pending}>
       {pending ? "Sending..." : "Send"}
+    </Button>
+  );
+}
+
+/**
+ * "Draft with AI" — asks the Messaging Assistant agent to draft a reply for
+ * this patient. The draft lands inline in the thread (and in the Approvals
+ * inbox) for the clinician to review and send; nothing is sent automatically.
+ */
+function DraftWithAiButton({ threadId }: { threadId: string }) {
+  const [pending, startTransition] = useTransition();
+  const { toast } = useToast();
+  const router = useRouter();
+
+  function onClick() {
+    startTransition(async () => {
+      const result = await requestAiDraftAction(threadId);
+      if (result.ok) {
+        toast({
+          title: "AI is drafting a reply",
+          description: "The draft will appear here and in Approvals for your review.",
+          variant: "success",
+        });
+        router.refresh();
+      } else {
+        toast({
+          title: "Couldn't request a draft",
+          description: result.error,
+          variant: "error",
+        });
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="secondary"
+      onClick={onClick}
+      disabled={pending}
+    >
+      {pending ? "Drafting…" : "✨ Draft with AI"}
     </Button>
   );
 }
@@ -71,7 +115,8 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
             placeholder="Type your reply, use the toolbar to format, or / for block commands…"
             aria-label="Reply body"
           />
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            <DraftWithAiButton threadId={threadId} />
             <ClinicReplySubmitButton />
           </div>
         </div>
@@ -89,6 +134,7 @@ export function ClinicReplyCompose({ threadId }: { threadId: string }) {
               aria-label="Reply body"
             />
           </div>
+          <DraftWithAiButton threadId={threadId} />
           <ClinicReplySubmitButton />
         </div>
       )}

--- a/src/app/(clinician)/clinic/page.tsx
+++ b/src/app/(clinician)/clinic/page.tsx
@@ -334,7 +334,7 @@ export default async function ClinicHomePage() {
     // 3. Notes needing review (full list for sidebar)
     prisma.note.findMany({
       where: {
-        status: { in: ["draft", "needs_review"] },
+        status: { in: ["draft", "pending_cosign"] },
         encounter: { organizationId },
       },
       include: {
@@ -468,9 +468,9 @@ export default async function ClinicHomePage() {
       })
     ),
 
-    // 16. Notes in needs_review status (for command strip count)
+    // 16. Notes awaiting co-signature (for command strip count)
     prisma.note.count({
-      where: { status: "needs_review", encounter: { organizationId } },
+      where: { status: "pending_cosign", encounter: { organizationId } },
     }),
 
     // 17. Recent agent jobs (fleet bridge — last 24h, succeeded + needs_approval)
@@ -1113,9 +1113,9 @@ export default async function ClinicHomePage() {
                           </p>
                         </div>
                         <Badge
-                          tone={note.status === "needs_review" ? "warning" : "neutral"}
+                          tone={note.status === "pending_cosign" ? "warning" : "neutral"}
                         >
-                          {note.status === "needs_review" ? "Review" : "Draft"}
+                          {note.status === "pending_cosign" ? "Co-sign" : "Draft"}
                         </Badge>
                       </Link>
                     </li>

--- a/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.start-visit.test.ts
@@ -17,6 +17,7 @@ const hoisted = vi.hoisted(() => {
     note: { findFirst: vi.fn() },
     agentJob: { findMany: vi.fn() },
     provider: { findFirst: vi.fn() },
+    appointment: { findFirst: vi.fn() },
   };
   return {
     mockPrisma,
@@ -100,6 +101,7 @@ beforeEach(() => {
   mockPrisma.encounter.create.mockResolvedValue(scheduledEncounter({ id: "new_enc", status: "in_progress" }));
   mockPrisma.note.findFirst.mockResolvedValue(null);
   mockPrisma.agentJob.findMany.mockResolvedValue([]);
+  mockPrisma.appointment.findFirst.mockResolvedValue(null);
   dispatchMock.mockResolvedValue([]);
 });
 
@@ -137,6 +139,34 @@ describe("startVisit — encounter selection", () => {
     await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
 
     expect(mockPrisma.encounter.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startVisit — modality fidelity (audit minor #2)", () => {
+  it("carries modality from today's confirmed appointment when minting an ad-hoc encounter", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    mockPrisma.appointment.findFirst.mockResolvedValue({ modality: "video" });
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ modality: "video" }),
+      }),
+    );
+  });
+
+  it("falls back to in_person when no appointment exists today", async () => {
+    mockPrisma.encounter.findMany.mockResolvedValue([]);
+    mockPrisma.appointment.findFirst.mockResolvedValue(null);
+
+    await expect(startVisit("patient_1")).rejects.toThrow(/redirect:/);
+
+    expect(mockPrisma.encounter.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ modality: "in_person" }),
+      }),
+    );
   });
 });
 

--- a/src/app/(clinician)/clinic/patients/[id]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/actions.ts
@@ -91,12 +91,34 @@ export async function startVisit(patientId: string) {
       redirect(`/clinic/patients/${patientId}/notes/${existingNote.id}`);
     }
   } else {
+    // Audit minor #2 — modality fidelity. When we mint an ad-hoc encounter
+    // (no front-desk encounter was materialized for today), carry the modality
+    // from today's confirmed appointment so a telehealth/phone visit isn't
+    // silently recorded as in_person. Falls back to in_person when there's no
+    // appointment to read from. Mirrors the day-window + calendar-block
+    // exclusions used by ensure-encounter's bridge.
+    const dayStart = new Date();
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date();
+    dayEnd.setHours(23, 59, 59, 999);
+    const todaysAppointment = await prisma.appointment.findFirst({
+      where: {
+        patientId,
+        status: "confirmed",
+        startAt: { gte: dayStart, lte: dayEnd },
+        NOT: { notes: { startsWith: "[CalendarBlock:" } },
+        patient: { organizationId: user.organizationId!, deletedAt: null },
+      },
+      select: { modality: true },
+      orderBy: { startAt: "asc" },
+    });
+
     encounter = await prisma.encounter.create({
       data: {
         organizationId: user.organizationId!,
         patientId,
         status: "in_progress",
-        modality: "in_person",
+        modality: todaysAppointment?.modality ?? "in_person",
         reason: "Visit",
         startedAt: new Date(),
         scheduledFor: new Date(),

--- a/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/chart-tabs.tsx
@@ -28,6 +28,10 @@ const TABS = [
   { key: "private_notes", label: "Private notes", dot: "bg-danger", group: "Clinical", hidden: true },
   { key: "labs", label: "Labs, Scores & Vitals", dot: "bg-[color:var(--success)]", group: "Clinical" },
   { key: "images", label: "Images", dot: "bg-[color:var(--info)]", group: "Clinical" },
+  // EMR-1103 (WS-D) — placed lab + imaging orders (ClinicalOrder). Pending
+  // orders surface here during pre-visit chart review; the panel links out
+  // to the per-modality order pages for placing new ones.
+  { key: "orders", label: "Orders", dot: "bg-[color:var(--success)]", group: "Clinical" },
   { key: "rx", label: "Rx", dot: "bg-[color:var(--highlight)]", group: "Clinical" },
   { key: "records", label: "Records", dot: "bg-accent", group: "Documents" },
   { key: "correspondence", label: "Correspondence", dot: "bg-[color:var(--info)]", group: "Documents" },

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/actions.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * EMR-1095/1096/1102 — state compliance form persistence.
+ * - Sign/submit must enforce required-field validation server-side and
+ *   return structured fieldErrors (M7).
+ * - A registry result with mode "manual_stub" must never move the form to
+ *   "submitted" (nothing was transmitted), but the attempt is persisted.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    stateComplianceForm: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    auditLog: { create: vi.fn() },
+  };
+  return {
+    mockPrisma,
+    requireUserMock: vi.fn(),
+    submitToStateRegistryMock: vi.fn(),
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/integrations/state-registries", () => ({
+  submitToStateRegistry: (...args: unknown[]) =>
+    hoisted.submitToStateRegistryMock(...args),
+}));
+
+import {
+  saveComplianceForm,
+  signComplianceForm,
+  submitComplianceForm,
+} from "./actions";
+
+const { mockPrisma, requireUserMock, submitToStateRegistryMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+/** Every required (non-signature) field of the CA template, filled. */
+function completeCaFields(over: Record<string, unknown> = {}) {
+  return {
+    patientName: "Pat Patient",
+    patientDob: "1990-01-01",
+    patientAddress: "1 Main St, Oakland, CA, 94601",
+    diagnosisCode: "G89.4",
+    diagnosisDescription: "Chronic pain syndrome",
+    recommendationDate: "2026-06-09",
+    expirationDate: "2027-06-09",
+    physicianName: "Dr. Cli Nician",
+    physicianLicense: "A12345",
+    ...over,
+  };
+}
+
+function formRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "form_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    encounterId: null,
+    stateCode: "CA",
+    formTemplateId: "ca-rec-001",
+    formName: "Physician's Recommendation",
+    fields: completeCaFields(),
+    status: "draft",
+    signedBy: null,
+    signedAt: null,
+    submittedAt: null,
+    createdAt: new Date("2026-06-09T10:00:00.000Z"),
+    updatedAt: new Date("2026-06-09T10:00:00.000Z"),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue({
+    id: "patient_1",
+    organizationId: "org_1",
+  });
+  mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(null);
+  mockPrisma.stateComplianceForm.create.mockImplementation(
+    async ({ data }: any) => ({ ...formRow(), ...data, id: "form_new" }),
+  );
+  mockPrisma.stateComplianceForm.update.mockImplementation(
+    async ({ where, data }: any) => ({ ...formRow(), id: where.id, ...data }),
+  );
+  mockPrisma.auditLog.create.mockResolvedValue({});
+});
+
+describe("saveComplianceForm", () => {
+  it("creates a draft and only persists template-defined keys", async () => {
+    const res = await saveComplianceForm({
+      patientId: "patient_1",
+      stateCode: "CA",
+      fields: { ...completeCaFields(), __registrySubmission: "spoofed", bogus: "x" },
+    });
+
+    expect(res.ok).toBe(true);
+    const created = mockPrisma.stateComplianceForm.create.mock.calls[0][0].data;
+    expect(created.status).toBe("draft");
+    expect(created.fields.bogus).toBeUndefined();
+    expect(created.fields.__registrySubmission).toBeUndefined();
+    expect(created.fields.patientName).toBe("Pat Patient");
+  });
+
+  it("refuses to edit a signed form", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(
+      formRow({ status: "complete", signedAt: new Date() }),
+    );
+
+    const res = await saveComplianceForm({
+      patientId: "patient_1",
+      stateCode: "CA",
+      fields: completeCaFields(),
+    });
+
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.stateComplianceForm.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects users without notes.edit", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["operator"] }));
+
+    const res = await saveComplianceForm({
+      patientId: "patient_1",
+      stateCode: "CA",
+      fields: completeCaFields(),
+    });
+
+    expect(res.ok).toBe(false);
+    expect(mockPrisma.stateComplianceForm.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("signComplianceForm — M7 server-side validation", () => {
+  it("returns structured fieldErrors when required fields are missing", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(
+      formRow({ fields: completeCaFields({ diagnosisCode: "", physicianLicense: undefined }) }),
+    );
+
+    const res = await signComplianceForm("form_1");
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected failure");
+    expect(res.fieldErrors?.diagnosisCode).toBeTruthy();
+    expect(res.fieldErrors?.physicianLicense).toBeTruthy();
+    expect(mockPrisma.stateComplianceForm.update).not.toHaveBeenCalled();
+  });
+
+  it("signs a complete draft: signer, server timestamp, status complete, audit log", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(formRow());
+
+    const res = await signComplianceForm("form_1");
+
+    expect(res.ok).toBe(true);
+    const update = mockPrisma.stateComplianceForm.update.mock.calls[0][0];
+    expect(update.data.status).toBe("complete");
+    expect(update.data.signedBy).toBe("Cli Nician");
+    expect(update.data.signedAt).toBeInstanceOf(Date);
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: "compliance.form.signed" }),
+      }),
+    );
+  });
+});
+
+describe("submitComplianceForm — registry honesty (B3)", () => {
+  function signedRow(over: Record<string, unknown> = {}) {
+    return formRow({
+      status: "complete",
+      signedBy: "Cli Nician",
+      signedAt: new Date("2026-06-09T11:00:00.000Z"),
+      ...over,
+    });
+  }
+
+  it("manual_stub: persists the attempt but does NOT mark the form submitted", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(signedRow());
+    submitToStateRegistryMock.mockResolvedValue({
+      success: true,
+      mode: "manual_stub",
+      submittedAt: "2026-06-09T12:00:00.000Z",
+    });
+
+    const res = await submitComplianceForm("form_1");
+
+    expect(res.ok).toBe(true);
+    const update = mockPrisma.stateComplianceForm.update.mock.calls[0][0];
+    expect(update.data.status).toBeUndefined();
+    expect(update.data.submittedAt).toBeUndefined();
+    expect(update.data.fields.__registrySubmission).toMatchObject({
+      mode: "manual_stub",
+      success: true,
+      confirmationNumber: null,
+    });
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "compliance.form.manual_submission_required",
+        }),
+      }),
+    );
+  });
+
+  it("api success: marks submitted with the registry confirmation", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(signedRow());
+    submitToStateRegistryMock.mockResolvedValue({
+      success: true,
+      mode: "api",
+      confirmationNumber: "FL-REAL-123",
+      submittedAt: "2026-06-09T12:00:00.000Z",
+    });
+
+    const res = await submitComplianceForm("form_1");
+
+    expect(res.ok).toBe(true);
+    const update = mockPrisma.stateComplianceForm.update.mock.calls[0][0];
+    expect(update.data.status).toBe("submitted");
+    expect(update.data.submittedAt).toBeInstanceOf(Date);
+    expect(update.data.fields.__registrySubmission).toMatchObject({
+      mode: "api",
+      confirmationNumber: "FL-REAL-123",
+    });
+  });
+
+  it("registry failure: persists the attempt, stays unsubmitted, returns ok:false", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(signedRow());
+    submitToStateRegistryMock.mockResolvedValue({
+      success: false,
+      mode: "api",
+      errors: ["Registry API error: 500"],
+      submittedAt: "2026-06-09T12:00:00.000Z",
+    });
+
+    const res = await submitComplianceForm("form_1");
+
+    expect(res.ok).toBe(false);
+    const update = mockPrisma.stateComplianceForm.update.mock.calls[0][0];
+    expect(update.data.status).toBeUndefined();
+    expect(update.data.fields.__registrySubmission).toMatchObject({
+      mode: "api",
+      success: false,
+    });
+  });
+
+  it("refuses to submit an unsigned form", async () => {
+    mockPrisma.stateComplianceForm.findFirst.mockResolvedValue(formRow());
+
+    const res = await submitComplianceForm("form_1");
+
+    expect(res.ok).toBe(false);
+    expect(submitToStateRegistryMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/actions.ts
@@ -1,0 +1,442 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import type { StateComplianceForm } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/rbac/permissions";
+import {
+  getStateForm,
+  type StateFormTemplate,
+} from "@/lib/domain/state-compliance";
+import { submitToStateRegistry } from "@/lib/integrations/state-registries";
+
+// ─── Shared shapes ──────────────────────────────────────
+
+/**
+ * Reserved key inside the `fields` JSON column where the latest registry
+ * submission attempt is recorded. Template field keys are plain camelCase
+ * identifiers, so the dunder prefix can never collide.
+ */
+const REGISTRY_ATTEMPT_KEY = "__registrySubmission";
+
+/**
+ * EMR-1096 (B3) — the persisted record of a registry submission attempt.
+ * `mode: "manual_stub"` means NOTHING was transmitted (no API connected for
+ * the state); the UI must surface that as "manual filing required", never as
+ * an electronic success, and there is never a fabricated confirmation number.
+ */
+export interface RegistryAttempt {
+  mode: "api" | "manual_stub";
+  success: boolean;
+  confirmationNumber: string | null;
+  registryPatientId: string | null;
+  expirationDate: string | null;
+  errors: string[] | null;
+  attemptedAt: string;
+}
+
+export type ComplianceFormStatus = "draft" | "complete" | "submitted";
+
+/** Serialized StateComplianceForm row, safe to hand to the client. */
+export interface ComplianceFormDto {
+  id: string;
+  patientId: string;
+  stateCode: string;
+  formTemplateId: string;
+  formName: string;
+  fields: Record<string, string | boolean>;
+  status: ComplianceFormStatus;
+  signedBy: string | null;
+  signedAt: string | null;
+  submittedAt: string | null;
+  registrySubmission: RegistryAttempt | null;
+}
+
+export type FieldErrors = Record<string, string>;
+
+export type ComplianceFormActionResult =
+  | { ok: true; form: ComplianceFormDto; missingRequired?: FieldErrors }
+  | {
+      ok: false;
+      error: string;
+      fieldErrors?: FieldErrors;
+      /** Present when the row was still updated (e.g. a failed registry
+       * attempt is persisted so the chart shows what happened). */
+      form?: ComplianceFormDto;
+    };
+
+// ─── Helpers ────────────────────────────────────────────
+
+function splitFields(fieldsJson: unknown): {
+  values: Record<string, string | boolean>;
+  registryAttempt: RegistryAttempt | null;
+} {
+  const values: Record<string, string | boolean> = {};
+  let registryAttempt: RegistryAttempt | null = null;
+  if (fieldsJson && typeof fieldsJson === "object" && !Array.isArray(fieldsJson)) {
+    for (const [key, value] of Object.entries(
+      fieldsJson as Record<string, unknown>,
+    )) {
+      if (key === REGISTRY_ATTEMPT_KEY) {
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+          registryAttempt = value as unknown as RegistryAttempt;
+        }
+        continue;
+      }
+      if (typeof value === "string" || typeof value === "boolean") {
+        values[key] = value;
+      }
+    }
+  }
+  return { values, registryAttempt };
+}
+
+function toDto(row: StateComplianceForm): ComplianceFormDto {
+  const { values, registryAttempt } = splitFields(row.fields);
+  return {
+    id: row.id,
+    patientId: row.patientId,
+    stateCode: row.stateCode,
+    formTemplateId: row.formTemplateId,
+    formName: row.formName,
+    fields: values,
+    status: row.status as ComplianceFormStatus,
+    signedBy: row.signedBy,
+    signedAt: row.signedAt?.toISOString() ?? null,
+    submittedAt: row.submittedAt?.toISOString() ?? null,
+    registrySubmission: registryAttempt,
+  };
+}
+
+/**
+ * EMR-1102 (M7) — server-side required-field validation against the state
+ * template. Returns a per-field error map the client renders inline. The
+ * signature field is satisfied by `signed` (it lives on the row as
+ * signedBy/signedAt, not in the fields JSON).
+ */
+function validateRequiredFields(
+  template: StateFormTemplate,
+  values: Record<string, string | boolean>,
+  signed: boolean,
+): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const field of template.requiredFields) {
+    if (!field.required) continue;
+    if (field.type === "signature") {
+      if (!signed) errors[field.key] = "Signature is required.";
+      continue;
+    }
+    const value = values[field.key];
+    if (field.type === "checkbox") {
+      if (value !== true) errors[field.key] = `${field.label} must be confirmed.`;
+      continue;
+    }
+    if (value === undefined || value === null || String(value).trim() === "") {
+      errors[field.key] = `${field.label} is required.`;
+    }
+  }
+  return errors;
+}
+
+async function loadOrgForm(formId: string, organizationId: string) {
+  return prisma.stateComplianceForm.findFirst({
+    where: { id: formId, organizationId },
+  });
+}
+
+// ─── Save (draft upsert) ────────────────────────────────
+
+const savePayloadSchema = z.object({
+  patientId: z.string().min(1),
+  stateCode: z.string().length(2),
+  encounterId: z.string().optional(),
+  fields: z.record(z.union([z.string(), z.boolean()])),
+});
+
+export type SaveCompliancePayload = z.infer<typeof savePayloadSchema>;
+
+/**
+ * EMR-1095 (B2) — persist the compliance form as a draft. Upserts the
+ * latest StateComplianceForm row for the patient+state (the model has no
+ * unique constraint, so we find-then-update). Drafts are allowed to be
+ * incomplete; any still-missing required fields are returned as
+ * `missingRequired` so the client can hint inline. Hard required-field
+ * enforcement happens at sign/submit time (M7).
+ */
+export async function saveComplianceForm(
+  payload: SaveCompliancePayload,
+): Promise<ComplianceFormActionResult> {
+  const user = await requireUser();
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: read-only access to compliance forms." };
+  }
+
+  const parsed = savePayloadSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+
+  const stateCode = parsed.data.stateCode.toUpperCase();
+  const template = getStateForm(stateCode);
+  if (!template) {
+    return { ok: false, error: `No compliance form template for state: ${stateCode}` };
+  }
+
+  // Org-scoped patient lookup — never trust a bare patient id.
+  const patient = await prisma.patient.findFirst({
+    where: {
+      id: parsed.data.patientId,
+      organizationId: user.organizationId!,
+      deletedAt: null,
+    },
+  });
+  if (!patient) return { ok: false, error: "Patient not found." };
+
+  // Server-side allowlist: only persist keys the template defines.
+  const templateKeys = new Set(template.requiredFields.map((f) => f.key));
+  const values: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(parsed.data.fields)) {
+    if (templateKeys.has(key)) values[key] = value;
+  }
+
+  const existing = await prisma.stateComplianceForm.findFirst({
+    where: {
+      patientId: patient.id,
+      organizationId: user.organizationId!,
+      stateCode,
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  // A signed/submitted certification is a locked record — editing it would
+  // invalidate the signature. Mirrors the signed-note guard.
+  if (existing && existing.status !== "draft") {
+    return {
+      ok: false,
+      error: "This form is signed and can no longer be edited.",
+      form: toDto(existing),
+    };
+  }
+
+  const row = existing
+    ? await prisma.stateComplianceForm.update({
+        where: { id: existing.id },
+        data: {
+          fields: values as any,
+          formTemplateId: template.formId,
+          formName: template.formName,
+          encounterId: parsed.data.encounterId ?? existing.encounterId,
+        },
+      })
+    : await prisma.stateComplianceForm.create({
+        data: {
+          organizationId: user.organizationId!,
+          patientId: patient.id,
+          encounterId: parsed.data.encounterId ?? null,
+          stateCode,
+          formTemplateId: template.formId,
+          formName: template.formName,
+          fields: values as any,
+          status: "draft",
+        },
+      });
+
+  revalidatePath(`/clinic/patients/${patient.id}/compliance`);
+
+  const missing = validateRequiredFields(template, values, false);
+  return {
+    ok: true,
+    form: toDto(row),
+    missingRequired: Object.keys(missing).length > 0 ? missing : undefined,
+  };
+}
+
+// ─── Sign ───────────────────────────────────────────────
+
+/**
+ * EMR-1095 (B2) + EMR-1102 (M7) — electronically sign a compliance form.
+ * Re-validates required fields server-side (the signature itself is being
+ * supplied by this call), then records signer + server timestamp and moves
+ * the row to "complete". Audit-logged: a physician certification signature
+ * is a legal act.
+ */
+export async function signComplianceForm(
+  formId: string,
+): Promise<ComplianceFormActionResult> {
+  const user = await requireUser();
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: you cannot sign compliance forms." };
+  }
+  if (!formId || typeof formId !== "string") {
+    return { ok: false, error: "Invalid input." };
+  }
+
+  const form = await loadOrgForm(formId, user.organizationId!);
+  if (!form) return { ok: false, error: "Form not found." };
+  if (form.status === "submitted") {
+    return { ok: false, error: "This form has already been submitted." };
+  }
+  if (form.signedAt) {
+    return { ok: false, error: "This form is already signed.", form: toDto(form) };
+  }
+
+  const template = getStateForm(form.stateCode);
+  if (!template) {
+    return { ok: false, error: `No compliance form template for state: ${form.stateCode}` };
+  }
+
+  // M7 — required fields must be present before a signature can attach.
+  const { values } = splitFields(form.fields);
+  const fieldErrors = validateRequiredFields(template, values, true);
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      ok: false,
+      error: "Complete the required fields before signing.",
+      fieldErrors,
+    };
+  }
+
+  const signerName =
+    [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
+
+  const updated = await prisma.stateComplianceForm.update({
+    where: { id: form.id },
+    data: {
+      status: "complete",
+      signedBy: signerName,
+      signedAt: new Date(),
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: "compliance.form.signed",
+      subjectType: "StateComplianceForm",
+      subjectId: form.id,
+      metadata: {
+        patientId: form.patientId,
+        stateCode: form.stateCode,
+        formTemplateId: form.formTemplateId,
+      } as any,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${form.patientId}/compliance`);
+  return { ok: true, form: toDto(updated) };
+}
+
+// ─── Submit to state registry ───────────────────────────
+
+/**
+ * EMR-1095/1096 — submit a signed form to the state registry, server-side.
+ * The attempt (mode + outcome) is always persisted into the fields JSON
+ * under a reserved key, but the row only moves to "submitted" when a real
+ * registry API accepted it (`mode: "api"` + success). A manual_stub result
+ * (no API connected) keeps the row at "complete" so nobody mistakes a
+ * stubbed call for an actual electronic filing.
+ */
+export async function submitComplianceForm(
+  formId: string,
+): Promise<ComplianceFormActionResult> {
+  const user = await requireUser();
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: you cannot submit compliance forms." };
+  }
+  if (!formId || typeof formId !== "string") {
+    return { ok: false, error: "Invalid input." };
+  }
+
+  const form = await loadOrgForm(formId, user.organizationId!);
+  if (!form) return { ok: false, error: "Form not found." };
+  if (form.status === "submitted") {
+    return { ok: false, error: "This form has already been submitted.", form: toDto(form) };
+  }
+  if (form.status !== "complete" || !form.signedAt) {
+    return { ok: false, error: "Sign the form before submitting it." };
+  }
+
+  const template = getStateForm(form.stateCode);
+  if (!template) {
+    return { ok: false, error: `No compliance form template for state: ${form.stateCode}` };
+  }
+
+  // M7 — re-validate at the submission boundary too; a row mutated outside
+  // this flow must not reach the registry incomplete.
+  const { values } = splitFields(form.fields);
+  const fieldErrors = validateRequiredFields(template, values, Boolean(form.signedAt));
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      ok: false,
+      error: "Complete the required fields before submitting.",
+      fieldErrors,
+    };
+  }
+
+  const result = await submitToStateRegistry({
+    stateCode: form.stateCode,
+    formData: values,
+    providerCredentials: {},
+  });
+
+  const attempt: RegistryAttempt = {
+    mode: result.mode,
+    success: result.success,
+    confirmationNumber: result.confirmationNumber ?? null,
+    registryPatientId: result.registryPatientId ?? null,
+    expirationDate: result.expirationDate ?? null,
+    errors: result.errors ?? null,
+    attemptedAt: result.submittedAt,
+  };
+
+  // Only a real API acceptance marks the form submitted. Stub/manual modes
+  // and failures keep the row at "complete" — but the attempt is persisted
+  // regardless so the chart shows exactly what happened.
+  const electronicallySubmitted = result.success && result.mode === "api";
+
+  const updated = await prisma.stateComplianceForm.update({
+    where: { id: form.id },
+    data: {
+      fields: { ...values, [REGISTRY_ATTEMPT_KEY]: attempt } as any,
+      ...(electronicallySubmitted
+        ? { status: "submitted", submittedAt: new Date() }
+        : {}),
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: electronicallySubmitted
+        ? "compliance.form.submitted"
+        : result.success
+          ? "compliance.form.manual_submission_required"
+          : "compliance.form.submission_failed",
+      subjectType: "StateComplianceForm",
+      subjectId: form.id,
+      metadata: {
+        patientId: form.patientId,
+        stateCode: form.stateCode,
+        formTemplateId: form.formTemplateId,
+        mode: result.mode,
+        success: result.success,
+        confirmationNumber: result.confirmationNumber ?? null,
+        errors: result.errors ?? null,
+      } as any,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${form.patientId}/compliance`);
+
+  if (!result.success) {
+    return {
+      ok: false,
+      error: (result.errors ?? ["Registry submission failed."]).join(" "),
+      form: toDto(updated),
+    };
+  }
+
+  return { ok: true, form: toDto(updated) };
+}

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/compliance-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/compliance-form.tsx
@@ -122,6 +122,19 @@ function ICD10SearchField({
   );
 }
 
+function PrinterIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="mr-1">
+      <path
+        d="M4 6V2h8v4M4 12H2.5A1.5 1.5 0 011 10.5v-3A1.5 1.5 0 012.5 6h11A1.5 1.5 0 0115 7.5v3a1.5 1.5 0 01-1.5 1.5H12M4 10h8v4H4v-4z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 // ─── Main Component ─────────────────────────────────────
 
 export function ComplianceFormView({
@@ -153,6 +166,13 @@ export function ComplianceFormView({
   const signed = Boolean(signedAt);
   const template = useMemo(() => getStateForm(selectedState), [selectedState]);
   const registry = useMemo(() => getRegistryForState(selectedState), [selectedState]);
+
+  // WS-C task 5: dedicated print-ready packet (server-rendered, letterhead) for
+  // manual filing. Available once the form is persisted (has an id); falls back
+  // to the in-page window.print() before then.
+  const printHref = formId
+    ? `/clinic/patients/${patient.id}/compliance/print?formId=${formId}`
+    : null;
 
   // Which fields were auto-populated (read-only)
   const autoPopKeys = useMemo(() => {
@@ -674,17 +694,19 @@ export function ComplianceFormView({
                       The patient will need to submit the physician certification along with
                       their application to the state program.
                     </p>
-                    <Button variant="secondary" size="sm" onClick={handlePrint} className="mt-3">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="mr-1">
-                        <path
-                          d="M4 6V2h8v4M4 12H2.5A1.5 1.5 0 011 10.5v-3A1.5 1.5 0 012.5 6h11A1.5 1.5 0 0115 7.5v3a1.5 1.5 0 01-1.5 1.5H12M4 10h8v4H4v-4z"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                      Print form
-                    </Button>
+                    {printHref ? (
+                      <Link href={printHref} target="_blank" rel="noopener noreferrer" className="inline-block mt-3">
+                        <Button variant="secondary" size="sm">
+                          <PrinterIcon />
+                          Print packet for filing
+                        </Button>
+                      </Link>
+                    ) : (
+                      <Button variant="secondary" size="sm" onClick={handlePrint} className="mt-3">
+                        <PrinterIcon />
+                        Print form
+                      </Button>
+                    )}
                   </div>
                 )}
 
@@ -740,9 +762,19 @@ export function ComplianceFormView({
                       No electronic submission was made and no confirmation
                       number exists.
                     </p>
-                    <Button variant="secondary" size="sm" onClick={handlePrint} className="mt-1">
-                      Print form
-                    </Button>
+                    {printHref ? (
+                      <Link href={printHref} target="_blank" rel="noopener noreferrer" className="inline-block mt-1">
+                        <Button variant="secondary" size="sm">
+                          <PrinterIcon />
+                          Print packet for filing
+                        </Button>
+                      </Link>
+                    ) : (
+                      <Button variant="secondary" size="sm" onClick={handlePrint} className="mt-1">
+                        <PrinterIcon />
+                        Print form
+                      </Button>
+                    )}
                     <p className="text-[10px] text-amber-600">
                       Attempt recorded {new Date(registryAttempt.attemptedAt).toLocaleString()}
                     </p>

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/compliance-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/compliance-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useTransition } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -20,15 +20,17 @@ import { Eyebrow, LeafSprig, EditorialRule } from "@/components/ui/ornament";
 import {
   getStateForm,
   type StateFormField,
-  type StateFormTemplate,
 } from "@/lib/domain/state-compliance";
 import { THERAPEUTIC_INDICATIONS } from "@/lib/domain/cannabis-icd10";
+import { getRegistryForState } from "@/lib/domain/state-registry";
 import {
-  submitToRegistry,
-  getRegistryForState,
-  type StateRegistryConfig,
-  type SubmissionResult,
-} from "@/lib/domain/state-registry";
+  saveComplianceForm,
+  signComplianceForm,
+  submitComplianceForm,
+  type ComplianceFormDto,
+  type FieldErrors,
+  type RegistryAttempt,
+} from "./actions";
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -48,6 +50,8 @@ interface ComplianceFormViewProps {
   availableStates: { code: string; name: string }[];
   defaultStateCode: string;
   prePopulatedFields: Record<string, string>;
+  /** Latest persisted StateComplianceForm per state code (EMR-1095). */
+  existingForms: Record<string, ComplianceFormDto>;
 }
 
 type FormStatus = "draft" | "complete" | "submitted";
@@ -125,97 +129,144 @@ export function ComplianceFormView({
   availableStates,
   defaultStateCode,
   prePopulatedFields,
+  existingForms,
 }: ComplianceFormViewProps) {
   const params = useParams<{ id: string }>();
-  const [selectedState, setSelectedState] = useState(defaultStateCode);
-  const [formValues, setFormValues] = useState<Record<string, string | boolean>>(
-    prePopulatedFields,
-  );
-  const [status, setStatus] = useState<FormStatus>("draft");
-  const [signed, setSigned] = useState(false);
-  const [signedAt, setSignedAt] = useState<string | null>(null);
+  const initial = existingForms[defaultStateCode] ?? null;
 
+  const [selectedState, setSelectedState] = useState(defaultStateCode);
+  const [formId, setFormId] = useState<string | null>(initial?.id ?? null);
+  const [formValues, setFormValues] = useState<Record<string, string | boolean>>(
+    initial ? { ...prePopulatedFields, ...initial.fields } : prePopulatedFields,
+  );
+  const [status, setStatus] = useState<FormStatus>(initial?.status ?? "draft");
+  const [signedAt, setSignedAt] = useState<string | null>(initial?.signedAt ?? null);
+  const [signedBy, setSignedBy] = useState<string | null>(initial?.signedBy ?? null);
+  const [registryAttempt, setRegistryAttempt] = useState<RegistryAttempt | null>(
+    initial?.registrySubmission ?? null,
+  );
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [draftSavedAt, setDraftSavedAt] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const signed = Boolean(signedAt);
   const template = useMemo(() => getStateForm(selectedState), [selectedState]);
   const registry = useMemo(() => getRegistryForState(selectedState), [selectedState]);
-  const [registrySubmitting, setRegistrySubmitting] = useState(false);
-  const [registryResult, setRegistryResult] = useState<SubmissionResult | null>(null);
-  const [registryError, setRegistryError] = useState<string[] | null>(null);
 
   // Which fields were auto-populated (read-only)
   const autoPopKeys = useMemo(() => {
     return new Set(Object.keys(prePopulatedFields));
   }, [prePopulatedFields]);
 
-  const handleStateChange = useCallback(
-    (code: string) => {
-      setSelectedState(code);
-      // Reset form but keep auto-populated values
-      setFormValues({ ...prePopulatedFields });
-      setStatus("draft");
-      setSigned(false);
-      setSignedAt(null);
-      setRegistryResult(null);
-      setRegistryError(null);
+  /** Sync all client state from a persisted form row (or reset to a fresh
+   * draft when null). */
+  const hydrate = useCallback(
+    (form: ComplianceFormDto | null) => {
+      setFormId(form?.id ?? null);
+      setFormValues(
+        form
+          ? { ...prePopulatedFields, ...form.fields }
+          : { ...prePopulatedFields },
+      );
+      setStatus(form?.status ?? "draft");
+      setSignedAt(form?.signedAt ?? null);
+      setSignedBy(form?.signedBy ?? null);
+      setRegistryAttempt(form?.registrySubmission ?? null);
+      setFieldErrors({});
+      setActionError(null);
+      setDraftSavedAt(null);
     },
     [prePopulatedFields],
   );
 
+  const handleStateChange = useCallback(
+    (code: string) => {
+      setSelectedState(code);
+      hydrate(existingForms[code] ?? null);
+    },
+    [existingForms, hydrate],
+  );
+
   const updateField = useCallback((key: string, value: string | boolean) => {
     setFormValues((prev) => ({ ...prev, [key]: value }));
+    // Editing a field clears its inline validation error.
+    setFieldErrors((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   }, []);
+
+  const handleSaveDraft = useCallback(() => {
+    setActionError(null);
+    startTransition(async () => {
+      const res = await saveComplianceForm({
+        patientId: patient.id,
+        stateCode: selectedState,
+        fields: formValues,
+      });
+      if (!res.ok) {
+        setActionError(res.error);
+        setFieldErrors(res.fieldErrors ?? {});
+        return;
+      }
+      setFormId(res.form.id);
+      setStatus(res.form.status);
+      setDraftSavedAt(new Date().toISOString());
+    });
+  }, [patient.id, selectedState, formValues]);
 
   const handleSign = useCallback(() => {
-    setSigned(true);
-    setSignedAt(new Date().toISOString());
-  }, []);
-
-  const handleGenerate = useCallback(() => {
-    if (!template) return;
-    // Validate required fields
-    const missing = template.requiredFields.filter((f) => {
-      if (f.type === "signature") return !signed;
-      const val = formValues[f.key];
-      return f.required && (!val || val === "");
+    setActionError(null);
+    startTransition(async () => {
+      // Persist the current draft first so the signature attaches to
+      // exactly what is on screen.
+      const saved = await saveComplianceForm({
+        patientId: patient.id,
+        stateCode: selectedState,
+        fields: formValues,
+      });
+      if (!saved.ok) {
+        setActionError(saved.error);
+        setFieldErrors(saved.fieldErrors ?? {});
+        return;
+      }
+      setFormId(saved.form.id);
+      const res = await signComplianceForm(saved.form.id);
+      if (!res.ok) {
+        setActionError(res.error);
+        setFieldErrors(res.fieldErrors ?? {});
+        return;
+      }
+      hydrate(res.form);
     });
-    if (missing.length > 0) {
-      alert(
-        `Please complete required fields: ${missing.map((f) => f.label).join(", ")}`,
-      );
-      return;
-    }
-    setStatus("complete");
-  }, [template, formValues, signed]);
+  }, [patient.id, selectedState, formValues, hydrate]);
 
   const handleSubmit = useCallback(() => {
-    setStatus("submitted");
-  }, []);
+    if (!formId) return;
+    setActionError(null);
+    startTransition(async () => {
+      const res = await submitComplianceForm(formId);
+      if (!res.ok) {
+        setFieldErrors(res.fieldErrors ?? {});
+        if (res.form) {
+          // The failed/manual attempt was persisted — render it honestly.
+          setRegistryAttempt(res.form.registrySubmission);
+          setStatus(res.form.status);
+        } else {
+          setActionError(res.error);
+        }
+        return;
+      }
+      hydrate(res.form);
+    });
+  }, [formId, hydrate]);
 
   const handlePrint = useCallback(() => {
     window.print();
   }, []);
-
-  const handleRegistrySubmit = useCallback(async () => {
-    if (!registry) return;
-    setRegistrySubmitting(true);
-    setRegistryError(null);
-    setRegistryResult(null);
-    try {
-      const result = await submitToRegistry(
-        selectedState,
-        formValues as Record<string, string | boolean | number>,
-        { npi: undefined, licenseNumber: undefined, registryId: undefined },
-      );
-      if (result.success) {
-        setRegistryResult(result);
-      } else {
-        setRegistryError(result.errors ?? ["Unknown error occurred."]);
-      }
-    } catch (err) {
-      setRegistryError([err instanceof Error ? err.message : "Submission failed. Please try again."]);
-    } finally {
-      setRegistrySubmitting(false);
-    }
-  }, [registry, selectedState, formValues]);
 
   // ─── Render field based on type ─────────────────────
 
@@ -338,6 +389,7 @@ export function ComplianceFormView({
                   </svg>
                   <span className="text-sm font-medium text-accent">
                     Electronically signed
+                    {signedBy ? ` — ${signedBy}` : ""}
                   </span>
                 </div>
                 {signedAt && (
@@ -351,9 +403,9 @@ export function ComplianceFormView({
                 variant="secondary"
                 size="sm"
                 onClick={handleSign}
-                disabled={status !== "draft"}
+                disabled={status !== "draft" || isPending}
               >
-                Sign electronically
+                {isPending ? "Signing..." : "Sign electronically"}
               </Button>
             )}
           </div>
@@ -488,6 +540,11 @@ export function ComplianceFormView({
                     </div>
                   )}
                   {renderField(field)}
+                  {fieldErrors[field.key] && (
+                    <p className="text-xs text-danger mt-1.5">
+                      {fieldErrors[field.key]}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>
@@ -495,16 +552,29 @@ export function ComplianceFormView({
 
           <EditorialRule className="mx-6" />
 
+          {actionError && (
+            <div className="mx-6 mt-4 p-3 rounded-xl bg-red-50 border border-red-200">
+              <p className="text-sm text-red-800">{actionError}</p>
+            </div>
+          )}
+
           <CardFooter className="flex-wrap gap-3">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
               {status === "draft" && (
-                <Button onClick={handleGenerate} size="md">
-                  Generate form
-                </Button>
+                <>
+                  <Button onClick={handleSaveDraft} size="md" disabled={isPending}>
+                    {isPending ? "Saving..." : "Save draft"}
+                  </Button>
+                  <span className="text-xs text-text-muted">
+                    {draftSavedAt
+                      ? `Draft saved ${new Date(draftSavedAt).toLocaleTimeString()}`
+                      : "Sign electronically to complete the form."}
+                  </span>
+                </>
               )}
               {status === "complete" && (
-                <Button onClick={handleSubmit} size="md">
-                  Submit form
+                <Button onClick={handleSubmit} size="md" disabled={isPending}>
+                  {isPending ? "Submitting..." : "Submit form"}
                 </Button>
               )}
               {status === "submitted" && (
@@ -576,19 +646,19 @@ export function ComplianceFormView({
                 {/* Electronic submission */}
                 {registry.supportsElectronicSubmission ? (
                   <div>
-                    {!registryResult && !registryError && (
+                    {status !== "submitted" && !registryAttempt && (
                       <Button
-                        onClick={handleRegistrySubmit}
-                        disabled={status !== "complete" || registrySubmitting}
+                        onClick={handleSubmit}
+                        disabled={status !== "complete" || isPending}
                         size="md"
                         className="w-full sm:w-auto"
                       >
-                        {registrySubmitting ? "Submitting..." : "Submit to registry"}
+                        {isPending ? "Submitting..." : "Submit to registry"}
                       </Button>
                     )}
-                    {status === "draft" && !registryResult && (
+                    {status === "draft" && (
                       <p className="text-xs text-text-muted mt-2">
-                        Generate the form first before submitting to the registry.
+                        Sign the form first before submitting to the registry.
                       </p>
                     )}
                   </div>
@@ -618,8 +688,10 @@ export function ComplianceFormView({
                   </div>
                 )}
 
-                {/* Success state */}
-                {registryResult && registryResult.success && (
+                {/* Success state — ONLY a real registry API acceptance is green.
+                    A stubbed/manual result must never look like an electronic
+                    submission (EMR-1096). */}
+                {registryAttempt && registryAttempt.success && registryAttempt.mode === "api" && (
                   <div className="p-4 rounded-xl bg-emerald-50 border border-emerald-200 space-y-2">
                     <div className="flex items-center gap-2">
                       <svg width="20" height="20" viewBox="0 0 20 20" fill="none" className="text-emerald-600 shrink-0">
@@ -631,37 +703,58 @@ export function ComplianceFormView({
                       </p>
                     </div>
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
-                      {registryResult.confirmationNumber && (
+                      {registryAttempt.confirmationNumber && (
                         <div>
                           <p className="text-[10px] text-emerald-600 uppercase tracking-wider">Confirmation #</p>
-                          <p className="text-sm font-mono text-emerald-900">{registryResult.confirmationNumber}</p>
+                          <p className="text-sm font-mono text-emerald-900">{registryAttempt.confirmationNumber}</p>
                         </div>
                       )}
-                      {registryResult.registryPatientId && (
+                      {registryAttempt.registryPatientId && (
                         <div>
                           <p className="text-[10px] text-emerald-600 uppercase tracking-wider">Registry patient ID</p>
-                          <p className="text-sm font-mono text-emerald-900">{registryResult.registryPatientId}</p>
+                          <p className="text-sm font-mono text-emerald-900">{registryAttempt.registryPatientId}</p>
                         </div>
                       )}
-                      {registryResult.expirationDate && (
+                      {registryAttempt.expirationDate && (
                         <div>
                           <p className="text-[10px] text-emerald-600 uppercase tracking-wider">Expires</p>
-                          <p className="text-sm text-emerald-900">{registryResult.expirationDate}</p>
+                          <p className="text-sm text-emerald-900">{registryAttempt.expirationDate}</p>
                         </div>
                       )}
                     </div>
                     <p className="text-[10px] text-emerald-600 mt-2">
-                      Submitted at {new Date(registryResult.submittedAt).toLocaleString()}
+                      Submitted at {new Date(registryAttempt.attemptedAt).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+
+                {/* Manual-stub state — the registry API is not connected, so
+                    nothing was transmitted. Amber, no confirmation number. */}
+                {registryAttempt && registryAttempt.success && registryAttempt.mode === "manual_stub" && (
+                  <div className="p-4 rounded-xl bg-amber-50 border border-amber-200 space-y-2">
+                    <p className="text-sm font-medium text-amber-800">
+                      Manual submission required — registry API not connected
+                    </p>
+                    <p className="text-xs text-amber-700 leading-relaxed">
+                      Form saved and signed; print the packet for manual filing.
+                      No electronic submission was made and no confirmation
+                      number exists.
+                    </p>
+                    <Button variant="secondary" size="sm" onClick={handlePrint} className="mt-1">
+                      Print form
+                    </Button>
+                    <p className="text-[10px] text-amber-600">
+                      Attempt recorded {new Date(registryAttempt.attemptedAt).toLocaleString()}
                     </p>
                   </div>
                 )}
 
                 {/* Error state */}
-                {registryError && (
+                {registryAttempt && !registryAttempt.success && (
                   <div className="p-4 rounded-xl bg-red-50 border border-red-200 space-y-2">
                     <p className="text-sm font-medium text-red-800">Submission failed</p>
                     <ul className="space-y-1">
-                      {registryError.map((err, i) => (
+                      {(registryAttempt.errors ?? ["Unknown error occurred."]).map((err, i) => (
                         <li key={i} className="text-xs text-red-700 flex items-start gap-2">
                           <span className="text-red-400 mt-0.5 shrink-0">-</span>
                           {err}
@@ -669,10 +762,10 @@ export function ComplianceFormView({
                       ))}
                     </ul>
                     <Button
-                      onClick={handleRegistrySubmit}
+                      onClick={handleSubmit}
                       variant="secondary"
                       size="sm"
-                      disabled={registrySubmitting}
+                      disabled={isPending}
                       className="mt-2"
                     >
                       Retry

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/page.tsx
@@ -8,9 +8,63 @@ import {
   autoPopulateForm,
 } from "@/lib/domain/state-compliance";
 import { ComplianceFormView } from "./compliance-form";
+import type {
+  ComplianceFormDto,
+  ComplianceFormStatus,
+  RegistryAttempt,
+} from "./actions";
 
 interface PageProps {
   params: { id: string };
+}
+
+// Mirrors the (non-exportable) serializer in ./actions.ts — "use server"
+// modules may only export async functions, so the row→DTO mapping for the
+// initial page load lives here.
+const REGISTRY_ATTEMPT_KEY = "__registrySubmission";
+
+function rowToDto(row: {
+  id: string;
+  patientId: string;
+  stateCode: string;
+  formTemplateId: string;
+  formName: string;
+  fields: unknown;
+  status: string;
+  signedBy: string | null;
+  signedAt: Date | null;
+  submittedAt: Date | null;
+}): ComplianceFormDto {
+  const values: Record<string, string | boolean> = {};
+  let registrySubmission: RegistryAttempt | null = null;
+  if (row.fields && typeof row.fields === "object" && !Array.isArray(row.fields)) {
+    for (const [key, value] of Object.entries(
+      row.fields as Record<string, unknown>,
+    )) {
+      if (key === REGISTRY_ATTEMPT_KEY) {
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+          registrySubmission = value as unknown as RegistryAttempt;
+        }
+        continue;
+      }
+      if (typeof value === "string" || typeof value === "boolean") {
+        values[key] = value;
+      }
+    }
+  }
+  return {
+    id: row.id,
+    patientId: row.patientId,
+    stateCode: row.stateCode,
+    formTemplateId: row.formTemplateId,
+    formName: row.formName,
+    fields: values,
+    status: row.status as ComplianceFormStatus,
+    signedBy: row.signedBy,
+    signedAt: row.signedAt?.toISOString() ?? null,
+    submittedAt: row.submittedAt?.toISOString() ?? null,
+    registrySubmission,
+  };
 }
 
 export const metadata = { title: "State Compliance" };
@@ -41,6 +95,17 @@ export default async function CompliancePage({ params }: PageProps) {
     where: { patientId: params.id },
     orderBy: { scheduledFor: "desc" },
   });
+
+  // EMR-1095 — load persisted compliance forms so a reload no longer loses
+  // drafts/signatures. One (latest) row per state hydrates the client form.
+  const existingRows = await prisma.stateComplianceForm.findMany({
+    where: { patientId: params.id, organizationId: user.organizationId! },
+    orderBy: { updatedAt: "desc" },
+  });
+  const existingForms: Record<string, ComplianceFormDto> = {};
+  for (const row of existingRows) {
+    if (!existingForms[row.stateCode]) existingForms[row.stateCode] = rowToDto(row);
+  }
 
   // Determine default state from patient address
   const defaultStateCode = patient.state ?? "CA";
@@ -90,6 +155,7 @@ export default async function CompliancePage({ params }: PageProps) {
         availableStates={availableStates}
         defaultStateCode={defaultStateCode}
         prePopulatedFields={prePopulated}
+        existingForms={existingForms}
       />
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/patients/[id]/compliance/print/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/compliance/print/page.tsx
@@ -1,0 +1,194 @@
+// /clinic/patients/[id]/compliance/print — print-ready state compliance form.
+//
+// WS-C task 5 (EMR-1096 follow-on). The manual-filing path tells the physician
+// to "print the packet for manual filing"; this is that packet. It mirrors the
+// note print pattern (notes/[noteId]/print/page.tsx): a server-rendered,
+// letterhead-styled view of the signed `StateComplianceForm` that auto-opens
+// the browser print dialog.
+//
+// Targeted by `?formId=` (preferred — set by the compliance form's amber
+// notices) or `?state=` (latest row for that state). Falls back to the latest
+// form on file for the patient.
+
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { formatDate } from "@/lib/utils/format";
+import { getStateForm } from "@/lib/domain/state-compliance";
+import { getRegistryForState } from "@/lib/domain/state-registry";
+import {
+  PrintDocument,
+  PrintSection,
+  PrintField,
+} from "@/components/print/PrintDocument";
+
+// Reserved key inside the `fields` JSON that holds the registry submission
+// attempt (mirrors compliance/actions.ts). Never rendered as a form field.
+const REGISTRY_ATTEMPT_KEY = "__registrySubmission";
+
+interface PageProps {
+  params: { id: string };
+  searchParams?: { formId?: string; state?: string };
+}
+
+export const metadata = { title: "State compliance form — print" };
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft — not signed",
+  complete: "Signed",
+  submitted: "Submitted to registry",
+};
+
+function renderValue(value: string | boolean, type?: string): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (type === "checkbox") return value === "true" ? "Yes" : "No";
+  return value;
+}
+
+export default async function CompliancePrintPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const user = await requireUser();
+
+  // Org-scoped lookup — by id when provided, otherwise the latest row for the
+  // patient (optionally filtered to a state).
+  const form = searchParams?.formId
+    ? await prisma.stateComplianceForm.findFirst({
+        where: {
+          id: searchParams.formId,
+          patientId: params.id,
+          organizationId: user.organizationId!,
+        },
+      })
+    : await prisma.stateComplianceForm.findFirst({
+        where: {
+          patientId: params.id,
+          organizationId: user.organizationId!,
+          ...(searchParams?.state
+            ? { stateCode: searchParams.state.toUpperCase() }
+            : {}),
+        },
+        orderBy: { updatedAt: "desc" },
+      });
+
+  if (!form) notFound();
+
+  const patient = await prisma.patient.findFirst({
+    where: {
+      id: params.id,
+      organizationId: user.organizationId!,
+      deletedAt: null,
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      dateOfBirth: true,
+    },
+  });
+  if (!patient) notFound();
+
+  const template = getStateForm(form.stateCode);
+  const registry = getRegistryForState(form.stateCode);
+  const practiceName = user.organizationName ?? "Leafjourney";
+
+  // Split the persisted field values from the reserved registry-attempt key.
+  const rawFields =
+    form.fields && typeof form.fields === "object" && !Array.isArray(form.fields)
+      ? (form.fields as Record<string, unknown>)
+      : {};
+  const values: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(rawFields)) {
+    if (key === REGISTRY_ATTEMPT_KEY) continue;
+    if (typeof value === "string" || typeof value === "boolean") {
+      values[key] = value;
+    }
+  }
+
+  const dob = patient.dateOfBirth ? new Date(patient.dateOfBirth) : null;
+  const age = dob
+    ? Math.floor((Date.now() - dob.getTime()) / (365.25 * 24 * 60 * 60 * 1000))
+    : null;
+  const dobLabel = dob
+    ? `${formatDate(dob)}${age !== null ? ` (${age} y/o)` : ""}`
+    : null;
+
+  // Template-ordered fields (signature handled separately in its own section).
+  const fieldRows = (template?.requiredFields ?? [])
+    .filter((f) => f.type !== "signature")
+    .map((f) => ({
+      key: f.key,
+      label: f.label,
+      value:
+        values[f.key] !== undefined
+          ? renderValue(values[f.key], f.type)
+          : "—",
+    }));
+
+  const providerName = form.signedBy ?? `${user.firstName} ${user.lastName}`.trim();
+  const electronic = registry?.supportsElectronicSubmission ?? false;
+
+  return (
+    <PrintDocument
+      eyebrow="State compliance"
+      title={form.formName}
+      practiceName={practiceName}
+      patientName={`${patient.firstName} ${patient.lastName}`}
+      patientDob={dobLabel}
+      patientMrn={patient.id.slice(0, 12).toUpperCase()}
+      providerName={providerName}
+    >
+      <PrintSection heading="Certification">
+        <div className="doc-grid">
+          <PrintField label="State" value={form.stateCode} />
+          <PrintField label="Form" value={`${form.formName} (${form.formTemplateId})`} />
+          <PrintField
+            label="Status"
+            value={STATUS_LABEL[form.status] ?? form.status}
+          />
+          <PrintField
+            label="Signed"
+            value={
+              form.signedAt
+                ? `${form.signedBy ?? "—"} · ${formatDate(form.signedAt)}`
+                : "Not signed"
+            }
+          />
+        </div>
+      </PrintSection>
+
+      <PrintSection heading="Form fields">
+        {fieldRows.length === 0 ? (
+          <p style={{ margin: 0, color: "#6e6e73" }}>No fields recorded.</p>
+        ) : (
+          <div className="doc-grid">
+            {fieldRows.map((f) => (
+              <PrintField key={f.key} label={f.label} value={f.value} />
+            ))}
+          </div>
+        )}
+      </PrintSection>
+
+      <PrintSection heading="Filing instructions">
+        {electronic ? (
+          <p style={{ margin: 0, fontSize: "11pt", lineHeight: 1.55 }}>
+            {registry?.stateName ?? form.stateCode} supports electronic
+            submission via {registry?.registryName ?? "the state registry"}.
+            {form.status === "submitted"
+              ? " This certification has been submitted electronically."
+              : " Submit electronically from the compliance screen, or file this printed copy if submitting by mail."}
+          </p>
+        ) : (
+          <p style={{ margin: 0, fontSize: "11pt", lineHeight: 1.55 }}>
+            {registry?.stateName ?? form.stateCode} does not support electronic
+            submission. Print this packet and file it with{" "}
+            {registry?.registryName ?? "the state registry"} per state
+            instructions. No electronic submission was made and no confirmation
+            number exists.
+          </p>
+        )}
+      </PrintSection>
+    </PrintDocument>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/inline-demographics-card.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/inline-demographics-card.tsx
@@ -43,6 +43,15 @@ interface Props {
     memberId: string;
     groupNumber: string;
   };
+  /**
+   * EMR-1103 (WS-D) — per-field flag: the displayed value was prefilled from
+   * the patient's intake answers because the structured chart record was
+   * empty (one-way). Keyed by field name (firstName, email, providerName…).
+   * Flagged fields render a subtle "from intake" hint; editing + saving
+   * commits the value to the structured record (and clears the hint on
+   * reload).
+   */
+  intakeHints?: Record<string, boolean>;
 }
 
 function unwrap<T extends { ok: true } | { ok: false; error: string }>(
@@ -56,6 +65,7 @@ export function InlineDemographicsCard({
   canEdit,
   initial,
   insurance,
+  intakeHints,
 }: Props) {
   const makeDemo =
     (field: Parameters<typeof updatePatientDemographicField>[1]) =>
@@ -77,7 +87,7 @@ export function InlineDemographicsCard({
           Demographics
         </h3>
         <dl className="grid grid-cols-[7rem_minmax(0,1fr)] gap-y-1 text-sm">
-          <Row label="First name">
+          <Row label="First name" hint={intakeHints?.firstName}>
             <InlineEdit
               value={initial.firstName}
               onSave={makeDemo("firstName")}
@@ -87,7 +97,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="Last name">
+          <Row label="Last name" hint={intakeHints?.lastName}>
             <InlineEdit
               value={initial.lastName}
               onSave={makeDemo("lastName")}
@@ -97,7 +107,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="DOB">
+          <Row label="DOB" hint={intakeHints?.dateOfBirth}>
             <InlineEdit
               value={initial.dateOfBirth}
               onSave={makeDemo("dateOfBirth")}
@@ -109,7 +119,7 @@ export function InlineDemographicsCard({
               renderDisplay={(v) => v || "Add DOB"}
             />
           </Row>
-          <Row label="Email">
+          <Row label="Email" hint={intakeHints?.email}>
             <div className="flex items-center gap-1.5">
               <div className="min-w-0 flex-1">
                 <InlineEdit
@@ -135,7 +145,7 @@ export function InlineDemographicsCard({
               )}
             </div>
           </Row>
-          <Row label="Phone">
+          <Row label="Phone" hint={intakeHints?.phone}>
             <div className="flex items-center gap-1.5">
               <div className="min-w-0 flex-1">
                 <InlineEdit
@@ -161,7 +171,7 @@ export function InlineDemographicsCard({
               )}
             </div>
           </Row>
-          <Row label="Address">
+          <Row label="Address" hint={intakeHints?.addressLine1}>
             <InlineEdit
               value={initial.addressLine1}
               onSave={makeDemo("addressLine1")}
@@ -170,7 +180,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="Apt / Suite">
+          <Row label="Apt / Suite" hint={intakeHints?.addressLine2}>
             <InlineEdit
               value={initial.addressLine2}
               onSave={makeDemo("addressLine2")}
@@ -179,7 +189,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="City">
+          <Row label="City" hint={intakeHints?.city}>
             <InlineEdit
               value={initial.city}
               onSave={makeDemo("city")}
@@ -188,7 +198,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="State">
+          <Row label="State" hint={intakeHints?.state}>
             <InlineEdit
               value={initial.state}
               onSave={makeDemo("state")}
@@ -197,7 +207,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="ZIP">
+          <Row label="ZIP" hint={intakeHints?.postalCode}>
             <InlineEdit
               value={initial.postalCode}
               onSave={makeDemo("postalCode")}
@@ -215,7 +225,7 @@ export function InlineDemographicsCard({
           Insurance
         </h3>
         <dl className="grid grid-cols-[7rem_minmax(0,1fr)] gap-y-1 text-sm">
-          <Row label="Carrier">
+          <Row label="Carrier" hint={intakeHints?.providerName}>
             <InlineEdit
               value={insurance.providerName}
               onSave={makeIns("providerName")}
@@ -224,7 +234,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="Member ID">
+          <Row label="Member ID" hint={intakeHints?.memberId}>
             <InlineEdit
               value={insurance.memberId}
               onSave={makeIns("memberId")}
@@ -233,7 +243,7 @@ export function InlineDemographicsCard({
               disabled={!canEdit}
             />
           </Row>
-          <Row label="Group #">
+          <Row label="Group #" hint={intakeHints?.groupNumber}>
             <InlineEdit
               value={insurance.groupNumber}
               onSave={makeIns("groupNumber")}
@@ -250,16 +260,36 @@ export function InlineDemographicsCard({
 
 function Row({
   label,
+  hint,
   children,
 }: {
   label: string;
+  /** EMR-1103 (WS-D) — show the "from intake" prefill hint under this field. */
+  hint?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <>
       <dt className="text-xs text-text-subtle py-1 self-center">{label}</dt>
-      <dd className="min-w-0 py-0.5">{children}</dd>
+      <dd className="min-w-0 py-0.5">
+        {children}
+        {hint && <FromIntakeHint />}
+      </dd>
     </>
+  );
+}
+
+// EMR-1103 (WS-D) — subtle marker that a value was prefilled from intake and
+// is not yet committed to the structured chart record.
+function FromIntakeHint() {
+  return (
+    <span
+      title="Prefilled from the patient's intake answers. Edit to save it to the chart record."
+      className="mt-0.5 inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-text-subtle/80"
+    >
+      <span className="h-1 w-1 rounded-full bg-accent/60" aria-hidden="true" />
+      from intake
+    </span>
   );
 }
 

--- a/src/app/(clinician)/clinic/patients/[id]/leaflet/actions.generate-for-note.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/leaflet/actions.generate-for-note.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * WS-B Task 2 (audit minor #8) — generateLeafletForNote backs the in-flow
+ * "Patient leaflet" preview in the visit-completion panel. It resolves a note's
+ * encounter (org-scoped) and assembles + narrates the leaflet. With an empty
+ * note the narrative takes the deterministic path, so no model mock is needed.
+ */
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    note: { findFirst: vi.fn() },
+    encounter: { findFirst: vi.fn() },
+    organization: { findUnique: vi.fn() },
+    patientMedication: { findMany: vi.fn() },
+    dosingRegimen: { findMany: vi.fn() },
+    outcomeLog: { findMany: vi.fn() },
+    appointment: { findMany: vi.fn() },
+    provider: { findUnique: vi.fn() },
+  },
+  requireUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/context", () => ({ createLightContext: vi.fn() }));
+
+import { generateLeafletForNote } from "./actions";
+
+const { mockPrisma, requireUserMock } = hoisted;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue({ id: "user_1", organizationId: "org_1" });
+  mockPrisma.note.findFirst.mockResolvedValue({ encounterId: "enc_1" });
+  mockPrisma.encounter.findFirst.mockResolvedValue({
+    id: "enc_1",
+    organizationId: "org_1",
+    providerId: null,
+    modality: "in_person",
+    reason: "Follow-up",
+    scheduledFor: new Date("2026-06-09T15:00:00.000Z"),
+    createdAt: new Date("2026-06-09T15:00:00.000Z"),
+    patient: {
+      id: "patient_1",
+      firstName: "Mia",
+      lastName: "Lopez",
+      dateOfBirth: null,
+      allergies: [],
+    },
+    notes: [], // empty → narrativeSource is "" → deterministic narrative
+  });
+  mockPrisma.organization.findUnique.mockResolvedValue({ timeZone: null });
+  mockPrisma.patientMedication.findMany.mockResolvedValue([]);
+  mockPrisma.dosingRegimen.findMany.mockResolvedValue([]);
+  mockPrisma.outcomeLog.findMany.mockResolvedValue([]);
+  mockPrisma.appointment.findMany.mockResolvedValue([]);
+  mockPrisma.provider.findUnique.mockResolvedValue(null);
+});
+
+describe("generateLeafletForNote", () => {
+  it("resolves the note's encounter and returns a narrative + leaflet data", async () => {
+    const result = await generateLeafletForNote("note_1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.patientName).toBe("Mia Lopez");
+    expect(result.narrative.length).toBeGreaterThan(0);
+    // The note lookup is org-scoped via the encounter relation.
+    expect(mockPrisma.note.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "note_1", encounter: { organizationId: "org_1" } },
+        select: { encounterId: true },
+      }),
+    );
+  });
+
+  it("returns an error when the note is not in the caller's org", async () => {
+    mockPrisma.note.findFirst.mockResolvedValue(null);
+    const result = await generateLeafletForNote("note_1");
+    expect(result).toEqual({ ok: false, error: "Note not found" });
+    expect(mockPrisma.encounter.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/leaflet/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/leaflet/actions.ts
@@ -138,6 +138,40 @@ export async function generateLeafletData(
 }
 
 // ---------------------------------------------------------------------------
+// WS-B (audit minor #8): generate a leaflet from a note id, for the
+// visit-completion panel's in-flow "Patient leaflet" preview. Resolves the
+// note's encounter (org-scoped), assembles the leaflet data, and runs the
+// narrative so the physician can preview the after-visit summary without
+// leaving the wrap-up flow. Read-only — nothing is persisted here; the
+// physician edits/saves via the full leaflet editor link-out.
+// ---------------------------------------------------------------------------
+
+export async function generateLeafletForNote(
+  noteId: string,
+): Promise<
+  | { ok: true; narrative: string; data: LeafletData }
+  | { ok: false; error: string }
+> {
+  const user = await requireUser();
+
+  const note = await prisma.note.findFirst({
+    where: { id: noteId, encounter: { organizationId: user.organizationId! } },
+    select: { encounterId: true },
+  });
+  if (!note) return { ok: false, error: "Note not found" };
+
+  const dataResult = await generateLeafletData(note.encounterId);
+  if (!dataResult.ok) return dataResult;
+
+  const narrativeResult = await generateLeafletNarrative(dataResult.data);
+  return {
+    ok: true,
+    narrative: narrativeResult.ok ? narrativeResult.narrative : "",
+    data: dataResult.data,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // EMR-150: AI narrative generation
 // ---------------------------------------------------------------------------
 

--- a/src/app/(clinician)/clinic/patients/[id]/notes-tab.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes-tab.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NotesTab, type NoteLite } from "./notes-tab";
+
+/**
+ * WS-A item 4 — honest labels. The primary button starts a visit (creates an
+ * encounter), not just a note; signed notes open read-only ("View"), drafts
+ * open the editor ("Open to edit").
+ */
+function dump(node: React.ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+function note(over: Partial<NoteLite> = {}): NoteLite {
+  return {
+    id: "n1",
+    status: "draft",
+    aiDrafted: false,
+    title: "Visit note",
+    reason: "Follow-up",
+    createdAt: "2026-06-09T12:00:00.000Z",
+    preview: "Some content",
+    pendingAttestation: false,
+    ...over,
+  };
+}
+
+async function noop(): Promise<void> {}
+
+describe("NotesTab honest labels", () => {
+  it("labels the primary action 'Start visit' (it creates an encounter)", () => {
+    const str = dump(
+      <NotesTab patientId="p1" notes={[note()]} startVisitAction={noop} />,
+    );
+    expect(str).toContain("Start visit");
+    expect(str).not.toContain("Draft a note");
+  });
+
+  it("shows 'View' for a finalized (signed) note, not 'Open to edit'", () => {
+    const str = dump(
+      <NotesTab
+        patientId="p1"
+        notes={[note({ status: "finalized" })]}
+        startVisitAction={noop}
+      />,
+    );
+    expect(str).toContain("View");
+    expect(str).not.toContain("Open to edit");
+  });
+
+  it("shows 'Open to edit' for a draft note", () => {
+    const str = dump(
+      <NotesTab
+        patientId="p1"
+        notes={[note({ status: "draft" })]}
+        startVisitAction={noop}
+      />,
+    );
+    expect(str).toContain("Open to edit");
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes-tab.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes-tab.tsx
@@ -31,8 +31,14 @@ export interface NoteLite {
 
 function statusTone(status: string): "active" | "mild" | "beige" {
   if (status === "finalized" || status === "amended") return "active";
-  if (status === "needs_review") return "mild";
+  if (status === "pending_cosign") return "mild";
   return "beige";
+}
+
+// Finalized/amended notes are signed legal records — they open read-only, so
+// the action reads "View"; drafts open the editor, so it reads "Open to edit".
+function isSignedStatus(status: string): boolean {
+  return status === "finalized" || status === "amended";
 }
 
 export function NotesTab({
@@ -67,8 +73,9 @@ export function NotesTab({
           </span>
         </div>
         <form action={startVisitAction}>
+          {/* This creates an encounter, not just a note — label it honestly. */}
           <Button type="submit" size="sm">
-            Draft a note
+            Start visit
           </Button>
         </form>
       </div>
@@ -134,7 +141,7 @@ export function NotesTab({
                     </div>
                     <Link href={`/clinic/patients/${patientId}/notes/${selected.id}`}>
                       <Button variant="secondary" size="sm">
-                        Open to edit
+                        {isSignedStatus(selected.status) ? "View" : "Open to edit"}
                       </Button>
                     </Link>
                   </div>

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.approve-coding.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.approve-coding.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForbiddenError } from "@/lib/rbac/permissions";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    encounter: { findFirst: vi.fn() },
+    note: { findUnique: vi.fn() },
+    codingSuggestion: { findUnique: vi.fn(), update: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return { mockPrisma, requireUserMock: vi.fn(), dispatchMock: vi.fn() };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatchMock }));
+vi.mock("@/lib/orchestration/runner", () => ({ runTick: vi.fn(), runJob: vi.fn() }));
+vi.mock("@/lib/orchestration/model-client", () => ({
+  resolveModelClient: vi.fn(),
+  isModelError: vi.fn(() => false),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/lib/agents/memory/agent-feedback", () => ({
+  recordFeedback: vi.fn(),
+}));
+
+// Mock assertChartAccess to allow testing chart restriction gates
+vi.mock("@/lib/rbac/permissions", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/rbac/permissions")>();
+  return {
+    ...original,
+    assertChartAccess: vi.fn().mockImplementation(async (user, patientId) => {
+      if (patientId === "restricted_patient") {
+        throw new ForbiddenError({
+          reason: "chart_restricted",
+          message: "Forbidden: chart is restricted",
+        });
+      }
+    }),
+  };
+});
+
+import { approveCodingSuggestion } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function note(over: Record<string, unknown> = {}) {
+  return {
+    id: "note_1",
+    encounterId: "enc_1",
+    status: "finalized",
+    aiDrafted: false,
+    blocks: [],
+    authorUserId: "user_1",
+    encounter: { id: "enc_1", patientId: "patient_1", status: "complete" },
+    ...over,
+  };
+}
+
+function encounter(over: Record<string, unknown> = {}) {
+  return {
+    id: "enc_1",
+    organizationId: "org_1",
+    patientId: "patient_1",
+    status: "complete",
+    ...over,
+  };
+}
+
+function suggestion(over: Record<string, unknown> = {}) {
+  return {
+    id: "cs_1",
+    noteId: "note_1",
+    icd10: [{ code: "G89.29", label: "Other chronic pain", confidence: 0.8 }],
+    emLevel: "99214",
+    rationale: "Chronic pain management.",
+    status: "suggested",
+    ...over,
+  };
+}
+
+const approvalInput = {
+  icd10: [{ code: "G89.29", label: "Other chronic pain" }],
+  emLevel: "99214",
+  modified: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.note.findUnique.mockResolvedValue(note());
+  mockPrisma.encounter.findFirst.mockResolvedValue(encounter());
+  mockPrisma.codingSuggestion.findUnique.mockResolvedValue(suggestion());
+  mockPrisma.codingSuggestion.update.mockResolvedValue({ id: "cs_1" });
+  mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
+  dispatchMock.mockResolvedValue([]);
+});
+
+describe("approveCodingSuggestion server action", () => {
+  it("records the approval, audits it, and emits coding.approved", async () => {
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "approved",
+      approvedByName: "Cli Nician",
+    });
+
+    expect(mockPrisma.codingSuggestion.update).toHaveBeenCalledWith({
+      where: { noteId: "note_1" },
+      data: expect.objectContaining({
+        status: "approved",
+        approvedById: "user_1",
+        approvedByName: "Cli Nician",
+        approvedAt: expect.any(Date),
+        approvedIcd10: [{ code: "G89.29", label: "Other chronic pain" }],
+        approvedEmLevel: "99214",
+      }),
+    });
+
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org_1",
+        actorUserId: "user_1",
+        action: "coding.approved",
+        subjectType: "CodingSuggestion",
+        subjectId: "cs_1",
+        metadata: expect.objectContaining({
+          noteId: "note_1",
+          status: "approved",
+          modified: false,
+          codeCount: 1,
+          emLevel: "99214",
+        }),
+      }),
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      name: "coding.approved",
+      noteId: "note_1",
+      encounterId: "enc_1",
+      patientId: "patient_1",
+      organizationId: "org_1",
+      approvedBy: "user_1",
+      approvedIcd10: ["G89.29"],
+      approvedEmLevel: "99214",
+    });
+  });
+
+  it("records a modified approval when the physician edited the codes", async () => {
+    const result = await approveCodingSuggestion("note_1", {
+      icd10: [{ code: "G89.4", label: "Chronic pain syndrome" }],
+      emLevel: "99215",
+      modified: true,
+    });
+
+    expect(result).toMatchObject({ ok: true, status: "modified" });
+    expect(mockPrisma.codingSuggestion.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "modified",
+          approvedEmLevel: "99215",
+        }),
+      }),
+    );
+  });
+
+  it("is idempotent — a re-approval updates the same decision row", async () => {
+    mockPrisma.codingSuggestion.findUnique.mockResolvedValue(
+      suggestion({ status: "approved", approvedById: "user_1" }),
+    );
+
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toMatchObject({ ok: true, status: "approved" });
+    // Always an update keyed by noteId — never a second decision record.
+    expect(mockPrisma.codingSuggestion.update).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        metadata: expect.objectContaining({ reapproval: true }),
+      }),
+    });
+  });
+
+  it("fails if the user lacks notes.edit permission", async () => {
+    requireUserMock.mockResolvedValue(clinician({ roles: ["front_office"] }));
+
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toEqual({ ok: false, error: "Forbidden: read-only access to notes" });
+    expect(mockPrisma.codingSuggestion.update).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails if the chart is restricted", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(
+      note({ encounter: { id: "enc_1", patientId: "restricted_patient", status: "complete" } }),
+    );
+    mockPrisma.encounter.findFirst.mockResolvedValue(
+      encounter({ patientId: "restricted_patient" }),
+    );
+
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toEqual({ ok: false, error: "Forbidden: chart is restricted" });
+    expect(mockPrisma.codingSuggestion.update).not.toHaveBeenCalled();
+  });
+
+  it("fails if the note is not signed", async () => {
+    mockPrisma.note.findUnique.mockResolvedValue(note({ status: "draft" }));
+
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toEqual({ ok: false, error: "Coding can only be approved on a signed note." });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails if no coding suggestion exists for the note", async () => {
+    mockPrisma.codingSuggestion.findUnique.mockResolvedValue(null);
+
+    const result = await approveCodingSuggestion("note_1", approvalInput);
+
+    expect(result).toEqual({ ok: false, error: "No coding suggestion exists for this note yet." });
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty approval (no codes and no E/M level)", async () => {
+    const result = await approveCodingSuggestion("note_1", {
+      icd10: [],
+      emLevel: null,
+      modified: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Approve at least one ICD-10 code or an E/M level.",
+    });
+    expect(mockPrisma.codingSuggestion.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -10,7 +10,7 @@ const hoisted = vi.hoisted(() => {
     visitCompletion: { findUnique: vi.fn(), create: vi.fn() },
     task: { create: vi.fn() },
     messageThread: { findFirst: vi.fn(), create: vi.fn() },
-    message: { create: vi.fn() },
+    message: { create: vi.fn(), findFirst: vi.fn() },
     $transaction: vi.fn(async (cb) => cb(mockPrisma)),
   };
   return { mockPrisma, requireUserMock: vi.fn(), recordFeedbackMock: vi.fn() };
@@ -183,6 +183,8 @@ beforeEach(() => {
   mockPrisma.messageThread.findFirst.mockResolvedValue({ id: "thread_1" });
   mockPrisma.messageThread.create.mockResolvedValue({ id: "thread_1" });
   mockPrisma.message.create.mockResolvedValue({ id: "msg_1" });
+  // EMR-1101 dedup probe: no pre-existing outreach draft by default.
+  mockPrisma.message.findFirst.mockResolvedValue(null);
   mockPrisma.auditLog.create.mockResolvedValue({ id: "audit_1" });
   recordFeedbackMock.mockResolvedValue({ id: "feedback_1" });
 });
@@ -400,6 +402,45 @@ describe("releaseVisitCompletion server action", () => {
       reviewerNote: "Patient Communication: Physician edited the patient communication.",
       editDelta: "Drafted patient email",
     });
+  });
+
+  it("skips the patient draft when the outreach agent already drafted one for this encounter (EMR-1101 dedup)", async () => {
+    // The Patient Outreach Agent fires on encounter.completed — usually before
+    // the physician reaches the release step. When its draft already exists,
+    // release must not stack a second near-identical draft into the thread.
+    mockPrisma.message.findFirst.mockResolvedValue({ id: "outreach_draft_1" });
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: true });
+
+    // The dedup probe scopes to recent, aiDrafted outreach-agent drafts for
+    // this patient.
+    expect(mockPrisma.message.findFirst).toHaveBeenCalledWith({
+      where: {
+        thread: { patientId: "patient_1" },
+        aiDrafted: true,
+        status: "draft",
+        senderAgent: { startsWith: "agent:patientOutreach" },
+        createdAt: { gte: expect.any(Date) },
+      },
+      select: { id: true },
+    });
+
+    // No second patient draft — but every other release side effect lands.
+    expect(mockPrisma.message.create).not.toHaveBeenCalled();
+    expect(mockPrisma.visitCompletion.create).toHaveBeenCalled();
+    expect(mockPrisma.task.create).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.auditLog.create).toHaveBeenCalled();
+  });
+
+  it("creates the patient draft when no outreach draft exists for the encounter", async () => {
+    mockPrisma.message.findFirst.mockResolvedValue(null);
+
+    const result = await releaseVisitCompletion("note_1", validPayload());
+
+    expect(result).toEqual({ ok: true });
+    expect(mockPrisma.message.create).toHaveBeenCalledTimes(1);
   });
 
   it("does not fail the care-plan release if feedback persistence fails", async () => {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.release.test.ts
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => {
     auditLog: { create: vi.fn() },
     visitCompletion: { findUnique: vi.fn(), create: vi.fn() },
     task: { create: vi.fn() },
+    appointment: { create: vi.fn() },
     messageThread: { findFirst: vi.fn(), create: vi.fn() },
     message: { create: vi.fn(), findFirst: vi.fn() },
     $transaction: vi.fn(async (cb) => cb(mockPrisma)),
@@ -180,6 +181,7 @@ beforeEach(() => {
   mockPrisma.visitCompletion.findUnique.mockResolvedValue(null);
   mockPrisma.visitCompletion.create.mockResolvedValue({ id: "vc_1" });
   mockPrisma.task.create.mockResolvedValue({ id: "task_1" });
+  mockPrisma.appointment.create.mockResolvedValue({ id: "appt_1" });
   mockPrisma.messageThread.findFirst.mockResolvedValue({ id: "thread_1" });
   mockPrisma.messageThread.create.mockResolvedValue({ id: "thread_1" });
   mockPrisma.message.create.mockResolvedValue({ id: "msg_1" });
@@ -460,5 +462,88 @@ describe("releaseVisitCompletion server action", () => {
 
     expect(result).toEqual({ ok: true });
     expect(mockPrisma.visitCompletion.create).toHaveBeenCalled();
+  });
+
+  describe("one-click follow-up booking (audit #7)", () => {
+    function bookingPayload() {
+      return validPayload({
+        includedSections: [
+          {
+            cardId: "follow_up",
+            title: "Follow-Up Plan",
+            status: "edited",
+            disposition: "include",
+            labels: ["RTC in 2 weeks"],
+            editNote: "Book a follow-up appointment in 2 weeks.",
+            structuredEdit: {
+              followUpInterval: "2 weeks",
+              followUpRouting: "book_appointment",
+            },
+            requiresPhysicianApproval: true,
+          },
+        ],
+      });
+    }
+
+    it("books a pre-filled Appointment instead of a front-desk task when routing is book_appointment", async () => {
+      mockPrisma.encounter.findFirst.mockResolvedValue(
+        encounter({ providerId: "prov_1", modality: "video" }),
+      );
+
+      const result = await releaseVisitCompletion("note_1", bookingPayload());
+      expect(result).toEqual({ ok: true });
+
+      // A real appointment is created, carrying provider + modality from the visit.
+      expect(mockPrisma.appointment.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            patientId: "patient_1",
+            providerId: "prov_1",
+            modality: "video",
+            status: "requested",
+          }),
+        }),
+      );
+      // ...and NO front-office follow-up task is created for this section.
+      const followUpTask = mockPrisma.task.create.mock.calls.find((c) =>
+        String(c[0]?.data?.title ?? "").startsWith("Follow-Up:"),
+      );
+      expect(followUpTask).toBeUndefined();
+      // Booking is audited.
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ action: "visit_completion.follow_up.booked" }),
+        }),
+      );
+    });
+
+    it("falls back to a front-desk task when the interval can't be parsed", async () => {
+      const payload = validPayload({
+        includedSections: [
+          {
+            cardId: "follow_up",
+            title: "Follow-Up Plan",
+            status: "edited",
+            disposition: "include",
+            labels: ["Follow up as needed"],
+            structuredEdit: {
+              followUpInterval: "as needed",
+              followUpRouting: "book_appointment",
+            },
+            requiresPhysicianApproval: true,
+          },
+        ],
+      });
+
+      const result = await releaseVisitCompletion("note_1", payload);
+      expect(result).toEqual({ ok: true });
+
+      expect(mockPrisma.appointment.create).not.toHaveBeenCalled();
+      expect(mockPrisma.task.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ assigneeRole: "front_office" }),
+        }),
+      );
+    });
   });
 });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/domain/notes";
 import { advanceVisitState } from "@/lib/domain/visit-state";
 import type { VisitCompletionReleasePayload } from "@/lib/domain/visit-completion-selection";
+import { deriveFollowUpBooking } from "@/lib/domain/visit-completion";
 
 const blockSchema = z.object({
   heading: z.string(),
@@ -943,21 +944,63 @@ export async function releaseVisitCompletion(
         });
       }
 
-      // 3. Follow-Up Plan: Create a Task for front-office scheduling
+      // 3. Follow-Up Plan. One-click booking (audit minor #7): when the
+      // physician chose "Book follow-up", create a real pre-filled Appointment
+      // (provider + modality + patient carried from this visit) instead of a
+      // free-text scheduling task — the appointment is `requested` so the front
+      // desk confirms the exact slot. Any other routing (or an unparseable
+      // interval) falls back to the front-office scheduling task.
       const followUpSection = payload.includedSections.find((s) => s.cardId === "follow_up");
       if (followUpSection && followUpSection.labels.length > 0) {
-        await tx.task.create({
-          data: {
-            organizationId: user.organizationId!,
-            patientId: encounter.patientId,
-            title: `Follow-Up: ${followUpSection.labels.join(", ")}`,
-            description: `Follow-up plan released by physician.\n\nNote: ${
-              followUpSection.editNote || followUpSection.confirmationNote || "Approved"
-            }`,
-            status: "open",
-            assigneeRole: "front_office",
-          },
-        });
+        const booking =
+          followUpSection.structuredEdit?.followUpRouting === "book_appointment"
+            ? deriveFollowUpBooking({
+                followUpInterval: followUpSection.structuredEdit.followUpInterval,
+                modality: encounter.modality,
+                now: new Date(),
+              })
+            : null;
+
+        if (booking) {
+          const appointment = await tx.appointment.create({
+            data: {
+              patientId: encounter.patientId,
+              providerId: encounter.providerId ?? encounter.renderingProviderId ?? undefined,
+              startAt: booking.startAt,
+              endAt: booking.endAt,
+              modality: booking.modality,
+              status: "requested",
+              notes: "Follow-up booked from visit wrap-up",
+            },
+          });
+          await tx.auditLog.create({
+            data: {
+              organizationId: user.organizationId!,
+              actorUserId: user.id,
+              action: "visit_completion.follow_up.booked",
+              subjectType: "Appointment",
+              subjectId: appointment.id,
+              metadata: {
+                noteId,
+                intervalDays: booking.intervalDays,
+                modality: booking.modality,
+              } as any,
+            },
+          });
+        } else {
+          await tx.task.create({
+            data: {
+              organizationId: user.organizationId!,
+              patientId: encounter.patientId,
+              title: `Follow-Up: ${followUpSection.labels.join(", ")}`,
+              description: `Follow-up plan released by physician.\n\nNote: ${
+                followUpSection.editNote || followUpSection.confirmationNote || "Approved"
+              }`,
+              status: "open",
+              assigneeRole: "front_office",
+            },
+          });
+        }
       }
 
       // 4. Patient Communication: Create a draft Message to the patient

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -712,6 +712,153 @@ Return ONLY the refined text — no JSON, no markdown, no explanation. Just the 
   }
 }
 
+// ---------------------------------------------------------------------------
+// Coding approval — EMR-1097 (B4)
+// ---------------------------------------------------------------------------
+// The Coding Readiness Agent attaches suggestions to a finalized note; nothing
+// downstream (charge extraction → claim construction) may run until the
+// physician approves them here. Approval is recorded on the CodingSuggestion
+// row, audited, and announced via the typed coding.approved event.
+
+const approveCodingSchema = z.object({
+  icd10: z
+    .array(z.object({ code: z.string().min(1), label: z.string().optional() }))
+    .max(50),
+  emLevel: z.string().nullable(),
+  modified: z.boolean(),
+});
+
+export type ApproveCodingResult =
+  | { ok: true; status: "approved" | "modified"; approvedByName: string; approvedAt: string }
+  | { ok: false; error: string };
+
+export async function approveCodingSuggestion(
+  noteId: string,
+  input: {
+    icd10: { code: string; label?: string }[];
+    emLevel: string | null;
+    modified: boolean;
+  },
+): Promise<ApproveCodingResult> {
+  const user = await requireUser();
+
+  // Same gate as finalize — coding approval is a signing-level decision.
+  if (!hasPermission(user, "notes.edit")) {
+    return { ok: false, error: "Forbidden: read-only access to notes" };
+  }
+
+  const parsed = approveCodingSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid coding approval input" };
+  }
+  if (parsed.data.icd10.length === 0 && !parsed.data.emLevel) {
+    return { ok: false, error: "Approve at least one ICD-10 code or an E/M level." };
+  }
+
+  const note = await prisma.note.findUnique({
+    where: { id: noteId },
+    include: { encounter: true },
+  });
+  if (!note) return { ok: false, error: "Note not found" };
+
+  const encounter = await prisma.encounter.findFirst({
+    where: {
+      id: note.encounterId,
+      organizationId: user.organizationId!,
+    },
+  });
+  if (!encounter) return { ok: false, error: "Unauthorized" };
+
+  try {
+    await assertChartAccess(user, encounter.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Forbidden: chart is restricted" };
+    }
+    throw err;
+  }
+
+  if (note.status !== "finalized" && note.status !== "amended") {
+    return { ok: false, error: "Coding can only be approved on a signed note." };
+  }
+
+  const suggestion = await prisma.codingSuggestion.findUnique({
+    where: { noteId },
+  });
+  if (!suggestion) {
+    return { ok: false, error: "No coding suggestion exists for this note yet." };
+  }
+
+  const approvedAt = new Date();
+  const approvedByName = `${user.firstName} ${user.lastName}`.trim();
+  const status = parsed.data.modified ? "modified" : "approved";
+  const approvedIcd10Payload = parsed.data.icd10.map((c) => ({
+    code: c.code,
+    label: c.label ?? "",
+  }));
+
+  // Idempotent by construction: CodingSuggestion is keyed by noteId, so a
+  // re-approval UPDATES the same decision row rather than duplicating it.
+  await prisma.codingSuggestion.update({
+    where: { noteId },
+    // Cast pending `prisma generate` for the new approval columns.
+    data: {
+      status,
+      approvedById: user.id,
+      approvedByName,
+      approvedAt,
+      approvedIcd10: approvedIcd10Payload,
+      approvedEmLevel: parsed.data.emLevel,
+    } as any,
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: "coding.approved",
+      subjectType: "CodingSuggestion",
+      subjectId: suggestion.id,
+      metadata: {
+        noteId,
+        encounterId: note.encounterId,
+        status,
+        modified: parsed.data.modified,
+        codeCount: approvedIcd10Payload.length,
+        emLevel: parsed.data.emLevel,
+        reapproval: (suggestion as any).status != null && (suggestion as any).status !== "suggested",
+      } as any,
+    },
+  });
+
+  // coding.approved → Encounter Intelligence (charge extraction) + Claim
+  // Construction. Carries the approved codes so billing reconciles against
+  // the physician's decision, not the raw suggestion.
+  await dispatch({
+    name: "coding.approved",
+    noteId,
+    encounterId: note.encounterId,
+    patientId: encounter.patientId,
+    organizationId: user.organizationId!,
+    approvedBy: user.id,
+    approvedIcd10: approvedIcd10Payload.map((c) => c.code),
+    approvedEmLevel: parsed.data.emLevel,
+  });
+
+  // In dev, run the queue inline so charges appear immediately.
+  if (process.env.NODE_ENV !== "production") {
+    await runTick("inline-dev", 4);
+  }
+
+  revalidatePath(`/clinic/patients/${encounter.patientId}`);
+  return {
+    ok: true,
+    status,
+    approvedByName,
+    approvedAt: approvedAt.toISOString(),
+  };
+}
+
 export async function releaseVisitCompletion(
   noteId: string,
   payload: VisitCompletionReleasePayload,
@@ -816,35 +963,60 @@ export async function releaseVisitCompletion(
       // 4. Patient Communication: Create a draft Message to the patient
       const commsSection = payload.includedSections.find((s) => s.cardId === "patient_message");
       if (commsSection && commsSection.labels.length > 0) {
-        const thread = await tx.messageThread.findFirst({
-          where: { patientId: encounter.patientId },
-          orderBy: { lastMessageAt: "desc" },
-        });
-        const threadId =
-          thread?.id ??
-          (
-            await tx.messageThread.create({
-              data: {
-                patientId: encounter.patientId,
-                subject: "Care Plan & Next Steps",
-                lastMessageAt: new Date(),
-              },
-            })
-          ).id;
-
-        await tx.message.create({
-          data: {
-            threadId,
-            senderUserId: user.id,
-            status: "draft",
-            body:
-              commsSection.editNote ||
-              commsSection.confirmationNote ||
-              commsSection.labels.join("\n"),
+        // EMR-1101 (M6) dedup rule: the visit-completion release is the
+        // authoritative post-visit patient message — the Patient Outreach
+        // Agent skips when a release exists (see patient-outreach-agent.ts).
+        // But that agent fires on encounter.completed, i.e. usually BEFORE
+        // the physician reaches this release step. If it already drafted a
+        // post-visit message for this patient since the encounter completed,
+        // do not stack a second near-identical draft into the same thread /
+        // approvals queue; the existing draft remains the single outgoing
+        // message awaiting send approval.
+        const existingOutreachDraft = await tx.message.findFirst({
+          where: {
+            thread: { patientId: encounter.patientId },
             aiDrafted: true,
-            sentAt: null,
+            status: "draft",
+            senderAgent: { startsWith: "agent:patientOutreach" },
+            createdAt: {
+              gte:
+                encounter.completedAt ??
+                new Date(Date.now() - 24 * 60 * 60 * 1000),
+            },
           },
+          select: { id: true },
         });
+        if (!existingOutreachDraft) {
+          const thread = await tx.messageThread.findFirst({
+            where: { patientId: encounter.patientId },
+            orderBy: { lastMessageAt: "desc" },
+          });
+          const threadId =
+            thread?.id ??
+            (
+              await tx.messageThread.create({
+                data: {
+                  patientId: encounter.patientId,
+                  subject: "Care Plan & Next Steps",
+                  lastMessageAt: new Date(),
+                },
+              })
+            ).id;
+
+          await tx.message.create({
+            data: {
+              threadId,
+              senderUserId: user.id,
+              status: "draft",
+              body:
+                commsSection.editNote ||
+                commsSection.confirmationNote ||
+                commsSection.labels.join("\n"),
+              aiDrafted: true,
+              sentAt: null,
+            },
+          });
+        }
       }
 
       // 5. Create audit log entry (minimize PHI)

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions.ts
@@ -91,7 +91,7 @@ export async function saveNoteBlocks(
   }
 
   // A signed note (finalized or amended) is a locked legal record. The editor
-  // hides the Save button once a note leaves draft/needs_review, but the server
+  // hides the Save button once a note leaves draft, but the server
   // must enforce it too: a direct action call (or a stale client) must not
   // silently mutate a signed note. Mirrors the guard saveObjectiveDocumentation
   // already applies. Amending a signed note is a deliberate, audited flow — not
@@ -801,7 +801,6 @@ export async function approveCodingSuggestion(
   // re-approval UPDATES the same decision row rather than duplicating it.
   await prisma.codingSuggestion.update({
     where: { noteId },
-    // Cast pending `prisma generate` for the new approval columns.
     data: {
       status,
       approvedById: user.id,
@@ -809,7 +808,7 @@ export async function approveCodingSuggestion(
       approvedAt,
       approvedIcd10: approvedIcd10Payload,
       approvedEmLevel: parsed.data.emLevel,
-    } as any,
+    },
   });
 
   await prisma.auditLog.create({
@@ -826,7 +825,7 @@ export async function approveCodingSuggestion(
         modified: parsed.data.modified,
         codeCount: approvedIcd10Payload.length,
         emLevel: parsed.data.emLevel,
-        reapproval: (suggestion as any).status != null && (suggestion as any).status !== "suggested",
+        reapproval: suggestion.status != null && suggestion.status !== "suggested",
       } as any,
     },
   });

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/agent-job-strip.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/agent-job-strip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentJobStrip, type AgentJobLite } from "./agent-job-strip";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+function dump(node: React.ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+describe("AgentJobStrip", () => {
+  it("renders friendly agent names and live statuses", () => {
+    const jobs: AgentJobLite[] = [
+      {
+        id: "1",
+        agentName: "codingReadiness",
+        status: "succeeded",
+        lastError: null,
+        completedAt: "2026-06-09T12:00:00.000Z",
+      },
+      {
+        id: "2",
+        agentName: "patientOutreach",
+        status: "needs_approval",
+        lastError: null,
+        completedAt: null,
+      },
+      {
+        id: "3",
+        agentName: "outcomeTracker",
+        status: "running",
+        lastError: null,
+        completedAt: null,
+      },
+    ];
+    const str = dump(<AgentJobStrip jobs={jobs} />);
+    expect(str).toContain("After-visit automations");
+    expect(str).toContain("Coding readiness");
+    expect(str).toContain("Patient outreach");
+    expect(str).toContain("Outcome tracker");
+    expect(str).toContain("Done");
+    expect(str).toContain("Awaiting approval");
+    expect(str).toContain("Running");
+  });
+
+  it("surfaces the failure reason for a failed job", () => {
+    const jobs: AgentJobLite[] = [
+      {
+        id: "1",
+        agentName: "codingReadiness",
+        status: "failed",
+        lastError: "model timeout",
+        completedAt: null,
+      },
+    ];
+    const str = dump(<AgentJobStrip jobs={jobs} />);
+    expect(str).toContain("Failed");
+    expect(str).toContain("model timeout");
+  });
+
+  it("shows an empty state when no downstream jobs exist", () => {
+    const str = dump(<AgentJobStrip jobs={[]} />);
+    expect(str).toContain("No downstream agent jobs");
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/agent-job-strip.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/agent-job-strip.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * Post-finalize agent strip (audit minor #6).
+ *
+ * After a note is signed, several downstream agents fire automatically
+ * (coding readiness, patient outreach, outcome tracker). They previously ran
+ * invisibly — a failure was silent. This strip surfaces their live `AgentJob`
+ * status so the physician knows the after-visit work actually happened.
+ *
+ * Jobs are server-fetched on the note page; this component only renders them
+ * and offers a manual Refresh (no polling infrastructure).
+ */
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface AgentJobLite {
+  id: string;
+  agentName: string;
+  status: string;
+  lastError: string | null;
+  completedAt: string | null;
+}
+
+const AGENT_LABELS: Record<string, string> = {
+  codingReadiness: "Coding readiness",
+  patientOutreach: "Patient outreach",
+  outcomeTracker: "Outcome tracker",
+};
+
+type StatusTone = "neutral" | "success" | "warning" | "info" | "danger";
+
+function statusBadge(status: string): { label: string; tone: StatusTone } {
+  switch (status) {
+    case "succeeded":
+      return { label: "Done", tone: "success" };
+    case "running":
+    case "claimed":
+      return { label: "Running", tone: "info" };
+    case "pending":
+      return { label: "Queued", tone: "neutral" };
+    case "needs_approval":
+      return { label: "Awaiting approval", tone: "warning" };
+    case "failed":
+      return { label: "Failed", tone: "danger" };
+    case "cancelled":
+      return { label: "Skipped", tone: "neutral" };
+    default:
+      return { label: status, tone: "neutral" };
+  }
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function AgentJobStrip({ jobs }: { jobs: AgentJobLite[] }) {
+  const router = useRouter();
+  const [refreshing, startRefresh] = React.useTransition();
+
+  return (
+    <Card className="mt-6">
+      <CardContent className="pt-5 pb-5">
+        <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+          <div>
+            <p className="text-sm font-medium text-text">After-visit automations</p>
+            <p className="text-xs text-text-muted">
+              Downstream agents triggered by signing this note.
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => startRefresh(() => router.refresh())}
+            disabled={refreshing}
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+
+        {jobs.length === 0 ? (
+          <p className="text-sm text-text-muted">
+            No downstream agent jobs have been queued for this encounter yet.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {jobs.map((job) => {
+              const badge = statusBadge(job.status);
+              return (
+                <li
+                  key={job.id}
+                  className="flex items-start justify-between gap-3 rounded-md border border-border/50 bg-surface/60 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm text-text">
+                      {AGENT_LABELS[job.agentName] ?? job.agentName}
+                    </p>
+                    {job.status === "failed" && job.lastError && (
+                      <p className="text-xs text-danger mt-0.5 leading-relaxed">
+                        {job.lastError}
+                      </p>
+                    )}
+                    {job.status === "succeeded" && job.completedAt && (
+                      <p className="text-[11px] text-text-subtle mt-0.5">
+                        Completed {fmtTime(job.completedAt)}
+                      </p>
+                    )}
+                  </div>
+                  <Badge tone={badge.tone} className="shrink-0">
+                    {badge.label}
+                  </Badge>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -33,6 +33,7 @@ import { NoteTemplatePicker, type PickerBlock } from "@/components/clinical/note
 import { AI_CONSENT_DISCLAIMER_HEADING } from "@/lib/clinical/ai-consent-disclaimer";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import { VisitCompletionPanel } from "./visit-completion-panel";
+import { noteStatusBadge } from "./note-status";
 
 interface NoteBlock {
   type?: NoteBlockType;
@@ -167,6 +168,14 @@ export function NoteEditor({
   const [isPending, startTransition] = useTransition();
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [currentStatus, setCurrentStatus] = useState(status);
+  // EMR audit minor #1 — autosave. `dirty` tracks unsaved block edits;
+  // `lastSavedAt` drives the "Saved 12:04" indicator; `autosaving` shows the
+  // in-flight state; `autosaveError` keeps the note dirty (and the beforeunload
+  // guard armed) when a background save fails.
+  const [dirty, setDirty] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [autosaving, setAutosaving] = useState(false);
+  const [autosaveError, setAutosaveError] = useState<string | null>(null);
   const [demeanor, setDemeanor] = useState<PatientDemeanor | null>(initialDemeanor ?? null);
   const [demeanorPending, setDemeanorPending] = useState(false);
   // EMR-131: clinician can acknowledge the grounding review once they've
@@ -188,7 +197,9 @@ export function NoteEditor({
       .finally(() => setDemeanorPending(false));
   }
 
-  const isEditable = currentStatus === "draft" || currentStatus === "needs_review";
+  // Only a draft is freely editable. (`needs_review` was a defined-but-never-set
+  // status — audit minor #5 — so it is no longer part of the editable set.)
+  const isEditable = currentStatus === "draft";
 
   // Only make AI "pre-drafted / already incorporates your talking points"
   // claims when the draft actually has substantive Assessment/Plan content —
@@ -299,12 +310,89 @@ export function NoteEditor({
     setSaveMessage(null);
   }
 
+  // ── Autosave (audit minor #1) ──────────────────────────────────────────
+  // Latest values mirrored into refs so the debounce timer and the save call
+  // always act on current state without re-arming on every keystroke.
+  const blocksRef = useRef(blocks);
+  useEffect(() => {
+    blocksRef.current = blocks;
+  }, [blocks]);
+  const isPendingRef = useRef(isPending);
+  useEffect(() => {
+    isPendingRef.current = isPending;
+  }, [isPending]);
+  const autosaveInFlight = useRef(false);
+
+  // Any block mutation after mount marks the note dirty. We skip the very
+  // first render so the initial APSO sort/labeling doesn't count as an edit.
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    setDirty(true);
+    setAutosaveError(null);
+  }, [blocks]);
+
+  async function runAutosave() {
+    // Never autosave a signed note (mirrors the server save-lock), and never
+    // race a manual Save / Finalize that's already writing.
+    if (!isEditable || autosaveInFlight.current || isPendingRef.current) return;
+    const snapshot = blocksRef.current;
+    autosaveInFlight.current = true;
+    setAutosaving(true);
+    try {
+      const result = await saveNoteBlocks(noteId, snapshot);
+      if (result.ok) {
+        setLastSavedAt(new Date());
+        setAutosaveError(null);
+        // Only clear dirty if nothing changed while the save was in flight;
+        // otherwise the debounce re-arms and saves the newer edits.
+        if (blocksRef.current === snapshot) setDirty(false);
+      } else {
+        setAutosaveError(result.error);
+      }
+    } catch {
+      setAutosaveError("Couldn't autosave — your changes are not saved.");
+    } finally {
+      autosaveInFlight.current = false;
+      setAutosaving(false);
+    }
+  }
+
+  // Debounced trigger: 3s after the last edit while the note is dirty + editable.
+  // Re-arms on every block change (debounce); clears once saved.
+  useEffect(() => {
+    if (!isEditable || !dirty) return;
+    const timer = setTimeout(() => {
+      void runAutosave();
+    }, 3000);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dirty, blocks, isEditable]);
+
+  // Warn before leaving with unsaved changes (audit minor #1).
+  useEffect(() => {
+    if (!dirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirty]);
+
   function handleSave() {
     startTransition(async () => {
       const result = await saveNoteBlocks(noteId, blocks);
       if (result.ok) {
-        setSaveMessage("Saved successfully");
-        setTimeout(() => setSaveMessage(null), 2000);
+        // Manual save shares the persistent "Saved 12:04" indicator with
+        // autosave — single source of truth for save state.
+        setDirty(false);
+        setLastSavedAt(new Date());
+        setAutosaveError(null);
+        setSaveMessage(null);
       } else {
         setSaveMessage(result.error);
       }
@@ -315,8 +403,20 @@ export function NoteEditor({
     startTransition(async () => {
       const result = await saveAndFinalizeNote(noteId, blocks);
       if (result.ok) {
-        setCurrentStatus("finalized");
-        setSaveMessage("Note finalized and signed");
+        // Finalize persists the blocks too, so the note is no longer dirty.
+        setDirty(false);
+        setLastSavedAt(new Date());
+        setAutosaveError(null);
+        setCurrentStatus(result.status);
+        // Honest messaging for the mid-level co-signature path (audit minor #3):
+        // a note routed for co-signature is NOT yet signed.
+        setSaveMessage(
+          result.status === "pending_cosign"
+            ? "Note routed for physician co-signature"
+            : "Note finalized and signed",
+        );
+        // Auto-clear the finalize toast like the save toast does (audit minor #12).
+        setTimeout(() => setSaveMessage(null), 4000);
         router.refresh();
       } else {
         setSaveMessage(result.error);
@@ -469,16 +569,8 @@ export function NoteEditor({
       {/* Status + AI badges + template picker (EMR-174) */}
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <div className="flex items-center gap-2 flex-wrap">
-          <Badge
-            tone={
-              currentStatus === "finalized"
-                ? "success"
-                : currentStatus === "needs_review"
-                  ? "warning"
-                  : "neutral"
-            }
-          >
-            {currentStatus}
+          <Badge tone={noteStatusBadge(currentStatus).tone}>
+            {noteStatusBadge(currentStatus).label}
           </Badge>
           {aiDrafted && <Badge tone="highlight">AI-drafted</Badge>}
           {aiConfidence !== null && hasSubstantiveDraft && (
@@ -663,7 +755,7 @@ export function NoteEditor({
 
       {/* Action buttons */}
       {isEditable && (
-        <div className="flex items-center gap-3 pt-2">
+        <div className="flex items-center gap-3 pt-2 flex-wrap">
           <Button variant="secondary" onClick={handleSave} disabled={isPending}>
             {isPending ? "Saving..." : "Save draft"}
           </Button>
@@ -675,6 +767,19 @@ export function NoteEditor({
               {scrubMessage(saveMessage)}
             </span>
           )}
+          {/* Autosave / dirty-state indicator (audit minor #1). Always
+              rendered + aria-live so screen readers hear the save state. */}
+          <span className="text-xs text-text-subtle tabular-nums" aria-live="polite">
+            {autosaveError ? (
+              <span className="text-danger">⚠ Autosave failed — changes not saved</span>
+            ) : autosaving ? (
+              "Saving…"
+            ) : dirty ? (
+              "Unsaved changes…"
+            ) : lastSavedAt ? (
+              `Saved ${lastSavedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+            ) : null}
+          </span>
         </div>
       )}
 

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-editor.tsx
@@ -10,6 +10,7 @@ import {
   saveAndFinalizeNote,
   refineSection,
   saveEmotionalVital,
+  approveCodingSuggestion,
   type RefineMode,
 } from "./actions";
 import {
@@ -65,6 +66,12 @@ interface NoteEditorProps {
     icd10: { code: string; label: string; confidence: number }[];
     emLevel: string | null;
     rationale: string | null;
+    /** EMR-1097 physician decision: suggested, approved, modified, dismissed. */
+    status?: string | null;
+    approvedByName?: string | null;
+    approvedAt?: string | null;
+    approvedIcd10?: { code: string; label?: string }[] | null;
+    approvedEmLevel?: string | null;
   } | null;
   initialDemeanor?: PatientDemeanor | null;
   releasedPayload?: any;
@@ -671,58 +678,11 @@ export function NoteEditor({
         </div>
       )}
 
-      {/* Finalized success state with coding suggestions */}
+      {/* Finalized success state with coding suggestions — EMR-1097: the
+          physician approves (or edits then approves) the suggested codes
+          here. Charges are NOT extracted until this approval is recorded. */}
       {currentStatus === "finalized" && codingSuggestion && (
-        <Card tone="ambient" className="mt-6">
-          <CardContent className="pt-6">
-            <h3 className="font-display text-lg font-medium text-text tracking-tight mb-3">
-              Coding Suggestions
-            </h3>
-            {codingSuggestion.icd10 &&
-              Array.isArray(codingSuggestion.icd10) &&
-              codingSuggestion.icd10.length > 0 && (
-                <div className="mb-4">
-                  <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-2">
-                    ICD-10 Codes
-                  </p>
-                  <ul className="space-y-1.5">
-                    {codingSuggestion.icd10.map(
-                      (
-                        code: { code: string; label: string; confidence: number },
-                        i: number
-                      ) => (
-                        <li key={i} className="flex items-center gap-2 text-sm">
-                          <Badge tone="accent">{code.code}</Badge>
-                          <span className="text-text">{code.label}</span>
-                          <span className="text-text-subtle text-xs">
-                            ({Math.round(code.confidence * 100)}%)
-                          </span>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                </div>
-              )}
-            {codingSuggestion.emLevel && (
-              <div className="mb-3">
-                <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-1">
-                  E/M Level
-                </p>
-                <Badge tone="info">{codingSuggestion.emLevel}</Badge>
-              </div>
-            )}
-            {codingSuggestion.rationale && (
-              <div>
-                <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-1">
-                  Rationale
-                </p>
-                <p className="text-sm text-text-muted leading-relaxed">
-                  {codingSuggestion.rationale}
-                </p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <CodingApprovalCard noteId={noteId} suggestion={codingSuggestion} />
       )}
 
       {currentStatus === "finalized" && !codingSuggestion && (
@@ -763,5 +723,267 @@ export function NoteEditor({
         />
       )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Coding approval — EMR-1097 (B4)
+// ---------------------------------------------------------------------------
+// The Coding Readiness Agent's suggestions render here for the physician to
+// approve as-is or edit (ICD-10 list + E/M level) and then approve. Approval
+// calls approveCodingSuggestion, which records the decision, audits it, and
+// emits coding.approved — the event that gates billing charge extraction.
+
+type CodingSuggestionProp = NonNullable<NoteEditorProps["codingSuggestion"]>;
+
+function CodingApprovalCard({
+  noteId,
+  suggestion,
+}: {
+  noteId: string;
+  suggestion: CodingSuggestionProp;
+}) {
+  const router = useRouter();
+  const initiallyApproved =
+    suggestion.status === "approved" || suggestion.status === "modified";
+
+  // Editable working set: starts from the approved decision (if one exists)
+  // so re-approval edits build on what the physician already signed off on.
+  const [codes, setCodes] = useState<{ code: string; label: string }[]>(() =>
+    initiallyApproved && suggestion.approvedIcd10 && suggestion.approvedIcd10.length > 0
+      ? suggestion.approvedIcd10.map((c) => ({ code: c.code, label: c.label ?? "" }))
+      : (Array.isArray(suggestion.icd10) ? suggestion.icd10 : []).map((c) => ({
+          code: c.code,
+          label: c.label,
+        })),
+  );
+  const [emLevel, setEmLevel] = useState<string>(
+    (initiallyApproved ? suggestion.approvedEmLevel : null) ?? suggestion.emLevel ?? "",
+  );
+  const [editing, setEditing] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [newCode, setNewCode] = useState("");
+  const [newLabel, setNewLabel] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [approval, setApproval] = useState<{
+    byName: string;
+    at: string | null;
+    status: string;
+  } | null>(
+    initiallyApproved
+      ? {
+          byName: suggestion.approvedByName ?? "Physician",
+          at: suggestion.approvedAt ?? null,
+          status: suggestion.status!,
+        }
+      : null,
+  );
+
+  const suggestedConfidence = (code: string) =>
+    (Array.isArray(suggestion.icd10) ? suggestion.icd10 : []).find((c) => c.code === code)
+      ?.confidence;
+
+  function removeCode(index: number) {
+    setCodes((prev) => prev.filter((_, i) => i !== index));
+    setDirty(true);
+  }
+
+  function addCode() {
+    const code = newCode.trim().toUpperCase();
+    if (!code) return;
+    if (codes.some((c) => c.code === code)) {
+      setNewCode("");
+      setNewLabel("");
+      return;
+    }
+    setCodes((prev) => [...prev, { code, label: newLabel.trim() }]);
+    setNewCode("");
+    setNewLabel("");
+    setDirty(true);
+  }
+
+  function handleApprove() {
+    setError(null);
+    startTransition(async () => {
+      const result = await approveCodingSuggestion(noteId, {
+        icd10: codes,
+        emLevel: emLevel.trim() ? emLevel.trim() : null,
+        modified: dirty,
+      });
+      if (result.ok) {
+        setApproval({
+          byName: result.approvedByName,
+          at: result.approvedAt,
+          status: result.status,
+        });
+        setEditing(false);
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  const approvedAtLabel = approval?.at
+    ? new Date(approval.at).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })
+    : null;
+
+  return (
+    <Card tone="ambient" className="mt-6" id="coding-suggestions">
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+          <h3 className="font-display text-lg font-medium text-text tracking-tight">
+            Coding Suggestions
+          </h3>
+          {approval ? (
+            <Badge tone="success">
+              {approval.status === "modified" ? "Approved with edits" : "Approved"}
+            </Badge>
+          ) : (
+            <Badge tone="warning">Awaiting physician approval</Badge>
+          )}
+        </div>
+
+        {approval && (
+          <p className="text-xs text-text-muted mb-3">
+            Approved by {approval.byName}
+            {approvedAtLabel ? ` · ${approvedAtLabel}` : ""}. Approved codes were
+            handed to billing for charge extraction.
+          </p>
+        )}
+        {!approval && (
+          <p className="text-xs text-text-muted mb-3">
+            Review the AI-suggested codes below. No billing charges are created
+            until you approve them — edit first if anything is wrong.
+          </p>
+        )}
+
+        <div className="mb-4">
+          <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-2">
+            ICD-10 Codes
+          </p>
+          {codes.length === 0 && (
+            <p className="text-sm text-text-muted mb-2">No codes selected.</p>
+          )}
+          <ul className="space-y-1.5">
+            {codes.map((code, i) => {
+              const confidence = suggestedConfidence(code.code);
+              return (
+                <li key={code.code} className="flex items-center gap-2 text-sm">
+                  <Badge tone="accent">{code.code}</Badge>
+                  <span className="text-text">{code.label}</span>
+                  {typeof confidence === "number" && (
+                    <span className="text-text-subtle text-xs">
+                      ({Math.round(confidence * 100)}%)
+                    </span>
+                  )}
+                  {editing && (
+                    <button
+                      type="button"
+                      onClick={() => removeCode(i)}
+                      aria-label={`Remove ${code.code}`}
+                      className="ml-1 text-text-subtle hover:text-danger transition-colors text-xs"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+          {editing && (
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+              <input
+                type="text"
+                value={newCode}
+                onChange={(e) => setNewCode(e.target.value)}
+                placeholder="ICD-10 code"
+                aria-label="New ICD-10 code"
+                className="w-28 rounded-md border border-border/60 bg-surface px-2 py-1.5 text-sm text-text focus:outline-none focus:border-accent transition-colors"
+              />
+              <input
+                type="text"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="Description"
+                aria-label="New ICD-10 description"
+                className="flex-1 min-w-40 rounded-md border border-border/60 bg-surface px-2 py-1.5 text-sm text-text focus:outline-none focus:border-accent transition-colors"
+              />
+              <Button size="sm" variant="secondary" onClick={addCode} disabled={!newCode.trim()}>
+                Add code
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <div className="mb-3">
+          <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-1">
+            E/M Level
+          </p>
+          {editing ? (
+            <input
+              type="text"
+              value={emLevel}
+              onChange={(e) => {
+                setEmLevel(e.target.value);
+                setDirty(true);
+              }}
+              placeholder="e.g. 99214"
+              aria-label="E/M level"
+              className="w-28 rounded-md border border-border/60 bg-surface px-2 py-1.5 text-sm text-text focus:outline-none focus:border-accent transition-colors"
+            />
+          ) : emLevel ? (
+            <Badge tone="info">{emLevel}</Badge>
+          ) : (
+            <p className="text-sm text-text-muted">No E/M level suggested.</p>
+          )}
+        </div>
+
+        {suggestion.rationale && (
+          <div className="mb-4">
+            <p className="text-xs font-medium text-text-subtle uppercase tracking-wider mb-1">
+              Rationale
+            </p>
+            <p className="text-sm text-text-muted leading-relaxed">
+              {suggestion.rationale}
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-3 flex items-start gap-2 rounded-md border border-highlight/30 bg-highlight-soft/50 px-3 py-2 text-[11px] text-[color:var(--highlight-hover)]"
+          >
+            <span aria-hidden="true" className="shrink-0 mt-0.5">⚠</span>
+            <span className="flex-1 leading-relaxed">{error}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1 flex-wrap">
+          <Button variant="primary" size="sm" onClick={handleApprove} disabled={isPending}>
+            {isPending
+              ? "Approving..."
+              : approval
+                ? "Re-approve codes"
+                : dirty
+                  ? "Approve with edits"
+                  : "Approve codes"}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setEditing((prev) => !prev)}
+            disabled={isPending}
+          >
+            {editing ? "Done editing" : "Edit codes"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-status.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { noteStatusBadge } from "./note-status";
+
+/**
+ * WS-A items 2 & 3 — the status badge is the one place the editor and the page
+ * header agree on a note's lifecycle. The behavioural contract that matters
+ * most: a note routed for co-signature must NOT read as "signed".
+ */
+describe("noteStatusBadge", () => {
+  it("labels a co-signature-pending note honestly (never 'signed')", () => {
+    const badge = noteStatusBadge("pending_cosign");
+    expect(badge.label).toBe("Awaiting co-signature");
+    expect(badge.tone).toBe("warning");
+    expect(badge.label.toLowerCase()).not.toContain("signed");
+  });
+
+  it("maps finalized → Signed (success)", () => {
+    expect(noteStatusBadge("finalized")).toEqual({ label: "Signed", tone: "success" });
+  });
+
+  it("maps amended → Amended (info)", () => {
+    expect(noteStatusBadge("amended")).toEqual({ label: "Amended", tone: "info" });
+  });
+
+  it("maps draft → Draft (neutral)", () => {
+    expect(noteStatusBadge("draft")).toEqual({ label: "Draft", tone: "neutral" });
+  });
+
+  it("passes unknown statuses through as neutral (e.g. retired needs_review)", () => {
+    expect(noteStatusBadge("needs_review")).toEqual({
+      label: "needs_review",
+      tone: "neutral",
+    });
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-status.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/note-status.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared note-status → badge mapping (WS-A items 2 & 3).
+ *
+ * One source of truth for how a clinical note's lifecycle status is labelled
+ * and toned, so the page header (page.tsx, server) and the editor
+ * (note-editor.tsx, client) never drift. Plain module — no React, no "use
+ * client" — so both a Server and a Client Component can import it.
+ *
+ * `needs_review` is intentionally absent: it is never set on a note anywhere
+ * in the codebase (audit minor #5), so it falls through to the default and is
+ * not treated as a first-class state here.
+ */
+export type NoteStatusTone = "neutral" | "success" | "warning" | "info";
+
+export interface NoteStatusBadge {
+  label: string;
+  tone: NoteStatusTone;
+}
+
+export function noteStatusBadge(status: string): NoteStatusBadge {
+  switch (status) {
+    case "finalized":
+      return { label: "Signed", tone: "success" };
+    case "amended":
+      return { label: "Amended", tone: "info" };
+    case "pending_cosign":
+      return { label: "Awaiting co-signature", tone: "warning" };
+    case "draft":
+      return { label: "Draft", tone: "neutral" };
+    default:
+      return { label: status, tone: "neutral" };
+  }
+}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatDate, formatModality } from "@/lib/utils/format";
 import { NoteEditor } from "./note-editor";
@@ -14,6 +15,8 @@ import { hasPermission, canDocumentObjective } from "@/lib/rbac/permissions";
 import { coerceVitals } from "@/lib/clinical/objective-vitals";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import { VisitCompletionPanel } from "./visit-completion-panel";
+import { noteStatusBadge } from "./note-status";
+import { AgentJobStrip, type AgentJobLite } from "./agent-job-strip";
 
 interface PageProps {
   params: { id: string; noteId: string };
@@ -130,21 +133,12 @@ export default async function NoteDetailPage({ params }: PageProps) {
         }
       : null;
 
-  // Parse coding suggestion. `icd10` is a JSON column — runtime-validate
-  // that it's actually an array before handing it to the client, otherwise
-  // a legacy/malformed row will crash the editor on render.
+  // Parse coding suggestion. `icd10` / `approvedIcd10` are JSON columns —
+  // runtime-validate they're actually arrays before handing them to the
+  // client, otherwise a legacy/malformed row will crash the editor on render.
   // EMR-1097: also surface the physician approval decision so the editor and
-  // the Practice Readiness card render the real coding state. The cast covers
-  // the new approval columns until `prisma generate` runs.
-  const codingRow = note.codingSuggestion as
-    | (typeof note.codingSuggestion & {
-        status?: string | null;
-        approvedByName?: string | null;
-        approvedAt?: Date | null;
-        approvedIcd10?: unknown;
-        approvedEmLevel?: string | null;
-      })
-    | null;
+  // the Practice Readiness card render the real coding state.
+  const codingRow = note.codingSuggestion;
   const codingSuggestion = codingRow
     ? {
         icd10: Array.isArray(codingRow.icd10)
@@ -173,6 +167,48 @@ export default async function NoteDetailPage({ params }: PageProps) {
   const releasedPayload = note.visitCompletion
     ? (note.visitCompletion.payload as any)
     : null;
+
+  // Post-finalize agent strip (audit minor #6): the downstream agents that fire
+  // when this note is signed. coding-readiness keys its job input by noteId;
+  // patient-outreach by encounterId; outcome-tracker carries only patientId, so
+  // scope that one to jobs created at/after this note was finalized.
+  const showAgentStrip = note.status === "finalized" || note.status === "amended";
+  const agentJobs: AgentJobLite[] = showAgentStrip
+    ? (
+        await prisma.agentJob.findMany({
+          where: {
+            agentName: {
+              in: ["codingReadiness", "patientOutreach", "outcomeTracker"],
+            },
+            OR: [
+              { input: { path: ["noteId"], equals: note.id } },
+              { input: { path: ["encounterId"], equals: note.encounterId } },
+              {
+                agentName: "outcomeTracker",
+                input: { path: ["patientId"], equals: note.encounter.patientId },
+                ...(note.finalizedAt ? { createdAt: { gte: note.finalizedAt } } : {}),
+              },
+            ],
+          },
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            agentName: true,
+            status: true,
+            lastError: true,
+            completedAt: true,
+          },
+        })
+      ).map((j) => ({
+        id: j.id,
+        agentName: j.agentName,
+        status: j.status,
+        lastError: j.lastError,
+        completedAt: j.completedAt ? j.completedAt.toISOString() : null,
+      }))
+    : [];
+
+  const headerStatus = noteStatusBadge(note.status);
   return (
     <PageShell maxWidth="max-w-[900px]">
       <PageHeader
@@ -181,6 +217,10 @@ export default async function NoteDetailPage({ params }: PageProps) {
         description={`${patient.firstName} ${patient.lastName} · ${formatModality(note.encounter.modality)} visit`}
         actions={
           <div className="flex items-center gap-2">
+            {/* Note lifecycle status, surfaced in the header (audit minor:
+                status visibility) so the physician sees draft / awaiting
+                co-sign / signed / amended without scrolling below the fold. */}
+            <Badge tone={headerStatus.tone}>{headerStatus.label}</Badge>
             {/* ux/print-stylesheets-clinical — single-note SOAP printout */}
             <Link
               href={`/clinic/patients/${params.id}/notes/${params.noteId}/print`}
@@ -250,6 +290,9 @@ export default async function NoteDetailPage({ params }: PageProps) {
           noteId={note.id}
         />
       )}
+
+      {/* Post-finalize downstream-agent status (audit minor #6) */}
+      {showAgentStrip && <AgentJobStrip jobs={agentJobs} />}
 
       {/* ux/comments-mentions-collab — inline collaboration on chart notes */}
       <div className="mt-8">

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -133,13 +133,32 @@ export default async function NoteDetailPage({ params }: PageProps) {
   // Parse coding suggestion. `icd10` is a JSON column — runtime-validate
   // that it's actually an array before handing it to the client, otherwise
   // a legacy/malformed row will crash the editor on render.
-  const codingSuggestion = note.codingSuggestion
+  // EMR-1097: also surface the physician approval decision so the editor and
+  // the Practice Readiness card render the real coding state. The cast covers
+  // the new approval columns until `prisma generate` runs.
+  const codingRow = note.codingSuggestion as
+    | (typeof note.codingSuggestion & {
+        status?: string | null;
+        approvedByName?: string | null;
+        approvedAt?: Date | null;
+        approvedIcd10?: unknown;
+        approvedEmLevel?: string | null;
+      })
+    | null;
+  const codingSuggestion = codingRow
     ? {
-        icd10: Array.isArray(note.codingSuggestion.icd10)
-          ? (note.codingSuggestion.icd10 as { code: string; label: string; confidence: number }[])
+        icd10: Array.isArray(codingRow.icd10)
+          ? (codingRow.icd10 as { code: string; label: string; confidence: number }[])
           : [],
-        emLevel: note.codingSuggestion.emLevel,
-        rationale: note.codingSuggestion.rationale,
+        emLevel: codingRow.emLevel,
+        rationale: codingRow.rationale,
+        status: codingRow.status ?? "suggested",
+        approvedByName: codingRow.approvedByName ?? null,
+        approvedAt: codingRow.approvedAt ? codingRow.approvedAt.toISOString() : null,
+        approvedIcd10: Array.isArray(codingRow.approvedIcd10)
+          ? (codingRow.approvedIcd10 as { code: string; label?: string }[])
+          : null,
+        approvedEmLevel: codingRow.approvedEmLevel ?? null,
       }
     : null;
   const visitCompletionBundle =

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -63,8 +63,11 @@ describe("VisitCompletionPanel", () => {
     expect(str).toContain("Progress toward release");
     expect(str).toContain("Next suggested step");
     expect(str).toContain("Review Practice Readiness");
-    expect(str).toContain("Practice Readiness feedback");
-    expect(str).toContain("Documentation gap");
+    // EMR-1100: the Practice Readiness card renders the real coding state,
+    // not placeholder copy.
+    expect(str).toContain("Coding review needed — 1 suggested code awaiting approval");
+    expect(str).toContain("Suggested E/M: 99214");
+    expect(str).toContain("ICD-10 candidate: G89.29 Chronic pain");
     expect(str).toContain(
       "Release creates only reviewed tasks, drafts, and audit records after physician approval.",
     );

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.test.tsx
@@ -13,10 +13,15 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({
     refresh: vi.fn(),
   }),
+  useParams: () => ({ id: "patient_1", noteId: "note_1" }),
 }));
 
 vi.mock("./actions", () => ({
   releaseVisitCompletion: vi.fn(),
+}));
+
+vi.mock("../../leaflet/actions", () => ({
+  generateLeafletForNote: vi.fn(),
 }));
 
 function dump(node: React.ReactElement | null): string {

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
 import {
   CalendarPlus,
   Check,
@@ -46,6 +47,8 @@ import {
   type VisitCompletionStructuredEdit,
 } from "@/lib/domain/visit-completion-selection";
 import { releaseVisitCompletion } from "./actions";
+import { generateLeafletForNote } from "../../leaflet/actions";
+import type { LeafletData } from "@/lib/domain/leaflet";
 
 interface VisitCompletionPanelProps {
   bundle: VisitCompletionBundle;
@@ -485,6 +488,10 @@ export function VisitCompletionPanel({
         ))}
       </div>
 
+      <div className="px-5 pb-1">
+        <PatientLeafletCard noteId={noteId} />
+      </div>
+
       {activeCard && activeCardState && (
         <VisitCompletionDetailsDrawer
           card={activeCard}
@@ -569,6 +576,88 @@ export function VisitCompletionPanel({
         </Badge>
       </div>
     </section>
+  );
+}
+
+/**
+ * Patient leaflet (after-visit summary) affordance inside the wrap-up flow
+ * (audit minor #8). Generates + previews the AI after-visit summary in place so
+ * the physician doesn't have to leave the visit-completion panel; the full
+ * leaflet editor (edit + save to chart) is one click away. Read-only here —
+ * generating a preview persists nothing.
+ */
+function PatientLeafletCard({ noteId }: { noteId: string }) {
+  const params = useParams();
+  const patientId = Array.isArray(params?.id) ? params.id[0] : (params?.id as string | undefined);
+  const [pending, startTransition] = React.useTransition();
+  const [preview, setPreview] = React.useState<{ narrative: string; data: LeafletData } | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  function generate() {
+    setError(null);
+    startTransition(async () => {
+      const result = await generateLeafletForNote(noteId);
+      if (result.ok) {
+        setPreview({ narrative: result.narrative, data: result.data });
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface-muted/35 px-4 py-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold text-text">Patient leaflet</p>
+          <p className="mt-1 text-xs leading-relaxed text-text-muted">
+            Preview the plain-language after-visit summary without leaving the wrap-up.
+            Open the editor to adjust the tone, edit, and save it to the chart.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button type="button" size="sm" variant="secondary" onClick={generate} disabled={pending}>
+            {pending ? "Generating…" : preview ? "Regenerate preview" : "Generate preview"}
+          </Button>
+          {patientId && (
+            <Link
+              href={`/clinic/patients/${patientId}/leaflet`}
+              className="text-sm font-medium text-accent hover:underline"
+            >
+              Open leaflet editor →
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-xs text-danger">{error}</p>}
+
+      {preview && (
+        <div className="mt-3 space-y-3 rounded-md border border-border bg-surface px-4 py-3">
+          {preview.narrative && (
+            <p className="text-sm leading-relaxed text-text">{preview.narrative}</p>
+          )}
+          {preview.data.nextSteps.length > 0 && (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                Next steps
+              </p>
+              <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-text">
+                {preview.data.nextSteps.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {preview.data.followUp && (
+            <p className="text-xs leading-relaxed text-text-muted">{preview.data.followUp}</p>
+          )}
+          <p className="text-[11px] text-text-subtle">
+            Preview only — nothing is sent or saved until you open the leaflet editor.
+          </p>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -354,8 +354,21 @@ export function VisitCompletionPanel({
         setEditDraft("");
         openCardDetails(card.id, "edit");
         return;
-      case "order_review":
       case "coding_review":
+        // EMR-1100: "Review coding" deep-links to the note's coding section
+        // (the EMR-1097 approval UI) rather than the generic drawer. Fall
+        // back to the drawer when the section isn't on this page (e.g. the
+        // read-only chart view doesn't render the coding editor).
+        if (action.href?.startsWith("#")) {
+          const target = document.querySelector(action.href);
+          if (target) {
+            target.scrollIntoView({ behavior: "smooth", block: "start" });
+            return;
+          }
+        }
+        openCardDetails(card.id);
+        return;
+      case "order_review":
       case "view_checks":
         openCardDetails(card.id);
         return;

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/visit-completion-panel.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import {
+  CalendarPlus,
   Check,
   ClipboardCheck,
   Clock3,
@@ -31,6 +32,7 @@ import type {
   VisitCompletionStatus,
   VisitCompletionTone,
 } from "@/lib/domain/visit-completion";
+import { deriveFollowUpBooking } from "@/lib/domain/visit-completion";
 import {
   applyVisitCompletionAction,
   buildVisitCompletionReleasePayload,
@@ -64,6 +66,7 @@ const actionIcons: Record<string, React.ComponentType<{ className?: string }>> =
   remove_item: X,
   edit_item: Pencil,
   defer_item: Clock3,
+  book_follow_up: CalendarPlus,
   send_to_front_desk: UserRoundCheck,
   text_scheduling_link: Send,
   edit_interval: Pencil,
@@ -139,8 +142,9 @@ const detailCopy: Record<
     instruction: "Confirm interval, routing, scheduling handoff, and any patient link.",
     question: "Is this follow-up handoff clinically and operationally correct?",
     confirmNote: "Follow-up plan reviewed in the card detail panel.",
-    releaseWillDo: "Creates a front-office scheduling task from the reviewed follow-up plan.",
-    releaseWillNotDo: "Does not book an appointment or text the patient automatically.",
+    releaseWillDo:
+      "Books a pre-filled follow-up appointment (front desk confirms the slot) or, as a fallback, creates a front-office scheduling task.",
+    releaseWillNotDo: "Does not text the patient or finalize the slot automatically.",
   },
   patient_message: {
     instruction: "Preview the patient-facing plan, channel, print needs, and translation needs.",
@@ -354,6 +358,24 @@ export function VisitCompletionPanel({
         setEditDraft("");
         openCardDetails(card.id, "edit");
         return;
+      case "book_follow_up": {
+        // One-click booking: stage the follow-up as a real appointment using the
+        // interval inferred from the note, then open the drawer so the physician
+        // sees the proposed slot. The Appointment is created on Release Care Plan
+        // (see releaseVisitCompletion); "Send to front desk" remains the fallback.
+        const interval = inferFollowUpInterval(card);
+        applyLocalAction({
+          type: "edit_card",
+          cardId: card.id,
+          note: `Book a follow-up appointment in ${interval}.`,
+          structuredEdit: {
+            followUpInterval: interval,
+            followUpRouting: "book_appointment",
+          },
+        });
+        openCardDetails(card.id, "edit");
+        return;
+      }
       case "coding_review":
         // EMR-1100: "Review coding" deep-links to the note's coding section
         // (the EMR-1097 approval UI) rather than the generic drawer. Fall
@@ -1007,11 +1029,29 @@ function VisitCompletionStructuredEditForm({
                 }))
               }
             >
+              <option value="book_appointment">Book follow-up appointment</option>
               <option value="front_desk">Front desk scheduling task</option>
               <option value="scheduling_link">Text scheduling link</option>
               <option value="no_handoff">No scheduling handoff</option>
             </select>
           </label>
+          {draft.followUpRouting === "book_appointment" && (
+            <p className="md:col-span-2 text-xs leading-relaxed text-text-muted">
+              {(() => {
+                const proposal = deriveFollowUpBooking({
+                  followUpInterval: draft.followUpInterval,
+                  modality: null,
+                  now: new Date(),
+                });
+                return proposal
+                  ? `Releasing will book a pre-filled appointment around ${proposal.startAt.toLocaleDateString(
+                      "en-US",
+                      { weekday: "short", month: "short", day: "numeric", year: "numeric" },
+                    )} (front desk confirms the exact slot).`
+                  : "Enter an interval like “6 weeks” to propose a slot; otherwise this routes to the front desk.";
+              })()}
+            </p>
+          )}
         </div>
       )}
 
@@ -1276,6 +1316,7 @@ const followUpRoutingLabel: Record<
   NonNullable<VisitCompletionStructuredEdit["followUpRouting"]>,
   string
 > = {
+  book_appointment: "book follow-up appointment",
   front_desk: "front desk scheduling task",
   scheduling_link: "text scheduling link",
   no_handoff: "no scheduling handoff",
@@ -1807,6 +1848,22 @@ function structuredReleaseDetailsForSection(
   }
   if (edit.followUpRouting) {
     details.push(`Handoff: ${followUpRoutingLabel[edit.followUpRouting]}`);
+  }
+  if (edit.followUpRouting === "book_appointment") {
+    const proposal = deriveFollowUpBooking({
+      followUpInterval: edit.followUpInterval,
+      modality: null,
+      now: new Date(),
+    });
+    if (proposal) {
+      details.push(
+        `Proposed: ${proposal.startAt.toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })}`,
+      );
+    }
   }
   if (edit.patientMessageChannel) {
     details.push(`Channel: ${patientMessageChannelLabel[edit.patientMessageChannel]}`);

--- a/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
@@ -21,7 +21,7 @@ const hoisted = vi.hoisted(() => {
     mockPrisma,
     requireUserMock: vi.fn(async () => mockUser),
     requirePermissionMock: vi.fn(),
-    assertChartAccessMock: vi.fn(async () => ({
+    assertChartAccessMock: vi.fn(async (..._args: any[]) => ({
       patientId: "patient_1",
       organizationId: "org_1",
       isRestricted: false,
@@ -47,7 +47,7 @@ vi.mock("@/lib/auth/session", () => ({
 vi.mock("@/lib/rbac/permissions", () => ({
   requirePermission: (...args: unknown[]) =>
     hoisted.requirePermissionMock(...args),
-  assertChartAccess: (...args: unknown[]) =>
+  assertChartAccess: (...args: any[]) =>
     hoisted.assertChartAccessMock(...args),
   ForbiddenError: hoisted.ForbiddenError,
 }));

--- a/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    clinicalOrder: { create: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  const mockUser = {
+    id: "user_1",
+    email: "clinician@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    roles: ["clinician"],
+    organizationId: "org_1",
+    organizationName: "Clinic",
+  };
+
+  class ForbiddenError extends Error {}
+
+  return {
+    mockPrisma,
+    requireUserMock: vi.fn(async () => mockUser),
+    requirePermissionMock: vi.fn(),
+    assertChartAccessMock: vi.fn(async () => ({
+      patientId: "patient_1",
+      organizationId: "org_1",
+      isRestricted: false,
+      isAllowed: true,
+      reason: null,
+    })),
+    ForbiddenError,
+  };
+});
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: hoisted.mockPrisma,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUser: () => hoisted.requireUserMock(),
+}));
+
+vi.mock("@/lib/rbac/permissions", () => ({
+  requirePermission: (...args: unknown[]) =>
+    hoisted.requirePermissionMock(...args),
+  assertChartAccess: (...args: unknown[]) =>
+    hoisted.assertChartAccessMock(...args),
+  ForbiddenError: hoisted.ForbiddenError,
+}));
+
+import { createClinicalOrder } from "./actions";
+
+const { mockPrisma } = hoisted;
+
+const validInput = {
+  patientId: "patient_1",
+  orderType: "lab" as const,
+  orderCode: "CBC,CMP",
+  orderName: "Complete Blood Count, Comprehensive Metabolic Panel",
+  priority: "routine" as const,
+  diagnosisCodes: ["G89.29"],
+  payload: { labs: ["CBC", "CMP"], reason: "Baseline" },
+};
+
+function resetAll() {
+  vi.clearAllMocks();
+  mockPrisma.clinicalOrder.create.mockResolvedValue({ id: "order_1" });
+  mockPrisma.auditLog.create.mockResolvedValue({});
+}
+
+describe("createClinicalOrder", () => {
+  beforeEach(resetAll);
+
+  it("persists the order as placed/simulated and returns the row id", async () => {
+    const result = await createClinicalOrder(validInput);
+
+    expect(result).toEqual({ ok: true, orderId: "order_1" });
+    expect(hoisted.requirePermissionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "labs.sign",
+    );
+    expect(hoisted.assertChartAccessMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "patient_1",
+    );
+    expect(mockPrisma.clinicalOrder.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationId: "org_1",
+          patientId: "patient_1",
+          orderType: "lab",
+          status: "placed",
+          transmissionMode: "simulated",
+          orderedById: "user_1",
+        }),
+      }),
+    );
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "order.lab.placed",
+          subjectId: "patient_1",
+        }),
+      }),
+    );
+  });
+
+  it("returns an error (and writes nothing) when the caller lacks permission", async () => {
+    hoisted.requirePermissionMock.mockImplementation(() => {
+      throw new hoisted.ForbiddenError("FORBIDDEN");
+    });
+
+    const result = await createClinicalOrder(validInput);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "You don't have permission to place orders.",
+    });
+    expect(mockPrisma.clinicalOrder.create).not.toHaveBeenCalled();
+    expect(mockPrisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid input before touching the database", async () => {
+    const result = await createClinicalOrder({
+      ...validInput,
+      orderType: "telepathy" as never,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Invalid order." });
+    expect(mockPrisma.clinicalOrder.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/actions.test.ts
@@ -4,6 +4,7 @@ const hoisted = vi.hoisted(() => {
   const mockPrisma = {
     clinicalOrder: { create: vi.fn() },
     auditLog: { create: vi.fn() },
+    document: { create: vi.fn() },
   };
   const mockUser = {
     id: "user_1",
@@ -29,6 +30,11 @@ const hoisted = vi.hoisted(() => {
       reason: null,
     })),
     ForbiddenError,
+    storageIsConfiguredMock: vi.fn((..._args: any[]) => true),
+    uploadDocumentMock: vi.fn(
+      async (..._args: any[]) => "docs/org_1/patient_1/file.pdf",
+    ),
+    dispatchMock: vi.fn(async (..._args: any[]) => undefined),
   };
 });
 
@@ -52,7 +58,16 @@ vi.mock("@/lib/rbac/permissions", () => ({
   ForbiddenError: hoisted.ForbiddenError,
 }));
 
-import { createClinicalOrder } from "./actions";
+vi.mock("@/lib/orchestration/dispatch", () => ({
+  dispatch: (...args: any[]) => hoisted.dispatchMock(...args),
+}));
+
+vi.mock("@/lib/storage/documents", () => ({
+  storageIsConfigured: () => hoisted.storageIsConfiguredMock(),
+  uploadDocument: (...args: any[]) => hoisted.uploadDocumentMock(...args),
+}));
+
+import { createClinicalOrder, uploadLabOrderAttachment } from "./actions";
 
 const { mockPrisma } = hoisted;
 
@@ -132,5 +147,79 @@ describe("createClinicalOrder", () => {
 
     expect(result).toEqual({ ok: false, error: "Invalid order." });
     expect(mockPrisma.clinicalOrder.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("uploadLabOrderAttachment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The createClinicalOrder suite leaves requirePermission throwing; reset it.
+    hoisted.requirePermissionMock.mockReset();
+    hoisted.storageIsConfiguredMock.mockReturnValue(true);
+    hoisted.uploadDocumentMock.mockResolvedValue("docs/org_1/patient_1/file.pdf");
+    hoisted.dispatchMock.mockResolvedValue(undefined);
+    mockPrisma.document.create.mockResolvedValue({
+      id: "doc_1",
+      originalName: "prior-results.pdf",
+    });
+  });
+
+  function formDataWithFile() {
+    const fd = new FormData();
+    fd.append("patientId", "patient_1");
+    fd.append(
+      "file",
+      new File(["%PDF-1.4 fake"], "prior-results.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    return fd;
+  }
+
+  it("persists the attachment as a chart document and returns its id", async () => {
+    const result = await uploadLabOrderAttachment(formDataWithFile());
+
+    expect(result).toEqual({
+      ok: true,
+      documentId: "doc_1",
+      name: "prior-results.pdf",
+    });
+    expect(hoisted.uploadDocumentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: "patient_1", organizationId: "org_1" }),
+    );
+    expect(mockPrisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          patientId: "patient_1",
+          organizationId: "org_1",
+          storageKey: "docs/org_1/patient_1/file.pdf",
+          tags: ["lab-order-attachment"],
+        }),
+      }),
+    );
+    expect(hoisted.dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "document.uploaded", documentId: "doc_1" }),
+    );
+  });
+
+  it("is honest (no fake success) when document storage is not configured", async () => {
+    hoisted.storageIsConfiguredMock.mockReturnValue(false);
+
+    const result = await uploadLabOrderAttachment(formDataWithFile());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not configured/i);
+    expect(mockPrisma.document.create).not.toHaveBeenCalled();
+    expect(hoisted.uploadDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no file is attached", async () => {
+    const fd = new FormData();
+    fd.append("patientId", "patient_1");
+
+    const result = await uploadLabOrderAttachment(fd);
+
+    expect(result).toEqual({ ok: false, error: "No file selected." });
+    expect(mockPrisma.document.create).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(clinician)/clinic/patients/[id]/orders/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/actions.ts
@@ -9,6 +9,13 @@ import {
   requirePermission,
   ForbiddenError,
 } from "@/lib/rbac/permissions";
+import { dispatch } from "@/lib/orchestration/dispatch";
+import { uploadDocument, storageIsConfigured } from "@/lib/storage/documents";
+import {
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE_BYTES,
+  inferKind,
+} from "@/lib/storage/document-types";
 
 // EMR-1094: persist lab + imaging orders to the chart. Previously the
 // order forms console.logged a payload and pretended to submit; now every
@@ -105,4 +112,96 @@ export async function createClinicalOrder(
   revalidatePath(`/clinic/patients/${parsed.data.patientId}`);
 
   return { ok: true, orderId: order.id };
+}
+
+// EMR-1103 (WS-D): honest attachment persistence for lab requisitions.
+// The lab order form previously simulated the upload client-side and only
+// recorded filenames — reload and the "attachment" was gone. This persists
+// each supporting file as a real chart Document (same storage + Document
+// pattern as the clinician document upload), returning the document id so
+// the order payload references durable artifacts. When object storage is
+// not configured we say so plainly rather than faking success.
+
+export type UploadOrderAttachmentResult =
+  | { ok: true; documentId: string; name: string }
+  | { ok: false; error: string };
+
+export async function uploadLabOrderAttachment(
+  formData: FormData,
+): Promise<UploadOrderAttachmentResult> {
+  const user = await requireUser();
+
+  if (!storageIsConfigured()) {
+    return {
+      ok: false,
+      error:
+        "Document storage is not configured, so attachments can't be saved yet. Send supporting documents to the lab manually.",
+    };
+  }
+
+  const patientId = formData.get("patientId");
+  if (typeof patientId !== "string" || patientId.length === 0) {
+    return { ok: false, error: "Missing patient." };
+  }
+
+  try {
+    requirePermission(user, "labs.sign");
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "You don't have permission to place orders." };
+    }
+    throw err;
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File) || file.size === 0) {
+    return { ok: false, error: "No file selected." };
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return { ok: false, error: "File is over the size limit." };
+  }
+  if (file.type && !ALLOWED_MIME_TYPES.has(file.type)) {
+    return { ok: false, error: `Unsupported file type: ${file.type}` };
+  }
+
+  const mimeType = file.type || "application/octet-stream";
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const storageKey = await uploadDocument({
+    organizationId: user.organizationId!,
+    patientId,
+    filename: file.name,
+    contentType: mimeType,
+    body: buffer,
+  });
+
+  const document = await prisma.document.create({
+    data: {
+      organizationId: user.organizationId!,
+      patientId,
+      uploadedById: user.id,
+      kind: inferKind(mimeType),
+      originalName: file.name.slice(0, 200),
+      mimeType,
+      sizeBytes: file.size,
+      storageKey,
+      tags: ["lab-order-attachment"],
+    },
+  });
+
+  await dispatch({
+    name: "document.uploaded",
+    documentId: document.id,
+    patientId,
+    organizationId: user.organizationId!,
+  });
+
+  revalidatePath(`/clinic/patients/${patientId}`);
+
+  return {
+    ok: true,
+    documentId: document.id,
+    name: document.originalName,
+  };
 }

--- a/src/app/(clinician)/clinic/patients/[id]/orders/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/actions.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  assertChartAccess,
+  requirePermission,
+  ForbiddenError,
+} from "@/lib/rbac/permissions";
+
+// EMR-1094: persist lab + imaging orders to the chart. Previously the
+// order forms console.logged a payload and pretended to submit; now every
+// "Submit order" writes a ClinicalOrder row. External transmission (HL7 /
+// FHIR to a lab or imaging center) is still NOT wired — rows are created
+// with transmissionMode "simulated" and status "placed" so the record is
+// honest about what actually happened.
+
+const schema = z.object({
+  patientId: z.string().min(1),
+  orderType: z.enum(["lab", "imaging"]),
+  /** Primary code(s) — comma-joined for multi-test lab requisitions. */
+  orderCode: z.string().min(1).max(500),
+  /** Human-readable name(s) for the order list view. */
+  orderName: z.string().min(1).max(1000),
+  priority: z.enum(["routine", "stat"]),
+  diagnosisCodes: z.array(z.string().min(1).max(16)).max(20),
+  /** Full structured order exactly as the form built it. */
+  payload: z.record(z.unknown()),
+});
+
+export type CreateClinicalOrderInput = z.infer<typeof schema>;
+
+export type CreateClinicalOrderResult =
+  | { ok: true; orderId: string }
+  | { ok: false; error: string };
+
+export async function createClinicalOrder(
+  input: CreateClinicalOrderInput,
+): Promise<CreateClinicalOrderResult> {
+  const user = await requireUser();
+
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid order." };
+
+  try {
+    // "labs.sign" is the diagnostic-ordering grant in the RBAC matrix
+    // ("Lab orders + results review") — held by mid-levels, clinicians,
+    // and practice owners. Imaging orders share it: there is no separate
+    // imaging key, and both are diagnostic orders signed by a provider.
+    requirePermission(user, "labs.sign");
+    // Org-scoped patient verification + chart-privacy gate.
+    await assertChartAccess(user, parsed.data.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "You don't have permission to place orders." };
+    }
+    throw err;
+  }
+
+  const order = await prisma.clinicalOrder.create({
+    data: {
+      organizationId: user.organizationId!,
+      patientId: parsed.data.patientId,
+      orderType: parsed.data.orderType,
+      orderCode: parsed.data.orderCode,
+      orderName: parsed.data.orderName,
+      priority: parsed.data.priority,
+      diagnosisCodes: parsed.data.diagnosisCodes as any,
+      payload: parsed.data.payload as any,
+      status: "placed",
+      transmissionMode: "simulated",
+      orderedById: user.id,
+      orderedByName:
+        `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email,
+    },
+  });
+
+  // Audit-log the order placement — same direct-write pattern as the
+  // referrals surface. No PHI beyond codes; the payload stays on the
+  // ClinicalOrder row itself.
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action:
+        parsed.data.orderType === "lab"
+          ? "order.lab.placed"
+          : "order.imaging.placed",
+      subjectType: "Patient",
+      subjectId: parsed.data.patientId,
+      metadata: {
+        clinicalOrderId: order.id,
+        orderCode: parsed.data.orderCode,
+        priority: parsed.data.priority,
+        diagnosisCodes: parsed.data.diagnosisCodes,
+        transmissionMode: "simulated",
+      } as any,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${parsed.data.patientId}/orders/labs`);
+  revalidatePath(`/clinic/patients/${parsed.data.patientId}/orders/imaging`);
+  revalidatePath(`/clinic/patients/${parsed.data.patientId}`);
+
+  return { ok: true, orderId: order.id };
+}

--- a/src/app/(clinician)/clinic/patients/[id]/orders/imaging/imaging-order-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/imaging/imaging-order-form.tsx
@@ -18,6 +18,7 @@ interface Props {
 
 const MODALITIES = ["X-ray", "MRI", "CT", "US", "DEXA"] as const;
 type Modality = (typeof MODALITIES)[number];
+type Priority = "routine" | "stat";
 
 export function ImagingOrderForm({ patientId, patientName }: Props) {
   const [modality, setModality] = useState<Modality>("X-ray");
@@ -25,6 +26,7 @@ export function ImagingOrderForm({ patientId, patientName }: Props) {
   const [indication, setIndication] = useState("");
   const [icd10Query, setIcd10Query] = useState("");
   const [icd10Selected, setIcd10Selected] = useState<string[]>([]);
+  const [priority, setPriority] = useState<Priority>("routine");
   const [priorAuth, setPriorAuth] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [placedOrderId, setPlacedOrderId] = useState<string | null>(null);
@@ -68,7 +70,7 @@ export function ImagingOrderForm({ patientId, patientName }: Props) {
         orderType: "imaging",
         orderCode: studyCode,
         orderName: `${modality} — ${study.name}`,
-        priority: "routine",
+        priority,
         diagnosisCodes: icd10Selected,
         payload: {
           patientName,
@@ -77,6 +79,7 @@ export function ImagingOrderForm({ patientId, patientName }: Props) {
           studyName: study.name,
           indication,
           diagnoses: icd10Selected,
+          priority,
           priorAuth,
           timestamp: new Date().toISOString(),
         },
@@ -107,6 +110,7 @@ export function ImagingOrderForm({ patientId, patientName }: Props) {
     setStudyCode("");
     setIndication("");
     setIcd10Selected([]);
+    setPriority("routine");
     setPriorAuth(false);
   }
 
@@ -288,6 +292,28 @@ export function ImagingOrderForm({ patientId, patientName }: Props) {
                 </div>
               )}
             </div>
+
+            <FieldGroup label="Priority">
+              <div className="flex gap-2">
+                {(["routine", "stat"] as Priority[]).map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setPriority(p)}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium rounded-full border transition-colors",
+                      priority === p
+                        ? p === "stat"
+                          ? "bg-red-600 text-white border-red-600"
+                          : "bg-emerald-600 text-white border-emerald-600"
+                        : "bg-surface-raised text-text-muted border-border hover:bg-surface-muted",
+                    )}
+                  >
+                    {p.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            </FieldGroup>
 
             <label className="flex items-center gap-2 cursor-pointer select-none">
               <input

--- a/src/app/(clinician)/clinic/patients/[id]/orders/imaging/imaging-order-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/imaging/imaging-order-form.tsx
@@ -9,21 +9,25 @@ import { IMAGING_CATALOG } from "@/lib/domain/clinical-orders";
 import { COMMON_PROBLEMS } from "@/lib/domain/problem-list";
 import { cn } from "@/lib/utils/cn";
 import { useToast } from "@/components/ui/toast";
+import { createClinicalOrder } from "../actions";
 
 interface Props {
+  patientId: string;
   patientName: string;
 }
 
 const MODALITIES = ["X-ray", "MRI", "CT", "US", "DEXA"] as const;
 type Modality = (typeof MODALITIES)[number];
 
-export function ImagingOrderForm({ patientName }: Props) {
+export function ImagingOrderForm({ patientId, patientName }: Props) {
   const [modality, setModality] = useState<Modality>("X-ray");
   const [studyCode, setStudyCode] = useState<string>("");
   const [indication, setIndication] = useState("");
   const [icd10Query, setIcd10Query] = useState("");
   const [icd10Selected, setIcd10Selected] = useState<string[]>([]);
   const [priorAuth, setPriorAuth] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [placedOrderId, setPlacedOrderId] = useState<string | null>(null);
   const { toast } = useToast();
 
   const availableStudies = useMemo(
@@ -51,29 +55,51 @@ export function ImagingOrderForm({ patientName }: Props) {
     setIcd10Selected((prev) => prev.filter((c) => c !== code));
   }
 
-  function submit() {
-    if (!studyCode) return;
+  async function submit() {
+    if (!studyCode || submitting) return;
     const study = IMAGING_CATALOG.find((i) => i.code === studyCode);
     if (!study) return;
-    const orderId = `IMG-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    setSubmitting(true);
 
-    const payload = {
-      orderId,
-      patientName,
-      modality,
-      studyCode,
-      studyName: study.name,
-      indication,
-      diagnoses: icd10Selected,
-      priorAuth,
-      timestamp: new Date().toISOString(),
-    };
+    let result: Awaited<ReturnType<typeof createClinicalOrder>>;
+    try {
+      result = await createClinicalOrder({
+        patientId,
+        orderType: "imaging",
+        orderCode: studyCode,
+        orderName: `${modality} — ${study.name}`,
+        priority: "routine",
+        diagnosisCodes: icd10Selected,
+        payload: {
+          patientName,
+          modality,
+          studyCode,
+          studyName: study.name,
+          indication,
+          diagnoses: icd10Selected,
+          priorAuth,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch {
+      result = { ok: false, error: "Something went wrong placing the order. Please try again." };
+    } finally {
+      setSubmitting(false);
+    }
 
-    console.log("[Simulation] Imaging Order Submitted:", JSON.stringify(payload, null, 2));
+    if (!result.ok) {
+      toast({
+        title: "Order failed",
+        description: result.error,
+        variant: "error",
+      });
+      return;
+    }
 
+    setPlacedOrderId(result.orderId);
     toast({
-      title: "Order simulated",
-      description: `Imaging order simulated & logged for ${patientName}.`,
+      title: "Order placed",
+      description: `Imaging order saved to ${patientName}'s chart.`,
       variant: "success",
     });
 
@@ -89,12 +115,31 @@ export function ImagingOrderForm({ patientName }: Props) {
       <div className="rounded-xl border border-accent/20 bg-accent/[0.03] p-4 flex gap-3 items-start">
         <span className="text-accent text-base mt-0.5">ℹ️</span>
         <div>
-          <p className="text-sm font-medium text-text">Demo mode enabled</p>
+          <p className="text-sm font-medium text-text">External transmission not yet connected</p>
           <p className="text-xs text-text-muted mt-0.5 leading-relaxed">
-            Imaging orders are simulated in this sandbox environment. Submitting an order prints the full HL7/FHIR payload to the terminal console log. No real transmission is performed.
+            Submitting an order saves it to the patient&apos;s chart as part of
+            the permanent record. However, electronic transmission to the
+            imaging center (HL7/FHIR) is not yet connected in this sandbox
+            environment — the order must be sent to the imaging center
+            manually.
           </p>
         </div>
       </div>
+
+      {placedOrderId && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+          <p className="text-sm font-medium text-emerald-800">
+            Order placed and saved to the chart
+          </p>
+          <p className="text-xs text-emerald-700 mt-1">
+            Order ID{" "}
+            <span className="font-mono">{placedOrderId}</span> was recorded for{" "}
+            {patientName}. It appears in the placed orders list below. External
+            transmission to the imaging center is not yet connected — send the
+            order manually.
+          </p>
+        </div>
+      )}
       <Card tone="raised">
         <CardHeader>
           <CardTitle className="text-base">Modality</CardTitle>
@@ -266,8 +311,8 @@ export function ImagingOrderForm({ patientName }: Props) {
       </Card>
 
       <div className="flex items-center justify-end gap-3">
-        <Button onClick={submit} disabled={!studyCode}>
-          Submit order
+        <Button onClick={submit} disabled={!studyCode || submitting}>
+          {submitting ? "Placing order..." : "Submit order"}
         </Button>
       </div>
     </div>

--- a/src/app/(clinician)/clinic/patients/[id]/orders/imaging/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/imaging/page.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Eyebrow } from "@/components/ui/ornament";
 import { ImagingOrderForm } from "./imaging-order-form";
+import { OrderHistory } from "../order-history";
 
 interface PageProps {
   params: { id: string };
@@ -53,9 +54,18 @@ export default async function ImagingOrdersPage({ params }: PageProps) {
         </Link>
       </div>
 
-      <ImagingOrderForm
-        patientName={`${patient.firstName} ${patient.lastName}`}
-      />
+      <div className="space-y-6">
+        <ImagingOrderForm
+          patientId={patient.id}
+          patientName={`${patient.firstName} ${patient.lastName}`}
+        />
+
+        <OrderHistory
+          patientId={patient.id}
+          organizationId={user.organizationId!}
+          orderType="imaging"
+        />
+      </div>
     </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
@@ -10,20 +10,24 @@ import { LAB_CATALOG } from "@/lib/domain/clinical-orders";
 import { COMMON_PROBLEMS } from "@/lib/domain/problem-list";
 import { cn } from "@/lib/utils/cn";
 import { useToast } from "@/components/ui/toast";
+import { createClinicalOrder } from "../actions";
 
 type Priority = "stat" | "routine";
 
 interface Props {
+  patientId: string;
   patientName: string;
 }
 
-export function LabOrderForm({ patientName }: Props) {
+export function LabOrderForm({ patientId, patientName }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
   const [reason, setReason] = useState("");
   const [icd10Query, setIcd10Query] = useState("");
   const [icd10Selected, setIcd10Selected] = useState<string[]>([]);
   const [priority, setPriority] = useState<Priority>("routine");
   const [attachments, setAttachments] = useState<FileUploadItem[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [placedOrderId, setPlacedOrderId] = useState<string | null>(null);
   const { toast } = useToast();
 
   const grouped = useMemo(() => {
@@ -65,26 +69,53 @@ export function LabOrderForm({ patientName }: Props) {
     .map((code) => LAB_CATALOG.find((l) => l.code === code))
     .filter((l) => l && l.fasting);
 
-  function submit() {
-    if (selected.length === 0) return;
-    const orderId = `LAB-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+  async function submit() {
+    if (selected.length === 0 || submitting) return;
+    setSubmitting(true);
 
-    const payload = {
-      orderId,
-      patientName,
-      labs: selected,
-      reason,
-      diagnoses: icd10Selected,
-      priority,
-      attachments: attachments.map(a => a.file.name),
-      timestamp: new Date().toISOString(),
-    };
+    const labs = selected.map((code) => {
+      const lab = LAB_CATALOG.find((l) => l.code === code);
+      return { code, name: lab?.name ?? code };
+    });
 
-    console.log("[Simulation] Lab Order Submitted:", JSON.stringify(payload, null, 2));
+    let result: Awaited<ReturnType<typeof createClinicalOrder>>;
+    try {
+      result = await createClinicalOrder({
+        patientId,
+        orderType: "lab",
+        orderCode: labs.map((l) => l.code).join(","),
+        orderName: labs.map((l) => l.name).join(", "),
+        priority,
+        diagnosisCodes: icd10Selected,
+        payload: {
+          patientName,
+          labs: selected,
+          reason,
+          diagnoses: icd10Selected,
+          priority,
+          attachments: attachments.map((a) => a.file.name),
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch {
+      result = { ok: false, error: "Something went wrong placing the order. Please try again." };
+    } finally {
+      setSubmitting(false);
+    }
 
+    if (!result.ok) {
+      toast({
+        title: "Order failed",
+        description: result.error,
+        variant: "error",
+      });
+      return;
+    }
+
+    setPlacedOrderId(result.orderId);
     toast({
-      title: "Order simulated",
-      description: `Lab order simulated & logged for ${patientName}.`,
+      title: "Order placed",
+      description: `Lab order saved to ${patientName}'s chart.`,
       variant: "success",
     });
 
@@ -101,12 +132,30 @@ export function LabOrderForm({ patientName }: Props) {
       <div className="rounded-xl border border-accent/20 bg-accent/[0.03] p-4 flex gap-3 items-start">
         <span className="text-accent text-base mt-0.5">ℹ️</span>
         <div>
-          <p className="text-sm font-medium text-text">Demo mode enabled</p>
+          <p className="text-sm font-medium text-text">External transmission not yet connected</p>
           <p className="text-xs text-text-muted mt-0.5 leading-relaxed">
-            Lab orders are simulated in this sandbox environment. Submitting an order prints the full HL7/FHIR payload to the terminal console log. No real transmission is performed.
+            Submitting an order saves it to the patient&apos;s chart as part of
+            the permanent record. However, electronic transmission to the lab
+            (HL7/FHIR) is not yet connected in this sandbox environment — the
+            requisition must be sent to the lab manually.
           </p>
         </div>
       </div>
+
+      {placedOrderId && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+          <p className="text-sm font-medium text-emerald-800">
+            Order placed and saved to the chart
+          </p>
+          <p className="text-xs text-emerald-700 mt-1">
+            Order ID{" "}
+            <span className="font-mono">{placedOrderId}</span> was recorded for{" "}
+            {patientName}. It appears in the placed orders list below. External
+            transmission to the lab is not yet connected — send the requisition
+            manually.
+          </p>
+        </div>
+      )}
       <Card tone="raised">
         <CardHeader>
           <CardTitle className="text-base">Select labs</CardTitle>
@@ -311,9 +360,9 @@ export function LabOrderForm({ patientName }: Props) {
         </p>
         <Button
           onClick={submit}
-          disabled={selected.length === 0}
+          disabled={selected.length === 0 || submitting}
         >
-          Submit order
+          {submitting ? "Placing order..." : "Submit order"}
         </Button>
       </div>
     </div>

--- a/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/labs/lab-order-form.tsx
@@ -10,7 +10,7 @@ import { LAB_CATALOG } from "@/lib/domain/clinical-orders";
 import { COMMON_PROBLEMS } from "@/lib/domain/problem-list";
 import { cn } from "@/lib/utils/cn";
 import { useToast } from "@/components/ui/toast";
-import { createClinicalOrder } from "../actions";
+import { createClinicalOrder, uploadLabOrderAttachment } from "../actions";
 
 type Priority = "stat" | "routine";
 
@@ -93,7 +93,14 @@ export function LabOrderForm({ patientId, patientName }: Props) {
           reason,
           diagnoses: icd10Selected,
           priority,
-          attachments: attachments.map((a) => a.file.name),
+          // Persisted chart Document references (id + name) for every
+          // supporting file that uploaded successfully — not just filenames.
+          attachments: attachments
+            .filter((a) => a.status === "uploaded" && a.result)
+            .map((a) => ({
+              documentId: a.result!.id,
+              name: a.result!.name ?? a.file.name,
+            })),
           timestamp: new Date().toISOString(),
         },
       });
@@ -298,15 +305,12 @@ export function LabOrderForm({ patientId, patientName }: Props) {
 
             <FieldGroup label="Supporting attachments (optional)">
               <p className="text-[11px] text-text-subtle -mt-1 mb-2">
-                Prior result PDFs, requisition forms, or insurance cards.
-                They&apos;ll travel with the order to the lab.
+                Prior result PDFs, requisition forms, or insurance cards. Each
+                file is saved to the chart as a document and referenced by this
+                order. Requires document storage to be configured — otherwise
+                the upload reports an error instead of silently dropping the
+                file.
               </p>
-              {/*
-                Server-side TODO: there is no /api/labs/orders/[id]/attachments
-                endpoint yet. The handler below resolves locally so the UI
-                ships ready-to-wire — once a real upload route is in place,
-                replace the resolve with `createFetchUploadHandler({ url: ... })`.
-              */}
               <FileUpload
                 accept=".pdf,.png,.jpg,.jpeg,.heic,.webp"
                 maxFiles={5}
@@ -315,13 +319,16 @@ export function LabOrderForm({ patientId, patientName }: Props) {
                 label="Drop requisitions or prior results"
                 hint="PDF or image — up to 15 MB per file"
                 onUpload={async (file, { onProgress }) => {
-                  // Local-only: simulate the upload so the queue UI is
-                  // exercisable today. Replace once the server route lands.
-                  for (let p = 0; p <= 100; p += 20) {
-                    onProgress?.(p);
-                    await new Promise((r) => setTimeout(r, 80));
-                  }
-                  return { id: `local-${file.name}`, name: file.name };
+                  // EMR-1103 (WS-D): persist the attachment as a real chart
+                  // Document. Throwing flips the file row to "failed" so a
+                  // storage-not-configured environment is honest, not faked.
+                  const fd = new FormData();
+                  fd.append("patientId", patientId);
+                  fd.append("file", file);
+                  const res = await uploadLabOrderAttachment(fd);
+                  if (!res.ok) throw new Error(res.error);
+                  onProgress?.(100);
+                  return { id: res.documentId, name: res.name };
                 }}
                 onComplete={(items) => setAttachments(items)}
               />

--- a/src/app/(clinician)/clinic/patients/[id]/orders/labs/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/labs/page.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Eyebrow } from "@/components/ui/ornament";
 import { LabOrderForm } from "./lab-order-form";
+import { OrderHistory } from "../order-history";
 
 interface PageProps {
   params: { id: string };
@@ -53,9 +54,18 @@ export default async function LabOrdersPage({ params }: PageProps) {
         </Link>
       </div>
 
-      <LabOrderForm
-        patientName={`${patient.firstName} ${patient.lastName}`}
-      />
+      <div className="space-y-6">
+        <LabOrderForm
+          patientId={patient.id}
+          patientName={`${patient.firstName} ${patient.lastName}`}
+        />
+
+        <OrderHistory
+          patientId={patient.id}
+          organizationId={user.organizationId!}
+          orderType="lab"
+        />
+      </div>
     </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/orders/order-history.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/order-history.tsx
@@ -1,0 +1,120 @@
+import { prisma } from "@/lib/db/prisma";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+// EMR-1094: read surface for placed orders. Server component — the labs
+// and imaging order pages render it below the form so a clinician can see
+// what has already been ordered for this patient before placing more.
+
+interface Props {
+  patientId: string;
+  organizationId: string;
+  orderType: "lab" | "imaging";
+}
+
+const STATUS_TONE = {
+  placed: "info",
+  transmitted: "accent",
+  resulted: "success",
+  cancelled: "neutral",
+} as const;
+
+export async function OrderHistory({ patientId, organizationId, orderType }: Props) {
+  const orders = await prisma.clinicalOrder.findMany({
+    where: { patientId, organizationId, orderType },
+    orderBy: { createdAt: "desc" },
+    take: 25,
+  });
+
+  const noun = orderType === "lab" ? "lab" : "imaging";
+
+  return (
+    <Card tone="raised">
+      <CardHeader>
+        <CardTitle className="text-base">
+          Placed {noun} orders
+        </CardTitle>
+        <CardDescription>
+          Most recent first. Orders are saved to the chart; external
+          transmission is not yet connected.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {orders.length === 0 ? (
+          <p className="text-sm text-text-muted">
+            No {noun} orders have been placed for this patient yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border/60">
+            {orders.map((order) => {
+              const diagnoses = Array.isArray(order.diagnosisCodes)
+                ? (order.diagnosisCodes as unknown[]).filter(
+                    (d): d is string => typeof d === "string",
+                  )
+                : [];
+              return (
+                <li key={order.id} className="py-3 first:pt-0 last:pb-0">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-mono text-xs text-text-subtle tabular-nums">
+                          {order.orderCode}
+                        </span>
+                        {order.priority === "stat" && (
+                          <Badge tone="danger" className="text-[10px]">
+                            STAT
+                          </Badge>
+                        )}
+                        <Badge
+                          tone={
+                            STATUS_TONE[
+                              order.status as keyof typeof STATUS_TONE
+                            ] ?? "neutral"
+                          }
+                          className="text-[10px]"
+                        >
+                          {order.status}
+                        </Badge>
+                        {order.transmissionMode === "simulated" && (
+                          <Badge tone="warning" className="text-[10px]">
+                            Not transmitted
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-sm text-text mt-0.5">
+                        {order.orderName}
+                      </p>
+                      {diagnoses.length > 0 && (
+                        <p className="text-xs text-text-subtle mt-0.5 font-mono">
+                          {diagnoses.join(", ")}
+                        </p>
+                      )}
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="text-xs text-text-muted">
+                        {order.createdAt.toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </p>
+                      <p className="text-xs text-text-subtle mt-0.5">
+                        {order.orderedByName}
+                      </p>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/orders/orders-chart-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/orders-chart-panel.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+// EMR-1103 (WS-D) — chart Orders tab. Renders placed ClinicalOrder rows
+// (lab + imaging) so pending orders are visible during pre-visit chart
+// review, and links out to the per-modality order pages for placing new
+// ones. Presentational only: page.tsx fetches and serializes the rows so
+// this stays a plain (server-renderable) component with no Date/Prisma deps.
+
+export interface ChartOrder {
+  id: string;
+  orderType: "lab" | "imaging";
+  orderCode: string;
+  orderName: string;
+  priority: string;
+  status: string;
+  transmissionMode: string;
+  diagnosisCodes: string[];
+  orderedByName: string;
+  /** ISO timestamp. */
+  createdAt: string;
+}
+
+const STATUS_TONE: Record<string, "info" | "accent" | "success" | "neutral"> = {
+  placed: "info",
+  transmitted: "accent",
+  resulted: "success",
+  cancelled: "neutral",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function OrdersTab({
+  patientId,
+  orders,
+}: {
+  patientId: string;
+  orders: ChartOrder[];
+}) {
+  const pending = orders.filter((o) => o.status === "placed").length;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="font-display text-xl text-text tracking-tight">
+            Orders
+          </h2>
+          <p className="text-sm text-text-muted mt-0.5">
+            {orders.length === 0
+              ? "No lab or imaging orders placed yet."
+              : `${orders.length} order${orders.length === 1 ? "" : "s"} on the chart${
+                  pending > 0 ? ` · ${pending} pending` : ""
+                }.`}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Link
+            href={`/clinic/patients/${patientId}/orders/labs`}
+            className="text-[12px] px-3 py-1.5 rounded-md border border-border text-accent hover:bg-accent-soft transition-colors"
+          >
+            Place lab order ↗
+          </Link>
+          <Link
+            href={`/clinic/patients/${patientId}/orders/imaging`}
+            className="text-[12px] px-3 py-1.5 rounded-md border border-border text-accent hover:bg-accent-soft transition-colors"
+          >
+            Place imaging order ↗
+          </Link>
+        </div>
+      </div>
+
+      <Card tone="raised">
+        <CardHeader>
+          <CardTitle className="text-base">Placed orders</CardTitle>
+          <CardDescription>
+            Most recent first. Orders are saved to the chart; external
+            transmission (HL7/FHIR) is not yet connected, so &quot;Not
+            transmitted&quot; orders must be sent to the lab or imaging center
+            manually.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {orders.length === 0 ? (
+            <p className="text-sm text-text-muted">
+              Nothing ordered yet. Use the buttons above to place a lab or
+              imaging order.
+            </p>
+          ) : (
+            <ul className="divide-y divide-border/60">
+              {orders.map((order) => {
+                const href = `/clinic/patients/${patientId}/orders/${
+                  order.orderType === "lab" ? "labs" : "imaging"
+                }`;
+                return (
+                  <li key={order.id} className="py-3 first:pt-0 last:pb-0">
+                    <Link
+                      href={href}
+                      className="flex items-start justify-between gap-3 -mx-2 px-2 py-1 rounded-md hover:bg-surface-muted transition-colors"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <Badge
+                            tone={order.orderType === "lab" ? "success" : "info"}
+                            className="text-[10px] uppercase"
+                          >
+                            {order.orderType}
+                          </Badge>
+                          <span className="font-mono text-xs text-text-subtle tabular-nums">
+                            {order.orderCode}
+                          </span>
+                          {order.priority === "stat" && (
+                            <Badge tone="danger" className="text-[10px]">
+                              STAT
+                            </Badge>
+                          )}
+                          <Badge
+                            tone={STATUS_TONE[order.status] ?? "neutral"}
+                            className="text-[10px]"
+                          >
+                            {order.status}
+                          </Badge>
+                          {order.transmissionMode === "simulated" && (
+                            <Badge tone="warning" className="text-[10px]">
+                              Not transmitted
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="text-sm text-text mt-0.5">
+                          {order.orderName}
+                        </p>
+                        {order.diagnosisCodes.length > 0 && (
+                          <p className="text-xs text-text-subtle mt-0.5 font-mono">
+                            {order.diagnosisCodes.join(", ")}
+                          </p>
+                        )}
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="text-xs text-text-muted">
+                          {formatDate(order.createdAt)}
+                        </p>
+                        <p className="text-xs text-text-subtle mt-0.5">
+                          {order.orderedByName}
+                        </p>
+                      </div>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -1060,7 +1060,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
               preview: firstBlock
                 ? `${firstBlock.heading ?? ""}: ${(firstBlock.body ?? "").slice(0, 280)}`
                 : (n.narrative ?? "").slice(0, 280),
-              pendingAttestation: n.status === "needs_review",
+              pendingAttestation: n.status === "pending_cosign",
             };
           })}
         />

--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -84,6 +84,7 @@ import { sexColorKey, SEX_BUBBLE_CLASSES } from "@/lib/clinical/chart-bubbles";
 import { CINDY_PREFIX } from "@/lib/clinical/cindy-says";
 import { RecordsTab, type ChartDoc } from "./records-tab";
 import { ImagesTab } from "./images-tab";
+import { OrdersTab, type ChartOrder } from "./orders/orders-chart-panel";
 import { LsvTab, type LsvLabMarker } from "./lsv-tab";
 import { NotesTab } from "./notes-tab";
 import { PrivateNotesButton } from "./private-notes-button";
@@ -160,6 +161,9 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     "prescribe",
     "labs",
     "imaging",
+    // EMR-1103 (WS-D) — the chart Orders tab lists placed lab/imaging
+    // orders; clinical-tier, so front-office bounces to demographics.
+    "orders",
     "problems",
     // EMR-588 — private clinician-only notes are clinical-tier and must
     // bounce front-office users back to demographics like the rest.
@@ -193,6 +197,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     pastConditions,
     pastSurgeries,
     labResults,
+    clinicalOrders,
   ] = await Promise.all([
     prisma.patient.findFirst({
       where: {
@@ -329,6 +334,13 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
         abnormalFlag: true,
       },
     }),
+    // EMR-1103 (WS-D) — placed lab + imaging orders for the chart Orders tab.
+    // 50 most recent is well past what the panel renders before scroll.
+    prisma.clinicalOrder.findMany({
+      where: { patientId: params.id, organizationId: user.organizationId! },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    }),
   ]);
 
   if (!patient) notFound();
@@ -339,6 +351,25 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
   );
   const imageDocs = patient.documents.filter((d) => d.kind === "image");
   const labDocs = patient.documents.filter((d) => d.kind === "lab");
+
+  // EMR-1103 (WS-D) — serialize placed orders for the Orders tab panel
+  // (plain JSON so the presentational component carries no Prisma/Date deps).
+  const chartOrders: ChartOrder[] = clinicalOrders.map((o) => ({
+    id: o.id,
+    orderType: o.orderType === "imaging" ? "imaging" : "lab",
+    orderCode: o.orderCode,
+    orderName: o.orderName,
+    priority: o.priority,
+    status: o.status,
+    transmissionMode: o.transmissionMode,
+    diagnosisCodes: Array.isArray(o.diagnosisCodes)
+      ? (o.diagnosisCodes as unknown[]).filter(
+          (d): d is string => typeof d === "string",
+        )
+      : [],
+    orderedByName: o.orderedByName,
+    createdAt: o.createdAt.toISOString(),
+  }));
 
   /* ── Tab counts ───────────────────────────────────────────── */
   const activeRegimens = dosingRegimens.filter((r: any) => r.active);
@@ -415,6 +446,7 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
     timeline: timelineCount,
     records: recordDocs.length,
     images: imageDocs.length,
+    orders: clinicalOrders.length,
     labs: labDocs.length + assessmentResponses.length,
     notes: allNotes.length,
     private_notes: privateNotes.length,
@@ -468,6 +500,12 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       title: d.originalName || "Untitled image",
       meta: formatRelative(d.createdAt),
       href: `/clinic/patients/${params.id}?tab=images`,
+    })),
+    orders: clinicalOrders.slice(0, 5).map((o: any) => ({
+      id: o.id,
+      title: o.orderName || o.orderCode,
+      meta: `${o.orderType} · ${o.status} · ${formatRelative(o.createdAt)}`,
+      href: `/clinic/patients/${params.id}/orders/${o.orderType === "imaging" ? "imaging" : "labs"}`,
     })),
     correspondence: threads.slice(0, 5).map((t: any) => ({
       id: t.id,
@@ -976,6 +1014,9 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
       {tab === "images" && (
         <ImagesTab documents={imageDocs.map(toChartDoc)} patientId={params.id} />
       )}
+      {tab === "orders" && (
+        <OrdersTab patientId={params.id} orders={chartOrders} />
+      )}
       {tab === "labs" && (
         <LsvTab
           patientId={params.id}
@@ -1093,6 +1134,71 @@ export default async function PatientChartPage({ params, searchParams }: PagePro
    Demographics tab (EMR-019)
    ═══════════════════════════════════════════════════════════════════ */
 
+/**
+ * EMR-1103 (WS-D) — read contact/identity values out of the patient's intake
+ * answers, checking the shapes intake has used over time (flat keys, a nested
+ * `demographics` object, and a nested `address`). Used to prefill the chart
+ * demographics card when the structured column is empty. Defensive like the
+ * chart-demographics formatters — never throws on odd JSON.
+ */
+function intakeContactPrefill(intake: Record<string, any>) {
+  const demo =
+    intake.demographics && typeof intake.demographics === "object"
+      ? (intake.demographics as Record<string, any>)
+      : {};
+  const addr =
+    demo.address && typeof demo.address === "object"
+      ? (demo.address as Record<string, any>)
+      : intake.address && typeof intake.address === "object"
+        ? (intake.address as Record<string, any>)
+        : {};
+  const pick = (...vals: unknown[]): string => {
+    for (const v of vals) {
+      if (typeof v === "string" && v.trim()) return v.trim();
+      if (typeof v === "number") return String(v);
+    }
+    return "";
+  };
+  return {
+    firstName: pick(intake.firstName, demo.firstName),
+    lastName: pick(intake.lastName, demo.lastName),
+    dateOfBirth: pick(intake.dateOfBirth, demo.dateOfBirth),
+    email: pick(intake.email, intake.emailAddress, demo.email),
+    phone: pick(
+      intake.phone,
+      intake.phoneNumber,
+      intake.mobile,
+      demo.phone,
+      demo.phoneNumber,
+    ),
+    addressLine1: pick(
+      intake.addressLine1,
+      intake.address1,
+      demo.addressLine1,
+      addr.line1,
+      addr.addressLine1,
+      addr.street,
+    ),
+    addressLine2: pick(
+      intake.addressLine2,
+      demo.addressLine2,
+      addr.line2,
+      addr.addressLine2,
+      addr.unit,
+    ),
+    city: pick(intake.city, demo.city, addr.city),
+    state: pick(intake.state, demo.state, addr.state),
+    postalCode: pick(
+      intake.postalCode,
+      intake.zip,
+      intake.zipCode,
+      demo.postalCode,
+      addr.postalCode,
+      addr.zip,
+    ),
+  };
+}
+
 function DemographicsTab({
   patient,
   medications,
@@ -1133,6 +1239,51 @@ function DemographicsTab({
   const insurancePlan = formatInsurancePlan(intake);
   const insuranceId = formatInsuranceMemberId(intake);
   const emergencyContact = formatEmergencyContact(intake.emergencyContact);
+
+  // EMR-1103 (WS-D) — prefill the editable identity/contact fields from intake
+  // where the structured chart column is empty (one-way; a physician edit
+  // commits it and clears the hint on reload).
+  const structuredContact = {
+    firstName: patient.firstName ?? "",
+    lastName: patient.lastName ?? "",
+    dateOfBirth: dob ? dob.toISOString().slice(0, 10) : "",
+    email: patient.email ?? "",
+    phone: patient.phone ?? "",
+    addressLine1: patient.addressLine1 ?? "",
+    addressLine2: patient.addressLine2 ?? "",
+    city: patient.city ?? "",
+    state: patient.state ?? "",
+    postalCode: patient.postalCode ?? "",
+  };
+  const intakePrefill = intakeContactPrefill(intake);
+  const demographicsInitial = { ...structuredContact };
+  const intakeHints: Record<string, boolean> = {};
+  for (const key of Object.keys(
+    structuredContact,
+  ) as (keyof typeof structuredContact)[]) {
+    if (!structuredContact[key] && intakePrefill[key]) {
+      demographicsInitial[key] = intakePrefill[key];
+      intakeHints[key] = true;
+    }
+  }
+  const insuranceInitial = {
+    providerName:
+      ((intake.insurance as any)?.providerName as string) ??
+      (typeof intake.insurance === "string"
+        ? (intake.insurance as string)
+        : "") ??
+      "",
+    memberId:
+      ((intake.insurance as any)?.memberId as string) ??
+      (intake.memberId as string) ??
+      "",
+    groupNumber: ((intake.insurance as any)?.groupNumber as string) ?? "",
+  };
+  // Insurance has no structured chart column — every populated value here is
+  // self-reported from intake, so flag it as such.
+  if (insuranceInitial.providerName) intakeHints.providerName = true;
+  if (insuranceInitial.memberId) intakeHints.memberId = true;
+  if (insuranceInitial.groupNumber) intakeHints.groupNumber = true;
 
   return (
     <div className="space-y-6">
@@ -1234,30 +1385,9 @@ function DemographicsTab({
             <InlineDemographicsCard
               patientId={patient.id}
               canEdit={canEditDemographics}
-              initial={{
-                firstName: patient.firstName ?? "",
-                lastName: patient.lastName ?? "",
-                dateOfBirth: dob ? dob.toISOString().slice(0, 10) : "",
-                email: patient.email ?? "",
-                phone: patient.phone ?? "",
-                addressLine1: patient.addressLine1 ?? "",
-                addressLine2: patient.addressLine2 ?? "",
-                city: patient.city ?? "",
-                state: patient.state ?? "",
-                postalCode: patient.postalCode ?? "",
-              }}
-              insurance={{
-                providerName:
-                  ((intake.insurance as any)?.providerName as string) ??
-                  (typeof intake.insurance === "string" ? (intake.insurance as string) : "") ??
-                  "",
-                memberId:
-                  ((intake.insurance as any)?.memberId as string) ??
-                  (intake.memberId as string) ??
-                  "",
-                groupNumber:
-                  ((intake.insurance as any)?.groupNumber as string) ?? "",
-              }}
+              initial={demographicsInitial}
+              insurance={insuranceInitial}
+              intakeHints={intakeHints}
             />
             <div className="grid grid-cols-1 gap-y-3 text-sm">
               <DemoField label="Sex" value={sex} />

--- a/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/peek-summary.ts
@@ -25,6 +25,7 @@ const TAB_LABELS: Record<TabKey, string> = {
   timeline: "Timeline",
   records: "Records",
   images: "Images",
+  orders: "Orders",
   labs: "Labs",
   notes: "Notes",
   // EMR-588 — Private clinician-only notes never feed the peek summary

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * WS-C — server-side prescribing safety gates in createPrescriptionAction.
+ *   T1: the v2 path requires a pharmacy routing target server-side.
+ *   T2: custom/free-text products are interaction-screened too (red blocks).
+ *   T3: controlled substances require CURES; high-risk non-controlled Rx
+ *       (high-dose THC / age ≥ 65 / psychiatric comorbidity) require the
+ *       clinical risk attestation — all validated server-side, not just client.
+ *
+ * The pure safety libs (drug-interactions, cures, dea-schedule,
+ * contraindications, high-risk-attestation) are exercised for real; only
+ * I/O boundaries (prisma, auth, dispatch, navigation) are mocked.
+ */
+const hoisted = vi.hoisted(() => {
+  const mockPrisma = {
+    patient: { findFirst: vi.fn() },
+    cannabisProduct: { findFirst: vi.fn(), create: vi.fn() },
+    patientMedication: { findMany: vi.fn() },
+    chartSummary: { findUnique: vi.fn() },
+    dosingRegimen: { create: vi.fn() },
+    auditLog: { create: vi.fn() },
+    user: { findFirst: vi.fn() },
+  };
+  return {
+    mockPrisma,
+    requireUserMock: vi.fn(),
+    dispatchMock: vi.fn(),
+  };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    // Next's redirect() throws to interrupt; emulate that so we can assert a
+    // request reached the success path (all gates passed).
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({ requireUser: () => hoisted.requireUserMock() }));
+vi.mock("@/lib/orchestration/dispatch", () => ({
+  dispatch: (...args: unknown[]) => hoisted.dispatchMock(...args),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { createPrescriptionAction } from "./actions";
+
+const { mockPrisma, requireUserMock, dispatchMock } = hoisted;
+
+function clinician(over: Record<string, unknown> = {}) {
+  return {
+    id: "user_1",
+    email: "doc@example.com",
+    firstName: "Cli",
+    lastName: "Nician",
+    organizationId: "org_1",
+    organizationName: "Clinic",
+    ...over,
+  };
+}
+
+function patient(over: Record<string, unknown> = {}) {
+  return {
+    id: "pat_1",
+    organizationId: "org_1",
+    firstName: "Pat",
+    lastName: "Patient",
+    dateOfBirth: null,
+    presentingConcerns: null,
+    intakeAnswers: null,
+    state: "CA",
+    ...over,
+  };
+}
+
+/** Build a FormData from a flat string map (the action reads via formData.get). */
+function form(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+const BASE = {
+  patientId: "pat_1",
+  productType: "tincture",
+  volumePerDose: "1",
+  volumeUnit: "mL",
+  frequencyPerDay: "1",
+  daysSupply: "30",
+  quantity: "30",
+  refills: "0",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserMock.mockResolvedValue(clinician());
+  mockPrisma.patient.findFirst.mockResolvedValue(patient());
+  mockPrisma.patientMedication.findMany.mockResolvedValue([]);
+  mockPrisma.chartSummary.findUnique.mockResolvedValue(null);
+  mockPrisma.dosingRegimen.create.mockResolvedValue({ id: "rx_1" });
+  mockPrisma.auditLog.create.mockResolvedValue({});
+  dispatchMock.mockResolvedValue(undefined);
+});
+
+describe("T1 — pharmacy enforcement on the v2 path", () => {
+  it("rejects a v2 submission with no pharmacy", async () => {
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, productId: "prod_1", rxFormVersion: "v2" }),
+    );
+    expect(res).toEqual({ ok: false, error: expect.stringMatching(/pharmacy/i) });
+  });
+
+  it("does not require pharmacy for legacy callers (no v2 marker)", async () => {
+    // Ketamine (Schedule III, non-opioid) trips the CURES gate, proving the
+    // request got PAST the pharmacy check without a pharmacy selected.
+    mockPrisma.cannabisProduct.create.mockResolvedValue({
+      id: "adhoc_1",
+      name: "Ketamine 10mg",
+      concentrationUnit: "mg/unit",
+    });
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, customProductName: "Ketamine 10mg" }),
+    );
+    expect(res).toEqual({ ok: false, error: expect.stringMatching(/CURES/i) });
+  });
+});
+
+describe("T2 — interaction screen for custom products", () => {
+  it("blocks an unacknowledged red interaction on a custom product", async () => {
+    mockPrisma.cannabisProduct.create.mockResolvedValue({
+      id: "adhoc_1",
+      name: "Custom blend tincture",
+      concentrationUnit: "mg/unit",
+    });
+    mockPrisma.patientMedication.findMany.mockResolvedValue([
+      { name: "Warfarin 5mg", active: true },
+    ]);
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, customProductName: "Custom blend tincture" }),
+    );
+    expect(res).toEqual({
+      ok: false,
+      error: expect.stringMatching(/interaction/i),
+    });
+  });
+
+  it("allows the custom Rx once the interaction is acknowledged", async () => {
+    mockPrisma.cannabisProduct.create.mockResolvedValue({
+      id: "adhoc_1",
+      name: "Custom blend tincture",
+      concentrationUnit: "mg/unit",
+    });
+    mockPrisma.patientMedication.findMany.mockResolvedValue([
+      { name: "Warfarin 5mg", active: true },
+    ]);
+    await expect(
+      createPrescriptionAction(
+        null,
+        form({
+          ...BASE,
+          customProductName: "Custom blend tincture",
+          interactionAcknowledged: "true",
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(mockPrisma.dosingRegimen.create).toHaveBeenCalledOnce();
+  });
+});
+
+describe("T3 — CURES + high-risk attestation", () => {
+  it("requires CURES for a controlled substance", async () => {
+    mockPrisma.cannabisProduct.create.mockResolvedValue({
+      id: "adhoc_1",
+      name: "Ketamine 10mg",
+      concentrationUnit: "mg/unit",
+    });
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, customProductName: "Ketamine 10mg" }),
+    );
+    expect(res).toEqual({ ok: false, error: expect.stringMatching(/CURES/i) });
+  });
+
+  it("requires the high-risk attestation for high-dose THC", async () => {
+    mockPrisma.cannabisProduct.findFirst.mockResolvedValue({
+      id: "prod_thc",
+      name: "House THC Oil",
+      organizationId: "org_1",
+      active: true,
+      thcConcentration: 20,
+      concentrationUnit: "mg/unit",
+    });
+    // 20 mg/unit × 1 unit × 3/day = 60 mg THC/day ≥ 40 mg/day threshold.
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, productId: "prod_thc", frequencyPerDay: "3" }),
+    );
+    expect(res).toEqual({
+      ok: false,
+      error: expect.stringMatching(/high-risk/i),
+    });
+  });
+
+  it("requires the high-risk attestation for older adults", async () => {
+    mockPrisma.patient.findFirst.mockResolvedValue(
+      patient({ dateOfBirth: new Date("1950-01-01") }),
+    );
+    mockPrisma.cannabisProduct.findFirst.mockResolvedValue({
+      id: "prod_cbd",
+      name: "CBD Oil",
+      organizationId: "org_1",
+      active: true,
+      thcConcentration: 1,
+      concentrationUnit: "mg/unit",
+    });
+    const res = await createPrescriptionAction(
+      null,
+      form({ ...BASE, productId: "prod_cbd" }),
+    );
+    expect(res).toEqual({
+      ok: false,
+      error: expect.stringMatching(/high-risk/i),
+    });
+  });
+
+  it("allows a high-risk Rx once the attestation is acknowledged", async () => {
+    mockPrisma.cannabisProduct.findFirst.mockResolvedValue({
+      id: "prod_thc",
+      name: "House THC Oil",
+      organizationId: "org_1",
+      active: true,
+      thcConcentration: 20,
+      concentrationUnit: "mg/unit",
+    });
+    await expect(
+      createPrescriptionAction(
+        null,
+        form({
+          ...BASE,
+          productId: "prod_thc",
+          frequencyPerDay: "3",
+          highRiskAttestationAcknowledged: "true",
+        }),
+      ),
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(mockPrisma.dosingRegimen.create).toHaveBeenCalledOnce();
+    // The high-risk acknowledgment is audited.
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: "prescribing.high_risk.attested" }),
+      }),
+    );
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.ts
@@ -5,8 +5,18 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
-import { checkInteractions } from "@/lib/domain/drug-interactions";
+import {
+  checkInteractions,
+  inferCannabinoidsFromName,
+} from "@/lib/domain/drug-interactions";
 import { recommendNarcan } from "@/lib/domain/cures";
+import { classifyDEASchedule } from "@/lib/domain/dea-schedule";
+import { checkContraindications } from "@/lib/domain/contraindications";
+import {
+  assessHighRiskAttestation,
+  ageFromDob,
+  psychiatricComorbidityLabels,
+} from "./high-risk-attestation";
 import { dispatch } from "@/lib/orchestration/dispatch";
 import { logger } from "@/lib/observability/log";
 
@@ -22,6 +32,12 @@ const schema = z.object({
   quantity: z.coerce.number().positive(),
   refills: z.coerce.number().int().min(0).max(12),
   timingInstructions: z.string().max(500).optional(),
+  // WS-C task 1: marks the v2 prescribe form so the server can require a
+  // pharmacy routing target on that path without breaking legacy/batch callers.
+  rxFormVersion: z.string().max(10).optional(),
+  // WS-C task 2: cannabinoid hints from the "open to" picker — used to infer a
+  // profile for custom/free-text products so interactions are still screened.
+  openCannabinoids: z.string().optional(), // JSON array of cannabinoid names
   diagnosisCodes: z.string().optional(), // JSON-encoded array of {code, label}
   // EMR-1099 (M3): pharmacy routing target. The form requires a selection
   // before "Sign & send"; optional here so legacy callers keep working.
@@ -42,6 +58,10 @@ const schema = z.object({
   curesMmePerDay: z.coerce.number().nonnegative().optional(),
   narcanCoPrescribe: z.string().optional(),
   narcanDeclineReason: z.string().max(2000).optional(),
+  // WS-C task 3: clinician acknowledgment of a high-risk (non-controlled)
+  // prescribing scenario — high-dose THC, age >= 65, psychiatric comorbidity.
+  highRiskAttestationAcknowledged: z.string().optional(), // "true" if acknowledged
+  highRiskReasons: z.string().optional(), // JSON array of HighRiskKind
 });
 
 export type PrescribeResult = { ok: true } | { ok: false; error: string };
@@ -64,6 +84,8 @@ export async function createPrescriptionAction(
     quantity: formData.get("quantity"),
     refills: formData.get("refills"),
     timingInstructions: formData.get("timingInstructions") || undefined,
+    rxFormVersion: formData.get("rxFormVersion") || undefined,
+    openCannabinoids: formData.get("openCannabinoids") || undefined,
     diagnosisCodes: formData.get("diagnosisCodes") || undefined,
     pharmacyId: formData.get("pharmacyId") || undefined,
     pharmacyName: formData.get("pharmacyName") || undefined,
@@ -83,6 +105,9 @@ export async function createPrescriptionAction(
     curesMmePerDay: formData.get("curesMmePerDay") || undefined,
     narcanCoPrescribe: formData.get("narcanCoPrescribe") || undefined,
     narcanDeclineReason: formData.get("narcanDeclineReason") || undefined,
+    highRiskAttestationAcknowledged:
+      formData.get("highRiskAttestationAcknowledged") || undefined,
+    highRiskReasons: formData.get("highRiskReasons") || undefined,
   });
 
   if (!parsed.success) {
@@ -112,6 +137,19 @@ export async function createPrescriptionAction(
   // Must have either a product from formulary or a custom name
   if (!productId && !customProductName) {
     return { ok: false, error: "Please select a product or enter a custom medication name." };
+  }
+
+  // WS-C task 1: the v2 prescribe form collects a pharmacy routing target and
+  // gates "Sign & send" on it client-side (EMR-1099/M3). Enforce that contract
+  // server-side too — the client gate is a convenience, not the boundary. The
+  // legacy v1 form and the batch flow (separate action, formulary bulk
+  // authorization with no per-item routing) don't collect a pharmacy and are
+  // intentionally exempt: they omit the `rxFormVersion=v2` marker.
+  if (parsed.data.rxFormVersion === "v2" && !pharmacyId) {
+    return {
+      ok: false,
+      error: "Select a pharmacy before signing & sending the prescription.",
+    };
   }
 
   // Verify patient belongs to org
@@ -144,18 +182,43 @@ export async function createPrescriptionAction(
     resolvedProductId = product.id;
   }
 
-  // Check for drug interactions server-side if product is from formulary
+  // Parse the cannabinoid "open to" hints once — used to infer a profile for
+  // custom/free-text products (WS-C task 2).
+  let openCannabinoidsHint: string[] = [];
+  if (parsed.data.openCannabinoids) {
+    try {
+      const raw = JSON.parse(parsed.data.openCannabinoids);
+      const result = z.array(z.string()).safeParse(raw);
+      openCannabinoidsHint = result.success ? result.data : [];
+    } catch {
+      openCannabinoidsHint = [];
+    }
+  }
+
+  // Check for drug interactions server-side for BOTH formulary and custom
+  // products. Formulary products read their structured cannabinoid profile;
+  // custom/free-text products (no concentration data) get a best-effort profile
+  // inferred from the name + hints so the screen still runs and red/yellow
+  // interactions block until acknowledged regardless of product source.
   if (product) {
     const patientMeds = await prisma.patientMedication.findMany({
       where: { patientId, active: true },
     });
 
     if (patientMeds.length > 0) {
-      const cannabinoids: string[] = [];
-      if (product.thcConcentration && product.thcConcentration > 0) cannabinoids.push("THC");
-      if (product.cbdConcentration && product.cbdConcentration > 0) cannabinoids.push("CBD");
-      if (product.cbnConcentration && product.cbnConcentration > 0) cannabinoids.push("CBN");
-      if (product.cbgConcentration && product.cbgConcentration > 0) cannabinoids.push("CBG");
+      let cannabinoids: string[];
+      if (productId) {
+        cannabinoids = [];
+        if (product.thcConcentration && product.thcConcentration > 0) cannabinoids.push("THC");
+        if (product.cbdConcentration && product.cbdConcentration > 0) cannabinoids.push("CBD");
+        if (product.cbnConcentration && product.cbnConcentration > 0) cannabinoids.push("CBN");
+        if (product.cbgConcentration && product.cbgConcentration > 0) cannabinoids.push("CBG");
+      } else {
+        cannabinoids = inferCannabinoidsFromName(
+          customProductName ?? product.name,
+          openCannabinoidsHint,
+        );
+      }
 
       const medNames = patientMeds.map((m) => m.name);
       const interactions = checkInteractions(medNames, cannabinoids);
@@ -250,6 +313,67 @@ export async function createPrescriptionAction(
     mmePerDay: parsed.data.curesMmePerDay ?? null,
   };
 
+  // ── WS-C task 3: high-risk attestation gate ──────────────────────────────
+  // A documented acknowledgment is owed not only for DEA-controlled substances
+  // but for high-risk non-controlled scenarios too. The risk is recomputed
+  // server-side; the client gate is a convenience, never the enforcement point.
+  const candidateRxName = product?.name ?? customProductName ?? "";
+  const deaMatch = candidateRxName ? classifyDEASchedule(candidateRxName) : null;
+  const isControlledRx = !!deaMatch;
+
+  // Controlled substances: enforce the CURES/PDMP attestation server-side (the
+  // v2 form gates it client-side — mirror that here so the API can't be driven
+  // around the UI).
+  if (isControlledRx && !curesSummary.acknowledged) {
+    return {
+      ok: false,
+      error: "Controlled substance: complete the CURES/PDMP attestation before signing.",
+    };
+  }
+
+  // Non-controlled high-risk scenarios (high-dose THC, age ≥ 65, documented
+  // psychiatric comorbidity) require the clinical risk attestation. Controlled
+  // substances are already covered by the CURES gate above.
+  let highRiskSummary: { reasons: string[]; acknowledged: true } | null = null;
+  if (!isControlledRx) {
+    const chartSummary = await prisma.chartSummary.findUnique({
+      where: { patientId },
+      select: { summaryMd: true },
+    });
+    const contraindicationMatches = checkContraindications({
+      dateOfBirth: patient.dateOfBirth,
+      presentingConcerns: patient.presentingConcerns,
+      intakeAnswers: patient.intakeAnswers,
+      medicationNames: activePatientMeds.map((m) => m.name),
+      historyText: chartSummary?.summaryMd ?? null,
+    });
+    const highRiskReasons = assessHighRiskAttestation({
+      thcMgPerDay,
+      patientAge: ageFromDob(patient.dateOfBirth),
+      psychiatricComorbidities: psychiatricComorbidityLabels(
+        contraindicationMatches.map((m) => ({
+          id: m.contraindication.id,
+          label: m.contraindication.label,
+        })),
+      ),
+    });
+    if (highRiskReasons.length > 0) {
+      if (parsed.data.highRiskAttestationAcknowledged !== "true") {
+        return {
+          ok: false,
+          error:
+            "High-risk prescription (" +
+            highRiskReasons.map((r) => r.label).join(", ") +
+            "). Acknowledge the clinical risk attestation before signing.",
+        };
+      }
+      highRiskSummary = {
+        reasons: highRiskReasons.map((r) => r.kind),
+        acknowledged: true,
+      };
+    }
+  }
+
   const narcanSummary = narcanRec.recommended
     ? {
         recommended: true,
@@ -271,6 +395,7 @@ export async function createPrescriptionAction(
     interactionAcknowledged: interactionAcknowledged === "true",
     cures: curesSummary,
     narcan: narcanSummary,
+    highRisk: highRiskSummary,
   });
 
   // Auto-generate patient instructions if not provided
@@ -413,6 +538,22 @@ export async function createPrescriptionAction(
             flags: curesSummary.flags,
             mmePerDay: curesSummary.mmePerDay,
           },
+        },
+      });
+    }
+
+    // WS-C task 3: audit the high-risk attestation whenever it was required
+    // and acknowledged — the clinician's documented acknowledgment of a
+    // high-dose THC / elderly / psychiatric-comorbidity prescription.
+    if (highRiskSummary) {
+      await prisma.auditLog.create({
+        data: {
+          organizationId: user.organizationId!,
+          actorUserId: user.id,
+          action: "prescribing.high_risk.attested",
+          subjectType: "DosingRegimen",
+          subjectId: regimen.id,
+          metadata: { reasons: highRiskSummary.reasons },
         },
       });
     }

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/actions.ts
@@ -23,6 +23,10 @@ const schema = z.object({
   refills: z.coerce.number().int().min(0).max(12),
   timingInstructions: z.string().max(500).optional(),
   diagnosisCodes: z.string().optional(), // JSON-encoded array of {code, label}
+  // EMR-1099 (M3): pharmacy routing target. The form requires a selection
+  // before "Sign & send"; optional here so legacy callers keep working.
+  pharmacyId: z.string().max(100).optional(),
+  pharmacyName: z.string().max(200).optional(),
   noteToPatient: z.string().max(2000).optional(),
   noteToPharmacy: z.string().max(2000).optional(),
   interactionAcknowledged: z.string().optional(), // "true" if acknowledged
@@ -61,6 +65,8 @@ export async function createPrescriptionAction(
     refills: formData.get("refills"),
     timingInstructions: formData.get("timingInstructions") || undefined,
     diagnosisCodes: formData.get("diagnosisCodes") || undefined,
+    pharmacyId: formData.get("pharmacyId") || undefined,
+    pharmacyName: formData.get("pharmacyName") || undefined,
     noteToPatient: formData.get("noteToPatient") || undefined,
     noteToPharmacy: formData.get("noteToPharmacy") || undefined,
     interactionAcknowledged: formData.get("interactionAcknowledged") || undefined,
@@ -96,6 +102,8 @@ export async function createPrescriptionAction(
     refills,
     timingInstructions,
     diagnosisCodes,
+    pharmacyId,
+    pharmacyName,
     noteToPatient,
     noteToPharmacy,
     interactionAcknowledged,
@@ -348,6 +356,10 @@ export async function createPrescriptionAction(
         clinicianNotes: structuredNotes,
         active: true,
         contraindicationOverride,
+        // EMR-1099 (M3): persist the routing target instead of silently
+        // dropping the hidden pharmacyId/pharmacyName inputs.
+        pharmacyId: pharmacyId || null,
+        pharmacyName: pharmacyName || null,
       },
     });
 

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/high-risk-attestation.test.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/high-risk-attestation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  ageFromDob,
+  assessHighRiskAttestation,
+  psychiatricComorbidityLabels,
+  HIGH_DOSE_THC_MG_PER_DAY,
+  ELDERLY_AGE_THRESHOLD,
+} from "./high-risk-attestation";
+
+/**
+ * WS-C task 3 — the high-risk attestation gate. A clinician acknowledgment is
+ * owed for high-dose THC, older adults, and documented psychiatric comorbidity
+ * even when the product is not DEA-controlled.
+ */
+describe("assessHighRiskAttestation", () => {
+  it("returns no reasons for a low-dose, young, comorbidity-free Rx", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: 10,
+      patientAge: 40,
+      psychiatricComorbidities: [],
+    });
+    expect(reasons).toEqual([]);
+  });
+
+  it("flags high-dose THC at or above the threshold", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: HIGH_DOSE_THC_MG_PER_DAY,
+      patientAge: 30,
+      psychiatricComorbidities: [],
+    });
+    expect(reasons.map((r) => r.kind)).toEqual(["high_dose_thc"]);
+  });
+
+  it("does not flag high-dose THC just below the threshold", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: HIGH_DOSE_THC_MG_PER_DAY - 0.1,
+      patientAge: 30,
+      psychiatricComorbidities: [],
+    });
+    expect(reasons).toEqual([]);
+  });
+
+  it("treats unknown THC mg/day (custom products) as not high-dose", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: null,
+      patientAge: 30,
+      psychiatricComorbidities: [],
+    });
+    expect(reasons).toEqual([]);
+  });
+
+  it("flags older adults at or above the age threshold", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: 5,
+      patientAge: ELDERLY_AGE_THRESHOLD,
+      psychiatricComorbidities: [],
+    });
+    expect(reasons.map((r) => r.kind)).toEqual(["elderly"]);
+  });
+
+  it("flags a documented psychiatric comorbidity", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: 5,
+      patientAge: 30,
+      psychiatricComorbidities: ["Bipolar I disorder (history of mania)"],
+    });
+    expect(reasons.map((r) => r.kind)).toEqual(["psychiatric_comorbidity"]);
+    expect(reasons[0].detail).toContain("Bipolar I");
+  });
+
+  it("can flag multiple reasons at once", () => {
+    const reasons = assessHighRiskAttestation({
+      thcMgPerDay: 80,
+      patientAge: 72,
+      psychiatricComorbidities: ["Schizophrenia / psychotic disorder"],
+    });
+    expect(reasons.map((r) => r.kind).sort()).toEqual(
+      ["elderly", "high_dose_thc", "psychiatric_comorbidity"].sort(),
+    );
+  });
+});
+
+describe("psychiatricComorbidityLabels", () => {
+  it("keeps only psychiatric contraindication ids, de-duplicated", () => {
+    const labels = psychiatricComorbidityLabels([
+      { id: "schizophrenia", label: "Schizophrenia / psychotic disorder" },
+      { id: "pregnancy", label: "Pregnancy" },
+      { id: "severe_mental_health_history", label: "Severe anxiety / panic disorder" },
+      { id: "schizophrenia", label: "Schizophrenia / psychotic disorder" },
+    ]);
+    expect(labels).toEqual([
+      "Schizophrenia / psychotic disorder",
+      "Severe anxiety / panic disorder",
+    ]);
+  });
+
+  it("returns empty when no psychiatric match", () => {
+    expect(
+      psychiatricComorbidityLabels([{ id: "pregnancy", label: "Pregnancy" }]),
+    ).toEqual([]);
+  });
+});
+
+describe("ageFromDob", () => {
+  it("computes whole-year age against a fixed now", () => {
+    const now = new Date("2026-06-09T00:00:00Z");
+    expect(ageFromDob(new Date("1960-01-01T00:00:00Z"), now)).toBe(66);
+  });
+
+  it("returns null for missing or unparseable DOB", () => {
+    expect(ageFromDob(null)).toBeNull();
+    expect(ageFromDob(undefined)).toBeNull();
+    expect(ageFromDob("not-a-date")).toBeNull();
+  });
+});

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/high-risk-attestation.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/high-risk-attestation.ts
@@ -1,0 +1,129 @@
+/**
+ * High-risk prescribing attestation (WS-C task 3, EMR-1103 item).
+ *
+ * A documented clinician acknowledgment isn't owed only for DEA-controlled
+ * substances (those are covered by the CURES/PDMP attestation). High-risk
+ * cannabis prescribing scenarios warrant the same documented acknowledgment
+ * even when the product isn't scheduled:
+ *
+ *   - High-dose THC — Bhaskar et al. (2021) dosing consensus places the
+ *     high-dose tier at > 40 mg THC/day; we gate at >= 40 mg/day.
+ *   - Older adults (>= 65) — heightened sedation, fall, and drug-interaction
+ *     risk; "start low, go slow" applies with extra force.
+ *   - Documented psychiatric comorbidity — THC can destabilize psychosis or
+ *     mania and worsen severe anxiety.
+ *
+ * This module is intentionally pure and dependency-light so the prescribe form
+ * (client) and `createPrescriptionAction` (server) compute the SAME gate from
+ * the SAME inputs. The client gate is a convenience; the server is the
+ * enforcement point.
+ */
+
+export const HIGH_DOSE_THC_MG_PER_DAY = 40;
+export const ELDERLY_AGE_THRESHOLD = 65;
+
+/**
+ * Contraindication ids (from `@/lib/domain/contraindications`) that represent
+ * a documented psychiatric comorbidity relevant to cannabis risk.
+ */
+export const PSYCHIATRIC_CONTRAINDICATION_IDS = [
+  "schizophrenia",
+  "bipolar_type_1",
+  "severe_mental_health_history",
+] as const;
+
+export type HighRiskKind = "high_dose_thc" | "elderly" | "psychiatric_comorbidity";
+
+export interface HighRiskReason {
+  kind: HighRiskKind;
+  /** Short chip-style label, e.g. "High-dose THC". */
+  label: string;
+  /** One-line clinician-facing explanation of why the gate fired. */
+  detail: string;
+}
+
+export interface HighRiskInput {
+  /**
+   * Calculated THC mg/day for the regimen, or null when unknown (custom /
+   * free-text products without a resolvable cannabinoid profile).
+   */
+  thcMgPerDay: number | null;
+  /** Patient age in years, or null when DOB is unknown. */
+  patientAge: number | null;
+  /** Labels of matched psychiatric-comorbidity contraindications. */
+  psychiatricComorbidities: string[];
+}
+
+/**
+ * Assess which high-risk attestation reasons apply. Empty array = no
+ * attestation required beyond the standard flow.
+ */
+export function assessHighRiskAttestation(input: HighRiskInput): HighRiskReason[] {
+  const reasons: HighRiskReason[] = [];
+
+  if (
+    input.thcMgPerDay != null &&
+    input.thcMgPerDay >= HIGH_DOSE_THC_MG_PER_DAY
+  ) {
+    reasons.push({
+      kind: "high_dose_thc",
+      label: "High-dose THC",
+      detail: `~${Math.round(input.thcMgPerDay)} mg THC/day meets the ≥ ${HIGH_DOSE_THC_MG_PER_DAY} mg/day high-dose threshold.`,
+    });
+  }
+
+  if (
+    input.patientAge != null &&
+    input.patientAge >= ELDERLY_AGE_THRESHOLD
+  ) {
+    reasons.push({
+      kind: "elderly",
+      label: "Older adult (≥ 65)",
+      detail: `Patient age ${input.patientAge} — heightened sedation, fall, and drug-interaction risk.`,
+    });
+  }
+
+  if (input.psychiatricComorbidities.length > 0) {
+    reasons.push({
+      kind: "psychiatric_comorbidity",
+      label: "Psychiatric comorbidity",
+      detail: `Documented: ${input.psychiatricComorbidities.join(", ")}.`,
+    });
+  }
+
+  return reasons;
+}
+
+/**
+ * Reduce a set of contraindication matches to the (de-duplicated) labels of
+ * those representing a psychiatric comorbidity. Accepts the minimal
+ * `{ id, label }` shape so both the form prop and the server's
+ * `ContraindicationMatch` can feed it.
+ */
+export function psychiatricComorbidityLabels(
+  matches: ReadonlyArray<{ id: string; label: string }>,
+): string[] {
+  const ids = new Set<string>(PSYCHIATRIC_CONTRAINDICATION_IDS);
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const m of matches) {
+    if (!ids.has(m.id) || seen.has(m.label)) continue;
+    seen.add(m.label);
+    labels.push(m.label);
+  }
+  return labels;
+}
+
+/**
+ * Whole-year age from a date of birth. Returns null when DOB is missing or
+ * unparseable. `now` is injectable for deterministic tests.
+ */
+export function ageFromDob(
+  dob: Date | string | null | undefined,
+  now: Date = new Date(),
+): number | null {
+  if (!dob) return null;
+  const d = dob instanceof Date ? dob : new Date(dob);
+  if (Number.isNaN(d.getTime())) return null;
+  return Math.floor((now.getTime() - d.getTime()) / (365.25 * 24 * 60 * 60 * 1000));
+}

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/page.tsx
@@ -124,6 +124,14 @@ export default async function PrescribePage({ params, searchParams }: PageProps)
 
   const patientState = patient.state ?? undefined;
 
+  // WS-C task 3: patient age gates the high-risk attestation for older adults.
+  const patientAge = patient.dateOfBirth
+    ? Math.floor(
+        (Date.now() - new Date(patient.dateOfBirth).getTime()) /
+          (365.25 * 24 * 60 * 60 * 1000),
+      )
+    : null;
+
   // EMR-883 — module gating. Cannabis is on by default for LeafJourney, but
   // when the org has opted out we scrub the word "Cannabis" from titles and
   // gate the psilocybin medication class on its own opt-in flag (EMR-885).
@@ -148,6 +156,7 @@ export default async function PrescribePage({ params, searchParams }: PageProps)
         patientPhone={patient.phone}
         patientPhotoUrl={null}
         patientState={patientState}
+        patientAge={patientAge}
         providerName={providerName}
         deaNumber={deaNumber}
         moduleFlags={moduleFlags}

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/page.tsx
@@ -2,20 +2,28 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
-import { PrescribeFormV2 } from "./prescribe-form-v2";
+import {
+  PrescribeFormV2,
+  type DiagnosisOption,
+  type RecommendationPrefill,
+} from "./prescribe-form-v2";
 import { checkContraindications } from "@/lib/domain/contraindications";
 import { resolveModuleFlags, scrubModuleWords } from "@/lib/clinical/module-opt-in";
+import { COMMON_PROBLEMS } from "@/lib/domain/problem-list";
 
 interface PageProps {
   params: { id: string };
+  // EMR-1098 (M2): ?rec={CannabisRecommendation.id} pre-fills the form from a
+  // saved AI recommendation.
+  searchParams?: { rec?: string };
 }
 
 export const metadata = { title: "New Prescription" };
 
-export default async function PrescribePage({ params }: PageProps) {
+export default async function PrescribePage({ params, searchParams }: PageProps) {
   const user = await requireUser();
 
-  const [patient, products, medications, chartSummary, eligibleCoSigners] =
+  const [patient, products, medications, chartSummary, problemListConditions, eligibleCoSigners] =
     await Promise.all([
       prisma.patient.findFirst({
         where: {
@@ -35,6 +43,12 @@ export default async function PrescribePage({ params }: PageProps) {
       prisma.chartSummary.findUnique({
         where: { patientId: params.id },
       }),
+      // EMR-1099 (M4): the patient's documented diagnoses (problem list).
+      // Rows store "ICD10 | description" in `condition` (see problems/page.tsx).
+      prisma.pastMedicalCondition.findMany({
+        where: { patientId: params.id, deletedAt: null },
+        orderBy: { createdAt: "desc" },
+      }),
       // EMR-088: optional dual sign-off — list other clinicians/owners in the
       // org so the prescriber can route a high-risk override for co-signature.
       prisma.user.findMany({
@@ -53,6 +67,50 @@ export default async function PrescribePage({ params }: PageProps) {
     ]);
 
   if (!patient) notFound();
+
+  // EMR-1098 (M2): load the saved recommendation referenced by ?rec= and map
+  // its payload onto the form's initial values. The catch keeps the page up
+  // while the CannabisRecommendation table migration is still rolling out.
+  const savedRecommendation = searchParams?.rec
+    ? await prisma.cannabisRecommendation
+        .findFirst({
+          where: {
+            id: searchParams.rec,
+            patientId: params.id,
+            organizationId: user.organizationId!,
+          },
+        })
+        .catch(() => null)
+    : null;
+
+  const recommendationPrefill: RecommendationPrefill | null = savedRecommendation
+    ? buildRecommendationPrefill(
+        savedRecommendation.id,
+        savedRecommendation.createdAt,
+        savedRecommendation.recommendation as Record<string, unknown>,
+      )
+    : null;
+
+  // EMR-1099 (M4): diagnosis-code options for the prescription — the patient's
+  // documented problem list first, then the common cannabis-context codes
+  // (same pattern as the referral form's diagnosis picker).
+  const chartDiagnoses: DiagnosisOption[] = problemListConditions
+    .map((c) => {
+      if (!c.condition.includes(" | ")) return null;
+      const [code, ...rest] = c.condition.split(" | ");
+      if (!code.trim()) return null;
+      return { code: code.trim(), label: rest.join(" | ").trim(), fromChart: true };
+    })
+    .filter((d): d is DiagnosisOption => d !== null);
+  const chartCodes = new Set(chartDiagnoses.map((d) => d.code));
+  const diagnosisOptions: DiagnosisOption[] = [
+    ...chartDiagnoses,
+    ...COMMON_PROBLEMS.filter((p) => !chartCodes.has(p.icd10)).map((p) => ({
+      code: p.icd10,
+      label: p.description,
+      fromChart: false,
+    })),
+  ];
 
   // EMR-088: run cannabis contraindication check
   const contraindicationMatches = checkContraindications({
@@ -95,6 +153,8 @@ export default async function PrescribePage({ params }: PageProps) {
         moduleFlags={moduleFlags}
         // EMR-883 — drop "Cannabis" from the heading when the module is off.
         heading={scrubModuleWords("New Cannabis Prescription", moduleFlags)}
+        recommendationPrefill={recommendationPrefill}
+        diagnosisOptions={diagnosisOptions}
         contraindicationMatches={contraindicationMatches.map((m) => ({
           id: m.contraindication.id,
           label: m.contraindication.label,
@@ -143,4 +203,63 @@ function deriveDeaPlaceholder(name: string): string {
   for (const ch of name) hash = (hash * 31 + ch.charCodeAt(0)) % 10_000_000;
   const first = (name[0] ?? "X").toUpperCase();
   return `B${first}${hash.toString().padStart(7, "0")}`;
+}
+
+/**
+ * EMR-1098 (M2) — map a saved recommendation payload (free-text, evidence
+ * oriented) onto the prescribe form's structured fields. Conservative: dose
+ * takes the LOW end of any range ("start low, go slow"), and anything that
+ * can't be parsed is left for the physician — the raw payload is always shown
+ * in the "Pre-filled from recommendation" note.
+ */
+function buildRecommendationPrefill(
+  id: string,
+  createdAt: Date,
+  payload: Record<string, unknown>,
+): RecommendationPrefill {
+  const productType = typeof payload.productType === "string" ? payload.productType : "";
+  const startingDose = typeof payload.startingDoseMg === "string" ? payload.startingDoseMg : "";
+  const frequency = typeof payload.frequency === "string" ? payload.frequency : "";
+
+  // "2.5-5 mg THC + 2.5-5 mg CBD" → dose "2.5", unit "mg"
+  const doseMatch = startingDose.match(/(\d+(?:\.\d+)?)/);
+  const unitMatch = startingDose.match(/\d\s*(mg|mcg|g|mL)\b/i);
+
+  // "1-2 times daily" → 1; "Once nightly" → 1; "twice daily" → 2; "3x" → 3
+  let frequencyPerDay: number | null = null;
+  const freqLower = frequency.toLowerCase();
+  if (/\bonce\b|\bnightly\b/.test(freqLower)) frequencyPerDay = 1;
+  else if (/\btwice\b/.test(freqLower)) frequencyPerDay = 2;
+  else {
+    const m = freqLower.match(/(\d+)(?:\s*[-–]\s*\d+)?\s*(?:x\b|times)/);
+    if (m) {
+      const n = parseInt(m[1], 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 12) frequencyPerDay = n;
+    }
+  }
+
+  // The qualifier after the first comma is timing guidance,
+  // e.g. "Once nightly, 1 hour before bed" → "1 hour before bed".
+  const commaIdx = frequency.indexOf(",");
+  const timingInstructions =
+    commaIdx >= 0 ? frequency.slice(commaIdx + 1).trim() || null : null;
+
+  return {
+    id,
+    createdAt: createdAt.toISOString(),
+    productType,
+    dose: doseMatch ? doseMatch[1] : null,
+    unit: unitMatch ? unitMatch[1] : null,
+    frequencyPerDay,
+    timingInstructions,
+    summary: {
+      productType,
+      cannabinoidRatio:
+        typeof payload.cannabinoidRatio === "string" ? payload.cannabinoidRatio : "",
+      startingDoseMg: startingDose,
+      deliveryMethod:
+        typeof payload.deliveryMethod === "string" ? payload.deliveryMethod : "",
+      frequency,
+    },
+  };
 }

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
@@ -94,6 +94,34 @@ interface CoSignerOption {
   label: string;
 }
 
+// EMR-1098 (M2) — initial values mapped from a saved CannabisRecommendation
+// (built server-side in ./page.tsx#buildRecommendationPrefill). `summary` is
+// the raw recommendation text shown in the "Pre-filled" note.
+export interface RecommendationPrefill {
+  id: string;
+  createdAt: string; // ISO
+  productType: string;
+  dose: string | null;
+  unit: string | null;
+  frequencyPerDay: number | null;
+  timingInstructions: string | null;
+  summary: {
+    productType: string;
+    cannabinoidRatio: string;
+    startingDoseMg: string;
+    deliveryMethod: string;
+    frequency: string;
+  };
+}
+
+// EMR-1099 (M4) — ICD-10 option for the diagnosis picker. `fromChart` marks
+// codes pulled from the patient's documented problem list.
+export interface DiagnosisOption {
+  code: string;
+  label: string;
+  fromChart: boolean;
+}
+
 export interface PrescribeFormV2Props {
   patientId: string;
   patientFirstName: string;
@@ -110,6 +138,8 @@ export interface PrescribeFormV2Props {
   medications: Medication[];
   contraindicationMatches?: ContraindicationMatch[];
   eligibleCoSigners?: CoSignerOption[];
+  recommendationPrefill?: RecommendationPrefill | null;
+  diagnosisOptions?: DiagnosisOption[];
 }
 
 /* ── Constants ──────────────────────────────────────────────── */
@@ -136,6 +166,10 @@ const FREQUENCY_PRESETS: Array<{ label: string; perDay: number }> = [
   { label: "As needed (PRN)", perDay: 1 },
 ];
 const DAYS_SUPPLY_PRESETS = ["30", "60", "90"];
+
+// EMR-1098 (M2) — flat list of the Type dropdown's preset values, used to
+// decide whether a recommendation prefill lands in preset or free-text mode.
+const TYPE_PRESET_VALUES = ADMINISTRATION_METHODS.flatMap((m) => m.examples);
 
 const FREE_TEXT = "__free__";
 
@@ -194,7 +228,18 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     medications,
     contraindicationMatches = [],
     eligibleCoSigners = [],
+    recommendationPrefill: prefill = null,
+    diagnosisOptions = [],
   } = props;
+
+  // EMR-1098 (M2) — resolve which frequency preset (if any) a prefilled
+  // doses-per-day count maps to; otherwise the field opens in free-text mode.
+  const prefillFreqLabel =
+    prefill?.frequencyPerDay != null
+      ? (FREQUENCY_PRESETS.find(
+          (f) => f.perDay === prefill.frequencyPerDay && f.label.endsWith("per day"),
+        )?.label ?? null)
+      : null;
 
   const patientName = `${patientFirstName} ${patientLastName}`.trim();
   const ledger = useChartLedger(patientId);
@@ -277,23 +322,41 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
   const hasMedication = !!selectedProductId || customProductName.trim().length > 0;
 
   // EMR-885 — Type field: MoA options + free text.
-  const [productType, setProductType] = useState("");
-  const [productTypeMode, setProductTypeMode] = useState<"preset" | "free">("preset");
+  // EMR-1098 (M2) — initial values come from the saved recommendation when
+  // the page was opened via "Apply to prescription" (?rec=…).
+  const [productType, setProductType] = useState(prefill?.productType ?? "");
+  const [productTypeMode, setProductTypeMode] = useState<"preset" | "free">(
+    prefill?.productType && !TYPE_PRESET_VALUES.includes(prefill.productType)
+      ? "free"
+      : "preset",
+  );
 
   /* ── Dosing (EMR-887) ─────────────────────────────────────── */
-  const [doseValue, setDoseValue] = useState("0.5");
-  const [doseMode, setDoseMode] = useState<"preset" | "free">("preset");
-  const [unitValue, setUnitValue] = useState("mg");
-  const [unitMode, setUnitMode] = useState<"preset" | "free">("preset");
-  const [freqLabel, setFreqLabel] = useState("1x per day");
-  const [freqMode, setFreqMode] = useState<"preset" | "free">("preset");
-  const [freqFreeText, setFreqFreeText] = useState("");
+  const [doseValue, setDoseValue] = useState(prefill?.dose ?? "0.5");
+  const [doseMode, setDoseMode] = useState<"preset" | "free">(
+    prefill?.dose && !DOSE_PRESETS.includes(prefill.dose) ? "free" : "preset",
+  );
+  const [unitValue, setUnitValue] = useState(prefill?.unit ?? "mg");
+  const [unitMode, setUnitMode] = useState<"preset" | "free">(
+    prefill?.unit && !UNIT_PRESETS.includes(prefill.unit) ? "free" : "preset",
+  );
+  const [freqLabel, setFreqLabel] = useState(prefillFreqLabel ?? "1x per day");
+  const [freqMode, setFreqMode] = useState<"preset" | "free">(
+    prefill?.frequencyPerDay != null && !prefillFreqLabel ? "free" : "preset",
+  );
+  const [freqFreeText, setFreqFreeText] = useState(
+    prefill?.frequencyPerDay != null && !prefillFreqLabel
+      ? String(prefill.frequencyPerDay)
+      : "",
+  );
   const [daysSupply, setDaysSupply] = useState("30");
   const [daysMode, setDaysMode] = useState<"preset" | "free">("preset");
   const [quantity, setQuantity] = useState("");
   const [quantityManual, setQuantityManual] = useState(false);
   const [refills, setRefills] = useState("0");
-  const [timingInstructions, setTimingInstructions] = useState("");
+  const [timingInstructions, setTimingInstructions] = useState(
+    prefill?.timingInstructions ?? "",
+  );
 
   // Resolve frequency-per-day integer for the server action.
   const frequencyPerDay = useMemo(() => {
@@ -322,6 +385,20 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
   /* ── Cannabinoids open to (EMR-886, pushed lower/secondary) ── */
   const [openCannabinoids, setOpenCannabinoids] = useState<string[]>(["THC", "CBD"]);
   const CANNABINOIDS = ["THC", "CBD", "CBDA", "CBG", "THCV", "CBDV", "CBC", "CBN", "CBGA"];
+
+  /* ── Diagnosis codes (EMR-1099 M4) ────────────────────────── */
+  // Same toggle-chip pattern as the referral form's diagnosis picker.
+  const [selectedDiagnoses, setSelectedDiagnoses] = useState<
+    { code: string; label: string }[]
+  >([]);
+
+  function toggleDiagnosis(diag: { code: string; label: string }) {
+    setSelectedDiagnoses((prev) =>
+      prev.some((d) => d.code === diag.code)
+        ? prev.filter((d) => d.code !== diag.code)
+        : [...prev, diag],
+    );
+  }
 
   /* ── Pharmacy (EMR-892) ───────────────────────────────────── */
   const [pharmacy, setPharmacy] = useState<PharmacyEntry | null>(null);
@@ -469,8 +546,11 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     parseInt(daysSupply, 10) > 0 &&
     parseFloat(quantity) > 0;
 
+  // EMR-1099 (M3): an Rx can't be signed without a routing target — the
+  // pharmacy selection now gates Sign & send.
   const blocked =
     !coreFilled ||
+    !pharmacy ||
     unresolvedRed ||
     mustAckContraindication ||
     (isControlled && !curesAcknowledged);
@@ -507,6 +587,14 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
       <input type="hidden" name="timingInstructions" value={timingInstructions} />
       <input type="hidden" name="noteToPatient" value={noteToPatient} />
       <input type="hidden" name="noteToPharmacy" value={noteToPharmacy} />
+      {/* EMR-1099 (M4): ICD-10 linkage — serialized for actions.ts#diagnosisCodes */}
+      {selectedDiagnoses.length > 0 && (
+        <input
+          type="hidden"
+          name="diagnosisCodes"
+          value={JSON.stringify(selectedDiagnoses)}
+        />
+      )}
       <input type="hidden" name="openCannabinoids" value={JSON.stringify(openCannabinoids)} />
       {pharmacy && (
         <>
@@ -584,6 +672,37 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
           <h1 className="sr-only">{heading}</h1>
         </CardContent>
       </Card>
+
+      {/* ── EMR-1098 (M2): pre-filled from AI recommendation ───── */}
+      {prefill && (
+        <Card className="rounded-2xl border-accent/30 bg-accent-soft/30 shadow-sm">
+          <CardContent className="py-3">
+            <details>
+              <summary className="text-sm font-medium text-text cursor-pointer">
+                <span aria-hidden>✨</span> Pre-filled from AI recommendation (
+                {new Date(prefill.createdAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+                ) — view what was applied
+              </summary>
+              <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+                <PreviewRow label="Product type" value={prefill.summary.productType || "—"} />
+                <PreviewRow label="Cannabinoid ratio" value={prefill.summary.cannabinoidRatio || "—"} />
+                <PreviewRow label="Starting dose" value={prefill.summary.startingDoseMg || "—"} />
+                <PreviewRow label="Delivery method" value={prefill.summary.deliveryMethod || "—"} />
+                <PreviewRow label="Frequency" value={prefill.summary.frequency || "—"} />
+              </div>
+              <p className="text-[11px] text-text-subtle mt-3 leading-snug">
+                Type, dose, and frequency below were seeded from this saved
+                recommendation (low end of any range). Review and adjust before
+                signing — the recommendation is decision support, not an order.
+              </p>
+            </details>
+          </CardContent>
+        </Card>
+      )}
 
       {/* ── EMR-088: contraindication banner (kept, condensed) ─── */}
       {contraindicationMatches.length > 0 && (
@@ -1029,6 +1148,46 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
         </div>
       </div>
 
+      {/* ── EMR-1099 (M4): diagnosis codes (ICD-10 linkage) ────── */}
+      <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Diagnosis codes</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-xs text-text-muted">
+            Link the ICD-10 diagnoses this prescription treats. Codes from the
+            patient&apos;s problem list are marked{" "}
+            <span className="font-medium text-accent">chart</span>.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {diagnosisOptions.map((diag) => {
+              const selected = selectedDiagnoses.some((d) => d.code === diag.code);
+              return (
+                <button
+                  key={diag.code}
+                  type="button"
+                  onClick={() => toggleDiagnosis({ code: diag.code, label: diag.label })}
+                  className={cn(
+                    "inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium border transition-all",
+                    selected
+                      ? "bg-accent/10 text-accent border-accent/30"
+                      : "bg-surface-muted text-text-muted border-border hover:border-accent/30",
+                  )}
+                >
+                  <span className="font-mono text-[10px]">{diag.code}</span>
+                  <span>{diag.label}</span>
+                  {diag.fromChart && (
+                    <Badge tone="accent" className="text-[9px] uppercase">
+                      chart
+                    </Badge>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
       {/* ── EMR-892: Pharmacy (moved up, next to the window) ───── */}
       <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
         <CardContent className="py-4 flex items-center justify-between gap-4 flex-wrap">
@@ -1047,8 +1206,9 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
                 {pharmacy.address}, {pharmacy.city}
               </p>
             ) : (
-              <p className="text-sm text-text-muted mt-1">
-                Click “Pharmacy” to search and select where to send this ℞.
+              // EMR-1099 (M3): pharmacy is now required to sign & send.
+              <p className="text-sm text-danger mt-1">
+                Required — select where to send this ℞ before signing.
               </p>
             )}
           </div>
@@ -1195,6 +1355,13 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
           <SubmitButton disabled={blocked} />
         </div>
       </div>
+      {/* EMR-1099 (M3): visible hint when the pharmacy gate blocks signing */}
+      {!pharmacy && (
+        <p className="text-[11px] text-danger text-right">
+          Select a pharmacy to enable Sign &amp; send — every ℞ needs a routing
+          target.
+        </p>
+      )}
       {!previewReady && (
         <p className="text-[11px] text-text-subtle text-right">
           Fill medication, dosing, notes &amp; pharmacy to open the preview.
@@ -1231,6 +1398,15 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
             <PreviewRow label="Days supply" value={daysSupply || "—"} />
             <PreviewRow label="Refills" value={refills} />
           </div>
+          {/* EMR-1099 (M4): linked ICD-10 diagnoses */}
+          {selectedDiagnoses.length > 0 && (
+            <PreviewRow
+              label="Diagnosis codes"
+              value={selectedDiagnoses
+                .map((d) => `${d.code} ${d.label}`)
+                .join(" · ")}
+            />
+          )}
           <PreviewRow
             label="Interaction status"
             value={

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
@@ -48,6 +48,7 @@ import { ADMINISTRATION_METHODS } from "@/lib/clinical/methods-of-administration
 import type { ModuleFlags } from "@/lib/clinical/module-opt-in";
 import {
   checkInteractions,
+  inferCannabinoidsFromName,
   type DrugInteraction,
 } from "@/lib/domain/drug-interactions";
 import {
@@ -55,6 +56,10 @@ import {
   DEA_SCHEDULE_LABEL,
   DEA_SCHEDULE_TONE,
 } from "@/lib/domain/dea-schedule";
+import {
+  assessHighRiskAttestation,
+  psychiatricComorbidityLabels,
+} from "./high-risk-attestation";
 
 /* ── Types ──────────────────────────────────────────────────── */
 
@@ -130,6 +135,9 @@ export interface PrescribeFormV2Props {
   patientPhone: string | null;
   patientPhotoUrl: string | null;
   patientState?: string;
+  /** Patient age in years (WS-C task 3 — gates the high-risk attestation for
+   *  older adults). Null when DOB is unknown. */
+  patientAge?: number | null;
   providerName: string;
   deaNumber: string;
   moduleFlags: ModuleFlags;
@@ -220,6 +228,7 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     patientPhone,
     patientPhotoUrl,
     patientState,
+    patientAge = null,
     providerName,
     deaNumber,
     moduleFlags,
@@ -425,15 +434,23 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
 
   /* ── Interactions / Safety check (EMR-888) ────────────────── */
   const cannabinoidsForCheck = useMemo(() => {
-    const c: string[] = [];
     if (selectedProduct) {
+      const c: string[] = [];
       if ((selectedProduct.thcConcentration ?? 0) > 0) c.push("THC");
       if ((selectedProduct.cbdConcentration ?? 0) > 0) c.push("CBD");
       if ((selectedProduct.cbnConcentration ?? 0) > 0) c.push("CBN");
       if ((selectedProduct.cbgConcentration ?? 0) > 0) c.push("CBG");
+      return c;
     }
-    return c;
-  }, [selectedProduct]);
+    // WS-C task 2: custom/free-text products have no structured profile —
+    // infer a best-effort one from the name + "open to" hints so the same
+    // interaction screen (and acknowledgment gate) runs as for formulary
+    // products. Mirrors the server in createPrescriptionAction.
+    if (customProductName.trim()) {
+      return inferCannabinoidsFromName(customProductName, openCannabinoids);
+    }
+    return [];
+  }, [selectedProduct, customProductName, openCannabinoids]);
 
   const interactions = useMemo<DrugInteraction[]>(() => {
     if (cannabinoidsForCheck.length === 0 || medications.length === 0) return [];
@@ -533,6 +550,47 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
   }
   const curesAcknowledged = isControlled ? curesChecked.every(Boolean) : true;
 
+  /* ── High-risk attestation (WS-C task 3) ──────────────────────
+     A documented acknowledgment is owed for high-risk NON-controlled Rx too
+     (high-dose THC, age ≥ 65, psychiatric comorbidity). Controlled substances
+     are already covered by the CURES attestation above, so we only surface
+     this gate when the Rx is not controlled. Mirrors the server gate in
+     createPrescriptionAction; the server re-validates the acknowledgment. */
+  const thcMgPerDayForRisk = useMemo(() => {
+    if (!selectedProduct) return null;
+    if (
+      selectedProduct.concentrationUnit !== "mg/mL" &&
+      selectedProduct.concentrationUnit !== "mg/unit"
+    )
+      return null;
+    const conc = selectedProduct.thcConcentration ?? 0;
+    const dose = parseFloat(doseValue);
+    if (conc <= 0 || !(dose > 0)) return null;
+    return conc * dose * frequencyPerDay;
+  }, [selectedProduct, doseValue, frequencyPerDay]);
+
+  const psychiatricLabels = useMemo(
+    () =>
+      psychiatricComorbidityLabels(
+        contraindicationMatches.map((m) => ({ id: m.id, label: m.label })),
+      ),
+    [contraindicationMatches],
+  );
+
+  const highRiskReasons = useMemo(
+    () =>
+      isControlled
+        ? []
+        : assessHighRiskAttestation({
+            thcMgPerDay: thcMgPerDayForRisk,
+            patientAge,
+            psychiatricComorbidities: psychiatricLabels,
+          }),
+    [isControlled, thcMgPerDayForRisk, patientAge, psychiatricLabels],
+  );
+  const highRiskAttestationRequired = highRiskReasons.length > 0;
+  const [highRiskAcknowledged, setHighRiskAcknowledged] = useState(false);
+
   /* ── Submit gating ────────────────────────────────────────── */
   const mustAckContraindication =
     hasBlockingContraindication &&
@@ -553,7 +611,8 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     !pharmacy ||
     unresolvedRed ||
     mustAckContraindication ||
-    (isControlled && !curesAcknowledged);
+    (isControlled && !curesAcknowledged) ||
+    (highRiskAttestationRequired && !highRiskAcknowledged);
 
   /* ── Preview modal (EMR-893) ──────────────────────────────── */
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -571,6 +630,9 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     <form action={formAction} className="space-y-4">
       {/* ── Hidden inputs preserving the action contract ──────── */}
       <input type="hidden" name="patientId" value={patientId} />
+      {/* WS-C task 1: marks this as the v2 path so the server enforces the
+          pharmacy routing target (legacy v1 / batch flows are exempt). */}
+      <input type="hidden" name="rxFormVersion" value="v2" />
       {selectedProductId && (
         <input type="hidden" name="productId" value={selectedProductId} />
       )}
@@ -604,6 +666,16 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
       )}
       {interactionAcknowledged && (
         <input type="hidden" name="interactionAcknowledged" value="true" />
+      )}
+      {highRiskAttestationRequired && highRiskAcknowledged && (
+        <>
+          <input type="hidden" name="highRiskAttestationAcknowledged" value="true" />
+          <input
+            type="hidden"
+            name="highRiskReasons"
+            value={JSON.stringify(highRiskReasons.map((r) => r.kind))}
+          />
+        </>
       )}
       {isControlled && curesAcknowledged && (
         <>
@@ -1294,6 +1366,62 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
             >
               Store your CURES credentials in Settings →
             </Link>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── WS-C task 3: high-risk clinical attestation (non-controlled) ── */}
+      {highRiskAttestationRequired && (
+        <Card className="rounded-2xl bg-amber-50/60 border-amber-200 shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base text-amber-900">
+              High-risk prescription — clinical attestation
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-xs text-amber-800">
+              This prescription is flagged high-risk for the reason
+              {highRiskReasons.length === 1 ? "" : "s"} below. Acknowledge that
+              you have weighed the risks and benefits before signing.
+            </p>
+            <ul className="space-y-1.5">
+              {highRiskReasons.map((r) => (
+                <li
+                  key={r.kind}
+                  className="flex items-start gap-2 text-sm text-amber-900"
+                >
+                  <Badge tone="warning" className="text-[10px] shrink-0 mt-0.5">
+                    {r.label}
+                  </Badge>
+                  <span className="text-amber-800">{r.detail}</span>
+                </li>
+              ))}
+            </ul>
+            <label className="flex items-start gap-2 text-sm text-amber-900 rounded-lg border border-amber-300 bg-white/70 px-3 py-2 cursor-pointer hover:bg-white">
+              <input
+                type="checkbox"
+                checked={highRiskAcknowledged}
+                onChange={() => {
+                  setHighRiskAcknowledged((prev) => {
+                    const next = !prev;
+                    if (next) {
+                      ledger.record({
+                        kind: "acknowledge",
+                        source: "High-risk attestation",
+                        subject: highRiskReasons.map((r) => r.label).join(", "),
+                        justification: "Clinician acknowledged high-risk prescription",
+                      });
+                    }
+                    return next;
+                  });
+                }}
+                className="mt-0.5 h-4 w-4 rounded border-amber-400 accent-amber-600"
+              />
+              <span>
+                I have reviewed the risks and benefits and judge this
+                prescription clinically appropriate for this patient.
+              </span>
+            </label>
           </CardContent>
         </Card>
       )}

--- a/src/app/(clinician)/clinic/patients/[id]/recommend/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/recommend/actions.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
 import { logger } from "@/lib/observability/log";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 /* ── Types ──────────────────────────────────────────────────── */
@@ -58,10 +58,36 @@ interface Corpus {
   symptom_categories: Record<string, CorpusCategory>;
 }
 
+const CORPUS_PATH = join(process.cwd(), "data", "cannabis-research-corpus.json");
+
+/** An empty corpus is a valid input: `findRelevantStudies` simply returns no
+ *  matches and the template recommendation still renders (citation-less). */
+const EMPTY_CORPUS: Corpus = { meta: {}, symptom_categories: {} };
+
+// Startup-time probe (EMR-1100, minor 10): surface a missing/unreadable corpus
+// once at module load instead of only blowing up mid-request. The recommend
+// flow degrades gracefully to template output either way (see `loadCorpus`).
+if (!existsSync(CORPUS_PATH)) {
+  logger.warn({
+    event: "clinic.recommend.corpus_missing",
+    path: CORPUS_PATH,
+    impact: "Recommendations fall back to template guidance with no citations.",
+  });
+}
+
+/**
+ * Load the research corpus. Never throws — a missing or malformed file
+ * degrades to an empty corpus so the template-path recommendation still
+ * works (just without PubMed citations) rather than failing the request.
+ */
 function loadCorpus(): Corpus {
-  const filePath = join(process.cwd(), "data", "cannabis-research-corpus.json");
-  const raw = readFileSync(filePath, "utf-8");
-  return JSON.parse(raw) as Corpus;
+  try {
+    const raw = readFileSync(CORPUS_PATH, "utf-8");
+    return JSON.parse(raw) as Corpus;
+  } catch (err) {
+    logger.warn({ event: "clinic.recommend.corpus_load_failed", path: CORPUS_PATH, err });
+    return EMPTY_CORPUS;
+  }
 }
 
 /* ── Keyword matching ───────────────────────────────────────── */

--- a/src/app/(clinician)/clinic/patients/[id]/recommend/actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/recommend/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { resolveModelClient } from "@/lib/orchestration/model-client";
+import { logger } from "@/lib/observability/log";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -28,7 +29,10 @@ export interface Recommendation {
 }
 
 export type RecommendResult =
-  | { ok: true; recommendation: Recommendation }
+  // EMR-1098 (M1): savedId is the persisted CannabisRecommendation row — used
+  // by "Apply to prescription" to carry the recommendation into /prescribe.
+  // Null only if the audit write failed (the recommendation still displays).
+  | { ok: true; recommendation: Recommendation; savedId: string | null }
   | { ok: false; error: string };
 
 /* ── Corpus loader ──────────────────────────────────────────── */
@@ -326,5 +330,26 @@ export async function generateRecommendation(
     recommendation = buildTemplateRecommendation(concerns, matchedStudies);
   }
 
-  return { ok: true, recommendation };
+  // EMR-1098 (M1): persist the recommendation so there is a durable record of
+  // the decision support shown to the physician (it previously lived only in
+  // React state). A failed write is logged but never blocks the result.
+  let savedId: string | null = null;
+  try {
+    const saved = await prisma.cannabisRecommendation.create({
+      data: {
+        organizationId: user.organizationId!,
+        patientId,
+        createdById: user.id,
+        createdByName:
+          `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || "Provider",
+        inputContext: { concerns, goals, outcomeSummary, assessmentSummary },
+        recommendation: JSON.parse(JSON.stringify(recommendation)),
+      },
+    });
+    savedId = saved.id;
+  } catch (err) {
+    logger.error({ event: "clinic.recommend.persist_failed", err });
+  }
+
+  return { ok: true, recommendation, savedId };
 }

--- a/src/app/(clinician)/clinic/patients/[id]/recommend/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/recommend/page.tsx
@@ -1,10 +1,21 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
 import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { RecommendForm } from "./recommend-form";
+import type { Recommendation } from "./actions";
 
 interface PageProps {
   params: { id: string };
@@ -24,6 +35,17 @@ export default async function RecommendPage({ params }: PageProps) {
   });
 
   if (!patient) notFound();
+
+  // EMR-1098 (M1): recent saved recommendations — the durable record of the
+  // decision support generated for this patient. The catch keeps the page up
+  // while the CannabisRecommendation table migration is still rolling out.
+  const recentRecommendations = await prisma.cannabisRecommendation
+    .findMany({
+      where: { patientId: params.id, organizationId: user.organizationId! },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+    })
+    .catch(() => []);
 
   return (
     <PageShell maxWidth="max-w-[800px]">
@@ -53,6 +75,69 @@ export default async function RecommendPage({ params }: PageProps) {
         concerns={patient.presentingConcerns}
         goals={patient.treatmentGoals}
       />
+
+      {/* EMR-1098 (M1): previously generated recommendations survive reloads. */}
+      {recentRecommendations.length > 0 && (
+        <Card tone="raised" className="mt-8">
+          <CardHeader>
+            <CardTitle>Recent saved recommendations</CardTitle>
+            <CardDescription>
+              Every generated recommendation is saved to the chart as a record
+              of the decision support used.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y divide-border/60">
+              {recentRecommendations.map((saved) => {
+                const rec = saved.recommendation as unknown as Recommendation;
+                return (
+                  <li
+                    key={saved.id}
+                    className="py-3 flex items-center justify-between gap-4 flex-wrap"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-medium text-text">
+                          {rec.productType} · {rec.cannabinoidRatio}
+                        </p>
+                        <Badge
+                          tone={
+                            rec.confidence === "high"
+                              ? "success"
+                              : rec.confidence === "moderate"
+                                ? "highlight"
+                                : "neutral"
+                          }
+                        >
+                          {rec.confidence} confidence
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-text-muted mt-0.5">
+                        {rec.startingDoseMg} — {rec.frequency}
+                      </p>
+                      <p className="text-[11px] text-text-subtle mt-0.5">
+                        {saved.createdAt.toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "short",
+                          day: "numeric",
+                        })}{" "}
+                        by {saved.createdByName}
+                      </p>
+                    </div>
+                    <Link
+                      href={`/clinic/patients/${params.id}/prescribe?rec=${saved.id}`}
+                    >
+                      <Button variant="secondary" size="sm">
+                        Apply to prescription
+                      </Button>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
     </PageShell>
   );
 }

--- a/src/app/(clinician)/clinic/patients/[id]/recommend/recommend-form.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/recommend/recommend-form.tsx
@@ -48,9 +48,11 @@ function ConfidenceBadge({ level }: { level: Recommendation["confidence"] }) {
 function RecommendationCard({
   rec,
   patientId,
+  savedId,
 }: {
   rec: Recommendation;
   patientId: string;
+  savedId: string | null;
 }) {
   return (
     <Card tone="ambient" className="mt-8">
@@ -118,7 +120,11 @@ function RecommendationCard({
           This is a decision-support tool, not a clinical order. The provider must
           review, adjust, and approve before prescribing.
         </p>
-        <Link href={`/clinic/patients/${patientId}/prescribe`}>
+        {/* EMR-1098 (M2): carry the saved recommendation into the prescribe
+            form so the physician doesn't re-type product type/dose/frequency. */}
+        <Link
+          href={`/clinic/patients/${patientId}/prescribe${savedId ? `?rec=${savedId}` : ""}`}
+        >
           <Button variant="primary" size="md">
             Apply to prescription
           </Button>
@@ -206,6 +212,7 @@ export function RecommendForm({
         <RecommendationCard
           rec={state.recommendation}
           patientId={patientId}
+          savedId={state.savedId}
         />
       )}
     </div>

--- a/src/app/(clinician)/clinic/sign-off/layout.tsx
+++ b/src/app/(clinician)/clinic/sign-off/layout.tsx
@@ -29,11 +29,11 @@ export default async function SignOffLayout({
       where: { organizationId: orgId, signedAt: null, status: "flagged" },
     }),
     prisma.note.count({
-      where: { status: "needs_review", encounter: { patient: { organizationId: orgId } } },
+      where: { status: "pending_cosign", encounter: { patient: { organizationId: orgId } } },
     }),
     prisma.note.count({
       where: {
-        status: "needs_review",
+        status: "pending_cosign",
         aiConfidence: { lt: 0.6 },
         encounter: { patient: { organizationId: orgId } },
       },

--- a/src/app/(clinician)/clinic/sign-off/notes/page.tsx
+++ b/src/app/(clinician)/clinic/sign-off/notes/page.tsx
@@ -13,7 +13,7 @@ export default async function NotesSignOffPage() {
 
   const notes = await prisma.note.findMany({
     where: {
-      status: "needs_review",
+      status: "pending_cosign",
       encounter: { patient: { organizationId: user.organizationId! } },
     },
     orderBy: { updatedAt: "desc" },

--- a/src/app/(clinician)/clinic/sign-off/page.tsx
+++ b/src/app/(clinician)/clinic/sign-off/page.tsx
@@ -30,7 +30,7 @@ export default async function SignOffPage() {
     }),
     prisma.note.findMany({
       where: {
-        status: "needs_review",
+        status: "pending_cosign",
         encounter: { patient: { organizationId: orgId } },
       },
       orderBy: { updatedAt: "desc" },

--- a/src/lib/agents/billing/coding-optimization-agent.ts
+++ b/src/lib/agents/billing/coding-optimization-agent.ts
@@ -90,7 +90,7 @@ export const codingOptimizationAgent: Agent<
       where: { id: encounterId },
       include: {
         notes: {
-          where: { status: { in: ["finalized", "needs_review"] } },
+          where: { status: { in: ["finalized", "pending_cosign"] } },
           orderBy: { createdAt: "desc" },
           take: 2,
         },

--- a/src/lib/agents/billing/encounter-intelligence-agent.ts
+++ b/src/lib/agents/billing/encounter-intelligence-agent.ts
@@ -97,7 +97,7 @@ export const encounterIntelligenceAgent: Agent<
       where: { id: encounterId },
       include: {
         notes: {
-          where: { status: { in: ["finalized", "needs_review"] } },
+          where: { status: { in: ["finalized", "pending_cosign"] } },
           orderBy: { createdAt: "desc" },
         },
         patient: {

--- a/src/lib/agents/billing/encounter-intelligence-agent.ts
+++ b/src/lib/agents/billing/encounter-intelligence-agent.ts
@@ -8,17 +8,20 @@ import { recallMemories, formatMemoriesForPrompt } from "../memory/patient-memor
 // ---------------------------------------------------------------------------
 // Encounter Intelligence Agent
 // ---------------------------------------------------------------------------
-// First agent in the clean claim path. Wakes up when an encounter completes,
-// reads the clinical documentation, and extracts billable charges.
+// First agent in the clean claim path. Wakes up when the physician approves
+// the coding suggestions on a finalized note (EMR-1097 — previously this ran
+// on encounter.completed, creating charges before the physician ever reviewed
+// the codes), reads the clinical documentation, and extracts billable charges.
 //
 // This agent answers: "What services were performed in this visit?"
 //
 // It does NOT assign final codes (that's the Coding Optimization Agent).
 // It identifies the billable INTENT from the documentation and creates
-// Charge objects with tentative CPT codes and linked diagnoses.
+// Charge objects with tentative CPT codes and linked diagnoses, reconciled
+// against the physician-approved ICD-10 set and E/M level when provided.
 //
 // Layer 3 state transition: (none) → charge.created
-// Layer 4 events: subscribes encounter.completed, emits charge.created
+// Layer 4 events: subscribes coding.approved, emits charge.created
 // ---------------------------------------------------------------------------
 
 function tryParseJSON(text: string): any | null {
@@ -37,6 +40,12 @@ function tryParseJSON(text: string): any | null {
 const input = z.object({
   encounterId: z.string(),
   patientId: z.string(),
+  // EMR-1097 — physician-approved codes from the coding.approved event.
+  // When present, they are authoritative and the extraction reconciles
+  // against them.
+  noteId: z.string().optional(),
+  approvedIcd10: z.array(z.string()).optional(),
+  approvedEmLevel: z.string().nullable().optional(),
 });
 
 const chargeOutput = z.object({
@@ -73,9 +82,13 @@ export const encounterIntelligenceAgent: Agent<
   ],
   requiresApproval: false,
 
-  async run({ encounterId, patientId }, ctx) {
+  async run({ encounterId, patientId, approvedIcd10, approvedEmLevel }, ctx) {
     const trace = startReasoning("encounterIntelligence", "1.0.0", ctx.jobId);
-    trace.step("begin charge extraction", { encounterId });
+    trace.step("begin charge extraction", {
+      encounterId,
+      approvedIcd10Count: approvedIcd10?.length ?? 0,
+      approvedEmLevel: approvedEmLevel ?? null,
+    });
 
     ctx.assertCan("read.encounter");
 
@@ -168,6 +181,10 @@ ${formatMemoriesForPrompt(memories)}
 ACTIVE CANNABIS REGIMENS:
 ${patient.dosingRegimens.map((r: any) => `  - ${r.product?.name ?? "cannabis product"}: ${r.volumePerDose}${r.volumeUnit} ${r.frequencyPerDay}x/day`).join("\n") || "  (none)"}
 
+PHYSICIAN-APPROVED CODING (authoritative — use these for the E/M level and diagnoses):
+${approvedEmLevel ? `- Approved E/M level: ${approvedEmLevel}` : "- No approved E/M level on file"}
+${approvedIcd10 && approvedIcd10.length > 0 ? `- Approved ICD-10 codes: ${approvedIcd10.join(", ")}` : "- No approved ICD-10 codes on file"}
+
 For each billable service, return a JSON array:
 [
   {
@@ -220,18 +237,50 @@ Return ONLY the JSON array. No markdown, no explanation.`;
 
     // ── Deterministic fallback ──────────────────────────────────
     if (charges.length === 0) {
-      // At minimum, every completed encounter with documentation gets a 99213
+      // At minimum, every completed encounter with documentation gets an E/M
+      // charge — the physician-approved level when we have one.
       charges = [
         {
-          cptCode: "99213",
-          cptDescription: "Office visit, established patient, low MDM",
+          cptCode: approvedEmLevel ?? "99213",
+          cptDescription: approvedEmLevel
+            ? "Office visit, established patient (physician-approved E/M)"
+            : "Office visit, established patient, low MDM",
           modifiers: [],
           units: 1,
-          icd10Codes: ["Z71.3"], // cannabis counseling as default
-          confidence: 0.6,
+          icd10Codes:
+            approvedIcd10 && approvedIcd10.length > 0
+              ? approvedIcd10
+              : ["Z71.3"], // cannabis counseling as default
+          confidence: approvedEmLevel ? 0.9 : 0.6,
         },
       ];
-      trace.step("used deterministic fallback — default 99213");
+      trace.step("used deterministic fallback", {
+        cptCode: approvedEmLevel ?? "99213",
+      });
+    }
+
+    // ── Reconcile with the physician-approved coding ────────────
+    // EMR-1097: the physician's approval (coding.approved) is the source of
+    // truth for the E/M level and diagnosis set. The LLM extraction supplies
+    // procedure detail; the approved codes override what it guessed.
+    if (approvedEmLevel || (approvedIcd10 && approvedIcd10.length > 0)) {
+      charges = charges.map((charge) => {
+        const isEmCode = /^99\d{3}$/.test(charge.cptCode);
+        return {
+          ...charge,
+          cptCode: isEmCode && approvedEmLevel ? approvedEmLevel : charge.cptCode,
+          icd10Codes:
+            approvedIcd10 && approvedIcd10.length > 0
+              ? approvedIcd10
+              : charge.icd10Codes,
+          // Physician review raises our confidence floor.
+          confidence: Math.max(charge.confidence, 0.9),
+        };
+      });
+      trace.step("reconciled charges with physician-approved coding", {
+        approvedEmLevel: approvedEmLevel ?? null,
+        approvedIcd10Count: approvedIcd10?.length ?? 0,
+      });
     }
 
     // ── Persist charges ─────────────────────────────────────────

--- a/src/lib/agents/patient-outreach-agent.ts
+++ b/src/lib/agents/patient-outreach-agent.ts
@@ -10,9 +10,10 @@ const input = z.object({
 });
 
 const output = z.object({
-  draftMessageId: z.string(),
+  draftMessageId: z.string().nullable(),
   subject: z.string(),
   tone: z.string(),
+  skipped: z.boolean().optional(),
 });
 
 const messageResponseSchema = z.object({
@@ -49,6 +50,26 @@ export const patientOutreachAgent: Agent<z.infer<typeof input>, z.infer<typeof o
       where: { id: encounterId },
     });
     if (!encounter) throw new Error(`Encounter not found: ${encounterId}`);
+
+    // EMR-1101 (M6) dedup rule: the physician-reviewed visit-completion
+    // release is the AUTHORITATIVE post-visit patient message. Releasing
+    // visit completion creates a reviewed patient draft in the same
+    // transaction as the VisitCompletion record, so if a release exists for
+    // any note on this encounter, this agent skips — otherwise the patient
+    // thread / approvals queue ends up with two near-identical drafts.
+    // (releaseVisitCompletion applies the mirror-image check for the
+    // opposite ordering, where this agent drafted first.)
+    const existingRelease = await prisma.visitCompletion.findFirst({
+      where: { note: { encounterId } },
+      select: { id: true },
+    });
+    if (existingRelease) {
+      ctx.log("info", "Visit-completion release already drafted a patient message — skipping outreach draft", {
+        encounterId,
+        visitCompletionId: existingRelease.id,
+      });
+      return { draftMessageId: null, subject: "", tone: "warm", skipped: true };
+    }
 
     // Load the latest note for this encounter (if finalized)
     ctx.assertCan("read.note");

--- a/src/lib/domain/drug-interactions.test.ts
+++ b/src/lib/domain/drug-interactions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { checkInteractions, inferCannabinoidsFromName } from "./drug-interactions";
+
+/**
+ * WS-C task 2 — custom/free-text products have no structured cannabinoid
+ * profile, so the prescribe flow infers a best-effort one from the name (and
+ * "open to" hints) before running the interaction screen. This must never
+ * silently produce an empty profile.
+ */
+describe("inferCannabinoidsFromName", () => {
+  it("extracts cannabinoid tokens present in the name", () => {
+    expect(inferCannabinoidsFromName("High-CBD CBN sleep oil").sort()).toEqual(
+      ["CBD", "CBN"].sort(),
+    );
+  });
+
+  it("treats a ratio as implying THC + CBD", () => {
+    expect(inferCannabinoidsFromName("1:1 balanced tincture").sort()).toEqual(
+      ["CBD", "THC"].sort(),
+    );
+  });
+
+  it("merges explicit 'open to' hints", () => {
+    expect(
+      inferCannabinoidsFromName("House blend", ["THC", "cbg"]).sort(),
+    ).toEqual(["CBG", "THC"].sort());
+  });
+
+  it("falls back to THC + CBD when nothing is recognizable", () => {
+    expect(inferCannabinoidsFromName("Mystery tincture").sort()).toEqual(
+      ["CBD", "THC"].sort(),
+    );
+  });
+
+  it("never returns an empty profile (so screening always runs)", () => {
+    expect(inferCannabinoidsFromName("").length).toBeGreaterThan(0);
+  });
+
+  it("produces a profile that surfaces a known red interaction (warfarin)", () => {
+    const cannabinoids = inferCannabinoidsFromName("Custom blend tincture");
+    const interactions = checkInteractions(["Warfarin 5mg"], cannabinoids);
+    expect(interactions.some((i) => i.severity === "red")).toBe(true);
+  });
+});

--- a/src/lib/domain/drug-interactions.ts
+++ b/src/lib/domain/drug-interactions.ts
@@ -87,6 +87,41 @@ export function checkInteractions(
   );
 }
 
+const KNOWN_CANNABINOIDS = ["THC", "CBD", "CBN", "CBG"] as const;
+
+/**
+ * Best-effort cannabinoid profile for a custom / free-text product that has no
+ * structured concentration data. Scans the product name (and any explicit
+ * "open to" cannabinoid hints) for cannabinoid tokens, treats a ratio like
+ * "1:1" as implying THC + CBD, and falls back to the THC + CBD pair a cannabis
+ * product almost always carries — so interaction screening still runs instead
+ * of silently passing. (WS-C task 2 / audit minor #9.)
+ */
+export function inferCannabinoidsFromName(
+  name: string,
+  hints: ReadonlyArray<string> = [],
+): string[] {
+  const found = new Set<string>();
+  const haystack = (name ?? "").toUpperCase();
+  for (const c of KNOWN_CANNABINOIDS) {
+    if (haystack.includes(c)) found.add(c);
+  }
+  for (const h of hints) {
+    const u = h.toUpperCase().trim();
+    if ((KNOWN_CANNABINOIDS as readonly string[]).includes(u)) found.add(u);
+  }
+  // A ratio like "1:1" or "20:1" implies both THC and CBD are present.
+  if (/\d+\s*:\s*\d+/.test(name ?? "")) {
+    found.add("THC");
+    found.add("CBD");
+  }
+  if (found.size === 0) {
+    found.add("THC");
+    found.add("CBD");
+  }
+  return Array.from(found);
+}
+
 /** Return the full interaction database sorted by severity (red → yellow → green). */
 export function getAllInteractions(): DrugInteraction[] {
   return (interactionData.interactions as InteractionEntry[])

--- a/src/lib/domain/golden-visit-harness.test.ts
+++ b/src/lib/domain/golden-visit-harness.test.ts
@@ -73,6 +73,8 @@ const h = vi.hoisted(() => {
     notes: [] as any[],
     auditLogs: [] as any[],
     agentJobs: [] as any[],
+    codingSuggestions: [] as any[],
+    charges: [] as any[],
   };
 
   const fixture = {
@@ -436,6 +438,43 @@ const h = vi.hoisted(() => {
         return clone(row);
       }),
     },
+    // EMR-1097 (B4) coding-approval control point. CodingSuggestion is keyed
+    // by noteId; the physician's approve/modify decision lands here and is
+    // what unblocks charge extraction.
+    codingSuggestion: {
+      findUnique: vi.fn(async (args?: any) =>
+        firstFrom(db.codingSuggestions, args, (row) => clone(row)),
+      ),
+      update: vi.fn(async ({ where, data }: any) =>
+        updateRow(db.codingSuggestions, where, data, (row) => clone(row)),
+      ),
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: data.id ?? `cs_golden_${db.codingSuggestions.length + 1}`,
+          status: "suggested",
+          generatedAt: new Date(),
+          ...clone(data),
+        };
+        db.codingSuggestions.push(row);
+        return clone(row);
+      }),
+    },
+    // Charges are extracted by the encounter-intelligence agent. In the real
+    // system the coding.approved event enqueues that job; the harness collapses
+    // the queue hop into the dispatch mock (mirroring the scribe simulation),
+    // so a charge appears here only once coding.approved has fired.
+    charge: {
+      findMany: vi.fn(async (args?: any) => manyFrom(db.charges, args, (row) => clone(row))),
+      create: vi.fn(async ({ data }: any) => {
+        const row = {
+          id: data.id ?? `charge_golden_${db.charges.length + 1}`,
+          createdAt: new Date(),
+          ...clone(data),
+        };
+        db.charges.push(row);
+        return clone(row);
+      }),
+    },
     $transaction: vi.fn(async (callback: any) => callback(prisma)),
   };
 
@@ -451,6 +490,25 @@ const h = vi.hoisted(() => {
   });
   const dispatch = vi.fn(async (event: any) => {
     fixture.dispatchEvents.push(clone(event));
+
+    // EMR-1097 (B4): the encounter-charge-extraction workflow is wired to
+    // coding.approved (NOT encounter.completed), so charges only ever
+    // materialize after the physician approves codes. Simulate that
+    // workflow here — same approach as the scribe-job simulation below.
+    if (event.name === "coding.approved") {
+      db.charges.push({
+        id: `charge_golden_${db.charges.length + 1}`,
+        organizationId: event.organizationId,
+        encounterId: event.encounterId,
+        patientId: event.patientId,
+        cptCode: event.approvedEmLevel,
+        icd10Codes: clone(event.approvedIcd10 ?? []),
+        source: "coding.approved",
+        createdAt: new Date(),
+      });
+      return [];
+    }
+
     if (event.name !== "encounter.note.draft.requested") return [];
     const id = "job_golden_1";
     if (!db.agentJobs.some((job) => job.id === id)) {
@@ -499,6 +557,8 @@ const h = vi.hoisted(() => {
     db.notes.splice(0);
     db.auditLogs.splice(0);
     db.agentJobs.splice(0);
+    db.codingSuggestions.splice(0);
+    db.charges.splice(0);
     fixture.dispatchEvents.splice(0);
     fixture.session.currentUser = users.patient;
 
@@ -624,7 +684,11 @@ import { bookAppointment } from "@/app/(patient)/portal/schedule/actions";
 import { kioskCheckIn, kioskVerifyDob } from "@/app/kiosk/(console)/actions";
 import { moveQueueEncounter, saveRoomingHandoff } from "@/app/(operator)/ops/queue/actions";
 import { startVisit } from "@/app/(clinician)/clinic/patients/[id]/actions";
-import { saveAndFinalizeNote } from "@/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions";
+import {
+  saveAndFinalizeNote,
+  approveCodingSuggestion,
+} from "@/app/(clinician)/clinic/patients/[id]/notes/[noteId]/actions";
+import { workflows } from "@/lib/orchestration/workflows";
 import { ensureEncounterForAppointment } from "./ensure-encounter";
 import { buildVisitCompletionBundle } from "./visit-completion";
 import {
@@ -903,6 +967,83 @@ describe("Golden Visit harness", () => {
       noteFinalizedDispatchCount: 1,
       encounterCompletedDispatchCount: 1,
       closeoutReady: true,
+    });
+  });
+
+  // EMR-1097 (B4 / WS-D) — the physician-in-control billing checkpoint. The
+  // golden visit must finalize WITHOUT auto-creating charges; a charge only
+  // appears after the physician approves the suggested codes.
+  it("gates charge creation on coding approval — no charge is created on finalize, only after the physician approves codes", async () => {
+    // Structural guarantee: charge extraction is bound to coding.approved and
+    // NOT encounter.completed. This is the control point that the wiring move
+    // in EMR-1097 established; assert it can't silently regress.
+    const chargeWorkflow = workflows.find(
+      (w) => w.name === "encounter-charge-extraction",
+    );
+    expect(chargeWorkflow, "encounter-charge-extraction workflow exists").toBeDefined();
+    expect(chargeWorkflow?.on).toContain("coding.approved");
+    expect(chargeWorkflow?.on).not.toContain("encounter.completed");
+
+    // Walk the full happy path through finalize (fires encounter.completed).
+    await runGoldenVisit();
+
+    // The note is signed and the encounter completed, but the physician has
+    // not yet seen/approved the coding suggestions — so NO charge exists and
+    // coding.approved has not fired.
+    expect(dispatchCount("encounter.completed")).toBe(1);
+    expect(dispatchCount("coding.approved")).toBe(0);
+    expect(fixture.db.charges, "no charge before approval").toHaveLength(0);
+
+    // The coding-readiness agent's suggestion is present on the signed note,
+    // awaiting the physician's decision.
+    await h.prisma.codingSuggestion.create({
+      data: {
+        id: "cs_golden_1",
+        noteId: NOTE_ID,
+        icd10: [
+          { code: "G89.29", label: "Other chronic pain", confidence: 0.95 },
+        ],
+        emLevel: "99214",
+        rationale: "Established follow-up, chronic pain management.",
+        status: "suggested",
+      },
+    });
+
+    // Physician approves the suggested codes.
+    fixture.session.currentUser = fixture.users.physician;
+    const approval = await approveCodingSuggestion(NOTE_ID, {
+      icd10: [{ code: "G89.29", label: "Other chronic pain" }],
+      emLevel: "99214",
+      modified: false,
+    });
+    expect(approval).toMatchObject({ ok: true, status: "approved" });
+
+    // The decision is recorded on the (noteId-keyed) suggestion row.
+    const suggestion = fixture.db.codingSuggestions.find(
+      (s) => s.noteId === NOTE_ID,
+    );
+    expect(suggestion).toMatchObject({
+      status: "approved",
+      approvedById: PHYSICIAN_USER_ID,
+      approvedEmLevel: "99214",
+    });
+
+    // coding.approved fires exactly once, carrying the approved codes.
+    expect(dispatchCount("coding.approved")).toBe(1);
+    const approvedEvent = fixture.dispatchEvents.find(
+      (e) => e.name === "coding.approved",
+    );
+    expect(approvedEvent).toMatchObject({
+      encounterId: ENCOUNTER_ID,
+      approvedEmLevel: "99214",
+      approvedIcd10: ["G89.29"],
+    });
+
+    // ...and only now does a charge exist, derived from the approved E/M.
+    expect(fixture.db.charges, "charge created after approval").toHaveLength(1);
+    expect(fixture.db.charges[0]).toMatchObject({
+      encounterId: ENCOUNTER_ID,
+      cptCode: "99214",
     });
   });
 });

--- a/src/lib/domain/state-registry.ts
+++ b/src/lib/domain/state-registry.ts
@@ -1,10 +1,9 @@
 // State Registry API Integration
 // Connects state compliance forms to real state medical cannabis registry systems.
-// Each state has a different API/portal. This module provides a unified interface
-// for the UI; the per-state submission logic lives in
-// `src/lib/integrations/state-registries/`.
-
-import { submitToStateRegistry } from "@/lib/integrations/state-registries";
+// Each state has a different API/portal. This module provides the registry
+// directory + config the compliance UI reads; the actual per-state submission
+// logic lives in `src/lib/integrations/state-registries/` and is called
+// directly from `compliance/actions.ts` via `submitToStateRegistry`.
 
 export type RegistryStatus = "connected" | "pending" | "error" | "not_configured";
 
@@ -20,15 +19,6 @@ export interface StateRegistryConfig {
   renewalPeriodDays: number;
   status: RegistryStatus;
   notes: string;
-}
-
-export interface SubmissionResult {
-  success: boolean;
-  confirmationNumber?: string;
-  registryPatientId?: string;
-  expirationDate?: string;
-  errors?: string[];
-  submittedAt: string;
 }
 
 // ── State registry configurations ──────────────────────
@@ -124,40 +114,6 @@ export const STATE_REGISTRIES: StateRegistryConfig[] = [
     notes: "California does not require physician registration. Prop 215 recommendations are physician-issued. Optional MMIC through county health departments.",
   },
 ];
-
-/**
- * Submit a certification to a state registry. Delegates to the per-state
- * integration module under `src/lib/integrations/state-registries/`.
- */
-export async function submitToRegistry(
-  stateCode: string,
-  formData: Record<string, string | boolean | number>,
-  providerCredentials: { registryId?: string; npi?: string; licenseNumber?: string }
-): Promise<SubmissionResult> {
-  const registry = STATE_REGISTRIES.find((r) => r.stateCode === stateCode);
-  if (!registry) {
-    return {
-      success: false,
-      errors: [`No registry configuration for state: ${stateCode}`],
-      submittedAt: new Date().toISOString(),
-    };
-  }
-
-  const result = await submitToStateRegistry({
-    stateCode,
-    formData,
-    providerCredentials,
-  });
-
-  return {
-    success: result.success,
-    confirmationNumber: result.confirmationNumber,
-    registryPatientId: result.registryPatientId,
-    expirationDate: result.expirationDate,
-    errors: result.errors,
-    submittedAt: result.submittedAt,
-  };
-}
 
 export function getRegistryForState(stateCode: string): StateRegistryConfig | undefined {
   return STATE_REGISTRIES.find((r) => r.stateCode === stateCode);

--- a/src/lib/domain/visit-completion-selection.ts
+++ b/src/lib/domain/visit-completion-selection.ts
@@ -27,7 +27,7 @@ export interface VisitCompletionStructuredEdit {
   customLabels?: string[];
   physicianNote?: string;
   followUpInterval?: string;
-  followUpRouting?: "front_desk" | "scheduling_link" | "no_handoff";
+  followUpRouting?: "front_desk" | "scheduling_link" | "no_handoff" | "book_appointment";
   patientMessageDraft?: string;
   patientMessageChannel?: "portal" | "print" | "sms" | "translation";
   practiceReadinessOwner?: "back_office" | "front_office" | "clinician" | "billing";

--- a/src/lib/domain/visit-completion.test.ts
+++ b/src/lib/domain/visit-completion.test.ts
@@ -166,12 +166,74 @@ describe("buildVisitCompletionBundle", () => {
       },
     });
 
-    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+    const items = bundle.cards.find((card) => card.id === "practice_readiness")?.items;
+    expect(items).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          label: "Coding review needed — 2 suggested codes awaiting approval",
+          tone: "warning",
+          source: "coding",
+          dataMode: "agent_output",
+          proposedActionType: "coding_review",
+        }),
         expect.objectContaining({ label: "Suggested E/M: 99214" }),
         expect.objectContaining({ label: "ICD-10 candidate: E11.9 Diabetes mellitus" }),
+        expect.objectContaining({ label: "ICD-10 candidate: I10 Essential hypertension" }),
       ]),
     );
+    // EMR-1100: no mocked placeholder items remain on this card.
+    expect(items?.every((item) => item.dataMode !== "mvp_mock")).toBe(true);
+  });
+
+  it("shows the approved coding state once the physician signs off", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      hasFutureAppointment: true,
+      codingSuggestion: {
+        emLevel: "99214",
+        rationale: "Chronic condition management with medication adjustment.",
+        icd10: [{ code: "E11.9", label: "Diabetes mellitus", confidence: 0.91 }],
+        status: "modified",
+        approvedByName: "Asha Patel",
+        approvedAt: "2026-06-09T15:00:00.000Z",
+        approvedIcd10: [{ code: "E11.65", label: "Diabetes with hyperglycemia" }],
+        approvedEmLevel: "99215",
+      },
+    });
+
+    expect(bundle.cards.find((card) => card.id === "practice_readiness")?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Codes approved ✓",
+          tone: "neutral",
+          source: "coding",
+          dataMode: "agent_output",
+          reason: expect.stringContaining("Approved by Asha Patel"),
+        }),
+        expect.objectContaining({ label: "Approved E/M: 99215" }),
+        expect.objectContaining({
+          label: "ICD-10 approved: E11.65 Diabetes with hyperglycemia",
+        }),
+      ]),
+    );
+  });
+
+  it("deep-links the Review coding action to the note's coding section", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: true,
+    });
+
+    const reviewCoding = bundle.cards
+      .find((card) => card.id === "practice_readiness")
+      ?.actions.find((action) => action.id === "review_coding");
+    expect(reviewCoding).toMatchObject({
+      proposedActionType: "coding_review",
+      href: "#coding-suggestions",
+    });
   });
 
   it("degrades practice readiness when coding is not available yet", () => {

--- a/src/lib/domain/visit-completion.test.ts
+++ b/src/lib/domain/visit-completion.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildVisitCompletionBundle } from "./visit-completion";
+import {
+  buildVisitCompletionBundle,
+  deriveFollowUpBooking,
+  parseFollowUpIntervalDays,
+} from "./visit-completion";
 
 const followUpBlocks = [
   {
@@ -50,6 +54,7 @@ describe("buildVisitCompletionBundle", () => {
 
     expect(labelsFor("orders")).toEqual(["Review orders", "Approve", "Remove", "Edit", "Defer"]);
     expect(labelsFor("follow_up")).toEqual([
+      "Book follow-up",
       "Send to front desk",
       "Text scheduling link",
       "Edit interval",
@@ -253,5 +258,73 @@ describe("buildVisitCompletionBundle", () => {
       ]),
     );
     expect(bundle.summary).toContain("billing readiness check");
+  });
+});
+
+describe("parseFollowUpIntervalDays", () => {
+  it("parses days, weeks, and months", () => {
+    expect(parseFollowUpIntervalDays("10 days")).toBe(10);
+    expect(parseFollowUpIntervalDays("6 weeks")).toBe(42);
+    expect(parseFollowUpIntervalDays("2 months")).toBe(60);
+    expect(parseFollowUpIntervalDays("3wk")).toBe(21);
+  });
+
+  it("returns null for unparseable or empty intervals", () => {
+    expect(parseFollowUpIntervalDays("as needed")).toBeNull();
+    expect(parseFollowUpIntervalDays("")).toBeNull();
+    expect(parseFollowUpIntervalDays(null)).toBeNull();
+    expect(parseFollowUpIntervalDays("0 weeks")).toBeNull();
+  });
+});
+
+describe("deriveFollowUpBooking", () => {
+  const now = new Date("2026-06-09T15:00:00.000Z");
+
+  it("derives a slot intervalDays out at the default morning hour", () => {
+    const proposal = deriveFollowUpBooking({
+      followUpInterval: "2 weeks",
+      modality: "video",
+      now,
+    });
+    expect(proposal).not.toBeNull();
+    expect(proposal!.intervalDays).toBe(14);
+    expect(proposal!.modality).toBe("video");
+    // 14 days after Jun 9 → Jun 23, 9am local.
+    expect(proposal!.startAt.getDate()).toBe(23);
+    expect(proposal!.startAt.getHours()).toBe(9);
+    // Default 30-minute slot.
+    expect(proposal!.endAt.getTime() - proposal!.startAt.getTime()).toBe(30 * 60_000);
+  });
+
+  it("normalizes an unknown modality to in_person", () => {
+    const proposal = deriveFollowUpBooking({
+      followUpInterval: "1 week",
+      modality: "async_message",
+      now,
+    });
+    expect(proposal!.modality).toBe("in_person");
+  });
+
+  it("returns null when the interval can't be parsed (caller falls back)", () => {
+    expect(
+      deriveFollowUpBooking({ followUpInterval: "soon", modality: "video", now }),
+    ).toBeNull();
+  });
+});
+
+describe("buildFollowUpCard — one-click booking action", () => {
+  it("exposes a primary 'Book follow-up' action with send-to-front-desk as fallback", () => {
+    const bundle = buildVisitCompletionBundle({
+      patientFirstName: "Miguel",
+      blocks: followUpBlocks,
+      codingSuggestion: null,
+      hasFutureAppointment: false,
+    });
+    const followUp = bundle.cards.find((c) => c.id === "follow_up")!;
+    const book = followUp.actions.find((a) => a.proposedActionType === "book_follow_up");
+    expect(book).toBeDefined();
+    expect(book!.variant).toBe("primary");
+    const frontDesk = followUp.actions.find((a) => a.proposedActionType === "send_to_staff");
+    expect(frontDesk!.variant).toBe("secondary");
   });
 });

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -50,6 +50,12 @@ export interface VisitCompletionAction {
   requiresPhysicianApproval: true;
   sideEffect: "none";
   placeholderCopy: string;
+  /**
+   * Optional deep-link target. When set, activating the action navigates
+   * (e.g. "#coding-suggestions" jumps to the note's coding section) instead
+   * of opening the generic details drawer.
+   */
+  href?: string;
 }
 
 export interface VisitCompletionCard {
@@ -95,6 +101,12 @@ export interface VisitCompletionCodingSuggestion {
   icd10: { code: string; label: string; confidence?: number }[];
   emLevel: string | null;
   rationale?: string | null;
+  /** EMR-1097 physician decision: suggested, approved, modified, dismissed. */
+  status?: string | null;
+  approvedByName?: string | null;
+  approvedAt?: Date | string | null;
+  approvedIcd10?: { code: string; label?: string }[] | null;
+  approvedEmLevel?: string | null;
 }
 
 export interface VisitCompletionBlock {
@@ -367,35 +379,11 @@ function buildPatientMessageCard(
 function buildPracticeReadinessCard(
   codingSuggestion: VisitCompletionCodingSuggestion | null,
 ): VisitCompletionCard {
-  const items: VisitCompletionItem[] = [
-    item(
-      "practice-readiness-overview",
-      "Practice Readiness feedback: coding, documentation, prior auth, and staff routing checks.",
-      "neutral",
-      "heuristic",
-      "mvp_mock",
-      "view_checks",
-      "AI summarizes operational checks here so the physician can release intent without doing back-office translation.",
-    ),
-    item(
-      "documentation-gap",
-      "Documentation gap: add medication risk discussion if dose changes proceed",
-      "warning",
-      "heuristic",
-      "deterministic_heuristic",
-      "coding_review",
-      "This strengthens billing readiness and makes the clinical reasoning easier for staff to follow.",
-    ),
-    item(
-      "staff-routing",
-      "Staff task draft: confirm pharmacy and monitor prior-auth need before fulfillment",
-      "neutral",
-      "heuristic",
-      "deterministic_heuristic",
-      "create_staff_task",
-      "This turns the physician's plan into a reviewable staff handoff without silently assigning work.",
-    ),
-  ];
+  // EMR-1100 (M5): this card renders the REAL coding state from the
+  // CodingSuggestion the Coding Readiness Agent attached to the note — no
+  // placeholder copy. The "Review coding" action deep-links to the note's
+  // coding section where the physician approves the codes (EMR-1097).
+  const items: VisitCompletionItem[] = [];
 
   if (!codingSuggestion) {
     items.push(
@@ -410,11 +398,56 @@ function buildPracticeReadinessCard(
       ),
     );
   } else {
-    if (codingSuggestion.emLevel) {
+    const approved =
+      codingSuggestion.status === "approved" || codingSuggestion.status === "modified";
+    const suggestedCount = codingSuggestion.icd10.length;
+
+    if (approved) {
+      const approvedDetail = [
+        codingSuggestion.approvedByName
+          ? `Approved by ${codingSuggestion.approvedByName}`
+          : "Approved by the physician",
+        codingSuggestion.approvedAt
+          ? `on ${new Date(codingSuggestion.approvedAt).toLocaleDateString("en-US")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      items.push(
+        item(
+          "coding-approval-status",
+          "Codes approved ✓",
+          "neutral",
+          "coding",
+          "agent_output",
+          "coding_review",
+          `${approvedDetail}. Charges are extracted from the approved codes.`,
+        ),
+      );
+    } else {
+      items.push(
+        item(
+          "coding-approval-status",
+          `Coding review needed — ${suggestedCount} suggested ${
+            suggestedCount === 1 ? "code" : "codes"
+          } awaiting approval`,
+          "warning",
+          "coding",
+          "agent_output",
+          "coding_review",
+          "No charges are created until the physician approves the suggested codes.",
+        ),
+      );
+    }
+
+    const emLevel = approved
+      ? codingSuggestion.approvedEmLevel ?? codingSuggestion.emLevel
+      : codingSuggestion.emLevel;
+    if (emLevel) {
       items.push(
         item(
           "em-level",
-          `Suggested E/M: ${codingSuggestion.emLevel}`,
+          `${approved ? "Approved" : "Suggested"} E/M: ${emLevel}`,
           "neutral",
           "coding",
           "agent_output",
@@ -422,11 +455,18 @@ function buildPracticeReadinessCard(
         ),
       );
     }
-    for (const candidate of codingSuggestion.icd10.slice(0, 2)) {
+
+    const displayCodes =
+      approved && codingSuggestion.approvedIcd10 && codingSuggestion.approvedIcd10.length > 0
+        ? codingSuggestion.approvedIcd10
+        : codingSuggestion.icd10;
+    for (const candidate of displayCodes.slice(0, 4)) {
       items.push(
         item(
           `icd10-${candidate.code}`,
-          `ICD-10 candidate: ${candidate.code} ${candidate.label}`,
+          `${approved ? "ICD-10 approved" : "ICD-10 candidate"}: ${candidate.code} ${
+            candidate.label ?? ""
+          }`.trim(),
           "neutral",
           "coding",
           "agent_output",
@@ -434,6 +474,7 @@ function buildPracticeReadinessCard(
         ),
       );
     }
+
     if (codingSuggestion.rationale) {
       items.push(
         item(
@@ -456,7 +497,8 @@ function buildPracticeReadinessCard(
     items,
     actions: [
       action("view_checks", "View checks", "primary", "view_checks"),
-      action("review_coding", "Review coding", "secondary", "coding_review"),
+      // Deep-link to the coding section of the note (EMR-1097 approval UI).
+      action("review_coding", "Review coding", "secondary", "coding_review", "#coding-suggestions"),
       action("create_staff_tasks", "Create staff tasks", "secondary", "create_staff_task"),
       action("defer_item", "Defer", "secondary", "defer"),
     ],
@@ -519,6 +561,7 @@ function action(
   label: string,
   variant: VisitCompletionAction["variant"],
   proposedActionType: VisitCompletionProposedActionType,
+  href?: string,
 ): VisitCompletionAction {
   return {
     id,
@@ -530,5 +573,6 @@ function action(
     placeholderCopy:
       ACTION_DISPOSITION_COPY[proposedActionType] ??
       "Physician review required. This control stages the card disposition; Release Care Plan is the only action that creates reviewed tasks, drafts, and audit records.",
+    ...(href ? { href } : {}),
   };
 }

--- a/src/lib/domain/visit-completion.ts
+++ b/src/lib/domain/visit-completion.ts
@@ -24,6 +24,7 @@ export type VisitCompletionProposedActionType =
   | "send_to_staff"
   | "send_to_patient"
   | "text_scheduling_link"
+  | "book_follow_up"
   | "print"
   | "coding_review"
   | "create_staff_task"
@@ -309,7 +310,10 @@ function buildFollowUpCard(text: string, hasFutureAppointment: boolean): VisitCo
     subtitle: "Recommended next touchpoint and scheduling handoff.",
     items,
     actions: [
-      action("send_to_front_desk", "Send to front desk", "primary", "send_to_staff"),
+      // One-click booking is the primary path; the free-text front-desk task
+      // stays as the fallback for complex scheduling (audit minor #7).
+      action("book_follow_up", "Book follow-up", "primary", "book_follow_up"),
+      action("send_to_front_desk", "Send to front desk", "secondary", "send_to_staff"),
       action("text_scheduling_link", "Text scheduling link", "secondary", "text_scheduling_link"),
       action("edit_interval", "Edit interval", "secondary", "edit"),
       action("defer_item", "Defer", "secondary", "defer"),
@@ -550,11 +554,81 @@ const ACTION_DISPOSITION_COPY: Record<VisitCompletionProposedActionType, string>
   send_to_staff: "Stage a front-desk hand-off — created only when you Release Care Plan.",
   send_to_patient: "Stage a patient message — sent only when you Release Care Plan.",
   text_scheduling_link: "Stage a scheduling-link text — sent only when you Release Care Plan.",
+  book_follow_up:
+    "Stage a pre-filled follow-up appointment — booked only when you Release Care Plan.",
   print: "Stage a printout — generated only when you Release Care Plan.",
   coding_review: "Stage coding for review. Nothing is submitted until you Release Care Plan.",
   create_staff_task: "Stage a staff task — created only when you Release Care Plan.",
   view_checks: "View the safety checks behind this card.",
 };
+
+// ───────────────────────────────────────────────────────────────────────────
+// One-click follow-up booking (WS-B / audit minor #7)
+// ───────────────────────────────────────────────────────────────────────────
+// The Follow-Up card's "Book follow-up" action derives a concrete slot from the
+// note's follow-up interval (the same free-text the heuristic already parses)
+// so the visit-completion release can create a real Appointment instead of a
+// free-text front-desk task. Pure + deterministic so both the panel (preview)
+// and the server (authoritative booking) compute the same slot. Returns null
+// when no interval can be parsed — the caller falls back to the front-desk task.
+
+export interface FollowUpBookingProposal {
+  intervalDays: number;
+  modality: string;
+  startAt: Date;
+  endAt: Date;
+}
+
+const FOLLOW_UP_DEFAULT_DURATION_MIN = 30;
+const FOLLOW_UP_DEFAULT_HOUR = 9; // propose a 9am slot; the front desk confirms
+
+/** Parse a free-text follow-up interval ("6 weeks", "10 days", "2 months") to days. */
+export function parseFollowUpIntervalDays(interval: string | null | undefined): number | null {
+  if (!interval) return null;
+  const match = interval.toLowerCase().match(/(\d+)\s*([a-z]+)/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = match[2];
+  if (unit.startsWith("d")) return n; // day / days
+  if (unit.startsWith("w")) return n * 7; // week / weeks / wk
+  if (unit.startsWith("m")) return n * 30; // month / months / mo
+  return null;
+}
+
+function normalizeFollowUpModality(modality: string | null | undefined): string {
+  return modality === "video" || modality === "phone" || modality === "in_person"
+    ? modality
+    : "in_person";
+}
+
+/**
+ * Derive a concrete follow-up appointment slot from the note's interval and the
+ * visit's modality. `now` is injected so the result is deterministic/testable.
+ */
+export function deriveFollowUpBooking(input: {
+  followUpInterval: string | null | undefined;
+  modality: string | null | undefined;
+  now: Date;
+  durationMinutes?: number;
+}): FollowUpBookingProposal | null {
+  const intervalDays = parseFollowUpIntervalDays(input.followUpInterval);
+  if (intervalDays == null) return null;
+
+  const startAt = new Date(input.now);
+  startAt.setDate(startAt.getDate() + intervalDays);
+  startAt.setHours(FOLLOW_UP_DEFAULT_HOUR, 0, 0, 0);
+
+  const durationMinutes = input.durationMinutes ?? FOLLOW_UP_DEFAULT_DURATION_MIN;
+  const endAt = new Date(startAt.getTime() + durationMinutes * 60_000);
+
+  return {
+    intervalDays,
+    modality: normalizeFollowUpModality(input.modality),
+    startAt,
+    endAt,
+  };
+}
 
 function action(
   id: string,

--- a/src/lib/integrations/state-registries/ca.ts
+++ b/src/lib/integrations/state-registries/ca.ts
@@ -3,14 +3,14 @@
 //
 // California does not require physician registration. Prop 215 / SB 420
 // recommendations are physician-issued; the optional MMIC is administered by
-// county health departments, which do not expose a unified API. This stub
-// records a manual submission.
+// county health departments, which do not expose a unified API. Nothing is
+// transmitted electronically — the result is an honest manual_stub marker.
 
-import { buildManualSuccess } from "./client";
+import { buildManualStubResult } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
 export async function submitCA(
   _submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
-  return buildManualSuccess("CA");
+  return buildManualStubResult();
 }

--- a/src/lib/integrations/state-registries/client.ts
+++ b/src/lib/integrations/state-registries/client.ts
@@ -1,9 +1,11 @@
-// Generic helpers shared across per-state registry stubs.
+// Generic helpers shared across per-state registry integrations.
 //
 // Real state registry APIs are heterogeneous (REST/SOAP/portal-only) and
-// most require provider onboarding before credentials are issued. Until
-// each state's contract is implemented, these helpers produce a deterministic
-// stub response so the EMR UI can be exercised end-to-end.
+// most require provider onboarding before credentials are issued. When a
+// state has no API configured (or is paper-based), we DO NOT pretend the
+// submission happened: the result is tagged `mode: "manual_stub"` with no
+// confirmation number, and the UI/server must route the clinician to a
+// manual filing workflow.
 
 import type {
   RegistrySubmission,
@@ -18,7 +20,7 @@ export interface RegistryEndpoint {
 /**
  * Resolve `STATE_REGISTRY_<CODE>_API_URL` and `STATE_REGISTRY_<CODE>_API_KEY`
  * from the environment. Returns null when either is missing — caller should
- * fall back to stub mode.
+ * fall back to manual-stub mode.
  */
 export function resolveRegistryEndpoint(
   stateCode: string,
@@ -30,28 +32,19 @@ export function resolveRegistryEndpoint(
   return { url, apiKey };
 }
 
-export function buildStubSuccess(
-  stateCode: string,
-  renewalPeriodDays: number,
-): RegistrySubmissionResult {
-  const expDate = new Date();
-  expDate.setDate(expDate.getDate() + renewalPeriodDays);
+/**
+ * Honest "nothing was transmitted" result for states without a connected
+ * registry API. Deliberately carries NO confirmation number, registry
+ * patient ID, or expiration date — those can only come from a real
+ * registry response. `success: true` here means "the attempt was recorded
+ * without error", not "the registry accepted a submission"; callers must
+ * branch on `mode` before presenting any success state.
+ */
+export function buildManualStubResult(): RegistrySubmissionResult {
   return {
     success: true,
-    confirmationNumber: `${stateCode.toUpperCase()}-${Date.now().toString(36).toUpperCase()}`,
-    registryPatientId: `REG-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
-    expirationDate: expDate.toISOString().slice(0, 10),
+    mode: "manual_stub",
     submittedAt: new Date().toISOString(),
-    channel: "stub",
-  };
-}
-
-export function buildManualSuccess(stateCode: string): RegistrySubmissionResult {
-  return {
-    success: true,
-    confirmationNumber: `${stateCode.toUpperCase()}-MANUAL-${Date.now().toString(36).toUpperCase()}`,
-    submittedAt: new Date().toISOString(),
-    channel: "manual",
   };
 }
 
@@ -60,14 +53,14 @@ export function buildErrorResult(errors: string[]): RegistrySubmissionResult {
     success: false,
     errors,
     submittedAt: new Date().toISOString(),
-    channel: "electronic",
+    mode: "api",
   };
 }
 
 /**
- * Generic POST submitter for state registry APIs. Each state's stub can call
- * this with its specific path/body shape; in production the path is the only
- * thing that typically differs per state (auth is bearer-token API key).
+ * Generic POST submitter for state registry APIs. Each state's module can
+ * call this with its specific path/body shape; in production the path is the
+ * only thing that typically differs per state (auth is bearer-token API key).
  */
 export async function postToRegistry(
   endpoint: RegistryEndpoint,
@@ -103,11 +96,11 @@ export async function postToRegistry(
 
     return {
       success: true,
+      mode: "api",
       confirmationNumber: result.confirmationNumber,
       registryPatientId: result.patientId,
       expirationDate: result.expirationDate,
       submittedAt: new Date().toISOString(),
-      channel: "electronic",
     };
   } catch (err) {
     return buildErrorResult([

--- a/src/lib/integrations/state-registries/co.ts
+++ b/src/lib/integrations/state-registries/co.ts
@@ -3,13 +3,14 @@
 //
 // Colorado does not require physician registration, and certifications are
 // paper-based: the patient applies to CDPHE with the physician certification.
-// This stub records a manual submission.
+// Nothing is transmitted electronically — the result is an honest manual_stub
+// marker.
 
-import { buildManualSuccess } from "./client";
+import { buildManualStubResult } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
 export async function submitCO(
   _submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
-  return buildManualSuccess("CO");
+  return buildManualStubResult();
 }

--- a/src/lib/integrations/state-registries/fl.ts
+++ b/src/lib/integrations/state-registries/fl.ts
@@ -1,23 +1,22 @@
 // Florida — Medical Marijuana Use Registry (MMUR)
 // https://mmuregistry.flhealth.gov/
 //
-// Stub implementation: production wiring requires onboarding as a qualified
-// physician with FDOH OMMU and obtaining MMUR API credentials. Until then,
-// missing env vars short-circuit to a simulated successful submission.
+// Production wiring requires onboarding as a qualified physician with FDOH
+// OMMU and obtaining MMUR API credentials. Until those env vars are set,
+// nothing is transmitted — the result is an honest manual_stub marker (no
+// fabricated confirmation numbers).
 
 import {
-  buildStubSuccess,
+  buildManualStubResult,
   postToRegistry,
   resolveRegistryEndpoint,
 } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
-const RENEWAL_DAYS = 210;
-
 export async function submitFL(
   submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
   const endpoint = resolveRegistryEndpoint("FL");
-  if (!endpoint) return buildStubSuccess("FL", RENEWAL_DAYS);
+  if (!endpoint) return buildManualStubResult();
   return postToRegistry(endpoint, "/v1/certifications", submission);
 }

--- a/src/lib/integrations/state-registries/il.ts
+++ b/src/lib/integrations/state-registries/il.ts
@@ -1,23 +1,21 @@
 // Illinois — IDPH Medical Cannabis Patient Program
 // https://dph.illinois.gov/topics-services/prevention-wellness/medical-cannabis.html
 //
-// Physician certifications are submitted through the IDPH portal. Stub
-// implementation falls back to a simulated submission when API credentials
-// are not configured.
+// Physician certifications are submitted through the IDPH portal. When API
+// credentials are not configured, nothing is transmitted — the result is an
+// honest manual_stub marker (no fabricated confirmation numbers).
 
 import {
-  buildStubSuccess,
+  buildManualStubResult,
   postToRegistry,
   resolveRegistryEndpoint,
 } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
-const RENEWAL_DAYS = 365;
-
 export async function submitIL(
   submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
   const endpoint = resolveRegistryEndpoint("IL");
-  if (!endpoint) return buildStubSuccess("IL", RENEWAL_DAYS);
+  if (!endpoint) return buildManualStubResult();
   return postToRegistry(endpoint, "/mcpp/certifications", submission);
 }

--- a/src/lib/integrations/state-registries/index.ts
+++ b/src/lib/integrations/state-registries/index.ts
@@ -22,6 +22,7 @@ import type {
 export type {
   ProviderCredentials,
   RegistrySubmission,
+  RegistrySubmissionMode,
   RegistrySubmissionResult,
   StateRegistrySubmitter,
 } from "./types";
@@ -52,7 +53,7 @@ export async function submitToStateRegistry(
         (i) => `${i.path.join(".") || "(root)"}: ${i.message}`,
       ),
       submittedAt: new Date().toISOString(),
-      channel: "electronic",
+      mode: "api",
     };
   }
 
@@ -63,7 +64,7 @@ export async function submitToStateRegistry(
       success: false,
       errors: [`No registry integration registered for state: ${code}`],
       submittedAt: new Date().toISOString(),
-      channel: "electronic",
+      mode: "api",
     };
   }
 

--- a/src/lib/integrations/state-registries/mi.ts
+++ b/src/lib/integrations/state-registries/mi.ts
@@ -3,13 +3,14 @@
 //
 // Michigan certifications are paper-based: the patient submits the physician
 // certification along with their application to LARA. There is no electronic
-// submission API, so this stub records a manual submission.
+// submission API, so nothing is transmitted — the result is an honest
+// manual_stub marker.
 
-import { buildManualSuccess } from "./client";
+import { buildManualStubResult } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
 export async function submitMI(
   _submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
-  return buildManualSuccess("MI");
+  return buildManualStubResult();
 }

--- a/src/lib/integrations/state-registries/ny.ts
+++ b/src/lib/integrations/state-registries/ny.ts
@@ -1,22 +1,21 @@
 // New York — NY Office of Cannabis Management (OCM) Medical Cannabis Program
 // https://cannabis.ny.gov/medical-cannabis
 //
-// Practitioners must be registered with NY OCM. Stub implementation falls back
-// to a simulated submission when API credentials are not configured.
+// Practitioners must be registered with NY OCM. When API credentials are not
+// configured, nothing is transmitted — the result is an honest manual_stub
+// marker (no fabricated confirmation numbers).
 
 import {
-  buildStubSuccess,
+  buildManualStubResult,
   postToRegistry,
   resolveRegistryEndpoint,
 } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
-const RENEWAL_DAYS = 365;
-
 export async function submitNY(
   submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
   const endpoint = resolveRegistryEndpoint("NY");
-  if (!endpoint) return buildStubSuccess("NY", RENEWAL_DAYS);
+  if (!endpoint) return buildManualStubResult();
   return postToRegistry(endpoint, "/practitioner/certifications", submission);
 }

--- a/src/lib/integrations/state-registries/oh.ts
+++ b/src/lib/integrations/state-registries/oh.ts
@@ -2,22 +2,21 @@
 // https://www.medicalmarijuana.ohio.gov/
 //
 // Physicians must hold a CTR certificate from the Ohio State Medical Board.
-// Stub implementation falls back to a simulated submission when API
-// credentials are not configured.
+// When API credentials are not configured, nothing is transmitted — the
+// result is an honest manual_stub marker (no fabricated confirmation
+// numbers).
 
 import {
-  buildStubSuccess,
+  buildManualStubResult,
   postToRegistry,
   resolveRegistryEndpoint,
 } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
-const RENEWAL_DAYS = 365;
-
 export async function submitOH(
   submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
   const endpoint = resolveRegistryEndpoint("OH");
-  if (!endpoint) return buildStubSuccess("OH", RENEWAL_DAYS);
+  if (!endpoint) return buildManualStubResult();
   return postToRegistry(endpoint, "/ctr/recommendations", submission);
 }

--- a/src/lib/integrations/state-registries/pa.ts
+++ b/src/lib/integrations/state-registries/pa.ts
@@ -2,22 +2,21 @@
 // https://padohmmp.custhelp.com/
 //
 // Practitioners must register with PA DOH and complete the 4-hour course.
-// Stub implementation falls back to a simulated submission when API
-// credentials are not configured.
+// When API credentials are not configured, nothing is transmitted — the
+// result is an honest manual_stub marker (no fabricated confirmation
+// numbers).
 
 import {
-  buildStubSuccess,
+  buildManualStubResult,
   postToRegistry,
   resolveRegistryEndpoint,
 } from "./client";
 import type { RegistrySubmission, RegistrySubmissionResult } from "./types";
 
-const RENEWAL_DAYS = 365;
-
 export async function submitPA(
   submission: RegistrySubmission,
 ): Promise<RegistrySubmissionResult> {
   const endpoint = resolveRegistryEndpoint("PA");
-  if (!endpoint) return buildStubSuccess("PA", RENEWAL_DAYS);
+  if (!endpoint) return buildManualStubResult();
   return postToRegistry(endpoint, "/v1/certifications", submission);
 }

--- a/src/lib/integrations/state-registries/types.ts
+++ b/src/lib/integrations/state-registries/types.ts
@@ -21,15 +21,27 @@ export const registrySubmissionSchema = z.object({
 
 export type RegistrySubmission = z.infer<typeof registrySubmissionSchema>;
 
+/**
+ * How the submission was (or wasn't) transmitted.
+ *
+ * - "api"         — a real registry API call was attempted. Confirmation
+ *                   numbers come from the registry, never fabricated.
+ * - "manual_stub" — no registry API is connected for this state (either the
+ *                   state is paper-based or credentials are not configured).
+ *                   NOTHING was transmitted. Callers must surface this as
+ *                   "manual filing required" — never as an electronic
+ *                   submission success, and never with a confirmation number.
+ */
+export type RegistrySubmissionMode = "api" | "manual_stub";
+
 export interface RegistrySubmissionResult {
   success: boolean;
+  mode: RegistrySubmissionMode;
   confirmationNumber?: string;
   registryPatientId?: string;
   expirationDate?: string;
   errors?: string[];
   submittedAt: string;
-  /** "electronic" = real/simulated API call; "manual" = paper-based state */
-  channel: "electronic" | "manual" | "stub";
 }
 
 export type StateRegistrySubmitter = (

--- a/src/lib/orchestration/events.ts
+++ b/src/lib/orchestration/events.ts
@@ -49,7 +49,10 @@ export type DomainEvent =
   | { name: "prior_auth.obtained"; patientId: string; authNumber: string; organizationId: string }
   | { name: "coding.recommended"; encounterId: string; patientId: string; overallConfidence: number; requiresReview: boolean; organizationId: string }
   | { name: "coding.review_needed"; encounterId: string; patientId: string; reason: string; organizationId: string }
-  | { name: "coding.approved"; encounterId: string; patientId: string; approvedBy: string; organizationId: string }
+  // EMR-1097: emitted when the physician approves (or edits-then-approves) the
+  // coding suggestions on a finalized note. Carries the approved codes so
+  // downstream billing agents reconcile against the physician's decision.
+  | { name: "coding.approved"; noteId: string; encounterId: string; patientId: string; organizationId: string; approvedBy: string; approvedIcd10: string[]; approvedEmLevel: string | null }
   | { name: "claim.scrubbed"; claimId: string; organizationId: string; status: "clean" | "warnings" | "blocked"; scrubResultId: string }
   | { name: "claim.blocked"; claimId: string; organizationId: string; violations: string[] }
   | { name: "clearinghouse.queued"; claimId: string; submissionId: string; organizationId: string; isSecondary: boolean }

--- a/src/lib/orchestration/runner.skip-noop.test.ts
+++ b/src/lib/orchestration/runner.skip-noop.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * WS-B Task 4 — queue hygiene.
+ *
+ * An approval-gated agent that runs but decides there is nothing to do (returns
+ * a top-level `skipped: true` no-op — e.g. the patient-outreach M6 dedup standing
+ * down because the visit-completion release already drafted the message) must NOT
+ * land in the needs_approval queue. A zero-action item there is a phantom in the
+ * physician's approvals inbox. The runner resolves a no-op skip as a benign
+ * success instead.
+ */
+const hoisted = vi.hoisted(() => {
+  const run = vi.fn();
+  return {
+    run,
+    fakeAgent: {
+      name: "patientOutreach",
+      version: "1.0.0",
+      description: "test",
+      allowedActions: [] as string[],
+      requiresApproval: true,
+      inputSchema: { parse: (v: unknown) => v },
+      outputSchema: { parse: (v: unknown) => v },
+      run: (...args: unknown[]) => run(...args),
+    },
+    markRunning: vi.fn(),
+    markSucceeded: vi.fn(),
+    markNeedsApproval: vi.fn(),
+    markFailed: vi.fn(),
+    markCancelled: vi.fn(),
+    applyDefaultDecision: vi.fn(),
+    claimNextJob: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/agents", () => ({ agentRegistry: { patientOutreach: hoisted.fakeAgent } }));
+vi.mock("@/lib/db/agent-settings", () => ({ isAgentEnabled: vi.fn().mockResolvedValue(true) }));
+vi.mock("./queue", () => ({
+  markRunning: hoisted.markRunning,
+  markSucceeded: hoisted.markSucceeded,
+  markNeedsApproval: hoisted.markNeedsApproval,
+  markFailed: hoisted.markFailed,
+  markCancelled: hoisted.markCancelled,
+  applyDefaultDecision: hoisted.applyDefaultDecision,
+  claimNextJob: hoisted.claimNextJob,
+}));
+vi.mock("./context", () => ({
+  createAgentContext: () => ({
+    ctx: { log: vi.fn() },
+    drainLogs: () => [],
+    reasoning: { steps: [], sources: {} },
+  }),
+}));
+
+import { runJob } from "./runner";
+
+function job(over: Record<string, unknown> = {}) {
+  return {
+    id: "job_1",
+    organizationId: null, // null → skip the owner default-decision lookup
+    workflowName: "patient-outreach",
+    agentName: "patientOutreach",
+    eventName: "encounter.completed",
+    input: { patientId: "p1", encounterId: "e1" },
+    requiresApproval: true,
+    ...over,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runJob — no-op skip routing", () => {
+  it("resolves a top-level `skipped: true` no-op as success, not needs_approval", async () => {
+    hoisted.run.mockResolvedValue({ draftMessageId: null, subject: "", tone: "warm", skipped: true });
+
+    await runJob(job(), "test-worker");
+
+    expect(hoisted.markSucceeded).toHaveBeenCalledWith("job_1", expect.objectContaining({ skipped: true }), []);
+    expect(hoisted.markNeedsApproval).not.toHaveBeenCalled();
+  });
+
+  it("still routes a real draft (no skip) to needs_approval", async () => {
+    hoisted.run.mockResolvedValue({ draftMessageId: "m_1", subject: "Hi", tone: "warm" });
+
+    await runJob(job(), "test-worker");
+
+    expect(hoisted.markNeedsApproval).toHaveBeenCalledWith("job_1", expect.objectContaining({ draftMessageId: "m_1" }), []);
+    expect(hoisted.markSucceeded).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/orchestration/runner.ts
+++ b/src/lib/orchestration/runner.ts
@@ -195,8 +195,20 @@ export async function runJob(job: AgentJob, workerId: string): Promise<void> {
       }
     }
 
+    // A no-op skip — the agent decided there was nothing to do (e.g. the
+    // patient-outreach M6 dedup, which stands down when the physician-reviewed
+    // visit-completion release already drafted the post-visit message) — is not
+    // an artifact awaiting human sign-off. Routing it to needs_approval leaves a
+    // phantom zero-action item in the physician's approvals surfaces (the clinic
+    // dashboard needs_approval count + fleet activity feed). Resolve it as a
+    // benign success so the inbox only shows actionable drafts.
+    const isNoOpSkip =
+      output != null &&
+      typeof output === "object" &&
+      (output as { skipped?: unknown }).skipped === true;
+
     const finalLogs = drainLogs();
-    if (!mustApprove) {
+    if (!mustApprove || isNoOpSkip) {
       await markSucceeded(job.id, output, finalLogs);
     } else if (resolved) {
       await applyDefaultDecision(

--- a/src/lib/orchestration/workflows.ts
+++ b/src/lib/orchestration/workflows.ts
@@ -332,16 +332,24 @@ export const workflows: WorkflowDefinition[] = [
       },
     ],
   },
-  // encounter.completed → Encounter Intelligence → charge.created
+  // coding.approved → Encounter Intelligence → charge.created
+  // EMR-1097 (B4): this used to fire on encounter.completed, which created
+  // charges BEFORE the physician ever saw the coding suggestions. Charges are
+  // billing artifacts of the physician's coding decision, so extraction now
+  // waits for coding.approved and carries the approved codes so the agent can
+  // reconcile its extraction against them.
   {
     name: "encounter-charge-extraction",
-    on: ["encounter.completed"],
+    on: ["coding.approved"],
     steps: [
       {
         agent: "encounterIntelligence",
         input: (e) => ({
           encounterId: (e as any).encounterId,
           patientId: (e as any).patientId,
+          noteId: (e as any).noteId,
+          approvedIcd10: (e as any).approvedIcd10,
+          approvedEmLevel: (e as any).approvedEmLevel ?? null,
         }),
       },
     ],


### PR DESCRIPTION
## Summary

This PR ships the full physician-workflow debt burn-down from the happy-path audit (`PHYSICIAN_WORKFLOW_AUDIT.md`, included): **4 blockers, 7 majors, and all 14 minor findings** across two phases, tracked in Linear as EMR-1094–1107.

### Phase 1 — blockers & majors (EMR-1094–1102)
- **Orders persist** (B1): new `ClinicalOrder` model + RBAC'd, audit-logged server action; lab/imaging orders leave a real trace instead of a `console.log` simulation
- **Compliance e-signature persists** (B2/M7): form wired to `StateComplianceForm` with save/sign/submit server actions, server-side required-field validation, locked records after signing
- **Honest registry stubs** (B3): no more fabricated confirmation numbers — stub mode shows an amber "manual submission required" notice; `submitted` only ever means a real API acceptance
- **Physician controls billing intent** (B4/M5): new `coding.approved` event + approve/modify UI on coding suggestions; **charge extraction now triggers on coding approval, not note finalization**; Practice Readiness card reads real coding data
- **Rx data integrity** (M1–M4): recommendations persist (`CannabisRecommendation`) and pre-fill the prescribe form; pharmacy selection required and saved; diagnosis codes captured from the problem list
- **Message dedup** (M6): exactly one post-visit patient draft (visit-completion release wins over the outreach agent)

### Phase 2 — four parallel workstreams (EMR-1104–1107)
- **WS-A Documentation Cockpit**: debounced autosave + beforeunload guard, cosign-aware finalize messaging, status badge in the header, honest button labels, post-finalize agent-status strip
- **WS-B Visit Wrap-Up**: one-click follow-up booking from the completion panel (cadence-derived, weekend-aware), leaflet preview in the release flow, appointment-derived encounter modality, no-op agent skips no longer clutter the approvals queue, Messaging Assistant wired to a real surface
- **WS-C Prescribing Safety**: pharmacy + CURES + high-risk attestation enforced **server-side** (high-dose THC, age ≥65, psychiatric comorbidity), drug-interaction re-check for custom/free-text products, compliance print packet, corpus fallback
- **WS-D Chart Data Reuse**: clinical orders surfaced on the chart (tab + peek + `/orders` index that previously 404'd), intake→demographics prefill, lab attachments persisted as chart Documents, golden-visit coverage of the no-charge-before-approval invariant
- Plus a repo-wide retirement of the never-written `needs_review` note status (sign-off queue, Mission Control, brief view, billing agents now key off `pending_cosign` — the sign-off queue was permanently empty before this)

## Database changes (action required on merge)

New migration: `prisma/migrations/20260609180000_emr1103_clinical_orders_and_coding_approval`

| Change | Detail |
|--------|--------|
| New table `ClinicalOrder` | lab/imaging orders + 2 indexes |
| New table `CannabisRecommendation` | persisted decision support + index |
| `DosingRegimen` | + `pharmacyId`, `pharmacyName` |
| `CodingSuggestion` | + `status` (default `suggested`), `approvedById`, `approvedByName`, `approvedAt`, `approvedIcd10`, `approvedEmLevel` |

All statements are `IF NOT EXISTS`/idempotent. **No manual step needed on Render** — `startCommand` already runs `npx prisma migrate deploy`. `prisma/seed.ts` extended so demo orgs exercise the new surfaces.

## Behavior change to be aware of

Charges are no longer auto-created at note finalization. They are created when the physician approves the coding suggestions (new approval card in the note editor, deep-linked from visit completion). This was the audit's core "physician in control" finding.

## Verification

- `npm run typecheck` clean, `prisma validate` passes
- Full vitest suite: **3,018/3,018 passing** (329 files; up from 2,959 pre-PR, ~60 new tests including coding-approval, compliance sign/submit, follow-up booking, high-risk attestation, and order-persistence coverage)
- Each workstream branch was independently verified green before merging; merge train C → A → B → D produced zero conflicts

https://claude.ai/code/session_0197HFLGFWpoNNQfYggGHS5q

---
_Generated by [Claude Code](https://claude.ai/code/session_0197HFLGFWpoNNQfYggGHS5q)_