### PR TITLE
Owner Portal Revisions — Slice 1: DataTable export (G6) + ops/master kit

### DIFF
--- a/src/app/(operator)/ops/cfo/expenses/delete-expense-button.tsx
+++ b/src/app/(operator)/ops/cfo/expenses/delete-expense-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { deleteExpenseAction } from "../actions";
+
+// EMR-1059 — Delete a logged expense behind a confirmation popup instead of
+// the bare one-click `<form action={deleteExpenseAction}>` (which deleted the
+// line item immediately, with no undo). The Delete button now opens a danger
+// ConfirmDialog; only "Delete" submits the original server-action form.
+//
+// (The companion directive — "stop the sidebar expanding on delete" — is
+// already handled globally by the PillarNav same-route guard, so this file
+// only owns the confirmation step.)
+export function DeleteExpenseButton({
+  id,
+  label,
+}: {
+  id: string;
+  label?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const formRef = React.useRef<HTMLFormElement>(null);
+
+  return (
+    <>
+      <form ref={formRef} action={deleteExpenseAction}>
+        <input type="hidden" name="id" value={id} />
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="text-[11px] text-danger hover:underline cursor-pointer"
+        >
+          Delete
+        </button>
+      </form>
+      <ConfirmDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => {
+          setOpen(false);
+          formRef.current?.requestSubmit();
+        }}
+        severity="danger"
+        title="Delete this line item?"
+        description={
+          label
+            ? `“${label}” will be permanently removed from your expense ledger. This can’t be undone.`
+            : "This expense line item will be permanently removed from your ledger. This can’t be undone."
+        }
+        confirmLabel="Delete"
+      />
+    </>
+  );
+}

--- a/src/app/(operator)/ops/cfo/expenses/page.tsx
+++ b/src/app/(operator)/ops/cfo/expenses/page.tsx
@@ -10,7 +10,8 @@ import { DatePicker } from "@/components/ui/date-picker";
 import { fmtMoney } from "@/lib/finance/formatting";
 import { classifyExpense } from "@/lib/finance/chart-of-accounts";
 import { CfoTabs } from "../components";
-import { createExpenseAction, deleteExpenseAction } from "../actions";
+import { createExpenseAction } from "../actions";
+import { DeleteExpenseButton } from "./delete-expense-button";
 import type { ExpenseCategory } from "@prisma/client";
 
 export const metadata = { title: "Expenses · CFO" };
@@ -223,10 +224,7 @@ export default async function ExpensesPage() {
                       </td>
                       <td className="py-2 px-4 text-right tabular-nums text-text">{fmtMoney(e.totalCents)}</td>
                       <td className="py-2 px-4 text-right">
-                        <form action={deleteExpenseAction}>
-                          <input type="hidden" name="id" value={e.id} />
-                          <button type="submit" className="text-[11px] text-danger hover:underline">Delete</button>
-                        </form>
+                        <DeleteExpenseButton id={e.id} label={e.vendor} />
                       </td>
                     </tr>
                   );

--- a/src/app/(operator)/ops/cfo/page.tsx
+++ b/src/app/(operator)/ops/cfo/page.tsx
@@ -3,12 +3,12 @@ import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow, EditorialRule } from "@/components/ui/ornament";
-import { Sparkline } from "@/components/ui/sparkline";
 import { rangeForPeriod } from "@/lib/finance/period";
 import { buildCfoReport, getLatestCfoBriefing } from "@/lib/finance/report";
 import { fmtMoney, fmtPct } from "@/lib/finance/formatting";
-import { CfoTabs, KpiTile, AnomaliesPanel, MiniBarChart, GenerateReportButton } from "./components";
+import { CfoTabs, KpiTile, AnomaliesPanel, GenerateReportButton } from "./components";
 import { TrendLine } from "@/components/charts";
+import { MetricBoxGroup } from "@/components/ops/master";
 
 export const metadata = { title: "CFO · Leafjourney" };
 export const dynamic = "force-dynamic";
