### PR TITLE
Workflows Revisions (June 2026): UPI triage engine, Rx safety guardrails, pre-flight denial engine, Fleet Command Directive

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,0 +1,54 @@
+---
+name: product-manager
+description: Product Manager Agent for LeafJourney EMR. Use when you need to chunk requirements docs into Linear cards, reconcile Linear tickets against source documents, prioritize/sequence an agent fleet's work, or decide what ships next. Reads Linear (MCP), TICKETS.md, ROADMAP.md, docs/product-feedback/, and codebase state. Opinionated output.
+tools: Read, Grep, Glob, Bash, WebFetch, mcp__Linear__list_issues, mcp__Linear__get_issue, mcp__Linear__save_issue, mcp__Linear__list_projects, mcp__Linear__get_project, mcp__Linear__save_comment, mcp__Linear__list_comments, mcp__Linear__list_issue_labels
+model: opus
+---
+
+You are the Product Manager Agent for LeafJourney — a cannabis-specialty,
+FHIR-native, AI-ambient EMR. You answer to Scott (founder) and Dr. Patel
+(clinical owner). Your job is to keep the Linear board the single source of
+truth and keep the build fleet pointed at the highest-leverage work.
+
+## What you know
+
+- The product vision lives in PRD.md, ROADMAP.md, CLAUDE.md (Dr. Patel
+  directives), and docs/product-feedback/ (ingested revision docs — each file
+  is a dated directive set; red-text files are NEW requirements).
+- The Linear workspace has one team ("EMR Project"). Active revision projects
+  follow the pattern: one project per source doc, [EPIC] parents, bite-size
+  child cards with acceptance criteria and a `Directive ID` or doc-phase
+  reference. The June 2026 ingest lives in "WorkFlows Revisions — Zero-Click
+  Ambient Intelligence (June 2026)" (EMR-1118…EMR-1162), labeled
+  `workflows-revisions-2026-06`.
+- The Fleet Command Directive (Four Golden Axioms) binds every card you write:
+  ≤2 clicks for routine workflows, single-viewport (no scroll for critical
+  views), typing-reduction (ambient capture + smart defaults), Zen-Density
+  (soft pastel accents, generous padding, no pop-ups — drawers and inline
+  cards only).
+
+## How you operate
+
+1. **Chunk, don't transcribe.** A card is bite-size: one engineer-agent, one
+   session, testable acceptance criteria, a doc/phase citation, and explicit
+   relations to existing tickets (enrich, don't duplicate — always search
+   Linear before creating).
+2. **Safety is product.** Clinical writes are human-in-the-loop. Hard stops
+   block signing; nothing auto-signs or auto-sends. Any card touching triage,
+   prescribing, or claims carries the `safety` framing in acceptance criteria.
+3. **Deterministic first.** Scoring engines (UPI, IR_risk, P_denial, A_prob,
+   RAF) land as pure, tested functions with persisted factor breakdowns; LLM
+   assist rides behind the existing agent harness afterward.
+4. **Sequencing.** Prefer: engine (lib + tests) → surface (UI, Zen-Density) →
+   serialization (FHIR) → automation (background listeners). Ship vertical
+   slices behind existing patterns; no new infra unless a card says so.
+5. **Reconciliation passes.** When given a source doc, map every section to
+   existing Linear coverage, file gap tickets, comment on stale tickets, and
+   produce a coverage table (section → ticket(s) → status → gap?).
+
+## Output style
+
+Opinionated, terse, decision-first. When you prioritize, give the cut list and
+why. When you create or update Linear issues, report identifiers + URLs. Never
+mark someone else's ticket Done — comment with evidence and leave state
+transitions to the owner unless instructed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,53 @@ Based on the Medical Cannabis Library (MCL) paper:
 3. **Drug Mix** — Drug interaction checker (public-facing version)
 4. **Research** — PubMed article browser
 5. **Learn** — Educational articles (moved from existing /learn page)
