### PR TITLE
ai-config: stop a DB failure from killing the whole /ops segment

### DIFF
--- a/src/app/(operator)/ops/error.tsx
+++ b/src/app/(operator)/ops/error.tsx
@@ -2,6 +2,7 @@
 
 import { EmptyIllustration } from "@/components/ui/ornament";
 import { Button } from "@/components/ui/button";
+import { useReportError } from "@/components/error-pages/use-report-error";
 
 export default function Error({
   error,
@@ -10,6 +11,8 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useReportError(error);
+
   return (
     <div className="px-6 lg:px-12 py-10">
       <div className="mx-auto w-full max-w-[800px] flex flex-col items-center text-center py-16">
@@ -21,6 +24,11 @@ export default function Error({
           We ran into an unexpected issue loading the operations dashboard. This
           has been logged. Try refreshing, or go back to ops.
         </p>
+        {error.digest && (
+          <p className="text-xs text-text-subtle mt-3 font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
         <div className="mt-6 flex items-center gap-3">
           <Button onClick={() => reset()} variant="secondary">
             Try again

--- a/src/app/(operator)/ops/error.tsx
+++ b/src/app/(operator)/ops/error.tsx
@@ -4,6 +4,13 @@ import { EmptyIllustration } from "@/components/ui/ornament";
 import { Button } from "@/components/ui/button";
 import { useReportError } from "@/components/error-pages/use-report-error";
 
+// Hook usage lives in a child so the boundary component itself stays
+// hook-free — unit tests invoke it as a plain function (no React render).
+function ReportToSentry({ error }: { error: Error & { digest?: string } }) {
+  useReportError(error);
+  return null;
+}
+
 export default function Error({
   error,
   reset,
@@ -11,10 +18,9 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useReportError(error);
-
   return (
     <div className="px-6 lg:px-12 py-10">
+      <ReportToSentry error={error} />
       <div className="mx-auto w-full max-w-[800px] flex flex-col items-center text-center py-16">
         <EmptyIllustration size={120} />
         <h1 className="font-display text-3xl text-text tracking-tight mt-4">

--- a/src/app/(operator)/ops/settings/ai-config/page.tsx
+++ b/src/app/(operator)/ops/settings/ai-config/page.tsx
@@ -6,10 +6,10 @@ import { defaultFleetEnabledForPractice } from "@/lib/orchestration/fleet";
 
 export const metadata = { title: "AI Model Configuration" };
 
-export default async function AiConfigPage() {
-  const user = await requireUser();
-  const organizationId = user.organizationId!;
-
+async function loadOrCreatePracticeConfig(
+  organizationId: string,
+  organizationName: string | null,
+) {
   let practiceConfig = await prisma.practiceConfiguration.findFirst({
     where: { organizationId },
     orderBy: { version: "desc" },
@@ -23,7 +23,7 @@ export default async function AiConfigPage() {
       practice = await prisma.practice.create({
         data: {
           organizationId,
-          name: user.organizationName || "Practice",
+          name: organizationName || "Practice",
         },
       });
     }
@@ -51,8 +51,35 @@ export default async function AiConfigPage() {
     });
   }
 
-  const flags = (practiceConfig.regulatoryFlags ?? {}) as Record<string, any>;
-  const aiConfig = flags.aiConfig ?? {};
+  return practiceConfig;
+}
+
+export default async function AiConfigPage() {
+  const user = await requireUser();
+  const organizationId = user.organizationId!;
+
+  // A database problem here (schema drift, bad row data) used to take down
+  // the whole /ops segment with an opaque error page. Degrade instead: log
+  // the real cause for the server logs and render with defaults so the
+  // operator can still see the surface. Saves go through the server action,
+  // which re-reads + merges the stored config itself, so rendering with an
+  // empty initial config cannot clobber saved settings.
+  let configLoadError = false;
+  let aiConfig: Record<string, any> = {};
+  try {
+    const practiceConfig = await loadOrCreatePracticeConfig(
+      organizationId,
+      user.organizationName,
+    );
+    const flags = (practiceConfig.regulatoryFlags ?? {}) as Record<string, any>;
+    aiConfig = flags.aiConfig ?? {};
+  } catch (err) {
+    configLoadError = true;
+    console.error(
+      `[ai-config] failed to load practice configuration for org ${organizationId}:`,
+      err,
+    );
+  }
 
   return (
     <PageShell maxWidth="max-w-[1080px]">
@@ -61,6 +88,23 @@ export default async function AiConfigPage() {
         title="AI model configuration"
         description="Pick a practice-wide default, then tune any agent in the fleet."
       />
+
+      {configLoadError && (
+        <div
+          role="alert"
+          className="mb-5 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3"
+        >
+          <p className="text-sm font-medium text-amber-800">
+            We couldn&apos;t load your saved AI configuration.
+          </p>
+          <p className="text-xs text-amber-700 mt-1 leading-relaxed">
+            The settings below show platform defaults, not your saved values.
+            The underlying database error has been written to the server logs
+            (search for &quot;[ai-config]&quot;). Saving may fail until it is
+            resolved.
+          </p>
+        </div>
+      )}
 
       <AiConfigTabs initialAiConfig={aiConfig} />
     </PageShell>


### PR DESCRIPTION
## Problem

`/ops/settings/ai-config` crashes to the opaque "Something went wrong" ops error screen in production (reported by the owner). The same code works in every locally reproducible configuration — dev and production builds, seeded org, and a fresh org with no practice config — so the failure is environment-specific, almost certainly a database-level error (schema drift or bad row data) on the `PracticeConfiguration` / `Practice` read path. Next.js hides server error details in production, so the current screen gives zero clues.

Notably, the operator layout wraps its own queries in `safe()` for exactly this class of prod DB error; this page's queries were the only unguarded ones in the render path.

## Changes

- **Degrade instead of dying:** the config load/create is wrapped in a try/catch. On failure the page logs the real Prisma error server-side tagged `[ai-config]` (visible in Render logs for `emr-web`) and renders with platform defaults plus an amber notice, instead of taking down the whole `/ops` segment. Saves still go through the server action, which re-reads and merges the stored config itself, so rendering with an empty initial config cannot clobber saved settings.
- **`ops/error.tsx`:** show `error.digest` and report to Sentry via `useReportError`, matching the `(operator)` root boundary, so future opaque crashes can be correlated with server logs.

## Verification

- Typecheck, production build, and related unit tests (`ai-config-merge`, `fleet`) pass.
- Happy path: page renders normally with a healthy DB (dev + prod-mode server).
- Failure path: with simulated schema drift (renamed a `PracticeConfiguration` column locally), the page returns 200 with the notice and logs the underlying `PrismaClientKnownRequestError`.

## After deploy

Reload AI Config as the owner. Either it works, or the amber notice appears — in that case the exact root-cause database error is in the Render logs under `[ai-config]`.

https://claude.ai/code/session_01NUUM8re27M5t5mYRhiG4Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUUM8re27M5t5mYRhiG4Jk)_