@@ -33,15 +33,20 @@ export default async function CfoOverviewPage({
     latestBriefing.periodStart.getTime() === range.start.getTime() &&
     latestBriefing.periodEnd.getTime() === range.end.getTime();
 
-  const weeklyRevenueSeries = report.weeklySeries.map((p) => p.revenueCents / 100);
-  const weeklyEbitdaSeries = report.weeklySeries.map((p) => p.ebitdaCents / 100);
-  const monthlySeries = report.monthlySeries.map((p) => ({ label: p.label.slice(0, 3), value: p.netIncomeCents }));
   // Branded TrendLine: revenue vs EBITDA over the same weekly window. Cents → dollars
   // so the y-axis ticks read as small integers, and so the tooltip stays compact.
   const weeklyTrendData = report.weeklySeries.map((p) => ({
     label: p.label,
     revenue: Math.round(p.revenueCents / 100),
     ebitda: Math.round(p.ebitdaCents / 100),
+  }));
+  // History series (whole dollars) powering the MetricBox drill-in popups —
+  // real per-week / per-month figures, never fabricated.
+  const weeklyRevenueHistory = weeklyTrendData.map((p) => ({ label: p.label, value: p.revenue }));
+  const weeklyEbitdaHistory = weeklyTrendData.map((p) => ({ label: p.label, value: p.ebitda }));
+  const monthlyNetHistory = report.monthlySeries.map((p) => ({
+    label: p.label.slice(0, 3),
+    value: Math.round(p.netIncomeCents / 100),
   }));
 
   return (
@@ -114,42 +119,57 @@ export default async function CfoOverviewPage({
 
       <EditorialRule className="my-10" />
 
-      {/* Trend visuals */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-10">
-        <Card tone="raised">
-          <CardContent className="pt-5 pb-5">
-            <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">
-              Weekly revenue (last 13 weeks)
-            </p>
-            <p className="font-display text-2xl text-text tabular-nums mt-1">
-              {fmtMoney(report.pnl.totals.revenueCents, { compact: true })}
-            </p>
-            <Sparkline data={weeklyRevenueSeries.length >= 2 ? weeklyRevenueSeries : [0, 0]} width={300} height={56} />
-          </CardContent>
-        </Card>
-        <Card tone="raised">
-          <CardContent className="pt-5 pb-5">
-            <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">
-              Weekly EBITDA (last 13 weeks)
-            </p>
-            <p className="font-display text-2xl text-text tabular-nums mt-1">
-              {fmtMoney(report.pnl.totals.ebitdaCents, { compact: true })}
-            </p>
-            <Sparkline data={weeklyEbitdaSeries.length >= 2 ? weeklyEbitdaSeries : [0, 0]} width={300} height={56} />
-          </CardContent>
-        </Card>
-        <Card tone="raised">
-          <CardContent className="pt-5 pb-5">
-            <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">
-              Monthly net income (last 12 months)
-            </p>
-            <p className="font-display text-2xl text-text tabular-nums mt-1">
-              {fmtMoney(report.pnl.totals.netIncomeCents, { compact: true })}
-            </p>
-            <MiniBarChart data={monthlySeries} width={300} height={56} />
-          </CardContent>
-        </Card>
-      </div>
+      {/* Trend visuals — each tile drills into a popup with the full history,
+          Google-Finance-style hover tooltips, and a "feather" button that
+          cycles line / area / bar (G10 + G11). Tick the compare boxes on ≥2
+          same-period tiles to overlay them on one chart (G9). */}
+      <MetricBoxGroup
+        className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-10"
+        compareTitle="Compare financial trends"
+        valueFormat="money"
+        metrics={[
+          {
+            id: "weekly-revenue",
+            eyebrow: "Weekly revenue · last 13 weeks",
+            headline: fmtMoney(report.pnl.totals.revenueCents, { compact: true }),
+            history: weeklyRevenueHistory,
+            valueFormat: "money",
+            goodWhen: "up",
+            initialChartType: "line",
+            popupTitle: "Weekly revenue",
+            popupDescription: "Revenue posted per week over the last 13 weeks.",
+            detailHref: "/ops/cfo/pnl",
+            detailLabel: "Open P&L",
+          },
+          {
+            id: "weekly-ebitda",
+            eyebrow: "Weekly EBITDA · last 13 weeks",
+            headline: fmtMoney(report.pnl.totals.ebitdaCents, { compact: true }),
+            history: weeklyEbitdaHistory,
+            valueFormat: "money",
+            goodWhen: "up",
+            initialChartType: "area",
+            popupTitle: "Weekly EBITDA",
+            popupDescription:
+              "Earnings before interest, taxes, depreciation & amortization, per week.",
+            detailHref: "/ops/cfo/pnl",
+            detailLabel: "Open P&L",
+          },
+          {
+            id: "monthly-net",
+            eyebrow: "Monthly net income · last 12 months",
+            headline: fmtMoney(report.pnl.totals.netIncomeCents, { compact: true }),
+            history: monthlyNetHistory,
+            valueFormat: "money",
+            goodWhen: "up",
+            initialChartType: "bar",
+            popupTitle: "Monthly net income",
+            popupDescription: "Net income per month over the last 12 months.",
+            detailHref: "/ops/cfo/pnl",
+            detailLabel: "Open P&L",
+          },
+        ]}
+      />
 
       {/* Deep-look: revenue vs EBITDA — branded TrendLine wrapper */}
       <div className="mb-10">

--- a/src/components/charts/DistributionBar.tsx
+++ b/src/components/charts/DistributionBar.tsx
@@ -36,6 +36,8 @@ export interface DistributionBarProps {
   yLabel?: string;
   xLabel?: string;
   unit?: string;
+  /** Optional custom tooltip value formatter (overrides `unit`). */
+  formatValue?: (value: number | string, name?: string) => React.ReactNode;
   height?: number;
   loading?: boolean;
   emptyTitle?: string;
@@ -59,6 +61,7 @@ export function DistributionBar({
   yLabel,
   xLabel,
   unit,
+  formatValue,
   height = 240,
   loading,
   rainbow,
@@ -127,7 +130,7 @@ export function DistributionBar({
           />
           <Tooltip
             cursor={{ fill: "var(--surface-muted)", opacity: 0.5 }}
-            content={<ChartTooltip unit={unit} />}
+            content={<ChartTooltip unit={unit} formatValue={formatValue} />}
           />
           <Bar
             dataKey="value"

--- a/src/components/charts/TrendArea.tsx
+++ b/src/components/charts/TrendArea.tsx
@@ -46,6 +46,8 @@ export interface TrendAreaProps<T extends object> {
   yLabel?: string;
   xLabel?: string;
   unit?: string;
+  /** Optional custom tooltip value formatter (overrides `unit`). */
+  formatValue?: (value: number | string, name?: string) => React.ReactNode;
   height?: number;
   loading?: boolean;
   emptyTitle?: string;
@@ -70,6 +72,7 @@ export function TrendArea<T extends object>({
   yLabel,
   xLabel,
   unit,
+  formatValue,
   height = 240,
   loading,
   stacked,
@@ -151,7 +154,7 @@ export function TrendArea<T extends object>({
           />
           <Tooltip
             cursor={{ stroke: "var(--border-strong)", strokeWidth: 1 }}
-            content={<ChartTooltip unit={unit} />}
+            content={<ChartTooltip unit={unit} formatValue={formatValue} />}
           />
           {lines.map((s, i) => {
             const color = s.color ?? chartColor(i);

--- a/src/components/charts/TrendLine.tsx
+++ b/src/components/charts/TrendLine.tsx
@@ -21,6 +21,18 @@ import {
   chartColor,
 } from "./theme";
 
+/**
+ * Compact Y-axis tick label so wide values like -90000 aren't clipped to
+ * ",000" by the narrow axis (matches <TrendArea>). Abbreviates thousands /
+ * millions; leaves sub-thousand values as-is.
+ */
+function formatCompactTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (abs >= 1_000) return `${(v / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return v.toLocaleString();
+}
+
 export interface TrendLineSeries {
   /** Key in each row that holds this series' numeric value. */
   dataKey: string;
@@ -42,6 +54,12 @@ export interface TrendLineProps<T extends object> {
   xLabel?: string;
   /** Optional unit suffix shown in tooltip values (e.g. "%"). */
   unit?: string;
+  /**
+   * Optional custom formatter for tooltip values (overrides `unit`). Lets
+   * callers render currency / compact / domain-specific values on hover —
+   * e.g. "$1,234" instead of the raw "1234".
+   */
+  formatValue?: (value: number | string, name?: string) => React.ReactNode;
   /** Container height. Default 240. */
   height?: number;
   /** Show loading skeleton. */
@@ -68,6 +86,7 @@ export function TrendLine<T extends object>({
   yLabel,
   xLabel,
   unit,
+  formatValue,
   height = 240,
   loading,
   emptyTitle = "No data yet",
@@ -117,6 +136,7 @@ export function TrendLine<T extends object>({
           />
           <YAxis
             {...Y_AXIS_DEFAULTS}
+            width={48}
             label={
               yLabel
                 ? {
@@ -129,12 +149,12 @@ export function TrendLine<T extends object>({
                 : undefined
             }
             tickFormatter={(v: number) =>
-              unit ? `${v}${unit}` : v.toLocaleString()
+              unit ? `${v}${unit}` : formatCompactTick(v)
             }
           />
           <Tooltip
             cursor={{ stroke: "var(--border-strong)", strokeWidth: 1 }}
-            content={<ChartTooltip unit={unit} />}
+            content={<ChartTooltip unit={unit} formatValue={formatValue} />}
           />
           {lines.map((s, i) => {
             const color = s.color ?? chartColor(i);

--- a/src/components/ops/master/MetricBox.tsx
+++ b/src/components/ops/master/MetricBox.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TrendLine, TrendArea, DistributionBar } from "@/components/charts";
+import { MiniSparkline } from "@/components/ui/mini-sparkline";
+import {
+  cycleChartType,
+  summarizeSeries,
+  formatMetricValue,
+  type MetricChartType,
+  type MetricValueFormat,
+} from "./metric-box-utils";
+
+// ---------------------------------------------------------------------------
+// MetricBox — MASTER-prompt G9/G10/G11 "click a box → popup" primitive.
+//
+// The Owner Portal Revisions doc asks, on nearly every dashboard tile:
+//   • G10 "click a box → popup with full historical/chronological data,
+//          beautiful charts; 'feather' icon re-beautifies / cycles chart types"
+//   • G11 "hover a datapoint → show value + time (Google-Finance style)"
+//
+// MetricBox renders an Apple-iOS-ish KPI tile that, on click, opens a Dialog
+// with the metric's history rendered through the branded chart wrappers
+// (which already carry the hover ChartTooltip), plus a "feather" button that
+// cycles line → area → bar. The tile also shows an inline sparkline so the
+// trend reads at a glance before the operator even opens the popup.
+//
+// History is passed in as plain serializable data so a Server Component page
+// can render this Client primitive directly with real (never fabricated)
+// series.
+// ---------------------------------------------------------------------------
+
+export interface MetricPoint {
+  /** x-axis label (week / month / date). */
+  label: string;
+  /** y-axis numeric value, in the unit implied by `valueFormat`. */
+  value: number;
+}
+
+export interface MetricBoxProps {
+  /** Small uppercase label on the tile. */
+  eyebrow: string;
+  /** Big headline value, already formatted by the caller (e.g. "$1.2M"). */
+  headline: React.ReactNode;
+  /** aria fallback used when `headline` is a non-string ReactNode. */
+  headlineLabel?: string;
+  /** Optional one-line hint under the headline. */
+  subtext?: string;
+  /** Historical series powering the drill-in popup + inline sparkline. */
+  history: MetricPoint[];
+  /** Dialog title (defaults to `eyebrow`). */
+  popupTitle?: string;
+  /** Longer description shown under the popup title. */
+  popupDescription?: string;
+  /** How to format y-values in the chart tooltip + summary stats. */
+  valueFormat?: MetricValueFormat;
+  /** Whether a rising series is good (revenue) or bad (denials, AR days). */
+  goodWhen?: "up" | "down" | "either";
+  /** Initial chart style in the popup. Default "line". */
+  initialChartType?: MetricChartType;
+  /** Optional deep-link rendered as "View details →" in the popup footer. */
+  detailHref?: string;
+  detailLabel?: string;
+  /**
+   * Render a compare checkbox in the top-right corner and report selection up
+   * (MASTER prompt G9). Managed by <MetricBoxGroup>, which overlays the
+   * selected metrics on one chart.
+   */
+  selectable?: boolean;
+  selected?: boolean;
+  onSelectedChange?: (next: boolean) => void;
+  className?: string;
+}
+
+export function MetricBox({
+  eyebrow,
+  headline,
+  headlineLabel,
+  subtext,
+  history,
+  popupTitle,
+  popupDescription,
+  valueFormat = "number",
+  goodWhen = "either",
+  initialChartType = "line",
+  detailHref,
+  detailLabel = "View details",
+  selectable = false,
+  selected = false,
+  onSelectedChange,
+  className,
+}: MetricBoxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [chartType, setChartType] =
+    React.useState<MetricChartType>(initialChartType);
+
+  const values = React.useMemo(() => history.map((p) => p.value), [history]);
+  const summary = React.useMemo(() => summarizeSeries(values), [values]);
+  const hasHistory = history.length >= 2;
+
+  const fmt = React.useCallback(
+    (v: number | string) => formatMetricValue(v, valueFormat),
+    [valueFormat],
+  );
+
+  const headlineAria =
+    headlineLabel ??
+    (typeof headline === "string" || typeof headline === "number"
+      ? String(headline)
+      : eyebrow);
+
+  // Trend semantics: is the first→last movement good, bad, or neutral?
+  const isGood =
+    !summary || summary.direction === "flat" || goodWhen === "either"
+      ? null
+      : (goodWhen === "up" && summary.direction === "up") ||
+        (goodWhen === "down" && summary.direction === "down");
+
+  return (
+    <>
+      <div className="relative">
+        {selectable && (
+          <label
+            className={cn(
+              "absolute right-3 top-3 z-10 flex items-center gap-1 rounded-full border border-border",
+              "bg-surface/90 px-2 py-0.5 text-[10px] font-medium shadow-sm backdrop-blur",
+              "cursor-pointer select-none",
+              selected ? "text-accent" : "text-text-muted hover:text-text",
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              className="h-3 w-3 accent-[color:var(--accent)]"
+              checked={selected}
+              onChange={(e) => onSelectedChange?.(e.target.checked)}
+              aria-label={`Compare ${eyebrow}`}
+            />
+            Compare
+          </label>
+        )}
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-haspopup="dialog"
+          aria-label={`${eyebrow}: ${headlineAria}. Open details`}
+          className={cn(
+            "group relative block w-full text-left rounded-2xl border border-border/80 bg-surface-raised",
+          "shadow-sm transition-all duration-200 ease-smooth",
+          "hover:shadow-md hover:-translate-y-0.5 hover:border-border-strong",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+          "px-6 py-6 [.density-dense_&]:px-4 [.density-dense_&]:py-4",
+          className,
+        )}
+      >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+          {eyebrow}
+        </p>
+
+        <div className="mt-3 flex items-baseline gap-2">
+          <span className="font-display text-3xl font-semibold text-text tabular-nums leading-none">
+            {headline}
+          </span>
+          {summary && summary.direction !== "flat" && (
+            <TrendBadge
+              direction={summary.direction}
+              deltaPct={summary.deltaPct}
+              isGood={isGood}
+            />
+          )}
+        </div>
+
+        {subtext && (
+          <p className="text-xs text-text-muted mt-3 leading-snug">{subtext}</p>
+        )}
+
+        {hasHistory && (
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <MiniSparkline values={values} width={88} height={20} />
+            <span className="text-[10px] font-medium text-text-subtle opacity-0 transition-opacity group-hover:opacity-100">
+              Tap to expand
+            </span>
+          </div>
+        )}
+        </button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{popupTitle ?? eyebrow}</DialogTitle>
+            {popupDescription && (
+              <p className="text-sm text-text-muted">{popupDescription}</p>
+            )}
+          </DialogHeader>
+
+          {summary ? (
+            <>
+              <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
+                <Stat label="Current" value={fmt(summary.last)} />
+                <Stat label="Average" value={fmt(summary.avg)} />
+                <Stat label="High" value={fmt(summary.max)} />
+                <Stat label="Low" value={fmt(summary.min)} />
+              </dl>
+
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                  Trend · {summary.count} points
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setChartType((t) => cycleChartType(t))}
+                  title="Cycle chart style"
+                  aria-label={`Change chart style (currently ${chartType})`}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1",
+                    "text-[11px] font-medium text-text-muted capitalize",
+                    "transition-colors hover:bg-surface-muted hover:text-text",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+                  )}
+                >
+                  <FeatherIcon className="h-3.5 w-3.5" />
+                  {chartType}
+                </button>
+              </div>
+
+              <DrillChart
+                chartType={chartType}
+                data={history}
+                seriesLabel={popupTitle ?? eyebrow}
+                formatValue={fmt}
+              />
+            </>
+          ) : (
+            <p className="py-10 text-center text-sm text-text-muted">
+              No history yet — the trend will appear here once data starts
+              flowing.
+            </p>
+          )}
+
+          {detailHref && (
+            <div className="mt-5 flex justify-end border-t border-border/60 pt-4">
+              <Link
+                href={detailHref}
+                className="text-sm font-medium text-accent hover:underline"
+              >
+                {detailLabel} &rarr;
+              </Link>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border/70 bg-surface px-3 py-2">
+      <dt className="text-[10px] font-medium uppercase tracking-[0.12em] text-text-subtle">
+        {label}
+      </dt>
+      <dd className="mt-0.5 font-display text-lg text-text tabular-nums leading-none">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function DrillChart({
+  chartType,
+  data,
+  seriesLabel,
+  formatValue,
+}: {
+  chartType: MetricChartType;
+  data: MetricPoint[];
+  seriesLabel: string;
+  formatValue: (value: number | string) => string;
+}) {
+  const height = 300;
+  if (chartType === "bar") {
+    return (
+      <DistributionBar
+        data={data}
+        height={height}
+        formatValue={formatValue}
+      />
+    );
+  }
+  if (chartType === "area") {
+    return (
+      <TrendArea
+        data={data}
+        xKey="label"
+        height={height}
+        formatValue={formatValue}
+        lines={[{ dataKey: "value", label: seriesLabel }]}
+      />
+    );
+  }
+  return (
+    <TrendLine
+      data={data}
+      xKey="label"
+      height={height}
+      formatValue={formatValue}
+      lines={[{ dataKey: "value", label: seriesLabel }]}
+    />
+  );
+}
+
+function TrendBadge({
+  direction,
+  deltaPct,
+  isGood,
+}: {
+  direction: "up" | "down" | "flat";
+  deltaPct: number | null;
+  isGood: boolean | null;
+}) {
+  const arrow = direction === "up" ? "↑" : "↓";
+  const pct =
+    deltaPct === null ? "new" : `${Math.abs(deltaPct).toFixed(0)}%`;
+  const color =
+    isGood === null
+      ? "text-text-muted"
+      : isGood
+        ? "text-accent"
+        : "text-danger";
+  return (
+    <span className={cn("text-xs font-medium tabular-nums", color)}>
+      {arrow} {pct}
+    </span>
+  );
+}
+
+function FeatherIcon({ className }: { className?: string }) {
+  // A simple feather outline — the doc's "feather" beautify affordance.
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z" />
+      <path d="M16 8 2 22" />
+      <path d="M17.5 15H9" />
+    </svg>
+  );
+}

--- a/src/components/ops/master/MetricBoxGroup.tsx
+++ b/src/components/ops/master/MetricBoxGroup.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils/cn";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TrendLine } from "@/components/charts";
+import { MetricBox, type MetricBoxProps } from "./MetricBox";
+import {
+  mergeSeriesByLabel,
+  formatMetricValue,
+  type MetricValueFormat,
+} from "./metric-box-utils";
+
+// ---------------------------------------------------------------------------
+// MetricBoxGroup — MASTER-prompt G9 "compare mode".
+//
+// "Small checkbox top-right of each box → select ≥2 → a Compare button appears
+//  → popup overlays the measures on one chart."
+//
+// Wraps a set of <MetricBox> tiles, manages which are checked, and overlays the
+// selected metrics' real histories on a single multi-line TrendLine (shared
+// hover tooltips, money/percent formatting). Metrics that don't share a time
+// axis are flagged instead of drawn as misleading parallel lines.
+// ---------------------------------------------------------------------------
+
+export interface MetricBoxGroupItem extends MetricBoxProps {
+  /** Stable id used for selection state + compare-series keys. */
+  id: string;
+  /** Optional explicit color for this metric's compare line. */
+  compareColor?: string;
+}
+
+export interface MetricBoxGroupProps {
+  metrics: MetricBoxGroupItem[];
+  /** Grid classes for the tile layout (e.g. "grid grid-cols-3 gap-4"). */
+  className?: string;
+  /** Title for the compare popup. */
+  compareTitle?: string;
+  /** Value format for the merged compare chart (all metrics share it). */
+  valueFormat?: MetricValueFormat;
+}
+
+export function MetricBoxGroup({
+  metrics,
+  className,
+  compareTitle = "Compare metrics",
+  valueFormat = "number",
+}: MetricBoxGroupProps) {
+  const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
+  const [compareOpen, setCompareOpen] = React.useState(false);
+
+  const toggle = (id: string, next: boolean) =>
+    setSelectedIds((prev) =>
+      next ? [...new Set([...prev, id])] : prev.filter((x) => x !== id),
+    );
+
+  const selected = metrics.filter((m) => selectedIds.includes(m.id));
+  const canCompare = selected.length >= 2;
+
+  const fmt = React.useCallback(
+    (v: number | string) => formatMetricValue(v, valueFormat),
+    [valueFormat],
+  );
+
+  const merged = React.useMemo(
+    () =>
+      mergeSeriesByLabel(
+        selected.map((m) => ({
+          id: m.id,
+          label: m.popupTitle ?? m.eyebrow,
+          points: m.history,
+          color: m.compareColor,
+        })),
+      ),
+    [selected],
+  );
+
+  return (
+    <div>
+      {/* Compare toolbar — surfaces selection + the Compare action (G9). */}
+      {selectedIds.length > 0 && (
+        <div className="mb-3 flex items-center justify-end gap-3">
+          <span className="text-xs text-text-muted tabular-nums">
+            {selectedIds.length} selected
+          </span>
+          <button
+            type="button"
+            disabled={!canCompare}
+            onClick={() => setCompareOpen(true)}
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-semibold transition-colors",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+              canCompare
+                ? "bg-accent text-white hover:bg-accent/90 cursor-pointer"
+                : "bg-surface-muted text-text-subtle cursor-not-allowed",
+            )}
+          >
+            Compare{canCompare ? ` (${selectedIds.length})` : ""}
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedIds([])}
+            className="text-xs text-text-subtle hover:text-text cursor-pointer"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      <div className={className}>
+        {metrics.map((m) => {
+          // Strip group-only props before forwarding to the tile.
+          const { id, compareColor: _compareColor, ...boxProps } = m;
+          return (
+            <MetricBox
+              key={id}
+              {...boxProps}
+              selectable
+              selected={selectedIds.includes(id)}
+              onSelectedChange={(next) => toggle(id, next)}
+            />
+          );
+        })}
+      </div>
+
+      <Dialog open={compareOpen} onOpenChange={setCompareOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{compareTitle}</DialogTitle>
+            {selected.length > 0 && (
+              <p className="text-sm text-text-muted">
+                {selected.map((m) => m.popupTitle ?? m.eyebrow).join(" vs ")}
+              </p>
+            )}
+          </DialogHeader>
+          {merged.disjoint ? (
+            <p className="py-10 text-center text-sm text-text-muted">
+              These metrics don&rsquo;t share a time axis, so they can&rsquo;t be
+              overlaid on one chart. Pick metrics from the same period (e.g. two
+              weekly tiles).
+            </p>
+          ) : (
+            <TrendLine
+              data={merged.data}
+              xKey="label"
+              height={320}
+              formatValue={fmt}
+              lines={merged.lines}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -1,0 +1,45 @@
+// MASTER-prompt kit — the shared owner-portal (/ops) UI primitives the
+// "Owner Portal Revisions" directive mandates across every page. A single
+// import surface so pages adopt the same building blocks instead of
+// hand-rolling each table / section / list.
+//
+// Coverage of the MASTER-prompt "layout law":
+//   G1 Collapsible sections        → <Collapsible>
+//   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
+//   G6 Table send/print/download   → <DataTable exportable> + table-export utils
+//   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
+//
+// Still to build (tracked, not yet shipped): global sidebar overlay/autohide
+// (G2), 7-result autocomplete inputs (G3), per-section AI search bar (G8),
+// compare-mode + "beautify" popups (G9/G10).
+
+export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  DataTable,
+  type ColumnDef,
+  type DataTableProps,
+  type DataTableSelection,
+  type DataTableAlign,
+  type DataTableDensity,
+} from "@/components/ui/data-table";
+
+export {
+  SortableList,
+  KanbanBoard,
+  reorder,
+  type SortableListProps,
+  type SortableRenderArgs,
+  type DragHandleProps,
+  type KanbanBoardProps,
+  type KanbanColumn,
+} from "@/components/ui/sortable";
+
+export {
+  buildCsv,
+  downloadCsv,
+  printTable,
+  escapeCsvCell,
+  tableToPrintableHtml,
+  type CellValue,
+} from "@/lib/ui/table-export";

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -8,12 +8,42 @@
 //   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
 //   G6 Table send/print/download   → <DataTable exportable> + table-export utils
 //   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
+//   G9 Compare mode               → <MetricBoxGroup> (select ≥2 → overlay chart)
+//   G10 "click a box → popup"      → <MetricBox> (history popup + feather cycle)
+//   G11 Hover tooltips on charts   → <MetricBox> drill-in (branded chart hover)
 //
 // Still to build (tracked, not yet shipped): global sidebar overlay/autohide
-// (G2), 7-result autocomplete inputs (G3), per-section AI search bar (G8),
-// compare-mode + "beautify" popups (G9/G10).
+// (G2 layered/autohide half remains; in-page-click re-open fixed via PR #648)
+// and the per-section AI search bar (G8).
 
 export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  MetricBox,
+  type MetricBoxProps,
+  type MetricPoint,
+} from "./MetricBox";
+
+export {
+  MetricBoxGroup,
+  type MetricBoxGroupProps,
+  type MetricBoxGroupItem,
+} from "./MetricBoxGroup";
+
+export {
+  cycleChartType,
+  summarizeSeries,
+  formatMetricValue,
+  mergeSeriesByLabel,
+  METRIC_CHART_TYPES,
+  type MetricChartType,
+  type MetricValueFormat,
+  type SeriesSummary,
+  type MetricDirection,
+  type CompareSeriesInput,
+  type CompareLine,
+  type CompareDataset,
+} from "./metric-box-utils";
 
 export {
   DataTable,

--- a/src/components/ops/master/metric-box-utils.test.ts
+++ b/src/components/ops/master/metric-box-utils.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  cycleChartType,
+  summarizeSeries,
+  formatMetricValue,
+  mergeSeriesByLabel,
+  METRIC_CHART_TYPES,
+  type MetricChartType,
+} from "./metric-box-utils";
+
+describe("cycleChartType", () => {
+  it("cycles line → area → bar → line", () => {
+    expect(cycleChartType("line")).toBe("area");
+    expect(cycleChartType("area")).toBe("bar");
+    expect(cycleChartType("bar")).toBe("line");
+  });
+
+  it("returns the first type for an unknown value (never gets stuck)", () => {
+    expect(cycleChartType("pie" as MetricChartType)).toBe("line");
+  });
+
+  it("visits every chart type exactly once per full cycle", () => {
+    const seen = new Set<MetricChartType>();
+    let t: MetricChartType = "line";
+    for (let i = 0; i < METRIC_CHART_TYPES.length; i++) {
+      seen.add(t);
+      t = cycleChartType(t);
+    }
+    expect(seen.size).toBe(METRIC_CHART_TYPES.length);
+    expect(t).toBe("line"); // back to start
+  });
+});
+
+describe("summarizeSeries", () => {
+  it("returns null for an empty series", () => {
+    expect(summarizeSeries([])).toBeNull();
+  });
+
+  it("computes min/max/avg/first/last over a multi-point series", () => {
+    const s = summarizeSeries([10, 20, 30, 40])!;
+    expect(s.count).toBe(4);
+    expect(s.min).toBe(10);
+    expect(s.max).toBe(40);
+    expect(s.avg).toBe(25);
+    expect(s.first).toBe(10);
+    expect(s.last).toBe(40);
+    expect(s.delta).toBe(30);
+    expect(s.deltaPct).toBeCloseTo(300);
+    expect(s.direction).toBe("up");
+  });
+
+  it("handles a single-point series (delta 0, flat)", () => {
+    const s = summarizeSeries([42])!;
+    expect(s.count).toBe(1);
+    expect(s.min).toBe(42);
+    expect(s.max).toBe(42);
+    expect(s.avg).toBe(42);
+    expect(s.delta).toBe(0);
+    expect(s.direction).toBe("flat");
+  });
+
+  it("reports a downward direction and negative delta", () => {
+    const s = summarizeSeries([100, 60])!;
+    expect(s.delta).toBe(-40);
+    expect(s.deltaPct).toBeCloseTo(-40);
+    expect(s.direction).toBe("down");
+  });
+
+  it("returns null deltaPct when the baseline is zero (no %% possible)", () => {
+    const s = summarizeSeries([0, 50])!;
+    expect(s.delta).toBe(50);
+    expect(s.deltaPct).toBeNull();
+    expect(s.direction).toBe("up");
+  });
+
+  it("uses |first| so recovery from a negative baseline reads positive", () => {
+    const s = summarizeSeries([-100, -25])!;
+    expect(s.delta).toBe(75);
+    expect(s.deltaPct).toBeCloseTo(75); // 75 / |−100| · 100
+    expect(s.direction).toBe("up");
+  });
+});
+
+describe("formatMetricValue", () => {
+  it("formats whole dollars", () => {
+    expect(formatMetricValue(1234, "money")).toBe("$1,234");
+  });
+
+  it("formats cents as dollars", () => {
+    expect(formatMetricValue(123400, "moneyCents")).toBe("$1,234");
+  });
+
+  it("formats percentages with at most one decimal", () => {
+    expect(formatMetricValue(12.34, "percent")).toBe("12.3%");
+    expect(formatMetricValue(50, "percent")).toBe("50%");
+  });
+
+  it("formats compact large numbers", () => {
+    expect(formatMetricValue(1200, "compact")).toBe("1.2K");
+  });
+
+  it("formats plain numbers with grouping", () => {
+    expect(formatMetricValue(1234567, "number")).toBe("1,234,567");
+  });
+
+  it("passes through non-finite values untouched", () => {
+    expect(formatMetricValue("n/a", "money")).toBe("n/a");
+  });
+});
+
+describe("mergeSeriesByLabel", () => {
+  const revenue = {
+    id: "rev",
+    label: "Revenue",
+    points: [
+      { label: "W1", value: 100 },
+      { label: "W2", value: 200 },
+      { label: "W3", value: 300 },
+    ],
+  };
+  const ebitda = {
+    id: "ebitda",
+    label: "EBITDA",
+    points: [
+      { label: "W1", value: 10 },
+      { label: "W2", value: 20 },
+      { label: "W3", value: 30 },
+    ],
+  };
+
+  it("aligns same-axis series into one row per label", () => {
+    const { data, lines, disjoint } = mergeSeriesByLabel([revenue, ebitda]);
+    expect(data).toEqual([
+      { label: "W1", rev: 100, ebitda: 10 },
+      { label: "W2", rev: 200, ebitda: 20 },
+      { label: "W3", rev: 300, ebitda: 30 },
+    ]);
+    expect(lines).toEqual([
+      { dataKey: "rev", label: "Revenue", color: undefined },
+      { dataKey: "ebitda", label: "EBITDA", color: undefined },
+    ]);
+    expect(disjoint).toBe(false);
+  });
+
+  it("preserves first-seen label order across series", () => {
+    const a = { id: "a", label: "A", points: [{ label: "Jan", value: 1 }, { label: "Feb", value: 2 }] };
+    const b = { id: "b", label: "B", points: [{ label: "Feb", value: 9 }, { label: "Mar", value: 8 }] };
+    const { data } = mergeSeriesByLabel([a, b]);
+    expect(data.map((r) => r.label)).toEqual(["Jan", "Feb", "Mar"]);
+  });
+
+  it("fills missing series columns with null (gapped line, no crash)", () => {
+    const a = { id: "a", label: "A", points: [{ label: "Jan", value: 1 }] };
+    const b = { id: "b", label: "B", points: [{ label: "Feb", value: 2 }] };
+    const { data } = mergeSeriesByLabel([a, b]);
+    expect(data).toEqual([
+      { label: "Jan", a: 1, b: null },
+      { label: "Feb", a: null, b: 2 },
+    ]);
+  });
+
+  it("flags disjoint series that share no labels", () => {
+    const weekly = { id: "w", label: "Weekly", points: [{ label: "W1", value: 1 }] };
+    const monthly = { id: "m", label: "Monthly", points: [{ label: "Jan", value: 2 }] };
+    expect(mergeSeriesByLabel([weekly, monthly]).disjoint).toBe(true);
+    // Overlapping series are NOT disjoint.
+    expect(mergeSeriesByLabel([revenue, ebitda]).disjoint).toBe(false);
+  });
+});

--- a/src/components/ops/master/metric-box-utils.ts
+++ b/src/components/ops/master/metric-box-utils.ts
@@ -1,0 +1,189 @@
+// Pure, framework-free helpers for <MetricBox>. Kept in their own module so
+// they can be unit-tested without a DOM / React renderer. The component
+// (MetricBox.tsx) is the only intended consumer, but everything here is
+// side-effect-free and safe to import anywhere.
+
+export const METRIC_CHART_TYPES = ["line", "area", "bar"] as const;
+export type MetricChartType = (typeof METRIC_CHART_TYPES)[number];
+
+/**
+ * Cycle line → area → bar → line. Drives the popup's "feather" button (G10:
+ * "feather icon re-beautifies / cycles chart types"). An unknown current
+ * value resolves to the first type so the button can never get stuck.
+ */
+export function cycleChartType(current: MetricChartType): MetricChartType {
+  const i = METRIC_CHART_TYPES.indexOf(current);
+  // indexOf returns -1 for an unknown value; (-1 + 1) % len === 0 → "line".
+  return METRIC_CHART_TYPES[(i + 1) % METRIC_CHART_TYPES.length];
+}
+
+export type MetricDirection = "up" | "down" | "flat";
+
+export interface SeriesSummary {
+  count: number;
+  min: number;
+  max: number;
+  avg: number;
+  first: number;
+  last: number;
+  /** last − first */
+  delta: number;
+  /** percent change first → last; null when first === 0 (no baseline). */
+  deltaPct: number | null;
+  direction: MetricDirection;
+}
+
+/**
+ * Summary stats for a numeric series, shown above the drill-in chart. Returns
+ * null for an empty series so callers can render an empty state instead of
+ * NaN-filled cells.
+ */
+export function summarizeSeries(values: number[]): SeriesSummary | null {
+  if (!values || values.length === 0) return null;
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const first = values[0];
+  const last = values[values.length - 1];
+  const delta = last - first;
+  // Use |first| so a recovery from a negative baseline reads as a positive %.
+  const deltaPct = first === 0 ? null : (delta / Math.abs(first)) * 100;
+  const direction: MetricDirection =
+    delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+  return {
+    count: values.length,
+    min,
+    max,
+    avg: sum / values.length,
+    first,
+    last,
+    delta,
+    deltaPct,
+    direction,
+  };
+}
+
+export type MetricValueFormat =
+  | "money" // value is whole dollars → "$1,234"
+  | "moneyCents" // value is cents → "$1,234"
+  | "percent" // value is a percentage → "12.3%"
+  | "number" // plain integer-ish → "1,234"
+  | "compact"; // large counts → "1.2k"
+
+function usd(maximumFractionDigits = 0): Intl.NumberFormat {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits,
+  });
+}
+
+/**
+ * Format a single y-value for the tooltip / summary stats. String inputs that
+ * aren't finite numbers pass through untouched (recharts occasionally hands a
+ * pre-formatted label). Kept pure (no locale surprises beyond Intl) so it's
+ * testable and identical on server and client.
+ */
+export function formatMetricValue(
+  value: number | string,
+  format: MetricValueFormat,
+): string {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  switch (format) {
+    case "money":
+      return usd(0).format(n);
+    case "moneyCents":
+      return usd(0).format(n / 100);
+    case "percent":
+      return `${n.toLocaleString("en-US", { maximumFractionDigits: 1 })}%`;
+    case "compact":
+      return new Intl.NumberFormat("en-US", {
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }).format(n);
+    case "number":
+    default:
+      return n.toLocaleString("en-US");
+  }
+}
+
+// --- G9 compare-mode -------------------------------------------------------
+
+export interface CompareSeriesInput {
+  /** Stable key used as the merged-row dataKey + recharts line id. */
+  id: string;
+  /** Human label for the line (tooltip / legend). */
+  label: string;
+  /** This series' points. */
+  points: { label: string; value: number }[];
+  /** Optional explicit line color. */
+  color?: string;
+}
+
+export interface CompareLine {
+  dataKey: string;
+  label: string;
+  color?: string;
+}
+
+export interface CompareDataset {
+  /** One row per distinct x-label, with a column per series id. */
+  data: Array<Record<string, number | string | null>>;
+  /** Line definitions to feed <TrendLine lines=...>. */
+  lines: CompareLine[];
+  /** True when the selected series share no x-labels (overlay won't align). */
+  disjoint: boolean;
+}
+
+/**
+ * Merge N selected metric series into a single dataset for the compare overlay
+ * (G9: "select ≥2 → overlay the measures on one chart"). Rows are keyed by
+ * x-label in first-seen order across all series; a series missing a given
+ * label yields null there (recharts simply gaps the line). `disjoint` flags the
+ * degenerate case where the chosen series share no labels, so the UI can warn
+ * instead of drawing parallel non-overlapping lines.
+ */
+export function mergeSeriesByLabel(series: CompareSeriesInput[]): CompareDataset {
+  const order: string[] = [];
+  const rows = new Map<string, Record<string, number | string | null>>();
+  for (const s of series) {
+    for (const p of s.points) {
+      let row = rows.get(p.label);
+      if (!row) {
+        row = { label: p.label };
+        rows.set(p.label, row);
+        order.push(p.label);
+      }
+      row[s.id] = p.value;
+    }
+  }
+  const data = order.map((label) => {
+    const row = rows.get(label)!;
+    // Fill missing series columns with null so every row has every key.
+    for (const s of series) {
+      if (!(s.id in row)) row[s.id] = null;
+    }
+    return row;
+  });
+  const lines: CompareLine[] = series.map((s) => ({
+    dataKey: s.id,
+    label: s.label,
+    color: s.color,
+  }));
+  // Disjoint = no label is shared by ≥2 series (every row has <2 non-null
+  // values). Only meaningful with ≥2 series.
+  const disjoint =
+    series.length >= 2 &&
+    data.every((row) => {
+      let present = 0;
+      for (const s of series) if (row[s.id] != null) present++;
+      return present < 2;
+    });
+  return { data, lines, disjoint };
+}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -47,6 +47,13 @@ import {
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
 import { useDensity } from "@/lib/ui/density";
+import {
+  buildCsv,
+  downloadCsv,
+  printTable,
+  type CellValue,
+} from "@/lib/ui/table-export";
+import { Download, Printer } from "lucide-react";
 
 // ----------------------------------------------------------------- types
 
@@ -77,6 +84,11 @@ export interface ColumnDef<Row> {
   headerCell?: () => React.ReactNode;
   /** Hide on mobile (<= sm). Useful for secondary numeric columns. */
   hideOnMobile?: boolean;
+  /** Plain value for CSV/print export. Defaults to the row's `key` field.
+   *  Set this on columns whose `cell` renders rich JSX so exports stay clean. */
+  exportValue?: (row: Row) => CellValue;
+  /** Exclude this column from exports (e.g. a checkbox / actions column). */
+  exportable?: boolean;
 }
 
 export interface DataTableSelection<Row> {
@@ -121,6 +133,12 @@ export interface DataTableProps<Row> {
   /** Per-row right-click / long-press menu items (Monday/Linear-tier).
    *  Return `null` or an empty array to skip the menu on a given row. */
   contextMenuItems?: (row: Row, index: number) => ContextMenuItem[] | null;
+  /** Show a Download-CSV + Print control in the table toolbar (MASTER prompt G6).
+   *  Exports the currently-sorted rows, including column + row titles. Columns
+   *  use `exportValue` (or fall back to the raw `key` field). */
+  exportable?: boolean;
+  /** Base filename / print title for exports. Defaults to `ariaLabel` or "table". */
+  exportName?: string;
 }
 
 interface SortState {
@@ -252,6 +270,8 @@ export function DataTable<Row>({
   className,
   rowClassName,
   contextMenuItems,
+  exportable = false,
+  exportName,
 }: DataTableProps<Row>) {
   // Density precedence (highest → lowest):
   //   1. Explicit `density` prop (controlled by caller).
@@ -298,6 +318,33 @@ export function DataTable<Row>({
     copy.sort((a, b) => (sort.dir === "asc" ? cmp(a, b) : -cmp(a, b)));
     return copy;
   }, [rows, columns, sort]);
+
+  // ---- Export (CSV download / print) — MASTER prompt G6 -------------------
+  // Exports the currently-sorted rows so what you download matches what you see.
+  const exportColumns = React.useMemo(
+    () => columns.filter((c) => c.exportable !== false),
+    [columns],
+  );
+  const exportTitle = exportName ?? ariaLabel ?? "table";
+  const buildExportData = React.useCallback(() => {
+    const headers = exportColumns.map((c) => c.label);
+    const exportRows: CellValue[][] = sortedRows.map((row) =>
+      exportColumns.map((c) =>
+        c.exportValue
+          ? c.exportValue(row)
+          : ((row as Record<string, unknown>)[c.key] as CellValue),
+      ),
+    );
+    return { headers, exportRows };
+  }, [exportColumns, sortedRows]);
+  const handleDownloadCsv = React.useCallback(() => {
+    const { headers, exportRows } = buildExportData();
+    downloadCsv(exportTitle, buildCsv(headers, exportRows));
+  }, [buildExportData, exportTitle]);
+  const handlePrint = React.useCallback(() => {
+    const { headers, exportRows } = buildExportData();
+    printTable(exportTitle, headers, exportRows);
+  }, [buildExportData, exportTitle]);
 
   // ---- Selection helpers --------------------------------------------------
   const selectionCtx: SelectionContext | null = React.useMemo(() => {
@@ -380,7 +427,7 @@ export function DataTable<Row>({
         className,
       )}
     >
-      {(toolbar || showDensityToggle) && (
+      {(toolbar || showDensityToggle || exportable) && (
         <div
           className={cn(
             "flex items-center gap-3 border-b border-border/60",
@@ -388,6 +435,9 @@ export function DataTable<Row>({
           )}
         >
           <div className="flex-1 min-w-0">{toolbar}</div>
+          {exportable && (
+            <ExportControls onCsv={handleDownloadCsv} onPrint={handlePrint} />
+          )}
           {showDensityToggle && (
             <DensityToggle
               value={density}
@@ -705,6 +755,39 @@ function SkeletonRows<Row>({
         </tr>
       ))}
     </>
+  );
+}
+
+// ----------------------------------------------------------- export controls
+
+function ExportControls({
+  onCsv,
+  onPrint,
+}: {
+  onCsv: () => void;
+  onPrint: () => void;
+}) {
+  const btn = cn(
+    "inline-flex items-center gap-1 h-7 px-2.5 rounded-full",
+    "border border-border bg-surface text-[11px] font-medium",
+    "text-text-muted hover:text-text transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+  );
+  return (
+    <div
+      role="group"
+      aria-label="Export table"
+      className="inline-flex items-center gap-1"
+    >
+      <button type="button" onClick={onCsv} className={btn}>
+        <Download aria-hidden="true" className="h-3.5 w-3.5" />
+        CSV
+      </button>
+      <button type="button" onClick={onPrint} className={btn}>
+        <Printer aria-hidden="true" className="h-3.5 w-3.5" />
+        Print
+      </button>
+    </div>
   );
 }
 

--- a/src/lib/ui/table-export.test.ts
+++ b/src/lib/ui/table-export.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCsv,
+  escapeCsvCell,
+  tableToPrintableHtml,
+} from "./table-export";
+
+describe("escapeCsvCell", () => {
+  it("passes plain strings and numbers through unchanged", () => {
+    expect(escapeCsvCell("Maya Reyes")).toBe("Maya Reyes");
+    expect(escapeCsvCell(42)).toBe("42");
+    expect(escapeCsvCell(0)).toBe("0");
+  });
+
+  it("renders null/undefined/empty as an empty cell", () => {
+    expect(escapeCsvCell(null)).toBe("");
+    expect(escapeCsvCell(undefined)).toBe("");
+    expect(escapeCsvCell("")).toBe("");
+  });
+
+  it("quotes cells containing commas, quotes, or newlines", () => {
+    expect(escapeCsvCell("Reyes, Maya")).toBe('"Reyes, Maya"');
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvCell("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("neutralises spreadsheet formula injection", () => {
+    expect(escapeCsvCell("=SUM(A1:A2)")).toBe("'=SUM(A1:A2)");
+    expect(escapeCsvCell("+1")).toBe("'+1");
+    expect(escapeCsvCell("-1")).toBe("'-1");
+    expect(escapeCsvCell("@cmd")).toBe("'@cmd");
+  });
+
+  it("quotes a formula-injection cell that also contains a comma", () => {
+    // guard prefix applied first, then RFC-4180 quoting
+    expect(escapeCsvCell("=1,2")).toBe('"\'=1,2"');
+  });
+});
+
+describe("buildCsv", () => {
+  it("joins a header row + body rows with CRLF and escapes cells", () => {
+    const csv = buildCsv(
+      ["Patient", "Billed", "Note"],
+      [
+        ["Maya Reyes", 240, "ok"],
+        ["Reyes, Sam", 99.5, 'has "quote"'],
+      ],
+    );
+    expect(csv).toBe(
+      'Patient,Billed,Note\r\n' +
+        'Maya Reyes,240,ok\r\n' +
+        '"Reyes, Sam",99.5,"has ""quote"""',
+    );
+  });
+
+  it("handles an empty body", () => {
+    expect(buildCsv(["A", "B"], [])).toBe("A,B");
+  });
+});
+
+describe("tableToPrintableHtml", () => {
+  it("includes the title, headers, and HTML-escaped cell values", () => {
+    const html = tableToPrintableHtml(
+      "Claims",
+      ["Patient", "Status"],
+      [["A&B <Co>", "paid"]],
+    );
+    expect(html).toContain("<title>Claims</title>");
+    expect(html).toContain("<th>Patient</th>");
+    expect(html).toContain("<th>Status</th>");
+    expect(html).toContain("<td>A&amp;B &lt;Co&gt;</td>");
+    expect(html).toContain("<td>paid</td>");
+  });
+});

--- a/src/lib/ui/table-export.ts
+++ b/src/lib/ui/table-export.ts
@@ -1,0 +1,109 @@
+// Client-safe CSV + print helpers for the DataTable primitive.
+//
+// MASTER prompt (Owner Portal Revisions) G6: "Have the ability to 'send' or
+// 'print' or 'Download' any table on any page that includes all the data and
+// the 'column' and 'row' titles."
+//
+// Kept dependency-free and client-safe (no server-only imports) so it ships in
+// the browser bundle alongside <DataTable>. The heavier server/audit export
+// path lives in src/lib/admin/csv-export.ts and is a separate concern.
+
+export type CellValue = string | number | boolean | null | undefined;
+
+// UTF-8 BOM — makes Excel open accented characters correctly.
+const UTF8_BOM = "\uFEFF";
+
+/**
+ * Escape a single CSV cell per RFC-4180, plus an Excel/Sheets formula-injection
+ * guard: cells beginning with `=`, `+`, `-`, `@`, tab, or CR are prefixed with a
+ * single quote so a downloaded financial export can't execute as a formula.
+ */
+export function escapeCsvCell(value: CellValue): string {
+  if (value == null) return "";
+  let s = typeof value === "string" ? value : String(value);
+  if (s.length === 0) return "";
+  // Neutralise spreadsheet formula injection.
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  // RFC-4180 quoting trigger: comma, quote, CR, or LF.
+  if (/[",\r\n]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Build an RFC-4180 CSV string from a header row plus body rows. */
+export function buildCsv(headers: string[], rows: CellValue[][]): string {
+  const lines = [headers.map(escapeCsvCell).join(",")];
+  for (const row of rows) lines.push(row.map(escapeCsvCell).join(","));
+  return lines.join("\r\n");
+}
+
+/**
+ * Trigger a browser download of `csv` as `filename`. Prepends a UTF-8 BOM.
+ * No-op outside the browser.
+ */
+export function downloadCsv(filename: string, csv: string): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([UTF8_BOM + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) =>
+    c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&quot;",
+  );
+}
+
+/** Build a minimal, print-styled HTML document for a table (column + row titles). */
+export function tableToPrintableHtml(
+  title: string,
+  headers: string[],
+  rows: CellValue[][],
+): string {
+  const th = headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("");
+  const trs = rows
+    .map(
+      (r) =>
+        `<tr>${r
+          .map((c) => `<td>${escapeHtml(c == null ? "" : String(c))}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(
+    title,
+  )}</title><style>
+    body{font:13px -apple-system,system-ui,sans-serif;color:#111;margin:24px}
+    h1{font-size:16px;margin:0 0 12px}
+    table{border-collapse:collapse;width:100%}
+    th,td{border:1px solid #ccc;padding:6px 10px;text-align:left}
+    thead th{background:#f3f4f6;font-weight:600}
+    tbody tr:nth-child(even){background:#fafafa}
+    @media print{body{margin:0}}
+  </style></head><body><h1>${escapeHtml(
+    title,
+  )}</h1><table><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></body></html>`;
+}
+
+/**
+ * Open a print dialog for the given table in a new window. No-op outside the
+ * browser or if the popup is blocked.
+ */
+export function printTable(
+  title: string,
+  headers: string[],
+  rows: CellValue[][],
+): void {
+  if (typeof window === "undefined") return;
+  const html = tableToPrintableHtml(title, headers, rows);
+  const w = window.open("", "_blank", "width=900,height=700");
+  if (!w) return;
+  w.document.write(html);
+  w.document.close();
+  w.focus();
+  w.print();
+}


### PR DESCRIPTION
## What

First increment of **Slice 1** of the Owner Portal Revisions — the reusable MASTER-prompt primitive kit. The shared `DataTable` already implements tri-state column-header sorting (**G5**); this adds the missing **G6**: _"send / print / download any table, including column + row titles."_

## Changes
- **`src/lib/ui/table-export.ts`** (new, client-safe) — RFC-4180 CSV builder with an Excel/Sheets **formula-injection guard** + UTF-8 BOM, `downloadCsv`, and a `printTable` helper. Unit-tested (8 tests).
- **`DataTable`** — additive `exportable` / `exportName` props + per-column `exportValue` / `exportable`. Renders a **CSV + Print** control in the toolbar that exports the *currently-sorted* rows. **Existing callers are unaffected** (all new props are optional/off-by-default).
- **`src/components/ops/master/index.ts`** (new) — barrel re-exporting the kit primitives (Collapsible `G1`, DataTable `G5/G6`, SortableList `G7`) so `/ops` pages adopt one set of building blocks instead of hand-rolling tables.

## Why this scope
Recon showed the primitives already largely exist (`DataTable` sort, `collapsible.tsx`, `sortable.tsx`) — the real gaps are **export** (built here) and **adoption** (45 `/ops` pages hand-roll `<table>`; that migration is Slice 3). Still-to-build kit pieces (sidebar overlay/autohide G2, 7-result autocomplete G3, compare/beautify popups G9/G10) are tracked in `docs/plans/owner-portal-revisions-2026-06-10-diff-analysis.md`.

## Verification
`tsc --noEmit` clean · `eslint` clean · `vitest` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)