+
+---
+
+## Fleet Command Directive (Core Master Prompt Blueprint — June 2026)
+
+Binding rules for **every** agent and contributor, per Dr. Patel's Core Master
+Prompt Blueprint (see
+`docs/product-feedback/2026-06-12_workflows-revisions-red-text.md`, "Core
+Master Prompt Blueprint"; epic EMR-1125). These rules **harmonize with — they
+do not replace — the Apple-iOS aesthetic directive above**: same calm,
+minimal, large-touch-target feel, now with hard efficiency budgets.
+
+### The Four Golden Axioms
+1. **Click-Elimination** — no routine clinical workflow (SOAP note, Rx
+   signing, lab review) may require more than **two clicks** from the primary
+   dashboard viewport. Mechanisms: contextual prediction, hover actions,
+   autofill, and the Cmd+K command box.
+2. **Scroll-Elimination** — critical patient/encounter details fit a
+   **single non-scrolling viewport**. Mechanisms: tabbed side drawers,
+   expanding canvas grids, split viewports. No endless vertical timelines.
+3. **Typing-Reduction** — clinicians **never manually type** standard
+   clinical prose or look up routine codes. Mechanisms: ambient capture
+   drafts + intelligent defaults from patient history and provider habits.
+4. **Zen-Density** — spacious **16–24px padding grid**, soft pastel status
+   indicators (see `--status-*` tokens), muted neutral backgrounds, clear
+   text hierarchy. Context-aware display: information appears only when
+   relevant.
+
+### Rejection rule
+Any design that requires scrolling to reveal mandatory forms, multi-step
+wizards, or stacked pop-up confirmations must be **rejected and rebuilt**
+using slide-out contextual drawers and predictive data entry.
+
+### No-popup rule (sub-workflows)
+Sub-workflows (picking lab tests, adding diagnoses, editing demographic
+cards) never spawn popup dialogs or nested windows. Use slide-out contextual
+drawers or clean inline expanding rows only, with a **minimum 12px
+separation** between components.
+
+### Agent-group directives
+- **UI/UX:** no popups or nested windows — drawers and inline expanding rows
+  with generous padding, validated against the single-viewport standard.
+- **Clinical NLP:** continuously convert spoken dialogue and note edits into
+  structured data, staged in a sidebar for single-click verification.
+- **CPOE:** no multi-step order wizards — auto-populate order parameters
+  (LOINC/RxNorm codes, doses, prior-auth justifications, fasting flags) so
+  one click authorizes from the checkout queue.
+- **Triage:** auto-sort inbound patient messages by clinical risk into the
+  clinician's task queue; convert visit notes into plain-language
+  instructions matched to the patient's language and reading level.

--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -31,6 +31,26 @@ The palette is intentionally narrow. One neutral ramp, one accent (a calm clinic
 
 **Rule:** never use more than two colors per screen. The accent exists to direct attention, not to decorate.
 
+#### Status accents (Fleet Command Directive, June 2026)
+
+Soft, low-saturation fill/text pairs for status communication in clinical
+workspaces. They are indicators, not decoration — they don't count against
+the two-color rule, but they obey its spirit: pastel fills, quiet presence.
+Defined in `src/app/globals.css` (light + dark) and exposed via
+`tailwind.config.ts`.
+
+| Token pair                                  | Light fill / text     | Purpose                                  |
+| ------------------------------------------- | --------------------- | ---------------------------------------- |
+| `--status-positive-bg` / `--status-positive-fg` | `#E2F0D9` / `#385723` | Approvals, positive status (sage)        |
+| `--status-alert-bg` / `--status-alert-fg`       | `#FCE4D6` / `#C65911` | Alerts, immediate gaps (soft terracotta) |
+| `--status-link-bg` / `--status-link-fg`         | `#DDEBF7` / `#1F4E78` | Interactive links (muted slate blue)     |
+
+Tailwind: `bg-status-positive-bg text-status-positive-fg`, etc. Dark mode
+follows the existing pastel approach — preserve hue, drop fill value,
+brighten text. Use these for status chips, highlighted rows, and inline
+insight cards; keep `--success` / `--warning` / `--danger` for hard semantic
+states (toasts, destructive actions, validation).
+
 ### Typography
 
 - **Sans:** Inter (via `next/font/google`), with variable font features enabled.
@@ -158,3 +178,41 @@ Totally distinct from the app shell. No nav chrome. Hero + clear CTA + trust mar
 - Excessive modals — prefer inline panels and drawers
 - "AI" branding on every feature
 - Dashboards that look like someone dragged 30 widgets onto a grid
+
+## 8. Fleet Command Directive (June 2026)
+
+Dr. Patel's Core Master Prompt Blueprint (epic EMR-1125) sets hard efficiency
+budgets on top of everything above. Full rules live in `CLAUDE.md`
+("Fleet Command Directive"); the design-relevant summary:
+
+### The Four Golden Axioms
+
+1. **Click-Elimination** — routine clinical workflows complete in **≤2
+   clicks** from the primary dashboard viewport. Contextual prediction,
+   hover actions, autofill, Cmd+K.
+2. **Scroll-Elimination** — critical patient/encounter details fit a
+   **single non-scrolling viewport**. Tabbed side drawers, expanding canvas
+   grids, split viewports. No endless vertical timelines.
+3. **Typing-Reduction** — no manual typing of standard clinical prose or
+   routine code lookups. Ambient capture drafts + intelligent defaults.
+4. **Zen-Density** — spacious 16–24px padding grid, soft pastel status
+   indicators (§1 status accents), muted neutral backgrounds, clear text
+   hierarchy. Information appears only when relevant.
+
+Designs requiring scrolling for mandatory forms, multi-step wizards, or
+stacked pop-up confirmations are rejected and rebuilt with slide-out
+contextual drawers and predictive entry. Sub-workflows never use popups —
+drawers or inline expanding rows only, minimum 12px separation.
+
+### Workspace geometry
+
+| Region                | Layout                                          | Scroll mitigation                                | Click shortcuts                                        |
+| --------------------- | ----------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| Global Control Box    | Centered floating search bar (Cmd+K)            | 0px — results render in a clean overlay          | Instant focus; contextual actions per query             |
+| Patient Summary HUD   | Sticky header row, top 80px of the screen       | 0px — key stats in horizontal groups             | Hover opens a tooltip bubble with trend graphs          |
+| Active Care Canvas    | Three-column grid with clean gutters            | Deep history lives inside scroll-free tab rows   | One click expands a section; click-away collapses it    |
+| Context Action Drawer | Right-hand slide-out drawer overlay             | Drawer height adapts dynamically to content      | Single-click approve / authorize / save actions         |
+
+The existing AppShell (§4) and side-panel patterns (§3) remain the
+foundation; the geometry above is the target composition for clinician
+encounter workspaces as they are rebuilt under EMR-1125.

--- a/docs/product-feedback/2026-06-12_workflows-revisions-red-text.md
+++ b/docs/product-feedback/2026-06-12_workflows-revisions-red-text.md
@@ -1,0 +1,633 @@
+# LeafJourney Workflows Revisions — RED-TEXT REQUIREMENTS (2026-06-12 ingest)
+
+> Source: "Scott_ LeafJourney Workflows Revisions.docx". This file archives the NEW requirements
+> written in red. Linear project: "WorkFlows Revisions — Zero-Click Ambient Intelligence (June 2026)"
+> — epics EMR-1118…EMR-1125, cards EMR-1126…EMR-1162. The black text of the doc is the consolidated
+> workflow bible already tracked across prior projects.
+
+Proactive, Context-Aware Clinical Intelligence
+Legacy Clinical Decision Support (CDS) is hated because it relies on annoying, rigid pop-ups that cause alert fatigue. AI-driven CDS is subtle, predictive, and highly contextual.
+[Continuous Wearable/Lab Stream] ──> Predictive AI Engine ──> Subtle Inline Insight (No Pop-ups)
+Inline Clinical Insights: Rather than flashing an interruptive alert, the AI subtly highlights text or displays sidebar insights. For example, if a provider is reviewing a metabolic panel, the AI might cross-reference historical glycemic trends and wearable data to calculate a predictive risk score for insulin resistance, offering a recommended intervention protocol tailored to the practice's philosophy.
+Phase 1: Contextual State Interception & Passive UI Render Hook
+The system avoids running heavy database queries by linking directly to the front-end user interface application state, analyzing what the provider is actively viewing.
+1.1 Viewport State Listener
+An observer pattern monitors the primary EMR navigation controller. When a provider opens a document, flows to a summary screen, or expands a laboratory visualization tile:
+The system reads the active domain context (e.g., detecting that the active screen is rendering a standard Metabolic Panel or an array of glycemic tracking biomarkers).
+It extracts the active patient identifier and the associated terminology tracking tokens (LOINC or SNOMED-CT) currently on display.
+1.2 Low-Latency Asynchronous Query Dispatcher
+Once a target context is confirmed, the system triggers a background data pull. It bypasses slow relational database reads by querying an in-memory database cache to instantly assemble the patient’s multi-domain clinical history, gathering data across three distinct categories:
+The Structured Biomarker Stream: Historical data maps for Fasting Glucose (LOINC: 74318-7), Fasting Insulin (LOINC: 6721-6), and Hemoglobin A1c (LOINC: 4548-4).
+The Wearable Telemetry Cache: Aggregated 30-day time-series variables, specifically mean nocturnal Glycemic Variability ($\sigma_{\text{cgm}}$) and fasting baseline Heart Rate Variability (HRV) metrics.
+The Narrative Problem Profile: Text extractions scanning for active metabolic diagnoses, past dietary protocol compliance entries, or documentation of ancestral risk factors.
+Phase 2: Multi-Domain Data Merging & Automated Feature Engineering
+Before running the predictive risk models, the data processor synchronizes disparate telemetry and clinical lab inputs into a standardized, time-aligned analysis vector.
+Time-Series Metric Normalization: Continuous telemetry points are downsampled into uniform, daily statistical summaries. The ingestion workers calculate a rolling 14-day median for fasting interstitial glucose to align wearable datasets with single-point venipuncture laboratory checks.
+Semantic Vector Synthesis: Relevant segments from historical progress notes are parsed using localized keyword matchers. These strings are converted into binary flags (e.g., lifestyle_modification_adherence = true) to incorporate qualitative patient behaviors directly into the predictive models.
+Phase 3: Wearable-Augmented Predictive Insulin Resistance Risk Score Calculation
+The system feeds the engineered analysis vector into a predictive metabolic risk processor. Rather than relying solely on traditional static equations like standard HOMA-IR, the platform computes a Wearable-Augmented Dynamic Insulin Resistance Risk Index ($IR_{\text{risk}}$).
+This index combines discrete biochemical metrics with continuous autonomic and glycemic telemetry to calculate a real-time risk assessment:
+Factor Definition Framework
+$G_f$: Fasting Plasma Glucose baseline value ($\text{mg/dL}$).
+$I_f$: Fasting Plasma Insulin baseline concentration ($\mu\text{IU/mL}$).
+$\sigma_{\text{cgm}}$: Normalized 14-day coefficient of continuous glycemic variability.
+$\Delta \text{HRV}_{\text{sleep}}$: Measured reduction in deep nocturnal Heart Rate Variability compared to the patient's long-term historical baseline ($\text{ms}$), serving as an early indicator of autonomic stress and metabolic dysfunction.
+$\alpha, \beta$: Standardized scaling coefficients calibrated against population longitudinal metabolic datasets.
+The resulting score ranges cleanly from $0.0$ (Optimal Homeostatic Sensitivity) to $1.0$ (Severe Advanced Target-Tissue Insulin Resistance).
+Phase 4: Non-Disruptive Ambient UI/UX Rendering Layer
+To maintain a clean provider workspace, the computed risk score completely bypasses the standard pop-up alert system. Instead, the interface applies subtle visual indicators directly onto the existing text and layout canvas.
+Micro-Contextual Inline Typography Highlights: When the calculated risk metric ($IR_{\text{risk}}$) breaks past a designated warning threshold ($\ge 0.65$), the system applies a soft background color tint beneath the raw Fasting Glucose and Insulin values on the screen. Hovering the mouse cursor over this highlighted region reveals a brief tooltip summary detailing the underlying telemetry factors without forcing the user to navigate away.
+The Ambient Analytics Sidebar Terminal: Concurrently, an integrated vertical sidebar panel expands smoothly on the right edge of the workspace layout. This panel displays a clear visual timeline showing how the laboratory markers correlate over time with wearable telemetry trends, keeping actionable diagnostic data easily scannable and accessible.
+Phase 5: Practice-Aligned Clinical Intervention Customization & Ordering Integration
+The insights engine coordinates its analytical outputs with a customizable configuration matrix that reflects the specific clinical philosophy of the practice group.
+5.1 The Clinic Preference Configuration Framework
+The system references a localized settings template to deliver tailored treatment recommendations, prioritizing metabolic restoration, lifestyle modifications, and structured therapeutic fasting intervals ahead of standard long-term pharmaceutical dependencies:
+5.2 Single-Click Ordering Integration
+Every recommended care option features an inline confirmation checkbox. Selecting an intervention automatically compiles the required billing codes, schedules the necessary follow-up labs, generates personalized patient educational handouts, and adds the elements directly to the provider's active checkout queue for immediate signature.
+Phase 6: FHIR Interoperability Architecture & Guidance State Serialization
+To support multi-facility data compliance, all background evaluations, model outcomes, and clinical recommendations are structured using standard SMART on FHIR Clinical Reasoning resources.
+6.1 System Resource Relationship Map
+GuidanceResponse: Captures the overarching lifecycle execution state of the ambient inference engine, verifying the active dataset components utilized.
+RiskAssessment: Houses the computed metric score ($IR_{\text{risk}}$), the formal mathematical validation parameters, and the relative risk classification markers.
+CarePlan: Formulates the philosophy-aligned intervention recommendations designed for the patient's record profile.
+Prescription Safety & Optimization Guardrails: The AI evaluates a drafted prescription against the patient’s complete multi-omic profile—including genomic data if available, liver/kidney function labs, and potential botanical or drug interactions—proactively suggesting dosage adjustments or safer alternatives.
+Phase 1: Order Intent Capture & Distributed Feature Ingestion Pipeline
+The safety engine activates silently the moment a provider populates the drug name field within the EMR's order entry terminal.
+1.1 Structural Order Interception
+The front-end user interface passes a structured transactional payload containing the target RxNorm Concept Unique Identifier (CUI), proposed dose, route of administration, and execution frequency to a background evaluation worker.
+1.2 Distributed Multi-Domain Ingestion Core
+The engine compiles the patient's physiological state concurrently across three specialized data layers:
+The Pharmacogenomic (PGx) Registry: Pulls structural genetic variants from storage, looking for human leukocyte antigen (HLA) markers and Cytochrome P450 (CYP450) star-allele configurations (e.g., CYP2D6*4, CYP2C19*2).
+The Organ Clearance Vault: Fetches recent metabolic diagnostics—specifically Serum Creatinine (LOINC: 2160-0), Total Bilirubin (LOINC: 1975-2), Albumin (LOINC: 1751-7), and International Normalized Ratio (INR; LOINC: 34714-6).
+The Botanical & Xenobiotic Manifest: Scans the active medication profile and patient-reported lifestyle logs to extract explicit exogenous compound exposures, prioritizing botanical therapeutic streams, over-the-counter supplements, and active cannabinoid usage patterns.
+Phase 2: Pharmacogenomic (PGx) Variant Evaluation Layer
+The system maps the incoming RxNorm CUI to its primary phase I and phase II metabolic clearance pathways using verified Clinical Pharmacogenetics Implementation Consortium (CPIC) and PharmGKB data frameworks.
+2.1 Metabolic Phenotype Stratification
+Extracted star-alleles are converted into functional metabolic phenotypes:
+Targeted Drug Class (RxNorm)
+Identified Genomic Variant Target
+Triggered Molecular Mechanism
+Automated Optimization Routing Engine Action
+Clopidogrel (RxCUI: 32968)
+CYP2C19 Intermediate or Poor Metabolizer (*2, *3 alleles)
+Profoundly reduced conversion of pro-drug to active thiol metabolite; increased risk of major adverse cardiovascular events.
+Hard Substitution Trigger: Block order. Suggest alternative antiplatelet therapy (e.g., Prasugrel or Ticagrelor) unimpacted by CYP2C19 polymorphisms.
+Codeine / Tramadol
+CYP2D6 Poor Metabolizer (*4, *5 variations)
+Inability to O-demethylate codeine into morphine; complete therapeutic failure.
+Dosing Deflection Action: Flag total lack of analgesic efficacy. Suggest non-opioid or alternative pathway analgesic strategies.
+Codeine / Tramadol
+CYP2D6 Ultra-Rapid Metabolizer (*1xN copies)
+Accelerated transformation to morphine; high risk of severe, life-threatening opioid toxicity at standard doses.
+Hard Stop Action: Cancel prescription intent immediately. Log critical respiratory safety warning.
+Allopurinol (RxCUI: 519)
+HLA-B*58:01 Positive Status
+High risk of Allopurinol Hypersensitivity Syndrome (Stevens-Johnson Syndrome / Toxic Epidermal Necrolysis).
+Absolute Contraindication: Hard stop order execution. Require alternative urate-lowering agent selection (e.g., Febuxostat).
+Phase 3: Organ Function Clearance Calculations & Adaptive Dosing
+To safeguard patients against drug accumulation and systemic toxicity, the engine evaluates current organ performance using real-time lab data rather than historical diagnostic codes.
+3.1 Renal Capacity Assessment (CKD-EPI 2021 Creatinine Equation)
+The processor evaluates the patient's Estimated Glomerular Filtration Rate (eGFR) using the current standardized mathematical framework to determine exact renal filtration capabilities:
+Where $S_{cr}$ is serum creatinine ($\text{mg/dL}$), $\kappa$ is $0.7$ for females and $0.9$ for males, $\alpha$ is $-0.241$ for females and $-0.302$ for males, $\min$ indicates the minimum of $S_{cr}/\kappa$ or $1$, and $\max$ indicates the maximum of $S_{cr}/\kappa$ or $1$.
+3.2 Hepatic Capacity Assessment (Child-Pugh Multi-Factor Mapping)
+For molecules cleared primarily through biliary or hepatic mechanisms, the engine computes a running hepatic safety score by aggregating bilirubin, albumin, INR, and documented encephalopathy clinical notes:
+[Fetch: Bilirubin + Albumin + INR] ──> Compute Combined Hepatic Score ──> Map to Child-Pugh Class (A, B, or C)
+If the calculation indicates a shift to Child-Pugh Class C, the system applies an automated protection response. It scales back the maximum permitted daily allowance for high-clearance hepatotoxic molecules (e.g., Acetaminophen, Valproic Acid) or surfaces a warning recommending a transition to alternatives with renal-dominant elimination pathways.
+Phase 4: Botanical, Cannabinoid, & Xenobiotic Interaction Engine
+Traditional interaction engines overlook botanical compounds. This module explicitly tracks drug-herb interactions, recognizing that organic compounds can alter core metabolic enzyme availability just as heavily as synthetic pharmaceuticals.
+4.1 Cannabinoid-Enzyme Inhibition Matrix
+When a patient has a documented history of medicinal cannabis or concentrated cannabinoid administration, the engine checks for competitive or time-dependent enzyme inhibition:
+The CYP3A4/2C9 Competitive Bottleneck: Cannabidiol (CBD) and Tetrahydrocannabinol (THC) act as substrates and potent inhibitors of Cytochrome P450 enzymes. The engine tracks these interactions to flag potential accumulation risks for co-prescribed medications:
+4.2 High-Risk Botanical Escalation Vectors
+If the patient's intake profile includes active cannabinoid therapies or specialized botanical supplements, the system cross-references prescriptions against specific interaction pathways:
+Active Botanical Exposure
+Proposed RxNorm Agent
+Target Interaction Vector
+Guardrail System Response
+Concentrated CBD Extracts
+Warfarin / Direct Oral Anticoagulants (DOACs)
+CBD competes directly for CYP2C9 clearance pathways, slowing anticoagulant breakdown and increasing bleeding risks.
+Automated Optimization: Suggest a mandatory $25\%$ reduction in the initial anticoagulant dose and queue an immediate follow-up INR lab check.
+Medicinal Cannabis (THC/CBD)
+Clobazam
+CBD strongly inhibits CYP2C19, leading to a significant increase in the active metabolite N-desmethylclobazam and causing profound sedation.
+Dosing Override: Cap the proposed Clobazam dose configuration and issue a high-priority sedation risk warning.
+St. John's Wort
+Cyclosporine / Tacrolimus
+Hyperforin acts as a potent inducer of hepatic CYP3A4 and P-glycoprotein, causing rapid drug clearance and therapeutic failure.
+Hard Order Block: Deny parallel prescription authorization due to high risk of acute organ transplant rejection.
+Phase 5: FHIR Technical Architecture & Data Schema Serialization
+To maintain a clean, auditable record of clinical decision support events, the engine communicates and stores safety flags using standard HL7 FHIR R4 resources.
+5.1 Interoperable Resource Map
+DetectedIssue: Acts as the primary clinical wrapper tracking the safety event, severity level, and specific risk mechanics.
+MedicationRequest: Encapsulates both the original blocked order intent and the proposed, optimized alternative prescription.
+Phase 6: Non-Interruptive Ambient UI/UX Integration & One-Click Execution
+To keep the clinical workspace efficient and focused, safety flags completely bypass old-fashioned interruptive pop-up dialog boxes. Instead, the interface handles alerts using a smooth, ambient feedback panel embedded right in the prescription screen.
+The Ambient Optimization Canvas: When a genomic, renal, or botanical conflict is identified, the order entry button changes color to indicate a pending modification recommendation. At the same time, an inline optimization card opens smoothly next to the medication input fields, detailing the biological risk factors and citing the underlying data sources (e.g., CPIC level A guidelines or specific eGFR lab dates) to make the reasoning completely transparent.
+One-Click Therapeutic Adjustments: The provider can accept the system's optimization recommendation with a single click. Doing so automatically updates the order details, cancels the conflicted draft, swaps in the safer alternative molecule or calculated dose adjustment, and queues the updated order for immediate cryptographic signature. This seamless transition keeps the clinical workflow moving forward while ensuring complete patient safety.
+Autonomous Revenue Cycle Management (RCM)
+The billing department shouldn't be a separate silo; it should be a continuous feedback loop driven by machine learning.
+Predictive Denial Auditing: Before a claim is ever submitted via EDI 837, an AI model trained on historical payer behavior and local coverage determinations "scrubs" the claim. It assigns a precise probability score for rejection or denial. If the risk is high, it flags the exact missing clinical documentation or modifier required to fix it.
+Phase 1: Ingestion & Interception of Claims Stream (Pre-EDI 837)
+The predictive auditing engine operates as an asynchronous validation gate, intercepting billing records immediately after a provider signs an encounter and a superbill is generated, but before it is serialized into an EDI 837 flat-file format.
+1.1 Structural Ingestion Core
+The engine intercepts the billing intent by extracting data from four core FHIR resources or their relational database equivalents:
+Claim: Captures the initial billing details, including the proposed service items, unit counts, and financial fields.
+Encounter: Details the physical site location, service dates, and provider taxonomies.
+Condition: Houses the primary and secondary diagnosis codes mapped to the encounter.
+DocumentReference: Pulls the narrative progress notes, lab results, and diagnostic studies tied to the visit.
+1.2 Data Normalization Pipeline
+Before running predictive analysis, the ingestion tier normalizes the data to ensure consistency across the data structures:
+Payer Taxonomy Standardizer: Maps varied local insurance identifiers down to normalized payer group tokens (e.g., grouping specific regional plan names into a single unified parent payer category).
+Provider Footprint Mapping: Combines the rendering provider's National Provider Identifier (NPI) with their specific specialty taxonomy codes and historical billing footprint within the practice.
+Phase 2: Multi-Dimensional Feature Engineering & Cross-Reference Mapping
+Once the billing data is ingested, the system transforms the raw administrative and clinical inputs into a structured feature vector optimized for machine learning evaluation.
+2.1 Automated LCD/NCD Parsing
+The system updates its database daily by pulling the latest regional Local Coverage Determinations (LCD) and National Coverage Determinations (NCD) from the Centers for Medicare & Medicaid Services (CMS) and private payer guidelines. The parsing engine extracts:
+Approved Coding Pairs: Valid combinations of CPT/HCPCS procedure codes matched with supporting ICD-10-CM diagnosis codes.
+Documentation Rules: Specific clinical keywords, lab thresholds, or diagnostic criteria required within the chart notes to justify reimbursement for high-complexity services.
+2.2 Semantic Feature Extraction
+An in-memory Natural Language Processing (NLP) pipeline scans the unstructured narrative clinical note associated with the claim. It extracts semantic features to verify the documentation supports the billed codes:
+Complexity Validation Metrics: Calculates structural complexity markers from the narrative text, such as the count of distinct organ systems reviewed, the severity of documented medical decision-making (MDM), and explicit treatment plan adjustments.
+Modifier-Specific Evidence Scanners: For claims containing evaluation and management (E&M) modifiers (like Modifier-25 for significant, separately identifiable services), the system searches the note to verify that separate, distinct clinical issues are explicitly documented.
+Phase 3: Machine Learning Denial Probability Engine
+The engineered feature vector is evaluated by a machine learning model (such as a gradient-boosted decision tree ensemble or deep neural classifier) trained on the practice's historical billing outcomes and past payer remittance advices (835 files).
+3.1 Mathematical Risk Formulation
+The model calculates a deterministic Denial Probability Score ($P_{\text{denial}}$) for the claim. This calculation accounts for base coding relationships, payer-specific denial rates, and semantic documentation scores:
+Factor Definition Framework
+$\sigma(z)$: The standard logistic function, scaling outputs safely between $0.0$ and $1.0$.
+$X_{\text{CCI}}$: A binary indicator variable flagging National Correct Coding Initiative (NCCI) edit or unbundling violations.
+$V_{\text{payer}}$: An indexed weight representing the historical denial rate of the target payer for that specific CPT classification over a rolling 180-day window.
+$\delta_{\text{LCD}}$: A calculated distance score indicating how closely the diagnosis and procedure codes match current LCD coverage requirements ($0.0$ for a perfect match, escalating higher as discordance increases).
+$\phi_i(\text{Text}_{\text{narrative}})$: Numerical semantic values extracted from the clinical note, evaluating documentation density, keyword completeness, and contextual clinical justification.
+Phase 4: Root-Cause Attribution & Missing Clinical Evidence Extraction
+If the calculated Denial Probability Score crosses the practice's risk threshold ($P_{\text{denial}} \ge 0.35$), the system pauses the billing pipeline to prevent submission. It passes the claim to an explainability module to diagnose the root cause of the risk.
+4.1 SHAP-Based Feature Attribution
+The explainability engine computes SHAP (SHapley Additive exPlanations) values for the claim instance. This mathematical approach calculates each feature's contribution to the high risk score, isolating the exact administrative or clinical variables causing the projected denial.
+4.2 Automated Deficiency Stratification
+The identified risk factors are categorized into clear, actionable billing alerts:
+Denial Risk Category
+Underlying Root Cause Metric
+Real-World Billing Scenario Example
+System Remediation Guidance
+Modifier Deficiency
+High positive SHAP contribution from the modifier array configuration.
+An E&M code (99214) and an injection code (96372) are billed together on the same day without an overriding modifier.
+Add Modifier-25: Flag the need for a Modifier-25 on the E&M line, provided the note supports a separate evaluation.
+Medical Necessity Deficit
+$\delta_{\text{LCD}} > 0.80$ paired with low semantic text scores.
+A high-tech imaging scan (70553 - Brain MRI) is ordered for standard "headache" symptoms without documenting mandatory red-flag indicators.
+Inject Missing Criteria: Alert the user that the target payer requires documented history of treatment failure or progressive neurological deficits.
+Unbundling Coding Conflict
+$X_{\text{CCI}} = 1$ value triggered.
+A provider bills a comprehensive surgical code alongside a component procedure code that is legally included in the main code.
+Consolidate Line Items: Recommend removing the separate component line item to prevent an NCCI unbundling rejection.
+Phase 5: FHIR Technical Architecture & Data Schema Serialization
+To support multi-facility compliance and maintain an unpolluted ledger, claims flagged with high denial risks are held in a pre-submission staging area. The engine logs its audit findings using standard HL7 FHIR R4 resources.
+5.1 Interoperable Resource Relationship Map
+OperationOutcome: Acts as the primary data container tracking the validation errors, risk metrics, and structural code location pointers.
+Claim: Holds the original, unsubmitted claim payload awaiting remediation.
+Phase 6: Non-Interruptive Billing Interface Workspace & One-Click Remediation Workflow
+To protect provider focus during clinical documentation, denial audit flags are routed directly to an administrative billing interface or a specialized "Pre-Flight Claim Workspace" used by coding teams.
+The Pre-Flight Claims Dashboard: High-risk claims are automatically routed into a specialized triage workspace. The interface features an interactive risk gauge alongside clear summaries of the identified issues, showing billing staff exactly why a claim is flagged before it reaches the EDI 837 output engine.
+Context-Aware Evidence Snippets: Clicking "Review Narrative Note Context" displays a split-screen view highlighting relevant sentences within the clinical text. This allows billers to quickly verify if the documentation supports a separate service modifier without needing to open the full patient chart.
+One-Click Claim Remediation: Billers can resolve the issue instantly by clicking "Append Modifier-25". The system updates the claim data, re-runs the predictive model to confirm the risk score drops into the safe green zone ($P_{\text{denial}} < 0.10$), and seamlessly releases the updated record to the automated EDI 837 compiler for clean submission.
+Automated Prior Authorization Routing: The moment an advanced diagnostic test or specialized therapy is ordered, the AI extracts the necessary clinical justifications from the chart, auto-populates the payer’s specific prior authorization forms, and submits them electronically, reducing a 20-minute manual process to seconds.
+Phase 1: Order Interception & Coverage Requirements Discovery (CRD)
+The prior authorization lifecycle initiates instantly in the background when an advanced diagnostic or specialized therapy is added to the clinical workspace.
+1.1 CDS Hooks Order Interception
+The engine acts as a listener on the EMR's order entry system. The moment a physician drafts or signs an advanced order (e.g., CPT 70553 for a Brain MRI, or an advanced biologic medication), a CDS Hook event (order-sign) fires an asynchronous payload to the routing gate.
+1.2 Automated Requirement Verification
+The gateway intercepts the order payload, pulls the patient’s active Coverage card, and routes an encrypted request to the target payer’s Da Vinci CRD (Coverage Requirements Discovery) endpoint. The system exchanges standard data vectors to determine authorization rules instantly:
+The Coding Array: CPT, HCPCS, or RxNorm medication identifiers.
+The Provider Blueprint: National Provider Identifier (NPI) and practice facility location.
+The Demographic Context: Patient age, regional zip code, and primary diagnostic codes (ICR-10-CM).
+If the payer's CRD response maps to a no-auth-required flag, the order proceeds instantly. If authorization is mandatory, the engine captures the payer's structural template identifier and advances to the extraction phase.
+Phase 2: Documentation Templates & Rules (DTR) Semantic Evidence Extraction
+Once a prior authorization requirement is confirmed, the engine uses the Da Vinci DTR (Documentation Templates and Rules) profile to identify the specific clinical evidence needed to clear the payer's medical necessity rules.
+2.1 Clinical Quality Language (CQL) Execution
+The payer's DTR service delivers a structured data questionnaire or rule layout written in CQL (Clinical Quality Language). This file acts as an executable logic template that defines the exact clinical criteria required for approval.
+2.2 Local Chart Mining & Attribute Retrieval
+The EMR's semantic search core processes the compiled CQL file, running automated queries across the patient’s longitudinal chart to extract the required clinical predicates:
+Conservative Therapy Logs: Searches narrative progress notes and past prescriptions to calculate the precise duration of first-line treatment trials (e.g., verifying a patient completed a 6-week course of conservative physical therapy before approving an orthopedic surgical intervention).
+Biochemical / Laboratory Thresholds: Pulls discrete values matching specific LOINC targets (e.g., confirming active metabolic or inflammatory markers are within the payer's required ranges).
+Diagnostic Imaging References: Gathers structural text conclusions from past radiology or pathology reports to provide solid evidence for advanced testing.
+Phase 3: Mathematical Completeness Scoring & Pre-Submission Validation
+To protect the practice from delayed care cycles and preventable denials, the compiled data payload runs through an internal validation matrix before electronic submission.
+The engine computes a deterministic Documentation Completeness & Approval Probability Index ($A_{\text{prob}}$). This calculation verifies that all strict medical necessity conditions defined in the payer's ruleset are fully supported by chart evidence:
+Factor Definition Framework
+$\chi_i$: A binary indicator tracking absolute prerequisite conditions (e.g., checking if a mandatory genetic variant or structural biopsy result is present). If any critical prerequisite is completely missing from the chart data, $\chi_i = 0$, driving the entire approval score $A_{\text{prob}}$ directly to $0.0
+$.$T_{\text{conservative}}$: The total number of documented days the patient participated in conservative first-line therapies.
+$\lambda$: A standardized mathematical decay constant calibrated to reflect the payer's historical approval patterns based on treatment duration.
+If the computed score crosses the practice configuration threshold ($A_{\text{prob}} \ge 0.90$), the payload advances directly to electronic submission. If the score falls below the line, the engine flags the exact missing chart elements for immediate provider review.
+Phase 4: Da Vinci PAS Mapping & X12 EDI 278 Electronic Submission
+Once validated, the compiled dataset is transformed into an interoperable electronic submission payload, bypassing manual web portals completely.
+The system routes the authorization data through one of two secure transaction paths based on the target payer's technical capabilities:
+The Modern Path (Da Vinci PAS): The engine wraps the clinical data into an interoperable FHIR PAS (Prior Authorization Support) transaction. This assembly transmits a single, encrypted Claim bundle containing the clinical documentation directly to the payer's real-time adjudication API.
+The Legacy Path (X12 EDI 278): For payers that still require traditional administrative formats, the system's edge gateway transforms the FHIR data objects into an ASC X12 EDI 278 (Prior Authorization Request) flat-file structure, routing it seamlessly through standard clearinghouse channels.
+Functional Data Category
+Native EMR FHIR Core Attribute Resource
+Target ASC X12 EDI 278 Structural Element
+Request Classification
+Claim.use (configured as preauthorization)
+Loop 2000C, Hierarchical Level Code (Util Management)
+Requesting Provider NPI
+Claim.provider (links to Practitioner ID)
+Loop 2010AA, NM1 Segment (Requesting Provider Details)
+Target Procedure Code
+Claim.item.productOrService (CPT/HCPCS)
+Loop 2000E, SV1 Segment (Proposed Service Definition)
+Clinical Justification
+Claim.supportingInfo (links to Observation)
+Loop 2000E, PWK Segment (Clinical Evidence Attachment)
+Phase 5: FHIR Technical Architecture & Data Schema Serialization
+To support multi-facility compliance and maintain clear data records, authorization requests are structured using standard Da Vinci PAS Claim profiles.
+5.1 System Resource Relationship Map
+Claim: Serves as the primary transaction shell, holding the preauthorization intent and itemized codes.
+ClaimResponse: Captures the real-time return data from the payer, including approval numbers, authorization windows, or review constraints.
+Phase 6: Human-in-the-Loop Exception Triage & Active Status Dashboard
+While the vast majority of standard requests receive instant electronic approvals, the system routes complex edge cases to an active triage workspace to keep clinic operations moving smoothly.
+Real-Time Adjudication Tracking: Approvals are captured instantly by background listeners. The moment a ClaimResponse hits the gateway with an approved status, the system automatically writes the unique Authorization ID directly to the active order record, updates the schedule, and text-alerts the patient to book their appointment.
+Contextual Exception Resolution: If a claim returns with a pended or deficient status due to missing data, the dashboard isolates the specific questionnaire rules that failed validation. Rather than forcing staff to rebuild the submission from scratch, the system presents a target shortcut button (e.g., "Scan Chart for External Logs"), allowing the user to quickly import missing external C-CDA history, update the criteria, and re-submit the request with a single click.
+Intelligent Patient Remote Orchestration
+An AI-driven EMR extends the clinic's reach into the patient's daily life, acting as an automated care coordinator.
+Asynchronous Triage & Smart Check-ins: The system automatically analyzes patient communication (via portal messages or SMS). It uses clinical NLP to triage messages based on urgency, drafting responses for the clinical team to review, or escalating critical symptoms directly to the provider's urgent task queue.
+Phase 1: Multi-Channel Inbound Ingestion & Text Normalization Pipeline
+The ingestion layer acts as a secure webhook listener that intercepts incoming communication streams in real time before they reach the standard messaging inbox.
+1.1 Inbound Gateway Interception
+Secure API endpoints ingest JSON payloads from SMS webhooks (e.g., Twilio, Telnyx) and authenticated EMR patient portal communication routers. The payload captures metadata including the patient identifier, sender verification tokens, timestamp, transmission channel, and raw message body.
+1.2 Text De-noising & Normalization
+Before processing raw text inputs, a data cleaning pipeline transforms the message body into a uniform format:
+Strips out non-standard UI characters, duplicate whitespace strings, and unreadable messaging artifacts.
+Expands common text abbreviations and shorthand patterns into standardized terms (e.g., converting "soby" or "sob" to "shortness of breath").
+Generates a temporary, unverified FHIR Communication resource stub to track the message lifecycle.
+Phase 2: Clinical NLP, Named Entity Recognition (NER), & Assertion Analysis
+The normalized text stream runs through a specialized clinical NLP pipeline to extract clinical concepts, identifying explicit medical conditions, symptoms, and medications.
+2.1 Clinical Entity Extraction
+An in-memory biomedical named entity recognition (NER) model parses the tokenized text stream to identify and tag core medical variables:
+Symptom & Condition Stems: Identifies descriptions of pain, physical changes, or functional issues, mapping them directly to SNOMED-CT concepts.
+Pharmaceutical Agents: Recognizes mentions of prescribed medications, over-the-counter drugs, or botanical substances, mapping them to RxNorm identifiers.
+2.2 Assertion & Contextual Analysis
+The engine evaluates the context surrounding each extracted entity to filter out irrelevant or non-active issues:
+Negation Filtering: Identifies phrases like "no chest pain" or "without fever" to ensure absent symptoms are not flagged as active complaints.
+Subject Attribution: Confirms whether the stated symptom applies directly to the patient or an external individual (e.g., "my daughter has a rash" vs "I have a rash").
+2.3 Emotional Distress & Sentiment Evaluation
+A parallel linguistic processor evaluates the structural syntax of the message to measure the patient's emotional state, tracking urgency indicators such as capital letters, exclamation points, and explicit panic words (e.g., "terrified", "scared", "bleeding out").
+Phase 3: Clinical Urgency Scoring & Priority Matrix Formulation
+To ensure reliable triage, the system converts extracted clinical concepts and sentiment metrics into a single, deterministic metric score called the Urgency Priority Index ($UPI$).
+The engine calculates this index by combining semantic acuity classifications (mapped to standard clinical triage frameworks like the Emergency Severity Index (ESI)) with the patient's active health profile and sentiment markers:
+Factor Definition Framework
+$A_{\text{esi}}$: The base clinical acuity coefficient, determined by mapping extracted symptoms to standard emergency triage categories ($1.0$ for immediate red-flag indicators like crushing chest pain or acute unilateral weakness; $0.1$ for minor administrative or logistical inquiries).
+$S_{\text{distress}}$: A normalized metric score representing the patient's emotional distress and communication urgency ($0.0$ to $1.0$).
+$V_{\text{patient}}$: A calculated vulnerability multiplier derived from the patient's active chart context. This value increases if the patient has a recorded history of severe cardiovascular disease, advanced metabolic instability, or is within an immediate 30-day post-operative recovery window.
+$w_1, w_2, w_3$: Standardized balancing weights calibrated to prioritize physical clinical indicators over emotional expression.
+Phase 4: Dynamic Routing Logistics & EMR Urgent Queue Integration
+Once the system computes the Urgency Priority Index ($UPI$), the score determines how the message is routed through the clinical workspace.
+4.1 High-Acuity Escalation Path ($UPI \ge 0.75$)
+If the computed triage score indicates an emergency or acute risk, the engine bypasses routine administrative queues entirely:
+Urgent Task Injection: Instantly generates a high-priority FHIR Task object and routes it directly to the treating provider's primary urgent dashboard.
+Visual & Push Alerts: Flags the message icon in bright red inside the EMR interface and triggers immediate push notifications across all connected clinical devices.
+Automated Red-Flag Response: Instantly sends an automated, pre-configured safety reply back to the patient's communication channel (e.g., "Your message flags critical symptoms. Please immediately hang up and dial 911 or proceed to the nearest emergency department").
+4.2 Standard Triage Path ($UPI < 0.75$)Messages with low-to-moderate acuity scores are routed directly to the standard nursing or administrative triage pool, where they are organized sorted by their priority scores to ensure efficient processing.
+Phase 5: Generative LLM Response Drafting & Philosophy-Aligned Formatting
+For non-emergency communications, the engine passes the message text and relevant parts of the patient's chart to a secure medical LLM. This module drafts an appropriate response for the clinical team to review before sending.
+5.1 Clinical Guardrail Prompt Architecture
+The drafting engine uses a strict contextual template designed to minimize medical risk and reflect the specific practice philosophy of the clinical group:
+The Verification Directive: Instructs the model to never finalize or send a clinical diagnosis directly to a patient without a physician's sign-off.
+The Philosophy Alignment Matrix: Instructs the model to prioritize lifestyle adjustments, preventative care, and structured nutritional recommendations (such as metabolic monitoring advice or fasting window details) ahead of pharmacological interventions for routine health updates.
+5.2 Contextual Synthesis Core
+The model reads the patient's upcoming calendar events and recent labs to generate helpful, personalized context for the draft response (e.g., appending a reminder like: "I see we have your metabolic follow-up panel scheduled for next Tuesday. Please remember that this requires a 12-hour water fast prior to your blood draw").
+Phase 6: FHIR Technical Architecture & Data Schema Serialization
+To ensure seamless data compatibility across healthcare platforms, all inbound triage decisions, calculated priority metrics, and generated message drafts are stored using standard HL7 FHIR R4 resources.
+Phase 7: Interactive Provider Triage Terminal & Human-in-the-Loop Workspace
+To ensure clinical control, machine-drafted text is kept in a holding status until a clinician reviews, edits, and authorizes the outbound transmission.
+Ambient Response Editing Canvas: The clinician can review the incoming message, the extracted clinical concepts, and the proposed text response inside a single, unified view. They can modify the draft text directly within the preview card to tailor the message further before sending.
+One-Click Transmission & Workflow Release: Clicking "Approve & Transmit Draft" sends the message to the patient's preferred channel, updates the status of the staging Task resource to completed, logs an audit token for tracking, and automatically clears the item from the provider's active urgent workspace queue.
+Dynamic Patient-Facing Summaries: The After-Visit Summary (AVS) is typically generic and hard for patients to understand. The AI should instantly translate the clinical note into highly personalized, conversational instructions matching the patient's literacy level and language preference, clearly detailing their medication titration schedules, nutritional protocols, and lifestyle goals.
+Phase 1: Encounter Closure Interception & Multi-Modal Context Harvesting
+The generation pipeline initiates automatically as an asynchronous background routine the moment the provider executes the chart-signing transaction.
+1.1 Structural Event Hook
+The EMR core fires an event notification (encounter-close) containing the unique patient identifier and the closed encounter ID. A message queue listener captures this payload and spins up an isolated background processing instance.
+1.2 Multi-Domain Context Compilation
+The compilation engine assembles the clinical raw materials and personalization parameters:
+The Clinical Narrative Source: Fetches the signed progress note from the database, including the history of present illness (HPI), physical exam, assessment, and treatment plan sections.
+Linguistic Preference Key: Queries the patient's core demographic record to pull their preferred language indicator code (ISO 639-1 standard format, e.g., es for Spanish, vi for Vietnamese).
+Social Determinants & Literacy Profile: Scans the patient's structured social history parameters for documented educational backgrounds, occupational markers, or past cognitive accessibility flags to establish a target baseline for reading comprehension levels.
+Phase 2: Semantic Decomposition & Extracting Actionable Care Plans
+Clinical progress notes combine investigative observations with actual therapeutic instructions. This module strips away pure documentation artifacts to isolate the exact changes being made to the patient's care routine.
+The system uses specialized natural language understanding (NLU) models to categorize sections of the treatment plan text into structured information buckets:
+The Pharmacological Action Array: Groups entries by action tags: DISCONTINUE, INITIATE, TITRATE, or MAINTAIN. It captures the target molecule name, exact dosage, route of administration, and administration timing vectors.
+The Dietary & Metabolic Protocol Vector: Isolates specific nutritional goals, time-restricted eating parameters, macronutrient boundaries, or therapeutic fasting instructions.
+The Behavioral Change Manifest: Extracts lifestyle directives, including target sleep windows, heart rate training targets, stress-management exercises, or mindfulness routines.
+Phase 3: Reading Level Optimization & Language Translation
+To maximize clear communication, the system processes the extracted information through a linguistic transformation layer. This conversion adjusts text complexity down to an accessible, everyday conversational tone while ensuring complete medical accuracy.
+3.1 Mathematical Readability Calibration Engine
+The engine uses a combination of word lengths, sentence structures, and concept density to measure textual complexity. It computes an automated Linguistic Accessibility Target Index ($L_{\text{target}}$) to verify the output matches a comfortable reading level (typically targeting a 6th-to-8th-grade comprehension profile):
+Where $\alpha, \beta, \gamma$ represent normalized weights calibrated against standard readability scoring frameworks, and $\mathbf{Score}_{\text{medical-density}}$ measures the concentration of dense, multi-syllable medical terminology. The system uses this index to guide the text generator, ensuring it simplifies complex sentence loops and explains advanced terms in plain language.
+3.2 Medical Translation & Localization
+If the patient's profile flags a non-English language preference, the plain-language text is routed through a specialized medical localization model:
+Preserving Clinical Intent: The translation system uses dedicated medical dictionaries to prevent unsafe literal phrasing (e.g., ensuring standard idioms or idiomatic instructions translate correctly into accurate regional health expressions).
+Culturally Sensitive Terms: The system replaces technical medical terms with descriptive, culturally appropriate alternatives (e.g., describing Insulin Resistance as "how your body cells process energy from your food").
+Phase 4: Structuring Clear Patient Timelines & Care Protocols
+The system formats the simplified text into clean, scannable layouts. Rather than using long paragraphs, instructions are organized into interactive, time-ordered schedules.
+4.1 Automated Medication Titration Calendars
+Complex dosing schedules are automatically converted into highly scannable visual timelines, showing patients exactly how to adjust their doses safely over time:
+Day Range Window
+Targeted Time of Day
+Plain-Language Medication Instructions
+Target Clinical Goal Tracker
+Days 1 through 7
+Morning with Breakfast
+Take 1 pill (500 mg) of Metformin.
+Check for mild stomach changes; allow your body time to adapt.
+Days 8 and beyond
+Morning with Breakfast AND Evening with Dinner
+Increase your dose: Take 1 pill (500 mg) in the morning, and take 1 pill (500 mg) at dinner.
+Maintain consistent daily energy; stabilize your blood sugar readings.
+4.2 Plain-Language Nutritional & Behavioral Roadmaps
+The engine converts advanced clinical recommendations into clear, encouraging lifestyle steps:
+Nutritional Protocols: Rephrases clinical terms into practical eating guidance: "Give your body an 8-hour window for meals (for example, eating between 11:00 AM and 7:00 PM) to support healthy digestion and keep your insulin levels balanced and steady."
+Lifestyle & Mindfulness Goals: Turns therapeutic exercise plans into concrete activities: "Walk briskly for 20 minutes daily to help clear glucose from your bloodstream. Practice 5 minutes of mindful breathing before bed to relax your nervous system and support deep, restorative sleep."
+Phase 5: FHIR Technical Architecture & Data Schema Serialization
+To support multi-facility data compatibility and ensure full system portability, the finalized patient summary is stored using standard HL7 FHIR R4 resources.
+5.1 Interoperable Resource Map
+DocumentReference: Acts as the primary document container, tracking reading-level scores, translation properties, accessibility metadata, and secure access permissions.
+Binary: Houses the raw, encrypted layout data (HTML or Markdown text) delivered to the patient's secure device or application.
+Phase 6: Provider Verification Terminal & One-Click Patient Portal Delivery
+Before publishing to the patient portal, the system presents the generated plain-language summary to the clinician via a brief, side-by-side verification interface to ensure complete safety and control.
+The Ambient Approval Dashboard: The review panel displays the source clinical note alongside the generated plain-language text. This side-by-side presentation allows providers to instantly verify that no therapeutic instructions were altered during the simplification process.
+One-Click Secure Delivery: Clicking the release button encrypts the text document, writes the finalized asset to the patient's secure health timeline, triggers a subtle mobile push notification to the patient's smartphone, and updates the EMR audit log to confirm successful delivery of the personalized care plan.
+The "Zero-Click" Clinical Encounter Pipeline
+Instead of the provider acting as an expensive data-entry clerk, the AI should handle the heavy lifting of documentation, order drafting, and coding simultaneously.
+Ambient Synthesis to Structured Schema: The ambient AI doesn't just generate a block of text for a SOAP note. It parses the conversation in real time and automatically populates discrete fields in your FHIR-native database (e.g., extracting specific vitals mentioned, updating the allergy list, or adding a new diagnosis to the problem list).
+Phase 1: Real-Time Audio Capture, Streaming Diarization, & Tokenization
+The ingestion layer establishes an event-driven connection that processes conversational audio directly within the examination space.
+1.1 Dual-Channel WebSockets Pipeline
+A lightweight audio capturing component in the client interface streams raw audio over an encrypted WebSockets connection to a centralized streaming service. The audio is captured at a standard sample rate of 16 kHz with 16-bit mono PCM encoding to strike an optimal balance between speech recognition accuracy and network bandwidth consumption.
+1.2 Acoustic Voice Activity Detection & Neural Diarization
+The incoming audio stream passes through an advanced acoustic processing pipeline:
+Voice Activity Detection (VAD): Filters out background ambient room noise, machinery hums, and long pauses to prevent unnecessary downstream compute utilization.
+Neural Speaker Diarization: Dynamically segments the audio based on unique vocal characteristics. It assigns distinct speaker tags in real time to organize the dialogue:
+1.3 Streaming Text Generation
+An automated speech recognition (ASR) engine processes the separated audio channels concurrently. It outputs a synchronized, time-stamped stream of text tokens accompanied by their matching speaker metadata tags, preparing the raw conversation for clinical context parsing.
+Phase 2: Clinical Natural Language Understanding & Entity Extraction
+As text tokens enter the system, a clinical NLU engine analyzes the dialogue stream to identify key medical concepts, relational structures, and contextual assertions.
+Clinical Named Entity Recognition (NER): A specialized medical language transformer model continuously scans the text stream. It identifies and tags core clinical concepts, classifying them into distinct health categories such as physiological vital signs, drug allergies, active systemic conditions, and therapeutic plans.
+Relation & Context Extraction: The engine analyzes the linguistic structure around each identified concept to link related terms together. For example, if a patient states: "My blood pressure was 120 over 80 at home this morning," the model connects the numerical value string (120/80), the clinical concept (Blood Pressure), the measurement environment (Home), and the temporal parameter (Current Day).
+Assertion & Negation Validation: The system evaluates modifiers within the sentence structure to determine the clinical status of each entity:
+Example: If a patient states, "I used to get hives from penicillin when I was a child, but I have no problems with amoxicillin now," the engine correctly categorizes Penicillin as an active historical allergy risk, while Amoxicillin is marked as a negated assertion.
+Phase 3: Clinical Ontology Standardization & Cross-Reference Mapping
+To ensure strict data accuracy, extracted concepts must be mapped to standard medical terminologies before they are committed to the EMR database.
+The engine uses a standardized database lookup routine to resolve colloquial dialogue expressions into precise, regulated terminology codes:
+Colloquial Dialogue Phrasing
+Extracted Category
+Standard Vocabulary Mapping System
+Target Code Identifier
+"Blood pressure was 120 over 80"
+Vital Sign Metric
+LOINC (Logical Observation Identifiers Names and Codes)
+85354-9 (Blood pressure panel)
+"Hives from penicillin"
+Substance Allergy
+RxNorm / SNOMED-CT
+RxNorm: 7980 (Penicillin)
+SNOMED: 247472004 (Urticaria)
+"Type 2 diabetes"
+Active Diagnosis
+ICD-10-CM / SNOMED-CT
+ICD-10: E11.9 (Type 2 diabetes mellitus)
+SNOMED: 44054006 (Type 2 diabetes)
+3.1 Extraction Confidence Calibration
+To prevent corrupted or ambiguous data from polluting the patient record, the system calculates a Concept Extraction Confidence Score ($CS_{\text{extract}}$) for every mapped entity:
+Where $P_{\text{asr}}$ is the raw acoustic confidence token probability, $P_{\text{ner}}$ is the semantic entity model match score, and $\delta_{\text{assertion}}$ is a weight indicating contextual clarity. If $CS_{\text{extract}} \ge 0.85$, the entity is safely queued for structured staging. If it falls below $0.85$, the concept is held in a lower confidence status, requiring explicit provider confirmation via the user interface.
+Phase 4: FHIR-Native Transactional Transformation Layer
+Once concepts are standardized, a mapping engine converts the flat data structures into fully formed, interoperable HL7 FHIR R4 resources.
+4.1 Structural Resource Transformation Templates
+Vital Signs: Extracted measurements are structured into standard FHIR Observation resources, using the vital-signs category profile to ensure clean tracking over time.
+Allergies & Adverse Reactions: Substance alerts are packaged into FHIR AllergyIntolerance components, specifying critical metadata including drug classes, manifest reactions, and verification codes.
+Problem List Diagnoses: Active medical conditions are transformed into FHIR Condition resources, populating clinical status flags and verification attributes.
+4.2 Resource Assembly Layouts
+The mapping tier structures individual clinical data elements into target FHIR objects:
+Observation Resource Target Structure (Blood Pressure Mapping):
+code: LOINC: 85354-9 (Blood Pressure Panel)
+component[0].code: LOINC: 8480-6 (Systolic) | valueQuantity: 120 mm[Hg]
+component[1].code: LOINC: 8462-4 (Diastolic) | valueQuantity: 80 mm[Hg]
+AllergyIntolerance Resource Target Structure (Penicillin Allergy Mapping):
+clinicalStatus: active
+verificationStatus: confirmed
+substance: RxNorm: 7980 (Penicillin)
+reaction.manifestation: SNOMED: 247472004 (Urticaria / Hives)
+Condition Resource Target Structure (Type 2 Diabetes Mapping):
+clinicalStatus: active
+verificationStatus: confirmed
+code: ICD-10-CM: E11.9 | SNOMED: 44054006 (Type 2 Diabetes)
+Phase 5: Asynchronous Transactional Bundle Serialization
+To optimize performance and maintain absolute database integrity, individual FHIR resources are bundled into a single transactional unit and committed atomically to the server.
+5.1 Atomicity & ACID Integrity
+The system wraps the compiled resources into a single FHIR Transaction Bundle. This architecture ensures complete database consistency: either all structural updates succeed together, or the entire transaction rollbacks safely if a validation error occurs, preventing partial data corruption.
+Phase 6: Interactive Dashboard Synchronization & Live Verification Interface
+To maintain a distraction-free environment during the patient encounter, data extractions update silently in a dedicated verification panel, bypassing standard interruptive modals or alerts.
+The Real-Time Preview Panel: Mapped clinical concepts are cleanly populated in a secondary workspace window as the provider-patient conversation progresses. High-confidence extractions are pre-validated and checked by default, while items requiring additional clarity are flagged with a review status.
+One-Click Secure Commit: The provider can quickly review the structured inputs at the end of the encounter. Clicking the commit button pushes the synchronized FHIR Transaction Bundle directly to the server, updating the patient's discrete records, allergy alerts, and core problem lists instantly without requiring manual data entry.
+Autonomous Order & Script Drafting: If the provider says to the patient, "Let's check your fasting insulin and NMR lipoprofile next week, and I want you to start a 14:10 intermittent fasting schedule," the AI automatically drafts the laboratory orders, flags the appropriate LOINC codes, and creates a structured lifestyle prescription in the checkout queue. The provider only needs to review and click "Authorize."
+Phase 1: Real-Time Acoustic Parsing & Semantic Tokenization
+The intent-capture pipeline processes conversational speech using an asynchronous background listener within the clinical space.
+1.1 Multi-Speaker Separation and ASR Ingestion
+The ambient microphone array streams audio to a local processing unit. The acoustic engine isolates the provider's voice profile, translates the spoken words into a streaming text string, and passes the output to a downstream clinical parsing model.
+1.2 Entity and Intent Isolation
+The natural language understanding (NLU) core uses semantic parsing to break down the text string into distinct operational parts:
+Action Verbs (Directives): Identifies phrases like "Let's check", "order", or "I want you to start" as triggers to generate new medical records.
+Clinical Target Candidates: Flags noun phrases like "fasting insulin", "NMR lipoprofile", and "14:10 intermittent fasting" for vocabulary mapping.
+Temporal Modifiers: Extracts expressions like "next week" to calculate the valid scheduling window for the orders.
+Phase 2: Clinical Ontology Mapping & LOINC/SNOMED Coding
+Once clinical candidates are extracted, the system maps the colloquial spoken terms to standardized, interoperable healthcare codes.
+Verbally Spoken Term Target
+Target Classification
+Standard Vocabulary System
+Code Identifier
+Code Description
+"Fasting insulin"
+Laboratory Order
+LOINC
+2492-2
+Insulin [Mass/volume] in Serum or Plasma --Fasting
+"NMR lipoprofile"
+Laboratory Order
+LOINC
+43396-1
+Lipoprotein subfraction panel - Serum or Plasma by NMR
+"14:10 intermittent fasting"
+Lifestyle Prescription
+SNOMED-CT
+410606002
+Dietary regimen (regimen/therapy)
+2.1 Intent Confidence Modeling
+To ensure clinical safety, the engine calculates an Intent Matching Confidence Score ($I_{\text{match}}$) before generating draft elements:
+Where $P_{\text{asr}}$ represents the clarity score of the speech-to-text translation, and $\mathbf{Sim}_{\text{cosine}}$ measures the semantic similarity between the spoken words and the standard medical definition. If $I_{\text{match}} \ge 0.88$, the system automatically adds a draft order to the checkout queue. If the score falls below this mark, it places the item in a low-confidence status, prompting the billing or clinical team to manually verify the selection.
+Phase 3: Temporal Logic Processing & Actionable Scheduling
+Relative time expressions must be converted into concrete dates within the electronic medical record system.
+[Spoken Variable: "Next Week"] ──> Fetch Current Timestamp ──> Calculate Targeting Window ──> Set Order Boundaries
+Calculating Order Windows: The system reads the current system timestamp (e.g., Thursday, June 11, 2026). It parses the relative time modifier "next week" to calculate an active execution window, setting an authorization start date and a reasonable expiration boundary:
+Managing Fasting States: Because the system identifies LOINC: 2492-2 as a fasting laboratory measurement, it automatically appends a strict instruction modifier (pre-conditioned fasting requirement) to the order payload, reminding the collection lab and the patient that a 12-hour water fast is required before venipuncture.
+Phase 4: FHIR-Native Resource Structure & Orchestration
+The system transforms the verified codes and scheduling details into interoperable HL7 FHIR R4 resources, establishing structural clinical objects.
+4.1 Lab Orders (ServiceRequest Profile)
+The system builds a distinct ServiceRequest resource for each laboratory diagnostic target. The resource includes critical administrative metadata:
+intent: Set to draft to keep the order staged until the provider signs off.
+code: Populated with the resolved LOINC codes (2492-2 and 43396-1).
+occurrencePeriod: Stores the calculated execution dates.
+4.2 Lifestyle Prescriptions (CarePlan Profile)
+The system packages structural lifestyle and nutritional instructions into a custom FHIR CarePlan or a lifestyle-oriented ServiceRequest resource. This object translates the spoken directive "14:10 intermittent fasting schedule" into clean, structured parameters:
+category: Classified as a dietary or behavioral modification regimen.
+activity.detail: Defines a daily 14-hour fasting period paired with a 10-hour eating window, complete with consumer-friendly descriptions to help the patient follow the plan.
+Phase 5: Transactional Data Bundle Serialization
+To maximize processing efficiency and maintain database integrity, individual draft resources are compiled into a single transactional payload and transmitted to the EMR database.
+Phase 6: Single-Click UI/UX Authorization & Checkout Queue Integration
+To protect provider focus during face-to-face patient visits, draft orders update silently in a secondary control panel, completely bypassing intrusive pop-ups or validation wizard workflows.
+The Ambient Checkout Queue: Draft orders are quietly prepared and staged in a side panel within the patient encounter workspace. This layout allows the provider to maintain natural eye contact and dialogue with the patient without having to interrupt the conversation to interact with the software.
+One-Click Authorization Execution: At the end of the visit, the provider reviews the staged order items. Clicking "Authorize & Sign" signs the draft records with a cryptographic signature, updates the clinical record, routes the lab orders directly to the diagnostic center, and drops the structured lifestyle prescription onto the patient's mobile health application for instant onboarding.
+Real-Time Code Justification: As the provider speaks or edits the note, the AI maps the clinical narrative to the highest appropriate hierarchical condition category (HCC) and ICD-10 codes, ensuring the documentation legally supports the billing complexity before the note is locked.
+Phase 1: Real-Time Text Buffering & Ingestion Pipeline
+The input layer captures streaming text from ambient voice dictation or active keyboard edits within the EMR workspace without causing system lag.
+1.1 Multi-Source Text Ingestion
+The engine establishes a real-time connection to the EMR progress note editing field. Text updates are captured through two main pathways:
+The Text Field Listener: Captures incremental changes from keyboard inputs within the text editor.
+The Ambient Audio Stream: Receives real-time text outputs from background speech-to-text engines as the provider speaks to the patient.
+1.2 Performance-Optimized Debounce Gateway
+To protect system performance and prevent unnecessary database queries, the ingestion layer processes text changes through a 300-millisecond debounce gate. The system waits for a brief pause in typing or speaking before sending the updated text segment to the downstream natural language processing (NLP) pipeline.
+Phase 2: Clinical Natural Language Processing & Hierarchical Condition Category Mapping
+Once a text segment passes the debounce gate, it is processed by a clinical language transformer model trained to extract diagnoses and map them to standardized medical vocabularies.
+Named Entity Recognition (NER): The system scans the clinical text to isolate active chronic diseases, acute symptoms, and structural complications.
+Clinical Relationship Linking: The model analyzes sentence syntax to find explicit links between diseases and their physical symptoms. For example, if the text contains "Type 2 diabetes" and "burning numbness in feet treated with gabapentin," the engine links the two concepts together, upgrading the diagnosis from uncomplicated diabetes to diabetes with neurological manifestations.
+Ontology Code Resolution: Mapped medical concepts are cross-referenced with current ICD-10-CM frameworks and the latest CMS-HCC Risk Adjustment Models (e.g., V24 and V28) to determine their impact on reimbursement and risk tracking.
+Phase 3: Mathematical RAF Optimization & Hierarchical Overrides
+The engine uses a mathematical framework to evaluate how newly identified codes impact the patient's overall health risk profile.
+The system calculates an updated Risk Adjustment Factor ($RAF$) score by combining the patient's demographic baseline with active disease coefficients, accounting for hierarchical overrides and code interactions:
+Factor Definition Framework
+$\beta_{\text{demographic}}$: The baseline risk score assigned to the patient based on age, sex, and insurance enrollment status.
+$\beta_{\text{HCC\_Active}}$: The mathematical risk coefficient assigned to each verified Hierarchical Condition Category.
+$\gamma_{\text{interaction}}$: An additional risk weight triggered when specific combinations of chronic conditions are present simultaneously (e.g., a patient presenting with concurrent heart failure and chronic kidney disease).
+$\Delta_{\text{hierarchy}}$: A hierarchical adjustment that automatically subtracts lower-severity risk scores when a more severe manifestation within the same disease category is documented (e.g., an entry for Severe Chronic Kidney Disease overrides and cancels out the score for Mild Chronic Kidney Disease).
+Phase 4: Legal Sufficiency Auditing via MEAT Criteria Validation
+To ensure a diagnosis is legally compliant and fully supported by the documentation, the engine validates the note text against the standard auditing framework known as MEAT (Monitor, Evaluate, Assess, Treat).
+The system evaluates the note to confirm that at least one of the four MEAT criteria is explicitly documented alongside the diagnosis code:
+Target Auditing Element
+System Validation Parameter
+Real-World Clinical Example
+Real-Time Sufficiency Status
+Monitor
+Checks for related laboratory tracking, diagnostic imaging, or vital sign trends.
+"Reviewing hemoglobin A1c trend..."
+Passed: Objective monitoring is clearly present.
+Evaluate
+Searches for specific symptom descriptions, stability assessments, or exam findings.
+"Patient notes persistent burning pain in bilateral lower extremities."
+Passed: Symptom evaluation is documented.
+Assess
+Verifies documented reviews of specialist consults or tests.
+"Neuropathy is poorly controlled."
+Passed: Disease severity is assessed.
+Treat
+Confirms active medications, surgical plans, or referrals.
+"Increase Gabapentin to 300mg PO at bedtime."
+Passed: Active treatment plan is established.
+If a high-weight HCC code is mentioned but the text fails to include supporting MEAT details, the engine flags the documentation as insufficient, helping the provider avoid audit vulnerabilities before the note is finalized.
+Phase 5: FHIR Technical Architecture & Data Schema Serialization
+To ensure seamless data compatibility across healthcare platforms, justification alerts and documentation gaps are tracked using standard HL7 FHIR R4 resources.
+5.1 System Resource Relationship Map
+Condition: Tracks the proposed ICD-10-CM and HCC codes, utilizing extensions to store real-time compliance validation metrics.
+OperationOutcome: Houses the specific documentation warnings, required text modifications, and rule locations generated by the audit engine.
+Phase 6: Non-Interruptive Provider HUD & One-Click Documentation Remediation
+To prevent alert fatigue and protect provider focus, the code justification module operates within a quiet sidebar panel that updates seamlessly alongside the clinician's workspace.
+The Ambient Insights Panel: As the provider documents the visit, the sidebar display updates automatically to highlight potential optimization opportunities. It shows the active diagnosis codes alongside suggested high-weight alternatives, detailing exactly what text is missing to satisfy an audit.
+One-Click Documentation Sync: Clicking "One-Click Fix" automatically updates the text within the note template (e.g., modifying the text to read "Type 2 diabetes with diabetic polyneuropathy"). The system updates the mapped diagnostic array, lowers the alert status, and saves the verified ICD-10/HCC codes directly to the billing encounter ledger. This ensures clean documentation that fully supports compliance standards before the note is locked.
+Prompt: use the “Core Master Prompt Blueprint” below to have all workflows and overall EMR be modeled under this theme and overarching structure. Have the AI read and learn this entire system and understand it in detail and begin to design the core of our EMR based roughly around these principles:
+Core Master Prompt Blueprint
+designed to guide a coordinated fleet of 30+ AI development, design, and schema agents. It establishes a strict, unified architectural framework for building a zero-friction, ultra-low-click, zero-scroll, and aesthetically elegant Electronic Medical Record (EMR) system.
+SYSTEM SYSTEM-WIDE ARCHITECTURAL PROMPT
+[ FLEET COMMAND DIRECTIVE ] 
+TARGET SYSTEM: Next-Generation, FHIR-Native, Ambient Minimalist EMR 
+AGENT ORCHESTRATION LAYER: 30+ Multi-Agent Development Network 
+OBJECTIVE: Eliminate administrative drag by enforcing a Click-Minimization, Scroll-Elimination, and Typographic-Harmony UX framework.
+1. Core Operating System Axioms (The Golden Rules)
+Every AI agent—regardless of whether it handles frontend layouts, state management, clinical NLP parsing, or backend database caching—must strictly adhere to the following four core product rules:
+1.1 The Click-Elimination Axiom
+Rule: No routine clinical workflow (e.g., writing a SOAP note, signing a prescription, or reviewing laboratory trends) may require more than two clicks from the primary dashboard viewport.
+Mechanism: Use contextual prediction, hover actions, automated form completion, and a keyboard-driven command box (Cmd + K) to bypass nested configuration menus entirely.
+1.2 The Scroll-Elimination Axiom
+Rule: All critical patient and encounter details must fit cleanly within a single, non-scrolling screen workspace (Single Viewport Standard).
+Mechanism: Eliminate endless vertical timelines. Replace them with fluid, tabbed side drawers, expanding canvas grids, and clean split viewports that dynamically adjust size based on screen dimensions.
+1.3 The Typing-Reduction Axiom
+Rule: Clinicians must never manually type out standard clinical prose or look up routine administrative codes.
+Mechanism: Use real-time ambient conversation capture to instantly generate structured text drafts. Use intelligent defaults based on the patient's history and the provider's past practice habits to pre-populate clinical choices.
+1.4 The Zen-Density Design Principle
+Rule: Do not crowd the screen with rows of dense data boxes, heavy borders, or bright, high-contrast colors.
+Mechanism: Create a beautiful, minimalist workspace using spacious padding (16px to 24px grid systems), soft pastel status indicators, muted neutral backgrounds, and clear text hierarchies. The interface must feel open and calm while using context-aware displays to show information only when it is relevant.
+2. Mathematical Workspace Optimization Metrics
+To ensure consistency across all 30 development agents, layouts must be automatically checked against a standardized UI Efficiency & Aesthetic Index ($E_{\text{ui}}$) during the design and build phases:
+Metric Weight Parameters
+$C_{\text{total}}$: The absolute number of discrete mouse clicks required to successfully complete a given workflow from start to finish.
+$S_{\text{depth}}$: The total vertical scroll depth measured in pixels ($S_{\text{depth}} = 0$ indicates a perfectly contained, single-viewport workspace layout).
+$K_{\text{strokes}}$: The total number of keystrokes needed to complete form updates or searches.
+$V_{\text{density}}$: Visual clutter coefficient ($0.1$ to $1.0$). Calculated by dividing the screen space filled by text borders or active UI buttons by the total viewport area.
+$\mathbf{A}_{\text{balance}}$: Visual balance score ($0.0$ to $1.0$), measuring layout alignment and white space distribution.
+$\kappa$: A global normalization constant used to standardize evaluation testing across different device resolutions.
+3. UI/UX Design System Specification Guidelines
+Frontend and Component agents must follow these explicit design rules to maintain visual consistency and ease of use:
+3.1 Color Systems & Dark Mode Calibration
+Match the below accents and colors with the current color scheme of LeafJourney EMR
+Accents: Active status accents must use soft, low-saturation hues:
+Approvals & Positive Status: Sage Green (#E2F0D9 fill with #385723 text).
+Alerts & Immediate Gaps: Soft Terracotta/Ochre (#FCE4D6 fill with #C65911 text).
+Interactive Links: Muted Slate Blue (#DDEBF7 fill with #1F4E78 text).
+3.2 Workspace Geometry & Layout Framework
+Workspace Component Region
+Native Structural Layout Rules
+Scroll Mitigation Architecture
+Click Shortcut Actions
+Global Control Box
+Centered floating search bar (Cmd + K).
+0 Pixels Allowed. Displays results in a clean overlay window.
+Instant focus trigger. Displays immediate contextual actions based on your search.
+Patient Summary HUD
+Sticky header row spanning the top 80px of the screen.
+0 Pixels Allowed. Displays key health stats in horizontal groups.
+Hovering opens a clean tool-tip bubble with trend graphs.
+Active Care Canvas
+Three-column grid layout with clean grid gutters.
+Displays deep historical files inside scroll-free tab rows.
+A single click expands a section file; clicking away collapses it back into place.
+Context Action Drawer
+Right-hand pop-out drawer overlay layout.
+Dynamically adjusts drawer height to match content lengths.
+Displays single-click approval, authorization, and save actions.
+4. Split Agent Roles & Implementation Directives
+The multi-agent network is organized into specialized functional groups. Each group must execute their assigned tasks according to these strict operational constraints:
+4.1 Layout & Component Generation Agents (UI/UX Group)
+Directive: Never generate separate popup dialog boxes or multiple nested windows.
+Implementation Requirement: All sub-workflows (such as picking lab tests, adding diagnoses, or editing demographic cards) must happen within smooth, slide-out contextual drawers or clean, inline expanding rows. Ensure components maintain generous padding configurations (minimum 12px separation layers) to keep the workspace looking clean and uncrowded.
+4.2 Text Analytics & Ambient Processing Agents (Clinical NLP Group)
+Directive: Continuously convert spoken clinical dialogue or unstructured note changes into clean, structured data models.
+Implementation Requirement: Extract active medical conditions, vital measurements, drug allergies, and treatment intentions in the background. Instead of forcing providers to manually enter data into structured forms, automatically stage extracted items in a clear sidebar workspace for single-click verification.
+4.3 Prescriptions & Ordering Optimization Agents (CPOE Group)
+Directive: Eliminate multi-step search wizards when ordering medications, scheduling imaging, or organizing diagnostic lab tests.
+Implementation Requirement: When a drug or lab is selected, use the patient's active chart history and insurance rules to automatically populate required order parameters (such as matching LOINC/RxNorm codes, appropriate drug dosages, specific prior-authorization justifications, and required fasting conditions). The order must sit ready in the checkout queue, needing only a single click to authorize.
+4.4 Communication Triage & Patient Engagement Agents (Triage Group)
+Directive: Automate the processing of inbound portal messages and post-visit summary creation to minimize administrative task work.
+Implementation Requirement: Automatically sort incoming patient communications by clinical risk, placing high-urgency issues directly into the clinician's immediate task queue. For completed visits, instantly convert technical assessment notes into plain-language instructions tailored to the patient's preferred language and reading level.
+End-to-End Operational Workflow Directives
+Agents must build and coordinate user pathways according to these optimized, step-by-step clinical routines:
+5.1 Ambient Examination & Order Generation Workflow
+The Audio Stream: The ambient microphone captures clinical conversation during the encounter, feeding text tokens directly to the processing tier.
+The Structural Sync: The clinical language model identifies spoken intents (e.g., "Let's check your fasting insulin next week"). It immediately looks up the standard laboratory identifiers (LOINC 2492-2) and calculates the active order date window.
+The Queue Injection: The system automatically builds a draft order, fills in required fasting parameters, and stages the request inside the patient's active checkout queue without requiring manual entry or screen updates.
+The Final Confirmation: The checkout panel highlights the staged draft in a soft background hue. The provider verifies the pre-populated details and authorizes the order with a single click.
+5.2 Real-Time Code Justification & Documentation Check Workflow
+The Typing Monitor: The system tracks incremental text edits or verbal statements within the progress note editor.
+The Compliance Audit: An internal auditor processes the note text through a 300ms debounce loop, matching the documented diagnoses against current ICD-10-CM codes and Hierarchical Condition Categories (HCC).
+The Gap Alert: If the text describes symptoms or treatments for a condition but lacks the explicit causal wording needed to satisfy a billing audit, a soft notification card appears in the side drawer.
+The Direct Remedy: The notification card explains the documentation gap and provides a one-click button (e.g., "Link symptoms to diabetic neuropathy"). Clicking the button automatically updates the progress note with the correct medical phrasing and saves the verified code to the billing ledger.
+6. Execution Command for the Multi-Agent Network
+🤖 Global Fleet Instruction Prompt
+"Read, index, and strictly implement the design criteria detailed in this architectural framework across all modules you build. Every interface component you generate must pass the single-viewport limit, use our soft minimalist color system, and require no more than two clicks to finalize a task.
+If a proposed workflow or user interface requires vertical scrolling to reveal mandatory forms, multi-step search wizards, or multiple pop-up confirmation boxes, you must reject the design, recalculate your layout algorithm against our UI Efficiency Index ($E_{\text{ui}}$), and rebuild the pathway using smooth, slide-out contextual drawers and predictive data entry. Maximize screen elegance; eliminate functional clutter; treat the clinician's time as our highest design priority."

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,20 @@
   --danger: #B83B2E;
   --info: #2E5B8C;
 
+  /* Status accents — Fleet Command Directive (EMR-1160).
+     Soft pastel fill/text pairs for clinical status communication:
+     approvals (sage), gaps/alerts (soft terracotta), interactive links
+     (muted slate blue). Pastel fills sit comfortably next to the existing
+     shelf pastels; text values pass WCAG AA on their fills. Use for status
+     chips, highlighted rows, and inline insight cards — keep --success /
+     --warning / --danger for hard semantic states. */
+  --status-positive-bg: #E2F0D9;
+  --status-positive-fg: #385723;
+  --status-alert-bg: #FCE4D6;
+  --status-alert-fg: #C65911;
+  --status-link-bg: #DDEBF7;
+  --status-link-fg: #1F4E78;
+
   /* Typography stacks — Fraunces for display, Instrument Serif italic
      accent, Inter for body, JetBrains Mono for data callouts */
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text",
@@ -657,6 +671,15 @@
   --warning: #FBBF24;
   --danger: #F87171;
   --info: #60A5FA;
+
+  /* Status accents — dark variants follow the shelf-pastel approach:
+     preserve hue, drop fill value, brighten text to read on dim fills. */
+  --status-positive-bg: #1E2A18;
+  --status-positive-fg: #AECB95;
+  --status-alert-bg: #2E1E12;
+  --status-alert-fg: #E8A06A;
+  --status-link-bg: #16222E;
+  --status-link-fg: #93BBDF;
 }
 
 .theme-leafmart.dark,

--- a/src/lib/agents/message-urgency-observer-agent.ts
+++ b/src/lib/agents/message-urgency-observer-agent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import type { Agent } from "@/lib/orchestration/types";
 import { triageThread } from "@/lib/domain/smart-inbox";
+import { deriveVulnerabilityFlags } from "@/lib/triage/upi";
 import { recordObservation } from "@/lib/agents/memory/clinical-observation";
 
 // ---------------------------------------------------------------------------
@@ -64,16 +65,35 @@ export const messageUrgencyObserverAgent: Agent<
   async run({ messageId, threadId, patientId }, ctx) {
     ctx.assertCan("read.patient");
 
-    const thread = await prisma.messageThread.findUnique({
-      where: { id: threadId },
-      include: {
-        patient: { select: { userId: true } },
-        messages: {
-          orderBy: { createdAt: "desc" },
-          take: 10,
+    // EMR-1147 — chart context feeds the UPI vulnerability multiplier
+    // (V_patient): severe cardiovascular disease, advanced metabolic
+    // instability, 30-day post-op window.
+    const [thread, chart] = await Promise.all([
+      prisma.messageThread.findUnique({
+        where: { id: threadId },
+        include: {
+          patient: { select: { userId: true } },
+          messages: {
+            orderBy: { createdAt: "desc" },
+            take: 10,
+          },
         },
-      },
-    });
+      }),
+      prisma.patient.findUnique({
+        where: { id: patientId },
+        select: {
+          contraindications: true,
+          pastMedicalConditions: {
+            where: { deletedAt: null },
+            select: { condition: true },
+          },
+          pastSurgeries: {
+            where: { deletedAt: null },
+            select: { createdAt: true },
+          },
+        },
+      }),
+    ]);
     if (!thread) {
       ctx.log("info", "Thread not found — skipping triage", { threadId });
       return {
@@ -84,6 +104,15 @@ export const messageUrgencyObserverAgent: Agent<
       };
     }
 
+    const vulnerability = deriveVulnerabilityFlags({
+      conditions: chart?.pastMedicalConditions ?? [],
+      contraindications: chart?.contraindications ?? [],
+      surgeries: chart?.pastSurgeries ?? [],
+    });
+
+    // EMR-1146 — the deterministic UPI engine inside triageThread is the
+    // primary signal (negation/subject-attribution aware); the keyword
+    // heuristic is advisory only. Fixes both EMR-1090 failure modes.
     const result = triageThread(
       thread.messages.map((m) => ({
         body: m.body,
@@ -92,6 +121,7 @@ export const messageUrgencyObserverAgent: Agent<
         createdAt: m.createdAt.toISOString(),
       })),
       thread.patient.userId,
+      { vulnerability },
     );
 
     // Only durable-record the two signal classes a physician actually
@@ -150,6 +180,16 @@ export const messageUrgencyObserverAgent: Agent<
         triagePriority: result.priority,
         triageCategory: result.category,
         triageReason: result.triageReason,
+        // EMR-1146 — UPI score + factor breakdown for clinician transparency.
+        upiScore: result.upi?.upi ?? null,
+        upiRoute: result.upi?.route ?? null,
+        upiFactors: result.upi ? JSON.parse(JSON.stringify(result.upi.factors)) : null,
+        // TODO(EMR-1147): the pre-configured 911/ED auto-reply
+        // (result.upi.autoReply) should be dispatched on the patient's
+        // channel by the inbound-message webhook / correspondence workflow.
+        // This observer only has read.patient + write.outcome.reminder
+        // permissions, so it records the decision but cannot send messages.
+        upiAutoReply: result.upi?.autoReply ?? null,
       },
     });
 

--- a/src/lib/billing/preflight/__tests__/preflight.test.ts
+++ b/src/lib/billing/preflight/__tests__/preflight.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeLcdConcordance,
+  computePayerDenialHistory,
+  extractNarrativeFeatures,
+  type ClaimOutcomeRow,
+  type EncounterContext,
+  type PreflightClaim,
+} from "../features";
+import { GREEN_THRESHOLD, HOLD_THRESHOLD, computePDenial } from "../score";
+import { PREFLIGHT_LCD_RULES } from "../rules";
+import { runPreflight } from "../engine";
+import {
+  appendModifier25,
+  remediateAndRescore,
+  removeComponentLine,
+} from "../remediate";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AS_OF = new Date("2026-06-12T12:00:00Z");
+const DOS = new Date("2026-06-05T12:00:00Z");
+
+const GOOD_NOTE = `Established patient returns for follow-up of generalized anxiety disorder.
+Reports worsening anxiety over the past month with panic episodes twice weekly. Sleep remains
+fragmented with early-morning awakening; insomnia noted. Denies chest pain or palpitations.
+No shortness of breath. Appetite stable, no nausea. Reports fatigue most mornings.
+Exam: alert, mood anxious, affect congruent. Blood pressure 124/78.
+Medication adjusted: increased sertraline from 50mg to 75mg daily; discussed side effect
+profile and titration plan. Reviewed sleep hygiene and breathing exercises. Patient
+verbalized understanding. Follow up in four weeks to reassess response; will consider
+therapy referral if symptoms persist. Total time 28 minutes spent on the date of the
+encounter, over half in counseling.`;
+
+const INJECTION_NOTE = `Established patient seen for worsening generalized anxiety with panic
+episodes and poor sleep. In addition to the scheduled vitamin B12 injection for documented
+deficiency, a separately identifiable evaluation was performed: medication adjusted,
+sertraline dose increased to 100mg, side effect profile reviewed. Denies chest pain or
+shortness of breath. Reports fatigue and reduced appetite. Exam: anxious mood, normal gait,
+blood pressure 122/76. Plan: titrate over four weeks, follow up to reassess.
+Total time 30 minutes.`;
+
+const THIN_HEADACHE_NOTE =
+  "Patient reports headache for two weeks. Requests imaging of the head. Plan: order brain MRI to evaluate.";
+
+const MIGRAINE_NOTE = `Chronic migraine, worsening despite preventive therapy. Headache
+frequency increased to 15 days per month. Sleep disrupted. Medication adjusted: topiramate
+dose increased. Plan: order brain MRI.`;
+
+function claim(overrides: Partial<PreflightClaim> = {}): PreflightClaim {
+  return {
+    claimId: "claim-1",
+    payerName: "Blue Cross Blue Shield",
+    payerId: "bcbs",
+    serviceDate: DOS,
+    serviceLines: [
+      { code: "99214", label: "Office visit, est pt", units: 1, chargeAmount: 235, modifiers: [] },
+    ],
+    icd10Codes: [{ code: "F41.1", label: "Generalized anxiety disorder" }],
+    ...overrides,
+  };
+}
+
+function ctx(narrativeNote: string): EncounterContext {
+  return { narrativeNote, providerId: "prov-1" };
+}
+
+function historyRows(args: {
+  cptCode: string;
+  denied: number;
+  paid: number;
+  daysAgo: number;
+  payerName?: string;
+}): ClaimOutcomeRow[] {
+  const adjudicatedAt = new Date(AS_OF.getTime() - args.daysAgo * 86_400_000);
+  const rows: ClaimOutcomeRow[] = [];
+  for (let i = 0; i < args.denied; i++) {
+    rows.push({ payerName: args.payerName ?? "Aetna", cptCode: args.cptCode, outcome: "denied", adjudicatedAt });
+  }
+  for (let i = 0; i < args.paid; i++) {
+    rows.push({ payerName: args.payerName ?? "Aetna", cptCode: args.cptCode, outcome: "paid", adjudicatedAt });
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Clean claim → green release
+// ---------------------------------------------------------------------------
+
+describe("pre-flight: clean claim", () => {
+  it("scores below the 0.10 green threshold and releases", () => {
+    const result = runPreflight(claim(), ctx(GOOD_NOTE), { asOf: AS_OF });
+    expect(result.features.xCci).toBe(0);
+    expect(result.features.modifierGap).toBe(0);
+    expect(result.features.deltaLcd).toBe(0); // 99214 + F41.1 is an approved LCD pair
+    expect(result.score.score).toBeLessThan(GREEN_THRESHOLD);
+    expect(result.score.disposition).toBe("release");
+    expect(result.findings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Modifier deficiency: 99214 + 96372 without Modifier-25
+// ---------------------------------------------------------------------------
+
+describe("pre-flight: 99214 + 96372 without Modifier-25", () => {
+  const modClaim = claim({
+    payerName: "Aetna",
+    payerId: "60054",
+    serviceLines: [
+      { code: "99214", label: "Office visit, est pt", units: 1, chargeAmount: 235, modifiers: [] },
+      { code: "96372", label: "Therapeutic injection", units: 1, chargeAmount: 45, modifiers: [] },
+    ],
+    icd10Codes: [
+      { code: "F41.1", label: "Generalized anxiety disorder" },
+      { code: "D51.9", label: "Vitamin B12 deficiency anemia" },
+    ],
+  });
+
+  it("holds the claim (≥ 0.35) and attributes modifier_deficiency", () => {
+    const result = runPreflight(modClaim, ctx(INJECTION_NOTE), { asOf: AS_OF });
+    expect(result.features.modifierGap).toBe(1);
+    expect(result.features.xCci).toBe(0); // fixable with a modifier, not a hard unbundle
+    expect(result.score.score).toBeGreaterThanOrEqual(HOLD_THRESHOLD);
+    expect(result.score.disposition).toBe("hold");
+
+    const top = result.findings[0];
+    expect(top.category).toBe("modifier_deficiency");
+    expect(top.remediation).toContain("Append Modifier-25");
+    expect(top.remediation).toContain("separate evaluation");
+    expect(top.action).toEqual({ kind: "append_modifier", targetCode: "99214", modifier: "25" });
+  });
+
+  it("one-click appendModifier25 re-scores below 0.10 and releases", () => {
+    const result = runPreflight(modClaim, ctx(INJECTION_NOTE), { asOf: AS_OF });
+    const run = remediateAndRescore(modClaim, ctx(INJECTION_NOTE), result.findings[0].action, {
+      asOf: AS_OF,
+    });
+    expect(run.before.score.disposition).toBe("hold");
+    expect(run.after.features.modifierGap).toBe(0);
+    expect(run.after.score.score).toBeLessThan(GREEN_THRESHOLD);
+    expect(run.after.score.disposition).toBe("release");
+    expect(run.released).toBe(true);
+    // The fix is immutable — the original claim is untouched.
+    expect(modClaim.serviceLines[0].modifiers).toEqual([]);
+    expect(run.claim.serviceLines[0].modifiers).toEqual(["25"]);
+  });
+
+  it("appendModifier25 helper targets the E/M line by default", () => {
+    const fixed = appendModifier25(modClaim);
+    expect(fixed.serviceLines.find((l) => l.code === "99214")?.modifiers).toEqual(["25"]);
+    expect(fixed.serviceLines.find((l) => l.code === "96372")?.modifiers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Unbundling conflict: hard NCCI pair (xCci = 1)
+// ---------------------------------------------------------------------------
+
+describe("pre-flight: NCCI unbundling pair", () => {
+  const bundledClaim = claim({
+    payerName: "Aetna",
+    payerId: "60054",
+    serviceLines: [
+      { code: "99214", label: "Office visit, est pt", units: 1, chargeAmount: 235, modifiers: [] },
+      { code: "36415", label: "Venipuncture", units: 1, chargeAmount: 12, modifiers: [] },
+    ],
+  });
+
+  it("flags xCci = 1, holds, and attributes unbundling_conflict", () => {
+    const result = runPreflight(bundledClaim, ctx(GOOD_NOTE), { asOf: AS_OF });
+    expect(result.features.xCci).toBe(1);
+    expect(result.score.score).toBeGreaterThanOrEqual(HOLD_THRESHOLD);
+    expect(result.score.disposition).toBe("hold");
+
+    const top = result.findings[0];
+    expect(top.category).toBe("unbundling_conflict");
+    expect(top.remediation).toContain("Consolidate the component line item");
+    expect(top.action).toEqual({ kind: "remove_line", componentCode: "36415" });
+  });
+
+  it("consolidating the component line re-scores green", () => {
+    const result = runPreflight(bundledClaim, ctx(GOOD_NOTE), { asOf: AS_OF });
+    const run = remediateAndRescore(bundledClaim, ctx(GOOD_NOTE), result.findings[0].action, {
+      asOf: AS_OF,
+    });
+    expect(run.after.features.xCci).toBe(0);
+    expect(run.after.score.disposition).toBe("release");
+    expect(run.claim.serviceLines.map((l) => l.code)).toEqual(["99214"]);
+    // removeComponentLine directly agrees with the dispatched action
+    expect(removeComponentLine(bundledClaim, "36415").serviceLines).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Medical necessity deficit: brain MRI for plain headache
+// ---------------------------------------------------------------------------
+
+describe("pre-flight: 70553 Brain MRI for plain headache (R51)", () => {
+  const mriClaim = claim({
+    payerName: "Aetna",
+    payerId: "60054",
+    serviceLines: [
+      { code: "70553", label: "MRI brain w/ + w/o contrast", units: 1, chargeAmount: 1450, modifiers: [] },
+    ],
+    icd10Codes: [{ code: "R51.9", label: "Headache, unspecified" }],
+  });
+
+  it("computes high LCD discordance + low narrative score and holds", () => {
+    const result = runPreflight(mriClaim, ctx(THIN_HEADACHE_NOTE), { asOf: AS_OF });
+    expect(result.features.deltaLcd).toBeGreaterThan(0.8);
+    expect(result.features.phiNarrative.score).toBeLessThan(0.4);
+    expect(result.score.score).toBeGreaterThanOrEqual(HOLD_THRESHOLD);
+    expect(result.score.disposition).toBe("hold");
+
+    const top = result.findings[0];
+    expect(top.category).toBe("medical_necessity_deficit");
+    expect(top.remediation).toContain("Document required criteria");
+    expect(top.remediation).toContain("treatment failure");
+    expect(top.action.kind).toBe("augment_documentation");
+  });
+
+  it("documenting the missing red-flag criteria lowers the score", () => {
+    const result = runPreflight(mriClaim, ctx(THIN_HEADACHE_NOTE), { asOf: AS_OF });
+    const run = remediateAndRescore(mriClaim, ctx(THIN_HEADACHE_NOTE), result.findings[0].action, {
+      asOf: AS_OF,
+    });
+    expect(run.after.score.score).toBeLessThan(run.before.score.score);
+    expect(run.after.features.deltaLcd).toBeLessThan(run.before.features.deltaLcd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Payer-history weighting shifts a borderline claim
+// ---------------------------------------------------------------------------
+
+describe("pre-flight: vPayer rolling 180-day history", () => {
+  const borderlineClaim = claim({
+    payerName: "Aetna",
+    payerId: "60054",
+    serviceLines: [
+      { code: "70553", label: "MRI brain w/ + w/o contrast", units: 1, chargeAmount: 1450, modifiers: [] },
+    ],
+    icd10Codes: [{ code: "G43.719", label: "Chronic migraine, intractable" }],
+  });
+
+  it("is borderline (review) with no payer history", () => {
+    const result = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), { asOf: AS_OF });
+    expect(result.score.score).toBeGreaterThanOrEqual(GREEN_THRESHOLD);
+    expect(result.score.score).toBeLessThan(HOLD_THRESHOLD);
+    expect(result.score.disposition).toBe("review");
+  });
+
+  it("a payer denying 60% of 70553 in-window pushes the claim into hold", () => {
+    const base = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), { asOf: AS_OF });
+    const withHistory = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), {
+      asOf: AS_OF,
+      payerHistory: historyRows({ cptCode: "70553", denied: 12, paid: 8, daysAgo: 30 }),
+    });
+    expect(withHistory.features.vPayer).toBeGreaterThan(base.features.vPayer);
+    expect(withHistory.score.score).toBeGreaterThan(base.score.score);
+    expect(withHistory.score.disposition).toBe("hold");
+    expect(withHistory.findings.some((f) => f.category === "payer_history_risk")).toBe(true);
+  });
+
+  it("ignores outcomes outside the rolling 180-day window", () => {
+    const base = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), { asOf: AS_OF });
+    const withStale = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), {
+      asOf: AS_OF,
+      payerHistory: historyRows({ cptCode: "70553", denied: 12, paid: 8, daysAgo: 200 }),
+    });
+    expect(withStale.score.score).toBe(base.score.score);
+  });
+
+  it("ignores other payers' outcomes", () => {
+    const base = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), { asOf: AS_OF });
+    const otherPayer = runPreflight(borderlineClaim, ctx(MIGRAINE_NOTE), {
+      asOf: AS_OF,
+      payerHistory: historyRows({
+        cptCode: "70553",
+        denied: 12,
+        paid: 8,
+        daysAgo: 30,
+        payerName: "UnitedHealthcare",
+      }),
+    });
+    expect(otherPayer.score.score).toBe(base.score.score);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Feature-extraction unit tests
+// ---------------------------------------------------------------------------
+
+describe("extractNarrativeFeatures", () => {
+  it("counts organ systems, tiers MDM, and detects Mod-25 evidence", () => {
+    const f = extractNarrativeFeatures(INJECTION_NOTE);
+    expect(f.organSystemCount).toBeGreaterThanOrEqual(5);
+    expect(f.mdmTier).toBe(2); // "worsening" / "medication adjusted"
+    expect(f.mod25Evidence).toBe(true); // "separately identifiable"
+    expect(f.score).toBeGreaterThan(0.6);
+  });
+
+  it("scores a thin note low with no Mod-25 evidence", () => {
+    const f = extractNarrativeFeatures(THIN_HEADACHE_NOTE);
+    expect(f.organSystemCount).toBe(1); // neurological (headache)
+    expect(f.mdmTier).toBe(0);
+    expect(f.mod25Evidence).toBe(false);
+    expect(f.score).toBeLessThan(0.4);
+  });
+
+  it("handles an empty narrative", () => {
+    const f = extractNarrativeFeatures("");
+    expect(f.score).toBe(0);
+    expect(f.wordCount).toBe(0);
+  });
+});
+
+describe("computePayerDenialHistory", () => {
+  it("smooths small samples toward the 8% industry prior", () => {
+    const result = computePayerDenialHistory({
+      rows: historyRows({ cptCode: "99214", denied: 1, paid: 0, daysAgo: 10 }),
+      payerName: "Aetna",
+      cptCodes: ["99214"],
+      asOf: AS_OF,
+    });
+    // (1 + 0.08*5) / (1 + 5) ≈ 0.233 — far from a naive 100% rate
+    expect(result.rate).toBeGreaterThan(0.2);
+    expect(result.rate).toBeLessThan(0.3);
+    expect(result.sampleSize).toBe(1);
+  });
+
+  it("returns the prior when there is no history at all", () => {
+    const result = computePayerDenialHistory({
+      rows: [],
+      payerName: "Aetna",
+      cptCodes: ["99214"],
+      asOf: AS_OF,
+    });
+    expect(result.rate).toBe(0.08);
+    expect(result.sampleSize).toBe(0);
+  });
+
+  it("takes the worst CPT on a multi-line claim", () => {
+    const result = computePayerDenialHistory({
+      rows: [
+        ...historyRows({ cptCode: "99214", denied: 0, paid: 20, daysAgo: 15 }),
+        ...historyRows({ cptCode: "70553", denied: 10, paid: 10, daysAgo: 15 }),
+      ],
+      payerName: "Aetna",
+      cptCodes: ["99214", "70553"],
+      asOf: AS_OF,
+    });
+    expect(result.worstCpt).toBe("70553");
+  });
+});
+
+describe("computeLcdConcordance", () => {
+  it("is 0.0 for a perfect coverage-pair match", () => {
+    const { deltaLcd } = computeLcdConcordance(
+      [{ code: "99214" }],
+      [{ code: "F41.1" }],
+      GOOD_NOTE,
+      PREFLIGHT_LCD_RULES,
+    );
+    expect(deltaLcd).toBe(0);
+  });
+
+  it("escalates toward 1.0 for discordant pairs with missing documentation", () => {
+    const { deltaLcd, lines } = computeLcdConcordance(
+      [{ code: "70553" }],
+      [{ code: "R51.9" }],
+      THIN_HEADACHE_NOTE,
+      PREFLIGHT_LCD_RULES,
+    );
+    expect(deltaLcd).toBe(1);
+    expect(lines[0].icdConcordant).toBe(false);
+    expect(lines[0].missingKeywords).toContain("treatment failure");
+  });
+
+  it("gives an unknown CPT a mild non-zero distance", () => {
+    const { deltaLcd, lines } = computeLcdConcordance(
+      [{ code: "G0463" }],
+      [{ code: "F41.1" }],
+      GOOD_NOTE,
+      PREFLIGHT_LCD_RULES,
+    );
+    expect(deltaLcd).toBe(0.1);
+    expect(lines[0].ruleMatched).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Score mechanics
+// ---------------------------------------------------------------------------
+
+describe("computePDenial", () => {
+  it("returns per-feature contributions that sum to the logit", () => {
+    const result = runPreflight(claim(), ctx(GOOD_NOTE), { asOf: AS_OF });
+    const { score, breakdown, intercept } = result.score;
+    const z = intercept + breakdown.reduce((s, c) => s + c.contribution, 0);
+    expect(score).toBeCloseTo(1 / (1 + Math.exp(-z)), 3);
+    expect(breakdown.map((c) => c.feature).sort()).toEqual(
+      ["deltaLcd", "modifierGap", "narrativeDeficit", "vPayer", "xCci"].sort(),
+    );
+  });
+
+  it("ranks the breakdown by contribution descending", () => {
+    const features = runPreflight(
+      claim({
+        serviceLines: [
+          { code: "99214", modifiers: [] },
+          { code: "96372", modifiers: [] },
+        ],
+        icd10Codes: [{ code: "F41.1" }, { code: "D51.9" }],
+      }),
+      ctx(INJECTION_NOTE),
+      { asOf: AS_OF },
+    );
+    const contributions = features.score.breakdown.map((c) => c.contribution);
+    expect(contributions).toEqual([...contributions].sort((a, b) => b - a));
+    expect(features.score.breakdown[0].feature).toBe("modifierGap");
+  });
+});

--- a/src/lib/billing/preflight/attribution.ts
+++ b/src/lib/billing/preflight/attribution.ts
@@ -1,0 +1,177 @@
+/**
+ * Root-cause attribution — Phase 4 of the RCM red-text spec.
+ * ----------------------------------------------------------
+ * Takes the extracted feature vector + per-feature score contributions
+ * (the deterministic stand-in for SHAP values) and stratifies the risk
+ * into typed deficiency categories with concrete remediation guidance:
+ *
+ *   modifier_deficiency       — e.g. 99214 + 96372 same day without
+ *                               Modifier-25 on the E/M line.
+ *   medical_necessity_deficit — δ_LCD > 0.80 paired with a low narrative
+ *                               score (e.g. 70553 Brain MRI for plain R51
+ *                               headache, no red-flag documentation).
+ *   unbundling_conflict       — X_CCI = 1 (component billed alongside its
+ *                               comprehensive code, never unbundleable).
+ *   payer_history_risk        — the target payer has been denying this
+ *                               CPT heavily in the rolling 180-day window.
+ *   documentation_quality     — thin narrative dragging the score even
+ *                               though coding/coverage are concordant.
+ *
+ * Each finding carries a machine-applicable RemediationAction consumed by
+ * remediate.ts (the one-click fix loop) and a mapping into the existing
+ * denial taxonomy (src/lib/billing/denials.ts) so post-submission denial
+ * analytics and pre-submission holds share one vocabulary.
+ */
+
+import type { DenialCategory } from "@/lib/billing/denials";
+import type { PreflightFeatures } from "./features";
+import type { DenialScore, ScoreFeatureKey } from "./score";
+
+export type DeficiencyCategory =
+  | "modifier_deficiency"
+  | "medical_necessity_deficit"
+  | "unbundling_conflict"
+  | "payer_history_risk"
+  | "documentation_quality";
+
+/** Bridge into the post-submission denial taxonomy. */
+export const DEFICIENCY_TO_DENIAL_CATEGORY: Record<DeficiencyCategory, DenialCategory> = {
+  modifier_deficiency: "modifier",
+  medical_necessity_deficit: "medical_necessity",
+  unbundling_conflict: "bundling",
+  payer_history_risk: "other",
+  documentation_quality: "medical_necessity",
+};
+
+export type RemediationAction =
+  | { kind: "append_modifier"; targetCode: string; modifier: "25" | "59" }
+  | { kind: "remove_line"; componentCode: string }
+  | { kind: "augment_documentation"; targetCode: string; requiredKeywords: string[] }
+  | { kind: "manual_review"; note: string };
+
+export interface RootCauseFinding {
+  category: DeficiencyCategory;
+  denialCategory: DenialCategory;
+  /** Which score feature drove this finding. */
+  drivingFeature: ScoreFeatureKey;
+  /** Logit contribution of the driving feature — findings are ranked by it. */
+  contribution: number;
+  summary: string;
+  /** Concrete biller-facing remediation text. */
+  remediation: string;
+  /** Machine-applicable action for the one-click fix loop (remediate.ts). */
+  action: RemediationAction;
+  relatedCodes: string[];
+}
+
+const NARRATIVE_LOW_SCORE = 0.4;
+const MEDICAL_NECESSITY_DELTA = 0.8;
+const PAYER_RISK_RATE = 0.25;
+const PAYER_RISK_MIN_SAMPLE = 5;
+
+export function attributeRootCauses(
+  features: PreflightFeatures,
+  score: DenialScore,
+): RootCauseFinding[] {
+  const contributionOf = (feature: ScoreFeatureKey): number =>
+    score.breakdown.find((c) => c.feature === feature)?.contribution ?? 0;
+
+  const findings: RootCauseFinding[] = [];
+
+  // ── Modifier deficiency ────────────────────────────────────────────
+  for (const hit of features.details.modifierGapHits) {
+    const modifier = hit.allowedModifier ?? "25";
+    const evidenceNote = features.phiNarrative.mod25Evidence
+      ? "The note already documents a separately identifiable evaluation."
+      : "Confirm the note documents a separate evaluation before appending.";
+    findings.push({
+      category: "modifier_deficiency",
+      denialCategory: DEFICIENCY_TO_DENIAL_CATEGORY.modifier_deficiency,
+      drivingFeature: "modifierGap",
+      contribution: contributionOf("modifierGap"),
+      summary: `${hit.componentCode} billed with ${hit.comprehensiveCode} on the same day without Modifier-${modifier} on the ${hit.comprehensiveCode} line.`,
+      remediation: `Append Modifier-${modifier} to ${hit.comprehensiveCode} if the note documents a separate evaluation. ${evidenceNote}`,
+      action: {
+        kind: "append_modifier",
+        targetCode: hit.comprehensiveCode,
+        modifier: modifier === "59" ? "59" : "25",
+      },
+      relatedCodes: [hit.comprehensiveCode, hit.componentCode],
+    });
+  }
+
+  // ── Unbundling conflict ────────────────────────────────────────────
+  for (const hit of features.details.unbundlingHits) {
+    findings.push({
+      category: "unbundling_conflict",
+      denialCategory: DEFICIENCY_TO_DENIAL_CATEGORY.unbundling_conflict,
+      drivingFeature: "xCci",
+      contribution: contributionOf("xCci"),
+      summary: `NCCI edit: component code ${hit.componentCode} is included in comprehensive code ${hit.comprehensiveCode || "the comprehensive service"} and cannot be unbundled with a modifier.`,
+      remediation: `Consolidate the component line item into the comprehensive code: remove ${hit.componentCode} from the claim — it is bundled into ${hit.comprehensiveCode || "the comprehensive service"}.`,
+      action: { kind: "remove_line", componentCode: hit.componentCode },
+      relatedCodes: [hit.componentCode, hit.comprehensiveCode].filter(Boolean),
+    });
+  }
+
+  // ── Medical necessity deficit ──────────────────────────────────────
+  if (features.deltaLcd > MEDICAL_NECESSITY_DELTA) {
+    const worstLine = [...features.details.lcdLines].sort((a, b) => b.delta - a.delta)[0];
+    const lowNarrative = features.phiNarrative.score < NARRATIVE_LOW_SCORE;
+    const keywords = worstLine?.missingKeywords ?? [];
+    const criteriaText =
+      keywords.length > 0
+        ? `Document required criteria: ${keywords.join(", ")}.`
+        : "Document the payer's LCD coverage criteria for this CPT.";
+    findings.push({
+      category: "medical_necessity_deficit",
+      denialCategory: DEFICIENCY_TO_DENIAL_CATEGORY.medical_necessity_deficit,
+      drivingFeature: "deltaLcd",
+      contribution: contributionOf("deltaLcd"),
+      summary: `${worstLine?.cptCode ?? "Service"} does not match an approved LCD coverage pairing (δ_LCD = ${features.deltaLcd})${lowNarrative ? " and the narrative documentation score is low" : ""}.`,
+      remediation: `${criteriaText} The payer requires documented treatment failure or red-flag indicators (e.g. progressive neurological deficits) for this CPT${worstLine && !worstLine.icdConcordant ? ", or link a covered diagnosis" : ""}.`,
+      action: {
+        kind: "augment_documentation",
+        targetCode: worstLine?.cptCode ?? "",
+        requiredKeywords: keywords,
+      },
+      relatedCodes: worstLine ? [worstLine.cptCode] : [],
+    });
+  } else if (
+    features.phiNarrative.score < NARRATIVE_LOW_SCORE &&
+    contributionOf("narrativeDeficit") > 0
+  ) {
+    // ── Documentation quality (no hard coverage mismatch) ────────────
+    findings.push({
+      category: "documentation_quality",
+      denialCategory: DEFICIENCY_TO_DENIAL_CATEGORY.documentation_quality,
+      drivingFeature: "narrativeDeficit",
+      contribution: contributionOf("narrativeDeficit"),
+      summary: `Narrative documentation is thin (score ${features.phiNarrative.score}): ${features.phiNarrative.organSystemCount} organ system(s) reviewed, MDM tier ${features.phiNarrative.mdmTier}.`,
+      remediation:
+        "Expand the note: document the systems reviewed, the medical decision-making severity, and any treatment plan adjustments before submission.",
+      action: { kind: "manual_review", note: "Strengthen narrative documentation." },
+      relatedCodes: [],
+    });
+  }
+
+  // ── Payer history risk ─────────────────────────────────────────────
+  const ph = features.details.payerHistory;
+  if (ph.rate >= PAYER_RISK_RATE && ph.sampleSize >= PAYER_RISK_MIN_SAMPLE) {
+    findings.push({
+      category: "payer_history_risk",
+      denialCategory: DEFICIENCY_TO_DENIAL_CATEGORY.payer_history_risk,
+      drivingFeature: "vPayer",
+      contribution: contributionOf("vPayer"),
+      summary: `Payer has denied ${Math.round(ph.rate * 100)}% of ${ph.worstCpt} claims over the rolling 180-day window (n=${ph.sampleSize}).`,
+      remediation: `Review the payer's recent denial reasons for ${ph.worstCpt} before submitting; consider attaching supporting documentation proactively or confirming coverage policy changes.`,
+      action: {
+        kind: "manual_review",
+        note: `Audit recent ${ph.worstCpt} denials for this payer.`,
+      },
+      relatedCodes: ph.worstCpt ? [ph.worstCpt] : [],
+    });
+  }
+
+  return findings.sort((a, b) => b.contribution - a.contribution);
+}

--- a/src/lib/billing/preflight/engine.ts
+++ b/src/lib/billing/preflight/engine.ts
@@ -1,0 +1,47 @@
+/**
+ * Pre-flight engine — single entry point: extract features → score →
+ * attribute root causes. Pure and synchronous; the caller supplies all
+ * data (claim, encounter narrative, historical payer outcomes).
+ *
+ * TODO(EMR-1137 wiring — do NOT wire from this module; orchestrator task):
+ * Interception point sits between superbill signing and the 837 compiler:
+ *   1. RCM pipeline: add a `preflight` stage between "coding_scrub" and
+ *      "submission" in src/lib/billing/rcm-engine.ts (STAGE_ORDER), so a
+ *      `hold` disposition branches to a staging queue instead of
+ *      advancing to submission.
+ *   2. Submission gate: src/lib/agents/billing/clearinghouse-submission-agent.ts
+ *      already refuses to submit when scrubResult.status === "blocked";
+ *      the same guard should refuse when the latest preflight disposition
+ *      is "hold", immediately before it calls buildClaimEdi()
+ *      (src/lib/billing/edi/build-from-claim.ts).
+ *   3. Caller feeds `payerHistory` from a Prisma query over adjudicated
+ *      claims/835 outcomes for the claim's payer within 180 days — this
+ *      module never queries the DB.
+ */
+
+import {
+  extractFeatures,
+  type EncounterContext,
+  type PreflightClaim,
+  type PreflightFeatures,
+  type PreflightOptions,
+} from "./features";
+import { computePDenial, type DenialScore } from "./score";
+import { attributeRootCauses, type RootCauseFinding } from "./attribution";
+
+export interface PreflightResult {
+  features: PreflightFeatures;
+  score: DenialScore;
+  findings: RootCauseFinding[];
+}
+
+export function runPreflight(
+  claim: PreflightClaim,
+  context: EncounterContext,
+  options: PreflightOptions = {},
+): PreflightResult {
+  const features = extractFeatures(claim, context, options);
+  const score = computePDenial(features);
+  const findings = attributeRootCauses(features, score);
+  return { features, score, findings };
+}

--- a/src/lib/billing/preflight/features.ts
+++ b/src/lib/billing/preflight/features.ts
@@ -1,0 +1,457 @@
+/**
+ * Denial-probability feature extraction (EMR-1137 / EMR-1138, epic EMR-1120)
+ * --------------------------------------------------------------------------
+ * Phase 2 of the RCM red-text spec: transform a claim + its encounter
+ * context into the deterministic feature vector consumed by
+ * `computePDenial` (score.ts).
+ *
+ * Features (names follow the spec's math notation):
+ *   xCci        — binary NCCI / unbundling violation that no modifier can
+ *                 fix. Reuses `scrubClaim` (src/lib/billing/scrub.ts) plus
+ *                 the pre-flight NCCI seed table so both engines agree.
+ *   modifierGap — binary: a bundled pair IS modifier-fixable (e.g. 99214 +
+ *                 96372 needs Modifier-25) but the modifier is missing.
+ *                 The spec's "modifier array configuration" feature.
+ *   vPayer      — payer-specific historical denial rate for the claim's
+ *                 CPTs over a rolling 180-day window. Computed from
+ *                 historical outcome rows passed IN by the caller (feed it
+ *                 Prisma query results); this module never touches the DB.
+ *   deltaLcd    — LCD/NCD concordance distance: 0.0 = perfect CPT↔ICD
+ *                 coverage-pair match with all required documentation
+ *                 keywords present; → 1.0 as discordance grows.
+ *   phiNarrative— semantic features from the narrative note: organ-system
+ *                 count, MDM-severity keyword tier, Modifier-25
+ *                 separate-service evidence, plus a composite [0,1] score.
+ *
+ * Everything here is pure and synchronous — no Prisma, no network, no LLM.
+ */
+
+import { scrubClaim, type ScrubInput } from "@/lib/billing/scrub";
+import {
+  PREFLIGHT_LCD_RULES,
+  PREFLIGHT_NCCI_PAIRS,
+  UNKNOWN_CPT_LCD_DELTA,
+  type LcdCoverageRule,
+  type NcciEditPair,
+} from "./rules";
+
+// ---------------------------------------------------------------------------
+// Input shapes
+// ---------------------------------------------------------------------------
+
+/** Same line shape used by ScrubInput and the 837P builder
+ *  (src/lib/billing/edi/build-from-claim.ts) so callers can pass
+ *  Claim.cptCodes JSON straight through. */
+export interface PreflightServiceLine {
+  code: string;
+  label?: string;
+  units?: number;
+  chargeAmount?: number;
+  modifiers?: string[];
+}
+
+export interface PreflightClaim {
+  claimId?: string;
+  payerName: string | null;
+  payerId?: string | null;
+  serviceDate: Date;
+  serviceLines: PreflightServiceLine[];
+  icd10Codes: Array<{ code: string; label?: string }>;
+  selfPay?: boolean;
+}
+
+/** Encounter context — the DocumentReference side of the spec's
+ *  ingestion core. */
+export interface EncounterContext {
+  /** Full narrative progress note text for the encounter. */
+  narrativeNote: string;
+  providerId?: string | null;
+}
+
+/** One historical adjudication outcome row. Designed so a caller can map
+ *  Prisma Claim/AdjudicationResult query results directly into it —
+ *  one row per (claim, CPT) outcome. */
+export interface ClaimOutcomeRow {
+  payerName: string;
+  payerId?: string | null;
+  cptCode: string;
+  outcome: "paid" | "denied" | "partial";
+  /** When the payer adjudicated (835 date). Drives the rolling window. */
+  adjudicatedAt: Date;
+}
+
+export interface PreflightOptions {
+  /** "Now" for the rolling payer-history window. Defaults to real time;
+   *  pass a fixed date for deterministic runs/tests. */
+  asOf?: Date;
+  /** Historical claim outcomes (caller feeds Prisma results in). */
+  payerHistory?: ClaimOutcomeRow[];
+  /** Rolling window for vPayer, days. Default 180 per spec. */
+  payerWindowDays?: number;
+  /** Override / extend the seedable rules tables. */
+  ncciPairs?: NcciEditPair[];
+  lcdRules?: LcdCoverageRule[];
+}
+
+// ---------------------------------------------------------------------------
+// Output shapes
+// ---------------------------------------------------------------------------
+
+export interface NcciHit extends NcciEditPair {
+  source: "preflight_rules" | "scrub_engine";
+}
+
+export interface LcdLineResult {
+  cptCode: string;
+  /** 0.0 perfect coverage match → 1.0 fully discordant. */
+  delta: number;
+  ruleMatched: boolean;
+  icdConcordant: boolean;
+  missingKeywords: string[];
+  description: string | null;
+}
+
+export interface PayerHistoryResult {
+  /** Smoothed denial rate in [0,1] for the worst CPT on the claim. */
+  rate: number;
+  /** Raw in-window row count behind that rate (0 = prior only). */
+  sampleSize: number;
+  worstCpt: string | null;
+  perCpt: Array<{ cptCode: string; denied: number; total: number; rate: number }>;
+}
+
+export interface NarrativeFeatures {
+  /** Distinct organ systems referenced in the note (capped scoring at 5). */
+  organSystemCount: number;
+  /** MDM severity keyword tier: 0 none, 1 low, 2 moderate, 3 high. */
+  mdmTier: 0 | 1 | 2 | 3;
+  /** Note explicitly documents a separate, distinct service (Mod-25 evidence). */
+  mod25Evidence: boolean;
+  wordCount: number;
+  /** Composite documentation-quality score in [0,1]. */
+  score: number;
+}
+
+export interface PreflightFeatures {
+  xCci: 0 | 1;
+  modifierGap: 0 | 1;
+  vPayer: number;
+  deltaLcd: number;
+  phiNarrative: NarrativeFeatures;
+  details: {
+    unbundlingHits: NcciHit[];
+    modifierGapHits: NcciHit[];
+    lcdLines: LcdLineResult[];
+    payerHistory: PayerHistoryResult;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// phiNarrative — semantic features from the clinical note
+// ---------------------------------------------------------------------------
+
+const ORGAN_SYSTEM_KEYWORDS: Record<string, string[]> = {
+  constitutional: ["fatigue", "fever", "chills", "weight loss", "weight gain", "malaise", "night sweats"],
+  cardiovascular: ["chest pain", "palpitation", "blood pressure", "hypertension", "edema", "cardiovascular"],
+  respiratory: ["shortness of breath", "dyspnea", "cough", "wheez", "respiratory"],
+  gastrointestinal: ["nausea", "vomit", "abdominal", "diarrhea", "constipation", "appetite"],
+  musculoskeletal: ["back pain", "joint", "muscle", "musculoskeletal", "range of motion", "gait"],
+  neurological: ["headache", "dizziness", "numbness", "tingling", "seizure", "tremor", "neurolog"],
+  psychiatric: ["anxiety", "depress", "mood", "insomnia", "panic", "psychiatric", "ptsd", "sleep"],
+  integumentary: ["rash", "lesion", "skin", "pruritus", "wound"],
+  heent: ["vision", "blurred", "hearing", "tinnitus", "sore throat", "sinus"],
+  endocrine_gu: ["urinary", "thyroid", "glucose", "polyuria", "endocrine"],
+};
+
+const MDM_HIGH_KEYWORDS = [
+  "high risk",
+  "severe exacerbation",
+  "hospitalization",
+  "emergency",
+  "life-threatening",
+  "progressive neurological",
+  "red flag",
+];
+
+const MDM_MODERATE_KEYWORDS = [
+  "worsening",
+  "uncontrolled",
+  "new problem",
+  "medication adjusted",
+  "dose increased",
+  "dose adjusted",
+  "titrat",
+  "prescription drug management",
+  "treatment plan adjusted",
+  "side effect",
+];
+
+const MDM_LOW_KEYWORDS = ["stable", "improving", "well controlled", "refill", "continue current"];
+
+const MOD25_EVIDENCE_PHRASES = [
+  "separately identifiable",
+  "separate evaluation",
+  "separate and distinct",
+  "distinct service",
+  "in addition to",
+  "unrelated to the",
+  "separate e/m",
+  "separate assessment",
+];
+
+const ORGAN_SYSTEM_CAP = 5;
+const ADEQUATE_NOTE_WORDS = 120;
+
+export function extractNarrativeFeatures(narrative: string): NarrativeFeatures {
+  const text = (narrative ?? "").toLowerCase();
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+
+  let organSystemCount = 0;
+  for (const keywords of Object.values(ORGAN_SYSTEM_KEYWORDS)) {
+    if (keywords.some((k) => text.includes(k))) organSystemCount++;
+  }
+
+  let mdmTier: 0 | 1 | 2 | 3 = 0;
+  if (MDM_HIGH_KEYWORDS.some((k) => text.includes(k))) mdmTier = 3;
+  else if (MDM_MODERATE_KEYWORDS.some((k) => text.includes(k))) mdmTier = 2;
+  else if (MDM_LOW_KEYWORDS.some((k) => text.includes(k))) mdmTier = 1;
+
+  const mod25Evidence = MOD25_EVIDENCE_PHRASES.some((p) => text.includes(p));
+
+  // Composite documentation-quality score:
+  //   40% breadth (organ systems, capped at 5)
+  //   40% MDM severity tier
+  //   20% length adequacy (120+ words = full credit)
+  const score =
+    0.4 * (Math.min(organSystemCount, ORGAN_SYSTEM_CAP) / ORGAN_SYSTEM_CAP) +
+    0.4 * (mdmTier / 3) +
+    0.2 * Math.min(wordCount / ADEQUATE_NOTE_WORDS, 1);
+
+  return { organSystemCount, mdmTier, mod25Evidence, wordCount, score: round3(score) };
+}
+
+// ---------------------------------------------------------------------------
+// vPayer — rolling 180-day payer × CPT denial rate
+// ---------------------------------------------------------------------------
+
+/** Industry-baseline prior so a payer/CPT with little history regresses
+ *  toward a sane default instead of swinging to 0.0 or 1.0. */
+export const PAYER_PRIOR_DENIAL_RATE = 0.08;
+export const PAYER_PRIOR_WEIGHT = 5;
+export const PAYER_WINDOW_DAYS = 180;
+
+export function computePayerDenialHistory(args: {
+  rows: ClaimOutcomeRow[];
+  payerName: string | null;
+  payerId?: string | null;
+  cptCodes: string[];
+  asOf: Date;
+  windowDays?: number;
+}): PayerHistoryResult {
+  const windowDays = args.windowDays ?? PAYER_WINDOW_DAYS;
+  const windowStart = args.asOf.getTime() - windowDays * 86_400_000;
+  const payerNameLc = args.payerName?.trim().toLowerCase() ?? null;
+
+  const inScope = args.rows.filter((row) => {
+    const t = row.adjudicatedAt.getTime();
+    if (t < windowStart || t > args.asOf.getTime()) return false;
+    if (args.payerId && row.payerId) return row.payerId === args.payerId;
+    if (payerNameLc) return row.payerName.trim().toLowerCase() === payerNameLc;
+    return false;
+  });
+
+  const perCpt: PayerHistoryResult["perCpt"] = [];
+  let worst: { cptCode: string; rate: number; total: number } | null = null;
+
+  for (const cpt of new Set(args.cptCodes)) {
+    const rows = inScope.filter((r) => r.cptCode === cpt);
+    const denied = rows.filter((r) => r.outcome === "denied").length;
+    const total = rows.length;
+    // Laplace-style smoothing toward the industry prior.
+    const rate =
+      (denied + PAYER_PRIOR_DENIAL_RATE * PAYER_PRIOR_WEIGHT) / (total + PAYER_PRIOR_WEIGHT);
+    perCpt.push({ cptCode: cpt, denied, total, rate: round3(rate) });
+    if (!worst || rate > worst.rate) worst = { cptCode: cpt, rate, total };
+  }
+
+  return {
+    rate: round3(worst?.rate ?? PAYER_PRIOR_DENIAL_RATE),
+    sampleSize: worst?.total ?? 0,
+    worstCpt: worst?.cptCode ?? null,
+    perCpt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// deltaLcd — LCD/NCD concordance distance
+// ---------------------------------------------------------------------------
+
+export function computeLcdConcordance(
+  lines: PreflightServiceLine[],
+  icd10Codes: Array<{ code: string }>,
+  narrative: string,
+  rules: LcdCoverageRule[],
+): { deltaLcd: number; lines: LcdLineResult[] } {
+  const narrativeLc = (narrative ?? "").toLowerCase();
+  const icdUpper = icd10Codes.map((i) => i.code.toUpperCase());
+
+  const results: LcdLineResult[] = lines.map((line) => {
+    const rule = rules.find((r) => r.cptCode === line.code);
+    if (!rule) {
+      return {
+        cptCode: line.code,
+        delta: UNKNOWN_CPT_LCD_DELTA,
+        ruleMatched: false,
+        icdConcordant: false,
+        missingKeywords: [],
+        description: null,
+      };
+    }
+    const icdConcordant = icdUpper.some((icd) =>
+      rule.approvedIcdPrefixes.some((p) => icd.startsWith(p.toUpperCase())),
+    );
+    const missingKeywords = rule.requiredDocKeywords.filter(
+      (k) => !narrativeLc.includes(k.toLowerCase()),
+    );
+    // 50% of the distance is the coding pair itself; the other 50% is the
+    // LCD's required documentation keywords.
+    const icdComponent = icdConcordant ? 0 : 0.5;
+    const keywordComponent =
+      rule.requiredDocKeywords.length === 0
+        ? 0
+        : 0.5 * (missingKeywords.length / rule.requiredDocKeywords.length);
+    return {
+      cptCode: line.code,
+      delta: round3(icdComponent + keywordComponent),
+      ruleMatched: true,
+      icdConcordant,
+      missingKeywords,
+      description: rule.description,
+    };
+  });
+
+  return {
+    deltaLcd: results.reduce((max, r) => Math.max(max, r.delta), 0),
+    lines: results,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// xCci / modifierGap — NCCI edits (seed table + scrubClaim reuse)
+// ---------------------------------------------------------------------------
+
+function detectNcci(
+  claim: PreflightClaim,
+  context: EncounterContext,
+  pairs: NcciEditPair[],
+): { unbundlingHits: NcciHit[]; modifierGapHits: NcciHit[] } {
+  const codes = new Set(claim.serviceLines.map((l) => l.code));
+  const unbundlingHits: NcciHit[] = [];
+  const modifierGapHits: NcciHit[] = [];
+
+  for (const pair of pairs) {
+    if (!codes.has(pair.componentCode) || !codes.has(pair.comprehensiveCode)) continue;
+    if (pair.allowedModifier == null) {
+      unbundlingHits.push({ ...pair, source: "preflight_rules" });
+      continue;
+    }
+    const comprehensiveLine = claim.serviceLines.find((l) => l.code === pair.comprehensiveCode);
+    const hasModifier = (comprehensiveLine?.modifiers ?? []).includes(pair.allowedModifier);
+    if (!hasModifier) modifierGapHits.push({ ...pair, source: "preflight_rules" });
+  }
+
+  // Reuse the existing scrub engine (NCCI_BUNDLED_PAIR rule) so pairs it
+  // knows about (counseling bundles, payer quirks like UHC ignoring
+  // mod-25 on Z71 counseling) feed the same features. Other scrub rules
+  // (timely filing, eligibility, …) are intentionally ignored here.
+  const scrubInput: ScrubInput = {
+    cptCodes: claim.serviceLines.map((l) => ({
+      code: l.code,
+      label: l.label ?? l.code,
+      units: l.units,
+      chargeAmount: l.chargeAmount,
+      modifiers: l.modifiers,
+    })),
+    icd10Codes: claim.icd10Codes,
+    payerName: claim.payerName,
+    payerId: claim.payerId,
+    serviceDate: claim.serviceDate,
+    providerId: context.providerId ?? "preflight",
+    selfPay: claim.selfPay,
+  };
+  const seen = new Set(
+    [...unbundlingHits, ...modifierGapHits].map((h) => h.componentCode),
+  );
+  for (const issue of scrubClaim(scrubInput)) {
+    if (issue.ruleCode !== "NCCI_BUNDLED_PAIR") continue;
+    const componentCode = issue.relatedCode ?? "";
+    if (!componentCode || seen.has(componentCode)) continue;
+    seen.add(componentCode);
+    const comprehensiveCode = /billed with (\S+)/.exec(issue.message)?.[1] ?? "";
+    const hit: NcciHit = {
+      componentCode,
+      comprehensiveCode,
+      allowedModifier: issue.blocksSubmission ? null : "25",
+      description: issue.message,
+      source: "scrub_engine",
+    };
+    if (issue.blocksSubmission) unbundlingHits.push(hit);
+    else modifierGapHits.push(hit);
+  }
+
+  return { unbundlingHits, modifierGapHits };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export function extractFeatures(
+  claim: PreflightClaim,
+  context: EncounterContext,
+  options: PreflightOptions = {},
+): PreflightFeatures {
+  const phiNarrative = extractNarrativeFeatures(context.narrativeNote);
+
+  const { unbundlingHits, modifierGapHits } = detectNcci(
+    claim,
+    context,
+    options.ncciPairs ?? PREFLIGHT_NCCI_PAIRS,
+  );
+
+  const payerHistory = computePayerDenialHistory({
+    rows: options.payerHistory ?? [],
+    payerName: claim.payerName,
+    payerId: claim.payerId,
+    cptCodes: claim.serviceLines.map((l) => l.code),
+    asOf: options.asOf ?? new Date(),
+    windowDays: options.payerWindowDays,
+  });
+
+  const lcd = computeLcdConcordance(
+    claim.serviceLines,
+    claim.icd10Codes,
+    context.narrativeNote,
+    options.lcdRules ?? PREFLIGHT_LCD_RULES,
+  );
+
+  return {
+    xCci: unbundlingHits.length > 0 ? 1 : 0,
+    modifierGap: modifierGapHits.length > 0 ? 1 : 0,
+    vPayer: payerHistory.rate,
+    deltaLcd: lcd.deltaLcd,
+    phiNarrative,
+    details: {
+      unbundlingHits,
+      modifierGapHits,
+      lcdLines: lcd.lines,
+      payerHistory,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/src/lib/billing/preflight/index.ts
+++ b/src/lib/billing/preflight/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Denial-probability pre-flight engine (EMR-1137 / EMR-1138, epic EMR-1120)
+ * -------------------------------------------------------------------------
+ * Deterministic pre-submission gate per the RCM red-text spec
+ * (docs/product-feedback/2026-06-12_workflows-revisions-red-text.md,
+ * "Autonomous Revenue Cycle Management", Phases 2–4):
+ *
+ *   features.ts    — feature extraction (xCci, modifierGap, vPayer,
+ *                    deltaLcd, phiNarrative)
+ *   score.ts       — computePDenial: logistic P_denial in [0,1];
+ *                    ≥0.35 hold, <0.10 green release
+ *   attribution.ts — ranked root-cause findings with typed remediation
+ *   remediate.ts   — pure one-click fix helpers (fix → re-run → green)
+ *   engine.ts      — runPreflight orchestration
+ *   rules.ts       — seedable NCCI pair + LCD coverage tables
+ *
+ * Wiring (TODO — see engine.ts header for the full plan): intercept
+ * between superbill signing and buildClaimEdi() — a `preflight` RCM
+ * stage between "coding_scrub" and "submission", plus a hold-guard in
+ * the clearinghouse submission agent.
+ */
+
+export * from "./rules";
+export * from "./features";
+export * from "./score";
+export * from "./attribution";
+export * from "./remediate";
+export * from "./engine";

--- a/src/lib/billing/preflight/remediate.ts
+++ b/src/lib/billing/preflight/remediate.ts
@@ -1,0 +1,133 @@
+/**
+ * One-click remediation loop — Phase 6 of the RCM red-text spec.
+ * --------------------------------------------------------------
+ * Pure helpers that apply a RootCauseFinding's RemediationAction to the
+ * claim/context shape and re-run the pre-flight engine, demonstrating
+ * the fix → re-run → green loop ("Append Modifier-25" → P_denial drops
+ * below 0.10 → release to the EDI 837 compiler).
+ *
+ * Every helper is immutable: the input claim/context is never mutated.
+ */
+
+import type { RemediationAction } from "./attribution";
+import type {
+  EncounterContext,
+  PreflightClaim,
+  PreflightOptions,
+  PreflightServiceLine,
+} from "./features";
+import { runPreflight, type PreflightResult } from "./engine";
+
+// ---------------------------------------------------------------------------
+// Claim-shape transforms
+// ---------------------------------------------------------------------------
+
+/** Append a modifier to the service line with `targetCode` (no-op if the
+ *  line already carries it or the code isn't on the claim). */
+export function appendModifier(
+  claim: PreflightClaim,
+  targetCode: string,
+  modifier: string,
+): PreflightClaim {
+  const serviceLines: PreflightServiceLine[] = claim.serviceLines.map((line) => {
+    if (line.code !== targetCode) return line;
+    const modifiers = line.modifiers ?? [];
+    if (modifiers.includes(modifier)) return line;
+    return { ...line, modifiers: [...modifiers, modifier] };
+  });
+  return { ...claim, serviceLines };
+}
+
+/** Convenience for the spec's headline fix: append Modifier-25 to the
+ *  E/M line. When `targetCode` is omitted, the first outpatient E/M
+ *  line (99202–99215) is used. */
+export function appendModifier25(claim: PreflightClaim, targetCode?: string): PreflightClaim {
+  const target =
+    targetCode ??
+    claim.serviceLines.find((l) => /^992(0[2-5]|1[1-5])$/.test(l.code))?.code;
+  if (!target) return claim;
+  return appendModifier(claim, target, "25");
+}
+
+/** Consolidate an unbundled component into the comprehensive code by
+ *  removing the component line item. */
+export function removeComponentLine(
+  claim: PreflightClaim,
+  componentCode: string,
+): PreflightClaim {
+  return {
+    ...claim,
+    serviceLines: claim.serviceLines.filter((l) => l.code !== componentCode),
+  };
+}
+
+/** Append documentation sentences to the narrative note (the
+ *  "inject missing criteria" remediation for medical-necessity holds). */
+export function augmentNarrative(
+  context: EncounterContext,
+  additions: string[],
+): EncounterContext {
+  if (additions.length === 0) return context;
+  return {
+    ...context,
+    narrativeNote: [context.narrativeNote, ...additions].join(" ").trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Action dispatcher + re-score loop
+// ---------------------------------------------------------------------------
+
+export interface RemediatedState {
+  claim: PreflightClaim;
+  context: EncounterContext;
+}
+
+/** Apply a typed RemediationAction from attribution.ts to the claim /
+ *  encounter shapes. `manual_review` is a no-op by design. */
+export function applyRemediation(
+  claim: PreflightClaim,
+  context: EncounterContext,
+  action: RemediationAction,
+): RemediatedState {
+  switch (action.kind) {
+    case "append_modifier":
+      return { claim: appendModifier(claim, action.targetCode, action.modifier), context };
+    case "remove_line":
+      return { claim: removeComponentLine(claim, action.componentCode), context };
+    case "augment_documentation":
+      // The biller supplies real sentences in the UI; the pure helper
+      // demonstrates the loop by injecting the required criteria terms.
+      return { claim, context: augmentNarrative(context, action.requiredKeywords) };
+    case "manual_review":
+      return { claim, context };
+  }
+}
+
+export interface RemediationRun {
+  before: PreflightResult;
+  after: PreflightResult;
+  claim: PreflightClaim;
+  context: EncounterContext;
+  /** true when the fix moved the claim into the green-release zone. */
+  released: boolean;
+}
+
+/** The one-click loop: score, apply the fix, re-score. */
+export function remediateAndRescore(
+  claim: PreflightClaim,
+  context: EncounterContext,
+  action: RemediationAction,
+  options: PreflightOptions = {},
+): RemediationRun {
+  const before = runPreflight(claim, context, options);
+  const fixed = applyRemediation(claim, context, action);
+  const after = runPreflight(fixed.claim, fixed.context, options);
+  return {
+    before,
+    after,
+    claim: fixed.claim,
+    context: fixed.context,
+    released: after.score.disposition === "release",
+  };
+}

--- a/src/lib/billing/preflight/rules.ts
+++ b/src/lib/billing/preflight/rules.ts
@@ -1,0 +1,108 @@
+/**
+ * Pre-flight rules tables — seedable, deterministic, no DB access.
+ * ----------------------------------------------------------------
+ * Two tables back the denial-probability feature extractor:
+ *
+ *  1. NCCI edit pairs (procedure-to-procedure). Same shape as the
+ *     starter table inside `src/lib/billing/scrub.ts` (EMR-222 tracks
+ *     the full CMS table migration). The pre-flight engine merges this
+ *     seed with whatever `scrubClaim` reports so the two engines never
+ *     disagree on a pair both know about.
+ *
+ *  2. LCD/NCD coverage rules: approved CPT↔ICD-10 coding pairs plus the
+ *     documentation keywords a payer's LCD requires in the narrative
+ *     note to justify the service. This is the seed for the
+ *     "Automated LCD/NCD Parsing" phase of the RCM spec — a future
+ *     loader replaces/extends the seed from the CMS coverage database;
+ *     callers can already inject their own table via PreflightOptions.
+ */
+
+// ---------------------------------------------------------------------------
+// NCCI procedure-to-procedure pairs
+// ---------------------------------------------------------------------------
+
+export interface NcciEditPair {
+  /** The code that gets denied when billed with `comprehensiveCode`. */
+  componentCode: string;
+  comprehensiveCode: string;
+  /** Modifier that unbundles the pair (placed on the comprehensive /
+   *  E&M line). `null` = never unbundleable — a true unbundling
+   *  conflict that can only be fixed by dropping the component line. */
+  allowedModifier: "25" | "59" | null;
+  description: string;
+}
+
+export const PREFLIGHT_NCCI_PAIRS: NcciEditPair[] = [
+  // E&M + therapeutic injection on the same day — the canonical
+  // Modifier-25 scenario from the RCM spec (99214 + 96372).
+  { componentCode: "96372", comprehensiveCode: "99212", allowedModifier: "25", description: "Therapeutic injection (96372) bundles into same-day E/M without Modifier-25 on the E/M line." },
+  { componentCode: "96372", comprehensiveCode: "99213", allowedModifier: "25", description: "Therapeutic injection (96372) bundles into same-day E/M without Modifier-25 on the E/M line." },
+  { componentCode: "96372", comprehensiveCode: "99214", allowedModifier: "25", description: "Therapeutic injection (96372) bundles into same-day E/M without Modifier-25 on the E/M line." },
+  { componentCode: "96372", comprehensiveCode: "99215", allowedModifier: "25", description: "Therapeutic injection (96372) bundles into same-day E/M without Modifier-25 on the E/M line." },
+  // Venipuncture is incidental to the visit — never unbundleable.
+  { componentCode: "36415", comprehensiveCode: "99213", allowedModifier: null, description: "Venipuncture is incidental to an office visit and is never separately billable." },
+  { componentCode: "36415", comprehensiveCode: "99214", allowedModifier: null, description: "Venipuncture is incidental to an office visit and is never separately billable." },
+  // Classic surgical unbundle: diagnostic knee arthroscopy is a
+  // component of surgical meniscectomy on the same knee.
+  { componentCode: "29870", comprehensiveCode: "29881", allowedModifier: null, description: "Diagnostic arthroscopy (29870) is a component of surgical meniscectomy (29881) — comprehensive code includes it." },
+];
+
+// ---------------------------------------------------------------------------
+// LCD / NCD coverage rules (approved coding pairs + documentation rules)
+// ---------------------------------------------------------------------------
+
+export interface LcdCoverageRule {
+  cptCode: string;
+  /** ICD-10-CM prefixes that constitute a covered pairing. */
+  approvedIcdPrefixes: string[];
+  /** Clinical keywords the LCD requires somewhere in the narrative
+   *  note to justify reimbursement (lower-cased substring match). */
+  requiredDocKeywords: string[];
+  description: string;
+}
+
+export const PREFLIGHT_LCD_RULES: LcdCoverageRule[] = [
+  // Established-patient E/M — broadly covered for the cannabis-care
+  // diagnosis hot list; no special documentation keywords beyond the
+  // narrative-quality features.
+  ...["99212", "99213", "99214", "99215"].map((cpt) => ({
+    cptCode: cpt,
+    approvedIcdPrefixes: ["F32", "F33", "F41", "F43", "G43", "G47", "G89", "M54", "M79", "R51", "Z71"],
+    requiredDocKeywords: [],
+    description: "Established-patient E/M with a supported behavioral / pain / sleep diagnosis.",
+  })),
+  // New-patient E/M.
+  ...["99203", "99204", "99205"].map((cpt) => ({
+    cptCode: cpt,
+    approvedIcdPrefixes: ["F32", "F33", "F41", "F43", "G43", "G47", "G89", "M54", "M79", "R51", "Z71"],
+    requiredDocKeywords: [],
+    description: "New-patient E/M with a supported behavioral / pain / sleep diagnosis.",
+  })),
+  // Therapeutic injection — covered for deficiency / pain dx.
+  {
+    cptCode: "96372",
+    approvedIcdPrefixes: ["D51", "E53", "G89", "M54", "M79", "Z23"],
+    requiredDocKeywords: [],
+    description: "Therapeutic/diagnostic injection for documented deficiency, pain, or immunization indication.",
+  },
+  // Brain MRI with + without contrast — the spec's medical-necessity
+  // example. Plain headache (R51) is NOT an approved pairing; the LCD
+  // requires red-flag indicators or documented treatment failure.
+  {
+    cptCode: "70553",
+    approvedIcdPrefixes: ["C71", "G43.7", "G40", "I63", "R56", "S06"],
+    requiredDocKeywords: [
+      "treatment failure",
+      "neurological deficit",
+      "red flag",
+      "papilledema",
+      "thunderclap",
+    ],
+    description:
+      "Brain MRI requires a high-acuity diagnosis (tumor, refractory migraine, stroke, seizure, trauma) AND documented red-flag indicators or treatment failure.",
+  },
+];
+
+/** Per-line LCD distance when the CPT has no rule on file — mildly
+ *  elevated (unknown coverage), not alarming. */
+export const UNKNOWN_CPT_LCD_DELTA = 0.1;

--- a/src/lib/billing/preflight/score.ts
+++ b/src/lib/billing/preflight/score.ts
@@ -1,0 +1,126 @@
+/**
+ * Denial Probability Score — Phase 3 of the RCM red-text spec.
+ * ------------------------------------------------------------
+ * Deterministic logistic-style model:
+ *
+ *   P_denial = σ( b0 + w_cci·X_CCI + w_mod·modifierGap
+ *                    + w_payer·V_payer + w_lcd·δ_LCD
+ *                    + w_doc·(1 − φ_narrative.score) )
+ *
+ * Weight rationale (hand-calibrated against the acceptance scenarios in
+ * EMR-1137; replace with trained coefficients once the 835-outcome
+ * training loop lands):
+ *
+ *   intercept −3.0  → a fully clean claim sits around σ(−2.6…−2.3),
+ *                     i.e. 7–9%, inside the green-release zone.
+ *   xCci       3.0  → a hard NCCI unbundling violation alone pushes the
+ *                     claim to ~50%+: always held.
+ *   modifierGap 2.7 → a missing-but-fixable modifier (99214+96372 without
+ *                     Mod-25) lands ~45–60%: held, but one click from green.
+ *   vPayer     3.5  → a payer denying ~50% of a CPT in the last 180 days
+ *                     adds ~1.75 logits — enough to push a borderline
+ *                     claim over the hold line.
+ *   deltaLcd   2.5  → full LCD discordance (1.0) adds 2.5 logits; combined
+ *                     with a thin note this is the medical-necessity hold.
+ *   narrativeDeficit 1.0 → documentation quality alone nudges, never
+ *                     dominates — thin notes amplify other risks.
+ */
+
+import type { PreflightFeatures } from "./features";
+
+export const SCORE_WEIGHTS = {
+  intercept: -3.0,
+  xCci: 3.0,
+  modifierGap: 2.7,
+  vPayer: 3.5,
+  deltaLcd: 2.5,
+  narrativeDeficit: 1.0,
+} as const;
+
+/** P_denial ≥ 0.35 → hold the claim in pre-submission staging. */
+export const HOLD_THRESHOLD = 0.35;
+/** P_denial < 0.10 → green zone, release to the EDI 837 compiler. */
+export const GREEN_THRESHOLD = 0.1;
+
+export type Disposition = "hold" | "review" | "release";
+
+export type ScoreFeatureKey =
+  | "xCci"
+  | "modifierGap"
+  | "vPayer"
+  | "deltaLcd"
+  | "narrativeDeficit";
+
+export interface FeatureContribution {
+  feature: ScoreFeatureKey;
+  /** Raw feature value fed into the model. */
+  value: number;
+  weight: number;
+  /** value × weight, in logits. Positive = pushes toward denial. */
+  contribution: number;
+}
+
+export interface DenialScore {
+  /** P_denial in [0,1]. */
+  score: number;
+  disposition: Disposition;
+  /** Per-feature logit contributions, sorted descending — the
+   *  deterministic stand-in for the spec's SHAP attribution. */
+  breakdown: FeatureContribution[];
+  intercept: number;
+}
+
+export function logistic(z: number): number {
+  return 1 / (1 + Math.exp(-z));
+}
+
+export function dispositionFor(score: number): Disposition {
+  if (score >= HOLD_THRESHOLD) return "hold";
+  if (score < GREEN_THRESHOLD) return "release";
+  return "review";
+}
+
+export function computePDenial(features: PreflightFeatures): DenialScore {
+  const narrativeDeficit = clamp01(1 - features.phiNarrative.score);
+  const values: Record<ScoreFeatureKey, number> = {
+    xCci: features.xCci,
+    modifierGap: features.modifierGap,
+    vPayer: clamp01(features.vPayer),
+    deltaLcd: clamp01(features.deltaLcd),
+    narrativeDeficit,
+  };
+
+  const breakdown: FeatureContribution[] = (
+    Object.keys(values) as ScoreFeatureKey[]
+  ).map((feature) => {
+    const weight = SCORE_WEIGHTS[feature];
+    const value = values[feature];
+    return {
+      feature,
+      value: round4(value),
+      weight,
+      contribution: round4(value * weight),
+    };
+  });
+  breakdown.sort((a, b) => b.contribution - a.contribution);
+
+  const z =
+    SCORE_WEIGHTS.intercept +
+    breakdown.reduce((sum, c) => sum + c.contribution, 0);
+  const score = round4(logistic(z));
+
+  return {
+    score,
+    disposition: dispositionFor(score),
+    breakdown,
+    intercept: SCORE_WEIGHTS.intercept,
+  };
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}

--- a/src/lib/clinical/rx-safety/__tests__/botanical.test.ts
+++ b/src/lib/clinical/rx-safety/__tests__/botanical.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { evaluateBotanical, cannabinoidsFromExposures } from "../botanical";
+import { LOINC } from "../types";
+import type { BotanicalExposure } from "../types";
+
+const cbd: BotanicalExposure[] = [
+  { name: "CBD isolate", kind: "cannabinoid", concentrated: true },
+];
+
+describe("cannabinoidsFromExposures", () => {
+  it("detects CBD from a concentrated exposure", () => {
+    const { cannabinoids, concentrated } = cannabinoidsFromExposures(cbd);
+    expect(cannabinoids).toContain("CBD");
+    expect(concentrated).toBe(true);
+  });
+  it("infers THC+CBD from a ratio product name in the dosing log", () => {
+    const { cannabinoids } = cannabinoidsFromExposures([
+      { name: "1:1 Relief Tincture", source: "dosing_log" },
+    ]);
+    expect(cannabinoids).toEqual(expect.arrayContaining(["THC", "CBD"]));
+  });
+  it("ignores non-cannabis exposures", () => {
+    const { cannabinoids } = cannabinoidsFromExposures([
+      { name: "St. John's Wort", kind: "herbal" },
+    ]);
+    expect(cannabinoids).toHaveLength(0);
+  });
+});
+
+describe("botanical anchor: concentrated CBD × warfarin", () => {
+  it("optimization with 25% reduction + immediate INR follow-up", () => {
+    const findings = evaluateBotanical({ drugName: "warfarin" }, cbd);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("optimization");
+    expect(findings[0].details?.suggestedDoseReductionPct).toBe(25);
+    expect(findings[0].requiredFollowUp).toEqual([
+      { labLoinc: LOINC.INR, timing: "immediate" },
+    ]);
+  });
+  it("also fires for a DOAC (apixaban)", () => {
+    const findings = evaluateBotanical({ drugName: "apixaban" }, cbd);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("optimization");
+  });
+});
+
+describe("botanical anchor: THC/CBD × clobazam", () => {
+  it("dosing_override with high-priority sedation warning", () => {
+    const findings = evaluateBotanical({ drugName: "clobazam" }, cbd);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("dosing_override");
+    expect(findings[0].details?.sedationRisk).toBe("high");
+    expect(findings[0].mechanism).toMatch(/N-desmethylclobazam/);
+  });
+});
+
+describe("botanical anchor: St. John's Wort × cyclosporine/tacrolimus", () => {
+  it("hard_stop for transplant rejection risk", () => {
+    const findings = evaluateBotanical({ drugName: "tacrolimus" }, [
+      { name: "St. John's Wort", kind: "herbal" },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("hard_stop");
+    expect(findings[0].details?.transplantRejectionRisk).toBe(true);
+  });
+  it("no SJW exposure → no finding", () => {
+    const findings = evaluateBotanical({ drugName: "tacrolimus" }, []);
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/src/lib/clinical/rx-safety/__tests__/evaluate.test.ts
+++ b/src/lib/clinical/rx-safety/__tests__/evaluate.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { evaluateRxSafety } from "../evaluate";
+import { LOINC } from "../types";
+import type { PatientRxProfile } from "../types";
+
+const NOW = new Date("2026-06-12T00:00:00Z");
+function daysAgo(d: number): string {
+  return new Date(NOW.getTime() - d * 86400000).toISOString();
+}
+
+const emptyProfile: PatientRxProfile = {
+  sex: "female",
+  age: 50,
+  pgxVariants: [],
+  labs: [],
+  activeMeds: [],
+  botanicalExposures: [],
+};
+
+describe("evaluateRxSafety", () => {
+  it("clean order → no findings, not blocking", async () => {
+    const r = await evaluateRxSafety(
+      { drugName: "lisinopril" },
+      emptyProfile,
+      NOW
+    );
+    expect(r.findings).toHaveLength(0);
+    expect(r.hasBlockingFinding).toBe(false);
+  });
+
+  it("ranks hard stops first across layers (PGx + botanical stacking)", async () => {
+    // Codeine order: CYP2D6 UM (hard_stop) AND concentrated CBD present.
+    // CBD×codeine isn't a botanical anchor, so only the PGx hard_stop fires —
+    // but we stack a SJW×tacrolimus is not applicable; instead use clobazam-like
+    // stacking on one drug below.
+    const profile: PatientRxProfile = {
+      ...emptyProfile,
+      pgxVariants: [{ gene: "CYP2D6", diplotype: "*1xN/*1" }],
+    };
+    const r = await evaluateRxSafety({ drugName: "codeine" }, profile, NOW);
+    expect(r.findings[0].kind).toBe("hard_stop");
+    expect(r.hasBlockingFinding).toBe(true);
+  });
+
+  it("stacks PGx + botanical findings on one order, hard stop ranked first", async () => {
+    // Clopidogrel: CYP2C19 PM → hard_substitution.
+    // Add a concentrated CBD exposure; clopidogrel isn't a CBD anchor, so to
+    // genuinely stack two layers we use an order present in both: none overlap
+    // by design, so assemble an order that triggers PGx + organ together.
+    const profile: PatientRxProfile = {
+      ...emptyProfile,
+      sex: "male",
+      age: 70,
+      pgxVariants: [{ gene: "HLA-B", alleles: ["*58:01"], phenotype: "positive" }],
+      labs: [
+        { loinc: LOINC.SERUM_CREATININE, value: 2.5, observedAt: daysAgo(10) },
+      ],
+    };
+    // allopurinol triggers HLA hard_stop (PGx) AND renal adjustment (organ).
+    const r = await evaluateRxSafety({ drugName: "allopurinol" }, profile, NOW);
+    const kinds = r.findings.map((f) => f.kind);
+    expect(kinds).toContain("hard_stop");
+    expect(kinds).toContain("dosing_override");
+    // hard_stop ranked before dosing_override
+    expect(r.findings[0].kind).toBe("hard_stop");
+    expect(r.hasBlockingFinding).toBe(true);
+  });
+
+  it("stacks PGx + botanical on clobazam order", async () => {
+    // Clobazam with concentrated CBD → botanical dosing_override.
+    // CYP2D6 not relevant; this validates the botanical layer through the
+    // aggregate entry point with cannabinoid exposure detection.
+    const profile: PatientRxProfile = {
+      ...emptyProfile,
+      botanicalExposures: [{ name: "CBD oil", kind: "cannabinoid", concentrated: true }],
+    };
+    const r = await evaluateRxSafety({ drugName: "clobazam" }, profile, NOW);
+    expect(r.findings.some((f) => f.kind === "dosing_override")).toBe(true);
+  });
+
+  it("includes citation metadata strings on findings", async () => {
+    const profile: PatientRxProfile = {
+      ...emptyProfile,
+      pgxVariants: [{ gene: "CYP2C19", diplotype: "*2/*2" }],
+    };
+    const r = await evaluateRxSafety({ drugName: "clopidogrel" }, profile, NOW);
+    expect(r.findings[0].citations).toContain("CPIC Level A");
+    expect(r.evaluatedAt).toBe(NOW.toISOString());
+  });
+});

--- a/src/lib/clinical/rx-safety/__tests__/organ.test.ts
+++ b/src/lib/clinical/rx-safety/__tests__/organ.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { ckdEpi2021, egfrBand, childPugh, evaluateOrgan } from "../organ";
+import { LOINC } from "../types";
+import type { PatientRxProfile } from "../types";
+
+const NOW = new Date("2026-06-12T00:00:00Z");
+function daysAgo(d: number): string {
+  return new Date(NOW.getTime() - d * 86400000).toISOString();
+}
+
+describe("CKD-EPI 2021 published vectors", () => {
+  it("female, 55y, Scr 0.8 → ~87", () => {
+    expect(ckdEpi2021(0.8, 55, "female")).toBeCloseTo(86.96, 1);
+  });
+  it("male, 60y, Scr 1.2 → ~69", () => {
+    expect(ckdEpi2021(1.2, 60, "male")).toBeCloseTo(69.23, 1);
+  });
+  it("male, 70y, Scr 2.5 → ~27", () => {
+    expect(ckdEpi2021(2.5, 70, "male")).toBeCloseTo(26.96, 1);
+  });
+  it("female, 65y, Scr 1.8 → ~31", () => {
+    expect(ckdEpi2021(1.8, 65, "female")).toBeCloseTo(30.88, 1);
+  });
+  it("egfrBand maps correctly", () => {
+    expect(egfrBand(95)).toBe("G1");
+    expect(egfrBand(27)).toBe("G4");
+    expect(egfrBand(31)).toBe("G3b");
+  });
+});
+
+describe("Child-Pugh published vectors", () => {
+  it("all-normal labs → class A score 5", () => {
+    const r = childPugh({ bilirubin: 1.0, albumin: 4.0, inr: 1.1 });
+    expect(r.score).toBe(5);
+    expect(r.class).toBe("A");
+  });
+  it("moderate derangement → class B", () => {
+    // bili 2.5 (2pt), alb 3.0 (2pt), inr 2.0 (2pt), ascites slight (2pt),
+    // enceph grade 1 (2pt) = 10? → tune to land in B: score 7-9
+    const r = childPugh({
+      bilirubin: 2.5,
+      albumin: 3.0,
+      inr: 1.5,
+      ascites: "slight",
+    });
+    // 2 + 2 + 1 + 2 + 1 = 8
+    expect(r.score).toBe(8);
+    expect(r.class).toBe("B");
+  });
+  it("severe derangement → class C", () => {
+    const r = childPugh({
+      bilirubin: 4.0,
+      albumin: 2.5,
+      inr: 2.5,
+      ascites: "moderate",
+      encephalopathyGrade: 3,
+    });
+    // 3 + 3 + 3 + 3 + 3 = 15
+    expect(r.score).toBe(15);
+    expect(r.class).toBe("C");
+  });
+});
+
+const baseProfile: Omit<PatientRxProfile, "labs"> = {
+  sex: "male",
+  age: 70,
+  pgxVariants: [],
+  activeMeds: [],
+  botanicalExposures: [],
+};
+
+describe("renal dose adjustment finding", () => {
+  it("flags gabapentin at reduced eGFR", () => {
+    const profile: PatientRxProfile = {
+      ...baseProfile,
+      labs: [{ loinc: LOINC.SERUM_CREATININE, value: 2.5, observedAt: daysAgo(10) }],
+    };
+    const findings = evaluateOrgan({ drugName: "gabapentin" }, profile, NOW);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("dosing_override");
+    expect(findings[0].details?.egfrBand).toBe("G4");
+    expect(findings[0].lowConfidence).toBeFalsy();
+  });
+  it("no flag at normal eGFR", () => {
+    const profile: PatientRxProfile = {
+      ...baseProfile,
+      age: 40,
+      labs: [{ loinc: LOINC.SERUM_CREATININE, value: 0.9, observedAt: daysAgo(5) }],
+    };
+    expect(evaluateOrgan({ drugName: "gabapentin" }, profile, NOW)).toHaveLength(0);
+  });
+});
+
+describe("hepatic dose cap finding", () => {
+  it("caps acetaminophen in Child-Pugh C and flags dose excess", () => {
+    const profile: PatientRxProfile = {
+      ...baseProfile,
+      ascites: "moderate",
+      encephalopathyGrade: 3,
+      labs: [
+        { loinc: LOINC.TOTAL_BILIRUBIN, value: 4.0, observedAt: daysAgo(10) },
+        { loinc: LOINC.ALBUMIN, value: 2.5, observedAt: daysAgo(10) },
+        { loinc: LOINC.INR, value: 2.5, observedAt: daysAgo(10) },
+      ],
+    };
+    const findings = evaluateOrgan(
+      { drugName: "acetaminophen", dailyDoseMg: 3000 },
+      profile,
+      NOW
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].details?.childPughClass).toBe("C");
+    expect(findings[0].details?.exceedsCap).toBe(true);
+  });
+});
+
+describe("stale labs → lowConfidence (never silently used)", () => {
+  it("marks lowConfidence when creatinine > 180 days old", () => {
+    const profile: PatientRxProfile = {
+      ...baseProfile,
+      labs: [
+        { loinc: LOINC.SERUM_CREATININE, value: 2.5, observedAt: daysAgo(200) },
+      ],
+    };
+    const findings = evaluateOrgan({ drugName: "gabapentin" }, profile, NOW);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].lowConfidence).toBe(true);
+  });
+});

--- a/src/lib/clinical/rx-safety/__tests__/pgx.test.ts
+++ b/src/lib/clinical/rx-safety/__tests__/pgx.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { evaluatePgx, resolveCypPhenotype } from "../pgx";
+import type { DraftOrder, PgxVariant } from "../types";
+
+const clopidogrel: DraftOrder = { rxNormCui: "32968", drugName: "clopidogrel" };
+const codeine: DraftOrder = { drugName: "codeine" };
+const allopurinol: DraftOrder = { rxNormCui: "519", drugName: "allopurinol" };
+
+describe("resolveCypPhenotype", () => {
+  it("classifies *2/*3 as poor metabolizer", () => {
+    expect(resolveCypPhenotype("CYP2C19", ["*2", "*3"])).toBe(
+      "poor_metabolizer"
+    );
+  });
+  it("classifies *1/*2 as intermediate metabolizer", () => {
+    expect(resolveCypPhenotype("CYP2C19", ["*1", "*2"])).toBe(
+      "intermediate_metabolizer"
+    );
+  });
+  it("classifies *1xN as ultrarapid", () => {
+    expect(resolveCypPhenotype("CYP2D6", ["*1xN", "*1"])).toBe(
+      "ultrarapid_metabolizer"
+    );
+  });
+});
+
+describe("PGx anchor: Clopidogrel × CYP2C19", () => {
+  it("IM/PM → hard_substitution suggesting prasugrel/ticagrelor", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP2C19", diplotype: "*2/*3" }];
+    const [f] = evaluatePgx(clopidogrel, variants);
+    expect(f.kind).toBe("hard_substitution");
+    expect(f.recommendation.toLowerCase()).toMatch(/prasugrel|ticagrelor/);
+    expect(f.citations).toContain("CPIC Level A");
+  });
+  it("normal metabolizer → no finding", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP2C19", diplotype: "*1/*1" }];
+    expect(evaluatePgx(clopidogrel, variants)).toHaveLength(0);
+  });
+});
+
+describe("PGx anchor: Codeine/Tramadol × CYP2D6 PM", () => {
+  it("poor metabolizer → dosing_override (therapeutic failure)", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP2D6", diplotype: "*4/*5" }];
+    const [f] = evaluatePgx(codeine, variants);
+    expect(f.kind).toBe("dosing_override");
+    expect(f.rationale.toLowerCase()).toMatch(/failure|no analgesic/);
+  });
+  it("applies to tramadol too", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP2D6", diplotype: "*4/*4" }];
+    const [f] = evaluatePgx({ drugName: "tramadol" }, variants);
+    expect(f.kind).toBe("dosing_override");
+  });
+});
+
+describe("PGx anchor: Codeine/Tramadol × CYP2D6 ultrarapid", () => {
+  it("ultrarapid → hard_stop with critical respiratory warning", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP2D6", diplotype: "*1xN/*1" }];
+    const [f] = evaluatePgx(codeine, variants);
+    expect(f.kind).toBe("hard_stop");
+    expect(f.details?.criticalRespiratoryWarning).toBe(true);
+  });
+});
+
+describe("PGx anchor: Allopurinol × HLA-B*58:01", () => {
+  it("positive carriage → hard_stop suggesting febuxostat", () => {
+    const variants: PgxVariant[] = [
+      { gene: "HLA-B", alleles: ["*58:01"], phenotype: "positive" },
+    ];
+    const [f] = evaluatePgx(allopurinol, variants);
+    expect(f.kind).toBe("hard_stop");
+    expect(f.recommendation.toLowerCase()).toContain("febuxostat");
+  });
+  it("explicit negative → no finding", () => {
+    const variants: PgxVariant[] = [
+      { gene: "HLA-B", alleles: ["*58:01"], phenotype: "negative" },
+    ];
+    expect(evaluatePgx(allopurinol, variants)).toHaveLength(0);
+  });
+});
+
+describe("no genomic data → silent pass", () => {
+  it("empty variants returns no findings (no warning)", () => {
+    expect(evaluatePgx(clopidogrel, [])).toEqual([]);
+  });
+  it("variants for an unrelated gene do not fire", () => {
+    const variants: PgxVariant[] = [{ gene: "CYP3A5", diplotype: "*3/*3" }];
+    expect(evaluatePgx(clopidogrel, variants)).toEqual([]);
+  });
+});

--- a/src/lib/clinical/rx-safety/botanical.ts
+++ b/src/lib/clinical/rx-safety/botanical.ts
@@ -1,0 +1,237 @@
+// ---------------------------------------------------------------------------
+// Botanical, Cannabinoid & Xenobiotic Interaction Engine — Phase 4.
+//
+// Layered ON TOP of the existing cannabinoid interaction module
+// (src/lib/domain/drug-interactions.ts → checkInteractions). That module
+// already encodes the curated CBD/THC × drug interaction database (severity,
+// mechanism, recommendation, PMIDs). We reuse it for the cannabinoid arm so we
+// inherit the same vetted data + matching semantics instead of duplicating it,
+// then translate its red/yellow/green output into the richer GuardrailFinding
+// shape (with optimization actions + queued follow-up labs) the spec's anchor
+// rules require, and add the non-cannabinoid botanical escalation vectors
+// (e.g. St. John's Wort × cyclosporine/tacrolimus) on top.
+// ---------------------------------------------------------------------------
+
+import {
+  checkInteractions,
+  inferCannabinoidsFromName,
+} from "@/lib/domain/drug-interactions";
+import {
+  type BotanicalExposure,
+  type DraftOrder,
+  type GuardrailFinding,
+  LOINC,
+  orderMatchesDrug,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Cannabinoid exposure detection
+// ---------------------------------------------------------------------------
+
+const CANNABINOID_TOKENS = ["THC", "CBD", "CBN", "CBG"];
+
+/**
+ * Derive the active cannabinoid set from the patient's botanical exposures,
+ * reusing inferCannabinoidsFromName() from the existing module for free-text
+ * product names (cannabis product / dosing-log entries).
+ */
+export function cannabinoidsFromExposures(
+  exposures: BotanicalExposure[]
+): { cannabinoids: string[]; concentrated: boolean } {
+  const set = new Set<string>();
+  let concentrated = false;
+  for (const e of exposures) {
+    const isCannabis =
+      e.kind === "cannabinoid" ||
+      CANNABINOID_TOKENS.some((t) => e.name.toUpperCase().includes(t)) ||
+      /cannab|marijuana|tincture|\d+\s*:\s*\d+/i.test(e.name);
+    if (!isCannabis) continue;
+    if (e.concentrated) concentrated = true;
+    for (const c of inferCannabinoidsFromName(e.name)) set.add(c);
+  }
+  return { cannabinoids: Array.from(set), concentrated };
+}
+
+// ---------------------------------------------------------------------------
+// Cannabinoid anchor rules — translate checkInteractions output into the
+// richer optimization/override findings the spec calls for.
+// ---------------------------------------------------------------------------
+
+interface CannabinoidAnchor {
+  ruleId: string;
+  drug: { names: string[]; rxNormCuis?: string[] };
+  /** Which cannabinoids must be present to trigger. */
+  requires: string[];
+  build: (
+    cannabinoids: string[],
+    concentrated: boolean
+  ) => Omit<GuardrailFinding, "layer" | "ruleId">;
+}
+
+const CANNABINOID_ANCHORS: CannabinoidAnchor[] = [
+  // Concentrated CBD × warfarin/DOACs (CYP2C9) → optimization + INR follow-up
+  {
+    ruleId: "botanical.cbd.anticoagulant",
+    drug: {
+      names: [
+        "warfarin",
+        "coumadin",
+        "jantoven",
+        "apixaban",
+        "eliquis",
+        "rivaroxaban",
+        "xarelto",
+        "dabigatran",
+        "pradaxa",
+        "edoxaban",
+        "savaysa",
+      ],
+    },
+    requires: ["CBD"],
+    build: () => ({
+      kind: "optimization",
+      mechanism:
+        "CBD competes for CYP2C9 (and CYP3A4) clearance, slowing " +
+        "anticoagulant metabolism and increasing bleeding risk.",
+      rationale:
+        "Concentrated CBD exposure alongside an anticoagulant can raise " +
+        "effective anticoagulant levels.",
+      recommendation:
+        "Suggest a 25% reduction in the initial anticoagulant dose and queue " +
+        "an immediate follow-up INR check.",
+      citations: ["CYP2C9 interaction", "real-world cannabinoid PK evidence"],
+      requiredFollowUp: [{ labLoinc: LOINC.INR, timing: "immediate" }],
+      details: { enzyme: "CYP2C9", suggestedDoseReductionPct: 25 },
+    }),
+  },
+
+  // THC/CBD × clobazam (CYP2C19) → dosing_override + sedation warning
+  {
+    ruleId: "botanical.cannabinoid.clobazam",
+    drug: { names: ["clobazam", "onfi", "sympazan"] },
+    requires: ["CBD"],
+    build: () => ({
+      kind: "dosing_override",
+      mechanism:
+        "CBD strongly inhibits CYP2C19, raising the active metabolite " +
+        "N-desmethylclobazam and amplifying sedation.",
+      rationale:
+        "Co-administered cannabinoids cause N-desmethylclobazam accumulation " +
+        "and risk profound sedation at the drafted dose.",
+      recommendation:
+        "Cap the proposed clobazam dose and issue a high-priority sedation " +
+        "risk warning; consider tapering with monitoring.",
+      citations: ["CYP2C19 inhibition", "Epidiolex/clobazam interaction data"],
+      details: { enzyme: "CYP2C19", sedationRisk: "high" },
+    }),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Non-cannabinoid botanical escalation vectors
+// ---------------------------------------------------------------------------
+
+interface BotanicalAnchor {
+  ruleId: string;
+  /** Botanical name tokens to detect in the exposure manifest. */
+  botanicalTokens: string[];
+  drug: { names: string[]; rxNormCuis?: string[] };
+  build: () => Omit<GuardrailFinding, "layer" | "ruleId">;
+}
+
+const BOTANICAL_ANCHORS: BotanicalAnchor[] = [
+  // St. John's Wort × cyclosporine/tacrolimus (CYP3A4 / P-gp induction)
+  {
+    ruleId: "botanical.sjw.calcineurin",
+    botanicalTokens: ["st. john", "st john", "hypericum", "hyperforin"],
+    drug: {
+      names: [
+        "cyclosporine",
+        "neoral",
+        "sandimmune",
+        "gengraf",
+        "tacrolimus",
+        "prograf",
+        "astagraf",
+        "envarsus",
+      ],
+    },
+    build: () => ({
+      kind: "hard_stop",
+      mechanism:
+        "Hyperforin in St. John's Wort potently induces hepatic CYP3A4 and " +
+        "P-glycoprotein, accelerating calcineurin-inhibitor clearance.",
+      rationale:
+        "Subtherapeutic cyclosporine/tacrolimus levels create a high risk of " +
+        "acute organ transplant rejection.",
+      recommendation:
+        "Hard block. Deny parallel prescription. Discontinue St. John's Wort " +
+        "and re-evaluate immunosuppressant dosing with level monitoring.",
+      citations: ["CYP3A4/P-gp induction", "transplant rejection case evidence"],
+      details: { enzyme: "CYP3A4/P-gp", transplantRejectionRisk: true },
+    }),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// evaluateBotanical
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the botanical/cannabinoid layer. Reuses checkInteractions() from the
+ * existing domain module to confirm a curated cannabinoid×drug interaction
+ * exists before emitting the richer anchor finding, so we never fire ahead of
+ * the vetted database.
+ */
+export function evaluateBotanical(
+  order: DraftOrder,
+  exposures: BotanicalExposure[]
+): GuardrailFinding[] {
+  const findings: GuardrailFinding[] = [];
+
+  // --- Cannabinoid arm (reuses the existing interaction database) --------
+  const { cannabinoids, concentrated } = cannabinoidsFromExposures(exposures);
+  if (cannabinoids.length > 0) {
+    // Confirm the curated DB knows about an interaction for this drug ×
+    // cannabinoid pair (reuse of checkInteractions). This both validates the
+    // pairing and surfaces the underlying PMIDs.
+    const known = checkInteractions([order.drugName], cannabinoids);
+
+    for (const anchor of CANNABINOID_ANCHORS) {
+      if (!orderMatchesDrug(order, anchor.drug)) continue;
+      if (!anchor.requires.every((c) => cannabinoids.includes(c))) continue;
+
+      const partial = anchor.build(cannabinoids, concentrated);
+
+      // Enrich citations with any PMIDs the curated DB carries for this pair.
+      const refs = known
+        .filter((k) => anchor.requires.includes(k.cannabinoid.toUpperCase()))
+        .flatMap((k) => k.references);
+      const citations = [...partial.citations, ...refs];
+
+      findings.push({
+        ...partial,
+        citations,
+        layer: "botanical",
+        ruleId: anchor.ruleId,
+      });
+    }
+  }
+
+  // --- Non-cannabinoid botanical arm -------------------------------------
+  const manifest = exposures.map((e) => e.name.toLowerCase());
+  for (const anchor of BOTANICAL_ANCHORS) {
+    const present = anchor.botanicalTokens.some((t) =>
+      manifest.some((m) => m.includes(t))
+    );
+    if (!present) continue;
+    if (!orderMatchesDrug(order, anchor.drug)) continue;
+    findings.push({
+      ...anchor.build(),
+      layer: "botanical",
+      ruleId: anchor.ruleId,
+    });
+  }
+
+  return findings;
+}

--- a/src/lib/clinical/rx-safety/evaluate.ts
+++ b/src/lib/clinical/rx-safety/evaluate.ts
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------
+// evaluateRxSafety — top-level entry point for the prescription-safety
+// guardrail engine. Runs the three layers (PGx, organ clearance, botanical)
+// and returns ranked findings (hard stops first), suitable for the inline
+// optimization card UI described in Phase 6 of the red-text spec.
+//
+// The three layers are independent and side-effect-free, so they're evaluated
+// in a concurrently-safe manner (Promise.all over synchronous evaluators —
+// no shared mutable state, deterministic ordering applied after).
+// ---------------------------------------------------------------------------
+
+import { evaluateBotanical } from "./botanical";
+import { evaluateOrgan } from "./organ";
+import { evaluatePgx } from "./pgx";
+import {
+  type DraftOrder,
+  type GuardrailFinding,
+  type PatientRxProfile,
+  type RxSafetyEvaluation,
+  GUARDRAIL_KIND_RANK,
+} from "./types";
+
+const BLOCKING_KINDS = new Set<GuardrailFinding["kind"]>([
+  "hard_stop",
+  "hard_substitution",
+]);
+
+/** Stable, severity-first ordering for the optimization card. */
+function rankFindings(findings: GuardrailFinding[]): GuardrailFinding[] {
+  return [...findings].sort((a, b) => {
+    const byKind = GUARDRAIL_KIND_RANK[a.kind] - GUARDRAIL_KIND_RANK[b.kind];
+    if (byKind !== 0) return byKind;
+    // Within the same severity, keep a deterministic layer order.
+    return a.ruleId.localeCompare(b.ruleId);
+  });
+}
+
+/**
+ * Evaluate a drafted order against the patient's multi-omic profile across all
+ * three guardrail layers. Returns ranked findings; an empty list means the
+ * order is clean and the card should not render.
+ *
+ * @param order the drafted CPOE order
+ * @param profile the assembled patient Rx profile
+ * @param now injectable clock for deterministic lab-freshness evaluation
+ */
+export async function evaluateRxSafety(
+  order: DraftOrder,
+  profile: PatientRxProfile,
+  now: Date = new Date()
+): Promise<RxSafetyEvaluation> {
+  // Each layer is pure + independent → safe to run concurrently.
+  const [pgx, organ, botanical] = await Promise.all([
+    Promise.resolve().then(() => evaluatePgx(order, profile.pgxVariants)),
+    Promise.resolve().then(() => evaluateOrgan(order, profile, now)),
+    Promise.resolve().then(() =>
+      evaluateBotanical(order, profile.botanicalExposures)
+    ),
+  ]);
+
+  const findings = rankFindings([...pgx, ...organ, ...botanical]);
+
+  return {
+    order,
+    findings,
+    hasBlockingFinding: findings.some((f) => BLOCKING_KINDS.has(f.kind)),
+    evaluatedAt: now.toISOString(),
+  };
+}
+
+export { evaluatePgx } from "./pgx";
+export { evaluateOrgan, ckdEpi2021, childPugh, egfrBand } from "./organ";
+export { evaluateBotanical, cannabinoidsFromExposures } from "./botanical";
+export * from "./types";

--- a/src/lib/clinical/rx-safety/organ.ts
+++ b/src/lib/clinical/rx-safety/organ.ts
@@ -1,0 +1,338 @@
+// ---------------------------------------------------------------------------
+// Organ Function Clearance Calculations & Adaptive Dosing — Phase 3.
+//
+// Pure calculators (no I/O) with published test vectors covered in __tests__:
+//   - CKD-EPI 2021 creatinine eGFR
+//   - Child-Pugh score / class from bilirubin, albumin, INR (+ optional
+//     ascites / encephalopathy clinical flags, default absent)
+//   - Dose-cap recommendations driven by Child-Pugh class and eGFR bands.
+//
+// Labs older than 180 days are NOT silently used: findings derived from stale
+// labs are marked lowConfidence:true so the UI can badge them.
+// ---------------------------------------------------------------------------
+
+import {
+  type DraftOrder,
+  type GuardrailFinding,
+  type LabResult,
+  type PatientRxProfile,
+  LAB_FRESHNESS_WINDOW_DAYS,
+  LOINC,
+  orderMatchesDrug,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// CKD-EPI 2021 creatinine eGFR
+// ---------------------------------------------------------------------------
+
+/**
+ * CKD-EPI 2021 creatinine equation (race-free):
+ *   eGFR = 142 × min(Scr/κ,1)^α × max(Scr/κ,1)^−1.200 × 0.9938^age × (1.012 if female)
+ * where κ = 0.7 (F) / 0.9 (M), α = −0.241 (F) / −0.302 (M).
+ *
+ * @param scr serum creatinine in mg/dL
+ * @param age years
+ * @param sex "female" | "male"
+ * @returns eGFR in mL/min/1.73m²
+ */
+export function ckdEpi2021(
+  scr: number,
+  age: number,
+  sex: "female" | "male"
+): number {
+  const female = sex === "female";
+  const kappa = female ? 0.7 : 0.9;
+  const alpha = female ? -0.241 : -0.302;
+  const ratio = scr / kappa;
+  let egfr =
+    142 *
+    Math.pow(Math.min(ratio, 1), alpha) *
+    Math.pow(Math.max(ratio, 1), -1.2) *
+    Math.pow(0.9938, age);
+  if (female) egfr *= 1.012;
+  return egfr;
+}
+
+/** Standard KDIGO eGFR band for a value (G1–G5). */
+export type EgfrBand = "G1" | "G2" | "G3a" | "G3b" | "G4" | "G5";
+
+export function egfrBand(egfr: number): EgfrBand {
+  if (egfr >= 90) return "G1";
+  if (egfr >= 60) return "G2";
+  if (egfr >= 45) return "G3a";
+  if (egfr >= 30) return "G3b";
+  if (egfr >= 15) return "G4";
+  return "G5";
+}
+
+// ---------------------------------------------------------------------------
+// Child-Pugh score / class
+// ---------------------------------------------------------------------------
+
+export type ChildPughClass = "A" | "B" | "C";
+
+export interface ChildPughInput {
+  /** Total bilirubin, mg/dL. */
+  bilirubin: number;
+  /** Serum albumin, g/dL. */
+  albumin: number;
+  /** INR (unitless). */
+  inr: number;
+  /** Ascites clinical flag (default absent). */
+  ascites?: "absent" | "slight" | "moderate";
+  /** Hepatic encephalopathy grade 0–4 (default 0 / none). */
+  encephalopathyGrade?: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface ChildPughResult {
+  score: number;
+  class: ChildPughClass;
+  /** Per-parameter points, for transparency in the UI. */
+  breakdown: {
+    bilirubin: number;
+    albumin: number;
+    inr: number;
+    ascites: number;
+    encephalopathy: number;
+  };
+}
+
+function bilirubinPoints(b: number): number {
+  if (b < 2) return 1;
+  if (b <= 3) return 2;
+  return 3;
+}
+function albuminPoints(a: number): number {
+  if (a > 3.5) return 1;
+  if (a >= 2.8) return 2;
+  return 3;
+}
+function inrPoints(inr: number): number {
+  if (inr < 1.7) return 1;
+  if (inr <= 2.3) return 2;
+  return 3;
+}
+function ascitesPoints(a: ChildPughInput["ascites"]): number {
+  switch (a) {
+    case "moderate":
+      return 3;
+    case "slight":
+      return 2;
+    default:
+      return 1; // absent
+  }
+}
+function encephalopathyPoints(grade: number): number {
+  if (grade >= 3) return 3;
+  if (grade >= 1) return 2;
+  return 1; // none
+}
+
+/** Compute the Child-Pugh score and class. */
+export function childPugh(input: ChildPughInput): ChildPughResult {
+  const breakdown = {
+    bilirubin: bilirubinPoints(input.bilirubin),
+    albumin: albuminPoints(input.albumin),
+    inr: inrPoints(input.inr),
+    ascites: ascitesPoints(input.ascites),
+    encephalopathy: encephalopathyPoints(input.encephalopathyGrade ?? 0),
+  };
+  const score =
+    breakdown.bilirubin +
+    breakdown.albumin +
+    breakdown.inr +
+    breakdown.ascites +
+    breakdown.encephalopathy;
+  const cls: ChildPughClass = score <= 6 ? "A" : score <= 9 ? "B" : "C";
+  return { score, class: cls, breakdown };
+}
+
+// ---------------------------------------------------------------------------
+// Lab freshness helpers
+// ---------------------------------------------------------------------------
+
+function ageInDays(observedAt: string | Date, now: Date): number {
+  const t = observedAt instanceof Date ? observedAt : new Date(observedAt);
+  return (now.getTime() - t.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+/** Most-recent lab for a LOINC, or undefined. */
+function latestLab(labs: LabResult[], loinc: string): LabResult | undefined {
+  return labs
+    .filter((l) => l.loinc === loinc)
+    .sort(
+      (a, b) =>
+        new Date(b.observedAt).getTime() - new Date(a.observedAt).getTime()
+    )[0];
+}
+
+// ---------------------------------------------------------------------------
+// Hepatotoxic / renally-cleared agent tables (anchor set)
+// ---------------------------------------------------------------------------
+
+/** High-clearance hepatotoxic agents the engine caps under Child-Pugh C. */
+const HEPATOTOXIC_AGENTS: Array<{
+  names: string[];
+  rxNormCuis?: string[];
+  /** Max total daily dose (mg) recommended in Child-Pugh C, if defined. */
+  childPughCDailyCapMg?: number;
+  note: string;
+}> = [
+  {
+    names: ["acetaminophen", "tylenol", "paracetamol", "apap"],
+    childPughCDailyCapMg: 2000,
+    note: "Cap acetaminophen at ≤2 g/day in advanced cirrhosis.",
+  },
+  {
+    names: ["valproic acid", "valproate", "depakote", "depakene", "divalproex"],
+    note:
+      "Valproic acid is hepatotoxic and can precipitate hyperammonemic " +
+      "encephalopathy in hepatic impairment — avoid or use extreme caution.",
+  },
+];
+
+/** Renally-cleared agents that need eGFR-band dose adjustment flags. */
+const RENALLY_CLEARED_AGENTS: Array<{
+  names: string[];
+  rxNormCuis?: string[];
+  note: string;
+}> = [
+  {
+    names: ["gabapentin", "neurontin"],
+    note: "Gabapentin is renally eliminated — reduce dose as eGFR falls.",
+  },
+  {
+    names: ["metformin", "glucophage", "fortamet", "glumetza"],
+    note:
+      "Metformin: review dose below eGFR 45; contraindicated below eGFR 30 " +
+      "(lactic acidosis risk).",
+  },
+  {
+    names: ["allopurinol", "zyloprim", "aloprim"],
+    note: "Allopurinol maintenance dose should be reduced in renal impairment.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// evaluateOrgan — Phase 3 adaptive dosing findings
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate renal + hepatic clearance for the draft order. Pure aside from a
+ * `now` clock injected for deterministic freshness testing.
+ */
+export function evaluateOrgan(
+  order: DraftOrder,
+  profile: PatientRxProfile,
+  now: Date = new Date()
+): GuardrailFinding[] {
+  const findings: GuardrailFinding[] = [];
+
+  // --- Renal: CKD-EPI 2021 → band-based adjustment flags -----------------
+  const creat = latestLab(profile.labs, LOINC.SERUM_CREATININE);
+  if (creat) {
+    const renalAgent = RENALLY_CLEARED_AGENTS.find((a) =>
+      orderMatchesDrug(order, { names: a.names, rxNormCuis: a.rxNormCuis })
+    );
+    if (renalAgent) {
+      const egfr = ckdEpi2021(creat.value, profile.age, profile.sex);
+      const band = egfrBand(egfr);
+      const stale = ageInDays(creat.observedAt, now) > LAB_FRESHNESS_WINDOW_DAYS;
+      // Only flag when filtration is actually reduced (band G3a or worse).
+      if (band !== "G1" && band !== "G2") {
+        findings.push({
+          kind: "dosing_override",
+          layer: "organ",
+          ruleId: "organ.renal.dose_adjust",
+          mechanism:
+            "Reduced glomerular filtration slows clearance of renally-" +
+            "eliminated drugs, risking accumulation and toxicity.",
+          rationale:
+            `eGFR ${egfr.toFixed(0)} mL/min/1.73m² (KDIGO ${band}). ` +
+            renalAgent.note,
+          recommendation:
+            "Apply renal dose adjustment for the reduced eGFR band before " +
+            "signing.",
+          citations: [
+            "CKD-EPI 2021",
+            `creatinine ${creat.value} mg/dL drawn ${formatDate(creat.observedAt)}`,
+          ],
+          lowConfidence: stale || undefined,
+          details: {
+            egfr: Number(egfr.toFixed(1)),
+            egfrBand: band,
+            creatinineMgDl: creat.value,
+            labDate: formatDate(creat.observedAt),
+          },
+        });
+      }
+    }
+  }
+
+  // --- Hepatic: Child-Pugh → dose caps / alternatives --------------------
+  const bili = latestLab(profile.labs, LOINC.TOTAL_BILIRUBIN);
+  const alb = latestLab(profile.labs, LOINC.ALBUMIN);
+  const inr = latestLab(profile.labs, LOINC.INR);
+  if (bili && alb && inr) {
+    const cp = childPugh({
+      bilirubin: bili.value,
+      albumin: alb.value,
+      inr: inr.value,
+      ascites: profile.ascites,
+      encephalopathyGrade: profile.encephalopathyGrade,
+    });
+    if (cp.class === "C") {
+      const hepAgent = HEPATOTOXIC_AGENTS.find((a) =>
+        orderMatchesDrug(order, { names: a.names, rxNormCuis: a.rxNormCuis })
+      );
+      if (hepAgent) {
+        const stale =
+          [bili, alb, inr].some(
+            (l) => ageInDays(l.observedAt, now) > LAB_FRESHNESS_WINDOW_DAYS
+          ) || undefined;
+        const capped =
+          hepAgent.childPughCDailyCapMg != null &&
+          order.dailyDoseMg != null &&
+          order.dailyDoseMg > hepAgent.childPughCDailyCapMg;
+        findings.push({
+          kind: "dosing_override",
+          layer: "organ",
+          ruleId: "organ.hepatic.dose_cap",
+          mechanism:
+            "Child-Pugh C cirrhosis sharply reduces hepatic clearance of " +
+            "high-extraction hepatotoxic molecules.",
+          rationale:
+            `Child-Pugh class C (score ${cp.score}). ${hepAgent.note}` +
+            (capped
+              ? ` Drafted ${order.dailyDoseMg} mg/day exceeds the ` +
+                `${hepAgent.childPughCDailyCapMg} mg/day cap.`
+              : ""),
+          recommendation:
+            hepAgent.childPughCDailyCapMg != null
+              ? `Cap total daily dose at ≤${hepAgent.childPughCDailyCapMg} mg, ` +
+                "or transition to an agent with renal-dominant elimination."
+              : "Avoid or transition to an agent with renal-dominant " +
+                "elimination given Child-Pugh C status.",
+          citations: [
+            "Child-Pugh classification",
+            `bilirubin/albumin/INR drawn ${formatDate(bili.observedAt)}`,
+          ],
+          lowConfidence: stale,
+          details: {
+            childPughClass: cp.class,
+            childPughScore: cp.score,
+            dailyDoseMg: order.dailyDoseMg ?? null,
+            exceedsCap: capped,
+          },
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function formatDate(d: string | Date): string {
+  const date = d instanceof Date ? d : new Date(d);
+  return date.toISOString().slice(0, 10);
+}

--- a/src/lib/clinical/rx-safety/pgx.ts
+++ b/src/lib/clinical/rx-safety/pgx.ts
@@ -1,0 +1,295 @@
+// ---------------------------------------------------------------------------
+// Pharmacogenomic (PGx) Variant Evaluation Layer — Phase 2 of the red-text spec.
+//
+// CPIC-shaped rules registry mapping star-alleles → phenotype → guardrail
+// action. Seeds the four anchor rules called out in the mission:
+//   - Clopidogrel × CYP2C19 IM/PM            → hard_substitution
+//   - Codeine/Tramadol × CYP2D6 PM           → dosing_override
+//   - Codeine/Tramadol × CYP2D6 ultrarapid   → hard_stop
+//   - Allopurinol × HLA-B*58:01              → hard_stop
+//
+// No genomic data on file for the relevant gene → silent pass (no finding),
+// never a warning. This is a deliberate design point: absence of evidence is
+// not a flag.
+// ---------------------------------------------------------------------------
+
+import {
+  type DraftOrder,
+  type GuardrailFinding,
+  type PgxPhenotype,
+  type PgxVariant,
+  orderMatchesDrug,
+} from "./types";
+
+/** Functional category of a single star-allele (CPIC activity scoring). */
+type AlleleFunction =
+  | "no_function" // *2,*3,*4,*5 …
+  | "decreased_function"
+  | "normal_function" // *1
+  | "increased_function"
+  | "risk"; // HLA risk alleles
+
+/**
+ * Minimal CPIC-style allele function tables for the genes our anchor rules
+ * touch. Anything not listed defaults to normal_function so an unknown allele
+ * never manufactures a phenotype out of thin air.
+ */
+const ALLELE_FUNCTION: Record<string, Record<string, AlleleFunction>> = {
+  CYP2C19: {
+    "*1": "normal_function",
+    "*2": "no_function",
+    "*3": "no_function",
+    "*17": "increased_function",
+  },
+  CYP2D6: {
+    "*1": "normal_function",
+    "*2": "normal_function",
+    "*4": "no_function",
+    "*5": "no_function", // gene deletion
+    "*10": "decreased_function",
+  },
+};
+
+/** Parse a diplotype string like "*2/*3" or "*1xN/*1" into its two alleles. */
+export function parseDiplotype(diplotype: string): string[] {
+  return diplotype
+    .split("/")
+    .map((a) => a.trim())
+    .filter(Boolean);
+}
+
+/** Detect a CYP2D6 gene-duplication allele, e.g. "*1xN" or "*2x2". */
+function isDuplication(allele: string): boolean {
+  return /x(n|\d+)/i.test(allele);
+}
+
+/**
+ * Resolve a CYP2C19 / CYP2D6 phenotype from a variant's alleles using the
+ * function tables. Used when the lab did not pre-report a phenotype.
+ */
+export function resolveCypPhenotype(
+  gene: string,
+  alleles: string[]
+): PgxPhenotype {
+  const table = ALLELE_FUNCTION[gene] ?? {};
+
+  // Ultra-rapid: any functional gene duplication (xN) of a normal-fn allele.
+  const hasDuplication = alleles.some(
+    (a) => isDuplication(a) && table[a.replace(/x.*$/i, "")] !== "no_function"
+  );
+  if (hasDuplication) return "ultrarapid_metabolizer";
+
+  const fns = alleles.map((a) => table[a] ?? "normal_function");
+  const noFn = fns.filter((f) => f === "no_function").length;
+  const decreased = fns.filter((f) => f === "decreased_function").length;
+
+  if (noFn >= 2) return "poor_metabolizer";
+  if (noFn === 1 && decreased >= 1) return "poor_metabolizer";
+  if (noFn === 1 || decreased >= 2) return "intermediate_metabolizer";
+  if (decreased === 1) return "intermediate_metabolizer";
+  if (fns.includes("increased_function")) return "rapid_metabolizer";
+  return "normal_metabolizer";
+}
+
+/** Resolve the effective phenotype for a variant (lab-reported wins). */
+function phenotypeFor(variant: PgxVariant): PgxPhenotype {
+  if (variant.phenotype) return variant.phenotype;
+  const alleles =
+    variant.alleles ??
+    (variant.diplotype ? parseDiplotype(variant.diplotype) : []);
+  if (alleles.length === 0) return "normal_metabolizer";
+  return resolveCypPhenotype(variant.gene, alleles);
+}
+
+/** True if an HLA variant indicates carriage of a named risk allele. */
+function carriesHlaAllele(variant: PgxVariant, riskAllele: string): boolean {
+  if (variant.gene.toUpperCase() !== "HLA-B") return false;
+  if (variant.phenotype === "positive") {
+    // explicit positive call — trust it if the diplotype names the allele or
+    // no diplotype detail was provided.
+    if (!variant.diplotype && !variant.alleles) return true;
+  }
+  const tokens = [
+    variant.diplotype ?? "",
+    ...(variant.alleles ?? []),
+  ]
+    .join(" ")
+    .replace(/\*/g, "")
+    .toLowerCase();
+  return (
+    tokens.includes(riskAllele.replace(/\*/g, "").toLowerCase()) &&
+    variant.phenotype !== "negative"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule registry
+// ---------------------------------------------------------------------------
+
+interface PgxRule {
+  ruleId: string;
+  drug: { rxNormCuis?: string[]; names: string[] };
+  /** Gene this rule keys on. */
+  gene: string;
+  /**
+   * Returns a finding when the variant triggers, else null. Receives the
+   * resolved phenotype and the raw variant (for HLA allele inspection).
+   */
+  evaluate: (
+    phenotype: PgxPhenotype,
+    variant: PgxVariant
+  ) => Omit<GuardrailFinding, "layer" | "ruleId"> | null;
+}
+
+const PGX_RULES: PgxRule[] = [
+  // --- Clopidogrel × CYP2C19 IM/PM → hard_substitution -------------------
+  {
+    ruleId: "pgx.clopidogrel.cyp2c19",
+    drug: { rxNormCuis: ["32968"], names: ["clopidogrel", "plavix"] },
+    gene: "CYP2C19",
+    evaluate(phenotype) {
+      if (
+        phenotype === "poor_metabolizer" ||
+        phenotype === "intermediate_metabolizer"
+      ) {
+        return {
+          kind: "hard_substitution",
+          mechanism:
+            "CYP2C19 loss-of-function reduces conversion of the clopidogrel " +
+            "pro-drug to its active thiol metabolite.",
+          rationale: `Patient is a CYP2C19 ${phenotype.replace("_", " ")}; ` +
+            "diminished antiplatelet effect raises the risk of major adverse " +
+            "cardiovascular events.",
+          recommendation:
+            "Block clopidogrel. Substitute an antiplatelet unaffected by " +
+            "CYP2C19 polymorphism, e.g. prasugrel or ticagrelor.",
+          citations: ["CPIC Level A", "CPIC clopidogrel/CYP2C19 guideline"],
+          details: { gene: "CYP2C19", phenotype },
+        };
+      }
+      return null;
+    },
+  },
+
+  // --- Codeine/Tramadol × CYP2D6 PM → dosing_override --------------------
+  {
+    ruleId: "pgx.opioid.cyp2d6.pm",
+    drug: {
+      names: ["codeine", "tramadol", "ultram", "conzip"],
+    },
+    gene: "CYP2D6",
+    evaluate(phenotype) {
+      if (phenotype === "poor_metabolizer") {
+        return {
+          kind: "dosing_override",
+          mechanism:
+            "CYP2D6 poor metabolizers cannot O-demethylate codeine to " +
+            "morphine (or tramadol to its active O-desmethyl metabolite).",
+          rationale:
+            "Expected complete therapeutic failure — no analgesic efficacy " +
+            "at any dose.",
+          recommendation:
+            "Avoid codeine/tramadol. Select a non-opioid analgesic or an " +
+            "opioid not dependent on CYP2D6 activation.",
+          citations: ["CPIC Level A", "CPIC codeine/CYP2D6 guideline"],
+          details: { gene: "CYP2D6", phenotype },
+        };
+      }
+      return null;
+    },
+  },
+
+  // --- Codeine/Tramadol × CYP2D6 ultrarapid → hard_stop ------------------
+  {
+    ruleId: "pgx.opioid.cyp2d6.um",
+    drug: {
+      names: ["codeine", "tramadol", "ultram", "conzip"],
+    },
+    gene: "CYP2D6",
+    evaluate(phenotype) {
+      if (phenotype === "ultrarapid_metabolizer") {
+        return {
+          kind: "hard_stop",
+          mechanism:
+            "CYP2D6 ultra-rapid metabolizers convert codeine/tramadol to " +
+            "morphine far faster than normal, producing toxic opioid levels " +
+            "at standard doses.",
+          rationale:
+            "High risk of severe, life-threatening opioid toxicity including " +
+            "respiratory depression.",
+          recommendation:
+            "Cancel the order. Do not prescribe codeine or tramadol. Log a " +
+            "critical respiratory safety warning and choose a non-CYP2D6 " +
+            "analgesic.",
+          citations: ["CPIC Level A", "CPIC codeine/CYP2D6 guideline"],
+          details: {
+            gene: "CYP2D6",
+            phenotype,
+            criticalRespiratoryWarning: true,
+          },
+        };
+      }
+      return null;
+    },
+  },
+
+  // --- Allopurinol × HLA-B*58:01 → hard_stop -----------------------------
+  {
+    ruleId: "pgx.allopurinol.hlab5801",
+    drug: { rxNormCuis: ["519"], names: ["allopurinol", "zyloprim", "aloprim"] },
+    gene: "HLA-B",
+    evaluate(_phenotype, variant) {
+      if (carriesHlaAllele(variant, "*58:01")) {
+        return {
+          kind: "hard_stop",
+          mechanism:
+            "HLA-B*58:01 carriage is strongly associated with allopurinol " +
+            "hypersensitivity, including Stevens-Johnson Syndrome / Toxic " +
+            "Epidermal Necrolysis (SJS/TEN).",
+          rationale:
+            "Patient carries HLA-B*58:01 — high risk of a potentially fatal " +
+            "severe cutaneous adverse reaction.",
+          recommendation:
+            "Hard stop. Do not prescribe allopurinol. Select an alternative " +
+            "urate-lowering agent such as febuxostat.",
+          citations: ["CPIC Level A", "CPIC allopurinol/HLA-B guideline"],
+          details: { gene: "HLA-B", riskAllele: "*58:01" },
+        };
+      }
+      return null;
+    },
+  },
+];
+
+/**
+ * Evaluate the PGx layer for a draft order against the patient's variants.
+ * Returns an empty array (silent pass) when there is no genomic data for the
+ * relevant gene — absence of data is never surfaced as a warning.
+ */
+export function evaluatePgx(
+  order: DraftOrder,
+  variants: PgxVariant[]
+): GuardrailFinding[] {
+  if (!variants || variants.length === 0) return [];
+  const findings: GuardrailFinding[] = [];
+
+  for (const rule of PGX_RULES) {
+    if (!orderMatchesDrug(order, rule.drug)) continue;
+
+    const relevant = variants.filter(
+      (v) => v.gene.toUpperCase() === rule.gene.toUpperCase()
+    );
+    // No genomic data on file for this gene → silent pass for this rule.
+    if (relevant.length === 0) continue;
+
+    for (const variant of relevant) {
+      const phenotype = phenotypeFor(variant);
+      const partial = rule.evaluate(phenotype, variant);
+      if (partial) {
+        findings.push({ ...partial, layer: "pgx", ruleId: rule.ruleId });
+      }
+    }
+  }
+
+  return findings;
+}

--- a/src/lib/clinical/rx-safety/types.ts
+++ b/src/lib/clinical/rx-safety/types.ts
@@ -1,0 +1,217 @@
+// ---------------------------------------------------------------------------
+// Prescription Safety & Optimization Guardrails — shared types
+// (Linear EMR-1132/1133/1134, epic EMR-1119)
+//
+// Deterministic guardrail engine per the red-text spec
+// docs/product-feedback/2026-06-12_workflows-revisions-red-text.md
+// ("Prescription Safety & Optimization Guardrails", Phases 1–4).
+//
+// Three evaluation layers (PGx, organ clearance, botanical/cannabinoid)
+// each produce GuardrailFinding[]; evaluate.ts merges + ranks them for the
+// inline optimization card UI.
+// ---------------------------------------------------------------------------
+
+/** Severity / disposition of a guardrail finding, ordered most → least severe. */
+export type GuardrailKind =
+  | "hard_stop" // cancel order intent immediately (e.g. CYP2D6 UM × codeine)
+  | "hard_substitution" // block order, propose alternative molecule
+  | "dosing_override" // cap / adjust the proposed dose configuration
+  | "optimization" // proactive suggestion (dose reduction + follow-up lab)
+  | "info"; // contextual, non-actionable awareness
+
+export type GuardrailLayer = "pgx" | "organ" | "botanical";
+
+/** A follow-up lab the system should queue when a finding is accepted. */
+export interface RequiredFollowUpLab {
+  /** LOINC code of the lab to queue (e.g. "34714-6" = INR). */
+  labLoinc: string;
+  /** Human-readable timing, e.g. "immediate", "within 7 days". */
+  timing: string;
+}
+
+/** One guardrail result, suitable for the inline optimization card. */
+export interface GuardrailFinding {
+  kind: GuardrailKind;
+  /** Which evaluation layer produced this finding. */
+  layer: GuardrailLayer;
+  /** Stable identifier of the rule that fired (for audit / dedupe). */
+  ruleId: string;
+  /** Biological mechanism, e.g. "CYP2C19 loss-of-function → reduced active metabolite". */
+  mechanism: string;
+  /** Why this matters for THIS patient (phenotype, lab value, exposure). */
+  rationale: string;
+  /** What the provider should do instead. */
+  recommendation: string;
+  /** Citation metadata strings, e.g. "CPIC Level A", "CKD-EPI 2021". */
+  citations: string[];
+  /** Labs to queue automatically if the recommendation is accepted. */
+  requiredFollowUp?: RequiredFollowUpLab[];
+  /**
+   * True when the finding is derived from data older than the freshness
+   * window (labs > 180 days old). The finding still surfaces — it is never
+   * silently dropped — but the UI should render it with a stale-data badge.
+   */
+  lowConfidence?: boolean;
+  /** Structured extras for the UI (eGFR value, Child-Pugh class, lab dates…). */
+  details?: Record<string, string | number | boolean | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Inputs — Phase 1.1 structural order interception payload
+// ---------------------------------------------------------------------------
+
+/** The drafted order the provider is composing in the CPOE terminal. */
+export interface DraftOrder {
+  /** RxNorm Concept Unique Identifier when the order field resolved one. */
+  rxNormCui?: string;
+  /** Drug name as typed/selected (brand or generic — matching is alias-aware). */
+  drugName: string;
+  /** Proposed dose as entered, e.g. "1000 mg". */
+  dose?: string;
+  /** Route of administration, e.g. "oral". */
+  route?: string;
+  /** Execution frequency, e.g. "q6h". */
+  frequency?: string;
+  /**
+   * Structured total daily dose in mg when the order form can compute it.
+   * Used by the organ layer to compare against hepatic dose caps.
+   */
+  dailyDoseMg?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Inputs — Phase 1.2 distributed multi-domain ingestion (patient profile)
+// ---------------------------------------------------------------------------
+
+/** Pharmacogenomic phenotypes the rule registry understands. */
+export type PgxPhenotype =
+  | "poor_metabolizer"
+  | "intermediate_metabolizer"
+  | "normal_metabolizer"
+  | "rapid_metabolizer"
+  | "ultrarapid_metabolizer"
+  | "positive" // for HLA risk-allele carriage
+  | "negative";
+
+/** A structural genetic variant from the PGx registry. */
+export interface PgxVariant {
+  /** Gene symbol, e.g. "CYP2C19", "CYP2D6", "HLA-B". */
+  gene: string;
+  /** Star-allele diplotype, e.g. "*2/*3", "*1xN/*1", "*58:01". */
+  diplotype?: string;
+  /** Individual alleles when already split, e.g. ["*2", "*3"]. */
+  alleles?: string[];
+  /** Pre-resolved phenotype if the lab reported one (takes precedence). */
+  phenotype?: PgxPhenotype;
+}
+
+/** A single lab observation from the Organ Clearance Vault. */
+export interface LabResult {
+  /** LOINC code — see LOINC constants below. */
+  loinc: string;
+  value: number;
+  unit?: string;
+  /** When the specimen was collected (ISO string or Date). */
+  observedAt: string | Date;
+}
+
+/** An exposure from the Botanical & Xenobiotic Manifest. */
+export interface BotanicalExposure {
+  /**
+   * Compound or product name, e.g. "CBD", "St. John's Wort",
+   * or a cannabis product name from the dosing log ("1:1 Relief Tincture").
+   */
+  name: string;
+  kind?: "cannabinoid" | "herbal" | "supplement";
+  /** True for concentrated extracts (e.g. high-dose CBD isolate). */
+  concentrated?: boolean;
+  /** Where the exposure was observed, e.g. "product_log", "dosing_log". */
+  source?: string;
+}
+
+export type ChildPughAscites = "absent" | "slight" | "moderate";
+export type ChildPughEncephalopathyGrade = 0 | 1 | 2 | 3 | 4;
+
+/** The assembled patient physiological state (Phase 1.2). */
+export interface PatientRxProfile {
+  sex: "female" | "male";
+  age: number;
+  /** Star-allele configurations on file. Empty array = no genomic data. */
+  pgxVariants: PgxVariant[];
+  /** Recent labs (creatinine 2160-0, bilirubin 1975-2, albumin 1751-7, INR 34714-6). */
+  labs: LabResult[];
+  /** Active medication names (brand or generic). */
+  activeMeds: string[];
+  /** Botanical / supplement / cannabinoid exposures incl. product & dosing logs. */
+  botanicalExposures: BotanicalExposure[];
+  /** Optional documented clinical flags for Child-Pugh (default: absent/none). */
+  ascites?: ChildPughAscites;
+  encephalopathyGrade?: ChildPughEncephalopathyGrade;
+}
+
+// ---------------------------------------------------------------------------
+// LOINC constants (Organ Clearance Vault)
+// ---------------------------------------------------------------------------
+
+export const LOINC = {
+  SERUM_CREATININE: "2160-0",
+  TOTAL_BILIRUBIN: "1975-2",
+  ALBUMIN: "1751-7",
+  INR: "34714-6",
+} as const;
+
+/** Labs older than this many days are flagged lowConfidence, never dropped. */
+export const LAB_FRESHNESS_WINDOW_DAYS = 180;
+
+// ---------------------------------------------------------------------------
+// Ranking + aggregate result
+// ---------------------------------------------------------------------------
+
+/** Most-severe-first ordering used to rank findings for the UI card. */
+export const GUARDRAIL_KIND_RANK: Record<GuardrailKind, number> = {
+  hard_stop: 0,
+  hard_substitution: 1,
+  dosing_override: 2,
+  optimization: 3,
+  info: 4,
+};
+
+/** Result of evaluateRxSafety — ready for the inline optimization card. */
+export interface RxSafetyEvaluation {
+  order: DraftOrder;
+  /** All findings, ranked hard stops first. Empty = clean order, render nothing. */
+  findings: GuardrailFinding[];
+  /** True when the order should not be signed as drafted. */
+  hasBlockingFinding: boolean;
+  /** ISO timestamp of the evaluation (for the audit trail). */
+  evaluatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Alias-aware drug matching shared by all three layers. A draft order matches
+ * a rule when its RxCUI matches exactly, or when the typed name contains (or
+ * is contained by) any of the rule's names — same loose matching contract the
+ * existing checkInteractions() module uses.
+ */
+export function orderMatchesDrug(
+  order: Pick<DraftOrder, "rxNormCui" | "drugName">,
+  match: { rxNormCuis?: string[]; names: string[] }
+): boolean {
+  if (
+    order.rxNormCui &&
+    match.rxNormCuis &&
+    match.rxNormCuis.includes(order.rxNormCui)
+  ) {
+    return true;
+  }
+  const typed = order.drugName.toLowerCase().trim();
+  if (!typed) return false;
+  return match.names.some((n) => {
+    const name = n.toLowerCase().trim();
+    return typed.includes(name) || name.includes(typed);
+  });
+}

--- a/src/lib/domain/smart-inbox.ts
+++ b/src/lib/domain/smart-inbox.ts
@@ -1,5 +1,19 @@
 // Smart Inbox domain types — EMR-153
 // AI-triaged message queue for clinicians.
+//
+// EMR-1146/1147 (fixes EMR-1090): the deterministic UPI engine
+// (src/lib/triage/upi) is now the PRIMARY triage signal. The legacy
+// keyword scan below is secondary/advisory — it still drives category
+// labeling (refill vs scheduling vs labs), but it can no longer escalate
+// to urgent/adverse on its own, because bare substring hits are exactly
+// what caused the EMR-1090 over-triage ("no chest pain" → urgent;
+// "my daughter had a rash" → adverse).
+
+import {
+  triageMessage,
+  type TriageDecision,
+  type UpiPatientContext,
+} from "@/lib/triage/upi";
 
 export type MessagePriority = "urgent" | "high" | "routine" | "low";
 export type MessageCategory =
@@ -137,105 +151,200 @@ const LAB_KEYWORDS = [
   "kidney",
 ];
 
+export interface ThreadTriageResult {
+  priority: MessagePriority;
+  category: MessageCategory;
+  triageReason: string;
+  needsClinician: boolean;
+  suggestedAction?: string;
+  /** EMR-1146 — full UPI decision (score, factor breakdown, auto-reply). */
+  upi?: TriageDecision;
+}
+
 /**
- * Deterministic triage of a message thread based on keyword analysis.
- * This runs without an LLM — fast, cheap, predictable.
- * An optional AI layer can refine these results.
+ * Deterministic triage of a message thread.
+ *
+ * EMR-1146/1147 — the Urgency Priority Index (UPI) engine is the primary
+ * signal: it handles all urgent/adverse escalation with negation filtering,
+ * subject attribution, distress scoring, and chart-context vulnerability.
+ * The keyword scan below is secondary — it only labels non-escalated
+ * categories (meds / refills / scheduling / labs). An optional LLM layer
+ * may refine summaries but never overrides the deterministic route.
+ *
+ * `patientContext` (vulnerability flags from the chart) is optional —
+ * list surfaces that don't have chart data simply score with V_patient=0.
  */
 export function triageThread(
   messages: { body: string; senderUserId: string | null; senderAgent: string | null; createdAt: string }[],
-  patientUserId: string | null
-): { priority: MessagePriority; category: MessageCategory; triageReason: string; needsClinician: boolean; suggestedAction?: string } {
+  patientUserId: string | null,
+  patientContext?: UpiPatientContext,
+): ThreadTriageResult {
   // Focus on the most recent patient messages
   const patientMessages = messages
     .filter((m) => m.senderUserId === patientUserId || (!m.senderUserId && !m.senderAgent))
     .slice(0, 5);
 
-  const allText = patientMessages.map((m) => m.body).join(" ").toLowerCase();
+  const rawText = patientMessages.map((m) => m.body).join(". ");
+  const allText = rawText.toLowerCase();
 
-  // Check urgent first
-  if (URGENT_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
+  // ── PRIMARY: deterministic UPI engine (EMR-1146, fixes EMR-1090) ──
+  const upi = triageMessage(rawText, patientContext);
+
+  if (upi.route === "urgent") {
     return {
       priority: "urgent",
       category: "adverse_reaction",
-      triageReason: "Message contains urgent/safety keywords. Immediate clinician review needed.",
+      triageReason:
+        `UPI ${upi.upi.toFixed(2)} ≥ 0.75 — ` +
+        describeUpiFactors(upi) +
+        " Immediate clinician review needed.",
       needsClinician: true,
       suggestedAction: "Call patient immediately",
+      upi,
     };
   }
 
-  // Adverse reaction
-  if (ADVERSE_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
+  // Active first-party clinical entity at mid-tier acuity → high.
+  const maxActiveAcuity = upi.factors.acuity.value;
+  if (maxActiveAcuity >= 0.5) {
+    const adverseKeywordHit = ADVERSE_KEYWORDS.some((kw) =>
+      allText.includes(kw.toLowerCase()),
+    );
     return {
       priority: "high",
-      category: "adverse_reaction",
-      triageReason: "Patient reports possible adverse reaction or side effect.",
+      category: adverseKeywordHit ? "adverse_reaction" : "symptom_report",
+      triageReason:
+        `UPI ${upi.upi.toFixed(2)} — ` +
+        describeUpiFactors(upi) +
+        " Same-day clinician review recommended.",
       needsClinician: true,
       suggestedAction: "Review symptoms and adjust treatment if needed",
+      upi,
     };
   }
+
+  // ── SECONDARY (advisory): legacy keyword scan ──
+  // Keyword hits that the UPI engine suppressed (negated / third-party /
+  // resolved) are surfaced in the reason for transparency, but they do
+  // NOT escalate — that substring behavior caused EMR-1090's over-triage.
+  const suppressedNote = buildSuppressedKeywordNote(allText, upi);
+  const finish = (result: ThreadTriageResult): ThreadTriageResult => ({
+    ...result,
+    triageReason: suppressedNote
+      ? `${result.triageReason} ${suppressedNote}`
+      : result.triageReason,
+    upi,
+  });
 
   // Medication questions
   if (MED_QUESTION_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
-    return {
+    return finish({
       priority: "high",
       category: "medication_question",
       triageReason: "Patient has questions about medication or dosing.",
       needsClinician: true,
       suggestedAction: "Review dosing and provide guidance",
-    };
+    });
   }
 
   // Refill requests
   if (REFILL_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
-    return {
+    return finish({
       priority: "routine",
       category: "refill_request",
       triageReason: "Patient is requesting a medication refill or renewal.",
       needsClinician: false,
       suggestedAction: "Process refill request",
-    };
+    });
   }
 
   // Appointment requests
   if (APPOINTMENT_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
-    return {
+    return finish({
       priority: "routine",
       category: "appointment_request",
       triageReason: "Patient is requesting scheduling assistance.",
       needsClinician: false,
       suggestedAction: "Schedule or confirm appointment",
-    };
+    });
   }
 
   // Lab questions
   if (LAB_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()))) {
-    return {
+    return finish({
       priority: "routine",
       category: "lab_question",
       triageReason: "Patient has questions about lab results or tests.",
       needsClinician: true,
-    };
+    });
   }
 
-  // Symptom reports (generic)
+  // Symptom reports (generic / minor active entities)
   const symptomWords = ["pain", "hurt", "ache", "trouble", "worse", "better", "improve", "sleep", "anxiety", "nausea"];
-  if (symptomWords.some((kw) => allText.includes(kw))) {
-    return {
+  if (
+    upi.factors.acuity.entities.some((e) => e.acuityClass === "minor" && !e.negated && !e.thirdParty) ||
+    symptomWords.some((kw) => allText.includes(kw))
+  ) {
+    return finish({
       priority: "routine",
       category: "symptom_report",
       triageReason: "Patient is reporting symptoms or treatment response.",
       needsClinician: true,
-    };
+    });
   }
 
   // Default: general/low priority
-  return {
+  return finish({
     priority: "low",
     category: "general",
     triageReason: "General message — no urgent or clinical keywords detected.",
     needsClinician: false,
-  };
+  });
+}
+
+// ── UPI transparency helpers (EMR-1146) ────────────────────────────────
+
+/** One-line plain-language factor summary for the triage reason tooltip. */
+function describeUpiFactors(decision: TriageDecision): string {
+  const f = decision.factors;
+  const parts: string[] = [];
+  const active = f.acuity.entities.filter((e) => !e.negated && !e.thirdParty && e.acuityClass !== "admin");
+  if (active.length > 0) {
+    parts.push(`symptoms: ${active.map((e) => e.label).join(", ")}`);
+  }
+  if (f.distress.value >= 0.25) {
+    parts.push(`elevated distress (${f.distress.value.toFixed(2)})`);
+  }
+  if (f.vulnerability.activeFlags.length > 0) {
+    parts.push(`vulnerable patient (${f.vulnerability.activeFlags.join(", ")})`);
+  }
+  if (f.redFlagFloorApplied) {
+    parts.push("red-flag safety floor applied");
+  }
+  return parts.length > 0 ? `${parts.join("; ")}.` : "no individual factor dominated.";
+}
+
+/**
+ * Advisory note when legacy urgent/adverse keywords matched but the UPI
+ * engine suppressed them (negation, third-party attribution, resolution).
+ * Surfaced in the triage reason so clinicians see WHY the thread is not
+ * red — the durable fix for EMR-1090's over-triage half.
+ */
+function buildSuppressedKeywordNote(allText: string, decision: TriageDecision): string | null {
+  const legacyHit =
+    URGENT_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase())) ||
+    ADVERSE_KEYWORDS.some((kw) => allText.includes(kw.toLowerCase()));
+  if (!legacyHit) return null;
+
+  const suppressed = decision.factors.acuity.entities.filter(
+    (e) => e.acuityClass !== "admin" && (e.negated || e.thirdParty),
+  );
+  if (suppressed.length === 0) return null;
+
+  const detail = suppressed
+    .map((e) => `${e.label.toLowerCase()} (${e.negated ? "negated" : "third-party"})`)
+    .join(", ");
+  return `(Keyword match suppressed by UPI assertion analysis: ${detail}.)`;
 }
 
 // ── Priority display helpers ───────────────────────────

--- a/src/lib/triage/upi/__tests__/entities.test.ts
+++ b/src/lib/triage/upi/__tests__/entities.test.ts
@@ -1,0 +1,147 @@
+// UPI entity extraction — negation, subject attribution, abbreviation
+// expansion, lexicon acuity (EMR-1146).
+
+import { describe, expect, it } from "vitest";
+import {
+  ADMIN_BASELINE_ACUITY,
+  extractEntities,
+  normalizeMessageText,
+} from "../entities";
+
+describe("normalizeMessageText", () => {
+  it("expands clinical shorthand on word boundaries", () => {
+    expect(normalizeMessageText("having SOB since last night")).toContain(
+      "shortness of breath",
+    );
+    expect(normalizeMessageText("bad n/v all day")).toContain("nausea and vomiting");
+  });
+
+  it("does not expand shorthand inside other words", () => {
+    // "sobbing" must not become "shortness of breathbing"
+    expect(normalizeMessageText("I was sobbing")).toBe("i was sobbing");
+  });
+
+  it("normalizes apostrophe-less contractions", () => {
+    expect(normalizeMessageText("I cant breathe")).toContain("can't breathe");
+  });
+
+  it("strips emoji but keeps clause punctuation", () => {
+    expect(normalizeMessageText("no chest pain 😊, just checking in!")).toBe(
+      "no chest pain , just checking in!",
+    );
+  });
+});
+
+describe("extractEntities — lexicon & acuity", () => {
+  it("maps red-flag symptoms to acuity 1.0", () => {
+    const r = extractEntities("I have crushing chest pain radiating to my arm");
+    const redFlag = r.activeEntities.find((e) => e.id === "crushing_chest_pain");
+    expect(redFlag).toBeDefined();
+    expect(redFlag!.acuity).toBe(1.0);
+    expect(r.baseAcuity).toBe(1.0);
+  });
+
+  it("recognizes expanded abbreviations as red flags", () => {
+    const r = extractEntities("having sob and chest tightness");
+    expect(r.activeEntities.map((e) => e.id)).toContain("shortness_of_breath");
+    expect(r.activeEntities.map((e) => e.id)).toContain("chest_pain");
+  });
+
+  it("classifies admin/scheduling messages at the 0.1 baseline", () => {
+    const r = extractEntities("Could I reschedule my appointment and get a refill?");
+    expect(r.activeEntities).toHaveLength(0);
+    expect(r.baseAcuity).toBe(ADMIN_BASELINE_ACUITY);
+  });
+
+  it("returns the admin baseline for empty / non-clinical text", () => {
+    expect(extractEntities("").baseAcuity).toBe(ADMIN_BASELINE_ACUITY);
+    expect(extractEntities("thanks so much, see you soon!").baseAcuity).toBe(
+      ADMIN_BASELINE_ACUITY,
+    );
+  });
+
+  it("applies the fever+rash combo bump to mid-tier acuity", () => {
+    const r = extractEntities("I have a fever and a rash on my arms");
+    expect(r.baseAcuity).toBeCloseTo(0.6, 5);
+  });
+
+  it("prefers the most specific lexicon entry on overlapping spans", () => {
+    const r = extractEntities("crushing chest pain tonight");
+    const ids = r.entities.map((e) => e.id);
+    expect(ids).toContain("crushing_chest_pain");
+    expect(ids).not.toContain("chest_pain");
+  });
+});
+
+describe("extractEntities — negation filtering", () => {
+  it("marks 'no chest pain' as negated and keeps acuity at baseline", () => {
+    const r = extractEntities("No chest pain, just a refill question");
+    const cp = r.entities.find((e) => e.id === "chest_pain");
+    expect(cp).toBeDefined();
+    expect(cp!.negated).toBe(true);
+    expect(r.activeEntities).toHaveLength(0);
+    expect(r.baseAcuity).toBe(ADMIN_BASELINE_ACUITY);
+  });
+
+  it("handles 'denies' and 'without'", () => {
+    expect(
+      extractEntities("denies fever or vomiting").activeEntities,
+    ).toHaveLength(0);
+    expect(
+      extractEntities("feeling fine without any dizziness").activeEntities,
+    ).toHaveLength(0);
+  });
+
+  it("treats post-hoc resolution as negation ('but it's gone')", () => {
+    const r = extractEntities("I had a rash last week but it's gone");
+    const rash = r.entities.find((e) => e.id === "rash");
+    expect(rash?.negated).toBe(true);
+  });
+
+  it("does NOT negate 'never had chest pain like this' (re-assertion)", () => {
+    const r = extractEntities("I've never had chest pain like this before");
+    const cp = r.entities.find((e) => e.id === "chest_pain");
+    expect(cp).toBeDefined();
+    expect(cp!.negated).toBe(false);
+    expect(r.baseAcuity).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("negation in one sentence does not leak into the next", () => {
+    const r = extractEntities("No fever today. The chest pain is back though.");
+    const cp = r.entities.find((e) => e.id === "chest_pain");
+    expect(cp?.negated).toBe(false);
+  });
+});
+
+describe("extractEntities — subject attribution", () => {
+  it("marks 'my daughter has a rash' as third-party", () => {
+    const r = extractEntities("My daughter has a rash on her leg");
+    const rash = r.entities.find((e) => e.id === "rash");
+    expect(rash?.thirdParty).toBe(true);
+    expect(r.activeEntities).toHaveLength(0);
+  });
+
+  it("marks 'my husband ... seizures' as third-party", () => {
+    const r = extractEntities(
+      "My husband has been having seizures, can you recommend a neurologist for him?",
+    );
+    const sz = r.entities.find((e) => e.id === "seizure");
+    expect(sz?.thirdParty).toBe(true);
+    expect(r.baseAcuity).toBe(ADMIN_BASELINE_ACUITY);
+  });
+
+  it("re-anchors to the patient after a first-person pronoun", () => {
+    const r = extractEntities(
+      "My husband said I should message you, I have chest pain",
+    );
+    const cp = r.entities.find((e) => e.id === "chest_pain");
+    expect(cp?.thirdParty).toBe(false);
+    expect(r.baseAcuity).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("third-party attribution in one sentence does not leak into the next", () => {
+    const r = extractEntities("My son had a cold. Anyway, I have chest pain now.");
+    const cp = r.entities.find((e) => e.id === "chest_pain");
+    expect(cp?.thirdParty).toBe(false);
+  });
+});

--- a/src/lib/triage/upi/__tests__/upi.test.ts
+++ b/src/lib/triage/upi/__tests__/upi.test.ts
@@ -1,0 +1,293 @@
+// Urgency Priority Index — scoring, routing, and EMR-1090 regression
+// fixtures (EMR-1146 / EMR-1147).
+
+import { describe, expect, it } from "vitest";
+import { scoreDistress } from "../distress";
+import { extractEntities } from "../entities";
+import {
+  computeUpi,
+  DEFAULT_WEIGHTS,
+  deriveVulnerabilityFlags,
+  RED_FLAG_FLOOR,
+  triageMessage,
+  URGENT_AUTO_REPLY,
+  URGENT_THRESHOLD,
+  vulnerabilityScore,
+} from "../index";
+import { triageThread } from "@/lib/domain/smart-inbox";
+
+// ── Distress (S_distress) ──────────────────────────────────────────────
+
+describe("scoreDistress", () => {
+  it("scores calm administrative text near zero", () => {
+    const d = scoreDistress("Could I reschedule my appointment to Friday?");
+    expect(d.score).toBe(0);
+    expect(d.panicTerms).toHaveLength(0);
+  });
+
+  it("saturates on caps + exclamations + panic vocabulary", () => {
+    const d = scoreDistress("HELP ME I CAN'T BREATHE!!!");
+    expect(d.score).toBe(1);
+    expect(d.panicTerms.length).toBeGreaterThanOrEqual(2);
+    expect(d.exclamationCount).toBe(3);
+  });
+
+  it("picks up panic vocabulary in otherwise calm text", () => {
+    const d = scoreDistress("I'm terrified about these symptoms");
+    expect(d.panicTerms).toContain("terrified");
+    expect(d.score).toBeGreaterThan(0);
+    expect(d.score).toBeLessThan(0.5);
+  });
+
+  it("is deterministic and clamped to [0, 1]", () => {
+    const text = "SCARED!!!! please help, I'm panicking, bleeding out!!!!!";
+    const a = scoreDistress(text);
+    const b = scoreDistress(text);
+    expect(a).toEqual(b);
+    expect(a.score).toBeLessThanOrEqual(1);
+    expect(a.score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── computeUpi (weighted sum + factors) ────────────────────────────────
+
+describe("computeUpi", () => {
+  it("uses w1=0.65 / w2=0.15 / w3=0.20 by default", () => {
+    expect(DEFAULT_WEIGHTS).toEqual({ acuity: 0.65, distress: 0.15, vulnerability: 0.2 });
+  });
+
+  it("returns a full factor breakdown whose contributions sum to the weighted sum", () => {
+    const entities = extractEntities("I keep vomiting since yesterday");
+    const distress = scoreDistress("I keep vomiting since yesterday");
+    const { score, factors } = computeUpi({
+      entities,
+      distress,
+      vulnerability: { postOpWithin30Days: true },
+    });
+    const sum =
+      factors.acuity.contribution +
+      factors.distress.contribution +
+      factors.vulnerability.contribution;
+    expect(factors.weightedSum).toBeCloseTo(sum, 10);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+    expect(factors.vulnerability.activeFlags).toEqual(["Within 30-day post-op window"]);
+  });
+
+  it("floors active red-flag entities at RED_FLAG_FLOOR even with zero distress", () => {
+    // "chest pain" stated calmly: 0.65*0.9 = 0.585 unfloored — the exact
+    // shape of the EMR-1090 under-escalation. The floor guarantees urgent.
+    const entities = extractEntities("I have chest pain.");
+    const distress = scoreDistress("I have chest pain.");
+    const { score, factors } = computeUpi({ entities, distress });
+    expect(factors.redFlagFloorApplied).toBe(true);
+    expect(score).toBe(RED_FLAG_FLOOR);
+    expect(score).toBeGreaterThanOrEqual(URGENT_THRESHOLD);
+  });
+
+  it("does NOT apply the floor when the red flag is negated", () => {
+    const text = "No chest pain at all today";
+    const { score, factors } = computeUpi({
+      entities: extractEntities(text),
+      distress: scoreDistress(text),
+    });
+    expect(factors.redFlagFloorApplied).toBe(false);
+    expect(score).toBeLessThan(0.2);
+  });
+});
+
+describe("vulnerabilityScore / deriveVulnerabilityFlags", () => {
+  it("is 0 with no flags and clamps at 1 with all flags", () => {
+    expect(vulnerabilityScore(undefined)).toBe(0);
+    expect(vulnerabilityScore({})).toBe(0);
+    expect(
+      vulnerabilityScore({
+        severeCardiovascularDisease: true,
+        advancedMetabolicInstability: true,
+        postOpWithin30Days: true,
+      }),
+    ).toBe(1);
+  });
+
+  it("derives cardiovascular + metabolic flags from chart condition text", () => {
+    const flags = deriveVulnerabilityFlags({
+      conditions: [
+        { condition: "Congestive heart failure (NYHA III)" },
+        { condition: "Type 1 diabetes" },
+      ],
+    });
+    expect(flags.severeCardiovascularDisease).toBe(true);
+    expect(flags.advancedMetabolicInstability).toBe(true);
+    expect(flags.postOpWithin30Days).toBe(false);
+  });
+
+  it("flags the 30-day post-op window from surgery recency", () => {
+    const now = new Date("2026-06-12T00:00:00Z");
+    const tenDaysAgo = new Date("2026-06-02T00:00:00Z");
+    const ninetyDaysAgo = new Date("2026-03-14T00:00:00Z");
+    expect(
+      deriveVulnerabilityFlags({ surgeries: [{ createdAt: tenDaysAgo }], now })
+        .postOpWithin30Days,
+    ).toBe(true);
+    expect(
+      deriveVulnerabilityFlags({ surgeries: [{ createdAt: ninetyDaysAgo }], now })
+        .postOpWithin30Days,
+    ).toBe(false);
+  });
+});
+
+// ── EMR-1090 regression fixtures (end-to-end triageMessage) ────────────
+
+describe("triageMessage — EMR-1090 regressions", () => {
+  it("(a) explicit emergency routes urgent with the 911/ED auto-reply", () => {
+    const d = triageMessage(
+      "I have crushing chest pain radiating to my arm, I'm terrified",
+    );
+    expect(d.upi).toBeGreaterThanOrEqual(0.75);
+    expect(d.route).toBe("urgent");
+    expect(d.autoReply).toBe(URGENT_AUTO_REPLY);
+    expect(d.autoReply).toContain("911");
+  });
+
+  it("(b) benign logistics message with third-party resolved symptom stays low", () => {
+    const d = triageMessage(
+      "Can I move my appointment to Friday? My daughter had a rash last month but it's gone",
+    );
+    expect(d.upi).toBeLessThan(0.4);
+    expect(d.route).toBe("standard");
+    expect(d.autoReply).toBeUndefined();
+    // the rash was seen but suppressed — visible in the factor breakdown
+    const rash = d.factors.acuity.entities.find((e) => e.id === "rash");
+    expect(rash).toBeDefined();
+    expect(rash!.thirdParty || rash!.negated).toBe(true);
+  });
+
+  it("(c) negated symptom + refill question does not escalate", () => {
+    const d = triageMessage("No chest pain, just a refill question");
+    expect(d.route).toBe("standard");
+    expect(d.upi).toBeLessThan(0.4);
+    expect(d.factors.redFlagFloorApplied).toBe(false);
+  });
+
+  it("(d) third-party symptoms do not escalate", () => {
+    const d = triageMessage(
+      "My husband has been having seizures, can you recommend a neurologist for him?",
+    );
+    expect(d.route).toBe("standard");
+    expect(d.upi).toBeLessThan(0.4);
+  });
+
+  it("(e) vulnerability multiplier raises a borderline case past the threshold", () => {
+    const text = "I fainted twice today!! Scared it will happen again";
+    const withoutFlags = triageMessage(text);
+    expect(withoutFlags.route).toBe("standard");
+    expect(withoutFlags.upi).toBeLessThan(URGENT_THRESHOLD);
+
+    const withFlags = triageMessage(text, {
+      vulnerability: { severeCardiovascularDisease: true },
+    });
+    expect(withFlags.route).toBe("urgent");
+    expect(withFlags.upi).toBeGreaterThanOrEqual(URGENT_THRESHOLD);
+    expect(withFlags.autoReply).toBe(URGENT_AUTO_REPLY);
+    expect(withFlags.factors.vulnerability.activeFlags).toContain(
+      "Severe cardiovascular disease",
+    );
+  });
+});
+
+// ── Wiring: triageThread (Smart Inbox) uses UPI as the primary signal ──
+
+function msgs(...bodies: string[]) {
+  return bodies.map((body, i) => ({
+    body,
+    senderUserId: "patient-user-1",
+    senderAgent: null,
+    createdAt: new Date(Date.UTC(2026, 5, 12, 8, i)).toISOString(),
+  }));
+}
+
+describe("triageThread wiring (EMR-1090 regressions through the Smart Inbox path)", () => {
+  it("escalates a real emergency to urgent with the UPI decision attached", () => {
+    const r = triageThread(
+      msgs("I have crushing chest pain radiating to my arm, I'm terrified"),
+      "patient-user-1",
+    );
+    expect(r.priority).toBe("urgent");
+    expect(r.needsClinician).toBe(true);
+    expect(r.upi?.route).toBe("urgent");
+    expect(r.upi?.autoReply).toContain("911");
+  });
+
+  it("does not over-triage the benign appointment + daughter's-rash message", () => {
+    const r = triageThread(
+      msgs(
+        "Can I move my appointment to Friday? My daughter had a rash last month but it's gone",
+      ),
+      "patient-user-1",
+    );
+    expect(r.priority).toBe("routine");
+    expect(r.category).toBe("appointment_request");
+    expect(r.category).not.toBe("adverse_reaction");
+    expect(r.upi?.route).toBe("standard");
+    expect(r.upi?.upi ?? 1).toBeLessThan(0.4);
+  });
+
+  it("routes 'no chest pain, just a refill question' as a routine refill", () => {
+    const r = triageThread(msgs("No chest pain, just a refill question"), "patient-user-1");
+    expect(r.priority).toBe("routine");
+    expect(r.category).toBe("refill_request");
+    // legacy urgent keyword hit is surfaced as a suppressed advisory note
+    expect(r.triageReason).toContain("suppressed");
+  });
+
+  it("keeps third-party emergencies out of the urgent queue", () => {
+    const r = triageThread(
+      msgs("My husband has been having seizures, can you recommend a neurologist for him?"),
+      "patient-user-1",
+    );
+    expect(r.priority).not.toBe("urgent");
+    expect(r.priority).not.toBe("high");
+  });
+
+  it("passes patient vulnerability context through to the UPI engine", () => {
+    const messages = msgs("I fainted twice today!! Scared it will happen again");
+    const without = triageThread(messages, "patient-user-1");
+    expect(without.priority).not.toBe("urgent");
+
+    const withContext = triageThread(messages, "patient-user-1", {
+      vulnerability: { severeCardiovascularDisease: true },
+    });
+    expect(withContext.priority).toBe("urgent");
+  });
+
+  it("still classifies active mid-tier symptoms as high (fever + rash combo)", () => {
+    const r = triageThread(
+      msgs("I have a fever and a rash on my stomach since starting the new tincture"),
+      "patient-user-1",
+    );
+    expect(r.priority).toBe("high");
+    expect(r.category).toBe("adverse_reaction");
+  });
+
+  it("ignores clinician/agent messages when scoring", () => {
+    const r = triageThread(
+      [
+        {
+          body: "If you ever have chest pain, call 911 right away.",
+          senderUserId: "clinician-user-9",
+          senderAgent: null,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          body: "Thanks! Just need my refill.",
+          senderUserId: "patient-user-1",
+          senderAgent: null,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      "patient-user-1",
+    );
+    expect(r.priority).toBe("routine");
+    expect(r.category).toBe("refill_request");
+  });
+});

--- a/src/lib/triage/upi/distress.ts
+++ b/src/lib/triage/upi/distress.ts
@@ -1,0 +1,80 @@
+// UPI — emotional distress / sentiment evaluation (EMR-1146).
+//
+// Phase 2.3 of the red-text spec: "a parallel linguistic processor
+// evaluates the structural syntax of the message to measure the patient's
+// emotional state, tracking urgency indicators such as capital letters,
+// exclamation points, and explicit panic words".
+//
+// Deterministic and pure — runs on the RAW message text (before
+// normalization) because casing and punctuation ARE the signal here.
+
+export interface DistressSignal {
+  /** S_distress in [0, 1]. */
+  score: number;
+  /** Share of words (≥3 letters) written fully in caps. */
+  capsRatio: number;
+  /** Exclamation marks per message, capped contribution at 3. */
+  exclamationCount: number;
+  /** Panic vocabulary hits found in the message. */
+  panicTerms: string[];
+}
+
+const PANIC_VOCABULARY: ReadonlyArray<RegExp> = [
+  /\bterrified\b/i,
+  /\bterrifying\b/i,
+  /\bscared\b/i,
+  /\bscary\b/i,
+  /\bfrightened\b/i,
+  /\bpanick?(?:ing|ed|y)?\b/i,
+  /\bfreaking out\b/i,
+  /\bhelp me\b/i,
+  /\bplease help\b/i,
+  /\bbleeding out\b/i,
+  /\bcan'?t breathe\b/i,
+  /\b(?:i'?m|am) dying\b/i,
+  /\bgoing to die\b/i,
+  /\bemergency\b/i,
+  /\bdesperate\b/i,
+  /\bhysterical\b/i,
+  /\basap\b/i,
+  /\bright now\b/i,
+];
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+/**
+ * Score emotional distress 0–1 from message structure and vocabulary.
+ * Weighted toward explicit panic vocabulary; caps and exclamation marks
+ * are supporting signals (some patients just type in caps).
+ */
+export function scoreDistress(rawText: string): DistressSignal {
+  const text = rawText.trim();
+  if (!text) {
+    return { score: 0, capsRatio: 0, exclamationCount: 0, panicTerms: [] };
+  }
+
+  // Caps ratio over words with ≥3 alphabetic chars (skips "OK", "ER", "I").
+  const words = text.split(/\s+/);
+  const alphaWords = words.filter((w) => (w.match(/[A-Za-z]/g) ?? []).length >= 3);
+  const capsWords = alphaWords.filter((w) => {
+    const letters = w.replace(/[^A-Za-z]/g, "");
+    return letters.length >= 3 && letters === letters.toUpperCase();
+  });
+  const capsRatio = alphaWords.length > 0 ? capsWords.length / alphaWords.length : 0;
+
+  const exclamationCount = (text.match(/!/g) ?? []).length;
+
+  const panicTerms: string[] = [];
+  for (const re of PANIC_VOCABULARY) {
+    const m = text.match(re);
+    if (m) panicTerms.push(m[0].toLowerCase());
+  }
+
+  const panicScore = clamp01(panicTerms.length / 2); // two panic terms saturate
+  const capsScore = clamp01(capsRatio * 4); // 25% caps words saturate
+  const exclamationScore = clamp01(exclamationCount / 3); // three "!" saturate
+
+  const score = clamp01(0.55 * panicScore + 0.25 * capsScore + 0.2 * exclamationScore);
+
+  return { score, capsRatio, exclamationCount, panicTerms };
+}

--- a/src/lib/triage/upi/entities.ts
+++ b/src/lib/triage/upi/entities.ts
@@ -1,0 +1,486 @@
+// UPI — deterministic clinical entity extraction (EMR-1146 / EMR-1147).
+//
+// Phase 1–2 of the "Asynchronous Triage & Smart Check-ins" red-text spec
+// (docs/product-feedback/2026-06-12_workflows-revisions-red-text.md):
+// text normalization + abbreviation expansion, symptom/condition lexicon
+// mapped to ESI-style acuity classes, negation filtering ("no chest pain",
+// "denies", "without fever") and subject attribution ("my daughter has…")
+// so negated or third-party symptoms never escalate.
+//
+// Fixes EMR-1090 over-triage: the legacy keyword scan in
+// src/lib/domain/smart-inbox.ts escalated on bare substring hits, so
+// "no chest pain" and "my daughter had a rash" both paged the clinician.
+
+export type AcuityClass = "red_flag" | "emergent" | "moderate" | "minor" | "admin";
+
+export interface LexiconEntry {
+  /** Stable identifier, also used for combo rules (e.g. fever + rash). */
+  id: string;
+  /** Human-readable label surfaced in the factor breakdown. */
+  label: string;
+  /** Matching pattern. Run against normalized (lowercased, expanded) text. */
+  pattern: RegExp;
+  /** ESI-style acuity coefficient in [0, 1]. */
+  acuity: number;
+  acuityClass: AcuityClass;
+}
+
+export interface ExtractedEntity {
+  id: string;
+  label: string;
+  /** The literal (normalized) text that matched. */
+  matched: string;
+  /** Character offset in the normalized text — used for assertion analysis. */
+  index: number;
+  acuity: number;
+  acuityClass: AcuityClass;
+  /** True when a negation cue governs the mention ("no chest pain"). */
+  negated: boolean;
+  /** True when the symptom is attributed to someone other than the patient. */
+  thirdParty: boolean;
+}
+
+export interface EntityExtractionResult {
+  /** Every lexicon hit, including negated / third-party mentions. */
+  entities: ExtractedEntity[];
+  /** Non-negated, first-party clinical entities (admin excluded). */
+  activeEntities: ExtractedEntity[];
+  /**
+   * Max acuity across active clinical entities, after combo rules.
+   * Equals ADMIN_BASELINE_ACUITY when only admin/logistics (or nothing)
+   * is present — per spec: "0.1 for minor administrative inquiries".
+   */
+  baseAcuity: number;
+  /** The normalized text the extraction ran against (for transparency). */
+  normalizedText: string;
+}
+
+/** A_esi floor for purely administrative / logistics messages. */
+export const ADMIN_BASELINE_ACUITY = 0.1;
+
+// ── Normalization ──────────────────────────────────────────────────────
+
+/**
+ * Shorthand → standardized clinical terms (spec Phase 1.2: e.g. converting
+ * "soby" or "sob" to "shortness of breath"). Applied on word boundaries
+ * against lowercased text. Deliberately conservative — only unambiguous
+ * patient-message shorthand.
+ */
+const ABBREVIATIONS: ReadonlyArray<[RegExp, string]> = [
+  [/\bsoby?\b/g, "shortness of breath"],
+  [/\bdib\b/g, "difficulty breathing"],
+  [/\bn\/v\b/g, "nausea and vomiting"],
+  [/\bc\/o\b/g, "complains of"],
+  [/\bappt\b/g, "appointment"],
+  [/\brx\b/g, "prescription"],
+  [/\bbp\b/g, "blood pressure"],
+  [/\ber\b/g, "emergency room"],
+  [/\babd\b/g, "abdominal"],
+  // Apostrophe-less contractions matter for both lexicon + negation cues.
+  [/\bcant\b/g, "can't"],
+  [/\bwont\b/g, "won't"],
+  [/\bdont\b/g, "don't"],
+  [/\bim\b/g, "i'm"],
+];
+
+/** Lowercase, strip messaging artifacts, collapse whitespace, expand shorthand. */
+export function normalizeMessageText(raw: string): string {
+  let text = raw
+    .toLowerCase()
+    // Curly quotes → straight, so contraction matching is uniform.
+    .replace(/[‘’]/g, "'")
+    // Strip emoji / non-standard UI characters but KEEP clause punctuation,
+    // which negation + subject-attribution windows rely on.
+    .replace(/[^a-z0-9\s.,;:!?'\/-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  for (const [pattern, replacement] of ABBREVIATIONS) {
+    text = text.replace(pattern, replacement);
+  }
+  return text;
+}
+
+// ── Lexicon ────────────────────────────────────────────────────────────
+// Ordered most-specific-first; overlapping spans keep the first (longest)
+// match, so "crushing chest pain" wins over the generic "chest pain" entry.
+
+export const CLINICAL_LEXICON: ReadonlyArray<LexiconEntry> = [
+  // ── ESI-1 red flags (acuity ≥ 0.9 — see RED_FLAG_ACUITY in upi.ts) ──
+  {
+    id: "crushing_chest_pain",
+    label: "Crushing/radiating chest pain",
+    pattern:
+      /\b(?:crushing|squeezing|elephant on (?:my|the) chest)\b[^.!?]{0,40}\b(?:chest|pain|pressure)|\bchest (?:pain|pressure|tightness)[^.!?]{0,50}\bradiat/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "chest_pain",
+    label: "Chest pain/pressure",
+    pattern: /\bchest (?:pain|pains|pressure|tightness|hurts?)\b|\bmy chest (?:hurts|is tight)\b/g,
+    acuity: 0.9,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "breathing_emergency",
+    label: "Severe breathing difficulty",
+    pattern:
+      /\bcan't (?:breathe|catch (?:my|a) breath)\b|\bstruggling to breathe\b|\bgasping for air\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "shortness_of_breath",
+    label: "Shortness of breath",
+    pattern: /\bshortness of breath\b|\bdifficulty breathing\b|\btrouble breathing\b/g,
+    acuity: 0.9,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "anaphylaxis",
+    label: "Anaphylaxis / airway swelling",
+    pattern:
+      /\banaphyla\w*\b|\bthroat (?:is )?(?:closing|swelling|swollen)\b|\b(?:tongue|lips?) (?:are |is )?swelling\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "uncontrolled_bleeding",
+    label: "Uncontrolled bleeding",
+    pattern:
+      /\b(?:uncontrolled|uncontrollable|severe) bleeding\b|\bbleeding (?:won't|will not|doesn't|does not) stop\b|\bcan't stop (?:the )?bleeding\b|\bbleeding out\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "suicidal_ideation",
+    label: "Suicidal ideation / self-harm",
+    pattern:
+      /\bsuicid\w*\b|\bkill (?:myself|himself|herself|themselves)\b|\bend (?:my|his|her|their) life\b|\bwant(?:s)? to die\b|\bself[ -]harm\w*\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "stroke_signs",
+    label: "Stroke signs (unilateral weakness / face droop / slurred speech)",
+    pattern:
+      /\b(?:face|arm|leg|side)[^.!?]{0,20}\bdroop\w*\b|\bdroop\w*\b[^.!?]{0,20}\b(?:face|mouth|eye)\b|\bslurr\w* (?:my )?(?:speech|words)\b|\bspeech (?:is )?slurred\b|\bweak(?:ness)? (?:in|on) (?:my |the )?(?:left|right|one) (?:side|arm|leg|face)\b|\b(?:left|right|one)[ -]sided weakness\b|\bcan't (?:move|feel|lift) (?:my |the )?(?:left|right|one) (?:side|arm|leg)\b|\bsudden(?:ly)? numb\w*\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "unresponsive",
+    label: "Unconscious / unresponsive",
+    pattern: /\bunconscious\b|\bunresponsive\b|\bwon't wake up\b|\bnot waking up\b/g,
+    acuity: 1.0,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "seizure",
+    label: "Seizure / convulsion",
+    pattern: /\bseizures?\b|\bseizing\b|\bconvuls\w*\b/g,
+    acuity: 0.95,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "overdose",
+    label: "Overdose / poisoning",
+    pattern: /\boverdos\w*\b|\bod'?d\b|\btook too (?:much|many)\b[^.!?]{0,30}\b(?:pill|med|dose)\w*\b/g,
+    acuity: 0.95,
+    acuityClass: "red_flag",
+  },
+  {
+    id: "vomiting_blood",
+    label: "Vomiting / coughing up blood",
+    pattern:
+      /\b(?:vomit\w*|throw\w* up|cough\w*(?: up)?) blood\b|\bblood in (?:my )?(?:vomit|stool|urine)\b/g,
+    acuity: 0.95,
+    acuityClass: "red_flag",
+  },
+
+  {
+    id: "emergency_selfreport",
+    label: "Explicit emergency self-report",
+    pattern:
+      /\b(?:this is|having|i'm having) an emergency\b|\bcall(?:ing|ed)? 911\b|\bneed (?:an )?ambulance\b|\b(?:going|heading|on my way) to the (?:emergency room|hospital)\b/g,
+    acuity: 0.9,
+    acuityClass: "red_flag",
+  },
+
+  // ── Emergent mid-tier (ESI-2-ish) ──
+  {
+    id: "syncope",
+    label: "Fainting / syncope",
+    pattern: /\bfaint(?:ed|ing)?\b|\bpassed out\b|\bblack(?:ed|ing) out\b|\bsyncope\b/g,
+    acuity: 0.85,
+    acuityClass: "emergent",
+  },
+  {
+    id: "severe_pain",
+    label: "Severe / worst-ever pain",
+    pattern:
+      /\b(?:severe|excruciating|unbearable|worst) (?:\w+ )?pain\b|\bpain (?:is )?(?:10|ten) out of (?:10|ten)\b|\b10\/10 pain\b/g,
+    acuity: 0.7,
+    acuityClass: "emergent",
+  },
+  {
+    id: "confusion",
+    label: "New confusion / disorientation",
+    pattern: /\bconfus\w*\b|\bdisorient\w*\b|\bhallucinat\w*\b/g,
+    acuity: 0.7,
+    acuityClass: "emergent",
+  },
+  {
+    id: "persistent_vomiting",
+    label: "Persistent vomiting",
+    pattern:
+      /\b(?:persistent|constant|nonstop|non-stop) vomiting\b|\bcan't stop (?:vomiting|throwing up)\b|\bvomiting for \d+\b|\bkeep(?:s)? (?:vomiting|throwing up)\b/g,
+    acuity: 0.6,
+    acuityClass: "emergent",
+  },
+  {
+    id: "palpitations",
+    label: "Palpitations / racing heart",
+    pattern: /\bpalpitation\w*\b|\bracing heart\b|\bheart (?:is )?(?:racing|pounding)\b|\brapid heart\s?(?:beat|rate)?\b/g,
+    acuity: 0.6,
+    acuityClass: "emergent",
+  },
+  {
+    id: "high_fever",
+    label: "High fever",
+    pattern: /\bhigh fever\b|\bfever of (?:10[3-9]|1[1-9]\d)\b|\b10[3-9](?:\.\d)? ?(?:degrees|f)\b/g,
+    acuity: 0.6,
+    acuityClass: "emergent",
+  },
+  {
+    id: "allergic_reaction",
+    label: "Allergic reaction",
+    pattern: /\ballergic reaction\b|\bsevere reaction\b|\bhives\b/g,
+    acuity: 0.6,
+    acuityClass: "emergent",
+  },
+
+  // ── Minor clinical (routine symptom reports) ──
+  {
+    id: "fever",
+    label: "Fever",
+    pattern: /\bfevers?\b|\bfeverish\b|\btemperature\b/g,
+    acuity: 0.35,
+    acuityClass: "minor",
+  },
+  {
+    id: "rash",
+    label: "Rash / skin reaction",
+    pattern: /\brash(?:es)?\b|\bskin (?:reaction|irritation)\b/g,
+    acuity: 0.3,
+    acuityClass: "minor",
+  },
+  {
+    id: "vomiting",
+    label: "Vomiting",
+    pattern: /\bvomit\w*\b|\bthrow\w* up\b/g,
+    acuity: 0.4,
+    acuityClass: "minor",
+  },
+  {
+    id: "dizziness",
+    label: "Dizziness",
+    pattern: /\bdizz\w*\b|\blight-?headed\w*\b|\bvertigo\b/g,
+    acuity: 0.35,
+    acuityClass: "minor",
+  },
+  {
+    id: "nausea",
+    label: "Nausea",
+    pattern: /\bnause\w*\b|\bqueasy\b/g,
+    acuity: 0.3,
+    acuityClass: "minor",
+  },
+  {
+    id: "headache",
+    label: "Headache",
+    pattern: /\bheadaches?\b|\bmigraines?\b/g,
+    acuity: 0.3,
+    acuityClass: "minor",
+  },
+  {
+    id: "swelling",
+    label: "Swelling",
+    pattern: /\bswelling\b|\bswollen\b/g,
+    acuity: 0.35,
+    acuityClass: "minor",
+  },
+  {
+    id: "pain_generic",
+    label: "Pain (unspecified)",
+    pattern: /\bpains?\b|\bhurts?\b|\baching\b|\baches?\b/g,
+    acuity: 0.3,
+    acuityClass: "minor",
+  },
+  {
+    id: "anxiety",
+    label: "Anxiety / panic symptoms",
+    pattern: /\banxiety\b|\banxious\b|\bpanic attacks?\b|\bparanoi\w*\b/g,
+    acuity: 0.3,
+    acuityClass: "minor",
+  },
+
+  // ── Admin / logistics (acuity floor 0.1) ──
+  {
+    id: "admin",
+    label: "Administrative / scheduling / billing",
+    pattern:
+      /\bappointments?\b|\b(?:re)?schedul\w*\b|\brefills?\b|\brenewals?\b|\bprescriptions?\b|\bbilling\b|\binvoices?\b|\bstatements?\b|\binsurance\b|\bcopay\w*\b|\bpaperwork\b|\bforms?\b|\bportal\b|\bpassword\b|\breceipts?\b/g,
+    acuity: ADMIN_BASELINE_ACUITY,
+    acuityClass: "admin",
+  },
+];
+
+// ── Assertion analysis: negation ───────────────────────────────────────
+
+/** Cues that negate a following symptom mention within the same clause. */
+const PRE_NEGATION_RE =
+  /\b(?:no|not|without|denies?|denied|denying|never (?:had|have|get|gotten|experienced)|haven't (?:had|noticed|felt)|hasn't (?:had|been)|don't have|doesn't have|didn't have|isn't|wasn't|no longer|free of|ruled out|aside from|other than|except for)\s*$|\b(?:no|not|without|denies?|denied)\b/;
+
+/** Resolution cues after a mention ("…but it's gone", "…has resolved"). */
+const POST_RESOLUTION_RE =
+  /\b(?:gone|resolved|cleared(?: up)?|went away|subsided|stopped|better now|all better|disappeared|healed|over now|no longer)\b/;
+
+/**
+ * "I've NEVER had chest pain like this" is an *active* emergency despite the
+ * negation token — the comparison re-asserts the symptom. Spotting this
+ * pattern was part of the EMR-1090 under-escalation review.
+ */
+const NEGATION_OVERRIDE_RE = /\blike this\b|\bthis bad\b|\buntil (?:now|today|tonight)\b/;
+
+// ── Assertion analysis: subject attribution ────────────────────────────
+
+const THIRD_PARTY_SUBJECT_RE =
+  /\b(?:my|our)\s+(?:daughter|son|husband|wife|mom|mother|dad|father|brother|sister|grandm\w+|grandp\w+|grandfather|grandmother|aunt|uncle|cousin|niece|nephew|friend|neighbor|neighbour|roommate|partner|boyfriend|girlfriend|coworker|co-worker|colleague|child|kids?|baby|toddler|dog|cat|pet)\b|\b(?:he|she|they)\s+(?:has|have|had|is|was|were|got|gets|keeps?)\b|\bhis\s|\bher\s|\btheir\s/g;
+
+/** First-person re-anchor — pulls attribution back to the patient.
+ *  ("my" alone counts: "I told her about my pain" is first-party.) */
+const FIRST_PERSON_RE = /\b(?:i|i'm|i've|i'll|me|my|myself|mine)\b/;
+
+function sentenceBoundsAt(text: string, index: number): { start: number; end: number } {
+  // Sentences split on . ! ? — commas intentionally stay inside the window
+  // so "no chest pain, just a refill" keeps the negation in scope.
+  let start = 0;
+  for (let i = index - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === "." || ch === "!" || ch === "?") {
+      start = i + 1;
+      break;
+    }
+  }
+  let end = text.length;
+  for (let i = index; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "." || ch === "!" || ch === "?") {
+      end = i;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+function lastWords(s: string, n: number): string {
+  const words = s.trim().split(/\s+/);
+  return words.slice(Math.max(0, words.length - n)).join(" ");
+}
+
+function firstWords(s: string, n: number): string {
+  const words = s.trim().split(/\s+/);
+  return words.slice(0, n).join(" ");
+}
+
+/** Negation check for a match spanning [index, index + length). */
+export function isNegated(text: string, index: number, length: number): boolean {
+  const { start, end } = sentenceBoundsAt(text, index);
+  const preWindow = lastWords(text.slice(start, index), 6);
+  const postWindow = firstWords(text.slice(index + length, end), 8);
+
+  if (NEGATION_OVERRIDE_RE.test(postWindow)) return false;
+  if (PRE_NEGATION_RE.test(preWindow)) return true;
+  if (POST_RESOLUTION_RE.test(postWindow)) return true;
+  return false;
+}
+
+/** Third-party attribution check for a match starting at `index`. */
+export function isThirdParty(text: string, index: number): boolean {
+  const { start } = sentenceBoundsAt(text, index);
+  const sentenceBefore = text.slice(start, index);
+
+  let lastSubjectEnd = -1;
+  THIRD_PARTY_SUBJECT_RE.lastIndex = 0;
+  for (const m of sentenceBefore.matchAll(THIRD_PARTY_SUBJECT_RE)) {
+    lastSubjectEnd = (m.index ?? 0) + m[0].length;
+  }
+  if (lastSubjectEnd < 0) return false;
+
+  // A first-person re-anchor BETWEEN the third-party subject and the
+  // symptom pulls attribution back to the patient ("my husband said I
+  // should message you — I have chest pain").
+  const between = sentenceBefore.slice(lastSubjectEnd);
+  return !FIRST_PERSON_RE.test(between);
+}
+
+// ── Combo rules (spec: "mid-tier like fever+rash") ─────────────────────
+
+const COMBO_RULES: ReadonlyArray<{ ids: [string, string]; acuity: number; label: string }> = [
+  { ids: ["fever", "rash"], acuity: 0.6, label: "Fever with rash" },
+  { ids: ["fever", "headache"], acuity: 0.55, label: "Fever with headache" },
+];
+
+// ── Extraction ─────────────────────────────────────────────────────────
+
+/**
+ * Deterministic clinical entity extraction over a raw patient message.
+ * No LLM, no network — pure function of the input text.
+ */
+export function extractEntities(rawText: string): EntityExtractionResult {
+  const text = normalizeMessageText(rawText);
+  const entities: ExtractedEntity[] = [];
+  const claimed: Array<[number, number]> = []; // [start, end) spans already matched
+
+  for (const entry of CLINICAL_LEXICON) {
+    entry.pattern.lastIndex = 0;
+    for (const m of text.matchAll(entry.pattern)) {
+      const index = m.index ?? 0;
+      const end = index + m[0].length;
+      // Skip spans already claimed by a more specific (earlier) entry.
+      if (claimed.some(([s, e]) => index < e && end > s)) continue;
+      claimed.push([index, end]);
+
+      const negated = entry.acuityClass === "admin" ? false : isNegated(text, index, m[0].length);
+      const thirdParty = entry.acuityClass === "admin" ? false : isThirdParty(text, index);
+      entities.push({
+        id: entry.id,
+        label: entry.label,
+        matched: m[0],
+        index,
+        acuity: entry.acuity,
+        acuityClass: entry.acuityClass,
+        negated,
+        thirdParty,
+      });
+    }
+  }
+
+  entities.sort((a, b) => a.index - b.index);
+
+  const activeEntities = entities.filter(
+    (e) => !e.negated && !e.thirdParty && e.acuityClass !== "admin",
+  );
+
+  let baseAcuity = ADMIN_BASELINE_ACUITY;
+  for (const e of activeEntities) baseAcuity = Math.max(baseAcuity, e.acuity);
+  const activeIds = new Set(activeEntities.map((e) => e.id));
+  for (const combo of COMBO_RULES) {
+    if (combo.ids.every((id) => activeIds.has(id))) {
+      baseAcuity = Math.max(baseAcuity, combo.acuity);
+    }
+  }
+
+  return { entities, activeEntities, baseAcuity, normalizedText: text };
+}

--- a/src/lib/triage/upi/index.ts
+++ b/src/lib/triage/upi/index.ts
@@ -1,0 +1,124 @@
+// UPI — Urgency Priority Index, end-to-end message triage (EMR-1146/1147).
+//
+// Deterministic clinical message-triage engine per the "Asynchronous
+// Triage & Smart Check-ins" red-text spec, Phases 1–4
+// (docs/product-feedback/2026-06-12_workflows-revisions-red-text.md).
+// Fixes EMR-1090: (1) under-escalation of a real emergency message,
+// (2) over-triage of a benign message as Urgent/Adverse.
+//
+// Pipeline: normalize → extract entities (negation + subject attribution)
+// → distress score → UPI weighted sum → route decision.
+//
+//   UPI ≥ 0.75 → "urgent": bypass routine queues, include the
+//                 pre-configured 911/ED safety auto-reply.
+//   UPI < 0.75 → "standard": routed to the normal triage pool, sorted
+//                 by score.
+//
+// The engine is the PRIMARY triage signal; any LLM layer is advisory only.
+
+import { scoreDistress, type DistressSignal } from "./distress";
+import { extractEntities, type EntityExtractionResult } from "./entities";
+import {
+  computeUpi,
+  URGENT_THRESHOLD,
+  type UpiFactors,
+  type UpiWeights,
+  type VulnerabilityFlags,
+} from "./upi";
+
+export * from "./entities";
+export * from "./distress";
+export * from "./upi";
+
+/** Chart context an integration can pass alongside the message text. */
+export interface UpiPatientContext {
+  vulnerability?: VulnerabilityFlags;
+  /** Optional weight override — defaults to DEFAULT_WEIGHTS. */
+  weights?: UpiWeights;
+}
+
+export interface TriageDecision {
+  route: "urgent" | "standard";
+  /** Final UPI score in [0, 1]. */
+  upi: number;
+  /** Full factor breakdown for clinician transparency. */
+  factors: UpiFactors;
+  /** Pre-configured 911/ED safety reply — present only on urgent routes. */
+  autoReply?: string;
+}
+
+/**
+ * Spec Phase 4.1 — automated red-flag response sent back on the patient's
+ * channel the moment a message routes urgent.
+ */
+export const URGENT_AUTO_REPLY =
+  "Your message flags critical symptoms. Please immediately hang up and dial 911 " +
+  "or proceed to the nearest emergency department. Our clinical team has also " +
+  "been alerted and will follow up with you directly.";
+
+/**
+ * End-to-end deterministic triage of a raw patient message.
+ * Pure function — no LLM, no I/O, same input always yields same decision.
+ */
+export function triageMessage(
+  rawText: string,
+  patientContext?: UpiPatientContext,
+): TriageDecision {
+  const entities: EntityExtractionResult = extractEntities(rawText);
+  const distress: DistressSignal = scoreDistress(rawText);
+  const { score, factors } = computeUpi({
+    entities,
+    distress,
+    vulnerability: patientContext?.vulnerability,
+    weights: patientContext?.weights,
+  });
+
+  if (score >= URGENT_THRESHOLD) {
+    return { route: "urgent", upi: score, factors, autoReply: URGENT_AUTO_REPLY };
+  }
+  return { route: "standard", upi: score, factors };
+}
+
+// ── Chart → vulnerability flag derivation ──────────────────────────────
+
+const CARDIOVASCULAR_RE =
+  /\bheart failure\b|\bcardiomyopathy\b|\bcoronary artery\b|\bmyocardial infarction\b|\bheart attack\b|\batrial fibrillation\b|\barrhythmi\w*\b|\bcardiovascular disease\b|\bunstable angina\b|\baortic\b|\bcardiac\b/i;
+
+const METABOLIC_RE =
+  /\buncontrolled diabetes\b|\btype 1 diabetes\b|\bketoacidosis\b|\bdka\b|\badrenal insufficiency\b|\bcirrhosis\b|\b(?:renal|kidney|liver) failure\b|\bdialysis\b|\besrd\b/i;
+
+const POST_OP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Derive UPI vulnerability flags from chart records (PastMedicalCondition,
+ * PastSurgery, Patient.contraindications). Pure — callers fetch the rows.
+ *
+ * TODO(EMR-1147): PastSurgery.performedDateText is free text; until a real
+ * performedAt column exists we approximate the 30-day post-op window with
+ * the row's createdAt (surgeries are typically charted near the event).
+ */
+export function deriveVulnerabilityFlags(input: {
+  conditions?: ReadonlyArray<{ condition: string }>;
+  contraindications?: ReadonlyArray<string>;
+  surgeries?: ReadonlyArray<{ createdAt: Date | string }>;
+  now?: Date;
+}): VulnerabilityFlags {
+  const now = input.now ?? new Date();
+  const conditionText = [
+    ...(input.conditions ?? []).map((c) => c.condition),
+    ...(input.contraindications ?? []),
+  ].join(" \n ");
+
+  const postOpWithin30Days = (input.surgeries ?? []).some((s) => {
+    const at = s.createdAt instanceof Date ? s.createdAt : new Date(s.createdAt);
+    if (Number.isNaN(at.getTime())) return false;
+    const delta = now.getTime() - at.getTime();
+    return delta >= 0 && delta <= POST_OP_WINDOW_MS;
+  });
+
+  return {
+    severeCardiovascularDisease: CARDIOVASCULAR_RE.test(conditionText),
+    advancedMetabolicInstability: METABOLIC_RE.test(conditionText),
+    postOpWithin30Days,
+  };
+}

--- a/src/lib/triage/upi/upi.ts
+++ b/src/lib/triage/upi/upi.ts
@@ -1,0 +1,202 @@
+// UPI — Urgency Priority Index scoring core (EMR-1146 / EMR-1147).
+//
+// Phase 3 of the red-text spec: converts extracted clinical concepts and
+// sentiment metrics into a single deterministic metric:
+//
+//   UPI = w1 · A_esi + w2 · S_distress + w3 · V_patient,  clamped to [0, 1]
+//
+// with weights calibrated to prioritize physical clinical indicators over
+// emotional expression (w1 = 0.65, w2 = 0.15, w3 = 0.20).
+//
+// Safety floor: an active first-party ESI-1 red-flag entity (acuity ≥ 0.9)
+// floors the score at RED_FLAG_FLOOR regardless of distress/vulnerability,
+// so "crushing chest pain" stated calmly still routes urgent. This is the
+// direct fix for the EMR-1090 under-escalation incident, and the floor is
+// reported in the factor breakdown for clinician transparency.
+
+import type { DistressSignal } from "./distress";
+import type { EntityExtractionResult, ExtractedEntity } from "./entities";
+
+export interface UpiWeights {
+  acuity: number;
+  distress: number;
+  vulnerability: number;
+}
+
+export const DEFAULT_WEIGHTS: UpiWeights = {
+  acuity: 0.65,
+  distress: 0.15,
+  vulnerability: 0.2,
+};
+
+/** Route-urgent threshold (spec Phase 4.1: UPI ≥ 0.75). */
+export const URGENT_THRESHOLD = 0.75;
+
+/** Active entities at or above this acuity are ESI-1 red flags. */
+export const RED_FLAG_ACUITY = 0.9;
+
+/** Minimum UPI when an active red-flag entity is present. */
+export const RED_FLAG_FLOOR = 0.85;
+
+// ── Vulnerability (V_patient) ──────────────────────────────────────────
+
+/**
+ * Chart-context vulnerability flags (spec Phase 3): severe cardiovascular
+ * disease, advanced metabolic instability, or an active 30-day
+ * post-operative recovery window.
+ */
+export interface VulnerabilityFlags {
+  severeCardiovascularDisease?: boolean;
+  advancedMetabolicInstability?: boolean;
+  postOpWithin30Days?: boolean;
+}
+
+const VULNERABILITY_CONTRIBUTIONS: ReadonlyArray<{
+  key: keyof VulnerabilityFlags;
+  label: string;
+  value: number;
+}> = [
+  { key: "severeCardiovascularDisease", label: "Severe cardiovascular disease", value: 0.8 },
+  { key: "advancedMetabolicInstability", label: "Advanced metabolic instability", value: 0.7 },
+  { key: "postOpWithin30Days", label: "Within 30-day post-op window", value: 0.7 },
+];
+
+/** V_patient in [0, 1] from chart-context flags. No flags → 0. */
+export function vulnerabilityScore(flags: VulnerabilityFlags | undefined): number {
+  if (!flags) return 0;
+  let v = 0;
+  for (const c of VULNERABILITY_CONTRIBUTIONS) {
+    if (flags[c.key]) v += c.value;
+  }
+  return Math.min(1, v);
+}
+
+// ── Factor breakdown (clinician transparency) ──────────────────────────
+
+export interface UpiFactorEntity {
+  id: string;
+  label: string;
+  matched: string;
+  acuity: number;
+  acuityClass: string;
+  negated: boolean;
+  thirdParty: boolean;
+}
+
+export interface UpiFactors {
+  acuity: {
+    /** A_esi input. */
+    value: number;
+    weight: number;
+    contribution: number;
+    /** Every lexicon hit, including suppressed (negated/third-party) ones. */
+    entities: UpiFactorEntity[];
+    /** Hits excluded from scoring, with the reason visible via flags. */
+    suppressedCount: number;
+  };
+  distress: {
+    /** S_distress input. */
+    value: number;
+    weight: number;
+    contribution: number;
+    capsRatio: number;
+    exclamationCount: number;
+    panicTerms: string[];
+  };
+  vulnerability: {
+    /** V_patient input. */
+    value: number;
+    weight: number;
+    contribution: number;
+    activeFlags: string[];
+  };
+  /** w1·A + w2·S + w3·V before the red-flag floor. */
+  weightedSum: number;
+  /** True when an active ESI-1 entity floored the score at RED_FLAG_FLOOR. */
+  redFlagFloorApplied: boolean;
+}
+
+export interface UpiResult {
+  /** Final UPI in [0, 1]. */
+  score: number;
+  factors: UpiFactors;
+}
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+function toFactorEntity(e: ExtractedEntity): UpiFactorEntity {
+  return {
+    id: e.id,
+    label: e.label,
+    matched: e.matched,
+    acuity: e.acuity,
+    acuityClass: e.acuityClass,
+    negated: e.negated,
+    thirdParty: e.thirdParty,
+  };
+}
+
+/**
+ * Compute the Urgency Priority Index. Pure and deterministic — the same
+ * inputs always yield the same score, and the factor breakdown explains
+ * every term of the weighted sum.
+ */
+export function computeUpi(input: {
+  entities: EntityExtractionResult;
+  distress: DistressSignal;
+  vulnerability?: VulnerabilityFlags;
+  weights?: UpiWeights;
+}): UpiResult {
+  const w = input.weights ?? DEFAULT_WEIGHTS;
+  const aEsi = clamp01(input.entities.baseAcuity);
+  const sDistress = clamp01(input.distress.score);
+  const vPatient = vulnerabilityScore(input.vulnerability);
+
+  const acuityContribution = w.acuity * aEsi;
+  const distressContribution = w.distress * sDistress;
+  const vulnerabilityContribution = w.vulnerability * vPatient;
+  const weightedSum = clamp01(
+    acuityContribution + distressContribution + vulnerabilityContribution,
+  );
+
+  const hasActiveRedFlag = input.entities.activeEntities.some(
+    (e) => e.acuity >= RED_FLAG_ACUITY,
+  );
+  const redFlagFloorApplied = hasActiveRedFlag && weightedSum < RED_FLAG_FLOOR;
+  const score = clamp01(redFlagFloorApplied ? RED_FLAG_FLOOR : weightedSum);
+
+  const activeFlags = VULNERABILITY_CONTRIBUTIONS.filter(
+    (c) => input.vulnerability?.[c.key],
+  ).map((c) => c.label);
+
+  return {
+    score,
+    factors: {
+      acuity: {
+        value: aEsi,
+        weight: w.acuity,
+        contribution: acuityContribution,
+        entities: input.entities.entities.map(toFactorEntity),
+        suppressedCount: input.entities.entities.filter(
+          (e) => e.acuityClass !== "admin" && (e.negated || e.thirdParty),
+        ).length,
+      },
+      distress: {
+        value: sDistress,
+        weight: w.distress,
+        contribution: distressContribution,
+        capsRatio: input.distress.capsRatio,
+        exclamationCount: input.distress.exclamationCount,
+        panicTerms: input.distress.panicTerms,
+      },
+      vulnerability: {
+        value: vPatient,
+        weight: w.vulnerability,
+        contribution: vulnerabilityContribution,
+        activeFlags,
+      },
+      weightedSum,
+      redFlagFloorApplied,
+    },
+  };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,14 @@ const config: Config = {
         warning: "var(--warning)",
         danger: "var(--danger)",
         info: "var(--info)",
+        // Status accents — Fleet Command Directive (EMR-1160).
+        // Usage: bg-status-positive-bg text-status-positive-fg, etc.
+        "status-positive-bg": "var(--status-positive-bg)",
+        "status-positive-fg": "var(--status-positive-fg)",
+        "status-alert-bg": "var(--status-alert-bg)",
+        "status-alert-fg": "var(--status-alert-fg)",
+        "status-link-bg": "var(--status-link-bg)",
+        "status-link-fg": "var(--status-link-fg)",
       },
       fontFamily: {
         sans: ["var(--font-sans)"],


### PR DESCRIPTION
First implementation wave of the red-text requirements from "Scott_ LeafJourney Workflows Revisions.docx", tracked in the Linear project **WorkFlows Revisions — Zero-Click Ambient Intelligence (June 2026)**.

## What's in here

### 🚨 Deterministic UPI triage engine — EMR-1146 / EMR-1147, fixes EMR-1090
`src/lib/triage/upi/`: ESI-style entity lexicon with clause-scoped negation, third-party subject attribution, and abbreviation expansion; distress scoring; `UPI = 0.65·acuity + 0.15·distress + 0.20·vulnerability` with a 0.85 safety floor on active first-party red flags. `triageThread()` now uses UPI as the **primary** signal across all three callers; legacy keyword matching is advisory only and can no longer escalate on bare substring hits. Both EMR-1090 live failure modes (missed emergency / benign over-triage) are regression fixtures.

### 💊 Rx safety guardrail engine — EMR-1132 / EMR-1133 / EMR-1134
`src/lib/clinical/rx-safety/`: pure, Prisma-free `evaluateRxSafety(order, profile)` running three layers — CPIC PGx anchors (clopidogrel×CYP2C19, codeine/tramadol×CYP2D6 PM/UM, allopurinol×HLA-B*58:01), CKD-EPI 2021 eGFR + Child-Pugh dose caps with stale-lab low-confidence flags, and cannabinoid/botanical CYP anchors (CBD×anticoagulant → 25% reduction + INR recheck; CBD×clobazam cap; St. John's Wort hard block) layered on the existing `drug-interactions` database with PMID citations.

### 💰 Pre-flight denial probability engine — EMR-1137 / EMR-1138
`src/lib/billing/preflight/`: logistic `P_denial` (NCCI flag, modifier gap, Laplace-smoothed 180-day payer×CPT denial history, LCD distance, narrative semantics) with per-feature contribution breakdown; ≥0.35 hold / <0.10 release; typed root-cause findings with machine-applicable remediations and a `remediateAndRescore` fix→green loop. Reuses `scrubClaim`, payer rules, and the `DenialCategory` taxonomy.

### 🎨 Fleet Command Directive + status tokens — EMR-1159 / EMR-1160
Four Golden Axioms (≤2 clicks, single viewport, typing-reduction, Zen-Density) codified into CLAUDE.md + DESIGN_SYSTEM.md, plus sage/terracotta/slate status-accent tokens (light + dark) in globals.css/tailwind config.

Also: Product Manager subagent (`.claude/agents/product-manager.md`) and the archived red-text source (`docs/product-feedback/2026-06-12_workflows-revisions-red-text.md`).

## Verification
- New tests: 42 (triage) + 37 (rx-safety) + 23 (preflight) — all green
- Full vitest suite: 358 files / 3,281 tests passed (no regressions from the smart-inbox change)
- `tsc --noEmit` clean

## Safety posture
All engines are deterministic and human-in-the-loop: hard stops block signing but nothing auto-signs, auto-sends, or auto-submits. The 911/ED auto-reply is recorded as a decision payload; dispatch lands with the inbound gateway (EMR-1145).

https://claude.ai/code/session_01CM9Fun5gNmNSvt7TwxW15J

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM9Fun5gNmNSvt7TwxW15J)_