### PR TITLE
Owner Portal Revisions — G2: stop the sidebar re-opening on in-page actions

### DIFF
--- a/src/components/shell/PillarNav.tsx
+++ b/src/components/shell/PillarNav.tsx
@@ -54,12 +54,27 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
     }
   };
 
+  // Open the active pillar's drawer ONLY when the route's pillar actually
+  // changes (a real navigation). A same-route re-render — e.g. a server action
+  // revalidating the page, which hands PillarNav a fresh `sections` array
+  // reference — must NOT re-open a drawer the user just collapsed. That was the
+  // "sidebar pops back open when I click Log / Add / Delete / Generate" bug
+  // (Owner Portal Revisions, MASTER prompt G2).
+  const prevPathPillar = React.useRef<string | null>(pathPillar);
+  React.useEffect(() => {
+    if (pathPillar && pathPillar !== prevPathPillar.current) {
+      setActivePillar(pathPillar);
+    }
+    prevPathPillar.current = pathPillar;
+  }, [pathPillar]);
+
+  // On mount only: if the current route isn't under any pillar, restore the
+  // last-used pillar so the drawer isn't empty on a neutral landing page.
+  // Deliberately mount-only — re-running on every `sections` change would
+  // re-open a dismissed drawer (the bug guarded against above).
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    if (pathPillar) {
-      setActivePillar(pathPillar);
-      return;
-    }
+    if (pathPillar) return;
     try {
       const stored = window.localStorage.getItem(LAST_PILLAR_KEY);
       if (!stored) return;
@@ -70,7 +85,8 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
     } catch {
       /* private mode — non-fatal */
     }
-  }, [pathPillar, sections]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;


### PR DESCRIPTION
## What
Fixes the most-repeated sidebar complaint in the MASTER prompt: _"stop the sidebar from expanding when clicking the Log / Add / Delete / Generate button."_

## Root cause
`PillarNav`'s route-following effect listed `sections` in its dependency array and called `setActivePillar(pathPillar)` on every run. A **server action that revalidates the current page** hands the operator layout — and thus `PillarNav` — a **fresh `sections` array reference**, which re-ran the effect and **re-opened a drawer the user had just collapsed**. Same route, no navigation, yet the sidebar popped open.

## Fix
Only auto-open the drawer when the route's pillar **actually changes** (a real navigation), tracked with a ref. Same-route re-renders no longer touch the drawer. The "restore last pillar on a neutral landing page" behavior is split into a **mount-only** effect so it can't re-open a dismissed drawer either. Real navigation still opens the matching pillar (`useState(pathPillar)` on mount + the on-change effect).

## Verified in the running app
Collapsed the Finance drawer → ran the Add-liability **server action** (the new row persisted, confirming revalidation + re-render actually happened) → **drawer stayed collapsed**. `tsc` 0 errors, `eslint` clean.

## Deliberately out of scope
The doc's two other sidebar asks — **overlay-the-sidebar-when-the-window-is-narrowed** and **autohide-on-every-navigation** — are **not** included. They conflict with the current *intentional* route-following design and the `AppShell` is shared across all three portals (patient/clinician/operator), so they need a product decision + cross-portal verification rather than a drive-by change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)