### PR TITLE
Owner Portal Revisions — Slice 2: per-page copy/color/bug sweep

### DIFF
--- a/docs/directives/owner-portal/2026-06-10.txt
+++ b/docs/directives/owner-portal/2026-06-10.txt
@@ -1,0 +1,1764 @@
+www.LeafJourney.com/ops Website Revisions
+
+Prompt: I will begin going through every single page of our www.LeafJourney.com/ops website and will go over the suggestions and what we need to clean up. This will be strictly for the desktop and computer site. Once this is fully cleaned up, de-bugged, and operational, I will begin going through the mobile site.
+Prompt: make it so the sidebar fully appears whenever the web browser is made smaller or made to fit only half the screen of any user’s monitor. It should not be hidden behind the webpage. It should be layered on the top, always.
+Prompt: For any policy module, training, procedure, module, etc on any part of this site, make it, including paragraphs, charts, visuals, words, teaching material, educational material be fun, interesting, and engaging. Make all AI agents remember that training and certificates and policies and anything educational will NOT be a boring task that the employee must go through. Rather it will be an experience. Although it is required, the AI agents will create such amazing, robust, well detailed yet understandable educational content that the employees will want to participate, engage, and retain the content they learned.. It can be fun and engaging, and LeafJourney and all of its AI agents and employees will make training be a fun and most importantly, memorable experience. Because it is imperative that all of the employees understand, comprehend, and apply what is taught in these modules. This is absolutely key for cooperation and efficient operations. 
+  - For each module that is currently in the system and will eventually be developed, make it so they leave with a one page printout that is fun, full of simple main points from the module or policy or procedure in a simple manner, some nice artwork or pictures surrounding the module in an artistic manner, and simple word recognition like homonyms, anagrams, palindromes, etc to be used when creating the main points of each module so they are more likely to be remembered and stored in memory.
+Prompt: although multiple sections and pages on this document have different notes on how to improve the graphical representation, the overall layout, click and scroll structure of each section and each page on the entire owner portal, have this MASTER prompt (below in bold) be the overarching structure on how the layout should be so the entire owner portal can be as streamlined, consistent and uniform as possible throughout the entire owner portal. It should either merge or override other prompts or revisions that may be confusing or not correlate with the below. The name of this MASTER prompt will be called “MASTER prompt” and whenever it is used on this document, the AI agents should refer to the structure below first. 
+- Make every “section” expandable and collapsible
+- Have the sidebar autohide whenever a new page opens or going forward or going back on a page.
+- Make every single search bar or drop down menu or searchable aspect of every single page on LeafJourney have a drop down menu system that auto populates the portion of the full name of the query or date or any other searchable number or string of text or query that is started to be typed into this. It should auto populate 7 of the top searched or most accurate or closely matched queries. 
+  - The queries should be specific to what is on those pages and not a query that allows for searching the entire site. It should be site specific and very detailed.
+  - Create a “search” icon at the bottom left of every page of LeafJourney that creates a full directory or full site query based on the above. This should be a detailed search of every page and every section. It is similar to searching the entire “computer” instead of just a “folder.”
+- Make every single “table” on any page that has titles for “columns” or titles for “rows”:
+  - Be able to click on any “column” titles and be able to organize them in either chronological order or highest to lowest based on what type of data or information the column is displaying
+    - Have the ability to “send” or “print” or “Download” any table on any page that includes all the data and the “column” and “row” titles
+- Make each “tile (or standalone box)” or “section” or “table” on the page (usually with the “green” header) moveable and rearrangeable 
+- For each section, place a “search” bar to the rightmost side across from the Header title that the owner can type in dates, times, or other parameters and have the ability to choose any chronological parameters to display that information. The search bar should be AI driven and the owner should be able to “type” in whatever type of parameters they are looking for which can help be generated with the use of our AI assistant, Cindy. 
+  - For every single “box/tile” in every section or subsection on every page:
+    - Have a small “clickable” box on each section in the top right corner that the owner can click on which can allow them to “compare” different measures in the same graphical presentation. Once two or more of the measures are selected, on the right part of the page across from the header, have a “compare” button appear and once clicked on, it opens a “pop up” window with the graphical presentation for both or multiple parameters on the same graph or visual presentation of 
+  - For all “pop up” windows,
+    - Have the full chronological and historical data on this populate as a pop-up window that can be modified, customized, and be represented in beautiful graphical representations that are aesthetically pleasing and convey the data in a very simple, elegant, yet powerful way that tells a story. Have the “feather” icon/emoji button be a part of the pop up window where if they click on it, it can “beautify” the data, and if clicked on again, it can create other types of graphical representations or creative ways to display or show the data.
+Prompt: important- Make any graph or data display whether it’s line graph, vector graph, etc have the ability for the owner to hover their cursor over it, and it gives details for that data point (for example, when hovering on one of the data points, be able to display “#” and “time”. Make sure to display the data from the “X” axis and “Y” axis. Do this for any part of the “patient”, “owner”, or “provider” portal wherever data and analytics can be utilized. Make it similar to: https://www.google.com/finance/beta/quote/F:NYSE?sca_esv=a82350b6429375af&rlz=1C1HKFL_enUS1206US1206&output=search&source=lnms&fbs=ADc_l-aN0CWEZBOHjofHoaMMDiKpWuJzWbn6y2Zf42jFClqc74f05r15SFp3eB7-_aeVssDFTrrVbm-92MfivJar7-BYYUkzgIb9YNW6Wky1DIUwHKhHpEocYnbyMA6A-0nAdumb9_Gui4kwOxKgBa22HGxdAjRYmb4tyizu7gB1fsK2eIhX4bM5VC4X3cn1q3yRQKwR-v0rOYwY94-xeddQCYr64nhkgA&sa=X&sqi=2&ved=2ahUKEwjd__fgxOyUAxV5J0QIHbu-PZ0Q0pQJegQIFBAB 
+Prompt: for every single part of LeafJourney whether it’s the “patient” portal, “owner” portal, or the “provider” portal, make any “tabs” that are indicated on this revision or any other revision have the functionality and layout as seen on https://leafjourney.com/ops/cfo. Make it a simple, clickable structure that is similar to a “google chrome” type of layout 
+Prompt: create fully functioning and independent and self sufficient clearinghouse for everything needed. Add this following prompt and merge and have AI read and learn every other revision on this page that talks about clearinghouse structuring and architecture. Have all AI agents study this roadmap and make sure that every step is checked, tested, and studied for any flaws or discrepancies. LeafJourney’s clearinghouse will be fully independent of all third party vendors and will connect directly to national payers (like Medicare, UnitedHealth Care, etc):
+- Establishing direct Electronic Data Interchange (EDI) connections with national insurance payers allows your EMR-clearinghouse platform to completely bypass vendor transaction fees, lower systemic latency, and capture highly granular data. However, eliminating the middleman shifts the responsibility of complex credentialing, onboarding, and pipeline maintenance entirely to your engineering team.
+- Architectural Roadmap for Direct Payer Connections
+  - [ Your EMR App ] ──(JSON)──> [ Custom EDI Engine ] ──(X12 270 via mTLS)──> [ Payer Gateway ]
+  - [ Your EMR App ] <──(JSON)── [ Ingestion Parser ] <──(X12 271 via mTLS)── [ Payer Gateway ]
+- Build a Unified Payer Connection Registry
+  - Every national payer operates its own distinct EDI gateway endpoint, security rules, and metadata requirements. You must design a database registry schema that stores these connection routes dynamically.
+  - Technical Configuration Mapping (DO NOT USE THIS EXACT CODE and make sure that all AI agents test out the code and trial it to make sure we get the best code needed for this part of the AI engine)
+    - {
+    -   "payer_id": "99999",
+    -   "payer_name": "UnitedHealthcare",
+    -   "connectivity": {
+    -     "protocol": "AS2", 
+    -     "endpoint_url": "https://uhc.com",
+    -     "auth_method": "mTLS_X509",
+    -     "client_cert_vault_key": "certs/uhc_prod_client_2026"
+    -   },
+    -   "isa_headers": {
+    -     "isa05": "ZZ",
+    -     "isa06": "YOUR_EMR_SENDER_ID",
+    -     "isa07": "01",
+    -     "isa08": "UHC_RECEIVER_ID"
+    -   },
+    -   "gs_headers": {
+    -     "gs02": "YOUR_APPLICATION_ID",
+    -     "gs03": "UHC_APP_ID"
+    -   }
+    - }
+- Complete Payer-Specific Clearinghouse Credentialing
+  - Before any payer routes transactions from your server, your platform must pass formal administrative onboarding. This process can take anywhere from 30 to 90 days per national payer.
+  - Submit Clearinghouse Applications: Register your platform as an official billing agent/clearinghouse with major national bodies including Medicare (CMS MACs), UnitedHealthcare, Aetna, Cigna, and Anthem Blue Cross Blue Shield.
+  - Acquire Submitter IDs: Complete paperwork to secure unique production Submitter IDs and Receiver IDs for your software system.
+  - Sign Business Associate Agreements (BAAs): Execute legal documentation verifying your HIPAA-compliant handling of Protected Health Information (PHI).
+- Implement Strict AS2 and CAQH CORE Connectivity
+  - National payers do not accept standard REST/JSON APIs; their gateways require compliance with standard enterprise protocol mandates.
+  - AS2 Protocol: Implement an Applicability Statement 2 (AS2) communication stack. This requires encrypting data payloads using S/MIME, using digital signatures, and demanding synchronous MDNs (Message Disposition Notifications) to guarantee receipt.
+  - CAQH CORE SOAP/WSDL endpoints: Build an alternative pipeline utilizing SOAP/XML messaging with WSS (Web Services Security) extensions. This configuration is widely mandated by Medicare and Medicaid portals.
+  - X.509 Certificate Management: Set up an automated rotation infrastructure (such as AWS Secrets Manager or HashiCorp Vault) to store and switch out the public/private encryption keys required for mutual TLS (mTLS) authentication.
+- Execute Sandbox Certification and Testing
+  - You cannot touch production environments until your engine can successfully format and send synthetic error-free files.
+  - Syntax and Validation Testing: Use validation suites like Edifecs or the payer’s integrated validator (e.g., Change Healthcare/Optum testing environments) to clear WEDI SNIP Levels 1 through 5. This certifies your file syntax, segment structure, balance rules, and line-item logic.
+  - Interactive Testing Scenarios: Payers will provide a testing deck featuring 10 to 20 fictional patient criteria (e.g., Test Patient A has active coverage; Test Patient B has an out-of-network plan; Test Patient C is terminated).
+  - Verify 271 Output Accuracy: Your code must process the test responses, properly catch errors, map the payload arrays, and display the expected mock results inside your platform UI before they will grant production keys.
+- Establish an X12 999 and TA1 Acknowledgement Loop
+  - Direct processing means handling network-level dropouts or syntax execution errors natively. You must build specific workflows to parse acknowledgements:
+    - TA1 Interchange Acknowledgement: Listen for this segment to instantly detect structural failures or corrupt header configurations within the outer transmission envelope.
+    - 999 Implementation Acknowledgement: Program your system to parse incoming 999 files. If a IK501 = 'R'(Rejected) status appears, your engine must translate the technical X12 element error code into a clean, human-readable notification for your software users (e.g., "Error: Scheduled provider NPI is missing or improperly mapped").
+- Strategy for Regional and Minor Local Payers
+  - While direct connections are cost-effective for top-tier national payers (which typically cover 70-80% of a clinic's patient panel), your multi-specialty users will also treat patients holding regional plans, local union options, or small workers' compensation coverages.
+  - Hybrid Architecture Suggestion: Build direct pathways for the high-volume national entities (Medicare, UHC, Aetna, BCBS) to maximize efficiency, but establish a fallback API path using a wholesale clearinghouse partner to route the remaining low-volume local payers. This ensures your users always experience 100% universal payer coverage.
+- Raw X12 270 Structural Template
+  - Here is a raw, production-compliant X12 270 (Version 5010X279A1) message template. This example demonstrates an eligibility inquiry from an outpatient specialist clinic to a major health insurance payer. DO NOT use this code below but make sure that all AI agents review and analyze the code to ensure we have the best and up to date coding information as possible:
+    - ISA*00*          *00*          *ZZ*EMRSOFTPRIME   *01*PAYERUHC       *260530*0805*^*00501*000000001*0*P*:~
+    - GS*HS*EMRAPP*UHCHUB*20260530*0805*1*X*005010X279A1~
+    - ST*270*0001*005010X279A1~
+    - BHT*0022*13*REQ20260530001*20260530*0805~
+    - HL*1**20*1~
+    - NM1*PR*2*UNITEDHEALTHCARE*****PI*87726~
+    - HL*2*1*21*1~
+    - NM1*1P*1*DOE*JOHN****XX*1234567890~
+    - HL*3*2*22*0~
+    - NM1*IL*1*SMITH*JANE****MI*98765432101~
+    - DMG*D8*19840315*F~
+    - EQ*1~
+    - SE*12*0001~
+    - GE*1*1~
+    - IEA*1*000000001~
+  - Outer Transmission Envelope
+    - ISA (Interchange Control Header): The outermost wrapper initiating the communication string.
+      - ZZ*EMRSOFTPRIME: Identifies your EMR platform using a custom routing ID.
+      - 01*PAYERUHC: Designates the receiving payer ID system.
+      - 260530*0805: The transmission date (YYMMDD) and time (HHMM).
+      - 00501: Mandated standard Version 5010 indicator.
+      - 000000001: A unique control number used to match subsequent 271 response files.
+    - GS (Functional Group Header): Groups similar transaction sets together.
+      - HS: Eligibility, Coverage, or Benefit Inquiry code.
+      - 005010X279A1: The official TR3 industry blueprint designator for modern 270 files.
+  - Transaction Set Core
+    - ST (Transaction Set Header): Indicates the official start of the eligibility request.
+      - 270: Specifies this file is a 270 Eligibility Inquiry.
+    - BHT (Beginning of Hierarchical Transaction): Establishes processing context.
+      - 0022: Identifies the file as an information request.
+      - REQ20260530001: Your internal database tracking string for audit logs.
+  - Hierarchical Loops (HL)
+    - Our engine must nest data structures using Hierarchical Level (HL) tags to tell the payer gateway exactly how the provider and patient relate to each other.
+    - HL*1**20*1 (Loop 2000A - Information Source): Establishes the target insurance company.
+      - NM1*PR*2*UNITEDHEALTHCARE*****PI*87726: Identifies the payer (PR) as UnitedHealthcare using Payer ID 87726.
+    - HL*2*1*21*1 (Loop 2000B - Information Receiver): Establishes the healthcare provider.
+      - NM1*1P*1*DOE*JOHN****XX*1234567890: Identifies the rendering provider (1P) as Dr. John Doe using National Provider Identifier (XX) 1234567890
+    - HL*3*2*22*0 (Loop 2000C - Service Subscriber): Establishes the patient holding the policy.
+      - NM1*IL*1*SMITH*JANE****MI*98765432101: Identifies the insured individual (IL) as Jane Smith with Member ID number (MI) 98765432101.
+      - DMG*D8*19840315*F: Transmits demographic constraints; Date of Birth format (D8) of March 15, 1984, and Female (F) gender.
+  - Inquiry Focus & Close
+    - EQ*1 (Eligibility Inquiry Segment): Specifies the medical services being checked.
+      - : The Service Type Code. Your software will dynamically replace this value depending on the clinic's medical focus (e.g., use 1 for Primary Care, 2 for Dermatology/Surgical, or 33 for Chiropractic/Cardiology).
+    - SE, GE, IEA (Transaction Trailers): Standard structural check lines closing out the files. They count total segments sent (SE*12) to verify no data was dropped mid-transit.
+  - Implementation Details
+    - Delimiters: The characters at the end of each segment matter. This template uses a tilde (~) as the segment terminator and an asterisk (*) as the element data separator.
+    - Trailing Fields: Blank asterisks (*****) represent optional fields your system can skip if the data is unavailable, ensuring you maintain rigid positional validation.
+
+For page: https://leafjourney.com/ops (“Main Page” section)
+- It’s saying it’s currently down so make sure it is up and running so appropriate revision can be made
+For page: https://leafjourney.com/ops/mission-control (“Mission Control” section)
+- For the main page with the boxes “Pending”, “Running”, “Needs Approval”, etc
+  - Have the ability to click on the “Needs Approval” window which then links to https://leafjourney.com/ops/mission-control?tab=approval
+- For “All Jobs” Tab:
+  - Have it organize by “chronological order”
+  - Have the feature where when “hovering” the cursor over a “workflow” job, it explains what this means in simple terms
+- For “Need Approval” Tab:
+  - Have an option to “approve all” or “reject all” which then allows all the “jobs” to be “approved” or “rejected”
+  - Create an “option” to make some “workflows” or “jobs” to be “defaulted” to “approve” or “reject”
+- For “Agent Fleet” section:
+  - Make the “Actions:” aspect of each agent fleet a little larger and easier to read. 
+  - Be able to “hover” over every “agent” box and have a 1 sentence summary in simple, third grade terminology of what it means and how it works.
+  - Create an “Agent Fleet” tab that once opened allows for “each and every” single “Agent” to be turned “on” or “off”
+    - The provider and staff should have the ability to click on any of the AI agents feature that they want or don’t want without it affecting the integrity of the platform and the overall LeafJourney AI harness.
+
+For page: https://leafjourney.com/ops/schedule (“Schedule” section)
+- Be able to “click” on every part of the ribbon of boxes (“This week”, “Today”, “Confirmed”, etc)
+  - Once clicked on each, have more detailed information show in the “Week View” section
+- For the “Week View” section:
+  - Have the “title” change based on what “ribbon box” is clicked on
+    - For example when clicking on “Today”, have the title change from “Week View” to “Today”
+    - For example, when clicking on “Confirmed”, have the title change from “Week View” to “Confirmed”
+    - Etc
+  - On each part of the “scheduled” patients, be able to click on the patient’s name and have it take the owner to the patient’s home page of their clinic chart
+    - Be able to right click on the patient’s row and have the drop down menu have a clickable option that says “schedule” and once clicked on, it take them to https://leafjourney.com/clinic/schedule where the patient is actually scheduled.
+      - From here the provider or owner can “change” or “rearrange” the schedule 
+  - Have a “filter” emoji/button all the way to the right of the “Week View” section that allows the provider/owner to change the time frame and date frame of the data that is being shown
+- For the “Providers This Week” section:
+  - Be able to “click” on the different providers and get a “snapshot” view of their schedule for the “week”, for “today”, “confirmed”, etc
+    - Have this information show up in the “Week View” box and change it from “Week View” to the provider’s {provider first name} and {provider last name}
+- Keep the overall layout of this section to remain on one static page without scrolling and not too many clicks
+For page: https://leafjourney.com/ops/patients (“Patients Subsection”)
+- Be able to “right click” on any patient column and have a drop down show with these options:
+  - “change” to “Prospect”, “active”, or “Inactive”
+    - Have the bubbles be these colors:
+      - “active” is a “green” bubble
+      - “prospect” is a “yellow” bubble
+      - “inactive” is a “red” bubble
+- When “clicking” on any of the patient’s column, when it expands, allow the provider to be able to “click” on the patient’s “full name” which then takes them to front page of the patient’s chart
+- Under the patient’s name, include their age 
+  - For example, under “Maya Reyes” have it display as “38F”
+- When the patient column has been expanded:
+  - Have ability to “click” on the patient’s “email” and have a pop up window with the ability to “draft”, “save”, and “send” message to the patient
+  - Have ability to “click” on the patient’s “phone” number and be able to call that patient immediately right there
+  - Be able to “click” on the “missing fields” and have them be directed to that aspect of the patient chart to see if it can “filled” out or if anything needs to be “uploaded”
+For page: https://leafjourney.com/clinic/command (“Command” section)
+- Consider finding a way to merge the content of this webpage with the webpage, https://leafjourney.com/ops. And remove the “overview” tab and merge it to the “command center tab”
+For page: https://leafjourney.com/ops/billing (“Billing” Section)
+- Change “Billing workqueue” to “Billing Dashboard”
+- For the “Total Billed” Section Box:
+  - Be able to “click” on any part of that box and have a pop up window display information of “total billed” “history” per “month”, per “week”, per “year”, per “day”, etc. 
+    - Use the LeafNerd analytics engine to analyze all of this type of data in the “owner” portal and display it in a simple, beautiful way in a graphical manner that makes sense to the owner
+  - Make the “16 claims” wording in a slightly bigger font
+- For the “Collected” Section Box: 
+  - Be able to “click” on any part of that box and have a pop up window display information of “total collected” “history” per “month”, per “week”, per “year”, per “day”, etc. 
+    - Use the LeafNerd analytics engine to analyze all of this type of data in the “owner” portal and display it in a simple, beautiful way in a graphical manner that makes sense to the owner
+  - Make the “17% of billed” wording in a slightly bigger font
+- For the “Pending Revenue” Section Box: 
+  - Be able to “click” on any part of that box and have a pop up window display information of “pending revenue” “history” per “month”, per “week”, per “year”, per “day”, etc. 
+    - Use the LeafNerd analytics engine to analyze all of this type of data in the “owner” portal and display it in a simple, beautiful way in a graphical manner that makes sense to the owner
+  - Make the “submitted or in process” wording in a slightly bigger font
+    - Change “process” to “progress”
+- For the “Outstanding” Section Box:
+  - Be able to “click” on any part of that box and have a pop up window display information of “Outstanding” “history” per “month”, per “week”, per “year”, per “day”, etc. 
+    - Use the LeafNerd analytics engine to analyze all of this type of data in the “owner” portal and display it in a simple, beautiful way in a graphical manner that makes sense to the owner
+  - Make the “6 denials need action” wording in a slightly bigger font
+    - Change “process” to “progress”
+- For the ribbon of buttons that include “all”, “draft”, “paid”, etc:
+  - Make sure each “number “ in a bubble is accompanied by a “word” description to the left of the “number” within that overall button
+  - Remove any button that does not have a “word” to the left of it
+  - Be able to “drag” and “rearrange” or “remove” or “add” any categories
+  - Make the “denied” button stay “red” even when not clicked on so it gets the attention of the provider or user to address that first
+  - Make all other buttons light up “green” when clicked on
+  - The buttons are sluggish and not very responsive to “click” 
+    - Make sure each AI agent tests out the “clicking” to give the provider and owners the best user interface experience with LeafJourney
+- For the column titles, such as “Patient”, “Date”, “Codes”, etc
+  - Be able to click on any title and organize the entries in top to bottom or bottom to top format
+    - For example, be able to click on the “patient” column title and have it arrange and rearrange the claims based on the new order
+    - For example, be able to click on “date” column title and have it arrange and rearrange the claims based on the “most recent’ date or the “oldest” date, etc
+    - For example, for “Payer” be able to click on the section title and have it arrange in alphabetical order
+    - For example, for “Billed” be able to click on the section title and have it organize by the “smallest” amount to the “largest” dollar amount in either order
+    - For example, for “Paid” have it arrange between “$..” and “$0.00”
+    - For example, for “status” have it arrange in order and lump all of the “draft” next to each other, “submitted” next to each other, “paid” next to each other, and “Denied” against of each other.
+  - Be able to “drag” and rearrange the column “titles” and be able to “add”, “subtract” column titles
+- For the “Denied” section:
+  - Once clicked on, make the “denial” reason under the “status” section show in a slightly larger font so it’s easy to read. 
+  - Be able to “click” on each denial row and have it “expand” more data and history of that claim. This should include somewhat of a “history” of that denial and a paper/audit trail of all the attempts, calls, claim information the provider has received along with what the patient has received. 
+    - Once expanded, have a button that says “take action” which then allows the provider or owner to “respond”, “refute”, “adjust” off a claim right there. By “taking action” they have direct connection with the insurance company and can connect them to the proper insurance department, type out a “denials” justification or explanation and then be able to send it to the appropriate insurance department.
+      - Once sent, an “audit trail” and these notes are placed into the patient’s chart under the “Correspondence” tab
+
+
+For page: https://leafjourney.com/ops/scrub (“Scrub” Tab)
+- Change name from “scrub” to “Scrub and Auths”
+  - Have this page not only be able to “scrub” all the data and do all the billings claims, but also be the central hub for prior authorizations. 
+  - Our billing team, back office, and office manager should be able to use this one webpage to:
+    - Review all claims, denials, pending, appeals, etc
+    - Submit claims, appeal letters, etc
+    - Submit prior authorization data and documents, etc
+  - Have a button that says: “prior authorization” which then once clicked on creates a fully functional, modifiable and adaptable prior authorization form with all of the required API modular plug ins and criteria as listed below
+    - Being able to click on this allows for the provider, staff, managers to manage, and submit claims and auths without going to a bunch of different websites.
+      - Have a fully modular API plug in for the major prior auth engines such as:
+        - Availity
+        - CoverMyMeds
+        - Innovaccer
+        - Insight Health
+        - ScribeRunner
+- Change “clean and ready” to “reviewed and ready” 
+  - Keep this font in “green”
+- Make the “Warnings” section box with a slightly lighter “yellow” color
+- Be able to click on “5 claims in queue” section box:
+  - Once clicked have it bring the page down to the “Claims Requiring review” section
+- Be able to click on “clean and ready” section box:
+  - Once clicked, have it bring the page down to the “Claims Requiring review” and have the title change and match the “section box” title. Therefore when clicking on “Reviewed and ready”, have the lower box match the title to “Reviewed and Ready” as well
+- Be able to click on “blocked” section box:
+  - Once clicked, have it bring the page down to the “Blocked” and have the title change and match the “section box” title. Therefore when clicking on “Blocked”, have the lower box match the title to “Blocked” as well
+- Be able to click on “Errors” section box:
+  - Once clicked, have it bring the page down to the “Errors” and have the title change and match the “section box” title. Therefore when clicking on “Errors”, have the lower box match the title to “Errors” as well
+- Be able to click on “Warnings” section box:
+  - Once clicked, have it bring the page down to the “Warnings” and have the title change and match the “section box” title. Therefore when clicking on “Warnings”, have the lower box match the title to “Warnings” as well
+- Have a “filter” emoji to the right of the “Claims Requiring review” section title
+  - Have this be able to open a pop up box with ability to search historical and chronological data on each aspect of claims management such as “claims in queue”, “claims reviewed and ready”, “claims blocked”, etc
+- For the “Top issues this week” section:
+  - Be able to “hover” over each “root cause” such as “missing_diagnosis”, “High_level_EM_review”, “past_timely_filing” and be able to explain in simple terms in 1-2 sentences what this means and how it works and how it will be fixed for the future. Make sure it explains how our AI system, Cindy, is continuing to learn from the data and improves over time
+  - Be able to click on the “bubbles” and then have it populate those “occurrences” in the “Claims requiring review” window. 
+    - Once “clicked” on the “occurrences”, have the title change from “Claims requiring review” to each “root cause”
+    - Be able to organize these in chronological order
+- For the “Claims requiring review” section:
+  - Make the “date”, “insurance” and “CLM” number slightly larger in font size and darker so it is easier to read
+  - Give explanations in simple terminology based on the entire workflow system as outlined below.
+  - Make the CPT codes slightly larger fonts
+  - Make the “bubbles” in this section remain the same color and descriptions
+  - For any “root cause” explanation that is written out, be able to “click” on the small  with the suggestion and have it link directly to where the provider can “input”, “edit”, “modify”, “remove” that certain data and requirements they are asking for
+  - Have clicking on “submit claim” send the data needed from LeafJourney directly to the insurance copay to create a claim. The general structure and workflow from the beginning to end that needs to incorporate into LeafJourney is as below. THIS IS TOP PRIORITY and ALL AI agents on LeafJourney need to analyze, understand, and fully automate and build this system below to make the billing process as clean, effective, and efficient as possible. Make sure every single part of this pathway and every specific part listed here is fully run and tested to make sure it works by our AI agents. This should be our priority and have every AI agent testing each part as both the insurance company and as the provider/staff. LeafJourney needs to make sure this is fully troubleshooted and seamless. This is a FLAGSHIP feature of LeafJourney and it must be flawless and state of the art
+    - Front-End Operations (Pre-Billing) – part 1
+      - [Patient Schedules] ➔ [Real-Time RTE Call] ➔ [Automated Auth Check] ➔ [Patient Portal Estimation] ➔ [Signed Note] ➔ [Specialty CCI Scrub] ➔ [Payer-Specific Rule Check] ➔ [Clean Claim Approval]
+      - Scheduling and Registration: Staff or AI chatbot collect patient demographics, insurance provider, and policy numbers.
+      - Insurance Verification: Staff or our AI chatbot confirm active coverage, effective dates, and policy copays.
+      - Prior Authorization: Staff obtain insurance approval for specific procedures before the visit.
+        - AI-Driven Prior Authorization: Integrate with automated authorization networks. The system should scan the scheduled CPT code against payer rules and automatically submit authorization requests (HIPAA 278 transactions) if required by that specialty.
+      - Real-Time Eligibility (RTE): 
+        - Prompt: Build an automated API engine that triggers a HIPAA 270 (Eligibility Inquiry) transaction the moment an appointment is scheduled, and again 48 hours before the visit. It must auto-parse the 271 response to extract copays, deductibles, and active coverage status.
+      - Check-In and Copay: Staff collect the contractually mandated patient copay upon arrival
+        - Patient Copay & Cost Estimator: Build a calculator that cross-references the contracted payer fee schedule with the patient’s remaining deductible. It flashes a clear dollar amount on the check-in screen so our front-desk team can collect exact patient liabilities at the point of service.
+    - Clinical Documentation – part 2
+      - The Encounter: The provider treats the patient for their specific medical complaints.
+      - Writing the Note: The provider documents the history, exam, and medical decision-making (MDM).
+        - Dynamic Template Mapping: The UI must morph based on the specialty. For example, a psychiatry note needs structured DSM-5/mental status check-boxes; an orthopedic note requires range-of-motion charts and joint injection documentation templates.
+          - Make these templates “specialty” specific 
+        - Time-Based vs. MDM Calculators: For Evaluation and Management (E/M) codes, build a built-in scoring engine. It should count documented elements to calculate Medical Decision Making (MDM) or track continuous active face-to-face minutes (critical for physical therapy and psychotherapy).
+      - Completion Timeline: Providers usually finalize and sign notes within 24 to 48 hours
+        - Encounter Locking Limits: Program hard stops. The EMR should prevent providers from leaving chart notes "open" longer than 120 hours, automatically flagging un-signed notes on an executive dashboard to prevent timely filing write-offs.
+          - Have ability to “override” the 120 hour window but must justify why it wasn’t written 
+    - Medical Coding – part 3
+      - CPT Code Selection: Coders assign Current Procedural Terminology codes for services performed (e.g., 99214 for a level 4 established office visit).
+        - Cross-Walking Logic: Build a database linking CPT, HCPCS (for specialty drugs/supplies), and ICD-10-CM codes. For example, if an OB/GYN bills an ultrasound (CPT 76830), the system should cross-reference a Local Coverage Determination (LCD) database and throw an alert if the paired ICD-10 code does not prove medical necessity.
+      - ICD-10 Code Selection: Coders assign International Classification of Diseases codes to establish medical necessity (e.g., E11.9 for Type 2 diabetes).
+      - Linking Codes: Coders explicitly connect each CPT code to a supporting ICD-10 diagnosis code.
+      - Modifier Application: Coders append two-digit modifiers (e.g., -25) to signal special circumstances to
+        - CCI Edit Validator: Integrate National Correct Coding Initiative (NCCI) edits. For example, if a dermatologist performs a biopsy and a destruction on the same day, the system must automatically assess if the procedures are unbundled and prompt the coder to append the correct modifier (e.g., Modifier -59 or -25).
+        - Specialty-Specific Rule Triggers:
+          - Therapy: Auto-calculate the 8-minute rule for timed physical/occupational therapy units.
+          - Pediatrics/OBGYN: Implement global billing rules where multiple visits roll up into a single delivery or surgical package code.
+          - Anesthesia: Build base-unit calculations that factor in continuous time ticks and physical status modifiers.
+    - Claim Preparation and Scrubbing – Part 4
+      - Prompt: make LeafJourney capable of being its fully own Native Healthcare Clearinghouse and require these parts of it to be incorporated into the LeafJourney Billing and Claims system:
+        - Have it compete against the major clearinghouse engines and RCM engines:
+          - Waystar
+          - Optum
+          - Experian Health
+          - R1 RCM
+        - Operating as a clearinghouse means our system must speak fluent ANSI ASC X12 EDI and maintain direct, secure communication tunnels to both commercial and government payer. 
+        - It should follow this structure: [Internal Database] ➔ [X12 Engine: JSON to 837P] ➔ [SFTP / AS2 Gateway] ➔ [Payer Systems]
+          - Data Serialization & The X12 Transmission Engine (Instead of mapping data directly to ugly X12 files, use a standard intermediate format like JSON or Protocol)
+            - The Bi-directional Parser
+              - 837P: Professional Claims Submission (Outbound).
+              - 999: Implementation Acknowledgment (Inbound, verifies structural integrity).
+              - 277CA: Claim Acknowledgement (Inbound, determines if the payer accepted or rejected the claim pre-adjudication).
+              - 835: Electronic Remittance Advice (Inbound, payment and denial data).
+              - 270/271: Eligibility Inquiry and Response (Real-time, Synchronous API).
+              - Segment and Loop Mapping: Code rigid constraints matching the official X12 5010 guide rules (e.g., ensuring loop 2010AA accurately maps our Billing Provider info, and loop 2420A maps the Rendering Provider specialty taxonomy)
+            - Multi-Protocol Connectivity Layer (Direct Payer Routing)
+              - Make sure we mirror and are superior to these payer engines:
+                - MCG Health
+                - Cohere Health
+                - Banjo Health
+              - Payers will not adapt to LeafJourney; LeafJourney must adapt to their strict connectivity standards. Our system requires a secure connectivity hub
+              - AS2 (Applicability Statement 2): Secure, real-time HTTP-based transmission using digital certificates, S/MIME encryption, and MDN (Message Disposition Notification) receipts.
+              - SFTP with SSH Keys: For large batch claims. Our engine must automate cron jobs to pull/push files from payer servers at specific intervals (e.g., hourly).
+              - CAQH CORE Operating Rules Compliance: Build our endpoints to comply with the latest CAQH CORE Connectivity Rules (such as version vC4.0.0 or later). This requires our server to support HTTPS SOAP/WSDL or RESTful API connections with secure OAuth 2.0 authentication
+            - Enterprise Validation & Strategic Routing Engine
+              - Before a file is transmitted to a payer, our system must decide where it goes using an internal "Traffic Controller" engine:
+              - Level 1 to 7 WEDI SNIP Validation: Build an internal validation script that tests outbound files against the 7 levels of Workgroup for Electronic Data Interchange (WEDI) Strategic National Implementation Process (SNIP) rules. It must block files containing fundamental structural failures (Level 1) or specific specialty-code combinations that defy modifier rules (Level 5).
+              - Smart Routing Layer: Create a database table mapping Payer IDs (e.g., 95930 for Cigna) to their respective direct connection endpoints. If a payer does not accept direct EDI connections from independent clearinghouses, program a fallback route that sends that specific file through a low-cost, aggregator network (like Availity or Change Healthcare).
+            - Legal, Security, and Compliance Guardrails
+              - EHNAC/DirectTrust Accreditation: Plan to seek Electronic Healthcare Network Accreditation Commission certification. Major commercial payers and state Medicaid portals will often reject direct connections until you prove structural and data-security compliance.
+              - HIPAA & SOC 2 Type II: All data resting in trading partner mailboxes must be encrypted using AES-256, and all data in transit must utilize TLS 1.3 encryption. Maintain detailed audit logs of who accessed, modified, or transmitted any EDI file
+          - The State – of – the – Art RCM Analytics Session
+            - Because we own the clearinghouse layer, our data is 100% real-time. Standard practices wait 30 days for reports; our analytics engine can flag an emerging billing issue within 10 minutes of file processing.
+            - Executive Revenue Cycle Dashboard (Core Financial KPIs)
+              - Build these vital metrics directly into the executive leadership suite with high-utility visual charts that are beautiful and aesthetically pleasing:
+                - Days in Accounts Receivable (Days in AR): Tracks how long it takes for a dollar of billed revenue to collect. State of the art target: < 35 days
+                - Days in AR = Total Accounts Receivable Balance / Average Daily Gross Charges
+                - Net Collection Rate (NCR): Measures the true efficiency of our in-house billers by calculating financial recovery after adjusting for contractually obligated insurance write-offs. State-of-the-art target: > 96%
+                - NCR = (Payments Received / Total Charges – Contractual Adjustments) x 100
+                - Clean Claim Rate (CCR): The percentage of claims that successfully pass both our internal scrubber and the payer’s front-end acceptance edits on the very first submission attempt. State-of-the-art target: > 98%
+            - Operational Clearinghouse & Biller Work-Queue Monitoring
+              - Real-Time EDI Status Pipeline: A visual Kanban or step-tracker showing the volume and cash value of claims currently stuck in each processing state: Draft  Scrubbed  Transmitted  Accepted via 277CA  Adjudicated via …
+              - Biller Productivity Tracker: Monitor staff performance by tracking daily key metrics, including claims touched, corrected claims submitted, and appeals successfully processed
+            - Predictive Denial Intelligence & Machine Learning Layer
+              - Do not just report historical denials; use incoming 835 data to proactively protect future cash flows
+              - CARC/RARC Denial Matrix: Build an interactive heatmap that correlates specific Claim Adjustment Reason Codes (e.g., CO-16 for missing info) to specific outpatient specialties, providers, and payers.
+              - Predictive Scrubbing Algorithm: Have our analytics engine constantly scan historically denied claims. If the system detects that Blue Cross is currently denying CPT 99214 whenever it is paired with ICD-10 M54.50 (Unspecified low back pain) for Physical Therapy clinics, the system must update its active front-end code-scrubber automatically to alert coders before submission
+            - Advanced Specialty-Specific Financial Analytics
+              - Provider Relative Value Unit (RVU) Tracking: Track clinician productivity by breaking down performance into Work RVUs (wRVUs), Practice Expense RVUs (peRVUs), and Malpractice RVUs (mpRVUs). This gives you clear visibility into true profitability per hour across our diverse, multi-specialty footprint.
+              - Contractual Underpayment Engine: Load the exact negotiated fee schedules for every payer contract into our database. When an 835 ERA posts, the software must compare the paid amount against the expected contractual rate down to the penny. If a payer pays $82 for an injection when the contract stipulates $95, the system automatically routes the claim into an automated "Underpayment Reclamation" work queue
+      - Superbill Generation: The system compiles codes, clinician information, and provider fees into an electronic charge item.
+      - Claim Formatting: Software formats data into an electronic HIPAA-compliant 837P file (or paper CMS-1500 form).
+        - For 837P Files, medical billing software must structure clinical data into specific fields. These requirements ensure that the health insurance payer can process and pay the claim without rejections. These requirements are listed as such:
+          - Provider Information (The Billing Entity)
+            - The software must pull and format specific details identifying who performed the services and who gets paid
+            - Billing Provider: The legal business name, physical address, and Tax ID (EIN or SSN) of the practice.
+            - National Provider Identifier (NPI): The unique 10-digit Type 2 (Group) or Type 1 (Individual) NPI for the billing entity.
+            - Rendering Provider: The specific clinician who treated the patient, along with their individual NPI.
+            - Referring Provider: The name and NPI of the physician who referred the patient, if required by the plan
+          - Patient and Insured Information (The Subscriber)
+            - The system must separate the patient from the policyholder, as they are not always the same person
+            - Subscriber Details: The primary policyholder's full name, address, date of birth, gender, and unique insurance policy ID number.
+            - Patient Details: The patient's full name, address, date of birth, gender, and relationship to the subscriber.
+            - Payer Information: The insurance company name, their 5-digit electronic Payer ID, and the specific claims mailing address
+          - Clinical Data (The Medical Necessity)
+            - The software translates the medical chart into standardized medical codes to prove why the care was necessary
+            - ICD-10-CM Diagnosis Codes: Up to 12 alphanumeric codes that describe the patient's condition or symptoms.
+            - Primary Diagnosis: The chief reason for the encounter, mapped to code position "A".
+            - CPT / HCPCS Procedure Codes: 5-character codes representing the exact medical services or equipment provided.
+            - Diagnosis Pointers: A data link connecting each procedure code to its corresponding diagnosis code to prove medical necessity.
+            - Modifiers: 2-character alphanumeric codes added to CPT codes to provide vital extra context (e.g., repeating a test, or treating the left side of the body)
+          - Service and Financial Data (The Bill)
+            - The software must calculate exact numbers and log the operational context of the medical encounter
+            - Dates of Service (DOS): The exact start and end dates when the care was provided.
+            - Place of Service (POS) Codes: 2-digit codes identifying where the care happened (e.g., 11 for Office, 21 for Inpatient Hospital, 02 or 10 for Telehealth).
+            - Line Item Charges: The specific dollar amount billed for each individual procedure code.
+            - Total Charge: The sum of all line item charges listed on that specific claim.
+            - Units of Service: The frequency or quantity of the procedure performed (e.g., 1 unit for an exam, or 4 units for 60 minutes of physical therapy)
+          - Facility and Control Data (Institutional Context)
+            - For certain claims, additional institutional tracking data elements must be formatted into the data stream
+            - Service Facility Location: The physical address and unique NPI of the location where care was delivered, if different from the billing office.
+            - Prior Authorization Number: The tracking number issued by the insurance company approving the care ahead of time.
+            - Patient Control Number: A unique account number generated by our software to track the claim internally
+        - Use these resources for AI to learn and analyze 837P file information from:
+          - https://www.cms.gov/files/document/837p-cms-1500pdf
+          - https://www.cgsmedicare.com/pdf/edi/837p_compguide.pdf
+          - https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms1500.pdf
+          - https://www.nucc.org/images/stories/PDF/1500_claim_form_map_to_837P_v3-3_2012_02.pdf
+        - The "Clean Claim" Gatekeeper: make sure LeafJourney validates scripts checking for missing NPI numbers, invalid zip codes, missing taxonomy codes, or expired Clia waiver numbers for in-office lab testing.
+        - Custom Payer Rule Builder: Give our in-house billers a UI where they can create custom rules without writing code (e.g., "If Payer = Aetna AND Specialty = Podiatry, require box 19 to contain specific text").
+        - Automated Batching: Once validated, the system automatically translates the charges into a formatted 837P electronic file format, ready for transmission.
+      - Clearinghouse Scrubbing: A third-party clearinghouse checks the claim for missing fields, formatting errors, or mismatched codes.
+        - To be state-of-the-art, LeafJourney must offer granular, FedEx-style package tracking for every single claim.
+        - Bi-Directional API Pipeline: Move away from manual SFTP file uploads. Integrate directly with clearinghouses via real-time APIs.
+        - Instant 999 and 277 Responses:
+          - 999 Acknowledgement: The software parses this within minutes to confirm the clearinghouse accepted the file format.
+          - 277 Claims Status: The system automatically maps payer front-end acceptance or rejections directly onto the biller's work queue, prioritizing rejections by dollar value.
+      - Error Rejection and Corrections: Claims failing this automated check are rejected instantly and sent back to the office for correction
+        - Use these resources for AI to learn and analyze from:
+          - https://cms.officeally.com/blog/rejection-codes
+          - https://health.maryland.gov/pophealth/Documents/Local%20Health%20Department%20Billing%20Manual/LHD%20Billing%20Manual%20V33/Section%20III%20RCM%20Updates/Claims/Common%20Claim%20Denials.pdf
+          - https://www.cms.gov/data-research/computer-data-systems/esmd/reason-statements-and-document-emdr-codes
+            - Study every single link on this website and have AI do an extremely deep research and through dive of these websites
+          - https://aihc-assn.org/root-cause-of-medicare-claim-denials/
+          - https://www.cms.gov/files/document/mln3171902-checking-medicare-claim-status.pdf
+        - Here is the comprehensive list of all the ways medical claims are checked and validated for error correction throughout the billing cycle:
+          - Front-End Practice Management Checks
+            - Demographic validation: Cross-references patient names, birthdates, and policy numbers for typos.
+            - Mandatory field verification: Flags blank boxes required for processing, such as provider Tax IDs.
+            - Code set verification: Confirms all ICD-10 (diagnosis) and CPT/HCPCS (procedure) codes are active and current.
+            - Gender/Age logic edits: Catches clinical mismatches, like pediatric codes billed for senior citizens
+          - Clearinghouse "Claim Scrubbing
+            - Payer ID routing check: Verifies the electronic routing number matches an active insurance company.
+            - National Provider Identifier (NPI) lookup: Confirms the rendering and billing provider NPI numbers are valid.
+            - National Correct Coding Initiative (NCCI) edits: Detects unbundling (billing component parts of a procedure separately to increase payout).
+            - Modifier appropriateness: Ensures billing modifiers (e.g., -25, -59) are used correctly according to coding guidelines.
+            - Duplicate claim screening: Identifies and halts identical claims sent for the same service date to prevent fraud flags.
+          - Payer Gateway & Adjudication Rules
+            - Real-time eligibility checking: Verifies the patient's policy was active on the exact date of service.
+            - Network status verification: Determines if the provider is contracted (in-network) or non-participating (out-of-network).
+            - Prior authorization matching: Links the claim to pre-approved authorization numbers on file for high-cost services.
+            - Benefit limit tracking: Checks if the service exceeds policy caps, such as a maximum number of physical therapy visits per year.
+            - Coordination of Benefits (COB) screening: Determines whether the primary or secondary insurance should pay first
+          - Back-End Human Auditing
+            - Medical necessity review: Clinicians review submitted medical records to ensure the procedure matches the diagnosis severity.
+            - Documentation reconciliation: Billers manually compare the doctor's clinical notes against the coded claim to fix discrepancies.
+            - Payer remittance advice analysis: Billers decode Electronic Remittance Advice (ERA) rejection reason codes to pinpoint the exact line-item error
+    - Adjudication by the Payer – Part 5
+      - When payers respond, LeafJourney should read the data and balance the financial ledgers with minimal human keystrokes.
+      - Receipt: The insurance payer accepts the clean claim file into their processing system.
+      - Policy Verification: Payer systems verify the patient's active enrollment and policy limits on the date of service.
+      - Medical Necessity Review: Automated payer algorithms verify if the ICD-10 code justifies the billed CPT code.
+      - Fee Determination: The payer calculates the contractually allowed amount for each approved code.
+    - Payer Determination and Financial Processing – Part 6
+      - The EOB and ERA: The payer sends an Explanation of Benefits (EOB) to the patient and an Electronic Remittance Advice (ERA) to the office.
+        - Auto-ERA (835) Parsing: The system ingests Electronic Remittance Advice files and automatically matches them to the original claim using the TRN (Trace Number).
+      - Payment Disbursement: The payer issues reimbursement to the practice via Electronic Funds Transfer (EFT).
+        - The Three-Way Financial Match: The software must mathematically verify: Billed Amount – Contractual Write – Off = Payer Paid Amount + Patient Balance
+      - Posting Payments: Billing staff apply the insurance payment and contractual write-offs to the patient's account ledger
+    - Post- Adjudication Outcomes – Part 6
+      - LeafJourney shouldn't work from paper reports. They should log into dynamic, action-oriented digital work queues.
+      - Scenario A: Full Resolution
+        - Payment Received: Payer pays 100% of the contractually allowed rate.
+        - Patient Billing: Staff bill the patient for remaining deductibles or coinsurance.
+        - Zero Balance: The account ledger reaches a $0 balance, and the claim closes
+          - Patient Balance Automation: Once insurance pays its portion, the system instantly shifts the remaining contractually allowed balance to "Patient Responsibility." It sends an automated text/email notification with a secure payment link, dropping paper statement costs by up to 80%.
+      - Scenario B: Claim Revision (Partial or Error Rejection)
+        - Coding Discrepancy: Payer identifies a correctable error, such as a missing modifier or incorrect demographic info.
+        - Ways to check claims for error corrections
+        - Correction: Billers correct the clerical error on the original claim.
+          - The "Corrected Claim" Single-Click UI: For claims requiring revision, give billers a split-screen interface (Original Claim vs. Edit Fields). When fixed, clicking "Resubmit" must auto-populate the frequency code "7" (Replacement of Prior Claim) and the original Payer Claim Number into the 837P file metadata.
+        - Resubmission: The office resubmits the file as a "Corrected Claim" within timely filing limits
+      - Scenario C: Claim Denial
+        - Hard Denial: Payer refuses payment due to unresolvable issues (e.g., services not covered under policy).
+          - Denial Code Cross-Mapping: If a claim is denied, the system reads the CARC (Claim Adjustment Reason Code) and RARC (Remittance Advice Remark Code). It automatically routes the claim into specialized internal queues based on the code (e.g., Code CO-167 for medical necessity goes to the clinical appeal queue; Code CO-22 for coordination of benefits goes to front-desk outreach).
+        - Appeals Process: The practice gathers clinical notes and sends a formal appeal letter to prove medical necessity.
+          - Appeals Packet Generator: For clinical denials, create a one-click compilation tool. It should pull the signed EMR chart note, the original claim data, the denial ERA, and attach a pre-formatted, specialty-specific medical necessity appeal letter into a single digital outbound fax or portal packet.
+          - To build a state-of-the-art "Single-Click Appeal Engine" directly inside our proprietary EMR/billing platform, you need to seamlessly bridge the gap between clinical documentation and automated EDI backend tools. When a provider or billing manager clicks "Fight Claim," our system should instantly assemble a legally binding, clinically sound appeal packet without forcing staff to print, manually fax, or navigate external insurance portals. Here is the comprehensive, highly detailed blueprint for engineering this system:
+            - Database Architecture & Logic Triggers
+              - Our platform must dynamically connect incoming electronic denials (from the clearinghouse layer) directly to the specific clinical
+              - The 835-to-Chart Mapping: When an 835 ERA (Electronic Remittance Advice) arrives with a denial code, your database must map the original claim ID to the provider’s signed progress note via a foreign key relation.
+              - The "Fight" Trigger Flag: Build a status column in your claims ledger called appeal_eligibility. The system flags a claim as "Appealable" only when it contains actionable CARC (Claim Adjustment Reason Codes), such as:
+                - CO-50: Services not deemed medically necessary.
+                - CO-119: Benefit maximum for this time period has been reached.
+                - CO-252: Add-on code cannot be billed without primary code.
+            - Automated Smart Data-Aggregator (The Compiling Engine)
+              - The moment the user clicks "Fight Claim," an automated background script runs a cross-database query to gather all required evidence. The user should never have to manually look up patient records. The system pulls: [Patient Demographics & Policy IDs] + [Original 837P Data (Dates, CPT, ICD-10, Modifiers)] + [Inbound 835 Denial Code + Payer Remarks] + [Full Text of the Signed EMR Clinical Note] = Combined into a Unified Smart Payload
+              - Clinical Extraction: The engine copies the full text of the signed note, including history of present illness (HPI), exam findings, and medical decision-making (MDM) tables.
+              - Specialty-Specific Attachments: If the logged-in clinic is an outpatient specialty, the aggregator auto-grabs specific required documents as examples:
+                - Orthopedics / Physical Therapy: Intakes, objective range-of-motion measurements, and signed care plans.
+                - Cardiology: EKG tracings and imaging reports.
+                - Dermatology / Wound Care: High-resolution skin photographs uploaded into the EMR gallery.
+                - Oncology / Specialty Infusions: Lab results, drug waste logs, and prior authorization logs
+            - Generative AI & Form-Fill Template Factory
+              - Do not make your staff write letters from scratch. Build a dynamic "Template Factory" that uses custom conditional text logic or a secure generative AI API layer to draft the argument
+              - Payer-Specific Appeal Forms: Build an internal library containing the PDF appeal forms for major payers (e.g., UnitedHealthcare, Aetna, Anthem). Your system uses programmatic PDF-form filling to map patient names, provider NPIs, original claim tracking numbers, and addresses directly into the exact fields required by that payer.
+              - The Argument Generator: Create a matrix of pre-vetted, legally tight paragraphs based on the specific denial reason code, for example:
+              - If Medical Necessity Denial (CO-50): The letter auto-generates text citing peer-reviewed clinical guidelines, cross-referencing the exact sections of the provider's note that match those guidelines.
+              - If Timely Filing Denial (CO-29): The letter automatically loops through your internal clearinghouse logs, extracts the exact timestamp showing when the claim was first transmitted, and inserts it as concrete proof of timely submission
+            - Interactive Provider Review Interface (Split-Screen UI)
+              - Before the appeal is sent, display a split-screen dashboard allowing for quick human review and minor editing
+              - Left Panel: Display the auto-generated appeal letter alongside the fully compiled packet (e.g., Form, Note, Photo, Labs).
+              - Right Panel (The Dynamic Action Checklist):
+                - A drop-down to quickly change the urgency (e.g., Standard Appeal vs. Expedited Clinical Appeal).
+                - An editable text field allowing the provider to append a custom clinical counter-argument if desired (e.g., "Patient has tried and failed two alternative first-line medications, requiring this specific brand").
+                - An digital signature pad mapping the provider's authenticated credentials onto the appeal document
+            - Multi-Channel Outbound Electronic Transmission Hub
+              - Once reviewed and signed, clicking [Submit Appeal] passes the payload to an outbound communications router. Because payers accept appeals in wildly different ways, your clearinghouse architecture must support three distinct electronic channels: ┌──> 1. Real-Time HIPAA 275 Transaction (Direct EDI Link) │ [Submit Appeal] ──┼──> 2. Automated e-Fax Gateway (For payers requiring fax) │ └──> 3. Secure Payer Portal API Scraper (Automated upload)
+              - The HIPAA 275 Transaction (The Gold Standard): Build an electronic workflow that wraps the appeal packet into an encrypted X12 275 (Patient Information) file. This attaches your clinical documentation directly to the original claim ID inside the payer's computer system via EDI, entirely bypassing physical paper.
+              - Automated Electronic Fax (e-Fax) Integration: For traditional or local Medicaid payers that do not process 275 transactions, integrate an API-driven e-fax service (like eFax Corporate or Twilio Programmable Fax). The system converts the completed appeal packet into a single multi-page PDF and faxes it directly to the payer's dedicated appeals department number, maintaining a secure digital fax receipt confirmation page.
+              - Portal API Web Automation: For major payers utilizing rigid online portals (e.g., Availity, Optum), use secure APIs or secure robotic process automation (RPA) scripts to auto-log in, navigate to the appeal submission page, populate the data fields, and upload the generated PDF packet automatically
+            - Dynamic Appeal Tracking & Lifecycle Automation
+              - You must ensure that sent appeals are actively tracked so they do not simply vanish into an insurance black hole
+              - The Appeal Clock Tracker: Create an internal ledger tracking the "Age of Appeal." Once submitted, the status shifts to Appeal Pending, and a 30-day countdown clock begins running on the billing manager's screen.
+              - Payer Status Ingestion: Program your inbound 277 Claim Status Request/Response engine to regularly poll payers using the specific tracking ID generated during submission
+              - Resolution Routines:
+                - Appeal Overturned (Success): An 835 ERA arrives with payment. The system auto-links the payment back to the appeal file, records the recovery metric, closes out the balance, and flashes a green notification to the billing team.
+                - Appeal Upheld (Failure): If the payer issues a final denial, the system blocks further basic resubmissions and automatically surfaces an option to escalate to an External Independent Review Organization (IRO) or route the balance to patient collection if a pre-visit billing waiver was signed
+        - Write-off: If the appeal fails, the practice must legally write off the balance or bill the patient if a waiver was signed
+- Prompt: build a Pre-service authorization appeals and Post-service claims denials software engines.  To build a state-of-the-art EMR, your system must treat Pre-Service Authorization Appeals and Post-Service Claim Denials as two entirely separate software engines. They use different transaction sets, have vastly different regulatory timelines, and are reviewed by different departments within an insurance company. Pre-service appeals are about gaining permission to treat a patient under tight clinical clocks. Post-service appeals are about collecting money for work already completed.
+  - Conceptual Architecture & Logic Divergence
+    - For Pre-Service Authorization Appeals (The Authorization Engine):
+      - Primary Goal: Secure clinical approval before medical care occurs.
+      - System Trigger: A rejected HIPAA 278 Response or a portal "Prior Auth Denied" flag.
+      - Core Document: Proposed care plan, peer-reviewed clinical guidelines, and intake note.
+      - Regulatory Clock: Urgent (72 hours) or Standard (15–30 days) dictated by state/federal law.
+      - End Destination: Payer Medical Management / Utilization Review Department.
+    - For Post-Service Claim Denials (The Claims Engine):
+      - Primary Goal: Recover financial reimbursement after medical care occurred.
+      - System Trigger: An inbound HIPAA 835 Remittance Advice with a specific denial code.
+      - Core Document: Signed clinical note, procedural log, proof of timely filing, and the final itemized claim.
+      - Regulatory Clock: Standard insurance timely filing limits (60 to 180+ days).
+      - End Destination: Payer Claims Adjudication / Grievances & Appeals Department.
+  - Pre-Service Authorization Appeal Logic (The Prior Auth Engine)
+    - When a proposed procedure (e.g., surgery, MRI, specialty infusion) is denied by a payer during the pre-authorization phase, your system must execute this high-speed protocol: [278 Auth Denial Ingested] ➔ [Check Urgency Flag] ➔ [Auto-Schedule Peer-to-Peer] ➔ [Generate Guideline Checklist]
+    - Step A: Ingestion & Status Routing
+      - The Trigger: The software parses an inbound electronic HIPAA 278 response containing an Action Code = CT (Contact Payer) or Certification Status = A3 (Not Certified / Denied).
+      - Database Action: The system updates the patient’s appointment status to Hold - Auth Denied and locks the schedule to prevent clinical staff from accidentally executing an unauthorized, un-reimbursable service
+    - Step B: The Triage & Urgency Gate
+      - Program an internal validation script to check the clinically documented date of service:
+        - Condition 1: If the service date is within the next 48–72 hours, or if the clinician checks a box marked Life/Health at Serious Risk, the system stamps the record as Expedited Priority Appeal.
+        - System Action: It automatically changes the internal SLA (Service Level Agreement) target to 24 Hours and pushes it to the top of the authorization team's work queue.
+        - Condition 2: If it is a routine procedure scheduled weeks out, it stamps it as Standard Appeal with a 14-Day internal SLA target
+    - Step C: The "Peer-to-Peer" (P2P) Consultation Scheduler
+      - Pre-service auth blocks are often overturned via a direct phone call between your provider and the payer’s medical director. The system scans the denial letter metadata, extracts the payer's direct phone extension for peer reviews, and generates a Peer-to-Peer Scheduling Ticket on the provider's EMR sidebar.
+      - The Cheat Sheet UI: When the provider clicks the P2P ticket, the EMR opens a split-screen dashboard displaying:
+        - The exact criteria the patient failed to meet (e.g., "Patient has not completed 6 weeks of physical therapy before requesting back surgery").
+        - A highlighted list of where to find the counter-evidence in the text of the charts.
+    - Step D: Clinical Guideline Integration
+      - Your template factory must integrate with industry-standard clinical criteria databases (such as InterQual or Milliman Care Guidelines (MCG)).
+      - The system generates an interactive checklist for the provider: "To approve this CPT code, select which criteria the patient satisfies." The software wraps this checklist directly into the cover letter header to make it easily scannable for the payer's reviewing nurse.
+  - Post-Service Claim Denial Logic (The Claims Engine)
+    - When a provider has already treated a patient, a claim has been sent, and it comes back rejected or unpaid, your system pivots to a financial recovery workflow as such: [835 ERA Ingested] ➔ [Cross-Ref Contract Fee Schedule] ➔ [Map CARC to Work Queue] ➔ [Auto-Populate Frequency Code 7]
+    - Step A: Ingestion & Financial Matching
+      - The Trigger: Your clearinghouse engine ingests a HIPAA 835 Electronic Remittance Advice (ERA) file.
+      - The Filter: The system identifies segments where the Paid Amount is less than the Contracted Allowed Amount or where an active denial code is present in the CAS (Claim Adjustment) loop.
+    - Step B: CARC-to-Queue Intelligence Matrix
+      - The system reads the Claim Adjustment Reason Code (CARC) and routes the claim into isolated work queues managed by specialized members of your billing team
+      - Queue 1: Coordination of Benefits (COB) / Demographics (CARC 16, 177)
+        - Route: Frontend front-desk work queue.
+        - System Action: Auto-triggers an SMS text/email to the patient via the patient portal: "Your insurance reported an incorrect policy number. Click here to upload a photo of your new card.”
+      - Queue 2: Technical / Coding Errors (CARC 4, 97, 18)
+        - Route: In-house certified medical coder queue.
+        - System Action: Opens the claim in edit mode, auto-highlighting NCCI bundling edits or invalid modifier combinations
+      - Queue 3: Medical Necessity (CARC 50, M143)
+        - Route: Clinical provider / Appeals specialist queue.
+        - System Action: Triggers the dynamic AI appeal letter engine to pull the entire progress note
+    - Step C: The Corrected Claim Formatting Engine
+      - Unlike pre-service workflows (which use letters and clinical charts), post-service revisions often require submitting a brand-new HIPAA 837P file marked as a correction. Your code must automatically inject specific metadata tags into the outbound file format
+      - Set Loop 2300, CLM05-3 (Claim Frequency Type Code) to exactly 7 (Replacement of Prior Claim).
+      - Populate Loop 2300, REF segment (REFF8) with the exact Original Payer Claim Control Number parsed from the denying 835 ERA.
+      - Why this matters: If your system fails to do this, the payer's computer will flag the resubmission as a "Duplicate Claim" and auto-deny it instantly
+  - Consolidated System Architecture Blueprint
+    - To ensure both engines run smoothly, structure your relational database schema to route objects using the following logic gates. Use code similar to the below, but make sure ALL of our AI agents review the code and create the code that is best suited for our system and for its integration into our system:
+    - IF encounter.status = 'Pre-Service' THEN
+    -     LAUNCH prior_auth_appeal_workflow;
+    -     USE transaction_set_278;
+    -     TARGET payer_medical_management;
+    - ELSE IF encounter.status = 'Post-Service' THEN
+    -     LAUNCH claim_denial_workflow;
+    -     USE transaction_set_837P_frequency_7 OR transaction_set_275;
+    -     TARGET payer_claims_appeals_dept;
+    - END IF;
+- Prompt: create a fully functioning and integrated “Prior Authorization” engine
+  - To build a state-of-the-art, fully operating Prior Authorization (PA) Engine within your proprietary EMR, you must architect a system that treats Medications and Procedures through two distinct logic pathways. Medication PAs rely heavily on real-time pharmacy network data standards (NCPDP SCRIPT), whereas Procedure PAs rely on institutional medical clearinghouse transactions (X12 278). Here is the complete blueprint, detailed steps, and requirements for engineering a unified Prior Authorization Engine:
+  - Part 1: High-Level Engine Architecture
+    - Your PA Engine requires three core software modules to eliminate manual staff telephone calls and portal log-ins:
+    - [Provider Orders Item] │ ▼ 1. The Rule Engine (Determines IF a PA is actually required) │ ▼ 2. The Question/Criteria Engine (Gathers clinical justifications dynamically) │ ▼ 3. The Transmission Hub (Dispatches via NCPDP SCRIPT for Meds or X12 278 for Procedures)
+  - Part 2: Step-by-Step Medication PA Workflow (NCPDP Standards)
+    - Medication authorizations must tie directly into your EMR’s e-Prescribing (eRx) module. You should build this using direct API integrations with a network like Surescripts or CoverMyMeds.
+    - Step 1: Order Entry & Real-Time Formulary Check
+      - The provider selects a medication (e.g., a specialty biologic) in the EMR prescription interface.
+      - The system fires a background API call to check the patient’s insurance Formulary and Benefit (F&B) profile.
+      - The system reads the metadata. If it flags the medication as "PA Required," the EMR dynamically displays a yellow warning icon next to the drug name
+    - Step 2: The Electronic Prior Authorization (ePA) Initiation
+      - The system executes an automated NCPDP SCRIPT paInitiation request to the patient's Pharmacy Benefit Manager (PBM).
+      - The PBM responds instantly with a specific, unique PA Tracking Case ID and a dynamic, drug-specific clinical questionnaire
+    - Step 3: Adaptive Questionnaire Population
+      - The EMR parses the incoming XML/JSON question payload from the PBM.
+      - The Smart-Fill Step: Instead of presenting a blank form, your engine runs a quick search across the patient's current chart (labs, active diagnoses, encounter notes). It uses regular expressions or NLP to auto-populate fields like A1C levels, previously tried-and-failed medications, and ICD-10 codes.
+      - The system presents the pre-filled questionnaire to the clinical staff to verify and complete any missing fields
+    - Step 4: ePA Submission & Real-Time Triage
+      - The system packages the answers into an NCPDP SCRIPT paRequest file and transmits it directly to the PBM's adjudication network.
+      - The system opens a tracking listener and updates the prescription state to PA Pending.
+    - Step 5: Decision Ingestion & Pharmacy Release
+      - The PBM returns an NCPDP SCRIPT paResponse message. Your code must parse the response status:
+        - Approved: The system automatically updates the internal prescription record with the Payer Authorization Number and routes the prescription directly to the patient's preferred pharmacy.
+        - Denied: The system routes the record to your Pre-Service Appeal Engine, extracting the PBM's written clinical rationale for the refusal
+  - Part 3: Step-by-Step Procedure PA Workflow (X12 278 Standards)
+    - Procedures (e.g., MRIs, surgeries, physical therapy blocks) do not go through pharmacy networks. They are processed via our clearinghouse architecture using medical EDI paths or direct payer portal integrations.
+    - Step 1: Order Generation & CPT Rules Validation
+      - A provider signs an order for a procedure (e.g., CPT 72148 for a Lumbar Spine MRI).
+      - The system cross-references your internal Payer Rules Matrix. It determines if that specific CPT code, when paired with the patient's specific insurance payer ID, legally requires an active prior authorization
+    - Step 2: Structure the HIPAA 278 Inquiry
+      - If a PA is required, your clearinghouse translation engine compiles the data into a HIPAA 278 Prior Authorization Request transaction file.
+      - The system populates critical data loops:
+        - Loop 2010B: Payer Identification.
+        - Loop 2010A: Utilizing/Rendering Provider NPI and Taxonomy code.
+        - Loop 2400: The specific CPT/HCPCS procedure codes and supporting ICD-10 diagnosis codes
+    - Step 3: Clinical Documentation Attachment (The 275 Wrapper)
+      - Most procedures cannot be authorized on codes alone; they require clinical evidence.
+      - Your system automatically runs an extraction script to generate a clean PDF containing the provider's recent clinical notes, relevant imaging reports, and conservative therapy trial histories.
+      - The software binds this PDF payload directly to the transaction using a HIPAA 275 Additional Information transmission file, cross-referenced with the 278 file's tracking control number
+    - Step 4: Direct Gate/Portal Transmission
+      - The system dispatches the 278/275 payload via your AS2 or SFTP Clearinghouse Pipeline directly to the payer's medical management gateway.
+      - Fallback Path: For regional payers lacking EDI capability, an internal automated script logs into the payer's portal (via secured API hooks), maps your form data to their layout, uploads the PDF attachments, and retrieves the web tracking reference number
+    - Step 5: Adjudication Parsing & Schedule Verification
+      - The system ingests the inbound HIPAA 278 Response transaction set. Your engine evaluates the UM01 element (Certification Status Code):
+        - A1 (Certified/Approved): The system reads the Authorization Reference Number, stamps it into the patient's appointment record, changes the status to Ready for Service, and sends a notification to the clinical scheduling desk.
+        - A3 (Not Certified/Denied) or A4 (Pending Review): The system leaves the scheduling hold active and creates a notification task in the authorization manager's work queue.
+  - Part 4: Key Requirements Matrix for System Developers
+    - To help your team build this successfully, implement these strict software safeguards:
+      - The Multi-Payer Rules Database: Build a comprehensive internal database that acts as a lookup table matching Payer ID + CPT/HCPCS Code = PA Required (Yes/No). This prevents your front-desk teams from spending hours manually checking insurance websites.
+      - The Authorization Dashboard UI: Provide a dedicated screen for your in-house authorization team. It should feature a clean, interactive grid categorized by urgency:
+        - Drafting: Missing clinical documentation.
+        - Pending Payer Response: Clock ticking down against timely care standards.
+        - Action Required: Denied or requires additional information (Request for Info/RFI tracking
+      - Dynamic Authorization Expiration Monitor: Authorizations are only valid for a specific window (e.g., 30, 60, or 90 days). Your database must store the fields auth_start_date and auth_end_date. If a patient’s procedure is rescheduled to a date past the expiration threshold, the system must trigger a critical flag: [⚠️ Warning: Scheduled Date Exceeds Auth Expiration}
+For page: https://leafjourney.com/ops/denials (“Denials Command Center”)
+- For the four main text boxes when the page opens:
+  - Make each one of them “clickable”
+    - Once clicked on, it connects to their appropriate links and locations
+    - For the “open denials” box:
+      - Have clicking on it take the owner down to the lower part of the page that shows “all denials” 
+    - For the “high urgency” box:
+      - Have clicking on it take the owner down to the lower part of the page that and have it filter all the claims that have the “high urgency” red bubble only
+    - For the “total at risk” box:
+      - Be able to click on it and have a pop window open that shows the “total at risk” and have a “filter” button that allows the owner to adjust the parameters around this, such as “time”, “date”, “amount”, “3 month view”, “6 month view”, etc
+    - For the “recovery” box:
+      - Be able to click on it and have a pop window open that shows the “total at risk” and have a “filter” button that allows the owner to adjust the parameters around this, such as “time”, “date”, “amount”, “3 month view”, “6 month view”, etc
+      - Be able to extrapolate not only what is the “recovery target” but have the ability to obtain the “actual recovered” amount. Then be able to graph both over different parameters and of course make it beautiful, aesthetically pleasing, etc
+- For the “Denial Root Cause” section:
+  - When clicking on each “number” in the bubble on the right next to the dollar amount and have clicking on it take the owner to the “detailed claims” section lower down on the page with that specific information 
+  - When clicking on each “root cause”, have a pop up window open that displays the data in a graphical manner. Have the time and date range be fully customizable and make the graph beautiful, simple, and aesthetically pleasing 
+    - As part of the pop up window have a section at the bottom of the pop up window that is a “Cindy says” section that displays our AI driven analytics and suggestions on why the provider is getting these denials, trends and patterns detected, and simple suggestions to reduce these in the future. Make it 2-4 simple, not too wordy bullet points 
+  - Be able to “hover” over each “root cause” and have a small window pop up that explains in one phrase “what this means” in simple terms
+- For “Denial Mix by Payer” section:
+  - Be able to click on the “number” in the yellow bubble on the right and then have it take the owner to the “detailed claims” section lower down on the page and have it populate with that specific information
+  - When clicking on each “insurance name,” have a pop up window open that displays the data in a graphical manner. Have the time and date range be fully customizable and make the graph beautiful, simple, and aesthetically pleasing 
+    - As part of the pop up window have a section at the bottom of the pop up window that is a “Cindy says” section that displays our AI driven analytics and suggestions on why the provider is getting these denials, trends and patterns detected, and simple suggestions to reduce these in the future. Make it 2-4 simple, not too wordy bullet points 
+    - As part of the graph, have the ability to compare the “provider’s” statistics compared to what is average for another provider in that same and how many denials they get. 
+      - Have as much comparative date for the provider as possible. For example:
+        - Provider vs other provider in his specialty
+        - Providers vs all providers across the board
+        - Provider vs age and demographic data
+        - Provider vs amount of money loss or on hold for denials, etc
+  - Be able to “hover” over each “root cause” and have a small window pop up that explains in one phrase “what this means” in simple terms
+  - Make the section have a “scroll” feature on the right inside the box so if there are many insurance carriers, the owner can just swipe inside the box instead of the box continuously expanding
+- For the “detailed claims” section below the “denial mix by payer” section:
+  - Only keep the “all denials” bubble that is clickable
+    - Make the bubble a “drop down” bubble that includes the other options.
+      - For example the owner “clicks” on the “drop down” bubble that then populates as a scrollable menu that includes “medical necessity”, “bundling”, “modifier”, etc
+    - Make another bubble to the right of it that says “date” in it
+      - Once clicked on, allow for a small calendar to appear or have the ability for the owner to manually input any specific date range that they may need
+    - Have another bubble once right of the “date” bubble that says “insurance”
+      - Once clicked on, allow for all the insurance carriers to populate such as “UnitedHealth”, “Aetna”, “Cigna”, etc 
+    - Have another bubble once right of the “insurance” bubble that says “urgency”
+      - Once clicked on, allow for all the insurance carriers to populate such as “High urgency”, “Medium Urgency”, “Low Urgency”
+  - For each “detailed claims” subsection:
+    - Make the bubble that has the “high urgency”, “medium urgency”, and “low urgency” more fitting and less empty space within the bubble 
+    - Remove the words next to the red bubble that has the reason for the denial such as “past timely filing”, “medical necessity”, etc. It’s redundant and not needed
+    - Within the box, keep the information below the “reason for denial” bubble. Make sure that the italicized text is directly from the claims denial letter or correspondence. It should be a word by word exact copy of the message from the payer
+    - Change “suggested action” to “Cindy suggests”
+      - Make the green bubbles fit the wording better and have less empty/ dead space in each bubble
+      - Keep these phrases to about 3 words maximum
+    - When clicking on the “take action” button, have a pop up window appear with three separate clickable options to choose from:
+      - “Submit a corrected claim” option: If the denial was due to a simple clerical, registration, or demographic typo, update the information and resubmit it as a "corrected claim" rather than a formal appeal
+        - Submit a claim via our clearinghouse 
+          - (Open the claim in your Practice Management (PM) software or Electronic Health Record (EHR) system. Change the Type of Bill code (Institutional) or the Resubmission Code (Professional) to indicate a correction, and include the Original Claim Number.
+        - Directly via payer
+          - Log into the specific insurance company's secure provider portal (e.g., Availity, UnitedHealthcare Link, Optum). Use this if the claim is processing past the standard timeline, or if your clearinghouse rejected the submission.
+        - Make sure our entire system is properly wired to the right website, secured sites, proper channels to create a seamless and efficient ways to submit claims and track claims 
+      - “Fix coding errors” option: Pass the claim to a Certified Professional Coder (CPC) if the denial involves invalid ICD-10, CPT, or HCPCS modifier combinations.
+      - “Request a Peer-to-Peer Review” option: For medical necessity denials, schedule a phone call between the ordering physician and the insurance company’s medical director to discuss the clinical case directly.
+    - Next to the “denied May 9, 2026” section, have a beige “history” bubble button that once clicked on it expands that “specific claims” box which then shows every step that has been taken since the denial was received. For example:
+      - Denied May 9, 2026
+      - Appeal sent May 10, 2026
+      - Corrections from “insurance company” received May 12,2026
+      - Revisions sent May 14,2026
+      - Resolved May 17, 2026 (or “claim denied, final – May 17, 2026”)
+      - The “history” bubble should serve not only as documentation but needs to be in place for audit purposes
+For page: https://leafjourney.com/ops/aging (“Aging workbench”)
+- Be able to “click” on any of the four main boxes and have it populate that specificity information with the appropriate titles to match in the “Aging buckets section right below it.
+- For the “Aging buckets” section:
+  - Next to the “aging buckets” title, have a small “feather” emoji icon that once clicked on utilizes our LeadNerd analytics engine to have a pop up window appear that shows this data in a graphical, simple, aesthetically pleasing manner
+  - In the pop up window, have a filter button to be able to have the provider track it based on date range, time range, amount in $, etc
+  - Give as much detail for the provider. All of the analytics and graphs on the owner portal must utilize all the power of our LeafNerd engine to provide as much data and insight into the provider and owner’s clinical operations
+  - Make sure all of the horizontal bar graphs are populating correctly 
+  - Move the “insurance A/R” and “patient A/R” titles and options from the bottom of this section to underneath the “how balances are distributed across age ranges” title
+- For the “Filter” section:
+  - Remove “insurance only” and “patient only” bubbles and have it as part of a “drop down” menu. So when someone clicks on “all” bubble a drop down menu will populate that also has “insurance only” and “patient only”
+  - Have another bubble to the right of “all” and have it be “days”. Have the drop down menu show:
+    - “0-30” days
+    - “31-60” days 
+    - Etc (have clicking on these number ranges  on the”Aging Buckets” section send the page to this “filter” section with the specific date range.
+      - Basically there should be a synchronicity between what is being clicked on and making sure that specific information is being properly presented and displayed
+  - Have a bubble to the right of the “days” section that says “% recoverable” which then displays the appropriate information based on it. Have the drop down menu show:
+    - “0-25%”
+    - “26-50%”
+    - “51-75%”
+    - “76-100%”
+- For the “Worklist” section, for each “balance” box:
+  - Put the “number of days” that it has been in denials in a “beige” bubble
+  - Remove the “Ins: $155” or “Pt: $64” from every “balance” box
+  - Underneath the “% recoverable” section, put in a beige bubble either “insurance” or “patient”
+    - Have the “Insurance” bubble be in “yellow”
+    - Have the “Patient” bubble be in “light purple”
+  - When clicking on each “balance” box:
+    - Have it expand which then shows every step that has been taken since the A/R has been ongoing. For example:
+      - Denied May 9, 2026
+      - Appeal sent May 10, 2026
+      - Corrections from “insurance company” received May 12,2026
+      - Revisions sent May 14,2026
+      - Accepted May 17, 2026 (or “claim denied, final – May 17, 2026”)
+      - The “history” bubble should serve not only as documentation but needs to be in place for audit purposes
+For page: https://leafjourney.com/ops/eligibility (“Eligibility” Tab)
+- Change “cannabis eligibility checker” to “eligibility checker” 
+- For the “patient eligibility check” section:
+  - Change “enter patient details to check qualification status” to “enter patient details to check insurance activity.”
+  - For specifically checking cannabis eligibility for this section, have another button next to “check eligibility” that says “cannabis eligibility”
+    - Remove the “cannabis eligibility” or “psilocybin eligibility” buttons if the provider and owner have opted out of the cannabis or psilocybin module. There should be no signs or wording indicative of cannabis or psilocybin anywhere 
+    - Have the “cannabis eligibility” section determine if a patient qualifies for a medical marijuana license on their respective state versus does not
+    - Therefore, when clicking on the “cannabis eligibility” button, make sure that it is properly connecting to all guidelines for insurance companies and for state guidelines on how to likely it is for them to obtain a medical marijuana license
+      - Have all AI agents do “test runs” and “check cannabis eligibility” for a patient in every single state that is over 21 years old, another “test run” for patients in every single state that is under 21 years old with the chronic conditions listed versus not. Harden this aspect of this page to make sure it is displaying proper “cannabis eligibility” criteria
+  - Make this section primarily to check a patient’s actual insurance eligibility and coverage and make sure that their insurance is active
+  - To check a patient’s eligibility make sure it goes through these detailed steps and make sure all of our AI agents are able to test this system and make sure it is working flawlessly and seamlessly from start to finish
+    - Collect Comprehensive Patient Information
+      - Gather complete details from the patient during initial scheduling or intake
+      - Demographics: Full legal name, date of birth, home address, and phone number
+      - Policy Specifics: Insurance provider name, member ID number, and group number.
+      - Policyholder Details: Full name of the primary subscriber and their relationship to the patient if the patient is a dependent.
+      - Card Images: A clear photocopy or digital scan of the front and back of the insurance card
+    - Verify Identity and Coordinate Benefits
+      - Confirm the patient is who they claim to be and uncover any secondary policies
+      - Cross-Check Identity: Compare the collected insurance details against a government-issued photo ID to avoid identity errors.
+      - Coordinate Benefits (COB): Ask if the patient is covered by multiple plans (e.g., primary commercial plan, secondary Medicare, or tertiary Medicaid)
+      - Determine Payer Order: Identify which policy bills first based on established coordination of benefits rules
+    - Contact the Payer to Confirm Coverage Status
+      - Submit an inquiry to the insurance company using electronic or manual tools
+      - Electronic Option (Preferred): Run a real-time eligibility check (an EDI 270/271 transaction) through your Electronic Health Record (EHR) system, practice management software, or a clearinghouse like Availity
+        - But remember that LeafJourney will serve as its own clearinghouse therefore make sure the system is ran through the LeafJourney clearinghouse instead of a third party clearing house 
+        - For LeafJourney being a clearinghouse, make sure it is fully functional and goes through these below steps to check patient eligibility:
+          - Developing an Electronic Medical Record (EMR) system that acts as its own clearinghouse for multi-specialty outpatient clinics requires automating the X12 270/271 Electronic Data Interchange (EDI) transaction loop. Instead of navigating user interfaces, your platform must programmatically translate user inputs into standard technical files and parse the complex response payloads back into a clean UI.
+          - Structure the ASC X12 270 Eligibility Inquiry
+            - Your EMR front-end must collect patient demographic, provider, and policy data, then automatically format it into a standard X12 270 (Version 5010) transaction file. This flat file uses specific segment loops to transmit data
+            - Loop 2000A & 2000B (Information Source & Receiver): Defines your clearinghouse/EMR entity and the target insurance payer via their unique National Payer ID.
+            - Loop 2100B (Provider Information): Transmits the billing or rendering provider's National Provider Identifier (NPI).
+            - Loop 2100C (Subscriber/Patient): Transmits the primary cardholder's member ID, first and last name, date of birth, and gender.
+            - EQ Segment (Eligibility Inquiry): Specifies what type of medical care is being evaluated. For a multi-specialty system, your EMR must dynamically inject the correct Service Type Code into the EQ01 element based on the provider's specialty.
+          - Map Core Service Type Codes by Specialty
+            - Because your system serves diverse outpatient specialists, your software cannot rely on a single generic code. Your EMR must automatically inject the appropriate X12 Service Type Code into the 270 request to pull accurate benefit lines:
+- Medical Specialty
+Recommended X12 Service Type Code
+Purpose / Data Retrieved
+Primary Care / Internal Medicine
+1 (Medical Care) or 98(Professional Visit)
+General office visit copays, deductible status, and preventative care coverage.
+Cardiology
+33 (Chiropractic) / 86 (Emergency) / 2 (Surgical) / 98
+Evaluates specialized cardiac diagnostic testing, imaging, and intervention allowances.
+Dermatology
+2 (Surgical) or BR (Clinical Laboratory)
+Validates skin biopsies, minor in-office surgical procedures, and laboratory pathologies.
+Mental / Behavioral Health
+A6 (Psychotherapy) or MH (Mental Health)
+Checks session limits, outpatient authorization thresholds, and specific DSM code coverages.
+Physical / Occupational Therapy
+50 (Physical Therapy) or 101(Occupational)
+Tracks cumulative annual visit limits, hard benefit caps, and medical necessity rules.
+          - Establish Direct Secure Core Connectivity
+            - To bypass intermediate clearinghouses and act as your own node, your platform must connect directly to each insurance payer's EDI gateway:
+            - CAQH CORE Compliance: Build your communication protocol around CAQH CORE Phase II rules, which mandate secure, real-time HTTP Post or SOAP/WSDL web services.
+            - X509 Digital Certificates: Implement secure mutual TLS (mTLS) authentication by managing unique security certificates for each major payer network.
+            - Real-Time API Failovers: Build endpoints capable of processing real-time batch requests, returning responses within the federally recommended 20-second threshold.
+          - Parse the ASC X12 271 Eligibility Response
+            - When the payer gateway returns an X12 271 file, your EMR backend parser must instantly deconstruct the loops and map them to your user dashboard. Your ingestion engine must look for these key data segments:
+              - AAA Segment (Request Validation): Check this first. If present, the request failed. It yields explicit error codes (e.g., AAA03 = '72' means "Invalid/Missing Member ID").
+              - EB Segment (Eligibility/Benefit Information): The core financial payload. Your engine must programmatically map EB01 codes to display clear financial statuses:
+                - EB01 = '1': Active Coverage.
+                - EB01 = '6': Inactive Policy.
+                - EB01 = 'C': Co-Insurance percentages.
+                - EB01 = 'A': Co-Payment flat amounts.
+                - EB01 = 'C1': Deductible details.
+              - REF Segment (Reference Identifiers): Parses and extracts prior authorization requirements (REF01 = '18') or referral rules linked to that service code.
+          - Automate the Verification Lifecycle
+            - To reduce manual administrative burdens for your clinic users, configure your software architecture to execute the 270/271 loop automatically at three distinct triggers:
+              - Trigger 1 (Real-Time Scheduling): Fire a 270 inquiry the moment a patient is booked on the calendar to catch immediate coverage red flags.
+              - Trigger 2 (Automated Batch Re-Verification): Run an automated CRON job 48 hours prior to all scheduled appointments to capture sudden plan terminations or updates.
+              - Trigger 3 (On-Demand Check-In): Provide a manual "Re-Verify Now" button directly on the front-desk intake dashboard for walk-ins or same-day plan alterations.
+      - Web Portal Option: Log directly into the specific health plan's provider portal (e.g., UnitedHealthcare, Aetna, or Blue Cross Blue Shield)
+      - Manual Phone Option: Call the insurance provider's provider services line directly if electronic data is ambiguous
+    - Validate Specific Policy Benefits
+      - Review the response data to confirm the plan covers the exact medical care scheduled
+      - Active Dates: Verify the policy is currently active for the exact planned date of service.
+      - Network Status: Confirm whether your healthcare provider or facility is in-network or out-of-network for this specific plan
+      - Service Exclusions: Verify that the precise procedure codes (CPT codes) or visit types are covered benefits
+    - Calculate Patient Cost Responsibilities
+      - Determine what the patient must pay out-of-pocket to prevent billing surprises
+      - Deductible: Check the patient's total deductible, how much has been met so far, and how much remains outstanding
+        - Make sure the updated “deductible” amount is reflected in the patient’s chart on this page, https://leafjourney.com/portal/billing, specifically on the “Your Insurance” section
+      - Copayment: Identify the flat dollar fee required for the specific office visit or specialist care.
+      - Coinsurance: Determine the percentage of the service cost the patient is responsible for after meeting their deductible
+        - Make sure the updated “coinsurnace” or “out of pocket max” amount is reflected in the patient’s chart on this page, https://leafjourney.com/portal/billing, specifically on the “Your Insurance” section
+      - Visit Limits: Look for maximum visit caps (e.g., a limit of 20 physical therapy sessions per calendar year)
+        - Add this as another measure in the “Your Insurance” section of this page, https://leafjourney.com/portal/billing
+    - Identify Prior Authorization and Referral Needs
+      - Determine if the insurer requires administrative hurdles before paying the claim
+      - Referrals: Check if the plan requires a formal referral from a primary care physician (PCP) to see a specialist.
+      - Prior Authorization: Identify if the scheduled treatment, scan, or surgery requires an approved pre-authorization before the appointment
+    - Document Findings and Update Records
+      - Log every piece of verified data into your billing software to protect against future claim denials
+      - Audit Trail: Save the electronic verification receipt or log the reference number, date, and name of the phone representative
+      - System Updates: Populate the fields in your Revenue Cycle Management (RCM) system with the correct copay, deductible, and payer claims mailing address
+    - Communicate Financial Expectations to the Patient
+      - Contact the patient prior to their arrival to review their coverage
+      - Out-of-Pocket Estimates: Clearly explain what their copay, deductible, or coinsurance responsibility will look like
+      - Resolution of Issues: If coverage shows as inactive, offer them the chance to provide updated policy information or opt for a self-pay agreement before care is provided
+- For the “Eligibility Result” section:
+  - Make sure it defaults to “insurance eligibility” and not “cannabis medical marijuana card eligibility”
+  - For the “bubble” have it like this:
+    - “green” bubble means “active” insurance
+    - “Yellow” bubble means “error” or “check” insurance
+    - “Red” bubble means “not active” insurance
+  - For the “Findings” subsection:
+    - For the first bullet, “Colorado has a legal medical cannabis program”, have a “leaf” emoji icon button next to it that once clicked on opens a pop up window that has a map of the USA that is beautiful, aesthetically pleasing that when hovering over any state, it tells the provider if the state has “recreational cannabis”, “medicinal cannabis”, “both”, or “neither” 
+    - For the second bullet, “‘anxiety’ is a qualifying condition in most medical cannabis states”, have a “leaf” emoji icon button next to it that once clicked opens a list of usual “qualifying conditions” for medical marijuana and have a running list of the top ten conditions
+  - For the “Recommended Next Steps” subsection:
+    - Have the “initiate medical cannabis card application” line be a “clickable” hyperlink that connects the provider directly to the website where the actual medical marijuana card application is located. Make sure all AI agents go through each state regulation and requirements to connect to the proper page
+    - Have “Document qualifying condition with ICD- 10 coding” line be a “clickable” hyperlink that opens a “pop up” window that will then allow the provider to populate all ICD 10 codes. Have a “search box” and on the right have an “enter” or “search” button
+      - As the provider types in either the ICD 10 code or the diagnosis, have it auto populate with the best results as a drop down menu that populates 5 top options. Once clicking “search” or “enter” have it show every single ICD 10 code and the diagnosis in two separate columns. Be able to click on it and have it “add” to the patient’s diagnoses.
+    - Have the “Schedule certification appointment with a cannabis certified provider” be a clickable hyperlink that once clicked on, it can take the provider to the “schedule” tab of the provider option and allows for the patient to be scheduled with a certified cannabis clinicians (hold this feature for now until we have our full directory of cannabis clinicians updated and available)
+For page: https://leafjourney.com/ops/mail-fax (“mail-fax OCR” tab)
+- Change name from “mail & fax OCR inbox” to “documents inbox and outbox”
+- Have two main “tabs” for this page:
+  - Tab 1 = “inbox” which should have all scanned, emailed, faxed, uploaded, or manually uploaded documents that are imported or received into LeafJourney along with the entire rest of the structure of the page
+  - Tab 2 = “outbox” which should have all scanned, emailed, faxed, uploaded, or manually uploaded documents that are exported or sent out from LeafJourney along with the entire rest of the structure of the page
+    - The outgoing documents should be placed in chronological order and should have similar identifiers such as the “inbox” for example it should have “fax – insurance card- sent (“date”), “time””
+    - The top of this page should have a “send” button that once clicked on, a pop up window opens where the provider can type in the patient or outgoing recipient’s “name” and “fax number” or “email” and a message box along with the ability to “attach” any document directly to it, which then allows the provider to “send” this information via fax and can keep documentation and a running history of everything sent
+      - Keep the history for 90 days before it starts to get archived.
+- Above the “flagged for review” box:
+  - Have two buttons: the left button should say “scan” which then allows for a pop up window to open with the ability to directly “scan” in documents based on their scanner, USB connectivity, etc with LeafJourney
+  - Have the right button say “deleted items” which once clicked on takes the owner to another page of all “deleted” scanned documents over the past 30 days placed in chronological order
+    - For each “deleted” item, have the ability to “recover” or “permanently delete” each item
+- Make sure this section is where ALL documents that are sent via e-fax, email, or manually uploaded or manually scanned come into this centralized “inbox” where it can then be divided up into its respective location via AI and human review
+  - For example, if the owner scans an image report of an MRI of one patient and the lab report of another patient, it should be able to determine what labs were drawn, what patient it belongs to, what the patient’s DOB is, and what date it was done. From there it should be able to properly organize and place this lab/document into the patient’s chart.
+- Be able to click on the patient’s “name” which then takes the owner back to the main patient page
+- Be able to click on each “box” and have clicking on it open and populate those specific files below this row of boxes
+- For the “scans today” section:
+  - Be able to click on it and have all the scans for the 24 hour window for that day populate in chronological order underneath it
+- For the “flagged for review” section:
+  - Be able to click on it and have the flagged scans populate in chronological order underneath it
+- For the “exact matches” section:
+  - Be able to click on it and have the “exact matches” scans populate in chronological order underneath it
+- For the “low confidence” section: 
+  - Be able to click on it and have the “low confidence” scans populate in chronological order underneath it
+- For each OCR detailed window:
+  - Be able to “click” on each “patient name” and have it open to that patient’s chart
+  - Make each detailed window fully “expandable” and “collapsible” 
+    - When “collapsed” keep only certain info visible: patient’s name, date and time of scanned document, “type” of document (for example, MRI, lab, PT, DMV handicap placard, etc)
+  - Be able to “approve” or “edit” or “delete” each “scanned” document
+    - If “approved” then it gets properly placed and filed into the patient’s chart based on the type of document and time 
+    - If “edited” then have the ability for a pop up window open that has the ability to change or search the “patient’s name” or “DOB” and find the “category” of what type of chart document this is, along with being able to type in or select the “date” of the specific chart document. Then be able to click on “route” the document which will then properly organize the document
+    - If “deleted” then have the document be deleted from the “inbox” and have it stored in the “trash” folder for 30 days before it is permanently deleted
+  - For the bubbles:
+    - Change the “MRN” number to “MLN” number which is the Medical Life number, which is central to LeafJourney
+    - “high confidence” should remain in a “green” bubble
+    - “medium confidence"” should remain in a “yellow” bubble
+    - “low confidence” should be in an “orange” bubble 
+    - All “error” messages should be in a “red” bubble
+    - The “new coverage” bubbles should be in a “blue” bubble
+  - For the “extracted” information section:
+    - Have a button on this section that says “insurance” which once clicked on, takes the owner directly to the part of LeafJourney where the provider or owner can manually enter all of the insurance data
+  - For the “view raw OCR text”
+    - Change to “view actual text”
+      - Make sure this shows the actual full sized PDF, JPG, DOCX document and have it fully “OCR” read and scanned
+      - Keep this window as “collapsible” and “expandable”
+For page: https://leafjourney.com/ops/billing-agents (“Billing Agents” Tab)
+- Have the ability to have this entire page in “light” mode and not only in “dark” mode. It should default to “light” mode
+- For now leave all as is and then once the rest of the EMR is up and running, make the data that is inputted into this section incorporate into the LeafNerd analytics engine
+For page: https://leafjourney.com/ops/revenue (“Revenue” Tab)
+- Move this page, https://leafjourney.com/ops/revenue, and have it as another tab in the https://leafjourney.com/ops section.
+  - Call this section: https://leafjourney.com/ops/revenue
+- For each box on the top, have the ability to click on each and have it give more data
+- Make every subsection of this page fully collapsible and expandable. The subsections below should be able to be displayed as just their title and once clicked on all the details populate. Do this for “Claims funnel”, “AR aging”, “Dispensary – Gross/Net (last 90 days)”, “Denial queue – ranked by recoverable dollars”, “claim status breakdown”, “provider productivity”, “payer mix”, “top billed codes”
+  - Each subsection can be “dragged” and rearranged to the owner’s liking
+- Change the “billing workqueue” button to “billing dashboard” button
+- Have two tabs on the main page of this:
+  - Tab 1: “Claims billing”
+    - This should include every aspect of billing that is part of claims, encounters, denials, etc
+  - Tab 2: “Product billing”
+    - This should include all products, inventory, amount per week, month, etc
+      - Have this tab include the “dispensary-gross/net (last 90 days)” section (this should include the other sub sections: “Gross product revenue”, “refunds”, “Tax collected”, “net revenue”, “inventory on hand”, “Top SKUs by net revenue”
+- For the “Total Billed” box:
+  - Have the ability to “click” on the box and have a pop up window appear that allows the owner to analyze this data chronologically and by amount
+    - Have it so the owner can adjust the parameters as desires (keep up to 5 years)
+    - Have a small button on this pop up window that says “details” and once clicked on, have it connect the owner to this page, https://leafjourney.com/ops/billing 
+- For the “Collected” box:
+  - Have the ability to “click” on the box and have a pop up window appear that allows the owner to analyze this data chronologically and by amount
+    - Have it so the owner can adjust the parameters as desires (keep up to 5 years)
+  - Have a small button on this pop up window that says “details” and once clicked on, have it connect the owner to this page, https://leafjourney.com/ops/billing?status=paid 
+- For the “Last 30 days” box:
+  - Have the ability to “click” on the box and have a pop up window appear that allows the owner to analyze this data chronologically and by amount
+    - Have it so the owner can adjust the parameters as desires (keep up to 5 years)
+  - Have a small button on this pop up window that says “details” and once clicked on, have it connect the owner to this page, https://leafjourney.com/ops/billing
+    - On this page have an option to look at all claims for the “past 30 days”
+- For the “Outstanding” box:
+  - Have the ability to “click” on the box and have a pop up window appear that allows the owner to analyze this data chronologically and by amount
+    - Have it so the owner can adjust the parameters as desires (keep up to 5 years)
+  - Have a small button on this pop up window that says “details” and once clicked on, have it connect the owner to this page, https://leafjourney.com/ops/billing?status=submitted 
+    - For the “outstanding amount”, have it so it pulls all claims data from these links into one list (submitted, partial, denied
+      - https://leafjourney.com/ops/billing?status=submitted, https://leafjourney.com/ops/billing?status=partial, https://leafjourney.com/ops/billing?status=denied 
+- For the “Claims Funnel” section:
+  - Make this smaller and be able to click on each part, for example, “coded”, “submitted”, etc and have it connect to the “billing dashboard” link which then populates those specific claims.
+    - For example, a provider clicks on “coded” which then takes him to the billing dashboard website which then automatically will populate the current claims that have been “coded”
+      - Be able to filter this chronologically from 0-90 days so the provider can see what claims are open and the time they’ve been opened, closed, denied, etc
+- For the “AR Aging” section:
+  - Have the ability to “click” on each section (“0-30”, “31-60”, etc) box and have a pop up window appear that allows the owner to analyze this data chronologically and by amount
+    - Have it so the owner can adjust the parameters as desires (keep up to 5 years)
+  - Have a small button on this pop up window that says “details” and once clicked on, have it connect the owner to this page, https://leafjourney.com/ops/billing and have it populate those specific claims for that time period.
+- For the “dispensary – gross/net (last 90 days)” section:
+  - Put everything in this section under “Tab 2”
+  - For the “bubble” color system:
+    - Make “critical SKUs” be in “red” and be when < or = to 5 units
+    - Make “order soon SKUs” be in “yellow” and be when < or = to 20 units
+    - Make “in stock SKUs” be in “green” and be when > or = to 21 units
+    - Have these four bubbles display in order of “red”, “yellow”, and “green” next to the “33” next to “reorder alerts” title
+  - For the “Inventory on hand” subsection:
+    - Have a display of the “crucial SKU” reorder red bubble populate to the right of the “Inventory on hand” title
+    - Make sure each SKU has a “number” of units as part of the inventory directory
+    - Make the “top SKU by net revenue” section be a part of the “Inventory on Hand” section. Have it incorporates into it along with streamline the search and data presentation abilities
+      - Have this bubble have the “number” of needed SKU refills in the middle of it
+      - Have a “filter” button towards the right corner of the subsection that when clicked on have the ability to “organize” all the products by alphabetical order, price, type, etc
+        - We want this to be a fully modifiable and customizable search to any parameter that the owner may need
+      - To the right of the “filter” button have a “search bar” 
+        - Once the owner starts typing in it, have a drop down menu auto populate the closest search to that specific product
+          - Make this search bar AI driven so it can search up SKUs and products just by “phytocannabinoid” such as THC, CBD, etc, “terpene” profile such as humulene, limonene, “type” of cannabis for example such as “tincture”, “vape,” etc, “strain” type such as Jack Herrer, Durban Poison, etc, 
+      - For the “estimated inventory value” subsection:
+        - Be able to click on it and have “pop up” window appear that shows a side by side comparison of “wholesale” price of each SKU and “retail” price of each SKU
+    - Place this entire section of “Reorder alerts” under the “inventory on hand” subsection below
+      - When clicking on any part of this subsection, have a new webpage open that shows all of the “reorder alerts” and everything else inventory based
+    - Be able to click on each SKU and have a pop up window open that has data on its selling history, the number of units moved based on chronological and financial parameters, trends of sales over time, demographic usage, etc
+      - Make all of the products have full analytics that ties into the patient side of LeafJourney along with all the data from the LeafNerd platform
+    - Have a small picture of each product next to it on the right. Be able to click on the picture to enlarge it and see different angles (the pictures should come from the actual product website for now)
+  - For the “Gross Product Revenue” subsection:
+    - Be able to click on it and have it connect to a new webpage where it displays in detail the number of orders, the number of units, gross product revenue based on chronological parameters and financial parameters along with graphical visualizations that are aesthetically pleasing and easy to understand to see trends and historical data
+  - For the “Refunds” subsection:
+    - Be able to click on it and have it connect to a new webpage where it displays in detail the number of refunds, reasons for refunds with chronological parameters and financial parameters along with graphical visualizations that are aesthetically pleasing and easy to understand to see trends and historical data
+      - Each “refund” should have an explanation of why it was returned, for example (“defective packaging”, “wrong item”, “not as expected”, etc)
+  - For the “Tax collected” subsection:
+    - Be able to click on it and have it connect to a new webpage where it displays in detail all the tax data required for tracking e-commerce supplies and revenue and expenses. 
+      - Have this section serve as a legitimate tax documentation location along with a profit and loss sheet along with deduction details 
+        - This section should be similar to a “Quickbooks” type of structure and functionality
+      - Once open on a new page, have a “generate tax documents” that once clicked on gives the owner a drop down menu of the most common types of IRS based tax filing documents that can be filled out and be part of the tax returns
+  - For the “Net Revenue” subsection:
+    - Be able to click on this section and have it open a pop-up window that breaks down the “gross” revenue in one column, “refunds” in another, and “taxes” in a third. Have it so it can clearly show calculations for all three of these parameters
+- For the “Denial Queue – ranked by recoverable dollars” section:
+  - Have a “name” column header and an “amount” column header that the owner can click on which alphabetizes the claims or can arrange the amount of dollars from high to low or low to high
+- For the “Claim Status Breakdown” section:
+  - Have this exact section also be placed in the https://leafjourney.com/ops/billing under the ribbon of bubble buttons and before the detailed columns list of all the claims
+    - For each status such as “draft”, “submitted”, etc
+      - Be able to click on each and have it populate all of those claims that meet that criteria and have it link back to the https://leafjourney.com/ops/billing section under the specific claim status
+      - Be able to arrange it by financial or numerical amount
+  - Make sure that each status is a different color for the graph
+- For the “Provider Productivity” section:
+  - If there are multiple providers, have them organized in list form with the information that is presented on the “expanded” form, which includes “total claims”, “billed”, “collected”, “denied”
+    - Be able to click on a small “feather” button in the top right of this section which then can graph the provider’s performance both chronologically and financially
+    - Have the ability to compare to the other providers to see the differences in real time
+  - When clicking on each provider:
+    - Have a pop up window appear with more detailed information including “rejection” rate, “denials”, “amount collected”, etc and have it as searchable and customizable in terms of parameters as possible
+- For the “Payer Mix” section:
+  - Have this section also be a part of the https://leafjourney.com/ops/billing page
+  - Have all payers that owe the provider money listed on here
+  - Be able to click on each individual payer which then leads to a pop up window appearing which shows the trends over the “past week”, “past month”, “3 months”, “6 months”, etc
+    - Be able to graph all payers to see how they all trend overall based on chronological and financial parameters
+    - For each payer, be able to have our AI LeafNerd try to determine the causes of denials, corrections, etc and then be able to see which one has the most of it
+- For “Top Billed Codes” section:
+  - Include “Top billed Codes” which include the CPT codes
+  - Be able to click on each “code” and have a pop up window appear that has a more detailed description and data/analysis
+    - When clicking on it, be able to see the “date” that the code was used
+  - Include another section called “top billed ICD 10 codes” which displays the most commonly used ICD 10 codes (include the amount used, etc)
+    - Once other providers start using LeafJourney, have the ability to analyze all of this data in terms of top billed codes across providers and our EMR based on specialty
+For page: https://leafjourney.com/ops/cfo (“CFO” tab):
+- Next to the “year” button, have a “search” feature that allows the owner to set any chronological parameter to check specific time ranges
+- Create a new tab called “Bookkeeping” and have the link be: https://leafjourney.com/ops/cfo/bookkeeping  
+  - In this section, have it similar to QuickBooks ledger that tracks all income and expenses in a chronological order. 
+  - Have a “tab” populate on the ribbon to the right of “cash” that says “bookkeeping”
+    - On this page, have a small tile with a “+” symbol that says “upload QuickBooks” file
+      - Be able to click on that “+” symbol and be able to upload QuickBooks files with these extensions:
+        - .QBW, .QBB, .QBM
+        - .QBX, .QBA, .QBY
+    - On this page, have a small tile with an “export” emoji that says “export” files
+      - Once clicked on, have an option to choose the ability to export the entire CFO data in a .CSV, .XLS, .XLSX, .QIF, .IIF files
+    - Take the “Log New Expense” section from https://leafjourney.com/ops/cfo/expenses and move it to this new page
+      - For the “Log New Expense” section:
+        - Change the title to “Log New Expense/Income”
+          - For the “Vendor” field:
+            - Once the “vendor” name begins to be typed, have it drop down as the owner starts typing it in
+          - For the “category” field:
+            - Make this field a “free text” box instead of a drop-down menu
+            - Once the “category” name begins to be typed, have it drop down as the owner starts typing it in
+          - Change “Tax” title to “Expense” title
+          - Change “Amount” title to “Income” title
+            - Have it so that the data and software tracks properly to each line item being either an “expense” or “income” 
+          - Remove the “date paid” section
+          - Stop the sidebar from expanding when clicking on the “Log” button
+    - At the bottom of this page, have a tile with a running list of all line items, both “expenses” and “income” organized in chronological order. Have this section named “Recent income and expenses”
+      - Have this section be similar to the “Recent expenses” section in https://leafjourney.com/ops/cfo/expenses but just include the “income” 
+      - Have another column title that says “income/expense”
+        - Have the bubbles populate as “income” and “expense” 
+          - “Income” bubble is “green” in color
+          - “Expense” bubble is “red” in color
+      - Have the last 20 entries shown in chronological order and then truncate this tile. At the bottom of the tile have an “expand” button which then populates another 50 entries. Continue to have the “expand” button at the bottom until every single entry is shown in a very long list
+- Make sure the “Generate weekly report” button works and does not cause the “sidebar” to open once clicked on
+- Have the sidebar stop appearing every time clicking on any part of this page
+- Check with all AI agents why there is a lag when clicking on “week”, “month”, “quarter” or “year” buttons on top
+- For “CFO Briefing” section:
+  - Make sure the overall section has “gross margin”, “revenue”, “EBITDA”, “amount in bank”, “working capital” stats presented in a simple chart rather than in sentences. Make the sentences be all of the “suggestions” that our AI assistant, Cindy, is making. Whenever an AI generated statement is created, have it be under a small header that says: “Cindy suggests” 
+  - Have a “feather” emoji in this section that once clicked on, it opens a pop up window that can show all of the data in this briefing and all of the pertinent markers in a beautiful, aesthetically pleasing manner. It should be beautiful, visual, etc
+  - For the “Briefing generated Jun 4, 2:01 AM by agent:cfo@1.0.0.”, remove the “agent:Cfo@1.0.0” aspect
+- For “Headline KPIS” section:
+  - Put in parentheses what “KPI” stands for (Key Performance Indicator)
+  - Next to the title of “Headline KPIs”:
+    - Place a “search” bar that the owner can type in dates, times, and also have the ability to choose any chronological parameters to display that information. This will show all of the KPIs in that set chronological parameter range
+  - For every single KPI in this section:
+    - Have a small “clickable” box on each section in the top right corner that the owner can click on which can allow them to “compare” different KPIs in the same graphical presentation. Once two or more of the KPIs are selected, on the right part of the page across from the header, “Headline KPIs” have a “compare” button appear and once clicked on, it opens a “pop up” window with the graphical presentation for both KPIs on the same graph or visual presentation of the data
+      - For example, the owner can click on the “revenue” clickable box and the “gross margin” clickable box which then has the pop up compare both of these KPIs together
+    - Have it so the owner can click on the box which then opens a pop up window that shows data for each KPI in a beautiful, aesthetically pleasing in different graphical manners and in the top right of the pop up window have a “search” bar that the owner can type in dates, times, and also have the ability to choose any chronological parameters to display that information.
+      - Make any graph or data display whether it’s line graph, vector graph, etc have the ability for the owner to hover their cursor over it, and it gives details for that data point (for example, when hovering on one of the data points, be able to display “#” and “time”. Make sure to display the data from the “X” axis and “Y” axis. Do this for any part of the “patient”, “owner”, or “provider” portal wherever data and analytics can be utilized. Make it similar to https://www.google.com/finance/beta/quote/F:NYSE?sca_esv=a82350b6429375af&rlz=1C1HKFL_enUS1206US1206&output=search&source=lnms&fbs=ADc_l-aN0CWEZBOHjofHoaMMDiKpWuJzWbn6y2Zf42jFClqc74f05r15SFp3eB7-_aeVssDFTrrVbm-92MfivJar7-BYYUkzgIb9YNW6Wky1DIUwHKhHpEocYnbyMA6A-0nAdumb9_Gui4kwOxKgBa22HGxdAjRYmb4tyizu7gB1fsK2eIhX4bM5VC4X3cn1q3yRQKwR-v0rOYwY94-xeddQCYr64nhkgA&sa=X&sqi=2&ved=2ahUKEwjd__fgxOyUAxV5J0QIHbu-PZ0Q0pQJegQIFBAB 
+  - For the “bubble” colors:
+    - Make the “red” bubble be if the KPIs are “negative” or lower than previous KPIs
+    - Make the “green” bubble be if the KPIs are “positive” or higher than previous KPIs
+    - Keep the “yellow” bubble to be “off goal”
+    - Make a “purple” bubble to be “on goal”
+  - Keep the “definitions” as they remain on the bottom part of each KPI box
+  - Make this entire section expandable and collapsible
+  - Make each tile moveable and rearrangeable 
+- For the “Anomalies and Flags” section:
+  - Merge this with the “CFO briefing” as a subsection of it.
+    - For example, have the KPIs and data presented on the left subsection, the right subsection has the “Anomalies and Flags” and the bottom subsection can be the “Cindy suggests” section
+      - For the Left subsection that has all of the KPIs, have the chart look similar to “This period vs. prior” on the https://leafjourney.com/ops/cfo/pnl page
+- For all of the graphs presented below, have it removed and have it part of the graphical and analytical structure as mentioned above
+- Remove the “Revenue vs EBITDA – Last 13 weeks” graph
+- For the “Profit and Loss”, “Cash Flow”, and “Balance Sheet” sections at the bottom of the page:
+  - Bring this at the top of the page after the “CFO” briefing
+  - Next to each section, have the “Dates” or “date ranges” shown
+For page: https://leafjourney.com/ops/cfo/pnl (“Profit and Loss” tab)
+- Have a “CFO Briefing” section on this tab
+- Make sure the “Generate weekly report” button works and does not cause the “sidebar” to open once clicked on
+- For the first section that has the “Revenue”, “Gross Margin”, etc boxes:
+  - Put this under the header of “Headline KPIs”
+  - Next to the title of “Headline KPIs”:
+    - Place a “search” bar that the owner can type in dates, times, and also have the ability to choose any chronological parameters to display that information. This will show all of the KPIs in that set chronological parameter range
+  - For every single KPI in this section:
+    - Have a small “clickable” box on each section in the top right corner that the owner can click on which can allow them to “compare” different KPIs in the same graphical presentation. Once two or more of the KPIs are selected, on the right part of the page across from the header, “Headline KPIs” have a “compare” button appear and once clicked on, it opens a “pop up” window with the graphical presentation for both KPIs on the same graph or visual presentation of the data
+      - For example, the owner can click on the “revenue” clickable box and the “gross margin” clickable box which then has the pop up compare both of these KPIs together
+    - Have it so the owner can click on the box which then opens a pop up window that shows data for each KPI in a beautiful, aesthetically pleasing in different graphical manners and in the top right of the pop up window have a “search” bar that the owner can type in dates, times, and also have the ability to choose any chronological parameters to display that information.
+      - Make any graph or data display whether it’s line graph, vector graph, etc have the ability for the owner to hover their cursor over it, and it gives details for that data point (for example, when hovering on one of the data points, be able to display “#” and “time”. Make sure to display the data from the “X” axis and “Y” axis. Do this for any part of the “patient”, “owner”, or “provider” portal wherever data and analytics can be utilized. Make it similar to https://www.google.com/finance/beta/quote/F:NYSE?sca_esv=a82350b6429375af&rlz=1C1HKFL_enUS1206US1206&output=search&source=lnms&fbs=ADc_l-aN0CWEZBOHjofHoaMMDiKpWuJzWbn6y2Zf42jFClqc74f05r15SFp3eB7-_aeVssDFTrrVbm-92MfivJar7-BYYUkzgIb9YNW6Wky1DIUwHKhHpEocYnbyMA6A-0nAdumb9_Gui4kwOxKgBa22HGxdAjRYmb4tyizu7gB1fsK2eIhX4bM5VC4X3cn1q3yRQKwR-v0rOYwY94-xeddQCYr64nhkgA&sa=X&sqi=2&ved=2ahUKEwjd__fgxOyUAxV5J0QIHbu-PZ0Q0pQJegQIFBAB 
+  - For the “bubble” colors:
+    - Make the “red” bubble be if the KPIs are “negative” or lower than previous KPIs
+    - Make the “green” bubble be if the KPIs are “positive” or higher than previous KPIs
+    - Keep the “yellow” bubble to be “off goal”
+    - Make a “purple” bubble to be “on goal”
+  - Make this entire section expandable and collapsible
+  - Make each tile moveable and rearrangeable 
+- For the “revenue”, “cost of goods and services”, “operating expenses”, etc sections: 
+  - Make them be part of the “pop up” window when opening the KPIs
+  - Remove these from the main page and be linked to each KPI
+- For the “This period vs prior” section:
+  - Be able to “click” on each row header to be able to arrange each row in numerical fashion or the “highest” or “least”
+- For the “Memo” section:
+  - Remove this section completely since it is part of the other site, https://leafjourney.com/ops/revenue 
+For page: https://leafjourney.com/ops/cfo/cash-flow (“Cash Flow” Tab)
+- Have the “opening cash”, “closing cash”, “net change”, etc boxes be under a section named “Financial Dashboard”
+- Have a “CFO Briefing” section on this tab
+- Make this entire section expandable and collapsible
+- Make each tile or section on this page moveable and rearrangeable 
+- For each section, place a “search” bar to the rightmost side across from the Header title that the owner can type in dates, times, and also have the ability to choose any chronological parameters to display that information. 
+  - For every single “box/tile” in every section or subsection on every page:
+    - Have a small “clickable” box on each section in the top right corner that the owner can click on which can allow them to “compare” different measures in the same graphical presentation. Once two or more of the measures are selected, on the right part of the page across from the header, have a “compare” button appear and once clicked on, it opens a “pop up” window with the graphical presentation for both or multiple parameters on the same graph or visual presentation of 
+  - For all “pop up” windows,
+    - Have the full chronological and historical data on this populate as a pop-up window that can be modified, customized, and be represented in beautifully graphical representations that are aesthetically pleasing and convey the data in a very simple, elegant, yet powerful way that tells a story
+- For the “Financial Dashboard” section:
+  - For the “Runway” subsection:
+    - Instead of “cash flow positive”, have a big green “+” symbol plus a happy emoji
+      - If the cash flow is “negative”, have a big red “-“symbol plus a sad emoji
+      - Consider having a small inline graph that can show the trends right there on the page
+- For “Operating activities” section:
+  - Keep it simple and display 3 “inflows” and 3 “outflows” as they populate and keep it in chronological order. 
+  - For all “pop up” windows,
+    - Have the full chronological and historical data on this populate as a pop-up window that can be modified, customized, and be represented in beautifully graphical representations that are aesthetically pleasing and convey the data in a very simple, elegant, yet powerful way that tells a story
+- For “Investing Activities” section:
+  - Keep it simple and display 3 “inflows” and 3 “outflows” as they populate and keep it in chronological order. 
+  - For all “pop up” windows,
+    - Have the full chronological and historical data on this populate as a pop-up window that can be modified, customized, and be represented in beautifully graphical representations that are aesthetically pleasing and convey the data in a very simple, elegant, yet powerful way that tells a story
+- For “Financing activities” section:
+  - Keep it simple and display 3 “inflows” and 3 “outflows” as they populate and keep it in chronological order. 
+  - For all “pop up” windows,
+    - Have the full chronological and historical data on this populate as a pop-up window that can be modified, customized, and be represented in beautifully graphical representations that are aesthetically pleasing and convey the data in a very simple, elegant, yet powerful way that tells a story
+- Make the bubbles be represented as such:
+  - “green” = positive markers or improving
+  - “yellow” = cautious for cash flow or something to monitor
+  - “red” = negative markers or worsening
+- For the “Reconciliation” section:
+  - On the right of all the dollar amounts have an “up” or “down” arrow that will show if the amount is the same, better, or worse than the previous time frame (that is designated by the owner)
+    - A green “up” arrow means positive growth or positive cashflow
+    - A red “down” arrow means negative growth or negative cashflow
+For page: https://leafjourney.com/ops/cfo/balance-sheet (“Balance Sheet” Tab)
+- For the “total assets”, “total liabilities”, “total equity”, etc tiles, put them all under the header of “Dashboard”
+- Have a “CFO Briefing” section on this tab at the top
+- Make sure every section and header here follows the layout and interface usability instructions as stated in the “MASTER prompt”
+- For the “Total Liabilities” tile:
+  - Have a “red” color on the L border that is similar to the “green” L borders found in “total assets”, “total liabilities”, and “working capital”
+- For the “Current ratio” tile:
+  - Have a simple explanation of what this means, like how it’s presented on other tiles on other pages
+- For the “Quick ratio” tile:
+  - Have a simple explanation of what this means, like how it’s presented on other tiles on other pages
+- For the “Books balanced” tile:
+  - Be able to click on it and have it open the full running list of all expenses and receivables like a QuickBooks style
+- For the “Assets” section:
+  - Have a way to put the “current assets” tile together the “Long term assets” tile in one larger tile but have a way to differentiate the tiles and main row titles within the larger tile
+- For the “Liabilities and Equity” section:
+  - Have a way to put the “current liabilities” tile together the “Long term liabilities” tile in one larger tile but have a way to differentiate the tiles and main row titles within the larger tile
+  - Rename the title from “liabilities and equity” to “liabilities”
+  - Remove the “Equities” section
+- For the “Equity” section:
+  - Move this section into the “Assets” section
+For page: https://leafjourney.com/ops/cfo/expenses (“Expenses” tab)
+- For the “Last 90 days by category” section:
+  - Make each title bigger and darker in font color
+  - Remove the “entries” from each tile
+  - Have another tile that displays “total” expenses which is a cumulative of all the expenses in the different categories
+  - Be able to click on each tile and have the actual expenses specifically for this category populate to a split screen “right window pane” to the right of this section and have the Title appear along with all of the expenses for this category.
+  - Make sure each tile follows the above “MASTER prompt”
+  - Have the option to change the date range from “90” to any amount desired by the owner
+  - Next to the title, have two buttons: 
+    - One that says “Vendors” and another that says “Categories”
+      - For the “Vendors” button
+        - Be able to click on the “Vendors” button and then have the actual list of vendors populate to a split screen “right window pane” to the right of this section and have the Title appear along with all of the vendors listed.
+        - Have a “+” button on the top right of this split screen which once clicked on, opens a “pop up” window that allows the owner to add new Vendors by the “name”, “address”, “phone number”, and “email” of this vendor
+      - For the “Categories” button
+        - Be able to click on the “Categories” button and then have the actual list of categories populate to a split screen “right window pane” to the right of this section and have the Title appear along with all of the categories listed.
+        - Have a “+” button on the top right of this split screen which once clicked on, opens a “pop up” window that allows the owner to add new categories by the “name”,  and “type” of category (for example, “marketing”, “dues”, “travel”, etc)
+  - For the “Recent Expenses” section:
+    - Make each column header be clickable to arrange in alphabetical order or by dollar amount
+    - Have the last 20 entries be shown in chronological order and then truncate this tile. At the bottom of the tile have an “expand” button which then populates another 50 entries. Continue to have the “expand” button at the bottom til every single entry is shown in a very long list
+    - For the “category” column,
+      - Be able to click on each type of “Categories” and then have the actual list of charges specific for that category populate to a split screen “right window pane” to the right of this section and have the Title appear along with all of the expenses listed in chronological order
+    - For the “delete” buttons:
+      - Stop the sidebar from expanding when clicking on the “delete” button
+      - Once the owner has clicked on the “delete” button, make sure a pop up window appears asking to confirm if they want to “delete” or “cancel” the line item
+For page: https://leafjourney.com/ops/cfo/cash (“Cash” Tab)
+- For the three tiles on top, place them under a header named “Dashboard” 
+- Make sure every tile and the overall layout of this page follows the “MASTER prompt” from above
+- For the “Log Cash Movement” section:
+  - Remove this section since it will be replaced by the “Bookkeeping tab” for both incoming and outgoing finances/money
+- For the “Accounts” section:
+  - Be able to click on any tile and have the last 10 entries be shown in chronological order and then truncate this tile. At the bottom of the tile have an “expand” button which then populates another 50 entries. Continue to have the “expand” button at the bottom til every single entry is shown in a very long list.
+  - Change “last synced” to “last reconciled”
+  - Make the different tiles rearrangeable in alphabetical order or numerical order based on how much cash they have
+- For the “Add Account” section:
+  - Once the “Name” has been inputted once into this aspect, have it be part of a drop-down list that auto populates when the provider types it in again
+  - For “Type” drop down menu:
+    - Have another option that says “other” and once clicked on pops up a window that allows the owner to freehand type what they want
+  - Once the “Institution” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+- For “Recent Cash Movements” section:
+  - Have the last 20 entries be shown in chronological order and then truncate this tile. At the bottom of the tile have an “expand” button which then populates another 50 entries. Continue to have the “expand” button at the bottom til every single entry is shown in a very long list.
+For page: https://leafjourney.com/ops/cfo/assets (“Assets” Tab):
+- Change title from “Capitalized Assets Register” to “Capitalized Assets”
+- Have the top four tiles under the header “Dashboard”
+- Make sure every tile and the overall layout of this page follows the “MASTER prompt” from above
+- Remove the “green” border from the “Net book value” tile
+- For “Add Capitalized Asset” section:
+  - Expand the “Date” text box to be longer so the entire date fits
+  - Have the “date” text box have a calendar icon that the owner can click and select the date from as a drop down calendar
+  - Change “salvage” to “residual”
+  - For “Category” drop down menu:
+    - Have another option that says “other” and once clicked on pops up a window that allows the owner to freehand type what they want
+    - Once the “Category” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+- Create a new header on top of the list of all the current capitalized assets and call it “Capitalized Assets” 
+  - Be able to click on each column name and have a pop up window present that has more detailed information such as the “vendor”, “name”, “phone”, “address”, “email”, etc
+  - Make every column header be arrangeable from high to low, alphabetically, etc
+For page: https://leafjourney.com/ops/cfo/liabilities (“Liabilities” tab):
+- Have the top four tiles under the header “Dashboard”
+- Remove the “green” border from the “outstanding balance”
+- Make sure every tile and the overall layout of this page follows the “MASTER prompt” from above
+- For the “Add Liability” section:
+  - Make the “Rate” text field longer so it fits up to “0.000”
+  - Stop making the sidebar display when clicking on “Add”
+  - For “Category” drop down menu:
+    - Have another option that says “other” and once clicked on pops up a window that allows the owner to freehand type what they want
+    - Once the “Category” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+  - Once the “Name” has been inputted once into this aspect, have it be part of a drop-down list that auto populates when the provider types it in again
+- Create a new header on top of the list of all the current liabilities and call it “Liabilities” 
+  - Be able to click on each column name and have a pop up window present that has more detailed information such as the “vendor”, “name”, “phone”, “address”, “email”, etc
+  - Make every column header be arrangeable from high to low, alphabetically, etc
+For page: https://leafjourney.com/ops/cfo/equity (“Equity” Tab):
+- Have the top three tiles under the header “Dashboard”
+- Remove the “green” accents from all the tiles
+- Make sure every tile and the overall layout of this page follows the “MASTER prompt” from above
+- For “Record Equity Entry” section:
+  - For “Type” drop down menu:
+    - Have another option that says “other” and once clicked on pops up a window that allows the owner to freehand type what they want
+    - Once the “Type” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+  - For “Description” field:
+    - Once the “Description” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+- Create a new header on top of the list of all the current Equities and call it “Equities” 
+  - Be able to click on each column name and have a pop up window present that has more detailed information such as the “vendor”, “name”, “phone”, “address”, “email”, etc
+  - Make every column header be arrangeable from high to low, alphabetically, etc
+For page: https://leafjourney.com/ops/cfo/goals (“Goals” tab):
+- For the “Add Goal” section:
+  - For “Kind” field:
+    - Have another option that says “other” and once clicked on pops up a window that allows the owner to freehand type what they want
+    - Once the “Kind” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+  - For “Label” text box:
+    - Once the “Label” has been inputted once into this aspect, have it be part of a drop-down list when the provider types it in again.
+  - Make the “period” field longer
+    - Make it fully customizable date ranges when clicking on the drop down
+- For the “Active Goals” section:
+  - Show the only 5 entries maximum. If more, have it truncate and have a small “show more” button at the bottom which then expands this
+  - Stop making the sidebar display when clicking on “Add”
+  - Stop making the sidebar display when clicking on “Archive”
+  - Have a small button to the right side of the “Active Goals” that says “archive”
+    - Once clicked, it will have a pop up window display all the archived goals
+For page: https://leafjourney.com/ops/cfo/reports (“Reports” tab):
+- Have the “generate weekly report” button be changed to “generate report” 
+  - Under this button have an option of “weekly”, “monthly”, “quarterly”, “annually”
+- For each tile: 
+  - There’s too much wording without distinguishing the different parts. Clean this aspect up to make the numerical data pop easier, make it simpler to read through as the owner, and make the “AI suggestions” be in a separate small sub box within each tile that has a green background to differentiate the them
+- When clicking on each tile:
+  - Have the top AI suggestions be less wordy, more graphical, more numerical, and in a more organized way. Have it under the title “CFO briefing”
+  - This page has way too much scrolling and needs to be fit on a static page more succinctly
+    - Remove a lot of the white/dead space around each tile and section
+  - Make every section on this page follow the prompts that have already been written for revisions from the above sections. This page should copy and follow all previous revisions from the other tabs and incorporate it into this one
+  - Have a “print” and “download” button at the top of this page so the owner can print or download this in PDF format
+    - Once printed or downloaded, it has to be in a proper format that is legible and easy to follow
+- For the “Anomalies Flagged at Generation Time” section:
+  - Change the title to “Anomalies Flagged”
+  - Incorporate this section into the “CFO briefing” section at the top of this page in a simpler, easier way to get the vital data needed
+For page: https://leafjourney.com/ops/staff-schedule (“Staff Schedule” tab):
+- Remove every single small “dot” and section per the “provider” and make it one large block
+  - When clicking on the “green” field have the “start” and “end” time populate as one large “green” field on that provider or worker’s schedule
+- Make the headers such as “staff”, “Sun”, “Mon”, etc larger font and easier to read along with the actual dates below it
+- For “Add shift” pop up window:
+  - Have the “start” and “end” time populate from “12AM” to “12PM”.
+    - It should be all 24 hours allowed so there is full flexibility of scheduling
+- Have each “employee” (which includes provider, nurse, etc) all have their individual color for their 
+- When clicking on “print” make sure the actual green blocks that the employee is supposed to work populates. Right now it’s showing blank when clicked on
+- Flip the row and column headers: 
+  - The “employee name” and “type” should be listed as “column” headers
+  - The “date” and “days” should be listed as “row” headers
+  - The “time” frames should still be listed in a “row” format as it currently is
+  - Therefore per day, the owner can see all employees working for that day in one static view without having to scroll
+- Be able to click on each individual “employee” name or “employee type” (Such as “provider”, “Nurse”, “reception”, etc) and have all of their shifts populate in the “All shifts this week” tile below and change the title of this tile to that specific “employee” name or “employee type” name
+- For the “All shifts this week” section:
+  - When clicking on “remove” have a pop up window show up to ask the owner if they are sure they want to remove and have the options “remove” and “Cancel” as buttons
+- For the “previous”, “today”, “next” buttons section:
+  - Keep as is
+- For the “week of may 31” title next to the above buttons:
+  - Make this clickable and allow the owner to manually search any time range from previous or from the future. Have a small “calendar” icon as in other sections that populates a drop down calendar
+For page: https://leafjourney.com/ops/time-clock (“Time Clock” section):
+- Make sure that the time remains running even if the employee signs off LeafJourney
+- The only way the clock should stop is by clicking the “clock out” button
+- For the “Today” and “This Week” tiles:
+  - Apply the “MASTER prompt” above to both
+- For “Recent Activity” section:
+  - Have it listed in chronological order of up to 30 entries and then truncate it. Allow for the owner to search any dates via a small “calendar” icon to the right of “recent activity”
+  - When clicking on “export timesheet” 
+    - Have the Excel file have separate columns for:
+      - “time” which displays only the time
+      - Keep the “type” column
+      - “date” column
+      - “hours” column (which calculates the number of hours worked in increments of “0.1 hours”
+For page: https://leafjourney.com/ops/training (“Training” tab)
+- For every training module, make every educational section, including paragraphs, charts, visuals be fun, interesting, and engaging. Make all AI agents remember that training will NOT be a boring task that the employee must go through. Although it is required, it doesn’t have to be boring or a dread. It can be fun and engaging, and LeafJourney and all of its AI agents and employees will make training be a fun and most importantly, memorable experience. Because it is imperative that all of the employees understand, comprehend, and apply what is taught in these modules. This is absolutely key for cooperation and efficient operations. 
+  - For each module that is currently in the system and will eventually be developed, make it so they leave with a one page printout that is fun, full of simple main points from the module in a simple manner, some nice artwork or pictures surrounding the module in an artistic manner, and simple word recognition like homonyms, palindromes, etc to be used when creating the main points of each module so they are more likely to be remembered and stored in memory.
+- Once the module has been completed for more than 1 year, it will be placed in the an “archive” section which will be a small button at the bottom. Once the owner or employee clicks on it, it will show all of their previous module completions in chronological order.
+- For each tile section
+  - Fix the error when clicking on “Start training” that opens an error box that says: “Demo: assigned "HIPAA Basics" to Avery Chen”
+  - For the bubbles:
+    - Have “not started” the current color it is
+    - Have the “in progress” be in “yellow”
+    - Have “completed” be in “green”
+    - Have “retake” be in “red”
+  - If “completed”, have it show next to the “not started” bubble
+    - Be able to click on it and have a pop up window display the actual PDF which will be on a beautiful LeafJourney official template and color scheme that will be similar to the website but with beautiful aesthetics. The certificates should have beautiful borders, with elegant designs and should be inspired by ancient Egyptian and antient Hindu/Indian artwork, sounds, language, etc.
+      - the certificate should include the module name, the assigned person’s name, the date, and an official stamp of LeafJourney (create a stamp similar to a seal or notary stamp that is beautiful, regal, and very official. The certificates should feel legit and as if the people who did these modules earned them
+    - Make the certificate downloadable, printable, sendable
+    - For the “assign to” it must be only people who are linked to that specific practice. This must be organized and decided by the client at time of 
+For page: https://leafjourney.com/ops/policies (“Policies” tab):
+- When clicking on “All” have a “green check mark” be listed next to the policy name to mark it “completed”.
+  - Do not do any type of visual representation for a policy that is “pending” or “incomplete”
+- For the “search policies” search bar: 
+  - Follow the “MASTER prompt” above that talks about the search bar aspect
+- For “Create New Policy” button:
+  - Fix the error that is popping up
+  - Have the pop up window have a few sections:
+    - Title at the top
+    - Description in the middle
+    - “Category” on the bottom
+      - This section should follow the “MASTER prompt”
+    - At the bottom have a “save” and “cancel” button
+    - Once the New Policy is created have it populate on the different sections by chronological order.
+- For every policy module or site, make it, including paragraphs, charts, visuals be fun, interesting, and engaging. Make all AI agents remember that training and certificates and policies will NOT be a boring task that the employee must go through. Although it is required, it doesn’t have to be boring or a dread. It can be fun and engaging, and LeafJourney and all of its AI agents and employees will make training be a fun and most importantly, memorable experience. Because it is imperative that all of the employees understand, comprehend, and apply what is taught in these modules. This is absolutely key for cooperation and efficient operations. 
+  - For each module that is currently in the system and will eventually be developed, make it so they leave with a one page printout that is fun, full of simple main points from the module or policy or procedure in a simple manner, some nice artwork or pictures surrounding the module in an artistic manner, and simple word recognition like homonyms, anagrams, palindromes, etc to be used when creating the main points of each module so they are more likely to be remembered and stored in memory.
+For page: https://leafjourney.com/ops/incidents (“Incidents” tab)**:
+- For “Severity” column:
+  - Make the bubbles these colors and associations:
+    - “Critical” is red
+    - “High” is orange
+    - “Yellow” is low
+    - “Blue” is low
+- For this entire page, make sure to follow the “MASTER prompt” from above
+- For the “Title” column:
+  - Be able to click on the “title” of the incident and have a pop up window open showing the entire message and incident report. It should include the date first reported, date resolved if resolved, person who resolved it, and explanation of resolution by the person who resolved it.
+  - Once resolved, have the reports be archived. 
+    - Have an “Archive” button be placed at the bottom right of the page that once clicked on populates all of the archived incidents in chronological order
+    - Build a search bar in the “archive” page that the owner can search anything they want based on the “MASTER Prompt above”
+- For the “New Report” pop up window when clicking “Report new incident button”:
+  - Make the colors of “low”, “medium”, etc match the colors of the bubbles above
+  - For the “Category” drop down:
+    - Make it so when clicking on “other” a pop up window opens allowing the owner to write in their own words. Once entered, it will show in parentheses such as: “Other (Clerical)”.
+  - For the “Title” field:
+    - Remove the “short summary” placeholder text
+For page: https://leafjourney.com/ops/supplies (“Supplies” tab):
+- Allow any of the “back office” or “staff” be able to “request” supplies as well. For example the back office may need more soap for the rooms so allow them to have  simple button that says “request” that opens a “pop up window” that they can then type in their “request” and the “dollar” amount”.
+- Have a “search” bar to the right of the four options and have it follow the “MASTER Prompt” above
+- For each option, have only the most recent 10 entries be displayed and then truncate the rest. 
+  - Have an “Archive” button at the bottom right of each page that once clicked on populates all previous entries in bouts of “50” entries at a time
+- For every entry, be able to click on it, and have options to “review”, “approve”, “cancel”, “modify”, have a “free text box” with the title saying “comments”.
+  - Have the time and title of the person sending it easily visible in this “Detailed” view
+  - Have a “send”, “Cancel”, or “resolve” button at the bottom of each of these pages as well.
+For page: https://leafjourney.com/ops/vendors (“Vendor” tab):
+- Make sure this page follows the “MASTER prompt” above in full detail and execution
+- Turn the “Expiring in < 30” button into a “drop down menu” that includes “< = 60 days”, “< = 90 days”, “custom”. 
+  - Once clicked on “custom” have a pop up window open with the owner typing in a free text box the exact number of days they want to populate. Do not allow any alphabetical characters in this box. Only numbers
+- For the “vendor” column:
+  - Be able to click on each “vendor” and have a pop up window open with all of the information that is stored when clicking on the “add vendor” button
+    - It should also include the “date” of first contract or service and have a very detailed database of all payments, invoices, and financial information that is transacted to and from the vendor. 
+      - Have a button that is a “tax documents” section to the right of “add vendor”
+        - Once clicked on “tax documents” have the table below populate with all tax statements that include end of the year W-9 or 1099 tax election based on the vendor’s “relationship”
+          - Be able to go back 10 years of data
+- For the “contact” column:
+  - Be able to click on the “phone number” or the “email” and have it be able to connect the owner either via a digital phone call right through LeafJourney or if it’s an email, the standard “new email” pop up window
+  - For the main column display, have it display these in order from top to bottom:
+    - “Title”:
+      - Such as “representative”, “owner”, “Manager”, “Service Manager”, etc
+      - Be able to click on the title and “edit” the “name” and “title” of each row in two separate free text boxes
+    - “Phone Number”
+    - “Email”
+- For “category” section:
+  - Be able to click on each bubble and once clicked a pop up window opens that is small but allows the owner to “assign” a different color to the category. Have the ability to choose from 6 main colors and the rest of the categories be “beige” colors
+- For the “Contract ends” section:
+  - Make the “renew soon” notification in a brighter red that is more visible
+  - Change the format of the date to dd-mm-yyyy
+- For the “Add Vendor” button:
+  - For the pop up section:
+    - For “Category” drop down, follow the “MASTER Prompt” as stated above
+  - Below “Monthly cost ($)” field:
+    - Have a new free text box with the header, “Description (Optional)” 
+      - The owner can then type in a description of the type of services or materials that is being provided
+- Create a new column with the title “Contract Started” to the right of the “Contract” Ends” title
+  - When clicking on “save vendor” have the date of the “contract” beginning appear in its respective column
+    - Underneath it have it say the “number of days” it has been in contract for
+- Change the “contract expiring” yellow tile on the top from “30 days” to “60 days”
+For page: https://leafjourney.com/ops/feedback (“Feedback” tab):
+- For the “Search bar”:
+  - When clicking on multiple “tags”:
+    - Make sure the bubbles are all separate and all are individually closeable
+- For each complaint tile:
+  - Make sure to spell out what the “NPS” acronym stands for
+  - Make it so that the patient feedback can just be “a scale from 1-10” and have it correlate to 3 different emoji levels of “Unhappy”, “ok or so so”, “happy”, “very happy”
+    - Make emojis so that it can be ranked and then numerically ranked as well
+    - If the “explanation” is too long, then be able to click on the tile and have it open a pop up window with the full sized window with the entire “explanation”
+  - For the “action taken” drop down:
+    - When clicking on “tag” have a pop up window display with a free text box that allows the owner to type in the name of the employee/staff/doctor that the message should be tagged to
+  - When clicking on the “Respond” button and when the pop up window appears:
+    - Have a “send” message button to the right of “Save draft” 
+      - Once clicked send, it will respond directly to that person or on the website.
+  - To the right of the “action taken” drop down menu, have a “resolved” button.
+    - Once clicked on, the feedback tile is removed and placed in the “archive” section 
+      - Have an “Archive” button at the bottom right of each page that once clicked on populates all previous entries in bouts of “50” entries at a time
+For page: https://leafjourney.com/ops/marketing (“Marketing” Tab):
+- Make sure every part of this page follows the “MASTER Prompt” as above
+- For the “patients by source” section tile:
+  - Make the different categories be displayed in different colors
+  - Remove the “CAC” aspect to the right of each category
+- Make the “CAC” (“Cash on Cash”) aspect a different tile and have it display its data similarly to the “Patients by source” tile
+- For the “Conversion Funnel” section tile:
+  - Make each bar color slightly darker and keep it “green”
+- For the “Monthly Trend – new patients” tile:
+  - Make sur that the actual line graph or bar graph displays as a visual. It is not being displayed
+- For the “ROI Calculator” tile:
+  - Be able to have an option to change the “Lifetime Revenue per patient” aspect to also include “Monthly” revenue per patient, “quarterly” revenue per patient, and “yearly” revenue per patient
+  - Make sure the “Spend” section is working. When trying different combinations and different numbers, it is still not working or calculating
+  - Make sure that the “revenue” and “net” are calculating the right way. Right now it’s showing the same number in both
+  - Make an “AI” suggestion section for this specific section too
+For page: https://leafjourney.com/ops/announcements (“Announcements” Tab):
+- Make sure this page follows the “MASTER Prompt” as above
+- Display a total of 7 tiles on the front page and then truncate it. If needed to see more, then click on “see more” and have it populate further
+- For each “Announcement” section tile:
+  - For the message thread, have a button on the right above “post” button that says “expand” and once clicked, it will display the message thread in a scrollable window (have the timestamp for each message)
+  - Be able to hover over each emoji response bubble (the “thumbs up”, “Heart”, etc) and be able to check to see the actual person that has voted.
+    - Allow each person/staff/provider to only be able to vote on one option and only once
+  - Have an “archive” wording or a “delete” wording at the top right of each tile that can be clicked and once clicked on, it removes it and puts it in the “archive” section
+    - Have an “Archive” button at the bottom right of each page that once clicked on populates all previous entries in bouts of “50” entries at a time
+    - Only allow the office manager or owners of the clinic to be able to “delete” message
+  - Have the tiles organized by chronological order with the “pinned” being at the top
+- For the “Post Announcement” button once clicked on:
+  - For the pop up box:
+    - For “category” drop down: 
+      - Have “other” and once clicked on another pop up window appears where the owner can free-text in a reason. It will be saved as “Other (free text reason here)”
+For page: https://leafjourney.com/ops/analytics (“Analytics” tab):
+- For all tabs in this section, please refer to the “LeafJourney Data Usage Revisions.docx” word document which will have a more detailed breakdown of the revisions
+- Make sure each page follows the “MASTER Prompt” above as well
+For page: https://leafjourney.com/ops/onboarding (“Onboarding” tab):
+- For the entire onboarding process, make sure that Leafjourney takes all the information from both Onboarding Process 1 and Onboarding Process 2 below and cross check it with what is currently in place for LeafJourney’s onboarding aspect. The entire onboarding process must be robust, fully encompassing and should be done as smoothly and as streamlined as possible. ALL AI agents need to very thoroughly review this entire document and section along with cross checking with the actual website to make sure everything is in place. This is crucuial for LeafJourney to make the entire process as seamless and fully integrated for new providers and clinics who want to use LeafJourney as their EMR. Follow all of the below and make sure to send any errors, questions, or concerns with any workflow discrepancies, errors, or suggestions to make it more efficient and effective to both neal@leafjourney.com and scott@leafjourney.com:
+  - Onboarding process 1 - Initiation, Identity, & Regulatory Compliance
+    - Legal and Compliance Agreements
+      - Business Associate Agreement (BAA): Execute the standard HIPAA-required contract defining how Protected Health Information (PHI) will be safeguarded.
+      - Master Services Agreement (MSA) & SLA: Finalize software licensing terms, uptime guarantees, and support response tiers.
+    - Clinic Identity & Hierarchy Mapping
+      - Organizational Architecture: Define the technical relationship between Parent Entity >> Individual Clinica/Locations >> Specific Departments
+      - Taxonomy Collection: Gather legal business names, physical addresses, corporate Tax IDs, and Employer Identification Numbers (EIN).
+    - Government & Payer Registry Onboarding
+      - NPI Verification: Collect and validate Type 1 (Individual Providers) and Type 2 (Organizational) National Provider Identifiers via the NPPES registry.
+      - Provider Enrollment: Map out DEA numbers, state medical licenses, and Controlled Substance Registrations (CSR) for prescribing privileges.
+      - Electronic Data Interchange (EDI) Enrollment: Submit enrollment forms to clearinghouses for claims processing, Electronic Remittance Advice (ERA), and Eligibility Verification (270/271 transactions).
+  - Technical Configuration & Integration
+    - Clearinghouse & Billing Setup
+      - Clearinghouse Integration: Connect the EMR to a clearinghouse (e.g., Change Healthcare, Waystar) for automated claims scrubbing.
+      - Fee Schedule Configuration: Ingest the clinic’s specific negotiated commercial insurance rates, Medicare/Medicaid schedules, and cash-pay prices.
+    - E-Prescribing (eRx) and EPCS Activation
+      - Surescripts Integration: Register the clinic on the e-prescribing network.
+      - Identity Proofing (NIST SP 800-63B): Require providers to complete Remote Identity Proofing (RIDP) via a third party (like ID.me) to enable Electronic Prescribing of Controlled Substances (EPCS).
+      - Two-Factor Authentication (2FA): Set up cryptographic hard tokens or biometric push notifications for signing controlled substances.
+    - Lab, Imaging, and Device Integrations
+      - HL7 Interfaces: Build inbound/outbound feeds for commercial laboratories (Labcorp, Quest) and local hospital imaging centers using HL7 ORU (Observation Result) and OMD (Order) message structures.
+      - Local Device Integration: Configure local hardware drivers for vitals monitors, EKGs, spirometers, or digital cameras to sync directly to the patient chart via DICOM or proprietary APIs.
+  - Data Migration & Environment Strategy
+    - Legacy Data Extraction & Mapping
+      - Demographic Ingestion: Parse legacy database files into clean formats (SQL, CSV, or CCDA/FHIR structures).
+      - Clinical Data Parsing: Map active problem lists (ICD-10-CM), medication lists (RxNorm), allergies (RxNorm/NDF-RT), and immunizations (CVX).
+    - Environment Segmentation
+      - Sandbox/Staging Instance: Provision an isolated environment mirroring the production build. This is populated with synthetic or de-identified test data for training and integration testing.
+      - Production Instance: Deploy the clean, empty, HIPAA-compliant cloud database instance where real patient data will live.
+  - System Customization & Clinical Workflows
+    - Role-Based Access Control (RBAC)
+      - Define precise security profiles across the organization to restrict or grant access to features: | Role | Charting Access | Prescribing | Billing / Claims | Admin Settings | | :--- | :--- | :--- | :--- | :--- | | MD / DO / NP / PA | Full | Full (incl. EPCS) | View Only | None | | RN / Medical Assistant | Triage/Vitals Only | Draft Only | None | None | | Biller | None | None | Full | None | | Practice Manager | Audit Logs Only | None | View Only | Full |
+    - Clinical Templates & Form Builders
+      - SOAP Note Architecture: Build custom layouts for Subjective, Objective, Assessment, and Plan fields.
+      - Review of Systems (ROS) & Physical Exam (PE): Build macro-driven "normal click" templates to speed up documentation while avoiding auto-populating fraudulent data.
+      - Order Sets: Group common diagnostics, labs, and therapies together for single-click ordering based on specific diagnoses.
+  - Training & Operational Readiness
+    - Asynchronous Foundation (Week 1-2)
+      - Require all staff to complete self-paced video modules covering the basic UI layout, navigation mechanics, and security protocols.
+    - Role-Specific Interactive Workshops (Week 3)
+      - Conduct targeted virtual or on-site deep dives. Providers practice charting complex cases; front-desk staff run check-ins and eligibility checks; billers process dummy claims.
+    - The Mock Clinic (Week 4)
+      - Run a full-day simulation in the Sandbox environment. Staff process synthetic patients from check-in, through vitals, clinical charting, eRx, check-out, and billing generation.
+  - Go-Live Support & Optimization
+    - The "Go-Live" Delta Ingestion
+      - Extract and upload the very last 48 hours of schedules, new patient registrations, and clinical notes recorded in the legacy system right before the freeze.
+    - Hyper-Care Support Deployment
+      - Dedicated Floor Support: Assign EMR specialists (either on-site or via dedicated real-time chats) to shadow providers during their first 3–5 days of live patient encounters.
+      - Reduced Patient Load: Recommend the clinic reduce its patient volume by 30-50% during the first 48 hours of go-live to absorb documentation lag.
+    - Post-Go-Live Optimization Audit
+      - 30-Day Clean Claim Rate (CCR) Review: Evaluate claims rejection logs to fix recurring ICD-10 or modifier mapping issues.
+      - Efficiency Analysis: Audit click-counts and time-logged-per-chart to build custom text-macros or modify clunky templates for lagging providers.
+- Onboarding Process 2 - Onboarding Timeline:
+  - Phase 1: Administrative Foundation
+    - Days 1-5
+    - Establish the practice legal profile, configure multi-state compliance, and onboard all rendering and administrative staff.
+  - Phase 2: Financial & Revenue Setup
+    - Days 6–12
+    - Configure merchant accounts, connect clearinghouses, and establish fee schedules to prevent cash-flow interruptions.
+  - Phase 3: Clinical & Formulary Customization
+    - Days 13-20
+    - Build custom chart templates, link e-prescribing networks, and build specialty or custom formularies.
+  - Phase 4: Patient Experience & Intake
+    - Days 21-25
+    - Design and automate the patient intake journey, including compliance documents, consents, and portal access.
+  - Phase 5: AI Scribe & Automation Configuration
+    - Days 26-28
+    - Train the ambient AI engine on provider-specific voice profiles and custom note formats (SOAP, H&P).
+  - Phase 6: Data Migration & Go-Live
+    - Days 29-30
+    - Execute final legacy data porting, conduct a full staff dry-run, and switch the system to live status.
+- Phase 1: Practice Basics & Administrative Setup
+  - Practice Profile & Architecture
+    - Legal Entity Verification: Input corporate legal name, Tax ID (EIN), and Type 2 Organizational NPI.
+    - Location Mapping: Configure physical clinics, administrative offices, and dedicated virtual/telehealth "rooms." Each location must have its physical address, local time zone, and specific place of service (POS) code attached for billing accuracy.
+    - State-Specific Compliance Rules: Define practice states. The EMR must automatically toggle state-specific restrictions, such as prescription monitoring program (PDMP) integrations, virtual care consent mandates, and minor privacy thresholds.
+  - User & Provider Onboarding
+    - Credential Verification: Gather and upload individual Type 1 NPIs, state medical licenses, DEA registration numbers, and CAQH profiles.
+    - Role-Based Access Control (RBAC): Map users to explicit permission tiers:
+      - Super Admin: Full system control, financial logs, and data exporting.
+      - Provider (MD/DO/NP/PA): Full charting, eRx authorization, laboratory signing.
+      - Clinical Staff (RN/MA): Vitals entry, intake review, chart prep, non-controlled medication queuing.
+      - Front Desk / Admin: Scheduling, basic demographics entry, patient communication.
+      - Biller: Claims submission, ledger modification, financial reporting.
+  - Availability Engines: Build specific calendar structures for each provider, linking specific appointment types (e.g., New Patient Consultation vs. Brief Follow-up) to precise time blocks.
+- Phase 2: Financial & Revenue Cycle Integration
+  - Merchant Account Integration: Connect the practice's merchant processing account (e.g., Stripe, Square) for instant card-on-file tokenization, copay processing via the patient portal, and automated invoice delivery.
+  - Clearinghouse Setup (EDI & ERA): Enroll the practice with integrated clearinghouses (e.g., Change Healthcare, Availity). Submit electronic data interchange (EDI) and electronic remittance advice (ERA) agreements to enable clean digital insurance claims processing and automated payment posting.
+  - Fee Schedules & Charge Masters: Upload standard fee schedules. Map internal service codes to global CPT/HCPCS modifiers. Pre-populate custom "favorites" list for standard ICD-10 diagnostic codes to speed up coding during encounters.
+- Phase 3: Clinical Setup & Formulary Building
+  - Advanced Custom Formulary Setup
+    - eRx Engine Activation: Integrate Surescripts or a comparable e-prescribing network. Complete identity verification (EPCS) for all prescribing clinicians to allow electronic transmission of controlled substances.
+    - Custom / Specialty Formularies: Build specialized medication lists for rapid selection. For clinics utilizing custom therapeutics, non-standard botanicals, or specialized compound formulations (e.g., bioidentical hormones, specific cannabinoids, custom dermatological topicals):
+      - Manually build custom compounding entries containing precise ingredient breakdowns, base solutions, and specific route parameters.
+      - Tie specific compounds to preferred specialty compounding pharmacies for direct electronic routing or secure faxing.
+    - Interaction Rule Engine: Set up custom clinical alerts for drug-to-drug, drug-to-disease, and allergen-to-drug cross-referencing.
+  - Charting & Documentation Templates
+    - Dynamic Template Creation: Rather than generic text fields, configure structured documentation layouts (SOAP notes, comprehensive H&Ps) featuring custom dropdown picklists, checkboxes, and smart-fill macros.
+    -  Flowsheets & Trackers: Build structured multi-visit tracking sheets for objective patient metrics over time (e.g., metabolic markers, glycemic trends, biometric data, custom clinical outcome scores).
+- Phase 4: Intakes, Consents, & Patient Experience
+  - Digital Intake Workflows
+    - Dynamic Intake Questionnaires: Build adaptive forms that adjust based on initial patient responses. Ensure direct data mapping—meaning that when a patient enters their surgical history or current supplement list in the intake portal, that data flows directly into the discrete fields of the EMR chart, eliminating administrative re-typing.
+    - Pharmacy Preferences: Allow patients to self-select their default retail and mail-order pharmacies during onboarding.
+  - Legal & Informed Consent Architecture
+    - Standard Regulatory Disclosures: Embed electronic signature blocks for mandatory forms:
+      - HIPAA Privacy Practices Notice.
+      - Financial Responsibility Agreements.
+      - Telehealth Delivery Terms and Disclosures.
+    - Specialized Informed Consents: Build out specific risk/benefit disclosure documents for non-standard, lifestyle, or specialized treatments (e.g., off-label therapeutics, prolonged therapeutic fasts, natural/botanical regimens).
+    - Automated Triggers: Configure system logic to automatically deliver the correct consent forms to the patient portal the moment a specific appointment type is scheduled or a particular diagnosis is added to the care plan.
+- Phase 5: AI Scribe & Automation Configuration
+  - Ambient Scribe Training: Set up the integrated audio capture framework. Train the machine learning model on provider-specific voice profiles, regional accents, and preferred medical terminologies.
+  - Output Formatting Preferences: Define how the AI structures raw conversational audio. Configure whether it should output standard, concise SOAP notes, bulleted narratives, or comprehensive, timeline-driven assessment plans.
+  - Smart Macro & Phrase Mapping: Link the AI engine with custom shorthand commands. For example, instruct the AI that if a provider mentions "Standard Diet Optimization Protocol" during a visit, it should automatically expand that phrase into a comprehensive, text-dense block of structured nutritional guidance inside the patient's plan.
+- Phase 6: Go-Live Strategy & Operational Deployment
+  - Data Migration Strategy
+    - Demographic & Insurance Porting: Execute a clean CSV/HL7 upload of all active patient demographics, contact details, and primary insurance tokens from the legacy system.
+    - Clinical Records Cutover: Port active medical problems, known allergy profiles, immunizations, and active medication lists.
+    - Important Legacy Data Policy: For deep narrative history, establish a hard cut-off date. Typically, records from the past two years are actively migrated into discrete EMR fields, while older historical records are uploaded as flattened, searchable PDFs into the patient's document management tab.
+- Operational Drills & Launch Day (Hypercare)
+  - The "Shadow Day" Simulation: Three days prior to go-live, run a full mock clinic day. Administrative staff check in dummy patients, clinical assistants perform intake routing, providers use the ambient AI to document simulated encounters, and billers push test claims through the clearinghouse.
+  - Dual-Documentation Phase Out: Minimize data discrepancies by running the new system completely live while keeping the legacy EMR in a read-only status for immediate historical reference.
+  - Go-Live Support (Hypercare): Dedicate the first 48 hours of live utilization to low-volume scheduling (e.g., 50% normal patient load) with dedicated technical support resources assigned directly to the clinical team to troubleshoot workflow speed bumps in real-time.
+- For the “0% complete” top tile section:
+  - When clicking on the “green button”
+    - Make sure that whatever part of the onboarding section populates in that button, once clicked on, it takes the owner directly to that specific part of the onboarding aspect and have only that detail and information populate
+  - Stop making the “sidebar” appearing every time clicking on any button. The sidebar should ALWAYS autohide
+For page: https://leafjourney.com/ops/launch (“Practice Launch” tab):
+- Make sure the “refresh” button actually works and it pulls and automatically updates the data needed to give an accurate percentage
+- Make sure the sidebar ALWAYS auto-hides every time
+- For the “Readiness score” tile:
+  - Make the “dates” larger font
+  - For the “Progress History” subsection:
+    - For the “%” where the “current” bubble is at, be able to “click” on the bubble and once clicked have it link directly to that section and all the required data that is still needed or which has been inputted will populate and can be revised or edited.
+    - Be able to also click on each part such “Initial assessment”, “added clinician profiles”, “intake from configured”, etc and once clicked have it link directly to that section and all the required data that is still needed or which has been inputted will populate and can be revised or edited. Make it look or connect to the overall breakdown listed in the “15-day launch countdown”
+      - Make it as simple and intuitive as possible to fill in all of the “blanks” and holes in the data and required information from the onboarding practice
+- For the “Blockers” tile:
+  - Be able to click on the “issues” that are listed and once clicked have it link directly to that section and all the required data that is still needed or which has been inputted will populate and can be revised or edited.
+- For the “Next steps” tile:
+  - In the top right corner of the tile, have an “all” wording that can be clicked on which will show all of the steps in the correct order which fully outlines what has been “checked” off and what is “pending”
+- For the “15-day launch countdown” section tile:
+  - Be able to click on the “tasks done” tile and once clicked on it will show all of the steps in the correct order which fully outlines what has been “checked” off and what is “pending”
+  - Remove the “Days closed” tile
+  - For the “Next Action – Day 11” subsection tile:
+    - Be able to “click” on the title or main header and once clicked have it link directly to that section and all the required data that is still needed or which has been inputted will populate and can be revised or edited. Make sure every website and link is correlating and connecting properly to where it needs to connect to
+  - For the “Blocker Alerts” subsection tile:
+    - Be able to “click” on the title/ each section or main header and once clicked have it link directly to that section and all the required data that is still needed or which has been inputted will populate and can be revised or edited. Make sure every website and link is correlating and connecting properly to where it needs to connect to
+  - For the “Compliance” subsection:
+    - Make this section follow the “MASTER prompt” in terms of making this section and the subsections “collapsible” and “expandable”
+    - Be able to actually “click” on the bullet points to mark them as “complete”
+    - Make this compliance section fully printable so it can be printed and displayed like a checklist in order of the “day”
+    - Change “exit” on each subsection tile to “goal”
+    - Change “blocker” to “blocked”
+      - Be able to click on each of these “blocked” statements and have it open a pop up window explaining what went wrong and what needs to be done
+  - For the “Launch-day runbook” section tile:
+    - Have the bubbles at the right that have “biller”, “operator”, etc be color coded so it’s easier to differentiate what parts of the operations is working and what parts need fixing
+    - Put a “green check” emoji next to the parts that have been successfully executed and are working
+    - Put a “yellow warning” emoji next to the parts that need to be looked at or corrected and did not execute
+    - Make this section “downloadable”, “printable”, etc so that LeafJourney and the clinic can have a hard copy of what’s working and what needs to be fixed
+    - Use the below WORKFLOW layouts (WORKFLOW ONE and WORKFLOW TWO) to merge, update, and to bolster into the current workflow that is in this section and make sure all of the backend hardening and connectivity is being created and tested and monitored by all AI agents to ensure efficiency and to make sure that LeafJourney can actually handle the entire process. Do NOT duplicate any steps but have the AI agents match what they currently have in the LeafJourney system as their overall process and review these current steps to make sure there aren’t any steps missing and then cross check to create the best, most efficient yet complete checklist system so onboarding practices are fully ready to operate under the LeafJourney EMR independently. Make sure that the information merges to give the most robust workflow for “Launch Day”:
+      - WORKFLOW ONE:
+      - Workflow Timeline Overview:
+        - [FRONT DESK] [CLINICAL ROOMING] [PROVIDER ENCOUNTER] [BILLING & REVENUE] Check-In --> Intake & Vitals --> Exam & SOAP/APSO Documentation --> Discharge & Follow-up --> Coding, Clearinghouse & Claim Closure
+      - Step 1: Patient Arrival & Front Desk Check-In
+        - Objective: Capture clean demographic and insurance data at the first point of contact to prevent downstream billing rejections.
+        - Scan Photo ID | --> | Verify Insurance | --> | Digital Consent & | | & Ins. Card | | via Real-Time | | Intake Forms via | | (OCR Ingestion)| | Eligibility (RTE) | | Patient Tablet
+        - Technical & Administrative Execution
+          - Physical Arrival: Front desk staff greets the patient and requests their physical photo identification and insurance card.
+          - Document Imaging: Staff scans both cards directly into the EMR using a localized desktop scanner. The EMR's Optical Character Recognition (OCR) automatically extracts and updates policy numbers, group numbers, and payer IDs.
+          - Real-Time Eligibility (RTE): Staff clicks the "Run RTE" button within the patient registration module. The EMR sends an automated X12 270 eligibility query to the clearinghouse.
+          - Eligibility Verification: Within 3–5 seconds, the EMR parses the incoming X12 271 response. Staff manually verifies the green checkmark confirming active coverage, copay requirements ($30 Specialist), and current deductible status.
+          - Intake & Consents: The patient is handed a clinical tablet. They review, digitally sign, and submit the following mandatory day-one forms:
+            - HIPAA Privacy Notice Authorization.
+            - Assignment of Benefits & Financial Responsibility Statement.
+            - Review of Systems (ROS) & Past Medical History questionnaire.
+          - Status Update: Upon submission, the EMR automatically populates the signed PDFs into the patient's document tree, updates the appointment status on the scheduling grid from "Scheduled" to "Checked In", and alerts the nursing queue.
+      - Step 2: Clinical Intake & Rooming (Medical Assistant / Nurse)
+        - Objective: Prepare the clinical chart, capture baseline medical metrics, and establish the chief complaint.
+        - Patient Escort: The Medical Assistant (MA) calls the patient to the triage area and confirms identity using two identifiers (Full Name and Date of Birth).
+        - Vitals Ingestion: The MA captures blood pressure, heart rate, respiratory rate, temperature, and weight.
+          - System Integration: The MA uses a smart vitals machine connected via USB or Bluetooth. Clicking "Sync Vitals" instantly writes the metrics directly into the EMR flowsheets, eliminating manual typing errors.
+        - Chief Complaint (CC): The MA opens the intake navigator and records the patient's primary reason for the visit using the patient's exact words (e.g., "Severe lower back pain radiating down the right leg for 3 weeks"). [1]
+        - Allergy & Medication Reconciliation:
+          - The MA reviews the active medication list imported via the SureScripts pharmacy data feed.
+          - The MA clicks "Reconcile" next to each verified medication and enters any new allergies, assigning the severity and reaction type (e.g., Penicillin -> Rash / Severe).
+        - Status Update: The MA updates the chart locator status to "In Exam Room 3" and changes the patient status to "Ready for Provider".
+      - Step 3: Provider Clinical Examination & Documentation
+        - Objective: Conduct the medical evaluation and construct a legally compliant, highly structured clinical note using either SOAP or APSO formatting
+        - Option A: APSO Layout (Modern Executive Flow)
+          - 1. ASSESSMENT (A) | | - Primary Diagnosis: M54.50 (Low back pain, unspecified) | | - Secondary Diagnosis: M54.16 (Radiculopathy, lumbar region) | +--------------------------------------------------------------------------+ | 2. PLAN (P) | | - Rx: Cyclobenzaprine 5mg PO TID x 7 days (#21, 0 refills) | | - Imaging: Order Lumbar Spine MRI without contrast | | - Follow-up: Return to clinic in 2 weeks | +--------------------------------------------------------------------------+ | 3. SUBJECTIVE (S) | | - Patient presents with radiating lower back pain. | | - Symptoms worsened by prolonged sitting. | +--------------------------------------------------------------------------+ | 4. OBJECTIVE (O) | | - Vitals: BP 122/80, HR 72. | | - Physical Exam: Positive straight leg raise test on the right side.
+      - Step 4: Order Management, Discharge, & Follow-Up Scheduling
+        - Objective: Finalize point-of-care actions, execute electronic prescriptions, and safely transition the patient out of the clinic.
+        - e-Prescribing (eRx): The provider opens the medication order window, selects the verified local pharmacy, attaches the diagnosis code to the script for prior authorization tracking, and signs it electronically using two-factor authentication for controlled substances.
+        - Ancillary Orders: The provider signs the digital order for the Lumbar Spine MRI. The EMR automatically routes this order to the internal authorization queue via an integrated medical necessity checking tool.
+        - Charge Capture (Superbill Automation): Before leaving the chart, the provider enters the EMR Evaluation and Management (E&M) coding calculator. Based on the documentation complexity and time spent, the system suggests CPT Code 99214 (Level 4 Established Office Visit). The provider clicks "Accept Charges" to bind CPT 99214 to ICD-10 M54.50. [1]
+        - Discharge and Booking: The patient exits the exam room to the checkout desk.
+          - The checkout staff opens the discharge navigator.
+          - Staff generates and prints the After Visit Summary (AVS) containing the updated medication list, MRI instructions, and self-care directions.
+          - Staff opens the scheduling matrix and books the 2-week follow-up appointment as directed in the provider's Plan. [1]
+        - Status Update: The appointment status shifts to "Discharged", and the physical patient leaves the building.
+      - Step 5: Chart Sign-Off & Billing Ingestion
+        - Objective: Lock the medical record and transform clinical documentation into a structured financial claim.
+        - [Provider Signs Note] │ ▼ [Charge Router Activates] │ ▼ [Internal Scrubber Checks] ──► (Fails? ──► Routes to Coder Queue) │ (Passes) ▼ [X12 837P Claim Created]
+        - Provider Note Closure: At the end of the shift, the provider reviews the completed SOAP/APSO document, verifies the linked diagnosis codes, and applies their electronic signature. This locks the note against further edits.
+        - Charge Routing: The act of signing the note automatically releases the digital superbill from the clinical application to the practice management/billing application interface.
+        - Internal Claim Scrubbing: The EMR's billing module passes the claim through an integrated rules engine. This system tests the claim against National Correct Coding Initiative (NCCI) edits, payer-specific local coverage determinations (LCDs), and missing modifiers (e.g., checking if an evaluation modifier like -25 is required).
+          - Exception Handling: If a rule fails, the claim drops into an internal "Charge Edit Workqueue" for a human coder to fix.
+          - Clean Claim Path: If the claim passes all internal validation checks, it compiles into a standardized EDI X12 837P (Professional) Electronic Claim File.
+      - Step 6: Clearinghouse Submission & Claim Validation
+        - Objective: Safely transmit the claim file through the medical clearinghouse to the target insurance payer.
+        - Batch Transmission: At 11:59 PM on Go-Live Day, the system collects all verified 837P files into a batch and transmits them securely via SFTP to the integrated clearinghouse (e.g., Change Healthcare, Waystar).
+        - Clearinghouse Scrubbing: The clearinghouse receives the batch and runs its own validation checks, matching the data fields against current payer validation tables.
+        - Electronic Acknowledgments:
+          - 999 Transaction File: The clearinghouse returns an X12 999 Functional Acknowledgment within hours, confirming that the clinic's file format was successfully accepted and parsed.
+          - 277CA Transaction File: The clearinghouse then transmits an X12 277 Claim Acknowledgment file back to the EMR. This file details claim-level acceptance or rejection by the individual payers (e.g., Blue Cross, Aetna).
+        - Dashboard Update: Inside the clinic's billing cockpit, the claim status automatically updates from "Ready to Send" to "Accepted by Payer".
+      - Step 7: Adjudication, Payment Ingestion, & Encounter Closure
+        - Objective: Process the payer's financial determination, reconcile patient balances, and close out the encounter file.
+        - Payer Adjudication: The insurance company evaluates the claim against the patient's benefits plan, applies the network discount rates, deducts the $30 copay, and approves the remaining payment amount.
+        - ERA Ingestion (X12 835): The payer sends an X12 835 Electronic Remittance Advice (ERA) back to the clinic's clearinghouse, which routes it directly into the EMR billing module.
+        - Auto-Posting Payments: The EMR reads the incoming 835 ERA file and auto-posts the payment amounts.
+          - Example: If the contract rate for 99214 is $120, and the patient paid a $30 copay, the system posts the $90 insurance check payment, applies a contractual write-off of any remaining balance above the contract rate, and drops the patient's remaining balance to exactly $0.00.
+        - Encounter Closure: With the clinical note locked, the claim successfully adjudicated, the payment balanced to zero, and no outstanding patient statements pending, the EMR automated system changes the financial ledger flag to "Encounter Closed". This archives the encounter out of active workflows and saves it to permanent financial storage.
+      - WORKFLOW 2 (Day 1 Go-Live: Hour-by-Hour Operational Playbook)
+        - Use these timelines and images to help format the overall experience: 
+        - 
+        - 
+        - 06:00 AM – System Launch & Triage Station Setup
+          - Action: Boot all Front Desk workstations, clinical tablets, and Workstations on Wheels (WOWs).
+          - Action: Log into the primary EMR application and verify that the active clinic scheduling grid matches the legacy system backup.
+          - Action: Run a test scan on local desktop scanners to ensure optical character recognition (OCR) software is responsive.
+          - Action: Confirm Bluetooth/USB connectivity on smart vitals machines across all exam rooms.
+          - Action: Open the central Command Center communication channel and verify that all on-site superusers are in position.
+          - 🟢 Gate 1: System Readiness Sign-off from IT Support Lead. Technical infrastructure must be fully functional before patients arrive.
+        - 07:00 AM – Front Desk Activation & RTE Validation
+          - Action: Greet the first arriving patients and initiate the scanning of photo IDs and insurance cards.
+          - Action: Trigger Real-Time Eligibility (RTE) queries inside the registration module.
+          - Action: Parse incoming X12 271 responses to manually verify active copay requirements and deductible metrics.
+          - Action: Distribute digital tablets to patients for the submission of mandatory HIPAA, consent, and intake forms.
+          - Action: Monitor the schedule interface to ensure patient status updates automatically transition from "Scheduled" to "Checked In".
+          - 🟢 Gate 2: Registration Workflow Sign-off from Front Desk Manager. Patient data ingestion must be working perfectly before clinical rooming begins.
+        - 08:00 AM – Clinical Intake, Rooming, & Care Team Handoff
+          - Action: Call patients back to triage utilizing two-identifier validation (Full Name and Date of Birth).
+          - Action: Sync vital signs from physical diagnostic hardware directly into the EMR flowsheet application.
+          - Action: Record the patient's specific Chief Complaint (CC) verbatim in the designated intake field.
+          - Action: Pull active medication feeds via SureScripts, reconcile old listings, and input current drug allergies.
+          - Action: Advance the room tracking locator flag to "Ready for Provider" to alert the clinical staff.
+        - 09:00 AM – Provider Encounter & SOAP/APSO Documentation
+          - Action: Open the patient chart via the provider dashboard to review intake vitals, history, and allergy panels.
+          - Action: Execute the physical evaluation and document notes directly using the mandated SOAP or APSO structured formatting templates.
+          - Action: Electronically transmit prescriptions (eRx) to local pharmacies using dual-factor authentication controls.
+          - Action: Sign digital orders for ancillary procedures, auto-attaching corresponding ICD-10-CM diagnosis codes.
+          - Action: Open the E&M coding calculator to select and accept the recommended Level 4 CPT codes (e.g., 99214).
+          - 🟢 Gate 3: Clinical Documentation Sign-off from Chief Medical Officer. Providers must successfully sign notes and capture charges without system lag.
+        - 10:00 AM – Patient Checkout, Discharge, & Charge Routing
+          - Action: Guide the patient to the exit reception desk and launch the discharge navigator module.
+          - Action: Compile and print the comprehensive After Visit Summary (AVS) containing follow-up instructions.
+          - Action: Book the requested return appointment inside the active calendar grid as outlined in the provider's Plan.
+          - Action: Transition the final patient status flag to "Discharged" to complete the physical clinic visit.
+          - Action: Verify that provider-approved superbills route cleanly from the clinical application to the practice management system.
+          - 🟢 Gate 4: Revenue Cycle Integration Sign-off from Billing Director. Charges must interface correctly between clinical and financial modules.
+        - 11:00 AM – Claims Scrubbing & Edit Workqueue Management
+          - Action: Trigger the EMR's integrated rules engine to screen all morning charges against NCCI edits and payer policies.
+          - Action: Route any flagged or failing claims immediately into the Charge Edit Workqueue.
+          - Action: Task certified medical coders with resolving documentation errors, missing modifiers, or mismatched ICD-10 groupings.
+          - Action: Release corrected charges back into the clean claim compilation pipeline.
+        - 12:00 PM – Midday Operational Audit & Support Review
+          - Action: Convene a brief, 15-minute sync with the Command Center to evaluate morning performance metrics.
+          - Action: Review IT helpdesk ticket counts to pinpoint widespread user obstacles or interface bottle-necks.
+          - Action: Validate that HL7 interface logs show zero dropped data packets across laboratory and pharmacy networks.
+          - Action: Adjust afternoon staffing support schedules to reinforce teams facing higher processing volumes.
+        - 11:59 PM – Batch Transmission & Clearinghouse Acknowledgment
+          - Action: Collect all finalized, clean 837P claim files into a single master electronic batch.
+          - Action: Transmit the compiled batch securely over SFTP protocols directly to the integrated medical clearinghouse.
+          - Action: Download and verify the incoming X12 999 Functional Acknowledgment to confirm successful file reception.
+          - Action: Audit the X12 277CA Claim Acknowledgment file to verify individual payer-level acceptances.
+          - Action: Refresh the billing dashboard to ensure all day-one claim tracking metrics update cleanly to "Accepted by Payer".
+        - Technical & Infrastructure Layer (The Missing Elements)
+          - Your current plan assumes the software works flawlessly. We must add structured technical checkpoints to catch system degradation before it impacts patient care.
+          - 07:15 AM – Scanner & Peripheral Stress Test: Right before peak check-in, have all front desk staff scan a dummy document simultaneously. This ensures local network switches and print servers can handle the massive day-one print queue load.
+          - 10:30 AM & 02:30 PM – Interface Engine Audit: Integration teams must manually audit the HL7 log queues. They need to verify that labs ordered at 08:00 AM or 09:00 AM are not getting stuck in a pending status between the EMR and the external laboratory/radiology systems.
+          - 01:00 PM – Database Performance & Session Lock Check: IT must check database query latency. With hundreds of users logged in concurrently for the first time, unoptimized queries can cause "session locks," freezing provider screens mid-documentation.
+        - Contingency & Fallback Layer (The Missing Elements)
+          - You must define the exact triggers for when to abandon the system temporarily to maintain patient safety.
+          - Downtime Form Readiness: At 06:00 AM, physical "Downtime Packets" (paper charts, paper prescriptions, paper superbills) must be visibly placed at every single desk.
+          - The "Go/No-Go" Cutoff Matrix: If a system freeze or critical interface failure occurs, how long do you troubleshoot before pulling the plug? You need hard limits injected into the playbook:
+            - Front Desk: If the EMR check-in screen is frozen for >15 minutes, switch to paper sign-in sheets.
+            - Clinical Rooming: If vitals cannot be entered for >20 minutes, write them on paper sticky notes and pass them to the doctor.
+            - Prescriptions: If the eRx network drops, immediately switch to physical, hand-signed paper prescription pads.
+        - Master Playbook Overview
+          - 06:00 AM ── [Downtime Packets Staged at Desks] 
+          - 06:45 AM ── [Staff Pre-Flight Huddle & Superuser Zone Matching] 
+          - 07:00 AM ── Front Desk Doors Open / Registration Begins 
+          - 07:15 AM ── [Peripheral Stress Test: Mass Print & Scan Verification] 
+          - 08:00 AM ── Clinical Intake & Scheduled Rooming Begins 
+          - 09:00 AM ── Provider Documentation Loops Activate 
+          - 10:30 AM ── [Interface Audit: Verify Lab/PACS Results Routing] 
+          - 12:00 PM ── Midday Performance Sync (IT vs. Operations) 
+          - 12:30 PM ── [Schedule Buffer Check: Assess Provider Backlog] 
+          - 01:00 PM ── [Technical Check: Database Latency & Session Lock Audit] 
+          - 02:30 PM ── [Interface Audit: Afternoon Order Validation] 
+          - 05:00 PM ── [Chart Sweep: Superusers Assist Providers with Locking SOAP/APSO Notes] 
+          - 06:00 PM ── Daily Debrief: Document Bugs, Log Helpdesk Tickets, Clear the Queue 
+          - 11:59 PM ── Outbound 837P Claims Batch Transmission
+For page: https://leafjourney.com/ops/intake-builder (“Intake Builder” Tab):
+- For the “Standard Cannabis Patient Intake” top tile:
+  - Change “add field” to “add new”
+    - For the “+add field” button, make sure that it disappears when clicking out of that area. For example I must click on “+add field” button to have the menu populate and for the menu disappear. It should disappear once the owner clicks away from that drop down
+  - For the “Standard Cannabis Patient Intake” part:
+    - Change it to a placeholder title that says “Title of New Form”
+  - For the “Default intake form for new cannabis care patients” part:
+    - Change it to a placeholder title that says “Description of New Form”
+- For the “Manage Sections” tile:
+  - Be able to use the “hand” icon to grab and drag around the order of the different sections.
+    - Have the option to “delete” the sections to the right of the “fields” 
+    - Make sure a pop up window shows up to confirm the owner wants to “delete” anything once clicked on
+- Have a button at the top that says “Forms” 
+  - Once clicked on, have it display all of the “saved” templates and forms in chronological order
+  - Be able to “delete” and “archive” forms if they are being used or not
+    - If deleted or “archived” make them unusable to use in the clinic
+- Make sure that every “drag” hand actually works and the owner can actually drag and rearrange every field within the “Sections”
+    - Once clicked on “add field button”:
+      - Keep the “Edit field” tile populate directly adjacent (Right) of the current field that is being edited so the owner doesn’t have to scroll to find it. Have the “edit field” tile be the same for “adding new section” or “adding new field” as well
+      - For the “edit field” tile:
+        - On top of the “label” field, create a new field called “Section Heading” field:
+          - Take this “section heading” option from the “field type” drop down menu
+            - Remove “Section heading” from the “field type” drop down menu
+          - Make it a drop down menu similar to the “filed type” that the owner can choose the “section” to assign this new field to for example they can click on “demographics”, “medical history”, “cannabis history”, etc
+            - Have an “add new” on the drop down that when the owner clicks another pop up displays where the owner can type in the new “Section” title
+        - For the “Label” field:
+          - Keep as is
+        - For “Field Type” field:
+          - For the drop down, include the actual symbols that populate when clicking the “+ add field” button at the top of the screen
+        - For the “Required” slider:
+          - If not optional, make sure to make a small phrase when the actual form is built that says in parentheses that this field is (optional)
+- For the “save template” button:
+  - Once clicked on it, have a pop up window open asking if they want to “display” the actual intake form. 
+    - If “yes” then have the overall form including the background, actual header/footer information along with all the fields, section titles, etc populate as organized on the “intake builder” as if the patient would actually be able to fill it out on a printable form or “test” it out digitally
+      - Make the form printable, downloadable, and sharable 
+    - In this page, have the ability to “edit” the template which then takes them back to the “intake builder” page so the owner can continue to revise and edit the template
+For page: https://leafjourney.com/ops/export (“Data Export” Tab):
+- For the “Select export format” section:
+  - To the rightmost of this title have an “archive” button that once clicked on it populates all of the previous data export cohorts in chronological order. 
+    - Be able to have the owner click on any of these and have the details in terms of what “outcome metrics”, “additional data”, and “dates” were selected and used. 
+    - LeafJourney should hold and archive exported data sets for 3 years and then have it begin deleting from this portal
+  - Have a button that says “other” and once clicked have a pop up window display a few other export formats and make sure the AI agents and LeafJourney and LeafNerd are able to properly format the data to fit this type of format or file type:
+    - Protocol Buffers (Protobuf)
+    - Apache Avro
+    - Apache Parquet
+- For the “Select Outcome Metrics” section:
+  - Have an “other” button
+    - Once clicked on it allows the patient to search for certain types of data points such as “constipation”, “neuropathy”, etc which then can be added as another “selectable” tile under this section.
+      - Allow the owner to select multiple, customizable outcome metrics with the help of the AI agents and the LeafNerd engine.
+- For the “include additional data” section:
+  - Have an “other” button
+    - Once clicked on it allows the patient to search for certain types of data points such as “labs”, “vitals”, “exact age range”, etc which then can be added as another “selectable” tile under this section.
+      - Allow the owner to select multiple, customizable outcome metrics with the help of the AI agents and the LeafNerd engine.
+- 

--- a/docs/plans/owner-portal-revisions-2026-06-10-diff-analysis.md
+++ b/docs/plans/owner-portal-revisions-2026-06-10-diff-analysis.md
@@ -1,0 +1,233 @@
+# Owner Portal Revisions — Diff / Gap Analysis (v3, 2026-06-10)
+
+**Source:** `Scott - LeafJourney Owner Portal Revisions.docx`
+**Author:** Neal Patel · **Created/Modified:** 2026-06-10 · **Size:** 107 pages / ~32,773 words / 1,764 directive lines
+**docx md5:** `8d84e66348b336bdb370fb237e062697` · **extracted-text md5:** `98a7afb2364c4a12ad321dabdee0ca90`
+**Supersedes:** v1 (6.1.2026 → ingested as EMR-919..986) and v2 delta (6.5.2026 → EMR-1002..1074). This is the **cumulative master doc**, not a delta — it restates everything plus refinements.
+
+> ⚠️ This is a desktop-only pass (`www.LeafJourney.com/ops`). Mobile is explicitly deferred ("Once this is fully cleaned up… I will begin going through the mobile site").
+
+---
+
+## 1. Reality check on scope
+
+Every `/ops` page the document references **already exists** — the codebase has **123 `/ops` route pages** under `src/app/(operator)/ops/`. So this document is overwhelmingly a **revision/refinement pass on existing pages**, not a greenfield build. The exceptions are a handful of net-new backend "engines" (native clearinghouse/EDI, unified prior-auth, pre/post-service appeals, RCM analytics) that are partially present already (billing/EDI scaffolding shipped Phase 9 + Megasprint).
+
+The directives fall into four very different buckets, and conflating them is the main risk:
+
+| Bucket | What it is | Codeable now? | Volume |
+|---|---|---|---|
+| **A. Cross-cutting UI primitives ("MASTER prompt")** | Collapsible sections, sortable/movable tables, sidebar-autohide, autocomplete dropdowns, hover-tooltip charts, table export, AI search bars | ✅ Yes — build once, reuse everywhere. Highest leverage. | ~10 primitives × ~30 pages |
+| **B. Per-page copy / color / layout tweaks** | Renames, bubble color systems, font sizes, "stop sidebar opening on button click", truncate+expand lists, move/merge tiles | ✅ Yes — cheap, mechanical, high volume | ~hundreds of small edits |
+| **C. Backend mega-engines** | Native clearinghouse (X12 270/271/276/277/278/275/837P/835/999/277CA), unified prior-auth, appeals engines, RCM analytics, OCR document routing, QuickBooks bookkeeping/import | ⚠️ Partially exists; each is a multi-PR program of work | ~8 programs |
+| **D. Non-codeable / administrative** | Medicare/UHC/Aetna/Cigna/BCBS direct EDI credentialing (30–90 days **per payer**), Submitter/Receiver IDs, BAAs, EHNAC/DirectTrust accreditation, SOC 2, mTLS cert provisioning, Surescripts/EPCS enrollment | ❌ Not something an agent can "implement" — these are legal/business onboarding tasks | ~6 items |
+
+**Implication for "implement each change":** Buckets A + B are genuinely shippable in sprints and are where the visible "cleaned up, de-bugged, operational" payoff lives. Bucket C is real engineering but should be tracked as named programs, much of it already scaffolded. Bucket D must be surfaced honestly as out-of-scope-for-code (business/legal blockers), with code stubs + fallback (aggregator) paths where applicable — consistent with the "honest registry stubs" approach already taken (EMR-1096).
+
+---
+
+## 2. The MASTER prompt — global UI contract (Bucket A)
+
+These recur on nearly every page; the doc explicitly says the MASTER prompt "merges or overrides" any conflicting per-page note. Build these as **shared primitives** once, then adopt per page. This is the single highest-value workstream.
+
+| # | Primitive | Spec | Reuse target |
+|---|---|---|---|
+| G1 | **Collapsible sections** | Every "section" expandable/collapsible (title-only collapsed state) | All pages |
+| G2 | **Sidebar overlay + autohide** | Sidebar layers on top (never hidden behind content) when viewport is narrowed/half-screen; **autohides** on every navigation and on forward/back; never re-expands when clicking in-page buttons (Log, Add, Delete, Generate, Archive…) | Global layout |
+| G3 | **Autocomplete dropdowns everywhere** | Every search bar / dropdown / searchable field auto-populates **7** top page-specific matches as you type; site-specific, not global | Every input |
+| G4 | **Global "search everything"** | A search icon at bottom-left of every page = full-directory query (search the whole "computer" vs one "folder") | Global layout |
+| G5 | **Sortable table columns** | Click any column header to sort (chronological / hi-lo / alphabetical, type-appropriate) | Every table |
+| G6 | **Table send/print/download** | Export any table (incl. column + row titles) | Every table |
+| G7 | **Movable/rearrangeable tiles** | Drag-reorder every tile/section/table (the green-header boxes); add/remove columns | Every dashboard |
+| G8 | **Per-section AI date/param search bar** | Search bar at far right across from each section header; AI-driven (Cindy) chronological/param filtering | Every section |
+| G9 | **Compare mode** | Small checkbox top-right of each box → select ≥2 → "Compare" button appears across from header → popup overlays the measures on one chart | Every metric box |
+| G10 | **Beautify popups + "feather" button** | Click a box → popup with full historical/chronological data, beautiful charts; "feather" icon re-beautifies / cycles chart types | Every metric box |
+| G11 | **Hover tooltips on all charts** | Every graph: hover a datapoint → show value + time (X/Y), Google-Finance style. Applies to patient/owner/provider portals everywhere | Every chart |
+| G12 | **Chrome-style tabs** | Any "tabs" should look/behave like the `/ops/cfo` tab strip (simple clickable Chrome-tab layout) | Pages w/ tabs |
+| G13 | **Bubble color system** | Recurring semantics: green = active/positive/in-stock, yellow = caution/off-goal/medium, red = inactive/negative/critical, orange = low-confidence, purple = on-goal, blue = new-coverage | Every status bubble |
+| G14 | **Truncate + expand lists** | Long lists show N (10/20/30) then truncate with an "expand/show more" that pages in +50 until fully shown | Every long list |
+| G15 | **Archive pattern** | Resolved/aged items move to an Archive (button bottom-right) that pages 50 at a time + has its own MASTER-prompt search | Many pages |
+| G16 | **"Cindy says/suggests" blocks** | AI analytics rendered under a labeled "Cindy suggests" header (2–4 short bullets), distinct from raw stats | Many pages |
+| G17 | **Calendar-picker + free date range** | Date fields get a calendar icon + manual range entry | Many forms |
+| G18 | **Educational content = "an experience"** | Training/policy/module content must be engaging; each module emits a 1-page fun printable summary (artwork + mnemonic devices: homonyms/anagrams/palindromes) | Training/Policies |
+
+**Status:** Several of these exist in pockets (recent PRs hardened denials/scrub/billing dashboards, added schedule drag-to-reschedule). There is **no single shared primitive set** adopted uniformly — that's the gap. Recommend a `components/ops/master/` kit: `<CollapsibleSection>`, `<SortableTable>` (sort+export+column DnD), `<MetricBox>` (compare+beautify+popup), `<AutocompleteInput>`, `<ArchiveDrawer>`, `<CindyBlock>`, `<HoverChart>`, plus a layout fix for sidebar overlay/autohide.
+
+---
+
+## 3. Page-by-page catalog (status + key gaps)
+
+Legend: **EXISTS** = route built; **REV** = revision/refinement requested; **GAP** = net-new behavior; status reflects codebase survey + prior ingestion (EMR-919..986 / 1002..1074), not line-level verification.
+
+### Mission Control — `/ops/mission-control` · EXISTS · REV
+- "Needs Approval" box links to `?tab=approval`; All Jobs sorted chronological; hover-explain each workflow job in plain terms.
+- Need-Approval tab: **Approve all / Reject all**; per-workflow **default approve/reject** rule.
+- Agent Fleet: bigger "Actions:" text; hover 1-sentence 3rd-grade summary per agent; a tab to toggle **each agent on/off** without harming platform integrity. *(ties to AgentSetting model, Megasprint P2 T4)*
+
+### Schedule — `/ops/schedule` · EXISTS · REV
+- Click every ribbon box (This week/Today/Confirmed…) → drill into Week View; Week-View **title changes** to the clicked box.
+- Patient name → patient chart home; right-click row → "schedule" → `/clinic/schedule`; filter button (date/time range) far right.
+- "Providers This Week" → click provider → snapshot in Week View, title → provider name. Keep on one static no-scroll page. *(drag-to-reschedule shipped #628)*
+
+### Patients — `/ops/patients` · EXISTS · REV
+- Right-click row → status change (Prospect/Active/Inactive) with bubbles (green/yellow/red).
+- Expand row → click full name → chart front page; show age under name ("38F"); click email → draft/save/send popup; click phone → call; click "missing fields" → jump to that chart area.
+
+### Command — `/clinic/command` · EXISTS · REV (structural)
+- Consider **merging** `/clinic/command` content into `/ops`; remove the "Overview" tab, merge into Command Center tab. *(architectural — needs design decision)*
+
+### Billing — `/ops/billing` · EXISTS · REV *(dashboards hardened #617/#630)*
+- Rename "Billing workqueue" → **"Billing Dashboard"**.
+- Total Billed / Collected / Pending Revenue / Outstanding boxes: click → LeafNerd analytics popup (per day/week/month/year); enlarge the sub-labels; copy fix "process"→"progress".
+- KPI ribbon buttons: every count-bubble needs a word label; remove word-less buttons; drag/rearrange/add/remove categories; **Denied stays red** even unselected; others light green on click; **fix sluggish click responsiveness**.
+- Column headers sortable (type-appropriate); drag/add/remove columns.
+- Denied section: bigger denial-reason font; expand row → full claim history/audit trail; **"Take action"** → respond/refute/adjust, connect to payer dept, compose justification, send → audit trail into chart **Correspondence** tab.
+
+### Scrub & Auths — `/ops/scrub` · EXISTS · REV + GAP *(Prior-Auth hub partly shipped, EMR-927..986)*
+- Rename "Scrub" → **"Scrub and Auths"**; becomes the central hub for claims **and** prior authorizations.
+- "Prior Authorization" button → fully modular PA form with API plug-ins: **Availity, CoverMyMeds, Innovaccer, Insight Health, ScribeRunner**.
+- Copy: "clean and ready"→"reviewed and ready" (green); lighter-yellow Warnings; clickable summary boxes scroll to matching lower section + retitle it; filter popup; hover-explain root causes (incl. "Cindy is learning"); click bubbles → populate occurrences + retitle.
+- Big embedded spec: **end-to-end billing pipeline** (RTE → auth → estimate → signed note → CCI scrub → payer-rule check → clean-claim). → Bucket C.
+
+### Denials Command Center — `/ops/denials` · EXISTS · REV *(hardened #579)*
+- 4 top boxes clickable (open denials → scroll; high urgency → filter red; total at risk / recovery → filter popup w/ time params; recovery target vs **actual recovered** dual-graph).
+- Denial Root Cause / Denial Mix by Payer: click count → detailed claims; click cause/payer → graph popup + **"Cindy says"** (2–4 bullets) + provider-vs-peer comparison; hover one-phrase explainers; scroll-inside-box.
+- Detailed claims: collapse urgency words; verbatim payer-letter italics; "suggested action"→**"Cindy suggests"** (≤3 words, tighter bubbles); **Take action** popup → 3 paths (corrected claim / fix coding / peer-to-peer); beige **History** audit bubble (denied→appeal→corrections→resolved timeline).
+
+### Aging Workbench — `/ops/aging` · EXISTS · REV
+- Top boxes drive Aging-buckets titles; feather→LeafNerd graph popup + filter; fix horizontal bar graphs; move Insurance/Patient A/R under the distribution title.
+- Filter: collapse Insurance/Patient-only into an "All" dropdown; add **Days** dropdown (0-30/31-60…) synced with bucket clicks; add **% recoverable** dropdown.
+- Worklist boxes: beige days-in-denial bubble; remove Ins/Pt split; insurance(yellow)/patient(purple) bubble; expand → audit history timeline.
+
+### Eligibility — `/ops/eligibility` · EXISTS · REV + GAP
+- Rename "cannabis eligibility checker"→"eligibility checker"; default to **insurance** eligibility (not cannabis); hide all cannabis/psilocybin UI if module opted out.
+- Separate **"cannabis eligibility"** button (state MMJ-license likelihood) from insurance check; bubbles green/yellow/red = active/check/not-active.
+- Embedded full **270/271 eligibility lifecycle** spec (service-type-code-by-specialty, AAA/EB/REF parsing, 3 triggers: schedule / 48h CRON / on-demand). → Bucket C.
+- Findings: leaf-icon US legal-status map popup; qualifying-conditions top-10 list; ICD-10 search popup (autocomplete, add-to-dx); state MMJ application deep links; reflect deductible/coinsurance/visit-limits into `/portal/billing` "Your Insurance".
+
+### Documents (Mail-Fax OCR) — `/ops/mail-fax` · EXISTS · REV + GAP *(documents hardened #579)*
+- Rename "Mail & Fax OCR Inbox" → **"Documents Inbox and Outbox"**; two tabs **Inbox / Outbox**; outbox chronological w/ identifiers; top **Send** button (name + fax/email + message + attach → send, 90-day history).
+- **Scan** + **Deleted items** (30-day recover/permanent-delete) buttons above "flagged for review".
+- AI document routing: one centralized inbox auto-classifies type + patient + DOB + date → files into chart. → Bucket C.
+- Box-click filters; collapsible OCR detail windows; approve/edit/delete (edit popup re-routes); MRN→**MLN** ("Medical Life number"); bubble colors (green/yellow/orange/red/blue); "insurance" jump button; "view raw OCR text"→"view actual text" (full-size PDF/JPG/DOCX, collapsible).
+
+### Billing Agents — `/ops/billing-agents` · EXISTS · REV
+- Add **light mode** (default light, not only dark). Defer LeafNerd integration until rest of EMR stable.
+
+### Revenue — `/ops/revenue` · EXISTS · REV (heavy)
+- Two tabs: **Claims billing** / **Product billing** (dispensary gross/net moves under Product).
+- All subsections collapsible + draggable (Claims funnel, AR aging, Dispensary, Denial queue, Claim status breakdown, Provider productivity, Payer mix, Top billed codes).
+- Top boxes → analytics popups (5-yr range) + "details" deep-links into `/ops/billing?status=…`; Outstanding aggregates submitted+partial+denied.
+- Dispensary: SKU bubble thresholds (≤5 red / ≤20 yellow / ≥21 green); inventory units; merge Top-SKU into Inventory-on-hand; AI SKU search (phytocannabinoid/terpene/type/strain); wholesale-vs-retail popup; per-SKU sales analytics + product image; Gross/Refunds(reasons)/Tax(**QuickBooks-style** + IRS doc generator)/Net breakdown pages.
+- Provider productivity list + feather-graph + compare; payer mix → also on `/ops/billing`, per-payer trend popups; Top billed CPT **and** new Top billed ICD-10 section.
+
+### CFO suite — `/ops/cfo` (+ `/pnl /cash-flow /balance-sheet /expenses /cash /assets /liabilities /equity /goals /reports`) · EXISTS · REV (heavy) *(v2 ingest EMR-1002..1074)*
+- **New `/ops/cfo/bookkeeping`** tab (QuickBooks-style ledger; upload `.QBW/.QBB/.QBM/.QBX/.QBA/.QBY`; export `.CSV/.XLS/.XLSX/.QIF/.IIF`; moves "Log New Expense"→"Log New Expense/Income"; income/expense bubbles green/red; "Recent income and expenses" 20+expand). → Bucket C-lite.
+- CFO Briefing: stats-as-chart (gross margin/revenue/EBITDA/bank/working-capital), sentences become "Cindy suggests"; feather popup; strip `agent:cfo@1.0.0`.
+- Headline KPIs: spell out KPI; per-section AI date search; compare-mode; beautify popups + hover tooltips; bubble colors (red/green/yellow/purple); collapsible + movable.
+- Merge Anomalies&Flags into CFO Briefing; remove standalone graphs / "Revenue vs EBITDA 13wk"; promote P&L/Cash-Flow/Balance-Sheet to top.
+- Recurring across every CFO subpage: top tiles under a **"Dashboard"/"Financial Dashboard"** header; MASTER-prompt compliance; **stop sidebar opening** on Log/Add/Delete/Generate/Archive; dropdown "Other → free text"; autocomplete remembered fields; delete-confirm popups; truncate+expand ledgers; remove stray green borders; runway happy/sad emoji + inline trend; reconciliation up/down arrows; rename "salvage"→"residual", "last synced"→"last reconciled"; assets/liabilities/equity tile groupings + column popups + sortable headers; reports print/download PDF + cadence dropdown.
+
+### Staff Schedule — `/ops/staff-schedule` · EXISTS · REV
+- One large block per shift (remove dots); larger headers; 24h Add-Shift range; per-employee colors; fix blank Print (green blocks must render); **flip axes** (employees as columns, dates as rows); click employee/type → "All shifts this week" retitles; remove-confirm popup; clickable week title + calendar picker.
+
+### Time Clock — `/ops/time-clock` · EXISTS · REV + GAP
+- **Clock keeps running after sign-off**; only "Clock out" stops it (server-side timer). MASTER prompt on tiles; Recent Activity 30+truncate + calendar search; export timesheet columns (time/type/date/hours in 0.1h).
+
+### Training — `/ops/training` · EXISTS · REV + GAP
+- Engaging content + 1-page printable summaries (Bucket-A G18); >1yr → Archive; **fix "Demo: assigned HIPAA Basics" error**; bubble colors (not-started/yellow/green/red); completed cert popup = beautiful PDF (Egyptian/Hindu-inspired border, official LeafJourney seal) — downloadable/printable/sendable; assign only to practice-linked people.
+
+### Policies — `/ops/policies` · EXISTS · REV
+- "All" → green check for completed (nothing for pending); MASTER-prompt search; **fix "Create New Policy" error** (Title/Description/Category + save/cancel; chronological insert); engaging content + printables.
+
+### Incidents — `/ops/incidents` · EXISTS · REV
+- Severity bubbles (critical red / high orange / low yellow/blue); MASTER prompt; click Title → full report popup (reported/resolved dates, resolver, resolution); resolved → archive (button + searchable archive); New Report color match; Category "Other → free text → 'Other (Clerical)'"; remove "short summary" placeholder.
+
+### Supplies — `/ops/supplies` · EXISTS · REV
+- Back-office/staff **Request** button (popup: request + dollar amount); MASTER-prompt search; 10+truncate w/ Archive (50 at a time); per-entry review/approve/cancel/modify + comments + send/cancel/resolve; show requester + time.
+
+### Vendors — `/ops/vendors` · EXISTS · REV + GAP
+- MASTER prompt; "Expiring < 30" → dropdown (≤60/≤90/custom numeric-only); click vendor → full info popup + payment/invoice history + **Tax documents** (W-9/1099, 10-yr); click phone/email → call/email; ordered contact display (title/phone/email, editable); category color assignment popup; brighter renew-soon red; date format dd-mm-yyyy; Add-Vendor Description field; new **Contract Started** column (+ days-in-contract); expiring tile 30→60 days.
+
+### Feedback — `/ops/feedback` · EXISTS · REV
+- Separate closeable tag bubbles; spell out **NPS**; 1-10 scale ↔ 3-4 emoji levels (numerically rankable); long-explanation popup; "action taken" tag → free-text staff name; Respond → **Send** button (real send); **Resolved** → archive (50 at a time).
+
+### Marketing — `/ops/marketing` · EXISTS · REV
+- MASTER prompt; colored "patients by source"; move CAC to its own tile (note: doc mislabels CAC as "Cash on Cash" — CAC = Customer Acquisition Cost; confirm intent); darker green conversion funnel; **fix Monthly-Trend graph not rendering**; ROI calculator monthly/quarterly/yearly options; **fix Spend not calculating**; **fix revenue==net bug**; AI suggestion block.
+
+### Announcements — `/ops/announcements` · EXISTS · REV
+- MASTER prompt; 7 tiles + see-more; expandable scrollable message thread (timestamps); hover emoji-reaction → who voted (one vote per person); archive/delete (manager/owner only); pinned-first chronological; Post Announcement Category "Other → free text".
+
+### Analytics — `/ops/analytics` · EXISTS · REV (external doc)
+- Defers to a separate **"LeafJourney Data Usage Revisions.docx"** (not in scope of this file) + MASTER prompt.
+
+### Onboarding — `/ops/onboarding` · EXISTS · REV + GAP (large)
+- Cross-check against the embedded **two full onboarding programs** (Process 1: compliance/identity/EDI/eRx/RBAC/templates/migration/training/go-live; Process 2: 6-phase 30-day timeline). Send discrepancies to neal@ + scott@leafjourney.com. → Bucket C/D (mostly process + integration enrollment).
+- Green-button deep-links into the specific onboarding step; sidebar always autohide.
+
+### Practice Launch — `/ops/launch` · EXISTS · REV + GAP
+- Fix Refresh (real recompute); sidebar autohide; readiness/blockers/next-steps clickable deep-links; 15-day countdown drill-ins; collapsible printable Compliance checklist (clickable complete); rename exit→goal, blocker→blocked (+ explainer popups); Launch-day runbook color-coded roles + green-check/yellow-warn + download/print; merge in **WORKFLOW ONE** (7-step encounter→claim lifecycle) + **WORKFLOW TWO** (hour-by-hour go-live playbook incl. technical stress tests + downtime/Go-No-Go contingencies) without duplicating existing steps.
+
+### Intake Builder — `/ops/intake-builder` · EXISTS · REV + GAP
+- "add field"→"add new"; menu dismiss-on-click-away; placeholder titles; drag-reorder sections (hand icon) + delete-confirm; **Forms** button (saved templates, delete/archive→unusable); working field drag; adjacent "Edit field" tile; new "Section Heading" assignment dropdown (+ add-new) removed from field-type list; field-type shows actual symbols; required→"(optional)" label; Save Template → preview/print/download/share + edit round-trip.
+
+### Data Export — `/ops/export` · EXISTS · REV + GAP
+- Archive of past export cohorts (3-yr retention, then purge); **Other** format options (Protobuf/Avro/Parquet); searchable custom **Outcome Metrics** ("constipation"/"neuropathy"…) and **Additional Data** ("labs"/"vitals"/"age range") tiles via LeafNerd.
+
+---
+
+## 4. Backend mega-engines (Bucket C) — named programs
+
+These are embedded multi-page technical specs. Much is already scaffolded (billing/EDI shipped Phase 9; prior-auth hub EMR-927..986; ERA/EOB/denials routes exist). Treat each as its own program, gap-fill against what's on `main`:
+
+1. **Native Clearinghouse / X12 EDI engine** — direct payer connections; 270/271, 276/277, 277CA, 278, 275, 837P, 835, 999, TA1; AS2 + SFTP + CAQH CORE SOAP/REST; WEDI SNIP L1–7 validation; smart routing w/ aggregator fallback; payer connection registry. *(Routes present: `/ops/era`, `/ops/eob`, `/ops/billing/*`, `/ops/prior-auth`. Verify engine coverage in `src/lib/billing|edi|clearinghouse`.)*
+2. **End-to-end billing pipeline** (Scrub spec) — RTE → auto-auth → estimate → signed-note → specialty CCI scrub → payer-rule check → clean-claim → submit; E/M & time-based calculators; 120h encounter-lock; NCCI/MUE; custom payer rule builder.
+3. **Unified Prior-Auth engine** — Rule engine + criteria engine + transmission hub; **Medication PA** (NCPDP SCRIPT ePA via Surescripts/CoverMyMeds) and **Procedure PA** (X12 278 + 275 attachment); auth-expiration monitor; PA dashboard.
+4. **Pre-service Auth Appeals engine** — 278-denial ingestion, urgency triage, peer-to-peer scheduler, InterQual/MCG guideline checklists.
+5. **Post-service Claim Denials engine** — 835 ingestion, CARC→queue matrix, corrected-claim frequency-7 formatter, single-click appeal packet generator (835→chart mapping, AI argument generator, split-screen review, HIPAA 275 / e-fax / portal-RPA transmission, appeal clock tracker).
+6. **RCM analytics** — Days-in-AR (<35), NCR (>96%), CCR (>98%); CARC/RARC heatmap; predictive scrubbing; RVU tracking; contractual underpayment engine. → LeafNerd.
+7. **OCR document routing** — centralized inbox auto-classify (type/patient/DOB/date) → chart filing.
+8. **Bookkeeping** — QuickBooks-style ledger, file import/export, IRS doc generation, P&L/deductions.
+
+---
+
+## 5. Non-codeable / administrative (Bucket D) — surface as blockers, not code
+
+- Direct-EDI **payer credentialing** with Medicare (CMS MACs), UHC, Aetna, Cigna, Anthem BCBS — 30–90 days **each**.
+- Production **Submitter/Receiver IDs**; **BAAs**; **EHNAC/DirectTrust** accreditation; **SOC 2 Type II**.
+- **mTLS X.509** cert provisioning per payer; Surescripts/**EPCS** identity proofing (NIST 800-63B, ID.me); merchant onboarding (Stripe/Square).
+
+Recommended handling: code the engines against a **sandbox/aggregator fallback** (Availity/Change Healthcare) so the product works end-to-end before direct connections are credentialed — exactly the "Hybrid Architecture" the doc itself prescribes. Keep registry/stubs honest (no fake "connected" states).
+
+---
+
+## 6. ⚠️ This doc is ALREADY ingested into Linear (verified 2026-06-10)
+
+**Key correction:** This 6.10 file is the *same* cumulative doc (identical filename "Scott - LeafJourney Owner Portal Revisions.docx") already ingested into Linear as the **Owner Portal Revisions v1** project (`090120c2-…`): **EMR-919..986** (v1, 6.1 baseline) + **EMR-1002..1074** (v2, 6.5 delta) — **~141 cards, all in Backlog**. Cards are page+section granular, each with a `Directive ID`, source attribution, and an **"Accommodation / diff (current state)"** block that already cites the exact `src/app/(operator)/ops/...` files and line numbers.
+
+Spot-checks confirming near-complete coverage of this doc:
+- MASTER prompt → **EMR-1072**; hover-tooltips → **EMR-1073**; Chrome tab-layout → **EMR-1074**.
+- staff-schedule **print fix** + per-employee colors → **EMR-1043**; axis flip → **EMR-1053**.
+- time-clock persistent clock → **EMR-1062**; timesheet export columns → **EMR-1069**.
+- revenue rename "Billing Workqueue→Billing Dashboard" → **EMR-1015**; tabs → **EMR-1034**.
+- cfo cash-flow runway emoji → **EMR-1065**; bubble colors → **EMR-1071**.
+
+**Implication:** Re-ingesting would **duplicate**, not enrich. The premise that this needed ticketing is false — the actual gap is **implementation** (the ~141 cards sit in Backlog). The right Linear action is to move the cards this work implements to In Progress/Done and comment the commit, **not** create new cards. New cards are warranted only for genuinely-missing items verified during implementation (e.g. Marketing ROI calc bugs, Training "Demo: assigned" stub, Policies "Create New Policy" error, the `/ops/cfo/bookkeeping` net-new tab).
+
+> Baseline stored at `docs/directives/owner-portal/2026-06-10.txt` (md5 `98a7afb2…`) so the next revision can be diffed mechanically against this one.
+
+---
+
+## 7. Recommended implementation plan (sliced & prioritized)
+
+**Slice 1 — MASTER-prompt primitive kit (Bucket A).** Build `components/ops/master/` (CollapsibleSection, SortableTable+export+column-DnD, MetricBox compare/beautify popup, AutocompleteInput, ArchiveDrawer, CindyBlock, HoverChart) + global sidebar overlay/autohide + "don't reopen sidebar on in-page button click". Highest leverage; unblocks every page. *(Buckets A)*
+
+**Slice 2 — Cheap per-page copy/color/bug fixes (Bucket B).** Mechanical sweep: renames (Billing Dashboard, Scrub and Auths, Documents Inbox/Outbox, eligibility checker, MLN, residual/last-reconciled, process→progress), bubble color systems, font sizes, delete/remove confirm popups, truncate+expand, calendar pickers, and the explicit **bug fixes** (Training demo error, Create-New-Policy error, Marketing graph/Spend/revenue==net, staff-schedule blank print, time-clock server timer). Fast, visible "de-bugged + operational" wins.
+
+**Slice 3 — Per-page interaction adoption.** Page-by-page adoption of the Slice-1 kit + the click-to-drill / popup-analytics behaviors, prioritized: Billing → Denials → Scrub → Aging → Revenue → CFO suite → Schedule/Patients → remaining ops pages.
+
+**Slice 4 — Backend programs (Bucket C).** Gap-fill each engine against `main` (clearinghouse/EDI, prior-auth, appeals, RCM analytics, OCR routing, bookkeeping) — separate PRs, separate tickets, sandbox/aggregator fallback.
+
+**Slice 5 — Administrative (Bucket D).** Track as business/legal blockers; not code.
+
+**Linear:** do **not** re-ingest — this doc is already the Owner Portal Revisions v1 project (EMR-919..986 + EMR-1002..1074, all Backlog; see §6). As work lands, move the matching existing cards to In Progress/Done and comment the commit. Create new cards **only** for items verified absent (Marketing ROI calc bugs, Training "Demo: assigned" stub, Policies "Create New Policy" error, `/ops/cfo/bookkeeping`).

--- a/src/app/(operator)/ops/billing/error.tsx
+++ b/src/app/(operator)/ops/billing/error.tsx
@@ -26,7 +26,7 @@ export default function BillingError({
             Something went wrong
           </Eyebrow>
           <h1 className="font-display text-2xl text-text tracking-tight">
-            Billing workqueue couldn&apos;t load
+            Billing Dashboard couldn&apos;t load
           </h1>
           <p className="text-sm text-text-muted mt-3 max-w-md mx-auto leading-relaxed">
             {error.message || "An unexpected error occurred."}

--- a/src/app/(operator)/ops/cfo/assets/page.tsx
+++ b/src/app/(operator)/ops/cfo/assets/page.tsx
@@ -48,7 +48,7 @@ export default async function AssetsPage() {
     <PageShell maxWidth="max-w-[1320px]">
       <PageHeader
         eyebrow="CFO · Fixed Assets"
-        title="Capitalized assets register"
+        title="Capitalized assets"
         description="Equipment, hardware, leasehold improvements, and other capitalized assets. Depreciation is computed automatically and flows to the P&L and balance sheet."
       />
       <CfoTabs active="assets" />
@@ -57,7 +57,7 @@ export default async function AssetsPage() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-10">
         <Tile label="Gross book value" value={fmtMoney(totalGross, { compact: true })} />
         <Tile label="Accumulated depreciation" value={fmtMoney(totalDeprec, { compact: true })} />
-        <Tile label="Net book value" value={fmtMoney(netBook, { compact: true })} accent />
+        <Tile label="Net book value" value={fmtMoney(netBook, { compact: true })} />
         <Tile label="Active assets" value={String(assets.length)} />
       </div>
 
@@ -84,7 +84,7 @@ export default async function AssetsPage() {
                 <Input name="cost" type="number" step="0.01" min="0" required placeholder="0.00" />
               </div>
               <div className="md:col-span-1">
-                <label className="block text-[11px] uppercase tracking-wider text-text-subtle mb-1">Salvage</label>
+                <label className="block text-[11px] uppercase tracking-wider text-text-subtle mb-1">Residual</label>
                 <Input name="salvage" type="number" step="0.01" min="0" placeholder="0" />
               </div>
               <div className="md:col-span-1">

--- a/src/app/(operator)/ops/cfo/balance-sheet/page.tsx
+++ b/src/app/(operator)/ops/cfo/balance-sheet/page.tsx
@@ -31,15 +31,15 @@ export default async function BalanceSheetPage() {
       {/* Headline */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-10">
         <Tile label="Total assets" value={fmtMoney(bs.assets.totalCents, { compact: true })} accent />
-        <Tile label="Total liabilities" value={fmtMoney(bs.liabilities.totalCents, { compact: true })} />
+        <Tile label="Total liabilities" value={fmtMoney(bs.liabilities.totalCents, { compact: true })} highlight="bad" />
         <Tile label="Total equity" value={fmtMoney(bs.equity.totalCents, { compact: true })} accent />
         <Tile label="Working capital" value={fmtMoney(bs.ratios.workingCapitalCents, { compact: true })} highlight={bs.ratios.workingCapitalCents < 0 ? "bad" : "good"} />
       </div>
 
       {/* Ratios */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-10">
-        <Ratio label="Current ratio" value={bs.ratios.currentRatio.toFixed(2)} target="≥ 2.0" met={bs.ratios.currentRatio >= 2} />
-        <Ratio label="Quick ratio" value={bs.ratios.quickRatio.toFixed(2)} target="≥ 1.0" met={bs.ratios.quickRatio >= 1} />
+        <Ratio label="Current ratio" value={bs.ratios.currentRatio.toFixed(2)} target="≥ 2.0" met={bs.ratios.currentRatio >= 2} definition="Current assets ÷ current liabilities — ability to cover short-term obligations." />
+        <Ratio label="Quick ratio" value={bs.ratios.quickRatio.toFixed(2)} target="≥ 1.0" met={bs.ratios.quickRatio >= 1} definition="Liquid assets ÷ current liabilities, excluding inventory." />
         <Ratio label="Debt / equity" value={bs.ratios.debtToEquity.toFixed(2)} target="≤ 2.0" met={bs.ratios.debtToEquity <= 2} />
         <Ratio
           label="Books balance"
@@ -122,13 +122,14 @@ function Tile({ label, value, accent, highlight }: { label: string; value: strin
   );
 }
 
-function Ratio({ label, value, target, met }: { label: string; value: string; target: string; met: boolean | null }) {
+function Ratio({ label, value, target, met, definition }: { label: string; value: string; target: string; met: boolean | null; definition?: string }) {
   return (
     <Card>
       <CardContent className="pt-4 pb-4">
         <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">{label}</p>
         <p className={`font-display text-xl tabular-nums mt-1 ${met === true ? "text-success" : met === false ? "text-danger" : "text-text"}`}>{value}</p>
         {target && <p className="text-[11px] text-text-subtle mt-1">Target: {target}</p>}
+        {definition && <p className="text-[11px] text-text-subtle mt-1 leading-tight">{definition}</p>}
       </CardContent>
     </Card>
   );

--- a/src/app/(operator)/ops/cfo/cash-flow/page.tsx
+++ b/src/app/(operator)/ops/cfo/cash-flow/page.tsx
@@ -37,7 +37,7 @@ export default async function CashFlowPage({ searchParams }: { searchParams?: { 
         <Tile label="Closing cash" value={fmtMoney(cf.closingCashCents, { compact: true })} accent />
         <Tile label="Net change" value={fmtMoney(cf.netChangeCents, { compact: true })} highlight={cf.netChangeCents >= 0 ? "good" : "bad"} />
         <Tile label="Daily burn" value={fmtMoney(cf.burnRateCentsPerDay)} />
-        <Tile label="Runway" value={cf.runwayDays === null ? "Cash-flow positive" : `${cf.runwayDays} days`} highlight={cf.runwayDays !== null && cf.runwayDays < 90 ? "bad" : undefined} />
+        <Tile label="Runway" value={cf.runwayDays === null ? "😊 + Cash-flow positive" : `😔 − ${cf.runwayDays} days`} highlight={cf.runwayDays === null ? "good" : cf.runwayDays < 90 ? "bad" : undefined} />
       </div>
 
       {/* Activity sections */}

--- a/src/app/(operator)/ops/cfo/cash/page.tsx
+++ b/src/app/(operator)/ops/cfo/cash/page.tsx
@@ -112,7 +112,7 @@ export default async function CashPage() {
                         {a.last4 && <span className="text-[11px] text-text-subtle">···{a.last4}</span>}
                       </div>
                       <p className="text-[11px] text-text-subtle mt-0.5">
-                        {a.institution ?? "—"} · last synced {a.asOfDate.toLocaleString("en-US", { month: "short", day: "numeric" })}
+                        {a.institution ?? "—"} · last reconciled {a.asOfDate.toLocaleString("en-US", { month: "short", day: "numeric" })}
                       </p>
                     </div>
                     <div className="text-right shrink-0">

--- a/src/app/(operator)/ops/cfo/components.tsx
+++ b/src/app/(operator)/ops/cfo/components.tsx
@@ -76,8 +76,13 @@ export function KpiTile({ kpi }: { kpi: KpiCard }) {
             </Badge>
           ) : null}
           {kpi.goalValue !== undefined && kpi.goalValue !== null ? (
-            <Badge tone={kpi.goalMet ? "success" : "warning"} className="text-[9px]">
-              {kpi.goalMet ? "goal met" : "off goal"}
+            <Badge
+              tone="neutral"
+              className={kpi.goalMet
+                ? "text-[9px] bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-300"
+                : "text-[9px] bg-highlight-soft text-[color:var(--highlight-hover)] border-highlight/25"}
+            >
+              {kpi.goalMet ? "on goal" : "off goal"}
             </Badge>
           ) : null}
         </div>

--- a/src/app/(operator)/ops/cfo/page.tsx
+++ b/src/app/(operator)/ops/cfo/page.tsx
@@ -88,8 +88,7 @@ export default async function CfoOverviewPage({
                   day: "numeric",
                   hour: "numeric",
                   minute: "2-digit",
-                })}{" "}
-                by {latestBriefing.generatedBy}.
+                })}.
               </p>
             )}
           </CardContent>
@@ -98,7 +97,7 @@ export default async function CfoOverviewPage({
 
       {/* KPI grid */}
       <div className="mb-10">
-        <Eyebrow className="mb-4">Headline KPIs</Eyebrow>
+        <Eyebrow className="mb-4">Headline KPIs (Key Performance Indicators)</Eyebrow>
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-3">
           {report.kpis.map((kpi) => (
             <KpiTile key={kpi.id} kpi={kpi} />

--- a/src/app/(operator)/ops/cfo/reports/[id]/page.tsx
+++ b/src/app/(operator)/ops/cfo/reports/[id]/page.tsx
@@ -105,7 +105,7 @@ export default async function ReportDetailPage({ params }: { params: { id: strin
       {/* Anomalies */}
       {anomalies.length > 0 && (
         <>
-          <Eyebrow className="mb-3">Anomalies flagged at generation time</Eyebrow>
+          <Eyebrow className="mb-3">Anomalies Flagged</Eyebrow>
           <AnomaliesPanel anomalies={anomalies} />
         </>
       )}

--- a/src/app/(operator)/ops/eligibility/page.tsx
+++ b/src/app/(operator)/ops/eligibility/page.tsx
@@ -286,7 +286,7 @@ export default function EligibilityPage() {
     <PageShell maxWidth="max-w-[960px]">
       <PageHeader
         eyebrow="Insurance & Eligibility"
-        title="Cannabis Eligibility Checker"
+        title="Eligibility Checker"
         description="Determine if a patient qualifies for medical cannabis, state card programs, and insurance-reimbursed CBD products."
       />
 
@@ -298,7 +298,7 @@ export default function EligibilityPage() {
             Patient Eligibility Check
           </CardTitle>
           <CardDescription>
-            Enter patient details to check qualification status.
+            Enter patient details to check insurance activity.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/app/(operator)/ops/feedback/feedback-view.tsx
+++ b/src/app/(operator)/ops/feedback/feedback-view.tsx
@@ -269,7 +269,7 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
           className="md:w-64 h-9"
         />
         <MultiSelectFilter
-          label="NPS band"
+          label="NPS (Net Promoter Score) band"
           options={(["detractor", "passive", "promoter"] as RatingBand[]).map((b) => ({
             value: b,
             label: RATING_BAND_LABELS[b],

--- a/src/app/(operator)/ops/incidents/incidents-view.tsx
+++ b/src/app/(operator)/ops/incidents/incidents-view.tsx
@@ -21,11 +21,18 @@ import {
 } from "@/lib/domain/overnight-batch";
 import { cn } from "@/lib/utils/cn";
 
-const SEVERITY_TONES: Record<IncidentSeverity, "neutral" | "warning" | "highlight" | "danger"> = {
-  low: "neutral",
+const SEVERITY_TONES: Record<IncidentSeverity, "info" | "warning" | "danger"> = {
+  low: "info",
   medium: "warning",
-  high: "highlight",
+  high: "danger",
   critical: "danger",
+};
+
+const SEVERITY_BADGE_CLASS: Record<IncidentSeverity, string> = {
+  low: "",
+  medium: "",
+  high: "bg-orange-50 text-orange-700 border-orange-200",
+  critical: "",
 };
 
 const SEVERITY_LABELS: Record<IncidentSeverity, string> = {
@@ -292,7 +299,7 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
               {filtered.map((i) => (
                 <tr key={i.id} className="border-b border-border/40 hover:bg-surface-muted/40">
                   <td className="px-5 py-3.5">
-                    <Badge tone={SEVERITY_TONES[i.severity]}>{SEVERITY_LABELS[i.severity]}</Badge>
+                    <Badge tone={SEVERITY_TONES[i.severity]} className={SEVERITY_BADGE_CLASS[i.severity]}>{SEVERITY_LABELS[i.severity]}</Badge>
                   </td>
                   <td className="px-5 py-3.5 text-text-muted text-xs">
                     {INCIDENT_CATEGORY_LABELS[i.category]}
@@ -368,7 +375,12 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
                       className={cn(
                         "py-2 rounded-md border text-xs font-medium transition-colors",
                         draft.severity === s
-                          ? "border-emerald-700 bg-emerald-700 text-white"
+                          ? {
+                              low: "border-blue-600 bg-blue-600 text-white",
+                              medium: "border-yellow-500 bg-yellow-500 text-white",
+                              high: "border-orange-600 bg-orange-600 text-white",
+                              critical: "border-red-600 bg-red-600 text-white",
+                            }[s]
                           : "border-border bg-surface text-text-muted hover:bg-surface-muted",
                       )}
                     >
@@ -394,7 +406,7 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
                 <Input
                   value={draft.title}
                   onChange={(e) => setDraft({ ...draft, title: e.target.value })}
-                  placeholder="Short summary"
+                  placeholder=""
                 />
               </FieldGroup>
 

--- a/src/app/(operator)/ops/intake-builder/form-builder.tsx
+++ b/src/app/(operator)/ops/intake-builder/form-builder.tsx
@@ -171,7 +171,7 @@ export function FormBuilder() {
                 size="sm"
                 onClick={() => setShowAddField((s) => !s)}
               >
-                + Add field
+                + Add new
               </Button>
               {showAddField && (
                 <div className="absolute right-0 top-full mt-2 z-50 bg-surface border border-border rounded-lg shadow-lg p-2 w-56 max-h-72 overflow-y-auto">

--- a/src/app/(operator)/ops/launch/page.tsx
+++ b/src/app/(operator)/ops/launch/page.tsx
@@ -334,7 +334,7 @@ export default async function LaunchPage() {
                           </div>
                           <p className="text-[12px] text-text-muted leading-relaxed">{d.theme}</p>
                           <p className="text-[11px] text-text-subtle mt-2 italic leading-relaxed">
-                            Exit: {d.exitCriteria}
+                            Goal: {d.exitCriteria}
                           </p>
                           <ul className="mt-3 space-y-1">
                             {d.tasks.map((t) => {
@@ -371,7 +371,7 @@ export default async function LaunchPage() {
                                     {t.title}
                                     {t.blocker && !done && (
                                       <span className="ml-1 text-[10px] uppercase tracking-wider text-danger font-medium">
-                                        blocker
+                                        blocked
                                       </span>
                                     )}
                                   </span>

--- a/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
+++ b/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
@@ -663,7 +663,7 @@ export function MailFaxClient({
       {/* Header and top commands */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold text-text tracking-tight">Documents Processing Center</h1>
+          <h1 className="text-2xl font-semibold text-text tracking-tight">Documents Inbox and Outbox</h1>
           <p className="text-sm text-text-subtle mt-1">
             Inbound mail packets, faxes, and portal uploads are OCR'd, parsed, and cross-checked.
           </p>

--- a/src/app/(operator)/ops/mail-fax/page.tsx
+++ b/src/app/(operator)/ops/mail-fax/page.tsx
@@ -5,7 +5,7 @@ import { MailFaxClient } from "./mail-fax-client";
 import { type DocumentSource } from "@/lib/billing/mail-fax-ocr";
 import { SAMPLE_DOCS } from "./sample-docs";
 
-export const metadata = { title: "Documents Processing Center" };
+export const metadata = { title: "Documents Inbox and Outbox" };
 
 interface ScanRow {
   id: string;

--- a/src/app/(operator)/ops/marketing/marketing-view.tsx
+++ b/src/app/(operator)/ops/marketing/marketing-view.tsx
@@ -33,6 +33,9 @@ export function MarketingView({
 }) {
   const [roiChannel, setRoiChannel] = useState(channels[0]?.channel ?? "");
   const [roiRevenuePerPatient, setRoiRevenuePerPatient] = useState<number>(1200);
+  // Spend seeds from the selected channel but is editable so the operator can
+  // model "what if we spent $X" scenarios. null = follow the channel's spend.
+  const [roiSpendOverride, setRoiSpendOverride] = useState<number | null>(null);
 
   const maxBar = Math.max(...channels.map((c) => c.newPatients), 1);
   const maxTrend = Math.max(...monthlyTrend.map((p) => p.value), 1);
@@ -45,12 +48,13 @@ export function MarketingView({
   const roi = useMemo(() => {
     const c = channels.find((x) => x.channel === roiChannel);
     if (!c) return null;
+    const spend = roiSpendOverride ?? c.spend;
     const revenue = c.newPatients * roiRevenuePerPatient;
-    const net = revenue - c.spend;
-    const cac = c.newPatients > 0 ? c.spend / c.newPatients : 0;
-    const multiple = c.spend > 0 ? revenue / c.spend : Infinity;
-    return { channel: c.channel, spend: c.spend, revenue, net, cac, multiple };
-  }, [channels, roiChannel, roiRevenuePerPatient]);
+    const net = revenue - spend;
+    const cac = c.newPatients > 0 ? spend / c.newPatients : 0;
+    const multiple = spend > 0 ? revenue / spend : Infinity;
+    return { channel: c.channel, spend, revenue, net, cac, multiple };
+  }, [channels, roiChannel, roiRevenuePerPatient, roiSpendOverride]);
 
   return (
     <div className="space-y-6">
@@ -90,7 +94,6 @@ export function MarketingView({
           <div className="space-y-3">
             {channels.map((c) => {
               const pct = (c.newPatients / maxBar) * 100;
-              const cac = c.newPatients > 0 ? c.spend / c.newPatients : 0;
               return (
                 <div key={c.channel} className="flex items-center gap-3">
                   <span className="w-44 text-xs text-text-muted shrink-0">{c.channel}</span>
@@ -103,9 +106,24 @@ export function MarketingView({
                       {c.newPatients}
                     </span>
                   </div>
-                  <span className="w-28 text-right text-[11px] text-text-subtle tabular-nums">
-                    CAC ${cac.toFixed(0)}
-                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card tone="raised">
+        <CardContent className="py-5">
+          <p className="text-sm font-medium text-text mb-1">Acquisition cost (CAC) by source</p>
+          <p className="text-xs text-text-muted mb-4">Customer acquisition cost = spend ÷ new patients.</p>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {channels.map((c) => {
+              const cac = c.newPatients > 0 ? c.spend / c.newPatients : 0;
+              return (
+                <div key={c.channel} className="p-3 rounded-md bg-surface-muted/60">
+                  <p className="text-[11px] text-text-muted truncate">{c.channel}</p>
+                  <p className="font-display text-lg tabular-nums text-text mt-1">${cac.toFixed(0)}</p>
                 </div>
               );
             })}
@@ -130,10 +148,12 @@ export function MarketingView({
             {monthlyTrend.map((p) => {
               const pct = (p.value / maxTrend) * 100;
               return (
-                <div key={p.month} className="flex-1 flex flex-col items-center gap-2">
-                  <div className="flex-1 w-full flex items-end">
+                <div key={p.month} className="flex-1 flex flex-col items-center gap-2 h-full">
+                  {/* definite-height, relative wrapper so the bar's % height
+                      resolves (a % height inside a flex-1 item collapses to 0) */}
+                  <div className="relative flex-1 min-h-0 w-full">
                     <div
-                      className="w-full bg-gradient-to-t from-accent to-accent-strong rounded-t"
+                      className="absolute bottom-0 left-0 w-full bg-gradient-to-t from-accent to-accent-strong rounded-t"
                       style={{ height: `${pct}%` }}
                     />
                   </div>
@@ -149,17 +169,29 @@ export function MarketingView({
       <Card tone="raised">
         <CardContent className="py-5">
           <p className="text-sm font-medium text-text mb-4">ROI calculator</p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <FieldGroup label="Channel">
               <select
                 value={roiChannel}
-                onChange={(e) => setRoiChannel(e.target.value)}
+                onChange={(e) => {
+                  setRoiChannel(e.target.value);
+                  // re-seed Spend from the newly selected channel
+                  setRoiSpendOverride(null);
+                }}
                 className="flex w-full rounded-md border border-border-strong bg-surface px-3 h-10 text-sm text-text"
               >
                 {channels.map((c) => (
                   <option key={c.channel} value={c.channel}>{c.channel}</option>
                 ))}
               </select>
+            </FieldGroup>
+            <FieldGroup label="Spend ($)">
+              <Input
+                type="number"
+                min={0}
+                value={roi?.spend ?? 0}
+                onChange={(e) => setRoiSpendOverride(Number(e.target.value) || 0)}
+              />
             </FieldGroup>
             <FieldGroup label="Lifetime revenue per patient ($)">
               <Input

--- a/src/app/(operator)/ops/policies/policies-view.tsx
+++ b/src/app/(operator)/ops/policies/policies-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { Check } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -35,15 +36,42 @@ function saveAcks(next: Record<string, string>) {
   window.localStorage.setItem(ACK_STORAGE, JSON.stringify(next));
 }
 
-export function PoliciesView({ policies }: { policies: Policy[] }) {
+export function PoliciesView({ policies: initialPolicies }: { policies: Policy[] }) {
+  const [policies, setPolicies] = useState<Policy[]>(initialPolicies);
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<PolicyCategory | "All">("All");
-  const [selectedId, setSelectedId] = useState<string>(policies[0]?.id ?? "");
+  const [selectedId, setSelectedId] = useState<string>(initialPolicies[0]?.id ?? "");
   const [acks, setAcks] = useState<Record<string, string>>({});
+  const [createOpen, setCreateOpen] = useState(false);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftCategory, setDraftCategory] = useState<PolicyCategory>(CATEGORIES[0]);
+  const [draftBody, setDraftBody] = useState("");
 
   useEffect(() => {
     setAcks(loadAcks());
   }, []);
+
+  function openCreate() {
+    setDraftTitle("");
+    setDraftCategory(CATEGORIES[0]);
+    setDraftBody("");
+    setCreateOpen(true);
+  }
+
+  function saveDraft() {
+    const title = draftTitle.trim();
+    if (!title) return;
+    const newPolicy: Policy = {
+      id: `pol-new-${Date.now()}`,
+      title,
+      category: draftCategory,
+      updatedAt: new Date().toISOString().slice(0, 10),
+      body: draftBody.trim() || "No description provided yet.",
+    };
+    setPolicies((prev) => [newPolicy, ...prev]);
+    setSelectedId(newPolicy.id);
+    setCreateOpen(false);
+  }
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -77,7 +105,7 @@ export function PoliciesView({ policies }: { policies: Policy[] }) {
           onChange={(e) => setQuery(e.target.value)}
           className="md:w-80"
         />
-        <Button size="sm" variant="secondary" onClick={() => alert("Demo: open new-policy editor")}>
+        <Button size="sm" variant="secondary" onClick={openCreate}>
           + Create new policy
         </Button>
       </div>
@@ -122,13 +150,19 @@ export function PoliciesView({ policies }: { policies: Policy[] }) {
                         type="button"
                         onClick={() => setSelectedId(p.id)}
                         className={cn(
-                          "w-full text-left px-2.5 py-1.5 rounded-md text-xs transition-colors",
+                          "w-full flex items-center justify-between gap-2 text-left px-2.5 py-1.5 rounded-md text-xs transition-colors",
                           active
                             ? "bg-surface-muted text-text"
                             : "text-text-muted hover:bg-surface-muted/60",
                         )}
                       >
-                        {p.title}
+                        <span>{p.title}</span>
+                        {category === "All" && acks[p.id] && (
+                          <Check
+                            className="h-3.5 w-3.5 shrink-0 text-success"
+                            aria-label="Completed"
+                          />
+                        )}
                       </button>
                     </li>
                   );
@@ -179,6 +213,64 @@ export function PoliciesView({ policies }: { policies: Policy[] }) {
           </CardContent>
         </Card>
       </div>
+
+      {createOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Create new policy"
+          onClick={() => setCreateOpen(false)}
+        >
+          <Card tone="raised" className="w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
+            <CardContent className="py-6 space-y-4">
+              <h2 className="font-display text-xl text-text">Create new policy</h2>
+              <div className="space-y-1">
+                <label className="text-xs uppercase tracking-wider text-text-subtle">Title</label>
+                <Input
+                  value={draftTitle}
+                  onChange={(e) => setDraftTitle(e.target.value)}
+                  placeholder="Policy title"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs uppercase tracking-wider text-text-subtle">Category</label>
+                <select
+                  value={draftCategory}
+                  onChange={(e) => setDraftCategory(e.target.value as PolicyCategory)}
+                  className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text"
+                >
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs uppercase tracking-wider text-text-subtle">
+                  Description
+                </label>
+                <textarea
+                  value={draftBody}
+                  onChange={(e) => setDraftBody(e.target.value)}
+                  placeholder="Describe the policy…"
+                  rows={5}
+                  className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text"
+                />
+              </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button size="sm" variant="ghost" onClick={() => setCreateOpen(false)}>
+                  Cancel
+                </Button>
+                <Button size="sm" variant="primary" onClick={saveDraft} disabled={!draftTitle.trim()}>
+                  Save policy
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(operator)/ops/revenue/page.tsx
+++ b/src/app/(operator)/ops/revenue/page.tsx
@@ -250,7 +250,7 @@ export default async function RevenuePage() {
         actions={
           <Link href="/ops/billing">
             <Button variant="secondary" size="sm">
-              Billing workqueue
+              Billing dashboard
             </Button>
           </Link>
         }

--- a/src/app/(operator)/ops/scrub/scrub-workbench.tsx
+++ b/src/app/(operator)/ops/scrub/scrub-workbench.tsx
@@ -462,7 +462,7 @@ function WarningsTile({
       <CardContent className="pt-5 pb-5">
         <p className="text-xs text-text-subtle uppercase tracking-wider">{label}</p>
         <p
-          className="font-display tabular-nums mt-1 text-3xl text-amber-400"
+          className="font-display tabular-nums mt-1 text-3xl text-amber-300"
         >
           {value}
         </p>

--- a/src/app/(operator)/ops/staff-schedule/schedule-view.tsx
+++ b/src/app/(operator)/ops/staff-schedule/schedule-view.tsx
@@ -42,6 +42,26 @@ const ROLE_TONES: Record<StaffRole, "accent" | "info" | "warning" | "highlight">
   billing: "highlight",
 };
 
+// Distinct, stable per-employee colors for shift blocks. Localized to this
+// page (inline styles) so the global theme tokens are untouched. The block
+// background is a soft tint and the dot/text uses the saturated ink so the
+// green shift blocks stay legible both on-screen and in print.
+const EMPLOYEE_COLORS: { soft: string; ink: string }[] = [
+  { soft: "#D8F0DE", ink: "#157347" }, // green
+  { soft: "#DCE8FB", ink: "#1D4ED8" }, // blue
+  { soft: "#F3E0F7", ink: "#9333EA" }, // purple
+  { soft: "#FCE4D6", ink: "#C2410C" }, // orange
+  { soft: "#FFF1C2", ink: "#A16207" }, // amber
+  { soft: "#D7F1EE", ink: "#0F766E" }, // teal
+  { soft: "#FBD9E3", ink: "#BE185D" }, // pink
+  { soft: "#E2E8D5", ink: "#4D7C0F" }, // olive
+];
+
+function employeeColor(staff: StaffMember[], staffId: string) {
+  const idx = staff.findIndex((s) => s.id === staffId);
+  return EMPLOYEE_COLORS[(idx < 0 ? 0 : idx) % EMPLOYEE_COLORS.length];
+}
+
 function startOfWeek(date: Date): Date {
   const d = new Date(date);
   d.setHours(0, 0, 0, 0);
@@ -126,6 +146,36 @@ export function ScheduleView({ staff }: { staff: StaffMember[] }) {
 
   return (
     <div className="space-y-5">
+      {/*
+        Page-scoped print fix. The global print stylesheet (src/app/globals.css)
+        hides every <button> with `display: none !important` and strips
+        background colors for ink economy. The scheduled shift blocks on this
+        page ARE buttons with inline background colors, so without this override
+        the printout renders a blank grid. We re-show the shift-block buttons
+        (only the ones flagged with data-shift-block) and force their colored
+        background + the column headers to print.
+      */}
+      <style>{`
+        @media print {
+          /* Re-show the scheduled (colored) shift blocks the global rule hides. */
+          .staff-schedule-print button[data-shift-block] {
+            display: flex !important;
+            -webkit-print-color-adjust: exact !important;
+            print-color-adjust: exact !important;
+          }
+          /* Keep the empty hour cells from cluttering the printout. */
+          .staff-schedule-print button.shift-cell:not([data-shift-block]) {
+            visibility: hidden !important;
+          }
+          /* Ensure the grid + header keep their structure on paper. */
+          .staff-schedule-print table,
+          .staff-schedule-print th,
+          .staff-schedule-print td {
+            -webkit-print-color-adjust: exact !important;
+            print-color-adjust: exact !important;
+          }
+        }
+      `}</style>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Button variant="secondary" size="sm" onClick={() => setWeekStart(addDays(weekStart, -7))}>
@@ -163,18 +213,18 @@ export function ScheduleView({ staff }: { staff: StaffMember[] }) {
         </div>
       </div>
 
-      <Card tone="raised">
+      <Card tone="raised" className="staff-schedule-print">
         <CardContent className="p-0 overflow-x-auto">
           <table className="min-w-[1000px] w-full text-xs">
             <thead>
               <tr className="border-b border-border">
-                <th className="sticky left-0 bg-surface px-3 py-2 text-left font-medium text-text-subtle w-40">
+                <th className="sticky left-0 bg-surface px-3 py-3 text-left text-base font-semibold text-text w-40">
                   Staff
                 </th>
                 {weekDates.map((d, i) => (
-                  <th key={i} className="px-2 py-2 font-medium text-text">
+                  <th key={i} className="px-2 py-3 text-base font-semibold text-text">
                     <div>{DAYS[i]}</div>
-                    <div className="text-[10px] text-text-subtle font-normal">{fmtDate(d)}</div>
+                    <div className="text-sm text-text-subtle font-normal">{fmtDate(d)}</div>
                   </th>
                 ))}
               </tr>
@@ -197,17 +247,24 @@ export function ScheduleView({ staff }: { staff: StaffMember[] }) {
                           const key = `${s.id}:${dayIdx}:${h}`;
                           const cellShifts = shiftsByCell.get(key) ?? [];
                           const primary = cellShifts[0];
+                          const color = primary ? employeeColor(staff, s.id) : null;
                           return (
                             <button
                               key={h}
                               type="button"
                               onClick={() => openEditor(dayIdx, h)}
+                              data-shift-block={primary ? "true" : undefined}
                               className={cn(
-                                "h-5 rounded text-[9px] flex items-center justify-center transition-colors",
+                                "shift-cell h-5 rounded text-[9px] flex items-center justify-center transition-colors",
                                 primary
-                                  ? "bg-accent-soft text-accent hover:brightness-105"
+                                  ? "hover:brightness-105"
                                   : "bg-surface-muted/60 text-text-subtle hover:bg-accent-soft/60",
                               )}
+                              style={
+                                color
+                                  ? { backgroundColor: color.soft, color: color.ink }
+                                  : undefined
+                              }
                               title={`${hourLabel(h)} – ${hourLabel(h + 1)}`}
                             >
                               {primary ? "●" : hourLabel(h)}

--- a/src/app/(operator)/ops/training/training-view.tsx
+++ b/src/app/(operator)/ops/training/training-view.tsx
@@ -110,21 +110,12 @@ export function TrainingView({ initialModules }: { initialModules: TrainingModul
                   {m.status === "complete" ? "Completed" : m.status === "in_progress" ? "Resume" : "Start training"}
                 </Button>
                 <select
-                  className="flex-1 rounded-md border border-border-strong bg-surface px-2 h-8 text-xs text-text-muted"
+                  className="flex-1 rounded-md border border-border-strong bg-surface px-2 h-8 text-xs text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
                   defaultValue=""
-                  onChange={(e) => {
-                    if (e.target.value) {
-                      alert(`Demo: assigned "${m.title}" to ${e.target.value}`);
-                      e.currentTarget.value = "";
-                    }
-                  }}
+                  disabled
+                  title="Assigning training to staff is not yet available."
                 >
-                  <option value="">Assign to…</option>
-                  <option value="Avery Chen">Avery Chen</option>
-                  <option value="Morgan Patel">Morgan Patel</option>
-                  <option value="Jordan Rivera">Jordan Rivera</option>
-                  <option value="Taylor Kim">Taylor Kim</option>
-                  <option value="Riley Okafor">Riley Okafor</option>
+                  <option value="">Assign to staff (coming soon)</option>
                 </select>
               </div>
             </CardContent>

--- a/src/app/(operator)/ops/vendors/vendors-view.tsx
+++ b/src/app/(operator)/ops/vendors/vendors-view.tsx
@@ -36,6 +36,12 @@ function daysUntil(end?: string): number | null {
   return Math.round((d.getTime() - TODAY.getTime()) / 86_400_000);
 }
 
+/** Format an ISO date string (YYYY-MM-DD) as dd-mm-yyyy */
+function fmtDMY(iso: string): string {
+  const [y, m, d] = iso.split("-");
+  return `${d}-${m}-${y}`;
+}
+
 type SortKey = "name-asc" | "ends-asc" | "ends-desc" | "cost-desc" | "cost-asc";
 
 type ViewState = {
@@ -72,6 +78,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     phone: "",
     contractEnds: "",
     monthlyCost: 0,
+    description: "",
   });
 
   const filtered = useMemo(() => {
@@ -82,7 +89,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
       }
       if (state.expiringOnly) {
         const d = daysUntil(v.contractEnds);
-        if (d === null || d < 0 || d > 30) return false;
+        if (d === null || d < 0 || d > 60) return false;
       }
       if (!q) return true;
       return (
@@ -118,7 +125,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     () =>
       vendors.filter((v) => {
         const d = daysUntil(v.contractEnds);
-        return d !== null && d >= 0 && d <= 30;
+        return d !== null && d >= 0 && d <= 60;
       }),
     [vendors],
   );
@@ -135,7 +142,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     });
   }
   if (state.expiringOnly) {
-    chips.push({ id: "expiring", label: "Status", value: "Expiring ≤ 30 days" });
+    chips.push({ id: "expiring", label: "Status", value: "Expiring ≤ 60 days" });
   }
 
   function removeChip(id: string) {
@@ -183,6 +190,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
       phone: "",
       contractEnds: "",
       monthlyCost: 0,
+      description: "",
     });
   }
 
@@ -193,7 +201,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
           <CardContent className="py-4 flex items-center justify-between gap-3 flex-wrap">
             <div>
               <p className="text-sm font-medium text-amber-900">
-                {expiring.length} {expiring.length === 1 ? "contract" : "contracts"} expiring in 30 days
+                {expiring.length} {expiring.length === 1 ? "contract" : "contracts"} expiring in 60 days
               </p>
               <p className="text-xs text-amber-800/80 mt-1">
                 {expiring.map((v) => `${v.name} (${v.contractEnds})`).join(" · ")}
@@ -248,7 +256,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
                 : "border-border-strong bg-surface text-text-muted hover:bg-surface-muted/60",
             )}
           >
-            Expiring ≤ 30d
+            Expiring ≤ 60d
           </button>
           <SortMenu
             options={[...SORT_OPTIONS]}
@@ -278,7 +286,7 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
             <tbody>
               {filtered.map((v) => {
                 const d = daysUntil(v.contractEnds);
-                const isExpiring = d !== null && d >= 0 && d <= 30;
+                const isExpiring = d !== null && d >= 0 && d <= 60;
                 return (
                   <tr key={v.id} className="border-b border-border/40 hover:bg-surface-muted/40">
                     <td className="px-5 py-3.5">
@@ -296,12 +304,12 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
                     <td className="px-5 py-3.5 text-right tabular-nums">
                       {v.monthlyCost ? `$${v.monthlyCost.toLocaleString()}` : "—"}
                     </td>
-                    <td className={cn("px-5 py-3.5 text-xs", isExpiring ? "text-[color:var(--highlight-hover)]" : "text-text-muted")}>
+                    <td className={cn("px-5 py-3.5 text-xs", isExpiring ? "text-red-600" : "text-text-muted")}>
                       {v.contractEnds ? (
                         <>
-                          <div>{v.contractEnds}</div>
+                          <div>{fmtDMY(v.contractEnds)}</div>
                           {d !== null && (
-                            <div className="text-[10px] text-text-subtle">
+                            <div className={cn("text-[10px]", isExpiring ? "text-red-600 font-semibold" : "text-text-subtle")}>
                               {d < 0 ? "expired" : `${d} days`}
                               {isExpiring && " — renew soon"}
                             </div>
@@ -389,6 +397,15 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
                     onChange={(e) => setDraft({ ...draft, monthlyCost: Number(e.target.value) || 0 })}
                   />
                 </FieldGroup>
+                <div className="md:col-span-2">
+                  <FieldGroup label="Description (Optional)">
+                    <Input
+                      value={draft.description}
+                      onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+                      placeholder="Notes about this vendor…"
+                    />
+                  </FieldGroup>
+                </div>
               </div>
               <div className="flex justify-end gap-2 pt-2">
                 <Button variant="ghost" size="sm" onClick={() => setShowAdd(false)}>


### PR DESCRIPTION
## What

Slice 2 of the LeafJourney Owner Portal Revisions (Dr. Patel's `/ops` directive doc, 2026-06-10). A per-page **copy / color / bug** sweep across ~20 `/ops` pages, plus the diff/gap analysis of the full doc.

This doc was already fully ticketed as the *Owner Portal Revisions v1* Linear project (EMR-919..986 + EMR-1002..1074), so **no new cards** — items already shipped were skipped (not duplicated), and the matching cards were reconciled separately.

## Real bug fixes
- **marketing** — Monthly-Trend chart now renders (was a `%`-height collapse inside a flex parent); ROI "Spend" input is now reactive; Net no longer equals Revenue; CAC moved to its own tile.
- **policies** — "Create New Policy" was a dead `alert()` stub → real Title/Category/Description create modal.
- **training** — the fake `Demo: assigned…` alert (from the Assign dropdown, not Start-training) → honest disabled "coming soon" state, since no assign backend exists.
- **staff-schedule** — Print was blank (the global stylesheet hides `<button>`s; shift blocks are buttons) → page-scoped `@media print` override + per-employee colors + larger headers. (EMR-1043)
- **cfo/cash-flow** — runway `+/−` emoji + color signal. (EMR-1065)

## Plus
Renames / color-systems / copy fixes across billing, scrub, mail-fax, eligibility, incidents, vendors, cfo (assets/cash/reports/balance-sheet), launch, intake-builder, revenue, feedback.

## Docs
- `docs/plans/owner-portal-revisions-2026-06-10-diff-analysis.md` — full 4-bucket diff/gap analysis
- `docs/directives/owner-portal/2026-06-10.txt` — directive baseline for mechanical future diffs

## Verification
`tsc --noEmit` clean · `eslint` clean (1 pre-existing unrelated `<img>` warning). No unit tests cover these client-view files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)