### PR TITLE
Owner Portal Revisions — Slice 3: adopt DataTable across 22 ops tables (sort + export)

### DIFF
--- a/src/app/(operator)/ops/access-log/page.tsx
+++ b/src/app/(operator)/ops/access-log/page.tsx
@@ -4,13 +4,13 @@ import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
-import { EmptyState } from "@/components/ui/empty-state";
 import {
   reconstructSessions,
   aggregateByRole,
   buildHipaaExport,
   type AccessRole,
 } from "@/lib/billing/access-log";
+import { RoleAnalyticsTable, type RoleAnalyticsRow } from "./role-analytics-table";
 
 export const metadata = { title: "Master Access Log" };
 
@@ -73,6 +73,17 @@ export default async function AccessLogPage({
 
   const sessions = reconstructSessions(normalized);
   const byRole = aggregateByRole(sessions);
+
+  const roleRows: RoleAnalyticsRow[] = byRole.map((r) => ({
+    role: r.role,
+    sessionCount: r.sessionCount,
+    avgClicksDisplay: r.avgClicksPerSession.toFixed(1),
+    avgClicks: r.avgClicksPerSession,
+    avgSessionDisplay: formatSeconds(r.avgSessionSeconds),
+    avgSessionSeconds: r.avgSessionSeconds,
+    topDestinationsDisplay:
+      r.topDestinations.map((d) => `${d.section} (${d.count})`).join(" · "),
+  }));
   const hipaaExport = searchParams.patient
     ? buildHipaaExport(searchParams.patient, normalized)
     : [];
@@ -126,55 +137,13 @@ export default async function AccessLogPage({
         </button>
       </form>
 
-      <Card tone="raised" className="mb-6">
-        <CardHeader>
-          <CardTitle>Click analytics by role</CardTitle>
-          <CardDescription>
-            Mean session length and click counts per role across the selected window.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {byRole.length === 0 ? (
-            <EmptyState
-              title="No sessions in this window"
-              description="Adjust the days filter or wait for activity."
-            />
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-left">
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Role</th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Sessions</th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Avg clicks</th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Avg session</th>
-                    <th className="py-2 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Top destinations</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {byRole.map((r) => (
-                    <tr key={r.role}>
-                      <td className="py-3 pr-4">
-                        <Badge tone={ROLE_TONE[r.role]}>{r.role}</Badge>
-                      </td>
-                      <td className="py-3 pr-4 tabular-nums text-text">{r.sessionCount}</td>
-                      <td className="py-3 pr-4 tabular-nums text-text">
-                        {r.avgClicksPerSession.toFixed(1)}
-                      </td>
-                      <td className="py-3 pr-4 tabular-nums text-text">
-                        {formatSeconds(r.avgSessionSeconds)}
-                      </td>
-                      <td className="py-3 text-text-muted text-xs">
-                        {r.topDestinations.map((d) => `${d.section} (${d.count})`).join(" · ") || "—"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {/* Click analytics by role — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <div className="mb-6">
+        <p className="text-sm text-text-muted mb-3">
+          Mean session length and click counts per role across the selected window.
+        </p>
+        <RoleAnalyticsTable rows={roleRows} />
+      </div>
 
       {searchParams.patient && (
         <Card tone="raised">

--- a/src/app/(operator)/ops/access-log/role-analytics-table.tsx
+++ b/src/app/(operator)/ops/access-log/role-analytics-table.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+// Click analytics by role, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the table can
+// be downloaded or printed (G6). Numeric fields (sessionCount,
+// avgClicksPerSession, avgSessionSeconds) ride along so columns sort by real
+// magnitude rather than display string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+import type { AccessRole } from "@/lib/billing/access-log";
+
+const ROLE_TONE: Record<
+  AccessRole,
+  "highlight" | "accent" | "info" | "success" | "warning" | "neutral"
+> = {
+  patient: "info",
+  provider: "highlight",
+  office_manager: "accent",
+  researcher: "success",
+  system: "neutral",
+};
+
+export interface RoleAnalyticsRow {
+  role: AccessRole;
+  sessionCount: number;
+  avgClicksDisplay: string;
+  avgClicks: number;
+  avgSessionDisplay: string;
+  avgSessionSeconds: number;
+  topDestinationsDisplay: string;
+}
+
+export function RoleAnalyticsTable({ rows }: { rows: RoleAnalyticsRow[] }) {
+  const columns: ColumnDef<RoleAnalyticsRow>[] = [
+    {
+      key: "role",
+      label: "Role",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone={ROLE_TONE[r.role]}>{r.role}</Badge>
+      ),
+    },
+    {
+      key: "sessionCount",
+      label: "Sessions",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.sessionCount,
+      sortFn: (a, b) => a.sessionCount - b.sessionCount,
+      exportValue: (r) => String(r.sessionCount),
+    },
+    {
+      key: "avgClicks",
+      label: "Avg clicks",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.avgClicksDisplay,
+      sortFn: (a, b) => a.avgClicks - b.avgClicks,
+      exportValue: (r) => r.avgClicks.toFixed(1),
+    },
+    {
+      key: "avgSession",
+      label: "Avg session",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.avgSessionDisplay,
+      sortFn: (a, b) => a.avgSessionSeconds - b.avgSessionSeconds,
+      exportValue: (r) => r.avgSessionSeconds.toFixed(0),
+    },
+    {
+      key: "topDestinationsDisplay",
+      label: "Top destinations",
+      sortable: true,
+      cell: (r) => (
+        <span className="text-xs text-text-muted">{r.topDestinationsDisplay || "—"}</span>
+      ),
+      exportValue: (r) => r.topDestinationsDisplay,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.role}
+      ariaLabel="Click analytics by role"
+      exportable
+      exportName="access-log-role-analytics"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No sessions in this window — adjust the days filter or wait for activity.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/billing/payer-rules/page.tsx
+++ b/src/app/(operator)/ops/billing/payer-rules/page.tsx
@@ -1,20 +1,17 @@
 import Link from "next/link";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import { Eyebrow } from "@/components/ui/ornament";
 import { isStaleRule, PAYER_RULE_STALE_MS } from "@/lib/billing/payer-rules-db";
 import { loadPayerRulesForOrg } from "./actions";
+import { PayerRulesTable, type PayerRuleRow } from "./payer-rules-table";
 
 export const metadata = { title: "Payer rules — admin" };
 
 // EMR-218 admin editor — shows the merged set of global + org-override
 // payer rules with a staleness banner on any rule reviewed > 6 months ago.
 
-function formatDays(n: number): string {
-  return `${n}d`;
-}
 
 export default async function PayerRulesPage() {
   const user = await requireUser();
@@ -23,6 +20,25 @@ export default async function PayerRulesPage() {
   }
   const rules = await loadPayerRulesForOrg(user.organizationId);
   const staleCount = rules.filter((r) => isStaleRule(r.lastReviewedAt)).length;
+
+  const rows: PayerRuleRow[] = rules.map((r) => ({
+    id: r.id,
+    displayName: r.displayName,
+    class: r.class,
+    timelyFilingDisplay: `${r.timelyFilingDays}d / ${r.correctedTimelyFilingDays}d`,
+    timelyFilingDays: r.timelyFilingDays,
+    correctedTimelyFilingDays: r.correctedTimelyFilingDays,
+    ackSlaDays: r.ackSlaDays,
+    cannabisLabel: r.excludesCannabis
+      ? "Excluded"
+      : r.requiresPriorAuthForCannabis
+      ? "Prior auth"
+      : "Covered",
+    lastReviewedDisplay: r.lastReviewedAt.toISOString().slice(0, 10),
+    lastReviewedMs: r.lastReviewedAt.getTime(),
+    isStale: isStaleRule(r.lastReviewedAt),
+    isOrgOverride: r.isOrgOverride,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -52,65 +68,13 @@ export default async function PayerRulesPage() {
         </Card>
       )}
 
-      <Card>
-        <CardHeader>
-          <Eyebrow>Active rules</Eyebrow>
-          <CardTitle>{rules.length} payer{rules.length === 1 ? "" : "s"}</CardTitle>
-          <CardDescription>Org-specific overrides win over the in-code defaults shown in muted rows.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-text-muted border-b">
-                  <th className="py-2 pr-4">Payer</th>
-                  <th className="py-2 pr-4">Class</th>
-                  <th className="py-2 pr-4">Timely filing</th>
-                  <th className="py-2 pr-4">Ack SLA</th>
-                  <th className="py-2 pr-4">Cannabis</th>
-                  <th className="py-2 pr-4">Last reviewed</th>
-                  <th className="py-2 pr-4">Source</th>
-                  <th className="py-2 pr-4"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {rules.map((r) => (
-                  <tr key={r.id} className="border-b last:border-b-0">
-                    <td className="py-2 pr-4 font-medium">{r.displayName}</td>
-                    <td className="py-2 pr-4">{r.class}</td>
-                    <td className="py-2 pr-4">{formatDays(r.timelyFilingDays)} / {formatDays(r.correctedTimelyFilingDays)}</td>
-                    <td className="py-2 pr-4">{formatDays(r.ackSlaDays)}</td>
-                    <td className="py-2 pr-4">
-                      {r.excludesCannabis ? (
-                        <Badge tone="danger">Excluded</Badge>
-                      ) : r.requiresPriorAuthForCannabis ? (
-                        <Badge tone="warning">Prior auth</Badge>
-                      ) : (
-                        <Badge tone="success">Covered</Badge>
-                      )}
-                    </td>
-                    <td className="py-2 pr-4">
-                      {isStaleRule(r.lastReviewedAt) ? (
-                        <Badge tone="warning">{r.lastReviewedAt.toISOString().slice(0, 10)} · stale</Badge>
-                      ) : (
-                        r.lastReviewedAt.toISOString().slice(0, 10)
-                      )}
-                    </td>
-                    <td className="py-2 pr-4">
-                      {r.isOrgOverride ? <Badge tone="accent">Org override</Badge> : <span className="text-text-muted">Global</span>}
-                    </td>
-                    <td className="py-2 pr-4">
-                      <Link href={`/ops/billing/payer-rules/editor?id=${encodeURIComponent(r.id)}`} className="text-accent hover:underline text-xs">
-                        edit →
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="mb-2">
+        <Eyebrow>Active rules</Eyebrow>
+        <p className="text-sm text-text-muted mt-1">
+          {rules.length} payer{rules.length === 1 ? "" : "s"} — org-specific overrides win over the in-code defaults.
+        </p>
+      </div>
+      <PayerRulesTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/billing/payer-rules/payer-rules-table.tsx
+++ b/src/app/(operator)/ops/billing/payer-rules/payer-rules-table.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Payer rules table, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-218) and the whole table can be
+// downloaded or printed (G6). Dates are pre-formatted server-side and passed
+// as display strings; raw epoch-ms fields ride along for sort fidelity.
+
+import Link from "next/link";
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface PayerRuleRow {
+  id: string;
+  displayName: string;
+  class: string;
+  timelyFilingDisplay: string;
+  timelyFilingDays: number;
+  correctedTimelyFilingDays: number;
+  ackSlaDays: number;
+  cannabisLabel: "Excluded" | "Prior auth" | "Covered";
+  lastReviewedDisplay: string;
+  lastReviewedMs: number;
+  isStale: boolean;
+  isOrgOverride: boolean;
+}
+
+const CANNABIS_TONE = {
+  Excluded: "danger",
+  "Prior auth": "warning",
+  Covered: "success",
+} as const;
+
+export function PayerRulesTable({ rows }: { rows: PayerRuleRow[] }) {
+  const columns: ColumnDef<PayerRuleRow>[] = [
+    {
+      key: "displayName",
+      label: "Payer",
+      sortable: true,
+      cell: (r) => <span className="font-medium">{r.displayName}</span>,
+    },
+    {
+      key: "class",
+      label: "Class",
+      sortable: true,
+    },
+    {
+      key: "timelyFiling",
+      label: "Timely filing",
+      sortable: true,
+      cell: (r) => r.timelyFilingDisplay,
+      sortFn: (a, b) => a.timelyFilingDays - b.timelyFilingDays,
+      exportValue: (r) => r.timelyFilingDisplay,
+    },
+    {
+      key: "ackSlaDays",
+      label: "Ack SLA",
+      sortable: true,
+      align: "right",
+      cell: (r) => `${r.ackSlaDays}d`,
+      sortFn: (a, b) => a.ackSlaDays - b.ackSlaDays,
+      exportValue: (r) => r.ackSlaDays,
+    },
+    {
+      key: "cannabis",
+      label: "Cannabis",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone={CANNABIS_TONE[r.cannabisLabel]}>{r.cannabisLabel}</Badge>
+      ),
+      sortFn: (a, b) => a.cannabisLabel.localeCompare(b.cannabisLabel),
+      exportValue: (r) => r.cannabisLabel,
+    },
+    {
+      key: "lastReviewed",
+      label: "Last reviewed",
+      sortable: true,
+      cell: (r) =>
+        r.isStale ? (
+          <Badge tone="warning">{r.lastReviewedDisplay} · stale</Badge>
+        ) : (
+          r.lastReviewedDisplay
+        ),
+      sortFn: (a, b) => a.lastReviewedMs - b.lastReviewedMs,
+      exportValue: (r) => r.lastReviewedDisplay,
+    },
+    {
+      key: "source",
+      label: "Source",
+      sortable: true,
+      cell: (r) =>
+        r.isOrgOverride ? (
+          <Badge tone="accent">Org override</Badge>
+        ) : (
+          <span className="text-text-muted">Global</span>
+        ),
+      sortFn: (a, b) => Number(a.isOrgOverride) - Number(b.isOrgOverride),
+      exportValue: (r) => (r.isOrgOverride ? "Org override" : "Global"),
+    },
+    {
+      key: "edit",
+      label: "",
+      sortable: false,
+      exportable: false,
+      width: "80px",
+      cell: (r) => (
+        <Link
+          href={`/ops/billing/payer-rules/editor?id=${encodeURIComponent(r.id)}`}
+          className="text-accent hover:underline text-xs"
+        >
+          edit →
+        </Link>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Payer rules"
+      exportable
+      exportName="payer-rules"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No payer rules configured yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/cfo/assets/assets-table.tsx
+++ b/src/app/(operator)/ops/cfo/assets/assets-table.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// Fixed assets register, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can be
+// downloaded or printed (G6). Money is pre-formatted server-side and passed as
+// display strings; the numeric *cents* fields ride along purely so the columns
+// sort by real magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface AssetRow {
+  id: string;
+  name: string;
+  categoryLabel: string;
+  acquiredDisplay: string;
+  acquiredMs: number;
+  costDisplay: string;
+  costCents: number;
+  lifeDisplay: string;
+  usefulLifeMonths: number;
+  netBookDisplay: string;
+  netBookCents: number;
+}
+
+export function AssetsTable({ rows }: { rows: AssetRow[] }) {
+  const columns: ColumnDef<AssetRow>[] = [
+    { key: "name", label: "Name", sortable: true },
+    {
+      key: "categoryLabel",
+      label: "Category",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone="neutral" className="text-[10px]">
+          {r.categoryLabel}
+        </Badge>
+      ),
+    },
+    {
+      key: "acquired",
+      label: "Acquired",
+      sortable: true,
+      cell: (r) => r.acquiredDisplay,
+      sortFn: (a, b) => a.acquiredMs - b.acquiredMs,
+      exportValue: (r) => r.acquiredDisplay,
+    },
+    {
+      key: "cost",
+      label: "Cost",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.costDisplay,
+      sortFn: (a, b) => a.costCents - b.costCents,
+      exportValue: (r) => (r.costCents / 100).toFixed(2),
+    },
+    {
+      key: "life",
+      label: "Life",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.lifeDisplay,
+      sortFn: (a, b) => a.usefulLifeMonths - b.usefulLifeMonths,
+      exportValue: (r) => String(r.usefulLifeMonths),
+    },
+    {
+      key: "netBook",
+      label: "Net book",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.netBookDisplay,
+      sortFn: (a, b) => a.netBookCents - b.netBookCents,
+      exportValue: (r) => (r.netBookCents / 100).toFixed(2),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Fixed Assets"
+      exportable
+      exportName="fixed-assets"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No capitalized assets yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/cfo/assets/page.tsx
+++ b/src/app/(operator)/ops/cfo/assets/page.tsx
@@ -2,7 +2,6 @@ import { requireUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Eyebrow } from "@/components/ui/ornament";
@@ -10,6 +9,7 @@ import { fmtMoney } from "@/lib/finance/formatting";
 import { FIXED_ASSET_MAP } from "@/lib/finance/chart-of-accounts";
 import { CfoTabs } from "../components";
 import { createFixedAssetAction } from "../actions";
+import { AssetsTable, type AssetRow } from "./assets-table";
 import type { FixedAssetCategory } from "@prisma/client";
 
 export const metadata = { title: "Assets · CFO" };
@@ -43,6 +43,26 @@ export default async function AssetsPage() {
     return a + (b.accumulatedDeprecCents > 0 ? b.accumulatedDeprecCents : computed);
   }, 0);
   const netBook = totalGross - totalDeprec;
+
+  const rows: AssetRow[] = assets.map((a) => {
+    const monthly = a.usefulLifeMonths > 0 ? (a.acquiredCostCents - a.salvageValueCents) / a.usefulLifeMonths : 0;
+    const months = (Date.now() - a.purchaseDate.getTime()) / (30.44 * 86_400_000);
+    const accum = a.accumulatedDeprecCents > 0 ? a.accumulatedDeprecCents : Math.min(a.acquiredCostCents - a.salvageValueCents, Math.round(monthly * Math.max(0, months)));
+    const net = a.acquiredCostCents - accum;
+    return {
+      id: a.id,
+      name: a.name,
+      categoryLabel: FIXED_ASSET_MAP[a.category].label,
+      acquiredDisplay: a.purchaseDate.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }),
+      acquiredMs: a.purchaseDate.getTime(),
+      costDisplay: fmtMoney(a.acquiredCostCents),
+      costCents: a.acquiredCostCents,
+      lifeDisplay: `${a.usefulLifeMonths}mo`,
+      usefulLifeMonths: a.usefulLifeMonths,
+      netBookDisplay: fmtMoney(net),
+      netBookCents: net,
+    };
+  });
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -103,48 +123,8 @@ export default async function AssetsPage() {
         </Card>
       </div>
 
-      {/* Asset list */}
-      <Card tone="raised">
-        <CardContent className="pt-3 pb-3 px-0">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-[10px] uppercase tracking-[0.12em] text-text-subtle border-b border-border/60">
-                <th className="text-left py-2 px-4 font-medium">Name</th>
-                <th className="text-left py-2 px-4 font-medium">Category</th>
-                <th className="text-left py-2 px-4 font-medium">Acquired</th>
-                <th className="text-right py-2 px-4 font-medium">Cost</th>
-                <th className="text-right py-2 px-4 font-medium">Life</th>
-                <th className="text-right py-2 px-4 font-medium">Net book</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {assets.length === 0 && (
-                <tr><td colSpan={6} className="py-6 text-center text-text-subtle italic">No capitalized assets yet.</td></tr>
-              )}
-              {assets.map((a) => {
-                const monthly = a.usefulLifeMonths > 0 ? (a.acquiredCostCents - a.salvageValueCents) / a.usefulLifeMonths : 0;
-                const months = (Date.now() - a.purchaseDate.getTime()) / (30.44 * 86_400_000);
-                const accum = a.accumulatedDeprecCents > 0 ? a.accumulatedDeprecCents : Math.min(a.acquiredCostCents - a.salvageValueCents, Math.round(monthly * Math.max(0, months)));
-                const net = a.acquiredCostCents - accum;
-                return (
-                  <tr key={a.id} className="hover:bg-surface-muted/50">
-                    <td className="py-2 px-4 text-text">{a.name}</td>
-                    <td className="py-2 px-4">
-                      <Badge tone="neutral" className="text-[10px]">{FIXED_ASSET_MAP[a.category].label}</Badge>
-                    </td>
-                    <td className="py-2 px-4 text-text-muted tabular-nums whitespace-nowrap">
-                      {a.purchaseDate.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
-                    </td>
-                    <td className="py-2 px-4 text-right tabular-nums text-text-muted">{fmtMoney(a.acquiredCostCents)}</td>
-                    <td className="py-2 px-4 text-right tabular-nums text-text-subtle">{a.usefulLifeMonths}mo</td>
-                    <td className="py-2 px-4 text-right tabular-nums text-text">{fmtMoney(net)}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+      {/* Asset list — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <AssetsTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/cfo/cash/cash-entries-table.tsx
+++ b/src/app/(operator)/ops/cfo/cash/cash-entries-table.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+// Recent cash movements table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole table
+// can be downloaded or printed (G6). Money and dates are pre-formatted
+// server-side and passed as display strings; numeric/ms fields ride along for
+// correct magnitude sorting.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface CashEntryRow {
+  id: string;
+  dateDisplay: string;
+  dateMs: number;
+  description: string;
+  activity: string;
+  accountName: string;
+  amountDisplay: string;
+  /** Signed cents: positive = in, negative = out */
+  amountSignedCents: number;
+  direction: "in" | "out";
+}
+
+export function CashEntriesTable({ rows }: { rows: CashEntryRow[] }) {
+  const columns: ColumnDef<CashEntryRow>[] = [
+    {
+      key: "date",
+      label: "Date",
+      sortable: true,
+      cell: (r) => (
+        <span className="tabular-nums whitespace-nowrap text-text-muted">
+          {r.dateDisplay}
+        </span>
+      ),
+      sortFn: (a, b) => a.dateMs - b.dateMs,
+      exportValue: (r) => r.dateDisplay,
+    },
+    {
+      key: "description",
+      label: "Description",
+      sortable: true,
+      cell: (r) => (
+        <span className="truncate max-w-md block text-text">{r.description}</span>
+      ),
+    },
+    {
+      key: "activity",
+      label: "Activity",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone="neutral" className="text-[10px]">
+          {r.activity}
+        </Badge>
+      ),
+    },
+    {
+      key: "accountName",
+      label: "Account",
+      sortable: true,
+      cell: (r) => (
+        <span className="text-text-muted">{r.accountName}</span>
+      ),
+    },
+    {
+      key: "amount",
+      label: "Amount",
+      sortable: true,
+      align: "right",
+      cell: (r) => (
+        <span
+          className={`tabular-nums ${
+            r.direction === "in" ? "text-success" : "text-danger"
+          }`}
+        >
+          {r.amountDisplay}
+        </span>
+      ),
+      sortFn: (a, b) => a.amountSignedCents - b.amountSignedCents,
+      exportValue: (r) => (r.amountSignedCents / 100).toFixed(2),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Recent cash movements"
+      exportable
+      exportName="cash-movements"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No cash movements logged yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/cfo/cash/page.tsx
+++ b/src/app/(operator)/ops/cfo/cash/page.tsx
@@ -13,6 +13,7 @@ import {
   updateBankBalanceAction,
   recordCashEntryAction,
 } from "../actions";
+import { CashEntriesTable, type CashEntryRow } from "./cash-entries-table";
 import type { BankAccountType } from "@prisma/client";
 
 export const metadata = { title: "Cash · CFO" };
@@ -51,6 +52,18 @@ export default async function CashPage() {
   const liabilityTotal = accounts
     .filter((a) => ["credit_card", "line_of_credit"].includes(a.type))
     .reduce((a, b) => a + b.currentBalanceCents, 0);
+
+  const entryRows: CashEntryRow[] = recentEntries.map((e) => ({
+    id: e.id,
+    dateDisplay: e.occurredOn.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+    dateMs: e.occurredOn.getTime(),
+    description: e.description,
+    activity: e.activity,
+    accountName: e.bankAccount?.name ?? "—",
+    amountDisplay: `${e.direction === "in" ? "+" : "−"}${fmtMoney(e.amountCents)}`,
+    amountSignedCents: e.direction === "in" ? e.amountCents : -e.amountCents,
+    direction: e.direction as "in" | "out",
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -221,48 +234,10 @@ export default async function CashPage() {
         </Card>
       </div>
 
-      {/* Recent cash flow entries */}
+      {/* Recent cash flow entries — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
       <div>
         <Eyebrow className="mb-4">Recent cash movements</Eyebrow>
-        <Card tone="raised">
-          <CardContent className="pt-3 pb-3 px-0">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-[10px] uppercase tracking-[0.12em] text-text-subtle border-b border-border/60">
-                  <th className="text-left py-2 px-4 font-medium">Date</th>
-                  <th className="text-left py-2 px-4 font-medium">Description</th>
-                  <th className="text-left py-2 px-4 font-medium">Activity</th>
-                  <th className="text-left py-2 px-4 font-medium">Account</th>
-                  <th className="text-right py-2 px-4 font-medium">Amount</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/60">
-                {recentEntries.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="py-6 text-center text-text-subtle italic">
-                      No cash movements logged yet.
-                    </td>
-                  </tr>
-                )}
-                {recentEntries.map((e) => (
-                  <tr key={e.id} className="hover:bg-surface-muted/50">
-                    <td className="py-2 px-4 text-text-muted tabular-nums whitespace-nowrap">
-                      {e.occurredOn.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-                    </td>
-                    <td className="py-2 px-4 text-text truncate max-w-md">{e.description}</td>
-                    <td className="py-2 px-4">
-                      <Badge tone="neutral" className="text-[10px]">{e.activity}</Badge>
-                    </td>
-                    <td className="py-2 px-4 text-text-muted">{e.bankAccount?.name ?? "—"}</td>
-                    <td className={`py-2 px-4 text-right tabular-nums ${e.direction === "in" ? "text-success" : "text-danger"}`}>
-                      {e.direction === "in" ? "+" : "−"}{fmtMoney(e.amountCents)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </CardContent>
-        </Card>
+        <CashEntriesTable rows={entryRows} />
       </div>
     </PageShell>
   );

--- a/src/app/(operator)/ops/cfo/equity/equity-table.tsx
+++ b/src/app/(operator)/ops/cfo/equity/equity-table.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+// Equity entries register, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole table
+// can be downloaded or printed (G6). Money is pre-formatted server-side and
+// passed as display strings; the numeric *cents* fields ride along purely so
+// the columns sort by real magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface EquityRow {
+  id: string;
+  dateDisplay: string;
+  dateMs: number;
+  typeLabel: string;
+  isInflow: boolean;
+  description: string;
+  ownerName: string;
+  amountDisplay: string;
+  amountCents: number;
+}
+
+export function EquityTable({ rows }: { rows: EquityRow[] }) {
+  const columns: ColumnDef<EquityRow>[] = [
+    {
+      key: "date",
+      label: "Date",
+      sortable: true,
+      cell: (r) => r.dateDisplay,
+      sortFn: (a, b) => a.dateMs - b.dateMs,
+      exportValue: (r) => r.dateDisplay,
+    },
+    {
+      key: "typeLabel",
+      label: "Type",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone={r.isInflow ? "success" : "warning"} className="text-[10px]">
+          {r.typeLabel}
+        </Badge>
+      ),
+    },
+    {
+      key: "description",
+      label: "Description",
+      sortable: true,
+    },
+    {
+      key: "ownerName",
+      label: "Owner",
+      sortable: true,
+    },
+    {
+      key: "amount",
+      label: "Amount",
+      sortable: true,
+      align: "right",
+      cell: (r) => (
+        <span className={r.isInflow ? "text-success" : "text-danger"}>
+          {r.amountDisplay}
+        </span>
+      ),
+      sortFn: (a, b) => a.amountCents - b.amountCents,
+      exportValue: (r) => (r.amountCents / 100).toFixed(2),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Equity entries"
+      exportable
+      exportName="equity"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No equity entries yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/cfo/equity/page.tsx
+++ b/src/app/(operator)/ops/cfo/equity/page.tsx
@@ -2,13 +2,13 @@ import { requireUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Eyebrow } from "@/components/ui/ornament";
 import { fmtMoney } from "@/lib/finance/formatting";
 import { CfoTabs } from "../components";
 import { recordEquityEntryAction } from "../actions";
+import { EquityTable, type EquityRow } from "./equity-table";
 import type { EquityEntryType } from "@prisma/client";
 
 export const metadata = { title: "Equity · CFO" };
@@ -42,6 +42,21 @@ export default async function EquityPage() {
   const totalDistributed = entries
     .filter((e) => e.type === "distribution" || e.type === "stock_buyback")
     .reduce((a, b) => a + Math.abs(b.amountCents), 0);
+
+  const rows: EquityRow[] = entries.map((e) => {
+    const isInflow = e.amountCents >= 0;
+    return {
+      id: e.id,
+      dateDisplay: e.occurredOn.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }),
+      dateMs: e.occurredOn.getTime(),
+      typeLabel: e.type.replace(/_/g, " "),
+      isInflow,
+      description: e.description,
+      ownerName: e.ownerName ?? "—",
+      amountDisplay: `${isInflow ? "+" : "−"}${fmtMoney(Math.abs(e.amountCents))}`,
+      amountCents: e.amountCents,
+    };
+  });
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -106,38 +121,9 @@ export default async function EquityPage() {
         </Card>
       </div>
 
-      {/* Entries */}
-      <Card tone="raised">
-        <CardContent className="pt-3 pb-3 px-0">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-[10px] uppercase tracking-[0.12em] text-text-subtle border-b border-border/60">
-                <th className="text-left py-2 px-4 font-medium">Date</th>
-                <th className="text-left py-2 px-4 font-medium">Type</th>
-                <th className="text-left py-2 px-4 font-medium">Description</th>
-                <th className="text-left py-2 px-4 font-medium">Owner</th>
-                <th className="text-right py-2 px-4 font-medium">Amount</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {entries.length === 0 && (
-                <tr><td colSpan={5} className="py-6 text-center text-text-subtle italic">No equity entries yet.</td></tr>
-              )}
-              {entries.map((e) => (
-                <tr key={e.id} className="hover:bg-surface-muted/50">
-                  <td className="py-2 px-4 text-text-muted tabular-nums whitespace-nowrap">{e.occurredOn.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</td>
-                  <td className="py-2 px-4">
-                    <Badge tone={e.amountCents >= 0 ? "success" : "warning"} className="text-[10px]">{e.type.replace(/_/g, " ")}</Badge>
-                  </td>
-                  <td className="py-2 px-4 text-text">{e.description}</td>
-                  <td className="py-2 px-4 text-text-muted">{e.ownerName ?? "—"}</td>
-                  <td className={`py-2 px-4 text-right tabular-nums ${e.amountCents >= 0 ? "text-success" : "text-danger"}`}>{e.amountCents >= 0 ? "+" : "−"}{fmtMoney(Math.abs(e.amountCents))}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+      {/* Entries — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <Eyebrow className="mb-4">Equity entries</Eyebrow>
+      <EquityTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/cfo/liabilities/liabilities-table.tsx
+++ b/src/app/(operator)/ops/cfo/liabilities/liabilities-table.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+// Liabilities register, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can be
+// downloaded or printed (G6). Money is pre-formatted server-side and passed as
+// display strings; the numeric *cents* fields ride along purely so the columns
+// sort by real magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface LiabilityRow {
+  id: string;
+  name: string;
+  typeLabel: string;
+  balanceDisplay: string;
+  balanceCents: number;
+  rateDisplay: string;
+  rate: number | null;
+  monthlyDisplay: string;
+  monthlyCents: number | null;
+  maturityDisplay: string;
+  maturityMs: number | null;
+}
+
+export function LiabilitiesTable({ rows }: { rows: LiabilityRow[] }) {
+  const columns: ColumnDef<LiabilityRow>[] = [
+    { key: "name", label: "Name", sortable: true },
+    {
+      key: "typeLabel",
+      label: "Type",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone="neutral" className="text-[10px]">
+          {r.typeLabel}
+        </Badge>
+      ),
+    },
+    {
+      key: "balance",
+      label: "Balance",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.balanceDisplay,
+      sortFn: (a, b) => a.balanceCents - b.balanceCents,
+      exportValue: (r) => (r.balanceCents / 100).toFixed(2),
+    },
+    {
+      key: "rate",
+      label: "Rate",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.rateDisplay,
+      sortFn: (a, b) => (a.rate ?? -1) - (b.rate ?? -1),
+      exportValue: (r) => (r.rate != null ? (r.rate * 100).toFixed(2) : ""),
+    },
+    {
+      key: "monthly",
+      label: "Monthly pmt",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.monthlyDisplay,
+      sortFn: (a, b) => (a.monthlyCents ?? -1) - (b.monthlyCents ?? -1),
+      exportValue: (r) =>
+        r.monthlyCents != null ? (r.monthlyCents / 100).toFixed(2) : "",
+    },
+    {
+      key: "maturity",
+      label: "Maturity",
+      sortable: true,
+      cell: (r) => r.maturityDisplay,
+      sortFn: (a, b) => (a.maturityMs ?? 0) - (b.maturityMs ?? 0),
+      exportValue: (r) => r.maturityDisplay,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Liabilities"
+      exportable
+      exportName="liabilities"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No outstanding liabilities — nice.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/cfo/liabilities/page.tsx
+++ b/src/app/(operator)/ops/cfo/liabilities/page.tsx
@@ -2,7 +2,6 @@ import { requireUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Eyebrow } from "@/components/ui/ornament";
@@ -10,6 +9,7 @@ import { fmtMoney } from "@/lib/finance/formatting";
 import { LIABILITY_MAP } from "@/lib/finance/chart-of-accounts";
 import { CfoTabs } from "../components";
 import { createLiabilityAction } from "../actions";
+import { LiabilitiesTable, type LiabilityRow } from "./liabilities-table";
 import type { LiabilityType } from "@prisma/client";
 
 export const metadata = { title: "Liabilities · CFO" };
@@ -39,6 +39,22 @@ export default async function LiabilitiesPage() {
   const totalPrincipal = liabilities.reduce((a, b) => a + b.principalCents, 0);
   const totalBalance = liabilities.reduce((a, b) => a + b.balanceCents, 0);
   const monthlyDebtService = liabilities.reduce((a, b) => a + (b.monthlyPaymentCents ?? 0), 0);
+
+  const rows: LiabilityRow[] = liabilities.map((l) => ({
+    id: l.id,
+    name: l.name,
+    typeLabel: LIABILITY_MAP[l.type].label,
+    balanceDisplay: fmtMoney(l.balanceCents),
+    balanceCents: l.balanceCents,
+    rateDisplay: l.interestRate ? `${(l.interestRate * 100).toFixed(2)}%` : "—",
+    rate: l.interestRate ?? null,
+    monthlyDisplay: l.monthlyPaymentCents ? fmtMoney(l.monthlyPaymentCents) : "—",
+    monthlyCents: l.monthlyPaymentCents ?? null,
+    maturityDisplay: l.maturityDate
+      ? l.maturityDate.toLocaleDateString("en-US")
+      : "—",
+    maturityMs: l.maturityDate ? l.maturityDate.getTime() : null,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -103,40 +119,9 @@ export default async function LiabilitiesPage() {
         </Card>
       </div>
 
-      {/* Liability list */}
-      <Card tone="raised">
-        <CardContent className="pt-3 pb-3 px-0">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-[10px] uppercase tracking-[0.12em] text-text-subtle border-b border-border/60">
-                <th className="text-left py-2 px-4 font-medium">Name</th>
-                <th className="text-left py-2 px-4 font-medium">Type</th>
-                <th className="text-right py-2 px-4 font-medium">Balance</th>
-                <th className="text-right py-2 px-4 font-medium">Rate</th>
-                <th className="text-right py-2 px-4 font-medium">Monthly pmt</th>
-                <th className="text-left py-2 px-4 font-medium">Maturity</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {liabilities.length === 0 && (
-                <tr><td colSpan={6} className="py-6 text-center text-text-subtle italic">No outstanding liabilities — nice.</td></tr>
-              )}
-              {liabilities.map((l) => (
-                <tr key={l.id} className="hover:bg-surface-muted/50">
-                  <td className="py-2 px-4 text-text">{l.name}</td>
-                  <td className="py-2 px-4">
-                    <Badge tone="neutral" className="text-[10px]">{LIABILITY_MAP[l.type].label}</Badge>
-                  </td>
-                  <td className="py-2 px-4 text-right tabular-nums text-text">{fmtMoney(l.balanceCents)}</td>
-                  <td className="py-2 px-4 text-right tabular-nums text-text-muted">{l.interestRate ? `${(l.interestRate * 100).toFixed(2)}%` : "—"}</td>
-                  <td className="py-2 px-4 text-right tabular-nums text-text-muted">{l.monthlyPaymentCents ? fmtMoney(l.monthlyPaymentCents) : "—"}</td>
-                  <td className="py-2 px-4 text-text-subtle">{l.maturityDate ? l.maturityDate.toLocaleDateString("en-US") : "—"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+      {/* Liability list — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <Eyebrow className="mb-4">Liabilities</Eyebrow>
+      <LiabilitiesTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/cfo/pnl/page.tsx
+++ b/src/app/(operator)/ops/cfo/pnl/page.tsx
@@ -7,6 +7,7 @@ import { rangeForPeriod, priorRange } from "@/lib/finance/period";
 import { buildPnl } from "@/lib/finance/pnl";
 import { fmtMoney, fmtPct, changeBadgeText } from "@/lib/finance/formatting";
 import { CfoTabs, GenerateReportButton, StatementSection } from "../components";
+import { PnlTable, type PnlRow } from "./pnl-table";
 
 export const metadata = { title: "P&L · CFO" };
 export const dynamic = "force-dynamic";
@@ -34,6 +35,26 @@ export default async function PnlPage({ searchParams }: { searchParams?: { perio
     { label: "Income & excise tax", current: pnl.totals.taxesCents, prior: priorPnl.totals.taxesCents, sign: -1 },
     { label: "Net income", current: pnl.totals.netIncomeCents, prior: priorPnl.totals.netIncomeCents, sign: 1 },
   ];
+
+  const pnlRows: PnlRow[] = lines.map((row) => {
+    const delta = row.current - row.prior;
+    const pct = row.prior !== 0 ? (delta / Math.abs(row.prior)) * 100 : null;
+    const change = changeBadgeText(pct, row.sign === 1);
+    return {
+      id: row.label,
+      line: row.label,
+      currentDisplay: fmtMoney(row.current),
+      currentCents: row.current,
+      priorDisplay: fmtMoney(row.prior),
+      priorCents: row.prior,
+      deltaDisplay: change.text,
+      deltaCents: delta,
+      badgeTone: change.tone === "good" ? "success" : change.tone === "bad" ? "danger" : "neutral",
+      badgeText: change.text,
+      periodLabel: range.period,
+      priorPeriodLabel: prior.period,
+    };
+  });
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -116,42 +137,10 @@ export default async function PnlPage({ searchParams }: { searchParams?: { perio
         />
       </div>
 
-      {/* Side by side: this period vs. prior */}
+      {/* Side by side: this period vs. prior — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
       <div className="mb-10">
         <Eyebrow className="mb-4">This period vs. prior</Eyebrow>
-        <Card tone="raised">
-          <CardContent className="pt-5 pb-5">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-[10px] uppercase tracking-[0.12em] text-text-subtle border-b border-border/60">
-                  <th className="text-left py-2 font-medium">Line</th>
-                  <th className="text-right py-2 font-medium">This {range.period}</th>
-                  <th className="text-right py-2 font-medium">Prior {prior.period}</th>
-                  <th className="text-right py-2 font-medium">Δ</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/60">
-                {lines.map((row) => {
-                  const delta = row.current - row.prior;
-                  const pct = row.prior !== 0 ? (delta / Math.abs(row.prior)) * 100 : null;
-                  const change = changeBadgeText(pct, row.sign === 1);
-                  return (
-                    <tr key={row.label}>
-                      <td className="py-2 text-text">{row.label}</td>
-                      <td className="py-2 text-right tabular-nums text-text">{fmtMoney(row.current)}</td>
-                      <td className="py-2 text-right tabular-nums text-text-muted">{fmtMoney(row.prior)}</td>
-                      <td className="py-2 text-right">
-                        <Badge tone={change.tone === "good" ? "success" : change.tone === "bad" ? "danger" : "neutral"} className="text-[10px]">
-                          {change.text}
-                        </Badge>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </CardContent>
-        </Card>
+        <PnlTable rows={pnlRows} periodLabel={range.period} priorPeriodLabel={prior.period} />
       </div>
 
       {/* Memo lines */}

--- a/src/app/(operator)/ops/cfo/pnl/pnl-table.tsx
+++ b/src/app/(operator)/ops/cfo/pnl/pnl-table.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+// P&L period comparison table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the table can be
+// downloaded or printed (G6). Money amounts are pre-formatted server-side and
+// passed as display strings; raw cents fields ride along for correct numeric sort.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface PnlRow {
+  id: string;
+  line: string;
+  currentDisplay: string;
+  currentCents: number;
+  priorDisplay: string;
+  priorCents: number;
+  deltaDisplay: string;
+  deltaCents: number;
+  badgeTone: "success" | "danger" | "neutral";
+  badgeText: string;
+  periodLabel: string;
+  priorPeriodLabel: string;
+}
+
+export function PnlTable({
+  rows,
+  periodLabel,
+  priorPeriodLabel,
+}: {
+  rows: PnlRow[];
+  periodLabel: string;
+  priorPeriodLabel: string;
+}) {
+  const columns: ColumnDef<PnlRow>[] = [
+    { key: "line", label: "Line", sortable: true },
+    {
+      key: "current",
+      label: `This ${periodLabel}`,
+      sortable: true,
+      align: "right",
+      cell: (r) => r.currentDisplay,
+      sortFn: (a, b) => a.currentCents - b.currentCents,
+      exportValue: (r) => (r.currentCents / 100).toFixed(2),
+    },
+    {
+      key: "prior",
+      label: `Prior ${priorPeriodLabel}`,
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="text-text-muted">{r.priorDisplay}</span>,
+      sortFn: (a, b) => a.priorCents - b.priorCents,
+      exportValue: (r) => (r.priorCents / 100).toFixed(2),
+    },
+    {
+      key: "delta",
+      label: "Δ",
+      sortable: true,
+      align: "right",
+      cell: (r) => (
+        <Badge tone={r.badgeTone} className="text-[10px]">
+          {r.badgeText}
+        </Badge>
+      ),
+      sortFn: (a, b) => a.deltaCents - b.deltaCents,
+      exportValue: (r) => r.badgeText,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="P&L period comparison"
+      exportable
+      exportName="pnl-period-comparison"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No P&L data for this period.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/daily-close/daily-close-table.tsx
+++ b/src/app/(operator)/ops/daily-close/daily-close-table.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// Last-30-days history table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole table
+// can be downloaded or printed (G6). Money and dates are pre-formatted
+// server-side; numeric sort fields ride along for correct magnitude ordering.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+
+export interface DailyCloseRow {
+  id: string;
+  /** Formatted date string, e.g. "06/10/2026" */
+  dateDisplay: string;
+  /** Epoch ms for sort */
+  dateMs: number;
+  billedDisplay: string;
+  billedCents: number;
+  paidDisplay: string;
+  paidCents: number;
+  arDisplay: string;
+  arCents: number;
+  stale: number;
+  overdue: number;
+}
+
+export function DailyCloseTable({ rows }: { rows: DailyCloseRow[] }) {
+  const columns: ColumnDef<DailyCloseRow>[] = [
+    {
+      key: "date",
+      label: "Date",
+      sortable: true,
+      cell: (r) => r.dateDisplay,
+      sortFn: (a, b) => a.dateMs - b.dateMs,
+      exportValue: (r) => r.dateDisplay,
+    },
+    {
+      key: "billed",
+      label: "Billed",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.billedDisplay,
+      sortFn: (a, b) => a.billedCents - b.billedCents,
+      exportValue: (r) => (r.billedCents / 100).toFixed(2),
+    },
+    {
+      key: "paid",
+      label: "Paid",
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="text-success">{r.paidDisplay}</span>,
+      sortFn: (a, b) => a.paidCents - b.paidCents,
+      exportValue: (r) => (r.paidCents / 100).toFixed(2),
+    },
+    {
+      key: "ar",
+      label: "AR",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.arDisplay,
+      sortFn: (a, b) => a.arCents - b.arCents,
+      exportValue: (r) => (r.arCents / 100).toFixed(2),
+    },
+    {
+      key: "stale",
+      label: "Stale",
+      sortable: true,
+      align: "right",
+      cell: (r) => String(r.stale),
+      sortFn: (a, b) => a.stale - b.stale,
+      exportValue: (r) => String(r.stale),
+    },
+    {
+      key: "overdue",
+      label: "Overdue",
+      sortable: true,
+      align: "right",
+      cell: (r) => String(r.overdue),
+      sortFn: (a, b) => a.overdue - b.overdue,
+      exportValue: (r) => String(r.overdue),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Daily close history"
+      exportable
+      exportName="daily-close"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No close history yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/daily-close/page.tsx
+++ b/src/app/(operator)/ops/daily-close/page.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow } from "@/components/ui/ornament";
 import { formatMoney } from "@/lib/domain/billing";
 import { formatDate } from "@/lib/utils/format";
+import { DailyCloseTable, type DailyCloseRow } from "./daily-close-table";
 
 export const metadata = { title: "RCM daily close" };
 
@@ -102,41 +103,29 @@ export default async function DailyClosePage() {
             </CardContent>
           </Card>
 
-          {recent.length > 1 && (
-            <>
-              <div className="mt-10 mb-4">
-                <Eyebrow>Last 30 days</Eyebrow>
-              </div>
-              <Card tone="raised">
-                <CardContent className="py-4">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wider border-b border-border/60">
-                        <th className="py-2">Date</th>
-                        <th className="py-2 text-right">Billed</th>
-                        <th className="py-2 text-right">Paid</th>
-                        <th className="py-2 text-right">AR</th>
-                        <th className="py-2 text-right">Stale</th>
-                        <th className="py-2 text-right">Overdue</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {recent.map((r) => (
-                        <tr key={r.id} className="border-b border-border/30 last:border-0">
-                          <td className="py-2 text-text">{formatDate(r.closeDate)}</td>
-                          <td className="py-2 text-right tabular-nums">{formatMoney(r.billedCents)}</td>
-                          <td className="py-2 text-right tabular-nums text-success">{formatMoney(r.paidCents)}</td>
-                          <td className="py-2 text-right tabular-nums">{formatMoney(r.outstandingArCents)}</td>
-                          <td className="py-2 text-right tabular-nums">{r.staleClaims}</td>
-                          <td className="py-2 text-right tabular-nums">{r.overdueAppeals}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </CardContent>
-              </Card>
-            </>
-          )}
+          {recent.length > 1 && (() => {
+            const historyRows: DailyCloseRow[] = recent.map((r) => ({
+              id: r.id,
+              dateDisplay: formatDate(r.closeDate),
+              dateMs: r.closeDate.getTime(),
+              billedDisplay: formatMoney(r.billedCents),
+              billedCents: r.billedCents,
+              paidDisplay: formatMoney(r.paidCents),
+              paidCents: r.paidCents,
+              arDisplay: formatMoney(r.outstandingArCents),
+              arCents: r.outstandingArCents,
+              stale: r.staleClaims,
+              overdue: r.overdueAppeals,
+            }));
+            return (
+              <>
+                <div className="mt-10 mb-4">
+                  <Eyebrow>Last 30 days</Eyebrow>
+                </div>
+                <DailyCloseTable rows={historyRows} />
+              </>
+            );
+          })()}
         </>
       )}
     </PageShell>

--- a/src/app/(operator)/ops/daily-report/appointments-table.tsx
+++ b/src/app/(operator)/ops/daily-report/appointments-table.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+// Appointments list, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5) and the table can be downloaded or
+// printed (G6).  Status uses the same colour tokens as the original inline
+// span; a raw statusKey field lets the column sort alphabetically by status
+// value.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { cn } from "@/lib/utils/cn";
+
+const STATUS_TONE: Record<string, { label: string; bg: string; text: string }> = {
+  completed:   { label: "Completed",   bg: "bg-emerald-50", text: "text-emerald-700" },
+  in_progress: { label: "In progress", bg: "bg-blue-50",    text: "text-blue-700"    },
+  no_show:     { label: "No-show",     bg: "bg-red-50",     text: "text-red-700"     },
+  cancelled:   { label: "Cancelled",   bg: "bg-gray-100",   text: "text-gray-600"    },
+};
+
+export interface AppointmentRow {
+  id: string;
+  time: string;
+  patient: string;
+  provider: string;
+  /** Raw status key — used as the sort field and for colour lookup */
+  statusKey: string;
+  /** Display label produced from statusKey */
+  statusLabel: string;
+  /** Modality display string (underscores replaced with dashes) */
+  modalityDisplay: string;
+  /** Raw modality key — used for CSV export */
+  modalityKey: string;
+}
+
+const columns: ColumnDef<AppointmentRow>[] = [
+  { key: "time",     label: "Time",     sortable: true },
+  { key: "patient",  label: "Patient",  sortable: true },
+  { key: "provider", label: "Provider", sortable: true },
+  {
+    key: "statusKey",
+    label: "Status",
+    sortable: true,
+    cell: (r) => {
+      const tone = STATUS_TONE[r.statusKey] ?? { label: r.statusLabel, bg: "bg-gray-100", text: "text-gray-600" };
+      return (
+        <span
+          className={cn(
+            "inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium",
+            tone.bg,
+            tone.text,
+          )}
+        >
+          {tone.label}
+        </span>
+      );
+    },
+    exportValue: (r) => r.statusLabel,
+  },
+  {
+    key: "modalityDisplay",
+    label: "Modality",
+    sortable: true,
+    sortFn: (a, b) => a.modalityKey.localeCompare(b.modalityKey),
+    exportValue: (r) => r.modalityKey,
+  },
+];
+
+export function AppointmentsTable({ rows }: { rows: AppointmentRow[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Appointments"
+      exportable
+      exportName="appointments"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No appointments for this date.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/daily-report/report-view.tsx
+++ b/src/app/(operator)/ops/daily-report/report-view.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils/cn";
 import type { DailyReportData, DemoAppointment } from "./page";
+import { AppointmentsTable, type AppointmentRow } from "./appointments-table";
 
 function fmtMoney(cents: number) {
   return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -142,46 +143,25 @@ export function ReportView({ data }: { data: DailyReportData }) {
         </Card>
       </div>
 
-      {/* Appointments table */}
-      <Card tone="raised">
-        <CardHeader>
-          <CardTitle className="text-base">Appointments</CardTitle>
-          <CardDescription>{data.appointments.length} on the schedule.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-[10px] uppercase tracking-wider text-text-subtle border-b border-border">
-                  <th className="py-2 font-medium">Time</th>
-                  <th className="py-2 font-medium">Patient</th>
-                  <th className="py-2 font-medium">Provider</th>
-                  <th className="py-2 font-medium">Status</th>
-                  <th className="py-2 font-medium">Modality</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.appointments.map((a) => {
-                  const tone = STATUS_TONE[a.status];
-                  return (
-                    <tr key={a.id} className="border-b border-border/40">
-                      <td className="py-2.5 font-mono text-xs">{a.time}</td>
-                      <td className="py-2.5">{a.patient}</td>
-                      <td className="py-2.5 text-text-muted">{a.provider}</td>
-                      <td className="py-2.5">
-                        <span className={cn("inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium", tone.bg, tone.text)}>
-                          {tone.label}
-                        </span>
-                      </td>
-                      <td className="py-2.5 text-text-muted capitalize">{a.modality.replace("_", "-")}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Appointments table — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <div>
+        <div className="mb-3">
+          <h2 className="text-base font-semibold text-text">Appointments</h2>
+          <p className="text-sm text-text-muted">{data.appointments.length} on the schedule.</p>
+        </div>
+        <AppointmentsTable
+          rows={data.appointments.map((a): AppointmentRow => ({
+            id: a.id,
+            time: a.time,
+            patient: a.patient,
+            provider: a.provider,
+            statusKey: a.status,
+            statusLabel: STATUS_TONE[a.status]?.label ?? a.status,
+            modalityDisplay: a.modality.replace("_", "-"),
+            modalityKey: a.modality,
+          }))}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/(operator)/ops/dispensary-reimbursement/page.tsx
+++ b/src/app/(operator)/ops/dispensary-reimbursement/page.tsx
@@ -12,16 +12,14 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import {
   Card,
   CardContent,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, LeafSprig } from "@/components/ui/ornament";
 import { getCurrentUser } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { DEFAULT_CAP_CENTS } from "@/lib/dispensary";
 import { homeForRoles } from "@/lib/rbac/roles";
+import { ReimbursementTable, type ReimbursementRow } from "./reimbursement-table";
 
 export const metadata = { title: "Dispensary reimbursement" };
 
@@ -43,10 +41,6 @@ function statusTone(status: string): "success" | "warning" | "accent" | "neutral
   }
 }
 
-function monthLabel(d: Date): string {
-  return d.toLocaleString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
-}
-
 export default async function DispensaryReimbursementPage() {
   const user = await getCurrentUser();
   if (!user) redirect("/sign-in");
@@ -63,7 +57,7 @@ export default async function DispensaryReimbursementPage() {
     );
   }
 
-  const rows = await prisma.dispensaryReimbursement.findMany({
+  const dbRows = await prisma.dispensaryReimbursement.findMany({
     where: { organizationId: user.organizationId },
     orderBy: [{ serviceMonth: "desc" }, { createdAt: "desc" }],
     include: {
@@ -72,9 +66,27 @@ export default async function DispensaryReimbursementPage() {
     },
   });
 
-  const totalDocumented = rows.reduce((s, r) => s + r.documentedSpendCents, 0);
-  const totalReimbursable = rows.reduce((s, r) => s + r.reimbursableCents, 0);
-  const submittedCount = rows.filter((r) => r.status === "submitted" || r.status === "approved").length;
+  const totalDocumented = dbRows.reduce((s, r) => s + r.documentedSpendCents, 0);
+  const totalReimbursable = dbRows.reduce((s, r) => s + r.reimbursableCents, 0);
+  const submittedCount = dbRows.filter((r) => r.status === "submitted" || r.status === "approved").length;
+
+  const rows: ReimbursementRow[] = dbRows.map((r) => ({
+    id: r.id,
+    patientName: `${r.patient.firstName} ${r.patient.lastName}`,
+    dispensaryName: r.dispensary.name,
+    serviceMonthDisplay: r.serviceMonth.toLocaleString("en-US", {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    }),
+    serviceMonthMs: r.serviceMonth.getTime(),
+    spendDisplay: `$${(r.documentedSpendCents / 100).toFixed(2)}`,
+    spendCents: r.documentedSpendCents,
+    reimbursableDisplay: `$${(r.reimbursableCents / 100).toFixed(2)}`,
+    reimbursableCents: r.reimbursableCents,
+    status: r.status,
+    statusTone: statusTone(r.status),
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1200px]">
@@ -119,59 +131,10 @@ export default async function DispensaryReimbursementPage() {
           description="When a patient documents cannabis spend, it shows up here. The annual cap ($500) is the maximum reimbursable per patient per calendar year."
         />
       ) : (
-        <Card tone="raised">
-          <CardHeader>
-            <CardTitle className="text-base">Reimbursement records</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-left">
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
-                      Patient
-                    </th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
-                      Dispensary
-                    </th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide">
-                      Service month
-                    </th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide text-right">
-                      Spend
-                    </th>
-                    <th className="py-2 pr-4 font-medium text-text-subtle text-xs uppercase tracking-wide text-right">
-                      Reimbursable
-                    </th>
-                    <th className="py-2 font-medium text-text-subtle text-xs uppercase tracking-wide">
-                      Status
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/40">
-                  {rows.map((r) => (
-                    <tr key={r.id}>
-                      <td className="py-3 pr-4 font-medium text-text">
-                        {r.patient.firstName} {r.patient.lastName}
-                      </td>
-                      <td className="py-3 pr-4 text-text-muted">{r.dispensary.name}</td>
-                      <td className="py-3 pr-4 text-text-muted">{monthLabel(r.serviceMonth)}</td>
-                      <td className="py-3 pr-4 text-right tabular-nums">
-                        {dollars(r.documentedSpendCents)}
-                      </td>
-                      <td className="py-3 pr-4 text-right tabular-nums">
-                        {dollars(r.reimbursableCents)}
-                      </td>
-                      <td className="py-3">
-                        <Badge tone={statusTone(r.status)}>{r.status}</Badge>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </CardContent>
-        </Card>
+        <>
+          <Eyebrow className="mb-4">Reimbursement records</Eyebrow>
+          <ReimbursementTable rows={rows} />
+        </>
       )}
 
       <p className="text-[11px] text-text-subtle mt-6 max-w-2xl leading-relaxed">

--- a/src/app/(operator)/ops/dispensary-reimbursement/reimbursement-table.tsx
+++ b/src/app/(operator)/ops/dispensary-reimbursement/reimbursement-table.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+// Dispensary reimbursement table, adopted onto the shared <DataTable> primitive
+// so every column header sorts (MASTER prompt G5) and the whole table can be
+// downloaded or printed (G6). Money is pre-formatted server-side and passed as
+// display strings; the numeric *cents* fields ride along purely so the columns
+// sort by real magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface ReimbursementRow {
+  id: string;
+  patientName: string;
+  dispensaryName: string;
+  serviceMonthDisplay: string;
+  serviceMonthMs: number;
+  spendDisplay: string;
+  spendCents: number;
+  reimbursableDisplay: string;
+  reimbursableCents: number;
+  status: string;
+  statusTone: "success" | "warning" | "accent" | "neutral";
+}
+
+export function ReimbursementTable({ rows }: { rows: ReimbursementRow[] }) {
+  const columns: ColumnDef<ReimbursementRow>[] = [
+    { key: "patientName", label: "Patient", sortable: true },
+    { key: "dispensaryName", label: "Dispensary", sortable: true },
+    {
+      key: "serviceMonth",
+      label: "Service month",
+      sortable: true,
+      cell: (r) => r.serviceMonthDisplay,
+      sortFn: (a, b) => a.serviceMonthMs - b.serviceMonthMs,
+      exportValue: (r) => r.serviceMonthDisplay,
+    },
+    {
+      key: "spend",
+      label: "Spend",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.spendDisplay,
+      sortFn: (a, b) => a.spendCents - b.spendCents,
+      exportValue: (r) => (r.spendCents / 100).toFixed(2),
+    },
+    {
+      key: "reimbursable",
+      label: "Reimbursable",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.reimbursableDisplay,
+      sortFn: (a, b) => a.reimbursableCents - b.reimbursableCents,
+      exportValue: (r) => (r.reimbursableCents / 100).toFixed(2),
+    },
+    {
+      key: "status",
+      label: "Status",
+      sortable: true,
+      cell: (r) => <Badge tone={r.statusTone}>{r.status}</Badge>,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Reimbursement records"
+      exportable
+      exportName="dispensary-reimbursement"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No reimbursement records yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/marketplace-benchmark/benchmark-table.tsx
+++ b/src/app/(operator)/ops/marketplace-benchmark/benchmark-table.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+// Marketplace Benchmark feature-matrix table, adopted onto the shared
+// <DataTable> primitive so every column header sorts (MASTER prompt G5 /
+// EMR-303) and the whole table can be downloaded or printed (G6).
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+const STATUS_TONE: Record<string, string> = {
+  shipped: "bg-leaf-soft text-leaf-ink",
+  partial: "bg-amber-100 text-amber-800",
+  missing: "bg-rose-100 text-rose-800",
+};
+
+export interface BenchmarkRow {
+  id: string;
+  name: string;
+  notes: string | null;
+  categoryLabel: string;
+  category: string;
+  amazonReference: string;
+  status: "shipped" | "partial" | "missing";
+  priority: "P0" | "P1" | "P2";
+  ticket: string | null;
+}
+
+export function BenchmarkTable({ rows }: { rows: BenchmarkRow[] }) {
+  const columns: ColumnDef<BenchmarkRow>[] = [
+    {
+      key: "name",
+      label: "Feature",
+      sortable: true,
+      cell: (r) => (
+        <div>
+          <div className="font-medium text-text">{r.name}</div>
+          {r.notes && (
+            <div className="text-xs text-text-muted mt-1">{r.notes}</div>
+          )}
+        </div>
+      ),
+      exportValue: (r) => r.name,
+    },
+    {
+      key: "categoryLabel",
+      label: "Category",
+      sortable: true,
+      cell: (r) => (
+        <span className="text-text-muted">{r.categoryLabel}</span>
+      ),
+    },
+    {
+      key: "amazonReference",
+      label: "Amazon reference",
+      sortable: true,
+      cell: (r) => (
+        <span className="text-text-muted">{r.amazonReference}</span>
+      ),
+    },
+    {
+      key: "status",
+      label: "Status",
+      sortable: true,
+      cell: (r) => (
+        <span
+          className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_TONE[r.status]}`}
+        >
+          {r.status}
+        </span>
+      ),
+      exportValue: (r) => r.status,
+    },
+    {
+      key: "priority",
+      label: "Priority",
+      sortable: true,
+      cell: (r) => <Badge>{r.priority}</Badge>,
+      exportValue: (r) => r.priority,
+    },
+    {
+      key: "ticket",
+      label: "Ticket",
+      sortable: true,
+      cell: (r) => (
+        <span className="font-mono text-xs">{r.ticket ?? "—"}</span>
+      ),
+      exportValue: (r) => r.ticket ?? "",
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Feature matrix"
+      exportable
+      exportName="marketplace-benchmark"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No benchmark features defined.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/marketplace-benchmark/page.tsx
+++ b/src/app/(operator)/ops/marketplace-benchmark/page.tsx
@@ -5,7 +5,6 @@
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import {
   BENCHMARK_FEATURES,
   categoryScores,
@@ -13,14 +12,9 @@ import {
   overallParity,
   type BenchmarkFeature,
 } from "@/lib/marketplace/benchmark";
+import { BenchmarkTable, type BenchmarkRow } from "./benchmark-table";
 
 export const metadata = { title: "Marketplace Benchmark" };
-
-const STATUS_TONE: Record<BenchmarkFeature["theleafmartStatus"], string> = {
-  shipped: "bg-leaf-soft text-leaf-ink",
-  partial: "bg-amber-100 text-amber-800",
-  missing: "bg-rose-100 text-rose-800",
-};
 
 const CATEGORY_LABEL: Record<BenchmarkFeature["category"], string> = {
   discovery: "Discovery",
@@ -38,6 +32,18 @@ export default async function MarketplaceBenchmarkPage() {
   const parity = overallParity();
   const scores = categoryScores().sort((a, b) => a.parityScore - b.parityScore);
   const gaps = gapAreas();
+
+  const rows: BenchmarkRow[] = BENCHMARK_FEATURES.map((f) => ({
+    id: f.id,
+    name: f.name,
+    notes: f.notes ?? null,
+    categoryLabel: CATEGORY_LABEL[f.category],
+    category: f.category,
+    amazonReference: f.amazonReference,
+    status: f.theleafmartStatus,
+    priority: f.priority,
+    ticket: f.ticket ?? null,
+  }));
 
   return (
     <PageShell>
@@ -118,54 +124,8 @@ export default async function MarketplaceBenchmarkPage() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Feature matrix</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-xs uppercase text-text-muted border-b border-border">
-                  <th className="py-2 pr-4">Feature</th>
-                  <th className="py-2 pr-4">Category</th>
-                  <th className="py-2 pr-4">Amazon reference</th>
-                  <th className="py-2 pr-4">Status</th>
-                  <th className="py-2 pr-4">Priority</th>
-                  <th className="py-2 pr-4">Ticket</th>
-                </tr>
-              </thead>
-              <tbody>
-                {BENCHMARK_FEATURES.map((f) => (
-                  <tr key={f.id} className="border-b border-border/50 align-top">
-                    <td className="py-3 pr-4">
-                      <div className="font-medium text-text">{f.name}</div>
-                      {f.notes && (
-                        <div className="text-xs text-text-muted mt-1">{f.notes}</div>
-                      )}
-                    </td>
-                    <td className="py-3 pr-4 text-text-muted">
-                      {CATEGORY_LABEL[f.category]}
-                    </td>
-                    <td className="py-3 pr-4 text-text-muted">{f.amazonReference}</td>
-                    <td className="py-3 pr-4">
-                      <span
-                        className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_TONE[f.theleafmartStatus]}`}
-                      >
-                        {f.theleafmartStatus}
-                      </span>
-                    </td>
-                    <td className="py-3 pr-4">
-                      <Badge>{f.priority}</Badge>
-                    </td>
-                    <td className="py-3 pr-4 font-mono text-xs">{f.ticket ?? "—"}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Feature matrix — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <BenchmarkTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/payment-methods/page.tsx
+++ b/src/app/(operator)/ops/payment-methods/page.tsx
@@ -1,13 +1,9 @@
-import Link from "next/link";
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
-import { EmptyState } from "@/components/ui/empty-state";
-import { Avatar } from "@/components/ui/avatar";
 import { formatDate } from "@/lib/utils/format";
+import { PaymentMethodsTable, type PaymentMethodRow } from "./payment-methods-table";
 
 export const metadata = { title: "Stored Payment Methods" };
 
@@ -32,6 +28,27 @@ export default async function PaymentMethodsPage() {
   const defaultCount = methods.filter((m) => m.isDefault).length;
   const uniquePatients = new Set(methods.map((m) => m.patientId)).size;
 
+  const rows: PaymentMethodRow[] = methods.map((m) => ({
+    id: m.id,
+    patientId: m.patient.id,
+    patientFirstName: m.patient.firstName,
+    patientLastName: m.patient.lastName,
+    type: m.type,
+    brand: m.brand ?? null,
+    last4: m.last4 ?? null,
+    expiresDisplay:
+      m.expiryMonth && m.expiryYear
+        ? `${String(m.expiryMonth).padStart(2, "0")}/${String(m.expiryYear).slice(-2)}`
+        : "—",
+    expiresOrdinal:
+      m.expiryMonth && m.expiryYear
+        ? m.expiryYear * 100 + m.expiryMonth
+        : 0,
+    savedDisplay: formatDate(m.createdAt),
+    savedMs: m.createdAt.getTime(),
+    isDefault: m.isDefault,
+  }));
+
   return (
     <PageShell maxWidth="max-w-[1320px]">
       <PageHeader
@@ -47,67 +64,8 @@ export default async function PaymentMethodsPage() {
         <StatCard label="ACH" value={String(achCount)} tone="info" size="md" />
       </div>
 
-      {methods.length === 0 ? (
-        <EmptyState
-          title="No stored methods yet"
-          description="Patients can save a card or bank account from the portal billing tab. Tokens are stored at Payabli — never PAN."
-        />
-      ) : (
-        <Card tone="raised">
-          <CardContent className="p-0">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-left">
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Patient</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Type</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Brand</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Last 4</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Expires</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Saved</th>
-                    <th className="py-3 px-5 font-medium text-text-subtle text-[10px] uppercase tracking-wider">Default</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {methods.map((m) => (
-                    <tr key={m.id} className="hover:bg-surface-muted/40 transition-colors">
-                      <td className="py-3 px-5">
-                        <Link
-                          href={`/clinic/patients/${m.patient.id}`}
-                          className="flex items-center gap-2 group"
-                        >
-                          <Avatar
-                            firstName={m.patient.firstName}
-                            lastName={m.patient.lastName}
-                            size="sm"
-                          />
-                          <span className="font-medium text-text group-hover:text-accent transition-colors">
-                            {m.patient.firstName} {m.patient.lastName}
-                          </span>
-                        </Link>
-                      </td>
-                      <td className="py-3 px-5">
-                        <Badge tone={m.type === "card" ? "accent" : "info"}>
-                          {m.type.toUpperCase()}
-                        </Badge>
-                      </td>
-                      <td className="py-3 px-5 text-text">{m.brand ?? "—"}</td>
-                      <td className="py-3 px-5 tabular-nums text-text">•••• {m.last4}</td>
-                      <td className="py-3 px-5 tabular-nums text-text-muted">
-                        {m.expiryMonth && m.expiryYear
-                          ? `${String(m.expiryMonth).padStart(2, "0")}/${String(m.expiryYear).slice(-2)}`
-                          : "—"}
-                      </td>
-                      <td className="py-3 px-5 text-text-muted">{formatDate(m.createdAt)}</td>
-                      <td className="py-3 px-5">{m.isDefault ? <Badge tone="success">Default</Badge> : null}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {/* Payment methods list — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <PaymentMethodsTable rows={rows} />
 
       <p className="text-xs text-text-subtle mt-6">
         {defaultCount} patient(s) have a default method set. Charges flow through{" "}

--- a/src/app/(operator)/ops/payment-methods/payment-methods-table.tsx
+++ b/src/app/(operator)/ops/payment-methods/payment-methods-table.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+// Stored payment methods list, adopted onto the shared <DataTable> primitive
+// so every column header sorts (MASTER prompt G5 / EMR-1018) and the whole
+// table can be downloaded or printed (G6). Dates are pre-formatted
+// server-side; numeric sort fields ride along for real-magnitude ordering.
+
+import Link from "next/link";
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+import { Avatar } from "@/components/ui/avatar";
+
+export interface PaymentMethodRow {
+  id: string;
+  patientId: string;
+  patientFirstName: string;
+  patientLastName: string;
+  type: "card" | "ach" | string;
+  brand: string | null;
+  last4: string | null;
+  expiresDisplay: string;
+  /** expiryYear * 100 + expiryMonth, or 0 when absent — used for sort only */
+  expiresOrdinal: number;
+  savedDisplay: string;
+  savedMs: number;
+  isDefault: boolean;
+}
+
+export function PaymentMethodsTable({ rows }: { rows: PaymentMethodRow[] }) {
+  const columns: ColumnDef<PaymentMethodRow>[] = [
+    {
+      key: "patient",
+      label: "Patient",
+      sortable: true,
+      sortFn: (a, b) =>
+        `${a.patientLastName} ${a.patientFirstName}`.localeCompare(
+          `${b.patientLastName} ${b.patientFirstName}`
+        ),
+      cell: (r) => (
+        <Link
+          href={`/clinic/patients/${r.patientId}`}
+          className="flex items-center gap-2 group"
+        >
+          <Avatar firstName={r.patientFirstName} lastName={r.patientLastName} size="sm" />
+          <span className="font-medium text-text group-hover:text-accent transition-colors">
+            {r.patientFirstName} {r.patientLastName}
+          </span>
+        </Link>
+      ),
+      exportValue: (r) => `${r.patientFirstName} ${r.patientLastName}`,
+    },
+    {
+      key: "type",
+      label: "Type",
+      sortable: true,
+      cell: (r) => (
+        <Badge tone={r.type === "card" ? "accent" : "info"}>
+          {r.type.toUpperCase()}
+        </Badge>
+      ),
+      exportValue: (r) => r.type.toUpperCase(),
+    },
+    {
+      key: "brand",
+      label: "Brand",
+      sortable: true,
+      cell: (r) => r.brand ?? "—",
+      exportValue: (r) => r.brand ?? "",
+    },
+    {
+      key: "last4",
+      label: "Last 4",
+      sortable: true,
+      cell: (r) => (r.last4 ? `•••• ${r.last4}` : "—"),
+      exportValue: (r) => r.last4 ?? "",
+    },
+    {
+      key: "expires",
+      label: "Expires",
+      sortable: true,
+      cell: (r) => r.expiresDisplay,
+      sortFn: (a, b) => a.expiresOrdinal - b.expiresOrdinal,
+      exportValue: (r) => r.expiresDisplay,
+    },
+    {
+      key: "saved",
+      label: "Saved",
+      sortable: true,
+      cell: (r) => r.savedDisplay,
+      sortFn: (a, b) => a.savedMs - b.savedMs,
+      exportValue: (r) => r.savedDisplay,
+    },
+    {
+      key: "isDefault",
+      label: "Default",
+      sortable: true,
+      sortFn: (a, b) => Number(b.isDefault) - Number(a.isDefault),
+      cell: (r) =>
+        r.isDefault ? <Badge tone="success">Default</Badge> : null,
+      exportValue: (r) => (r.isDefault ? "Yes" : ""),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Stored payment methods"
+      exportable
+      exportName="payment-methods"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No stored methods yet — patients can save a card or bank account from
+          the portal billing tab.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/platform/business-plan/funding-table.tsx
+++ b/src/app/(operator)/ops/platform/business-plan/funding-table.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+// Use-of-proceeds table adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can be
+// downloaded or printed (G6). Money is pre-formatted server-side and passed as
+// display strings; the numeric field rides along purely so the Allocation column
+// sorts by real magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+
+export interface FundingUseRow {
+  id: string;
+  category: string;
+  allocationDisplay: string;
+  allocationUsd: number;
+  rationale: string;
+}
+
+export function FundingTable({ rows }: { rows: FundingUseRow[] }) {
+  const columns: ColumnDef<FundingUseRow>[] = [
+    { key: "category", label: "Use of proceeds", sortable: true },
+    {
+      key: "allocation",
+      label: "Allocation",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.allocationDisplay,
+      sortFn: (a, b) => a.allocationUsd - b.allocationUsd,
+      exportValue: (r) => r.allocationUsd.toFixed(2),
+    },
+    { key: "rationale", label: "Rationale", sortable: true },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Funding use of proceeds"
+      exportable
+      exportName="funding-use-of-proceeds"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No use-of-proceeds entries defined.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/platform/business-plan/page.tsx
+++ b/src/app/(operator)/ops/platform/business-plan/page.tsx
@@ -11,6 +11,7 @@ import {
   fundingSanityCheck,
   totalQuarterlySpend,
 } from "@/lib/platform/business-plan";
+import { FundingTable, type FundingUseRow } from "./funding-table";
 
 export const metadata = { title: "Business plan" };
 
@@ -33,6 +34,14 @@ export default async function BusinessPlanPage() {
   const sanity = fundingSanityCheck();
   const totalSpend = totalQuarterlySpend();
   const expectedCloses = expectedQuarterlyCloses();
+
+  const fundingRows: FundingUseRow[] = FUNDING.use.map((u, i) => ({
+    id: String(i),
+    category: u.category,
+    allocationDisplay: fmtUsd(u.allocationUsd),
+    allocationUsd: u.allocationUsd,
+    rationale: u.rationale,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1100px]">
@@ -210,28 +219,7 @@ export default async function BusinessPlanPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wide">
-                    <th className="py-2 pr-4">Use of proceeds</th>
-                    <th className="py-2 pr-4 text-right">Allocation</th>
-                    <th className="py-2">Rationale</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {FUNDING.use.map((u) => (
-                    <tr key={u.category} className="border-t border-border/60 align-top">
-                      <td className="py-3 pr-4 font-medium">{u.category}</td>
-                      <td className="py-3 pr-4 text-right font-mono">
-                        {fmtUsd(u.allocationUsd)}
-                      </td>
-                      <td className="py-3 text-text-muted">{u.rationale}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <FundingTable rows={fundingRows} />
             <p
               className={`text-[11px] mt-4 ${
                 sanity.matchesRaise ? "text-text-subtle" : "text-danger"

--- a/src/app/(operator)/ops/platform/fhir-bridge/fhir-resources-table.tsx
+++ b/src/app/(operator)/ops/platform/fhir-bridge/fhir-resources-table.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// FHIR resource coverage table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can
+// be downloaded or printed (G6).
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface FhirResourceRow {
+  id: string;
+  resource: string;
+  description: string;
+  /** Comma-separated for export; rendered as individual badges in the cell. */
+  operationsDisplay: string;
+  /** The raw array, used by the sort function and badge cell. */
+  operations: string[];
+}
+
+export function FhirResourcesTable({ rows }: { rows: FhirResourceRow[] }) {
+  const columns: ColumnDef<FhirResourceRow>[] = [
+    {
+      key: "resource",
+      label: "Resource",
+      sortable: true,
+      cell: (r) => <span className="font-mono">{r.resource}</span>,
+    },
+    {
+      key: "description",
+      label: "Description",
+      sortable: true,
+      cell: (r) => <span className="text-text-muted">{r.description}</span>,
+    },
+    {
+      key: "operationsDisplay",
+      label: "Operations",
+      sortable: true,
+      cell: (r) => (
+        <div className="flex flex-wrap gap-1">
+          {r.operations.map((op) => (
+            <Badge key={op} tone="success">
+              {op}
+            </Badge>
+          ))}
+        </div>
+      ),
+      sortFn: (a, b) => a.operations.length - b.operations.length,
+      exportValue: (r) => r.operationsDisplay,
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="FHIR resource coverage"
+      exportable
+      exportName="fhir-resources"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No FHIR resources configured.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/platform/fhir-bridge/page.tsx
+++ b/src/app/(operator)/ops/platform/fhir-bridge/page.tsx
@@ -3,7 +3,7 @@ import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { FhirResourcesTable, type FhirResourceRow } from "./fhir-resources-table";
 
 export const metadata = { title: "FHIR bridge" };
 
@@ -37,6 +37,15 @@ const RESOURCES = [
 
 export default async function FhirBridgePage() {
   await requireUser();
+
+  const rows: FhirResourceRow[] = RESOURCES.map((r) => ({
+    id: r.name,
+    resource: r.name,
+    description: r.description,
+    operationsDisplay: r.coverage.join(", "),
+    operations: r.coverage,
+  }));
+
   return (
     <PageShell maxWidth="max-w-[960px]">
       <PageHeader
@@ -81,42 +90,10 @@ export default async function FhirBridgePage() {
         </Card>
       </div>
 
-      <Card className="mb-8">
-        <CardHeader>
-          <CardTitle>Resource coverage</CardTitle>
-          <CardDescription>Each row maps a Leafjourney concept to a FHIR R4 resource.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wide">
-                  <th className="py-2 pr-4">Resource</th>
-                  <th className="py-2 pr-4">Description</th>
-                  <th className="py-2">Operations</th>
-                </tr>
-              </thead>
-              <tbody>
-                {RESOURCES.map((r) => (
-                  <tr key={r.name} className="border-t border-border/60 align-top">
-                    <td className="py-3 pr-4 font-mono">{r.name}</td>
-                    <td className="py-3 pr-4 text-text-muted">{r.description}</td>
-                    <td className="py-3">
-                      <div className="flex flex-wrap gap-1">
-                        {r.coverage.map((op) => (
-                          <Badge key={op} tone="success">
-                            {op}
-                          </Badge>
-                        ))}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Resource coverage — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <div className="mb-8">
+        <FhirResourcesTable rows={rows} />
+      </div>
 
       <Card>
         <CardHeader>

--- a/src/app/(operator)/ops/platform/mips/mips-table.tsx
+++ b/src/app/(operator)/ops/platform/mips/mips-table.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+// MIPS measure detail table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the table can be
+// downloaded or printed (G6). Numerics are pre-formatted server-side and passed
+// as display strings; raw numeric fields ride along purely for sort magnitude.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface MipsMeasureRow {
+  id: string;
+  /** e.g. "MIPS-001" */
+  measureId: string;
+  title: string;
+  categoryLabel: string;
+  numerator: number;
+  denominator: number;
+  /** display string e.g. "73%" */
+  performanceDisplay: string;
+  /** raw 0–1 fraction for sorting */
+  performance: number;
+  /** display string e.g. "8.5" */
+  scoreDisplay: string;
+  /** raw number for sorting */
+  scorePoints: number;
+  /** raw blocker count for sorting */
+  blockerCount: number;
+}
+
+export function MipsTable({ rows }: { rows: MipsMeasureRow[] }) {
+  const columns: ColumnDef<MipsMeasureRow>[] = [
+    {
+      key: "measure",
+      label: "Measure",
+      sortable: true,
+      sortFn: (a, b) => a.title.localeCompare(b.title),
+      exportValue: (r) => `${r.measureId} – ${r.title} (${r.categoryLabel})`,
+      cell: (r) => (
+        <div>
+          <p className="font-medium">{r.title}</p>
+          <p className="text-[11px] text-text-subtle font-mono">
+            {r.measureId} · {r.categoryLabel}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: "numerator",
+      label: "Numerator",
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="font-mono">{r.numerator}</span>,
+      sortFn: (a, b) => a.numerator - b.numerator,
+      exportValue: (r) => String(r.numerator),
+    },
+    {
+      key: "denominator",
+      label: "Denominator",
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="font-mono">{r.denominator}</span>,
+      sortFn: (a, b) => a.denominator - b.denominator,
+      exportValue: (r) => String(r.denominator),
+    },
+    {
+      key: "performance",
+      label: "Performance",
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="font-mono">{r.performanceDisplay}</span>,
+      sortFn: (a, b) => a.performance - b.performance,
+      exportValue: (r) => r.performanceDisplay,
+    },
+    {
+      key: "score",
+      label: "Score",
+      sortable: true,
+      align: "right",
+      cell: (r) => <span className="font-mono">{r.scoreDisplay}</span>,
+      sortFn: (a, b) => a.scorePoints - b.scorePoints,
+      exportValue: (r) => r.scoreDisplay,
+    },
+    {
+      key: "blockers",
+      label: "Blockers",
+      sortable: true,
+      sortFn: (a, b) => a.blockerCount - b.blockerCount,
+      exportValue: (r) =>
+        r.blockerCount === 0 ? "All clear" : `${r.blockerCount} patient(s)`,
+      cell: (r) =>
+        r.blockerCount === 0 ? (
+          <Badge tone="success">All clear</Badge>
+        ) : (
+          <span className="text-text-muted text-xs">
+            {r.blockerCount} patient(s)
+          </span>
+        ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="MIPS measures"
+      exportable
+      exportName="mips-measures"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No measures available for this period.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/platform/mips/page.tsx
+++ b/src/app/(operator)/ops/platform/mips/page.tsx
@@ -1,8 +1,8 @@
 import { requireUser } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { extrapolate, demoCohort, type MipsCategory } from "@/lib/platform/mips";
+import { MipsTable, type MipsMeasureRow } from "./mips-table";
 
 export const metadata = { title: "MIPS console" };
 
@@ -19,6 +19,20 @@ export default async function MipsPage() {
   // Until the live cohort builder is wired in, we render the demo cohort.
   // The agent (mipsExtrapolator) is what production will call.
   const result = extrapolate(demoCohort());
+
+  const rows: MipsMeasureRow[] = result.measures.map((m) => ({
+    id: m.measureId,
+    measureId: m.measureId,
+    title: m.title,
+    categoryLabel: CATEGORY_LABELS[m.category as MipsCategory],
+    numerator: m.numerator,
+    denominator: m.denominator,
+    performanceDisplay: `${(m.performance * 100).toFixed(0)}%`,
+    performance: m.performance,
+    scoreDisplay: m.scorePoints.toFixed(1),
+    scorePoints: m.scorePoints,
+    blockerCount: m.blockers.length,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1100px]">
@@ -101,55 +115,8 @@ export default async function MipsPage() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Measure detail</CardTitle>
-          <CardDescription>
-            Numerator / denominator with the patients blocking each measure.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wide">
-                  <th className="py-2 pr-4">Measure</th>
-                  <th className="py-2 pr-4 text-right">Numerator</th>
-                  <th className="py-2 pr-4 text-right">Denominator</th>
-                  <th className="py-2 pr-4 text-right">Performance</th>
-                  <th className="py-2 pr-4 text-right">Score</th>
-                  <th className="py-2">Blockers</th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.measures.map((m) => (
-                  <tr key={m.measureId} className="border-t border-border/60 align-top">
-                    <td className="py-3 pr-4">
-                      <p className="font-medium">{m.title}</p>
-                      <p className="text-[11px] text-text-subtle font-mono">
-                        {m.measureId} · {CATEGORY_LABELS[m.category as MipsCategory]}
-                      </p>
-                    </td>
-                    <td className="py-3 pr-4 text-right font-mono">{m.numerator}</td>
-                    <td className="py-3 pr-4 text-right font-mono">{m.denominator}</td>
-                    <td className="py-3 pr-4 text-right font-mono">
-                      {(m.performance * 100).toFixed(0)}%
-                    </td>
-                    <td className="py-3 pr-4 text-right font-mono">{m.scorePoints.toFixed(1)}</td>
-                    <td className="py-3 text-text-muted text-xs">
-                      {m.blockers.length === 0 ? (
-                        <Badge tone="success">All clear</Badge>
-                      ) : (
-                        <span>{m.blockers.length} patient(s)</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Measure detail — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <MipsTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/app/(operator)/ops/platform/modules/modules-tier-table.tsx
+++ b/src/app/(operator)/ops/platform/modules/modules-tier-table.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// Tier reference table, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5) and the whole table can be downloaded
+// or printed (G6). monthlyList rides along as the numeric field so the Monthly
+// column sorts by real price rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+
+export interface TierRow {
+  id: string;
+  label: string;
+  monthlyLabel: string;
+  monthlyList: number | null;
+  bestFor: string;
+  blurb: string;
+}
+
+export function ModulesTierTable({ rows }: { rows: TierRow[] }) {
+  const columns: ColumnDef<TierRow>[] = [
+    { key: "label", label: "Tier", sortable: true },
+    {
+      key: "monthly",
+      label: "Monthly",
+      sortable: true,
+      cell: (r) => r.monthlyLabel,
+      sortFn: (a, b) => (a.monthlyList ?? -1) - (b.monthlyList ?? -1),
+      exportValue: (r) =>
+        r.monthlyList != null ? String(r.monthlyList) : r.monthlyLabel,
+    },
+    { key: "bestFor", label: "Best for", sortable: true },
+    { key: "blurb", label: "Pitch", sortable: true },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Tier reference"
+      exportable
+      exportName="platform-modules-tiers"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No tiers defined.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/platform/modules/page.tsx
+++ b/src/app/(operator)/ops/platform/modules/page.tsx
@@ -10,6 +10,7 @@ import {
   type ModulePillar,
   type ModuleStatus,
 } from "@/lib/platform/modules";
+import { ModulesTierTable, type TierRow } from "./modules-tier-table";
 
 export const metadata = { title: "Platform modules" };
 
@@ -49,6 +50,15 @@ export default async function PlatformModulesPage() {
     ([, a], [, b]) => a.ordering - b.ordering,
   );
 
+  const tierRows: TierRow[] = tierEntries.map(([id, t]) => ({
+    id,
+    label: t.label,
+    monthlyLabel: t.monthlyLabel,
+    monthlyList: t.monthlyList,
+    bestFor: t.bestFor,
+    blurb: t.blurb,
+  }));
+
   return (
     <PageShell maxWidth="max-w-[1200px]">
       <PageHeader
@@ -87,38 +97,15 @@ export default async function PlatformModulesPage() {
         </Card>
       </div>
 
-      <Card className="mb-10">
-        <CardHeader>
+      <div className="mb-10">
+        <CardHeader className="px-0 pt-0">
           <CardTitle>Tier reference</CardTitle>
           <CardDescription>
             Each tier bundles a default module mix; à la carte add-ons available.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wide">
-                  <th className="py-2 pr-4">Tier</th>
-                  <th className="py-2 pr-4">Monthly</th>
-                  <th className="py-2 pr-4">Best for</th>
-                  <th className="py-2">Pitch</th>
-                </tr>
-              </thead>
-              <tbody>
-                {tierEntries.map(([id, t]) => (
-                  <tr key={id} className="border-t border-border/60 align-top">
-                    <td className="py-3 pr-4 font-medium">{t.label}</td>
-                    <td className="py-3 pr-4 font-mono text-[12px]">{t.monthlyLabel}</td>
-                    <td className="py-3 pr-4 text-text-muted">{t.bestFor}</td>
-                    <td className="py-3 text-text-muted">{t.blurb}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+        <ModulesTierTable rows={tierRows} />
+      </div>
 
       {orderedPillars.map((pillar) => (
         <section key={pillar} className="mb-10">

--- a/src/app/(operator)/ops/pricing/feature-matrix-table.tsx
+++ b/src/app/(operator)/ops/pricing/feature-matrix-table.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+// Feature matrix table, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole
+// table can be downloaded or printed (G6).
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+
+export interface FeatureMatrixRow {
+  feature: string;
+  starter: boolean;
+  growth: boolean;
+  scale: boolean;
+  enterprise: boolean;
+}
+
+function BoolCell({ value }: { value: boolean }) {
+  return value ? (
+    <span className="text-success font-medium">✓</span>
+  ) : (
+    <span className="text-text-subtle">—</span>
+  );
+}
+
+export function FeatureMatrixTable({ rows }: { rows: FeatureMatrixRow[] }) {
+  const columns: ColumnDef<FeatureMatrixRow>[] = [
+    { key: "feature", label: "Feature", sortable: true },
+    {
+      key: "starter",
+      label: "Starter",
+      sortable: true,
+      align: "center",
+      cell: (r) => <BoolCell value={r.starter} />,
+      sortFn: (a, b) => Number(a.starter) - Number(b.starter),
+      exportValue: (r) => (r.starter ? "Yes" : "No"),
+    },
+    {
+      key: "growth",
+      label: "Growth",
+      sortable: true,
+      align: "center",
+      cell: (r) => <BoolCell value={r.growth} />,
+      sortFn: (a, b) => Number(a.growth) - Number(b.growth),
+      exportValue: (r) => (r.growth ? "Yes" : "No"),
+    },
+    {
+      key: "scale",
+      label: "Scale",
+      sortable: true,
+      align: "center",
+      cell: (r) => <BoolCell value={r.scale} />,
+      sortFn: (a, b) => Number(a.scale) - Number(b.scale),
+      exportValue: (r) => (r.scale ? "Yes" : "No"),
+    },
+    {
+      key: "enterprise",
+      label: "Enterprise",
+      sortable: true,
+      align: "center",
+      cell: (r) => <BoolCell value={r.enterprise} />,
+      sortFn: (a, b) => Number(a.enterprise) - Number(b.enterprise),
+      exportValue: (r) => (r.enterprise ? "Yes" : "No"),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.feature}
+      ariaLabel="Feature matrix"
+      exportable
+      exportName="feature-matrix"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No features listed.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/pricing/page.tsx
+++ b/src/app/(operator)/ops/pricing/page.tsx
@@ -17,11 +17,29 @@ import {
   type CompetitorTier,
 } from "@/lib/billing/subscription";
 import { RoiCalculator } from "./RoiCalculator";
+import {
+  FeatureMatrixTable,
+  type FeatureMatrixRow,
+} from "./feature-matrix-table";
 
 export const metadata = { title: "Pricing · Leafjourney" };
 
 export default async function OpsPricingPage() {
   await requireUser();
+
+  const featureMatrixRows: FeatureMatrixRow[] = [
+    { feature: "Charting + scheduling + e-Rx", starter: true, growth: true, scale: true, enterprise: true },
+    { feature: "Patient portal", starter: true, growth: true, scale: true, enterprise: true },
+    { feature: "Basic claims billing", starter: true, growth: true, scale: true, enterprise: true },
+    { feature: "Dispensary POS + inventory", starter: false, growth: true, scale: true, enterprise: true },
+    { feature: "RCM agents (eligibility, scrubbing, denial)", starter: false, growth: true, scale: true, enterprise: true },
+    { feature: "ChatCB + cannabis contraindication checks", starter: false, growth: true, scale: true, enterprise: true },
+    { feature: "Multi-location consolidation", starter: false, growth: false, scale: true, enterprise: true },
+    { feature: "Research export (de-identified cohorts)", starter: false, growth: false, scale: true, enterprise: true },
+    { feature: "On-prem / VPC deployment", starter: false, growth: false, scale: false, enterprise: true },
+    { feature: "Custom HL7/FHIR/EDI integrations", starter: false, growth: false, scale: false, enterprise: true },
+    { feature: "Dedicated success manager", starter: false, growth: false, scale: true, enterprise: true },
+  ];
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -41,7 +59,7 @@ export default async function OpsPricingPage() {
       <EditorialRule className="my-10" />
 
       <Eyebrow className="mb-4">Feature matrix</Eyebrow>
-      <FeatureMatrix />
+      <FeatureMatrixTable rows={featureMatrixRows} />
 
       <EditorialRule className="my-10" />
 
@@ -131,60 +149,3 @@ function CompetitorCard({ competitor }: { competitor: CompetitorTier }) {
   );
 }
 
-function FeatureMatrix() {
-  const rows: Array<{ feature: string; tiers: Record<SubscriptionTier["id"], boolean> }> = [
-    { feature: "Charting + scheduling + e-Rx", tiers: { starter: true, growth: true, scale: true, enterprise: true } },
-    { feature: "Patient portal", tiers: { starter: true, growth: true, scale: true, enterprise: true } },
-    { feature: "Basic claims billing", tiers: { starter: true, growth: true, scale: true, enterprise: true } },
-    { feature: "Dispensary POS + inventory", tiers: { starter: false, growth: true, scale: true, enterprise: true } },
-    { feature: "RCM agents (eligibility, scrubbing, denial)", tiers: { starter: false, growth: true, scale: true, enterprise: true } },
-    { feature: "ChatCB + cannabis contraindication checks", tiers: { starter: false, growth: true, scale: true, enterprise: true } },
-    { feature: "Multi-location consolidation", tiers: { starter: false, growth: false, scale: true, enterprise: true } },
-    { feature: "Research export (de-identified cohorts)", tiers: { starter: false, growth: false, scale: true, enterprise: true } },
-    { feature: "On-prem / VPC deployment", tiers: { starter: false, growth: false, scale: false, enterprise: true } },
-    { feature: "Custom HL7/FHIR/EDI integrations", tiers: { starter: false, growth: false, scale: false, enterprise: true } },
-    { feature: "Dedicated success manager", tiers: { starter: false, growth: false, scale: true, enterprise: true } },
-  ];
-
-  return (
-    <Card tone="raised">
-      <CardContent className="pt-4 pb-4">
-        <div className="overflow-x-auto -mx-6">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left">
-                <th className="px-6 py-2 text-[10px] font-medium uppercase tracking-[0.14em] text-text-subtle">
-                  Feature
-                </th>
-                {TIERS.map((t) => (
-                  <th
-                    key={t.id}
-                    className="px-6 py-2 text-[10px] font-medium uppercase tracking-[0.14em] text-text-subtle text-center"
-                  >
-                    {t.name}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {rows.map((row) => (
-                <tr key={row.feature} className="hover:bg-surface-muted/40">
-                  <td className="px-6 py-2.5 text-text">{row.feature}</td>
-                  {TIERS.map((t) => (
-                    <td key={t.id} className="px-6 py-2.5 text-center">
-                      {row.tiers[t.id] ? (
-                        <span className="text-success font-medium">✓</span>
-                      ) : (
-                        <span className="text-text-subtle">—</span>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}

--- a/src/app/(operator)/ops/reports/page.tsx
+++ b/src/app/(operator)/ops/reports/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
+import { ReportsTable, type ReportDataRow } from "./reports-table";
 import { ReportChart } from "@/components/analytics/report-chart";
 import {
   renderReport,
@@ -130,6 +131,17 @@ export default function ReportsPage({ searchParams }: PageProps) {
     }
     return v.toLocaleString(undefined, { maximumFractionDigits: 2 });
   }
+
+  const dimensionLabel =
+    DIMENSION_OPTIONS.find((d) => d.value === dimension)?.label ?? "Dimension";
+
+  const reportRows: ReportDataRow[] = report.rows.map((r) => ({
+    id: r.label,
+    label: r.label,
+    valueDisplay: fmt(r.value),
+    value: r.value,
+    forecast: r.forecast ?? false,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -296,38 +308,7 @@ export default function ReportsPage({ searchParams }: PageProps) {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border text-left">
-                  <th className="py-2 pr-3 text-text-subtle text-[11px] uppercase tracking-wider">
-                    {DIMENSION_OPTIONS.find((d) => d.value === dimension)?.label}
-                  </th>
-                  <th className="py-2 pr-3 text-right text-text-subtle text-[11px] uppercase tracking-wider">
-                    Value
-                  </th>
-                  <th className="py-2 text-text-subtle text-[11px] uppercase tracking-wider">
-                    Source
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {report.rows.map((r) => (
-                  <tr key={r.label}>
-                    <td className="py-2 pr-3 text-text">{r.label}</td>
-                    <td className="py-2 pr-3 text-right tabular-nums">{fmt(r.value)}</td>
-                    <td className="py-2">
-                      {r.forecast ? (
-                        <Badge tone="warning">forecast</Badge>
-                      ) : (
-                        <Badge tone="neutral">observed</Badge>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <ReportsTable rows={reportRows} dimensionLabel={dimensionLabel} />
           <div className="mt-4 flex flex-wrap gap-3 text-sm text-text-muted">
             <Link
               href="/ops/research-exports/builder"

--- a/src/app/(operator)/ops/reports/reports-table.tsx
+++ b/src/app/(operator)/ops/reports/reports-table.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+// Backing-data table for the Reports page, adopted onto the shared
+// <DataTable> primitive so every column header sorts (MASTER prompt G5 /
+// EMR-1018) and the whole table can be downloaded or printed (G6).
+// Values are pre-formatted server-side and passed as display strings; the
+// raw numeric field rides along purely so the Value column sorts by real
+// magnitude rather than by the formatted string.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface ReportDataRow {
+  /** Stable React key — same as label in practice. */
+  id: string;
+  /** Human label on the X axis (e.g. "Cannabis" or "2026-03"). */
+  label: string;
+  /** Pre-formatted display value (e.g. "$1,234" or "42"). */
+  valueDisplay: string;
+  /** Raw numeric value for correct magnitude sort. */
+  value: number;
+  /** True when this row is a forecast (projection reports). */
+  forecast: boolean;
+}
+
+interface ReportsTableProps {
+  rows: ReportDataRow[];
+  /** Column header for the dimension (e.g. "Conditions", "Providers"). */
+  dimensionLabel: string;
+}
+
+export function ReportsTable({ rows, dimensionLabel }: ReportsTableProps) {
+  const columns: ColumnDef<ReportDataRow>[] = [
+    {
+      key: "label",
+      label: dimensionLabel,
+      sortable: true,
+    },
+    {
+      key: "value",
+      label: "Value",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.valueDisplay,
+      sortFn: (a, b) => a.value - b.value,
+      exportValue: (r) => r.value,
+    },
+    {
+      key: "source",
+      label: "Source",
+      sortable: true,
+      cell: (r) =>
+        r.forecast ? (
+          <Badge tone="warning">forecast</Badge>
+        ) : (
+          <Badge tone="neutral">observed</Badge>
+        ),
+      sortFn: (a, b) =>
+        Number(a.forecast) - Number(b.forecast),
+      exportValue: (r) => (r.forecast ? "forecast" : "observed"),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Backing data"
+      exportable
+      exportName="report-data"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No data rows — adjust the dimension or metric and re-render.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/research-exports/claim-cohort-table.tsx
+++ b/src/app/(operator)/ops/research-exports/claim-cohort-table.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// Claim cohort table, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5) and the table can be downloaded or
+// printed (G6). Money pre-formatted server-side; raw cents fields ride along
+// for correct numeric sort.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface ClaimCohortRow {
+  claimPseudonym: string;
+  claimShort: string;
+  patientPseudonym: string;
+  patientShort: string;
+  serviceMonth: string;
+  payerCategory: string;
+  cptCodes: string;
+  icd10Codes: string;
+  billedDisplay: string;
+  billedCents: number;
+  paidDisplay: string;
+  paidCents: number;
+  status: string;
+}
+
+export function ClaimCohortTable({ rows }: { rows: ClaimCohortRow[] }) {
+  const columns: ColumnDef<ClaimCohortRow>[] = [
+    {
+      key: "claimShort",
+      label: "Claim",
+      sortable: true,
+      exportValue: (r) => r.claimPseudonym,
+    },
+    {
+      key: "patientShort",
+      label: "Patient",
+      sortable: true,
+      exportValue: (r) => r.patientPseudonym,
+    },
+    { key: "serviceMonth", label: "Month", sortable: true },
+    { key: "payerCategory", label: "Payer", sortable: true },
+    { key: "cptCodes", label: "CPTs", sortable: true },
+    { key: "icd10Codes", label: "ICD-10", sortable: true },
+    {
+      key: "billed",
+      label: "Billed",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.billedDisplay,
+      sortFn: (a, b) => a.billedCents - b.billedCents,
+      exportValue: (r) => (r.billedCents / 100).toFixed(2),
+    },
+    {
+      key: "paid",
+      label: "Paid",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.paidDisplay,
+      sortFn: (a, b) => a.paidCents - b.paidCents,
+      exportValue: (r) => (r.paidCents / 100).toFixed(2),
+    },
+    {
+      key: "status",
+      label: "Status",
+      sortable: true,
+      cell: (r) => (
+        <Badge
+          tone={
+            r.status === "paid"
+              ? "success"
+              : r.status === "denied"
+              ? "danger"
+              : "neutral"
+          }
+        >
+          {r.status}
+        </Badge>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.claimPseudonym}
+      ariaLabel="Claim cohort"
+      exportable
+      exportName="research-exports-claims"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No claims in the filtered cohort.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/research-exports/page.tsx
+++ b/src/app/(operator)/ops/research-exports/page.tsx
@@ -2,7 +2,6 @@ import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
-import { EmptyState } from "@/components/ui/empty-state";
 import {
   CohortPseudonymizer,
   buildCohortManifest,
@@ -13,6 +12,8 @@ import {
   type RawPatientFacts,
   type RawClaimFacts,
 } from "@/lib/billing/research-export";
+import { PatientCohortTable, type PatientCohortRow } from "./patient-cohort-table";
+import { ClaimCohortTable, type ClaimCohortRow } from "./claim-cohort-table";
 
 export const metadata = { title: "Researcher Exports" };
 
@@ -64,6 +65,35 @@ export default function ResearchExportsPage({
     return acc;
   }, {});
 
+  const patientRows: PatientCohortRow[] = kept.map((p) => ({
+    pseudonym: p.pseudonym,
+    ageDisplay: String(p.ageYears),
+    ageNum: p.ageYears === "90+" ? 90 : p.ageYears,
+    sex: p.sex ?? "—",
+    race: p.race ?? "—",
+    ethnicity: p.ethnicity ?? "—",
+    smokingStatus: p.smokingStatus ?? "—",
+    zipPrefix: p.zipPrefix === "000" ? "000" : (p.zipPrefix ?? "—"),
+    zipSuppressed: p.zipPrefix === "000",
+    socioeconomicTier: p.socioeconomicTier ?? "—",
+  }));
+
+  const claimRows: ClaimCohortRow[] = filteredClaims.map((c) => ({
+    claimPseudonym: c.claimPseudonym,
+    claimShort: c.claimPseudonym.slice(0, 12) + "…",
+    patientPseudonym: c.patientPseudonym,
+    patientShort: c.patientPseudonym.slice(0, 12) + "…",
+    serviceMonth: c.serviceMonth,
+    payerCategory: c.payerCategory,
+    cptCodes: c.cptCodes.join(", "),
+    icd10Codes: c.icd10Codes.join(", "),
+    billedDisplay: `$${(c.billedCents / 100).toFixed(2)}`,
+    billedCents: c.billedCents,
+    paidDisplay: `$${(c.paidCents / 100).toFixed(2)}`,
+    paidCents: c.paidCents,
+    status: c.status,
+  }));
+
   return (
     <PageShell maxWidth="max-w-[1320px]">
       <PageHeader
@@ -108,45 +138,7 @@ export default function ResearchExportsPage({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {kept.length === 0 ? (
-            <EmptyState
-              title="All buckets suppressed"
-              description="Lower the minimum cell size to view the cohort."
-            />
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs">
-                <thead>
-                  <tr className="border-b border-border text-left">
-                    <th className="py-2 pr-3 text-text-subtle">Pseudonym</th>
-                    <th className="py-2 pr-3 text-text-subtle">Age</th>
-                    <th className="py-2 pr-3 text-text-subtle">Sex</th>
-                    <th className="py-2 pr-3 text-text-subtle">Race</th>
-                    <th className="py-2 pr-3 text-text-subtle">Ethnicity</th>
-                    <th className="py-2 pr-3 text-text-subtle">Smoking</th>
-                    <th className="py-2 pr-3 text-text-subtle">ZIP3</th>
-                    <th className="py-2 text-text-subtle">SES</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {kept.map((p) => (
-                    <tr key={p.pseudonym}>
-                      <td className="py-2 pr-3 font-mono text-[11px]">{p.pseudonym}</td>
-                      <td className="py-2 pr-3 tabular-nums">{p.ageYears}</td>
-                      <td className="py-2 pr-3">{p.sex}</td>
-                      <td className="py-2 pr-3">{p.race}</td>
-                      <td className="py-2 pr-3">{p.ethnicity}</td>
-                      <td className="py-2 pr-3">{p.smokingStatus}</td>
-                      <td className="py-2 pr-3 tabular-nums">
-                        {p.zipPrefix === "000" ? <Badge tone="warning">000</Badge> : p.zipPrefix}
-                      </td>
-                      <td className="py-2">{p.socioeconomicTier}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+          <PatientCohortTable rows={patientRows} />
         </CardContent>
       </Card>
 
@@ -168,44 +160,7 @@ export default function ResearchExportsPage({
               </Badge>
             ))}
           </div>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border text-left">
-                  <th className="py-2 pr-3 text-text-subtle">Claim</th>
-                  <th className="py-2 pr-3 text-text-subtle">Patient</th>
-                  <th className="py-2 pr-3 text-text-subtle">Month</th>
-                  <th className="py-2 pr-3 text-text-subtle">Payer</th>
-                  <th className="py-2 pr-3 text-text-subtle">CPTs</th>
-                  <th className="py-2 pr-3 text-text-subtle">ICD-10</th>
-                  <th className="py-2 pr-3 text-text-subtle text-right">Billed</th>
-                  <th className="py-2 pr-3 text-text-subtle text-right">Paid</th>
-                  <th className="py-2 text-text-subtle">Status</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {filteredClaims.map((c) => (
-                  <tr key={c.claimPseudonym}>
-                    <td className="py-2 pr-3 font-mono text-[11px]">{c.claimPseudonym.slice(0, 12)}…</td>
-                    <td className="py-2 pr-3 font-mono text-[11px]">{c.patientPseudonym.slice(0, 12)}…</td>
-                    <td className="py-2 pr-3 tabular-nums">{c.serviceMonth}</td>
-                    <td className="py-2 pr-3">{c.payerCategory}</td>
-                    <td className="py-2 pr-3">{c.cptCodes.join(", ")}</td>
-                    <td className="py-2 pr-3">{c.icd10Codes.join(", ")}</td>
-                    <td className="py-2 pr-3 text-right tabular-nums">${(c.billedCents / 100).toFixed(2)}</td>
-                    <td className="py-2 pr-3 text-right tabular-nums">${(c.paidCents / 100).toFixed(2)}</td>
-                    <td className="py-2">
-                      <Badge
-                        tone={c.status === "paid" ? "success" : c.status === "denied" ? "danger" : "neutral"}
-                      >
-                        {c.status}
-                      </Badge>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <ClaimCohortTable rows={claimRows} />
         </CardContent>
       </Card>
     </PageShell>

--- a/src/app/(operator)/ops/research-exports/patient-cohort-table.tsx
+++ b/src/app/(operator)/ops/research-exports/patient-cohort-table.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+// Patient cohort table, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5) and the table can be downloaded or
+// printed (G6). Rows are plain text/numbers with one Badge for suppressed ZIP3.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+
+export interface PatientCohortRow {
+  pseudonym: string;
+  ageDisplay: string;
+  ageNum: number;
+  sex: string;
+  race: string;
+  ethnicity: string;
+  smokingStatus: string;
+  zipPrefix: string;
+  zipSuppressed: boolean;
+  socioeconomicTier: string;
+}
+
+export function PatientCohortTable({ rows }: { rows: PatientCohortRow[] }) {
+  const columns: ColumnDef<PatientCohortRow>[] = [
+    { key: "pseudonym", label: "Pseudonym", sortable: true },
+    {
+      key: "age",
+      label: "Age",
+      sortable: true,
+      align: "right",
+      cell: (r) => r.ageDisplay,
+      sortFn: (a, b) => a.ageNum - b.ageNum,
+      exportValue: (r) => r.ageDisplay,
+    },
+    { key: "sex", label: "Sex", sortable: true },
+    { key: "race", label: "Race", sortable: true },
+    { key: "ethnicity", label: "Ethnicity", sortable: true },
+    { key: "smokingStatus", label: "Smoking", sortable: true },
+    {
+      key: "zipPrefix",
+      label: "ZIP3",
+      sortable: true,
+      cell: (r) =>
+        r.zipSuppressed ? (
+          <Badge tone="warning">000</Badge>
+        ) : (
+          r.zipPrefix
+        ),
+      exportValue: (r) => r.zipPrefix,
+    },
+    { key: "socioeconomicTier", label: "SES", sortable: true },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.pseudonym}
+      ariaLabel="Patient cohort (de-identified)"
+      exportable
+      exportName="research-exports-patients"
+      emptyState={
+        <EmptyState
+          title="All buckets suppressed"
+          description="Lower the minimum cell size to view the cohort."
+        />
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/research-exports/studies/allocation-roster-table.tsx
+++ b/src/app/(operator)/ops/research-exports/studies/allocation-roster-table.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// Allocation roster, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can be
+// downloaded or printed (G6).
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface AllocationRosterRow {
+  patientId: string;
+  stratum: string;
+  block: string;
+  blindingCode: string;
+  arm: string;
+}
+
+const columns: ColumnDef<AllocationRosterRow>[] = [
+  { key: "patientId", label: "Patient", sortable: true },
+  { key: "stratum", label: "Stratum", sortable: true },
+  { key: "block", label: "Block", sortable: true },
+  { key: "blindingCode", label: "Blinding code", sortable: true },
+  {
+    key: "arm",
+    label: "Arm",
+    sortable: true,
+    cell: (r) => <Badge tone="accent">{r.arm}</Badge>,
+    exportValue: (r) => r.arm,
+  },
+];
+
+export function AllocationRosterTable({ rows }: { rows: AllocationRosterRow[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.patientId}
+      ariaLabel="Allocation roster"
+      exportable
+      exportName="allocation-roster"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No allocations — configure a study and click Re-randomize.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/research-exports/studies/page.tsx
+++ b/src/app/(operator)/ops/research-exports/studies/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
+import { AllocationRosterTable, type AllocationRosterRow } from "./allocation-roster-table";
 import {
   allocate,
   balanceChiSquare,
@@ -74,6 +75,14 @@ export default function StudiesPage({
   const spec: StudySpec = { studyId, arms, seed, stratifyBy };
   const plan = allocate(DEMO_SUBJECTS, spec);
   const chi2 = balanceChiSquare(plan);
+
+  const rosterRows: AllocationRosterRow[] = plan.allocations.map((a) => ({
+    patientId: a.patientId,
+    stratum: a.blockId.split("#")[0],
+    block: a.blockId.split("#")[1],
+    blindingCode: a.blindingCode,
+    arm: a.arm,
+  }));
 
   return (
     <PageShell maxWidth="max-w-[1320px]">
@@ -220,38 +229,7 @@ export default function StudiesPage({
             Blinding codes are HMAC(seed, studyId|patientId). Reveal at the end of the trial only.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border text-left">
-                  <th className="py-2 pr-3 text-text-subtle">Patient</th>
-                  <th className="py-2 pr-3 text-text-subtle">Stratum</th>
-                  <th className="py-2 pr-3 text-text-subtle">Block</th>
-                  <th className="py-2 pr-3 text-text-subtle">Blinding code</th>
-                  <th className="py-2 text-text-subtle">Arm</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {plan.allocations.map((a) => (
-                  <tr key={a.patientId}>
-                    <td className="py-2 pr-3 font-mono text-[11px]">{a.patientId}</td>
-                    <td className="py-2 pr-3 font-mono text-[11px] text-text-subtle">
-                      {a.blockId.split("#")[0]}
-                    </td>
-                    <td className="py-2 pr-3 tabular-nums text-text-subtle">
-                      {a.blockId.split("#")[1]}
-                    </td>
-                    <td className="py-2 pr-3 font-mono text-[11px]">{a.blindingCode}</td>
-                    <td className="py-2">
-                      <Badge tone="accent">{a.arm}</Badge>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
+        <AllocationRosterTable rows={rosterRows} />
       </Card>
     </PageShell>
   );

--- a/src/app/(operator)/ops/team/role-matrix-table.tsx
+++ b/src/app/(operator)/ops/team/role-matrix-table.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+// Role-permission matrix, adopted onto the shared <DataTable> primitive so
+// every column header sorts (MASTER prompt G5 / EMR-1018) and the whole table
+// can be downloaded or printed (G6). Booleans are pre-evaluated server-side
+// and passed as `granted` flags; the display cell renders ✓ or — from those.
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+
+export interface RoleMatrixRow {
+  id: string;
+  role: string;
+  demographics: boolean;
+  billing: boolean;
+  readNotes: boolean;
+  authorSignNotes: boolean;
+  prescribe: boolean;
+  sensitiveDx: boolean;
+  chartPrivacy: boolean;
+}
+
+function PermCell({ granted }: { granted: boolean }) {
+  return granted ? (
+    <span className="text-accent" aria-label="yes">
+      ✓
+    </span>
+  ) : (
+    <span className="text-text-muted/40" aria-label="no">
+      —
+    </span>
+  );
+}
+
+export function RoleMatrixTable({ rows }: { rows: RoleMatrixRow[] }) {
+  const columns: ColumnDef<RoleMatrixRow>[] = [
+    { key: "role", label: "Role", sortable: true },
+    {
+      key: "demographics",
+      label: "Demographics",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.demographics} />,
+      sortFn: (a, b) => Number(a.demographics) - Number(b.demographics),
+      exportValue: (r) => (r.demographics ? "Yes" : "No"),
+    },
+    {
+      key: "billing",
+      label: "Billing",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.billing} />,
+      sortFn: (a, b) => Number(a.billing) - Number(b.billing),
+      exportValue: (r) => (r.billing ? "Yes" : "No"),
+    },
+    {
+      key: "readNotes",
+      label: "Read notes",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.readNotes} />,
+      sortFn: (a, b) => Number(a.readNotes) - Number(b.readNotes),
+      exportValue: (r) => (r.readNotes ? "Yes" : "No"),
+    },
+    {
+      key: "authorSignNotes",
+      label: "Author & sign notes",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.authorSignNotes} />,
+      sortFn: (a, b) => Number(a.authorSignNotes) - Number(b.authorSignNotes),
+      exportValue: (r) => (r.authorSignNotes ? "Yes" : "No"),
+    },
+    {
+      key: "prescribe",
+      label: "Prescribe",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.prescribe} />,
+      sortFn: (a, b) => Number(a.prescribe) - Number(b.prescribe),
+      exportValue: (r) => (r.prescribe ? "Yes" : "No"),
+    },
+    {
+      key: "sensitiveDx",
+      label: "Sensitive dx",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.sensitiveDx} />,
+      sortFn: (a, b) => Number(a.sensitiveDx) - Number(b.sensitiveDx),
+      exportValue: (r) => (r.sensitiveDx ? "Yes" : "No"),
+    },
+    {
+      key: "chartPrivacy",
+      label: "Chart privacy",
+      sortable: true,
+      align: "right",
+      cell: (r) => <PermCell granted={r.chartPrivacy} />,
+      sortFn: (a, b) => Number(a.chartPrivacy) - Number(b.chartPrivacy),
+      exportValue: (r) => (r.chartPrivacy ? "Yes" : "No"),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Role permission matrix"
+      exportable
+      exportName="role-matrix"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No roles defined.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/team/role-matrix.tsx
+++ b/src/app/(operator)/ops/team/role-matrix.tsx
@@ -1,76 +1,40 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { type Permission, permissionsForRole } from "@/lib/rbac/permissions";
+import { permissionsForRole } from "@/lib/rbac/permissions";
 import { STAFF_ROLES } from "@/lib/rbac/team-management";
+import { RoleMatrixTable, type RoleMatrixRow } from "./role-matrix-table";
 
 // A curated, scannable slice of the full permission matrix. The point the
 // audit insists on — "clinical authoring/signing is a permission, not a
 // default" — is the "Author & sign notes" column: every non-clinical role
 // reads as "—" there. Values are computed from `permissionsForRole`, the
 // same source enforcement uses, so this viewer can never drift from reality.
-const COLUMNS: Array<{ label: string; permission: Permission }> = [
-  { label: "Demographics", permission: "patient.demographics.edit" },
-  { label: "Billing", permission: "billing.edit" },
-  { label: "Read notes", permission: "notes.read" },
-  { label: "Author & sign notes", permission: "notes.edit" },
-  { label: "Prescribe", permission: "prescriptions.write" },
-  { label: "Sensitive dx", permission: "sensitive_diagnoses.read" },
-  { label: "Chart privacy", permission: "chart.privacy.manage" },
-];
 
 export function RoleMatrix() {
+  const rows: RoleMatrixRow[] = STAFF_ROLES.map((meta) => {
+    const granted = new Set(permissionsForRole(meta.role));
+    return {
+      id: meta.role,
+      role: meta.label,
+      demographics: granted.has("patient.demographics.edit"),
+      billing: granted.has("billing.edit"),
+      readNotes: granted.has("notes.read"),
+      authorSignNotes: granted.has("notes.edit"),
+      prescribe: granted.has("prescriptions.write"),
+      sensitiveDx: granted.has("sensitive_diagnoses.read"),
+      chartPrivacy: granted.has("chart.privacy.manage"),
+    };
+  });
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>What each role can do</CardTitle>
-        <CardDescription>
-          Read-only reference, computed from the live permission matrix.
-          Clinical authoring and signing are gated permissions — only Provider
-          and Owner-as-provider roles carry them.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto">
-          <table className="w-full border-collapse text-sm">
-            <thead>
-              <tr className="border-b border-border/70 text-left">
-                <th className="py-2 pr-4 font-medium text-text-muted">Role</th>
-                {COLUMNS.map((col) => (
-                  <th
-                    key={col.permission}
-                    className="px-3 py-2 text-center font-medium text-text-muted whitespace-nowrap"
-                  >
-                    {col.label}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {STAFF_ROLES.map((meta) => {
-                const granted = new Set(permissionsForRole(meta.role));
-                return (
-                  <tr key={meta.role} className="border-b border-border/40">
-                    <td className="py-2.5 pr-4">
-                      <span className="font-medium text-text">{meta.label}</span>
-                    </td>
-                    {COLUMNS.map((col) => {
-                      const has = granted.has(col.permission);
-                      return (
-                        <td key={col.permission} className="px-3 py-2.5 text-center">
-                          {has ? (
-                            <span className="text-accent" aria-label="yes">✓</span>
-                          ) : (
-                            <span className="text-text-muted/40" aria-label="no">—</span>
-                          )}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </CardContent>
-    </Card>
+    <div>
+      <h2 className="text-base font-semibold text-text mb-1">
+        What each role can do
+      </h2>
+      <p className="text-sm text-text-muted mb-4">
+        Read-only reference, computed from the live permission matrix.
+        Clinical authoring and signing are gated permissions — only Provider
+        and Owner-as-provider roles carry them.
+      </p>
+      <RoleMatrixTable rows={rows} />
+    </div>
   );
 }

--- a/src/app/(operator)/ops/volunteer-program/charity-table.tsx
+++ b/src/app/(operator)/ops/volunteer-program/charity-table.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+// Charity registry table, adopted onto the shared <DataTable> primitive so every
+// column header sorts (MASTER prompt G5 / EMR-1018) and the whole table can be
+// downloaded or printed (G6).
+
+import { DataTable, type ColumnDef } from "@/components/ops/master";
+import { Badge } from "@/components/ui/badge";
+
+export interface CharityRow {
+  id: string;
+  charityName: string;
+  categoryDisplay: string;
+  opportunity: string;
+  vetted: boolean;
+  vettedDisplay: string;
+}
+
+export function CharityTable({ rows }: { rows: CharityRow[] }) {
+  const columns: ColumnDef<CharityRow>[] = [
+    { key: "charityName", label: "Charity", sortable: true },
+    { key: "categoryDisplay", label: "Category", sortable: true },
+    { key: "opportunity", label: "Opportunity", sortable: true },
+    {
+      key: "vetted",
+      label: "Vetted",
+      sortable: true,
+      sortFn: (a, b) => Number(b.vetted) - Number(a.vetted),
+      exportValue: (r) => r.vettedDisplay,
+      cell: (r) =>
+        r.vetted ? (
+          <Badge tone="success">{r.vettedDisplay}</Badge>
+        ) : (
+          <Badge tone="warning">Pending</Badge>
+        ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={rows}
+      rowKey={(r) => r.id}
+      ariaLabel="Charity registry"
+      exportable
+      exportName="volunteer-program"
+      emptyState={
+        <p className="py-6 text-center text-text-subtle italic">
+          No charities in the registry yet.
+        </p>
+      }
+    />
+  );
+}

--- a/src/app/(operator)/ops/volunteer-program/page.tsx
+++ b/src/app/(operator)/ops/volunteer-program/page.tsx
@@ -1,9 +1,9 @@
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { lex } from "@/lib/lexicon";
 import { DEMO_OPPORTUNITIES } from "@/lib/domain/volunteer-demo";
+import { CharityTable, type CharityRow } from "./charity-table";
 
 export const metadata = { title: "Volunteer Program · Operator" };
 
@@ -26,6 +26,18 @@ const KPIS: ProgramKpi[] = [
 
 export default async function VolunteerProgramPage() {
   await requireUser();
+
+  const rows: CharityRow[] = DEMO_OPPORTUNITIES.map((o) => ({
+    id: o.id,
+    charityName: o.charityName,
+    categoryDisplay: o.category.replace("_", " "),
+    opportunity: o.title,
+    vetted: o.vetted,
+    vettedDisplay: o.vetted
+      ? `Audited ${o.vettedAt ? new Date(o.vettedAt).toLocaleDateString() : ""}`
+      : "Pending",
+  }));
+
   return (
     <PageShell maxWidth="max-w-[1200px]">
       <PageHeader
@@ -45,37 +57,9 @@ export default async function VolunteerProgramPage() {
         ))}
       </div>
 
-      <Card className="mt-6">
-        <CardContent className="py-6">
-          <p className="text-xs uppercase tracking-wider text-text-subtle mb-4">Charity registry</p>
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wider">
-                <th className="pb-2 font-medium">Charity</th>
-                <th className="pb-2 font-medium">Category</th>
-                <th className="pb-2 font-medium">Opportunity</th>
-                <th className="pb-2 font-medium">Vetted</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {DEMO_OPPORTUNITIES.map((o) => (
-                <tr key={o.id}>
-                  <td className="py-2.5 text-text">{o.charityName}</td>
-                  <td className="py-2.5 text-text-muted">{o.category.replace("_", " ")}</td>
-                  <td className="py-2.5 text-text-muted">{o.title}</td>
-                  <td className="py-2.5">
-                    {o.vetted ? (
-                      <Badge tone="success">Audited {o.vettedAt ? new Date(o.vettedAt).toLocaleDateString() : ""}</Badge>
-                    ) : (
-                      <Badge tone="warning">Pending</Badge>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+      {/* Charity registry — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
+      <p className="text-xs uppercase tracking-wider text-text-subtle mt-6 mb-4">Charity registry</p>
+      <CharityTable rows={rows} />
     </PageShell>
   );
 }

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -1,0 +1,45 @@
+// MASTER-prompt kit — the shared owner-portal (/ops) UI primitives the
+// "Owner Portal Revisions" directive mandates across every page. A single
+// import surface so pages adopt the same building blocks instead of
+// hand-rolling each table / section / list.
+//
+// Coverage of the MASTER-prompt "layout law":
+//   G1 Collapsible sections        → <Collapsible>
+//   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
+//   G6 Table send/print/download   → <DataTable exportable> + table-export utils
+//   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
+//
+// Still to build (tracked, not yet shipped): global sidebar overlay/autohide
+// (G2), 7-result autocomplete inputs (G3), per-section AI search bar (G8),
+// compare-mode + "beautify" popups (G9/G10).
+
+export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  DataTable,
+  type ColumnDef,
+  type DataTableProps,
+  type DataTableSelection,
+  type DataTableAlign,
+  type DataTableDensity,
+} from "@/components/ui/data-table";
+
+export {
+  SortableList,
+  KanbanBoard,
+  reorder,
+  type SortableListProps,
+  type SortableRenderArgs,
+  type DragHandleProps,
+  type KanbanBoardProps,
+  type KanbanColumn,
+} from "@/components/ui/sortable";
+
+export {
+  buildCsv,
+  downloadCsv,
+  printTable,
+  escapeCsvCell,
+  tableToPrintableHtml,
+  type CellValue,
+} from "@/lib/ui/table-export";

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -47,6 +47,13 @@ import {
   type ContextMenuItem,
 } from "@/components/ui/context-menu";
 import { useDensity } from "@/lib/ui/density";
+import {
+  buildCsv,
+  downloadCsv,
+  printTable,
+  type CellValue,
+} from "@/lib/ui/table-export";
+import { Download, Printer } from "lucide-react";
 
 // ----------------------------------------------------------------- types
 
@@ -77,6 +84,11 @@ export interface ColumnDef<Row> {
   headerCell?: () => React.ReactNode;
   /** Hide on mobile (<= sm). Useful for secondary numeric columns. */
   hideOnMobile?: boolean;
+  /** Plain value for CSV/print export. Defaults to the row's `key` field.
+   *  Set this on columns whose `cell` renders rich JSX so exports stay clean. */
+  exportValue?: (row: Row) => CellValue;
+  /** Exclude this column from exports (e.g. a checkbox / actions column). */
+  exportable?: boolean;
 }
 
 export interface DataTableSelection<Row> {
@@ -121,6 +133,12 @@ export interface DataTableProps<Row> {
   /** Per-row right-click / long-press menu items (Monday/Linear-tier).
    *  Return `null` or an empty array to skip the menu on a given row. */
   contextMenuItems?: (row: Row, index: number) => ContextMenuItem[] | null;
+  /** Show a Download-CSV + Print control in the table toolbar (MASTER prompt G6).
+   *  Exports the currently-sorted rows, including column + row titles. Columns
+   *  use `exportValue` (or fall back to the raw `key` field). */
+  exportable?: boolean;
+  /** Base filename / print title for exports. Defaults to `ariaLabel` or "table". */
+  exportName?: string;
 }
 
 interface SortState {
@@ -252,6 +270,8 @@ export function DataTable<Row>({
   className,
   rowClassName,
   contextMenuItems,
+  exportable = false,
+  exportName,
 }: DataTableProps<Row>) {
   // Density precedence (highest → lowest):
   //   1. Explicit `density` prop (controlled by caller).
@@ -298,6 +318,33 @@ export function DataTable<Row>({
     copy.sort((a, b) => (sort.dir === "asc" ? cmp(a, b) : -cmp(a, b)));
     return copy;
   }, [rows, columns, sort]);
+
+  // ---- Export (CSV download / print) — MASTER prompt G6 -------------------
+  // Exports the currently-sorted rows so what you download matches what you see.
+  const exportColumns = React.useMemo(
+    () => columns.filter((c) => c.exportable !== false),
+    [columns],
+  );
+  const exportTitle = exportName ?? ariaLabel ?? "table";
+  const buildExportData = React.useCallback(() => {
+    const headers = exportColumns.map((c) => c.label);
+    const exportRows: CellValue[][] = sortedRows.map((row) =>
+      exportColumns.map((c) =>
+        c.exportValue
+          ? c.exportValue(row)
+          : ((row as Record<string, unknown>)[c.key] as CellValue),
+      ),
+    );
+    return { headers, exportRows };
+  }, [exportColumns, sortedRows]);
+  const handleDownloadCsv = React.useCallback(() => {
+    const { headers, exportRows } = buildExportData();
+    downloadCsv(exportTitle, buildCsv(headers, exportRows));
+  }, [buildExportData, exportTitle]);
+  const handlePrint = React.useCallback(() => {
+    const { headers, exportRows } = buildExportData();
+    printTable(exportTitle, headers, exportRows);
+  }, [buildExportData, exportTitle]);
 
   // ---- Selection helpers --------------------------------------------------
   const selectionCtx: SelectionContext | null = React.useMemo(() => {
@@ -380,7 +427,7 @@ export function DataTable<Row>({
         className,
       )}
     >
-      {(toolbar || showDensityToggle) && (
+      {(toolbar || showDensityToggle || exportable) && (
         <div
           className={cn(
             "flex items-center gap-3 border-b border-border/60",
@@ -388,6 +435,9 @@ export function DataTable<Row>({
           )}
         >
           <div className="flex-1 min-w-0">{toolbar}</div>
+          {exportable && (
+            <ExportControls onCsv={handleDownloadCsv} onPrint={handlePrint} />
+          )}
           {showDensityToggle && (
             <DensityToggle
               value={density}
@@ -705,6 +755,39 @@ function SkeletonRows<Row>({
         </tr>
       ))}
     </>
+  );
+}
+
+// ----------------------------------------------------------- export controls
+
+function ExportControls({
+  onCsv,
+  onPrint,
+}: {
+  onCsv: () => void;
+  onPrint: () => void;
+}) {
+  const btn = cn(
+    "inline-flex items-center gap-1 h-7 px-2.5 rounded-full",
+    "border border-border bg-surface text-[11px] font-medium",
+    "text-text-muted hover:text-text transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+  );
+  return (
+    <div
+      role="group"
+      aria-label="Export table"
+      className="inline-flex items-center gap-1"
+    >
+      <button type="button" onClick={onCsv} className={btn}>
+        <Download aria-hidden="true" className="h-3.5 w-3.5" />
+        CSV
+      </button>
+      <button type="button" onClick={onPrint} className={btn}>
+        <Printer aria-hidden="true" className="h-3.5 w-3.5" />
+        Print
+      </button>
+    </div>
   );
 }
 

--- a/src/lib/ui/table-export.test.ts
+++ b/src/lib/ui/table-export.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCsv,
+  escapeCsvCell,
+  tableToPrintableHtml,
+} from "./table-export";
+
+describe("escapeCsvCell", () => {
+  it("passes plain strings and numbers through unchanged", () => {
+    expect(escapeCsvCell("Maya Reyes")).toBe("Maya Reyes");
+    expect(escapeCsvCell(42)).toBe("42");
+    expect(escapeCsvCell(0)).toBe("0");
+  });
+
+  it("renders null/undefined/empty as an empty cell", () => {
+    expect(escapeCsvCell(null)).toBe("");
+    expect(escapeCsvCell(undefined)).toBe("");
+    expect(escapeCsvCell("")).toBe("");
+  });
+
+  it("quotes cells containing commas, quotes, or newlines", () => {
+    expect(escapeCsvCell("Reyes, Maya")).toBe('"Reyes, Maya"');
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvCell("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("neutralises spreadsheet formula injection", () => {
+    expect(escapeCsvCell("=SUM(A1:A2)")).toBe("'=SUM(A1:A2)");
+    expect(escapeCsvCell("+1")).toBe("'+1");
+    expect(escapeCsvCell("-1")).toBe("'-1");
+    expect(escapeCsvCell("@cmd")).toBe("'@cmd");
+  });
+
+  it("quotes a formula-injection cell that also contains a comma", () => {
+    // guard prefix applied first, then RFC-4180 quoting
+    expect(escapeCsvCell("=1,2")).toBe('"\'=1,2"');
+  });
+});
+
+describe("buildCsv", () => {
+  it("joins a header row + body rows with CRLF and escapes cells", () => {
+    const csv = buildCsv(
+      ["Patient", "Billed", "Note"],
+      [
+        ["Maya Reyes", 240, "ok"],
+        ["Reyes, Sam", 99.5, 'has "quote"'],
+      ],
+    );
+    expect(csv).toBe(
+      'Patient,Billed,Note\r\n' +
+        'Maya Reyes,240,ok\r\n' +
+        '"Reyes, Sam",99.5,"has ""quote"""',
+    );
+  });
+
+  it("handles an empty body", () => {
+    expect(buildCsv(["A", "B"], [])).toBe("A,B");
+  });
+});
+
+describe("tableToPrintableHtml", () => {
+  it("includes the title, headers, and HTML-escaped cell values", () => {
+    const html = tableToPrintableHtml(
+      "Claims",
+      ["Patient", "Status"],
+      [["A&B <Co>", "paid"]],
+    );
+    expect(html).toContain("<title>Claims</title>");
+    expect(html).toContain("<th>Patient</th>");
+    expect(html).toContain("<th>Status</th>");
+    expect(html).toContain("<td>A&amp;B &lt;Co&gt;</td>");
+    expect(html).toContain("<td>paid</td>");
+  });
+});

--- a/src/lib/ui/table-export.ts
+++ b/src/lib/ui/table-export.ts
@@ -1,0 +1,109 @@
+// Client-safe CSV + print helpers for the DataTable primitive.
+//
+// MASTER prompt (Owner Portal Revisions) G6: "Have the ability to 'send' or
+// 'print' or 'Download' any table on any page that includes all the data and
+// the 'column' and 'row' titles."
+//
+// Kept dependency-free and client-safe (no server-only imports) so it ships in
+// the browser bundle alongside <DataTable>. The heavier server/audit export
+// path lives in src/lib/admin/csv-export.ts and is a separate concern.
+
+export type CellValue = string | number | boolean | null | undefined;
+
+// UTF-8 BOM — makes Excel open accented characters correctly.
+const UTF8_BOM = "\uFEFF";
+
+/**
+ * Escape a single CSV cell per RFC-4180, plus an Excel/Sheets formula-injection
+ * guard: cells beginning with `=`, `+`, `-`, `@`, tab, or CR are prefixed with a
+ * single quote so a downloaded financial export can't execute as a formula.
+ */
+export function escapeCsvCell(value: CellValue): string {
+  if (value == null) return "";
+  let s = typeof value === "string" ? value : String(value);
+  if (s.length === 0) return "";
+  // Neutralise spreadsheet formula injection.
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  // RFC-4180 quoting trigger: comma, quote, CR, or LF.
+  if (/[",\r\n]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Build an RFC-4180 CSV string from a header row plus body rows. */
+export function buildCsv(headers: string[], rows: CellValue[][]): string {
+  const lines = [headers.map(escapeCsvCell).join(",")];
+  for (const row of rows) lines.push(row.map(escapeCsvCell).join(","));
+  return lines.join("\r\n");
+}
+
+/**
+ * Trigger a browser download of `csv` as `filename`. Prepends a UTF-8 BOM.
+ * No-op outside the browser.
+ */
+export function downloadCsv(filename: string, csv: string): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([UTF8_BOM + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) =>
+    c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&quot;",
+  );
+}
+
+/** Build a minimal, print-styled HTML document for a table (column + row titles). */
+export function tableToPrintableHtml(
+  title: string,
+  headers: string[],
+  rows: CellValue[][],
+): string {
+  const th = headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("");
+  const trs = rows
+    .map(
+      (r) =>
+        `<tr>${r
+          .map((c) => `<td>${escapeHtml(c == null ? "" : String(c))}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(
+    title,
+  )}</title><style>
+    body{font:13px -apple-system,system-ui,sans-serif;color:#111;margin:24px}
+    h1{font-size:16px;margin:0 0 12px}
+    table{border-collapse:collapse;width:100%}
+    th,td{border:1px solid #ccc;padding:6px 10px;text-align:left}
+    thead th{background:#f3f4f6;font-weight:600}
+    tbody tr:nth-child(even){background:#fafafa}
+    @media print{body{margin:0}}
+  </style></head><body><h1>${escapeHtml(
+    title,
+  )}</h1><table><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></body></html>`;
+}
+
+/**
+ * Open a print dialog for the given table in a new window. No-op outside the
+ * browser or if the popup is blocked.
+ */
+export function printTable(
+  title: string,
+  headers: string[],
+  rows: CellValue[][],
+): void {
+  if (typeof window === "undefined") return;
+  const html = tableToPrintableHtml(title, headers, rows);
+  const w = window.open("", "_blank", "width=900,height=700");
+  if (!w) return;
+  w.document.write(html);
+  w.document.close();
+  w.focus();
+  w.print();
+}


### PR DESCRIPTION
## What
Slice 3 of the Owner Portal Revisions — **adoption** of the MASTER-kit `DataTable` onto hand-rolled `/ops` tables, giving each one click-to-sort column headers (**G5**) and CSV/Print export (**G6**).

> **Stacked on #645** (Slice 1 — the kit + export feature). Base is `owner-portal-revisions-slice1`; it will retarget to `main` once #645 merges. Review #645 first.

## Coverage
A parallel sweep assessed 26 raw-`<table>` pages: **22 tables migrated** (incl. the `cfo/liabilities` proof), **5 skipped**, 4 of those skips being one-table-of-several on a page.

**Migrated:** cfo/liabilities · cfo/equity · cfo/assets · cfo/pnl · cfo/cash · team/role-matrix · volunteer-program · billing/payer-rules · payment-methods · platform/fhir-bridge · platform/mips · platform/modules · marketplace-benchmark · dispensary-reimbursement · daily-close · pricing · research-exports · reports · (+ the static table on access-log, business-plan, research-exports/studies, daily-report).

**Skipped (left untouched, never half-migrated):** `billing/dead-letter` (per-row resolve form), `billing/identifiers` (inline-edit rows), `platform/pricing` (cross-tab feature matrix), `waitlist` (per-row offer/expire actions), `cfo/expenses` (per-row delete form), plus the dynamic-column / total-footer tables noted in commits.

## Pattern
Each page gets a small `"use client"` wrapper rendering `DataTable`. Money/dates stay **formatted server-side** (display strings) with numeric `cents`/epoch fields passed alongside purely so columns sort by real magnitude. Column set, order, badges, navigation links, and empty states are preserved.

## Verification
`tsc --noEmit` **0 errors** · `eslint` clean. **Visual QA still pending** — this is a broad sweep; any per-page polish lands as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)