### PR TITLE
EMR-614: /clinic/providers Ancillary Services section — modality gate dispensaries

### DIFF
--- a/src/app/(clinician)/clinic/providers/ancillary-services-directory.tsx
+++ b/src/app/(clinician)/clinic/providers/ancillary-services-directory.tsx
@@ -146,9 +146,30 @@ function SearchIcon() {
 
 const ALL_CATEGORIES = Object.keys(CATEGORY_LABELS) as ServiceCategory[];
 
-export function AncillaryServicesDirectory() {
+interface Props {
+  /** Gate dispensary entries behind the cannabis-medicine modality. */
+  showDispensaries?: boolean;
+}
+
+export function AncillaryServicesDirectory({ showDispensaries = false }: Props) {
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<ServiceCategory | null>(null);
+
+  const visibleCategories = useMemo(
+    () =>
+      showDispensaries
+        ? ALL_CATEGORIES
+        : ALL_CATEGORIES.filter((c) => c !== "dispensary"),
+    [showDispensaries],
+  );
+
+  const visibleServices = useMemo(
+    () =>
+      showDispensaries
+        ? SERVICES
+        : SERVICES.filter((s) => s.category !== "dispensary"),
+    [showDispensaries],
+  );
 
   // Listen for "ancillary:filter" events dispatched by the provider-directory
   // slash-command handler (e.g. /ancillary lab) so the two sibling client
@@ -156,24 +177,30 @@ export function AncillaryServicesDirectory() {
   useEffect(() => {
     function handleFilter(e: Event) {
       const cat = (e as CustomEvent<{ category: string }>).detail.category;
-      setActiveCategory(ALL_CATEGORIES.includes(cat as ServiceCategory) ? (cat as ServiceCategory) : null);
+      setActiveCategory(
+        visibleCategories.includes(cat as ServiceCategory)
+          ? (cat as ServiceCategory)
+          : null,
+      );
     }
     document.addEventListener("ancillary:filter", handleFilter);
     return () => document.removeEventListener("ancillary:filter", handleFilter);
-  }, []);
+  }, [visibleCategories]);
 
   const categoryCounts = useMemo(() => {
     const counts = {} as Record<ServiceCategory, number>;
-    SERVICES.forEach((s) => { counts[s.category] = (counts[s.category] ?? 0) + 1; });
+    visibleServices.forEach((s) => {
+      counts[s.category] = (counts[s.category] ?? 0) + 1;
+    });
     return counts;
-  }, []);
+  }, [visibleServices]);
 
   const filtered = useMemo(() => {
-    let list = SERVICES;
+    let list = visibleServices;
     if (activeCategory) list = list.filter((s) => s.category === activeCategory);
     if (search.trim()) list = list.filter((s) => matchesQuery(s, search));
     return list;
-  }, [search, activeCategory]);
+  }, [search, activeCategory, visibleServices]);
 
   return (
     <section id="ancillary" className="space-y-5">
@@ -199,9 +226,9 @@ export function AncillaryServicesDirectory() {
           aria-pressed={activeCategory === null}
         >
           All
-          <span className="opacity-60 tabular-nums">{SERVICES.length}</span>
+          <span className="opacity-60 tabular-nums">{visibleServices.length}</span>
         </button>
-        {ALL_CATEGORIES.map((cat) => (
+        {visibleCategories.map((cat) => (
           <button
             key={cat}
             onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
@@ -272,7 +299,7 @@ export function AncillaryServicesDirectory() {
                         <path
                           d="M2 1h2.5l1 3-1.5 1a7.5 7.5 0 003 3l1-1.5 3 1V10a1 1 0 01-1 1A9 9 0 011 2a1 1 0 011-1z"
                           stroke="currentColor"
-                          strokeWidth="1.1"
+                          strokeWidth="1.2"
                           strokeLinejoin="round"
                         />
                       </svg>

--- a/src/app/(clinician)/clinic/providers/page.tsx
+++ b/src/app/(clinician)/clinic/providers/page.tsx
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { EmptyState } from "@/components/ui/empty-state";
 import { logger } from "@/lib/observability/log";
+import { isModalityEnabled } from "@/lib/modality/server";
 import {
   ProvidersDirectoryClient,
   type ProviderRow,
@@ -18,6 +19,10 @@ const PROVIDER_DIRECTORY_CAP = 5_000;
 
 export default async function ProvidersPage() {
   const user = await requireUser();
+  const cannabisEnabled = await isModalityEnabled(
+    user.organizationId ?? "",
+    "cannabis-medicine",
+  );
 
   const providers = await prisma.provider.findMany({
     where: {
@@ -69,12 +74,12 @@ export default async function ProvidersPage() {
           description="There are no active providers in your organization yet."
         />
       ) : (
-        <ProvidersDirectoryClient providers={rows} />
+        <ProvidersDirectoryClient providers={rows} showDispensaries={cannabisEnabled} />
       )}
 
-      {/* EMR-667 — Ancillary Services directory (labs, imaging, pharmacy, dispensary) */}
+      {/* EMR-614 — Ancillary Services directory (labs, imaging, pharmacy, dispensary) */}
       <div className="mt-12 pt-8 border-t border-border">
-        <AncillaryServicesDirectory />
+        <AncillaryServicesDirectory showDispensaries={cannabisEnabled} />
       </div>
     </PageShell>
   );

--- a/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
+++ b/src/app/(clinician)/clinic/providers/providers-directory-client.tsx
@@ -29,6 +29,8 @@ export interface ProviderRow extends SearchableProvider {
 
 interface Props {
   providers: ProviderRow[];
+  /** Gate the /ancillary dispensary slash-command behind the cannabis modality. */
+  showDispensaries?: boolean;
 }
 
 // ── Slash-command helpers ──────────────────────────────────────────────────
@@ -73,7 +75,11 @@ function applyFilter(providers: ProviderRow[], search: string): ProviderRow[] {
   return providers.filter((p) => providerMatchesQuery(p, search));
 }
 
-function getSuggestions(raw: string, providers: ProviderRow[]): string[] {
+function getSuggestions(
+  raw: string,
+  providers: ProviderRow[],
+  ancillaryKeys: string[],
+): string[] {
   if (!raw.startsWith("/")) return [];
   const body = raw.slice(1);
 
@@ -88,12 +94,14 @@ function getSuggestions(raw: string, providers: ProviderRow[]): string[] {
   }
   if (body.startsWith("ancillary")) {
     const term = body.slice("ancillary".length).trimStart().toLowerCase();
-    return ANCILLARY_CATEGORY_KEYS.filter(
-      (c) =>
-        !term ||
-        c.startsWith(term) ||
-        ANCILLARY_CATEGORY_LABELS[c].toLowerCase().startsWith(term),
-    ).map((c) => `/ancillary ${c}`);
+    return ancillaryKeys
+      .filter(
+        (c) =>
+          !term ||
+          c.startsWith(term) ||
+          ANCILLARY_CATEGORY_LABELS[c].toLowerCase().startsWith(term),
+      )
+      .map((c) => `/ancillary ${c}`);
   }
   if (body.startsWith("specialty ")) {
     const term = body.slice(10).toLowerCase();
@@ -134,13 +142,24 @@ function SearchIcon() {
 
 // ── Main component ─────────────────────────────────────────────────────────
 
-export function ProvidersDirectoryClient({ providers }: Props) {
+export function ProvidersDirectoryClient({ providers, showDispensaries = false }: Props) {
   const [search, setSearch] = useState("");
   const [showDropdown, setShowDropdown] = useState(false);
   const [activeIdx, setActiveIdx] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const suggestions = useMemo(() => getSuggestions(search, providers), [search, providers]);
+  const ancillaryKeys = useMemo(
+    () =>
+      showDispensaries
+        ? ANCILLARY_CATEGORY_KEYS
+        : ANCILLARY_CATEGORY_KEYS.filter((k) => k !== "dispensary"),
+    [showDispensaries],
+  );
+
+  const suggestions = useMemo(
+    () => getSuggestions(search, providers, ancillaryKeys),
+    [search, providers, ancillaryKeys],
+  );
   const filtered = useMemo(() => applyFilter(providers, search), [providers, search]);
   const { mode } = parseSlashCommand(search);
 


### PR DESCRIPTION
Implements EMR-614.

## What changed
- `page.tsx`: calls `isModalityEnabled(orgId, "cannabis-medicine")` at render time and threads the boolean down as `showDispensaries` prop to both child components
- `ancillary-services-directory.tsx`: accepts `showDispensaries?: boolean`; derives `visibleCategories` and `visibleServices` via `useMemo` so dispensary cards and the Dispensary filter pill are suppressed when the modality is off. The `useEffect` event listener and `categoryCounts` memos now depend on the gated lists, keeping them in sync
- `providers-directory-client.tsx`: accepts `showDispensaries?: boolean`; filters `ANCILLARY_CATEGORY_KEYS` to exclude `"dispensary"` before passing to `getSuggestions`, so the `/ancillary dispensary` slash-command suggestion only appears for cannabis-enabled practices

## How to verify
- Enable `cannabis-medicine` for a test practice → navigate to `/clinic/providers`; Dispensary cards (Leafly, Harvest House) and the Dispensary filter pill should appear; `/ancillary dispensary` should appear in the slash-command dropdown
- Disable `cannabis-medicine` → same page; no Dispensary cards, no Dispensary pill, `/ancillary dispensary` absent from suggestions; all other categories (Lab, Imaging, Pharmacy, Rehab) unaffected

## Notes
- The Ancillary Services section itself was first introduced in EMR-667 (commit `7dc3bc54`); this PR retroactively closes the modality-gate gap that ticket left open
- No schema changes, no new dependencies
- Follow-up: persist the ancillary services list to an `AncillaryFacility` DB table so practices can manage their own referral contacts

---
_Generated by [Claude Code](https://claude.ai/code/session_014i5dEhkuVnzq7k55fdQ6Zo)_