### PR TITLE
Workflows Revisions wave 2: Pre-Flight Claims Dashboard, inline Rx safety card, inbound SMS gateway + 911 auto-reply

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,9 @@ STORAGE_BUCKET=documents
 # Personal API key from Linear (Settings -> API -> Personal API keys).
 # Used by internal tooling to fetch issue specs + pinned briefing comments.
 LINEAR_API_KEY=
+
+# ---- Inbound SMS gateway (EMR-1145, /api/webhooks/sms-inbound) ----
+# Shared secret the SMS provider must send in the `x-sms-webhook-secret`
+# header. The route fails closed (503) when unset — generate with
+# `openssl rand -hex 32` and configure the same value on the provider side.
+SMS_WEBHOOK_SECRET=

--- a/docs/security/route-auth.yaml
+++ b/docs/security/route-auth.yaml
@@ -478,6 +478,12 @@ routes:
     owner: leafmart
     notes: "HMAC-SHA256 timing-safe verification, fail-closed on missing secret."
 
+  webhooks/sms-inbound:
+    methods: [POST]
+    auth: webhook
+    owner: communications
+    notes: "EMR-1145 inbound SMS gateway. Shared-secret header (SMS_WEBHOOK_SECRET), timing-safe compare, fail-closed (503) when unset. Sender verified by exact phone-digit match; unmatched/ambiguous senders quarantined to AuditLog dead-letter, never written to a chart."
+
   # ── Cron (inbound triggers) ───────────────────────────────
   cron/anomaly-sweep:
     methods: [POST]

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/prescribe-form-v2.tsx
@@ -60,6 +60,15 @@ import {
   assessHighRiskAttestation,
   psychiatricComorbidityLabels,
 } from "./high-risk-attestation";
+import type {
+  GuardrailFinding,
+  RxSafetyEvaluation,
+} from "@/lib/clinical/rx-safety/types";
+import {
+  RxGuardrailCard,
+  type GuardrailAdjustment,
+} from "./rx-guardrail-card";
+import { evaluateDraftRxAction, acceptRxSafetyRecommendationAction } from "./rx-safety-actions";
 
 /* ── Types ──────────────────────────────────────────────────── */
 
@@ -203,13 +212,27 @@ const MED_CLASS_TONE: Record<MedClass, "neutral" | "highlight" | "success" | "in
 
 /* ── Submit button ──────────────────────────────────────────── */
 
-function SubmitButton({ disabled }: { disabled?: boolean }) {
+function SubmitButton({
+  disabled,
+  alert,
+}: {
+  disabled?: boolean;
+  /** EMR-1135 — the order button changes color while a guardrail
+   *  modification recommendation is pending (Phase 6, status tokens). */
+  alert?: boolean;
+}) {
   const { pending } = useFormStatus();
   return (
     <Button
       type="submit"
       size="lg"
-      className="rounded-xl h-12 px-8 font-semibold"
+      variant={alert ? "secondary" : "primary"}
+      className={cn(
+        "rounded-xl h-12 px-8 font-semibold",
+        alert &&
+          "bg-status-alert-bg text-status-alert-fg border-[color:var(--status-alert-fg)]/30 " +
+            "hover:bg-status-alert-bg hover:text-status-alert-fg hover:border-[color:var(--status-alert-fg)]/50",
+      )}
       disabled={pending || disabled}
     >
       {pending ? "Signing & sending..." : "Sign & send ℞"}
@@ -519,6 +542,131 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     interactions.some((i) => i.severity === "red" || i.severity === "yellow") &&
     !visibleSafetyBoxes.some((b) => b.tier === "red" || b.tier === "yellow");
 
+  /* ── Ambient Optimization Canvas (EMR-1131/EMR-1135) ──────────
+     Guardrail engine evaluation of the drafted order against the patient's
+     multi-omic profile (PGx / organ clearance / botanical). Runs debounced
+     ~400ms after the drug name or dose configuration settles; findings render
+     as the inline card beside the medication fields — never a pop-up. */
+  const draftDrugName = selectedProduct
+    ? selectedProduct.name
+    : customProductName.trim();
+
+  // Structured total daily dose in mg, when the form can compute it.
+  const draftDailyDoseMg = useMemo(() => {
+    const dose = parseFloat(doseValue);
+    if (!Number.isFinite(dose) || dose <= 0) return undefined;
+    if (unitValue.trim().toLowerCase() !== "mg") return undefined;
+    return dose * frequencyPerDay;
+  }, [doseValue, unitValue, frequencyPerDay]);
+
+  const draftFrequency = freqMode === "free" ? freqFreeText.trim() : freqLabel;
+
+  const [rxSafety, setRxSafety] = useState<RxSafetyEvaluation | null>(null);
+  const [rxSafetyEvaluating, setRxSafetyEvaluating] = useState(false);
+  const [rxSafetyAccepting, setRxSafetyAccepting] = useState(false);
+  // Monotonic sequence guards against out-of-order responses.
+  const rxSafetySeq = useRef(0);
+
+  useEffect(() => {
+    if (!draftDrugName || draftDrugName.length < 3) {
+      rxSafetySeq.current += 1;
+      setRxSafety(null);
+      setRxSafetyEvaluating(false);
+      return;
+    }
+    const seq = ++rxSafetySeq.current;
+    setRxSafetyEvaluating(true);
+    const timer = setTimeout(async () => {
+      try {
+        const res = await evaluateDraftRxAction(patientId, {
+          drugName: draftDrugName,
+          dose: `${doseValue} ${unitValue}`.trim(),
+          route: productType.trim() || undefined,
+          frequency: draftFrequency || undefined,
+          dailyDoseMg: draftDailyDoseMg,
+        });
+        if (seq !== rxSafetySeq.current) return;
+        setRxSafety(res.ok ? res.evaluation : null);
+      } catch {
+        if (seq === rxSafetySeq.current) setRxSafety(null);
+      } finally {
+        if (seq === rxSafetySeq.current) setRxSafetyEvaluating(false);
+      }
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [
+    patientId,
+    draftDrugName,
+    doseValue,
+    unitValue,
+    productType,
+    draftFrequency,
+    draftDailyDoseMg,
+  ]);
+
+  const rxSafetyBlocking = rxSafety?.hasBlockingFinding ?? false;
+  // Hard stops disable signing entirely until the conflict is resolved
+  // (swap accepted or medication changed → re-evaluation clears the card).
+  const rxSafetyHardStop =
+    rxSafety?.findings.some((f) => f.kind === "hard_stop") ?? false;
+
+  const rxAdjustmentContext = useMemo(
+    () => ({ doseValue, unitValue, frequencyPerDay }),
+    [doseValue, unitValue, frequencyPerDay],
+  );
+
+  // One-click accept — applies the suggested swap/dose adjustment into the
+  // DRAFT fields only (provider still signs), records the acceptance in the
+  // chart ledger + server AuditLog, and lets the debounced effect re-run the
+  // evaluation so the card clears itself.
+  function handleGuardrailAccept(
+    finding: GuardrailFinding,
+    adjustment: GuardrailAdjustment,
+  ) {
+    const before = {
+      drugName: draftDrugName,
+      dose: `${doseValue} ${unitValue}`.trim(),
+    };
+    let after = before;
+    if (adjustment.type === "swap") {
+      setSelectedProductId("");
+      setCustomProductName(adjustment.drugName);
+      setMedQuery(adjustment.drugName);
+      after = { ...before, drugName: adjustment.drugName };
+    } else {
+      setDoseMode("free");
+      setDoseValue(adjustment.dose);
+      if (adjustment.unit && adjustment.unit !== unitValue) {
+        setUnitMode("preset");
+        setUnitValue(adjustment.unit);
+      }
+      setQuantityManual(false); // let quantity re-derive from the new dose
+      after = {
+        ...before,
+        dose: `${adjustment.dose} ${adjustment.unit || unitValue}`.trim(),
+      };
+    }
+
+    ledger.record({
+      kind: "acknowledge",
+      source: "Rx guardrail",
+      subject: `${finding.ruleId} — ${adjustment.label}`,
+      justification: finding.recommendation,
+    });
+
+    setRxSafetyAccepting(true);
+    void acceptRxSafetyRecommendationAction(patientId, {
+      ruleId: finding.ruleId,
+      kind: finding.kind,
+      layer: finding.layer,
+      recommendation: finding.recommendation,
+      adjustmentLabel: adjustment.label,
+      before,
+      after,
+      requiredFollowUp: finding.requiredFollowUp ?? [],
+    }).finally(() => setRxSafetyAccepting(false));
+  }
+
   /* ── CURES attestation (EMR-889) ──────────────────────────── */
   const CURES_ATTESTATIONS = [
     "Queried the CURES/PDMP database for this patient.",
@@ -611,6 +759,8 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
     !pharmacy ||
     unresolvedRed ||
     mustAckContraindication ||
+    // EMR-1135: hard-stop guardrail findings disable signing until resolved.
+    rxSafetyHardStop ||
     (isControlled && !curesAcknowledged) ||
     (highRiskAttestationRequired && !highRiskAcknowledged);
 
@@ -855,7 +1005,8 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
 
       {/* ── EMR-883: 2-column window (Medication | Dosing+Notes) ─ */}
       <div className="grid gap-4 lg:grid-cols-2 items-start">
-        {/* LEFT — Medication */}
+        {/* LEFT — Medication + Ambient Optimization Canvas */}
+        <div className="space-y-4">
         <Card className="rounded-2xl bg-white border-border/60 shadow-sm">
           <CardHeader className="pb-2">
             <CardTitle className="text-base flex items-center gap-2 flex-wrap">
@@ -1021,6 +1172,18 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
             </div>
           </CardContent>
         </Card>
+
+        {/* EMR-1131/EMR-1135 — inline optimization card beside the
+            medication fields. Renders nothing for a clean order; height
+            animates so the column never jumps. */}
+        <RxGuardrailCard
+          evaluation={rxSafety}
+          evaluating={rxSafetyEvaluating}
+          adjustmentContext={rxAdjustmentContext}
+          onAccept={handleGuardrailAccept}
+          accepting={rxSafetyAccepting}
+        />
+        </div>
 
         {/* RIGHT — Dosing & directions + Notes (EMR-887, EMR-891) */}
         <div className="space-y-4">
@@ -1480,9 +1643,16 @@ export function PrescribeFormV2(props: PrescribeFormV2Props) {
           >
             Prescription preview
           </Button>
-          <SubmitButton disabled={blocked} />
+          <SubmitButton disabled={blocked} alert={rxSafetyBlocking} />
         </div>
       </div>
+      {/* EMR-1135: ambient hint while a guardrail conflict blocks signing */}
+      {rxSafetyHardStop && (
+        <p className="text-[11px] text-status-alert-fg text-right">
+          A safety hard stop is active — resolve the conflict in the
+          optimization card to enable Sign &amp; send.
+        </p>
+      )}
       {/* EMR-1099 (M3): visible hint when the pharmacy gate blocks signing */}
       {!pharmacy && (
         <p className="text-[11px] text-danger text-right">

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-guardrail-card.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-guardrail-card.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * EMR-1131 / EMR-1135 — The Ambient Optimization Canvas.
+ *
+ * Inline optimization card rendered NEXT TO the medication fields on the
+ * prescribe form (never a modal/pop-up, per the red-text spec Phase 6 and
+ * the Fleet Command no-popup rule). Shows ranked guardrail findings (hard
+ * stops first) with mechanism, patient-specific rationale, recommendation,
+ * citations (CPIC level, lab dates) and queued follow-up labs.
+ *
+ * One-click accept: findings carrying an actionable recommendation expose an
+ * "Apply" button; the form applies the swap/dose adjustment into the DRAFT
+ * fields (the provider still reviews and signs), logs the acceptance, and
+ * re-evaluates — the card then clears on its own.
+ *
+ * Zen-Density: soft pastel fills (--status-* tokens), 16px padding grid, and
+ * a grid-rows height animation so the card never causes layout jumps.
+ */
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils/cn";
+import {
+  LOINC,
+  type GuardrailFinding,
+  type RxSafetyEvaluation,
+} from "@/lib/clinical/rx-safety/types";
+
+/* ── One-click adjustment resolution ─────────────────────────────────── */
+
+export type GuardrailAdjustment =
+  | { type: "swap"; drugName: string; label: string }
+  | { type: "dose"; dose: string; unit: string; label: string };
+
+export interface AdjustmentContext {
+  doseValue: string;
+  unitValue: string;
+  frequencyPerDay: number;
+}
+
+/**
+ * Safer-alternative swaps for rules whose recommendation names a specific
+ * replacement molecule (spec Phase 2 table). Strengths follow the usual
+ * starting strengths; the provider reviews dose/frequency before signing.
+ */
+const RULE_SWAPS: Record<string, string> = {
+  "pgx.clopidogrel.cyp2c19": "Ticagrelor 90mg",
+  "pgx.allopurinol.hlab5801": "Febuxostat 40mg",
+};
+
+function round2(n: number): string {
+  return String(Math.round(n * 100) / 100);
+}
+
+/**
+ * Map a finding to a concrete draft mutation, when one can be derived
+ * deterministically:
+ *   - rule-keyed molecule swaps (hard_substitution / HLA hard stop);
+ *   - details.suggestedDoseReductionPct (e.g. CBD × anticoagulant −25%);
+ *   - hepatic daily-dose caps ("≤2000 mg" parsed from the recommendation,
+ *     divided across the drafted frequency) when dosing in mg.
+ * Findings without a derivable mutation render without an Apply button —
+ * the provider acts on the prose recommendation manually.
+ */
+export function actionableAdjustment(
+  finding: GuardrailFinding,
+  ctx: AdjustmentContext
+): GuardrailAdjustment | null {
+  const swap = RULE_SWAPS[finding.ruleId];
+  if (swap) {
+    return { type: "swap", drugName: swap, label: `Switch to ${swap}` };
+  }
+
+  const dose = parseFloat(ctx.doseValue);
+  const doseIsUsable = Number.isFinite(dose) && dose > 0;
+
+  const pct = finding.details?.suggestedDoseReductionPct;
+  if (typeof pct === "number" && pct > 0 && pct < 100 && doseIsUsable) {
+    const next = round2(dose * (1 - pct / 100));
+    return {
+      type: "dose",
+      dose: next,
+      unit: ctx.unitValue,
+      label: `Reduce dose ${pct}% → ${next} ${ctx.unitValue}`,
+    };
+  }
+
+  // Hepatic cap: "Cap total daily dose at ≤2000 mg, …"
+  if (finding.ruleId === "organ.hepatic.dose_cap") {
+    const capMatch = finding.recommendation.match(/≤\s*(\d+(?:\.\d+)?)\s*mg/);
+    const exceeds = finding.details?.exceedsCap === true;
+    if (
+      capMatch &&
+      exceeds &&
+      doseIsUsable &&
+      ctx.unitValue.trim().toLowerCase() === "mg" &&
+      ctx.frequencyPerDay > 0
+    ) {
+      const capMg = parseFloat(capMatch[1]);
+      const next = round2(capMg / ctx.frequencyPerDay);
+      return {
+        type: "dose",
+        dose: next,
+        unit: "mg",
+        label: `Cap at ${capMg} mg/day → ${next} mg per dose`,
+      };
+    }
+  }
+
+  return null;
+}
+
+/* ── Presentation maps ───────────────────────────────────────────────── */
+
+const KIND_LABEL: Record<GuardrailFinding["kind"], string> = {
+  hard_stop: "Hard stop",
+  hard_substitution: "Substitution required",
+  dosing_override: "Dose adjustment",
+  optimization: "Optimization",
+  info: "Info",
+};
+
+const KIND_TONE: Record<
+  GuardrailFinding["kind"],
+  "danger" | "warning" | "info" | "neutral"
+> = {
+  hard_stop: "danger",
+  hard_substitution: "danger",
+  dosing_override: "warning",
+  optimization: "info",
+  info: "neutral",
+};
+
+const LAYER_LABEL: Record<GuardrailFinding["layer"], string> = {
+  pgx: "Genomic",
+  organ: "Organ clearance",
+  botanical: "Botanical",
+};
+
+const FOLLOW_UP_LAB_LABEL: Record<string, string> = {
+  [LOINC.INR]: "INR",
+  [LOINC.SERUM_CREATININE]: "Serum creatinine",
+  [LOINC.TOTAL_BILIRUBIN]: "Total bilirubin",
+  [LOINC.ALBUMIN]: "Albumin",
+};
+
+const BLOCKING_KINDS = new Set<GuardrailFinding["kind"]>([
+  "hard_stop",
+  "hard_substitution",
+]);
+
+/* ── Card ────────────────────────────────────────────────────────────── */
+
+export interface RxGuardrailCardProps {
+  evaluation: RxSafetyEvaluation | null;
+  /** True while a (debounced) evaluation is in flight. */
+  evaluating: boolean;
+  adjustmentContext: AdjustmentContext;
+  onAccept: (finding: GuardrailFinding, adjustment: GuardrailAdjustment) => void;
+  /** Disables Apply buttons while an acceptance is being logged. */
+  accepting?: boolean;
+}
+
+export function RxGuardrailCard({
+  evaluation,
+  evaluating,
+  adjustmentContext,
+  onAccept,
+  accepting = false,
+}: RxGuardrailCardProps) {
+  const findings = useMemo(() => evaluation?.findings ?? [], [evaluation]);
+  const open = findings.length > 0;
+  const blocking = evaluation?.hasBlockingFinding ?? false;
+
+  // Memoize adjustment resolution so render stays cheap while typing.
+  const adjustments = useMemo(
+    () => findings.map((f) => actionableAdjustment(f, adjustmentContext)),
+    [findings, adjustmentContext]
+  );
+
+  return (
+    <div
+      aria-live="polite"
+      className="grid transition-[grid-template-rows] duration-300 ease-smooth"
+      style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+    >
+      <div className="min-h-0 overflow-hidden">
+        <section
+          aria-label="Prescription safety guardrails"
+          className={cn(
+            "rounded-2xl border shadow-sm",
+            blocking
+              ? "bg-status-alert-bg/50 border-[color:var(--status-alert-fg)]/25"
+              : "bg-status-link-bg/40 border-[color:var(--status-link-fg)]/15"
+          )}
+        >
+          <header className="flex items-center justify-between gap-3 px-5 pt-4 pb-1">
+            <p
+              className={cn(
+                "text-[11px] font-semibold uppercase tracking-[0.14em]",
+                blocking
+                  ? "text-status-alert-fg"
+                  : "text-status-link-fg"
+              )}
+            >
+              Safety &amp; optimization
+            </p>
+            {evaluating ? (
+              <span className="text-[11px] text-text-subtle animate-pulse">
+                re-checking…
+              </span>
+            ) : (
+              evaluation && (
+                <span className="text-[11px] text-text-subtle">
+                  checked{" "}
+                  {new Date(evaluation.evaluatedAt).toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </span>
+              )
+            )}
+          </header>
+
+          <ul className="px-4 pb-4 pt-1 space-y-3">
+            {findings.map((finding, i) => (
+              <FindingRow
+                key={`${finding.ruleId}-${i}`}
+                finding={finding}
+                adjustment={adjustments[i]}
+                onAccept={onAccept}
+                accepting={accepting}
+              />
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function FindingRow({
+  finding,
+  adjustment,
+  onAccept,
+  accepting,
+}: {
+  finding: GuardrailFinding;
+  adjustment: GuardrailAdjustment | null;
+  onAccept: RxGuardrailCardProps["onAccept"];
+  accepting: boolean;
+}) {
+  const isBlocking = BLOCKING_KINDS.has(finding.kind);
+  return (
+    <li
+      className={cn(
+        "rounded-xl border bg-white/80 p-4 space-y-2",
+        isBlocking
+          ? "border-[color:var(--status-alert-fg)]/30"
+          : "border-border/70"
+      )}
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge tone={KIND_TONE[finding.kind]} className="uppercase text-[10px]">
+          {KIND_LABEL[finding.kind]}
+        </Badge>
+        <Badge tone="neutral" className="text-[10px]">
+          {LAYER_LABEL[finding.layer]}
+        </Badge>
+        {finding.lowConfidence && (
+          <span className="text-[11px] text-text-subtle italic">
+            stale labs — drawn &gt;180 days ago, verify before relying on this
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm text-text leading-relaxed">{finding.rationale}</p>
+      <p className="text-xs text-text-muted leading-snug">{finding.mechanism}</p>
+      <p className="text-sm font-medium text-text leading-snug">
+        {finding.recommendation}
+      </p>
+
+      {finding.requiredFollowUp && finding.requiredFollowUp.length > 0 && (
+        <p className="text-xs text-text-muted">
+          Follow-up on accept:{" "}
+          {finding.requiredFollowUp
+            .map(
+              (f) =>
+                `${FOLLOW_UP_LAB_LABEL[f.labLoinc] ?? `LOINC ${f.labLoinc}`} (${f.timing})`
+            )
+            .join(" · ")}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between gap-3 flex-wrap pt-1">
+        <p className="text-[11px] text-text-subtle">
+          {finding.citations.join(" · ")}
+        </p>
+        {adjustment && (
+          <button
+            type="button"
+            disabled={accepting}
+            onClick={() => onAccept(finding, adjustment)}
+            className={cn(
+              "shrink-0 rounded-full px-4 py-1.5 text-xs font-semibold transition-colors",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              isBlocking
+                ? "bg-status-alert-fg text-white hover:brightness-110"
+                : "bg-status-positive-bg text-status-positive-fg border border-[color:var(--status-positive-fg)]/25 hover:brightness-[0.97]"
+            )}
+          >
+            ✓ {adjustment.label}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-safety-actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/prescribe/rx-safety-actions.ts
@@ -1,0 +1,230 @@
+"use server";
+
+/**
+ * EMR-1131 / EMR-1135 — Ambient Optimization Canvas server actions.
+ *
+ * Wires the deterministic Rx safety guardrail engine
+ * (src/lib/clinical/rx-safety) into the live prescribe form:
+ *
+ *   - evaluateDraftRxAction: assembles the PatientRxProfile from Prisma
+ *     (labs by LOINC, active meds, botanical/cannabinoid exposures from the
+ *     product + dosing logs, sex/age) and runs evaluateRxSafety against the
+ *     drafted order. Called debounced from the form as the drug name/dose
+ *     fields resolve — no rows are written.
+ *
+ *   - acceptRxSafetyRecommendationAction: audit trail for the one-click
+ *     "apply recommendation" affordance. The draft mutation itself happens
+ *     client-side (the provider still reviews + signs); this action records
+ *     the acceptance in AuditLog using the same pattern as the refill
+ *     sign-off actions.
+ *
+ * TODO(EMR-1135 follow-up): persist blocking evaluations as FHIR
+ * DetectedIssue + the proposed alternative as a draft MedicationRequest
+ * (Phase 5 of the red-text spec). Deferred until the FHIR resource store
+ * lands; AuditLog rows carry the full finding payload meanwhile.
+ */
+
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  ForbiddenError,
+  assertChartAccess,
+  hasPermission,
+} from "@/lib/rbac/permissions";
+import {
+  evaluateRxSafety,
+  type RxSafetyEvaluation,
+} from "@/lib/clinical/rx-safety/evaluate";
+import { buildPatientRxProfile } from "@/lib/clinical/rx-safety/profile";
+
+// How far back the Organ Clearance Vault looks for labs. Wider than the
+// 180-day freshness window on purpose: stale labs still surface as
+// lowConfidence findings instead of silently disappearing.
+const LAB_LOOKBACK_DAYS = 730;
+// Recent dose logs window for the botanical/cannabinoid exposure manifest.
+const DOSE_LOG_LOOKBACK_DAYS = 90;
+
+const orderSchema = z.object({
+  drugName: z.string().min(2).max(200),
+  rxNormCui: z.string().max(20).optional(),
+  dose: z.string().max(60).optional(),
+  route: z.string().max(100).optional(),
+  frequency: z.string().max(100).optional(),
+  dailyDoseMg: z.number().positive().max(1_000_000).optional(),
+});
+
+export type EvaluateDraftRxResult =
+  | { ok: true; evaluation: RxSafetyEvaluation }
+  | { ok: false; error: string };
+
+/**
+ * Evaluate a drafted order against the patient's assembled Rx profile.
+ * Org-scoped + permission-gated like the neighboring prescribe action:
+ * requires prescriptions.write and chart access (privacy restrictions).
+ */
+export async function evaluateDraftRxAction(
+  patientId: string,
+  order: z.infer<typeof orderSchema>
+): Promise<EvaluateDraftRxResult> {
+  const user = await requireUser();
+  if (!hasPermission(user, "prescriptions.write")) {
+    return { ok: false, error: "Not permitted to draft prescriptions." };
+  }
+
+  const parsed = orderSchema.safeParse(order);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid draft order." };
+  }
+
+  try {
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Chart access denied." };
+    }
+    throw err;
+  }
+
+  const now = new Date();
+  const labSince = new Date(now.getTime() - LAB_LOOKBACK_DAYS * 86_400_000);
+  const logSince = new Date(
+    now.getTime() - DOSE_LOG_LOOKBACK_DAYS * 86_400_000
+  );
+
+  const productSelect = {
+    name: true,
+    thcConcentration: true,
+    cbdConcentration: true,
+    cbnConcentration: true,
+    cbgConcentration: true,
+  } as const;
+
+  const [patient, labResults, medications, dosingRegimens, doseLogs] =
+    await Promise.all([
+      prisma.patient.findFirst({
+        where: {
+          id: patientId,
+          organizationId: user.organizationId!,
+          deletedAt: null,
+        },
+        select: { id: true, dateOfBirth: true, intakeAnswers: true },
+      }),
+      prisma.labResult.findMany({
+        where: { patientId, receivedAt: { gte: labSince } },
+        orderBy: { receivedAt: "desc" },
+        select: { receivedAt: true, results: true },
+        take: 40,
+      }),
+      prisma.patientMedication.findMany({
+        where: { patientId, active: true },
+        select: { name: true, type: true, active: true },
+      }),
+      prisma.dosingRegimen.findMany({
+        where: { patientId, active: true },
+        select: { active: true, product: { select: productSelect } },
+        take: 50,
+      }),
+      prisma.doseLog.findMany({
+        where: { patientId, loggedAt: { gte: logSince } },
+        orderBy: { loggedAt: "desc" },
+        select: {
+          estimatedThcMg: true,
+          estimatedCbdMg: true,
+          regimen: { select: { product: { select: productSelect } } },
+        },
+        take: 100,
+      }),
+    ]);
+
+  if (!patient) return { ok: false, error: "Patient not found." };
+
+  const profile = buildPatientRxProfile(
+    { patient, labResults, medications, dosingRegimens, doseLogs },
+    now
+  );
+
+  const evaluation = await evaluateRxSafety(parsed.data, profile, now);
+  return { ok: true, evaluation };
+}
+
+const acceptSchema = z.object({
+  ruleId: z.string().min(1).max(120),
+  kind: z.string().min(1).max(40),
+  layer: z.string().min(1).max(40),
+  recommendation: z.string().max(2000),
+  adjustmentLabel: z.string().max(300),
+  before: z.object({
+    drugName: z.string().max(200),
+    dose: z.string().max(60),
+  }),
+  after: z.object({
+    drugName: z.string().max(200),
+    dose: z.string().max(60),
+  }),
+  requiredFollowUp: z
+    .array(z.object({ labLoinc: z.string().max(20), timing: z.string().max(100) }))
+    .max(10)
+    .default([]),
+});
+
+export type AcceptRxSafetyResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Record acceptance of a guardrail recommendation. The form has already
+ * applied the swap/dose adjustment to the DRAFT (nothing is signed); this
+ * writes the durable audit entry, same shape as refillRequest.approved.
+ */
+export async function acceptRxSafetyRecommendationAction(
+  patientId: string,
+  payload: z.infer<typeof acceptSchema>
+): Promise<AcceptRxSafetyResult> {
+  const user = await requireUser();
+  if (!hasPermission(user, "prescriptions.write")) {
+    return { ok: false, error: "Not permitted to draft prescriptions." };
+  }
+
+  const parsed = acceptSchema.safeParse(payload);
+  if (!parsed.success) return { ok: false, error: "Invalid payload." };
+
+  const patient = await prisma.patient.findFirst({
+    where: {
+      id: patientId,
+      organizationId: user.organizationId!,
+      deletedAt: null,
+    },
+    select: { id: true, organizationId: true },
+  });
+  if (!patient) return { ok: false, error: "Patient not found." };
+
+  try {
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) {
+      return { ok: false, error: "Chart access denied." };
+    }
+    throw err;
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: patient.organizationId,
+      actorUserId: user.id,
+      action: "rxSafety.recommendation.accepted",
+      subjectType: "Patient",
+      subjectId: patient.id,
+      metadata: {
+        ruleId: parsed.data.ruleId,
+        kind: parsed.data.kind,
+        layer: parsed.data.layer,
+        recommendation: parsed.data.recommendation,
+        adjustmentLabel: parsed.data.adjustmentLabel,
+        before: parsed.data.before,
+        after: parsed.data.after,
+        requiredFollowUp: parsed.data.requiredFollowUp,
+      },
+    },
+  });
+
+  return { ok: true };
+}

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -146,6 +146,8 @@ export default async function OperatorLayout({
       items: [
         { label: "Overview", href: "/ops/billing" },
         { label: "Scrub and Auths", href: "/ops/scrub" },
+        // EMR-1139 — denial-risk gate between scrub and submission.
+        { label: "Pre-Flight", href: "/ops/preflight" },
         { label: "Denials", href: "/ops/denials", badge: denialsBadge },
         { label: "Aging", href: "/ops/aging", badge: agingBadge },
         { label: "Eligibility", href: "/ops/eligibility" },

--- a/src/app/(operator)/ops/preflight/actions.ts
+++ b/src/app/(operator)/ops/preflight/actions.ts
@@ -1,0 +1,246 @@
+"use server";
+
+/**
+ * EMR-1139 — one-click remediation server action for the Pre-Flight
+ * Claims Dashboard (red-text spec, RCM Phase 6).
+ *
+ * Flow (mirrors the ops/billing + ops/queue mutation pattern: requireUser →
+ * role gate → org-scoped load → mutate → append-only AuditLog → revalidate):
+ *
+ *   1. Re-load the claim org-scoped and re-run the pre-flight engine
+ *      server-side — the client's requested fix is validated against the
+ *      CURRENT findings, never trusted blindly.
+ *   2. `remediateAndRescore` applies the typed RemediationAction and
+ *      re-scores (fix → re-run → green loop).
+ *   3. Persist the updated service lines back into Claim.cptCodes; a claim
+ *      that re-scores into the green zone (< 0.10) is promoted to "ready"
+ *      so the submission pipeline picks it up.
+ *   4. Write an append-only AuditLog row with the before/after scores.
+ *
+ * Only machine-applicable actions are accepted (append_modifier,
+ * remove_line). Documentation fixes stay human-in-the-loop: persisting
+ * engine-injected keywords into a clinical note would fabricate
+ * documentation, so those findings render as guidance only.
+ */
+
+import { revalidatePath } from "next/cache";
+import type { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import {
+  remediateAndRescore,
+  runPreflight,
+  PAYER_WINDOW_DAYS,
+  type Disposition,
+  type RemediationAction,
+  type RootCauseFinding,
+} from "@/lib/billing/preflight";
+import {
+  PREFLIGHT_CANDIDATE_STATUSES,
+  displayCode,
+  groupPayerHistory,
+  payerKey,
+  pickEncounterNarrative,
+  serviceLinesToCptJson,
+  toPreflightClaim,
+} from "./helpers";
+
+// Same role set the operator layout admits (mirrors the ops/queue action
+// allowlist pattern) — mutations are gated like every other operator write.
+const PREFLIGHT_MUTATION_ROLES = new Set(["operator", "practice_owner", "system"]);
+
+const remediationSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("append_modifier"),
+    claimId: z.string().min(1),
+    targetCode: z.string().min(1).max(10),
+    modifier: z.enum(["25", "59"]),
+  }),
+  z.object({
+    kind: z.literal("remove_line"),
+    claimId: z.string().min(1),
+    componentCode: z.string().min(1).max(10),
+  }),
+]);
+
+export type RemediationInput = z.infer<typeof remediationSchema>;
+
+export type RemediationResult =
+  | {
+      ok: true;
+      beforeScore: number;
+      afterScore: number;
+      afterDisposition: Disposition;
+      released: boolean;
+      findings: RootCauseFinding[];
+      cptDisplay: string[];
+      message: string;
+    }
+  | { ok: false; error: string };
+
+export async function applyPreflightRemediation(
+  input: RemediationInput,
+): Promise<RemediationResult> {
+  const user = await requireUser();
+  const organizationId = user.organizationId;
+  if (!organizationId) return { ok: false, error: "No organization in session." };
+  if (!user.roles.some((r) => PREFLIGHT_MUTATION_ROLES.has(r))) {
+    return { ok: false, error: "You don't have permission to remediate claims." };
+  }
+
+  const parsed = remediationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "Invalid remediation request." };
+  }
+  const payload = parsed.data;
+
+  // Org-scoped load; only pre-submission claims can be remediated.
+  const claim = await prisma.claim.findFirst({
+    where: {
+      id: payload.claimId,
+      organizationId,
+      status: { in: [...PREFLIGHT_CANDIDATE_STATUSES] },
+    },
+    select: {
+      id: true,
+      status: true,
+      payerName: true,
+      payerId: true,
+      providerId: true,
+      serviceDate: true,
+      cptCodes: true,
+      icd10Codes: true,
+      encounter: {
+        select: {
+          notes: {
+            select: { status: true, narrative: true, blocks: true, updatedAt: true },
+            orderBy: { updatedAt: "desc" },
+            take: 5,
+          },
+        },
+      },
+    },
+  });
+  if (!claim) {
+    return { ok: false, error: "Claim not found or already submitted." };
+  }
+
+  // Rebuild the engine inputs exactly as the page does.
+  const preflightClaim = toPreflightClaim(claim);
+  const context = {
+    narrativeNote: pickEncounterNarrative(claim.encounter?.notes ?? []),
+    providerId: claim.providerId,
+  };
+
+  const asOf = new Date();
+  let payerHistory: ReturnType<typeof groupPayerHistory> = new Map();
+  if (claim.payerName) {
+    const cutoff = new Date(asOf.getTime() - PAYER_WINDOW_DAYS * 86_400_000);
+    const adjudicated = await prisma.claim.findMany({
+      where: {
+        organizationId,
+        status: { in: ["paid", "denied", "partial"] },
+        payerName: { equals: claim.payerName, mode: "insensitive" },
+        OR: [{ paidAt: { gte: cutoff } }, { deniedAt: { gte: cutoff } }],
+      },
+      select: {
+        payerName: true,
+        payerId: true,
+        status: true,
+        cptCodes: true,
+        paidAt: true,
+        deniedAt: true,
+      },
+      take: 2000,
+    });
+    payerHistory = groupPayerHistory(adjudicated);
+  }
+  const options = {
+    asOf,
+    payerHistory: payerHistory.get(payerKey(claim.payerName) ?? "") ?? [],
+  };
+
+  // Validate the requested fix against the CURRENT findings — if the claim
+  // changed since the page rendered, the fix may no longer apply.
+  const current = runPreflight(preflightClaim, context, options);
+  const matching = current.findings.find((f) => actionMatches(f.action, payload));
+  if (!matching) {
+    return {
+      ok: false,
+      error: "This fix no longer applies to the claim — refresh the worklist.",
+    };
+  }
+
+  // Fix → re-run → (hopefully) green.
+  const run = remediateAndRescore(preflightClaim, context, matching.action, options);
+
+  const released = run.released;
+  const actionLabel =
+    payload.kind === "append_modifier"
+      ? `Appended Modifier-${payload.modifier} to ${payload.targetCode}`
+      : `Removed bundled line ${payload.componentCode}`;
+
+  // Persist the remediated codes + append-only audit trail atomically.
+  await prisma.$transaction([
+    prisma.claim.update({
+      where: { id: claim.id },
+      data: {
+        cptCodes: serviceLinesToCptJson(
+          run.claim.serviceLines,
+        ) as Prisma.InputJsonValue,
+        // Green-zone claims are released to the submission pipeline.
+        ...(released ? { status: "ready" } : {}),
+        // Every one-click fix is a human intervention on the claim.
+        humanTouches: { increment: 1 },
+      },
+    }),
+    prisma.auditLog.create({
+      data: {
+        organizationId,
+        actorUserId: user.id,
+        action: "billing.preflight.remediate",
+        subjectType: "Claim",
+        subjectId: claim.id,
+        metadata: {
+          remediation: payload,
+          findingCategory: matching.category,
+          beforeScore: run.before.score.score,
+          beforeDisposition: run.before.score.disposition,
+          afterScore: run.after.score.score,
+          afterDisposition: run.after.score.disposition,
+          released,
+          payerName: claim.payerName,
+        },
+      },
+    }),
+  ]);
+
+  revalidatePath("/ops/preflight");
+
+  return {
+    ok: true,
+    beforeScore: run.before.score.score,
+    afterScore: run.after.score.score,
+    afterDisposition: run.after.score.disposition,
+    released,
+    findings: run.after.findings,
+    cptDisplay: run.claim.serviceLines.map(displayCode),
+    message: released
+      ? `${actionLabel} — P(denial) dropped into the green zone. Released to submission.`
+      : `${actionLabel} — claim re-scored.`,
+  };
+}
+
+function actionMatches(action: RemediationAction, payload: RemediationInput): boolean {
+  if (payload.kind === "append_modifier") {
+    return (
+      action.kind === "append_modifier" &&
+      action.targetCode === payload.targetCode &&
+      action.modifier === payload.modifier
+    );
+  }
+  return (
+    action.kind === "remove_line" && action.componentCode === payload.componentCode
+  );
+}

--- a/src/app/(operator)/ops/preflight/error.tsx
+++ b/src/app/(operator)/ops/preflight/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageShell } from "@/components/shell/PageHeader";
+import { Eyebrow } from "@/components/ui/ornament";
+
+export default function PreflightError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[ops/preflight] error:", error);
+  }, [error]);
+
+  return (
+    <PageShell maxWidth="max-w-[720px]">
+      <Card tone="raised" className="border-l-4 border-l-danger">
+        <CardContent className="py-10 text-center">
+          <Eyebrow className="justify-center mb-3">
+            Something went wrong
+          </Eyebrow>
+          <h1 className="font-display text-2xl text-text tracking-tight">
+            Pre-Flight couldn&apos;t load
+          </h1>
+          <p className="text-sm text-text-muted mt-3 max-w-md mx-auto leading-relaxed">
+            {error.message || "An unexpected error occurred."}
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Button onClick={reset}>Try again</Button>
+            <Link href="/ops">
+              <Button variant="secondary">Back to overview</Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/preflight/helpers.test.ts
+++ b/src/app/(operator)/ops/preflight/helpers.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectHighlightTerms,
+  displayCode,
+  groupPayerHistory,
+  noteToNarrativeText,
+  parseServiceLines,
+  payerKey,
+  pickEncounterNarrative,
+  serviceLinesToCptJson,
+  splitNarrativeForEvidence,
+  toPreflightClaim,
+} from "./helpers";
+import type { RootCauseFinding } from "@/lib/billing/preflight";
+
+// ---------------------------------------------------------------------------
+// Claim JSON parsing
+// ---------------------------------------------------------------------------
+
+describe("parseServiceLines", () => {
+  it("maps the Claim.cptCodes JSON shape into engine service lines", () => {
+    const lines = parseServiceLines([
+      { code: "99214", label: "Office visit", units: 1, chargeAmount: 18500 },
+      { code: "96372", modifiers: ["59"] },
+    ]);
+    expect(lines).toEqual([
+      { code: "99214", label: "Office visit", units: 1, chargeAmount: 18500, modifiers: undefined },
+      { code: "96372", label: undefined, units: undefined, chargeAmount: undefined, modifiers: ["59"] },
+    ]);
+  });
+
+  it("drops malformed entries and non-array input", () => {
+    expect(parseServiceLines([{ code: 99214 }, null, { label: "x" }])).toEqual([]);
+    expect(parseServiceLines(null)).toEqual([]);
+    expect(parseServiceLines("nope")).toEqual([]);
+  });
+});
+
+describe("serviceLinesToCptJson", () => {
+  it("round-trips losslessly and omits empty modifier arrays", () => {
+    const json = [
+      { code: "99214", label: "Office visit", units: 1, chargeAmount: 18500 },
+      { code: "96372", modifiers: ["25"] },
+    ];
+    const round = serviceLinesToCptJson(parseServiceLines(json));
+    expect(round).toEqual([
+      { code: "99214", label: "Office visit", units: 1, chargeAmount: 18500 },
+      { code: "96372", modifiers: ["25"] },
+    ]);
+  });
+});
+
+describe("toPreflightClaim / displayCode", () => {
+  it("builds the engine claim shape from a Prisma row", () => {
+    const claim = toPreflightClaim({
+      id: "c1",
+      payerName: "Aetna",
+      payerId: "60054",
+      serviceDate: new Date("2026-06-01"),
+      cptCodes: [{ code: "99214", modifiers: ["25"] }],
+      icd10Codes: [{ code: "M54.5", label: "Low back pain" }],
+    });
+    expect(claim.claimId).toBe("c1");
+    expect(claim.serviceLines).toHaveLength(1);
+    expect(claim.icd10Codes[0]).toEqual({ code: "M54.5", label: "Low back pain" });
+    expect(displayCode(claim.serviceLines[0])).toBe("99214-25");
+    expect(displayCode({ code: "96372" })).toBe("96372");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Payer history grouping (one query → per-payer ClaimOutcomeRow buckets)
+// ---------------------------------------------------------------------------
+
+describe("groupPayerHistory", () => {
+  const paidAt = new Date("2026-05-01");
+  const deniedAt = new Date("2026-05-15");
+
+  it("expands one adjudicated claim into per-CPT outcome rows", () => {
+    const grouped = groupPayerHistory([
+      {
+        payerName: "Aetna",
+        payerId: "60054",
+        status: "denied",
+        cptCodes: [{ code: "99214" }, { code: "96372" }],
+        paidAt: null,
+        deniedAt,
+      },
+    ]);
+    const rows = grouped.get("aetna")!;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      payerName: "Aetna",
+      payerId: "60054",
+      cptCode: "99214",
+      outcome: "denied",
+      adjudicatedAt: deniedAt,
+    });
+  });
+
+  it("groups by case-insensitive trimmed payer name", () => {
+    const grouped = groupPayerHistory([
+      { payerName: "Aetna ", payerId: null, status: "paid", cptCodes: [{ code: "99213" }], paidAt, deniedAt: null },
+      { payerName: "AETNA", payerId: null, status: "denied", cptCodes: [{ code: "99213" }], paidAt: null, deniedAt },
+      { payerName: "Cigna", payerId: null, status: "paid", cptCodes: [{ code: "99213" }], paidAt, deniedAt: null },
+    ]);
+    expect(grouped.get("aetna")).toHaveLength(2);
+    expect(grouped.get("cigna")).toHaveLength(1);
+    expect(payerKey("  AETNA ")).toBe("aetna");
+    expect(payerKey(null)).toBeNull();
+  });
+
+  it("picks the status-appropriate adjudication timestamp", () => {
+    const grouped = groupPayerHistory([
+      { payerName: "Aetna", payerId: null, status: "paid", cptCodes: [{ code: "1" }], paidAt, deniedAt },
+      { payerName: "Aetna", payerId: null, status: "denied", cptCodes: [{ code: "2" }], paidAt, deniedAt },
+      { payerName: "Aetna", payerId: null, status: "partial", cptCodes: [{ code: "3" }], paidAt, deniedAt: null },
+    ]);
+    const rows = grouped.get("aetna")!;
+    expect(rows.find((r) => r.cptCode === "1")!.adjudicatedAt).toBe(paidAt);
+    expect(rows.find((r) => r.cptCode === "2")!.adjudicatedAt).toBe(deniedAt);
+    expect(rows.find((r) => r.cptCode === "3")!.adjudicatedAt).toBe(paidAt);
+  });
+
+  it("drops rows missing payer, date, codes, or with unknown statuses", () => {
+    const grouped = groupPayerHistory([
+      { payerName: null, payerId: null, status: "paid", cptCodes: [{ code: "1" }], paidAt, deniedAt: null },
+      { payerName: "Aetna", payerId: null, status: "paid", cptCodes: [{ code: "1" }], paidAt: null, deniedAt: null },
+      { payerName: "Aetna", payerId: null, status: "paid", cptCodes: [], paidAt, deniedAt: null },
+      { payerName: "Aetna", payerId: null, status: "voided", cptCodes: [{ code: "1" }], paidAt, deniedAt: null },
+    ]);
+    expect(grouped.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Narrative extraction
+// ---------------------------------------------------------------------------
+
+describe("narrative extraction", () => {
+  it("flattens note blocks and free-form narrative into one blob", () => {
+    const text = noteToNarrativeText({
+      narrative: "Free text tail.",
+      blocks: [
+        { type: "assessment", heading: "Assessment", body: "Chronic low back pain, worsening." },
+        { type: "plan", heading: "Plan", body: "" },
+      ],
+    });
+    expect(text).toBe("Chronic low back pain, worsening.\n\nFree text tail.");
+  });
+
+  it("prefers the newest finalized note over a newer draft", () => {
+    const narrative = pickEncounterNarrative([
+      { status: "draft", narrative: "draft text", blocks: null, updatedAt: new Date("2026-06-02") },
+      { status: "finalized", narrative: "final text", blocks: null, updatedAt: new Date("2026-06-01") },
+    ]);
+    expect(narrative).toBe("final text");
+  });
+
+  it("falls back to the newest draft, then to empty", () => {
+    expect(
+      pickEncounterNarrative([
+        { status: "draft", narrative: "old", blocks: null, updatedAt: new Date("2026-06-01") },
+        { status: "draft", narrative: "new", blocks: null, updatedAt: new Date("2026-06-02") },
+      ]),
+    ).toBe("new");
+    expect(pickEncounterNarrative([])).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Context-aware evidence highlighting
+// ---------------------------------------------------------------------------
+
+function finding(partial: Partial<RootCauseFinding>): RootCauseFinding {
+  return {
+    category: "modifier_deficiency",
+    denialCategory: "modifier",
+    drivingFeature: "modifierGap",
+    contribution: 2.7,
+    summary: "",
+    remediation: "",
+    action: { kind: "append_modifier", targetCode: "99214", modifier: "25" },
+    relatedCodes: [],
+    ...partial,
+  };
+}
+
+describe("collectHighlightTerms", () => {
+  it("includes Modifier-25 evidence phrases when a modifier finding exists", () => {
+    const terms = collectHighlightTerms([finding({})], ["99214", "96372"]);
+    expect(terms).toContain("separately identifiable");
+  });
+
+  it("includes LCD documentation keywords for the claim's CPTs", () => {
+    const terms = collectHighlightTerms([], ["70553"]);
+    expect(terms).toContain("treatment failure");
+    expect(terms).toContain("red flag");
+    // No modifier finding → no Mod-25 phrases.
+    expect(terms).not.toContain("separately identifiable");
+  });
+
+  it("includes the missing keywords from augment_documentation actions", () => {
+    const terms = collectHighlightTerms(
+      [
+        finding({
+          category: "medical_necessity_deficit",
+          action: { kind: "augment_documentation", targetCode: "70553", requiredKeywords: ["Papilledema"] },
+        }),
+      ],
+      [],
+    );
+    expect(terms).toContain("papilledema");
+  });
+});
+
+describe("splitNarrativeForEvidence", () => {
+  it("marks sentences containing a highlight term, case-insensitively", () => {
+    const sentences = splitNarrativeForEvidence(
+      "Patient seen for follow-up. A separately identifiable evaluation was performed for new wrist pain! Plan unchanged.",
+      ["separately identifiable"],
+    );
+    expect(sentences.map((s) => s.highlight)).toEqual([false, true, false]);
+    expect(sentences[1].matchedTerms).toEqual(["separately identifiable"]);
+  });
+
+  it("splits on newlines too and skips blanks", () => {
+    const sentences = splitNarrativeForEvidence("Line one\n\nLine two with red flag", ["red flag"]);
+    expect(sentences).toHaveLength(2);
+    expect(sentences[1].highlight).toBe(true);
+  });
+
+  it("returns no sentences for an empty narrative", () => {
+    expect(splitNarrativeForEvidence("", ["x"])).toEqual([]);
+  });
+});

--- a/src/app/(operator)/ops/preflight/helpers.ts
+++ b/src/app/(operator)/ops/preflight/helpers.ts
@@ -1,0 +1,305 @@
+/**
+ * EMR-1139 — pure helpers for the Pre-Flight Claims Dashboard.
+ *
+ * Everything in this file is synchronous and side-effect free (no Prisma,
+ * no network) so it can be unit-tested directly (see helpers.test.ts) and
+ * shared between the server page and the remediation server action.
+ *
+ * The heavy lifting (feature extraction, P_denial scoring, root-cause
+ * attribution, one-click remediation) lives in the pre-flight engine —
+ * src/lib/billing/preflight — and is consumed strictly via its public
+ * exports per the engine's input contract.
+ */
+
+import type {
+  ClaimOutcomeRow,
+  PreflightClaim,
+  PreflightServiceLine,
+  RootCauseFinding,
+} from "@/lib/billing/preflight";
+import { PREFLIGHT_LCD_RULES } from "@/lib/billing/preflight";
+
+// ---------------------------------------------------------------------------
+// Candidate selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-submission claims the pre-flight gate evaluates: drafts still being
+ * coded plus "ready" claims awaiting submission (scrub passed). Mirrors the
+ * "ready to submit" population the scrub workbench queries — the gate sits
+ * between coding_scrub and submission, so already-submitted statuses are
+ * out of scope.
+ */
+export const PREFLIGHT_CANDIDATE_STATUSES = ["draft", "ready"] as const;
+
+// ---------------------------------------------------------------------------
+// Claim JSON → engine input shapes
+// ---------------------------------------------------------------------------
+
+/** Loose shape of one entry in Claim.cptCodes / Claim.icd10Codes JSON. */
+interface CodeJsonEntry {
+  code?: unknown;
+  label?: unknown;
+  units?: unknown;
+  chargeAmount?: unknown;
+  modifiers?: unknown;
+}
+
+/** Parse the Claim.cptCodes JSON column into engine service lines. */
+export function parseServiceLines(cptCodesJson: unknown): PreflightServiceLine[] {
+  if (!Array.isArray(cptCodesJson)) return [];
+  const lines: PreflightServiceLine[] = [];
+  for (const raw of cptCodesJson as CodeJsonEntry[]) {
+    if (!raw || typeof raw.code !== "string" || raw.code.length === 0) continue;
+    lines.push({
+      code: raw.code,
+      label: typeof raw.label === "string" ? raw.label : undefined,
+      units: typeof raw.units === "number" ? raw.units : undefined,
+      chargeAmount:
+        typeof raw.chargeAmount === "number" ? raw.chargeAmount : undefined,
+      modifiers: Array.isArray(raw.modifiers)
+        ? (raw.modifiers as unknown[]).filter(
+            (m): m is string => typeof m === "string",
+          )
+        : undefined,
+    });
+  }
+  return lines;
+}
+
+/** Parse the Claim.icd10Codes JSON column into engine diagnosis entries. */
+export function parseIcdCodes(
+  icd10CodesJson: unknown,
+): Array<{ code: string; label?: string }> {
+  if (!Array.isArray(icd10CodesJson)) return [];
+  const codes: Array<{ code: string; label?: string }> = [];
+  for (const raw of icd10CodesJson as CodeJsonEntry[]) {
+    if (!raw || typeof raw.code !== "string" || raw.code.length === 0) continue;
+    codes.push({
+      code: raw.code,
+      label: typeof raw.label === "string" ? raw.label : undefined,
+    });
+  }
+  return codes;
+}
+
+/** Minimal claim row the page/action select for the engine input. */
+export interface CandidateClaimInput {
+  id: string;
+  payerName: string | null;
+  payerId: string | null;
+  serviceDate: Date;
+  cptCodes: unknown;
+  icd10Codes: unknown;
+}
+
+export function toPreflightClaim(claim: CandidateClaimInput): PreflightClaim {
+  return {
+    claimId: claim.id,
+    payerName: claim.payerName,
+    payerId: claim.payerId,
+    serviceDate: claim.serviceDate,
+    serviceLines: parseServiceLines(claim.cptCodes),
+    icd10Codes: parseIcdCodes(claim.icd10Codes),
+  };
+}
+
+/** Map engine service lines back into the Claim.cptCodes JSON shape so a
+ *  remediated claim persists losslessly (label/units/chargeAmount kept). */
+export function serviceLinesToCptJson(
+  lines: PreflightServiceLine[],
+): Array<Record<string, unknown>> {
+  return lines.map((l) => {
+    const entry: Record<string, unknown> = { code: l.code };
+    if (l.label !== undefined) entry.label = l.label;
+    if (l.units !== undefined) entry.units = l.units;
+    if (l.chargeAmount !== undefined) entry.chargeAmount = l.chargeAmount;
+    if (l.modifiers !== undefined && l.modifiers.length > 0)
+      entry.modifiers = l.modifiers;
+    return entry;
+  });
+}
+
+/** "99214" → "99214-25" when modifiers are present (worklist display). */
+export function displayCode(line: PreflightServiceLine): string {
+  const mods = line.modifiers ?? [];
+  return mods.length > 0 ? `${line.code}-${mods.join("-")}` : line.code;
+}
+
+// ---------------------------------------------------------------------------
+// Narrative note extraction (Encounter → Note → text)
+// ---------------------------------------------------------------------------
+
+interface NoteRow {
+  status: string;
+  narrative: string | null;
+  blocks: unknown;
+  updatedAt: Date;
+}
+
+/** Flatten a Note's structured blocks + free-form narrative into one text
+ *  blob for the engine's phi_narrative extractor. */
+export function noteToNarrativeText(note: Pick<NoteRow, "narrative" | "blocks">): string {
+  const parts: string[] = [];
+  if (Array.isArray(note.blocks)) {
+    for (const raw of note.blocks as Array<{ heading?: unknown; body?: unknown }>) {
+      if (raw && typeof raw.body === "string" && raw.body.trim().length > 0) {
+        parts.push(raw.body.trim());
+      }
+    }
+  }
+  if (note.narrative && note.narrative.trim().length > 0) {
+    parts.push(note.narrative.trim());
+  }
+  return parts.join("\n\n");
+}
+
+/** Prefer the most recent finalized note, falling back to the most recent
+ *  draft, falling back to empty (the engine treats it as a thin note). */
+export function pickEncounterNarrative(notes: NoteRow[]): string {
+  const sorted = [...notes].sort(
+    (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+  );
+  const best =
+    sorted.find((n) => n.status === "finalized") ?? sorted[0] ?? null;
+  return best ? noteToNarrativeText(best) : "";
+}
+
+// ---------------------------------------------------------------------------
+// Payer history — one adjudicated-claims query, grouped by payer
+// ---------------------------------------------------------------------------
+
+/** Shape of the single adjudicated-outcomes query the page runs (claims
+ *  with a payer decision in the rolling window). */
+export interface AdjudicatedClaimRow {
+  payerName: string | null;
+  payerId: string | null;
+  status: string; // paid | denied | partial (filtered in the query)
+  cptCodes: unknown;
+  paidAt: Date | null;
+  deniedAt: Date | null;
+}
+
+export function payerKey(payerName: string | null | undefined): string | null {
+  const trimmed = payerName?.trim().toLowerCase();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+const OUTCOME_BY_STATUS: Record<string, ClaimOutcomeRow["outcome"]> = {
+  paid: "paid",
+  denied: "denied",
+  partial: "partial",
+};
+
+/**
+ * Expand adjudicated claims into per-(claim, CPT) ClaimOutcomeRows — the
+ * engine's payerHistory contract — and group them by payer so the page
+ * runs ONE history query and each claim's runPreflight only sees its own
+ * payer's rows. Rows without a payer name or an adjudication date are
+ * dropped (the engine's window filter needs a real timestamp).
+ */
+export function groupPayerHistory(
+  rows: AdjudicatedClaimRow[],
+): Map<string, ClaimOutcomeRow[]> {
+  const byPayer = new Map<string, ClaimOutcomeRow[]>();
+  for (const row of rows) {
+    const key = payerKey(row.payerName);
+    if (!key) continue;
+    const outcome = OUTCOME_BY_STATUS[row.status];
+    if (!outcome) continue;
+    const adjudicatedAt =
+      outcome === "denied"
+        ? (row.deniedAt ?? row.paidAt)
+        : (row.paidAt ?? row.deniedAt);
+    if (!adjudicatedAt) continue;
+    const lines = parseServiceLines(row.cptCodes);
+    if (lines.length === 0) continue;
+    const bucket = byPayer.get(key) ?? [];
+    for (const line of lines) {
+      bucket.push({
+        payerName: row.payerName!,
+        payerId: row.payerId,
+        cptCode: line.code,
+        outcome,
+        adjudicatedAt,
+      });
+    }
+    byPayer.set(key, bucket);
+  }
+  return byPayer;
+}
+
+// ---------------------------------------------------------------------------
+// Context-aware evidence — narrative sentences + highlight terms
+// ---------------------------------------------------------------------------
+
+/**
+ * Phrases the engine's Modifier-25 evidence scanner looks for in the note
+ * (mirrors MOD25_EVIDENCE_PHRASES in src/lib/billing/preflight/features.ts,
+ * which is not exported — keep in sync).
+ */
+export const MOD25_HIGHLIGHT_PHRASES = [
+  "separately identifiable",
+  "separate evaluation",
+  "separate and distinct",
+  "distinct service",
+  "in addition to",
+  "unrelated to the",
+  "separate e/m",
+  "separate assessment",
+];
+
+/**
+ * Build the set of phrases worth highlighting in the narrative for a given
+ * claim: Modifier-25 evidence phrases when a modifier finding exists, plus
+ * every LCD documentation keyword for the claim's CPTs (both the present
+ * ones — proof of coverage — and the missing ones, which simply won't
+ * match anything).
+ */
+export function collectHighlightTerms(
+  findings: RootCauseFinding[],
+  cptCodes: string[],
+): string[] {
+  const terms = new Set<string>();
+  if (findings.some((f) => f.category === "modifier_deficiency")) {
+    for (const p of MOD25_HIGHLIGHT_PHRASES) terms.add(p);
+  }
+  const cptSet = new Set(cptCodes);
+  for (const rule of PREFLIGHT_LCD_RULES) {
+    if (!cptSet.has(rule.cptCode)) continue;
+    for (const k of rule.requiredDocKeywords) terms.add(k.toLowerCase());
+  }
+  for (const f of findings) {
+    if (f.action.kind === "augment_documentation") {
+      for (const k of f.action.requiredKeywords) terms.add(k.toLowerCase());
+    }
+  }
+  return [...terms];
+}
+
+export interface EvidenceSentence {
+  text: string;
+  highlight: boolean;
+  /** Which highlight terms this sentence matched (tooltip/aria use). */
+  matchedTerms: string[];
+}
+
+/**
+ * Split the narrative into sentences and mark the ones containing any
+ * highlight term — the inline "Review narrative note context" panel.
+ */
+export function splitNarrativeForEvidence(
+  narrative: string,
+  terms: string[],
+): EvidenceSentence[] {
+  const normalizedTerms = terms.map((t) => t.toLowerCase()).filter(Boolean);
+  return narrative
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((text) => {
+      const lower = text.toLowerCase();
+      const matchedTerms = normalizedTerms.filter((t) => lower.includes(t));
+      return { text, highlight: matchedTerms.length > 0, matchedTerms };
+    });
+}

--- a/src/app/(operator)/ops/preflight/loading.tsx
+++ b/src/app/(operator)/ops/preflight/loading.tsx
@@ -1,0 +1,40 @@
+import { PageShell } from "@/components/shell/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PreflightLoading() {
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <div className="mb-6">
+        <Skeleton className="h-3 w-32 mb-3" />
+        <Skeleton className="h-9 w-64 mb-2" />
+        <Skeleton className="h-4 w-96" />
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        {[...Array(4)].map((_, i) => (
+          <Card key={i} tone="raised">
+            <CardContent className="pt-5 pb-5">
+              <Skeleton className="h-9 w-16 mb-1" />
+              <Skeleton className="h-3 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        {[...Array(4)].map((_, i) => (
+          <Card key={i} tone="raised">
+            <CardContent className="py-5 flex items-center gap-5">
+              <Skeleton className="h-11 w-[76px] rounded-full" />
+              <div className="flex-1">
+                <Skeleton className="h-4 w-48 mb-2" />
+                <Skeleton className="h-3 w-72" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/preflight/page.tsx
+++ b/src/app/(operator)/ops/preflight/page.tsx
@@ -1,0 +1,171 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { formatDate, formatMoney } from "@/lib/utils/format";
+import {
+  runPreflight,
+  PAYER_WINDOW_DAYS,
+  type ClaimOutcomeRow,
+} from "@/lib/billing/preflight";
+import {
+  PREFLIGHT_CANDIDATE_STATUSES,
+  collectHighlightTerms,
+  displayCode,
+  groupPayerHistory,
+  payerKey,
+  pickEncounterNarrative,
+  splitNarrativeForEvidence,
+  toPreflightClaim,
+} from "./helpers";
+import {
+  PreflightWorklist,
+  type PreflightRow,
+  type PreflightTile,
+} from "./preflight-worklist";
+
+// EMR-1139 — Pre-Flight Claims Dashboard (red-text spec, RCM Phases 5–6).
+export const metadata = { title: "Pre-Flight" };
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default async function PreflightPage() {
+  const user = await requireUser();
+  const organizationId = user.organizationId!;
+  const asOf = new Date();
+
+  // Pre-submission claims (drafts in coding + "ready" awaiting submission)
+  // — the population the pre-flight gate evaluates before the EDI 837
+  // compiler ever sees them. Same org-scoped access pattern as /ops/scrub.
+  const claims = await prisma.claim.findMany({
+    where: {
+      organizationId,
+      status: { in: [...PREFLIGHT_CANDIDATE_STATUSES] },
+    },
+    select: {
+      id: true,
+      claimNumber: true,
+      status: true,
+      payerName: true,
+      payerId: true,
+      providerId: true,
+      serviceDate: true,
+      billedAmountCents: true,
+      cptCodes: true,
+      icd10Codes: true,
+      patient: { select: { id: true, firstName: true, lastName: true } },
+      encounter: {
+        select: {
+          notes: {
+            select: { status: true, narrative: true, blocks: true, updatedAt: true },
+            orderBy: { updatedAt: "desc" },
+            take: 5,
+          },
+        },
+      },
+    },
+    orderBy: { serviceDate: "desc" },
+    take: 50,
+  });
+
+  // One adjudicated-outcomes query for the whole page (engine contract:
+  // the caller feeds payerHistory; querying per claim would be N+1).
+  // Rolling 180-day window over paid/denied/partial decisions, grouped by
+  // payer so each claim's run only sees its own payer's rows.
+  const cutoff = new Date(asOf.getTime() - PAYER_WINDOW_DAYS * 86_400_000);
+  const adjudicated = await prisma.claim.findMany({
+    where: {
+      organizationId,
+      status: { in: ["paid", "denied", "partial"] },
+      OR: [{ paidAt: { gte: cutoff } }, { deniedAt: { gte: cutoff } }],
+    },
+    select: {
+      payerName: true,
+      payerId: true,
+      status: true,
+      cptCodes: true,
+      paidAt: true,
+      deniedAt: true,
+    },
+    take: 2000,
+  });
+  const historyByPayer = groupPayerHistory(adjudicated);
+  const EMPTY_HISTORY: ClaimOutcomeRow[] = [];
+
+  // Run the pre-flight engine on every candidate, server-side.
+  const rows: PreflightRow[] = claims.map((claim) => {
+    const preflightClaim = toPreflightClaim(claim);
+    const narrativeNote = pickEncounterNarrative(claim.encounter?.notes ?? []);
+    const result = runPreflight(
+      preflightClaim,
+      { narrativeNote, providerId: claim.providerId },
+      {
+        asOf,
+        payerHistory:
+          historyByPayer.get(payerKey(claim.payerName) ?? "") ?? EMPTY_HISTORY,
+      },
+    );
+
+    // Context-aware evidence: the note split into sentences with the
+    // engine-relevant phrases (Mod-25 evidence, LCD keywords) marked.
+    const cptCodes = preflightClaim.serviceLines.map((l) => l.code);
+    const highlightTerms = collectHighlightTerms(result.findings, cptCodes);
+    const evidence = splitNarrativeForEvidence(narrativeNote, highlightTerms);
+
+    return {
+      id: claim.id,
+      claimNumber: claim.claimNumber,
+      status: claim.status,
+      patientId: claim.patient.id,
+      patientName: `${claim.patient.firstName} ${claim.patient.lastName}`,
+      payerName: claim.payerName,
+      serviceDateLabel: formatDate(claim.serviceDate),
+      billedLabel: formatMoney(claim.billedAmountCents),
+      billedAmountCents: claim.billedAmountCents,
+      cptDisplay: preflightClaim.serviceLines.map(displayCode),
+      icdDisplay: preflightClaim.icd10Codes.map((i) => i.code),
+      score: result.score.score,
+      disposition: result.score.disposition,
+      findings: result.findings,
+      evidence,
+      payerSampleSize: result.features.details.payerHistory.sampleSize,
+    };
+  });
+
+  // Highest risk first — staff work the worklist top-down.
+  rows.sort((a, b) => b.score - a.score);
+
+  const holds = rows.filter((r) => r.disposition === "hold");
+  const reviews = rows.filter((r) => r.disposition === "review");
+  const releases = rows.filter((r) => r.disposition === "release");
+  const dollarsHeld = holds.reduce((acc, r) => acc + r.billedAmountCents, 0);
+
+  const tiles: PreflightTile[] = [
+    { label: "In pre-flight", value: rows.length.toString(), tone: "neutral" },
+    {
+      label: "Held",
+      value: holds.length.toString(),
+      tone: "danger",
+      hint: holds.length > 0 ? `${formatMoney(dollarsHeld)} held` : undefined,
+    },
+    { label: "Needs review", value: reviews.length.toString(), tone: "warning" },
+    {
+      label: "Green — clear to submit",
+      value: releases.length.toString(),
+      tone: "success",
+    },
+  ];
+
+  return (
+    <PageShell maxWidth="max-w-[1320px]">
+      <PageHeader
+        eyebrow="Practice management"
+        title="Pre-Flight"
+        description="Every claim is scored for denial risk before it reaches the EDI 837 compiler. Held claims show exactly why — with the note evidence inline — and most fixes are one click."
+      />
+
+      <PreflightWorklist rows={rows} tiles={tiles} />
+    </PageShell>
+  );
+}

--- a/src/app/(operator)/ops/preflight/preflight-worklist.tsx
+++ b/src/app/(operator)/ops/preflight/preflight-worklist.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+/**
+ * EMR-1139 — interactive worklist for the Pre-Flight Claims Dashboard.
+ *
+ * Fleet Command Directive compliance:
+ *   - ≤2 clicks: click a row to expand (the riskiest row starts expanded),
+ *     click the fix — done. No wizards, no confirmation pop-ups.
+ *   - No pop-ups: the narrative evidence panel is an inline expanding
+ *     section, never a modal.
+ *   - Zen-Density: 16–24px padding grid, soft pastel --status-* tokens for
+ *     dispositions, information appears only when a row is expanded.
+ */
+
+import * as React from "react";
+import { useState, useTransition } from "react";
+import { ChevronDown, FileText, Sparkles, Wrench } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { StatCard, type StatCardTone } from "@/components/ui/stat-card";
+import { useToast } from "@/components/ui/toast";
+import { cn } from "@/lib/utils/cn";
+import type {
+  DeficiencyCategory,
+  Disposition,
+  RootCauseFinding,
+} from "@/lib/billing/preflight";
+import type { EvidenceSentence } from "./helpers";
+import {
+  applyPreflightRemediation,
+  type RemediationInput,
+} from "./actions";
+
+// ---------------------------------------------------------------------------
+// Serialized prop shapes (computed server-side in page.tsx)
+// ---------------------------------------------------------------------------
+
+export interface PreflightRow {
+  id: string;
+  claimNumber: string | null;
+  status: string;
+  patientId: string;
+  patientName: string;
+  payerName: string | null;
+  serviceDateLabel: string;
+  billedLabel: string;
+  billedAmountCents: number;
+  cptDisplay: string[];
+  icdDisplay: string[];
+  score: number;
+  disposition: Disposition;
+  findings: RootCauseFinding[];
+  evidence: EvidenceSentence[];
+  /** In-window adjudication rows behind the payer-history feature. */
+  payerSampleSize: number;
+}
+
+export interface PreflightTile {
+  label: string;
+  value: string;
+  tone: StatCardTone;
+  hint?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Disposition + category vocab (soft pastel --status-* tokens)
+// ---------------------------------------------------------------------------
+
+const DISPOSITION_PILL: Record<Disposition, { label: string; className: string }> = {
+  hold: { label: "Hold", className: "bg-status-alert-bg text-status-alert-fg" },
+  review: { label: "Review", className: "bg-status-link-bg text-status-link-fg" },
+  release: {
+    label: "Release",
+    className: "bg-status-positive-bg text-status-positive-fg",
+  },
+};
+
+const GAUGE_COLOR: Record<Disposition, string> = {
+  hold: "var(--status-alert-fg)",
+  review: "var(--status-link-fg)",
+  release: "var(--status-positive-fg)",
+};
+
+const CATEGORY_LABEL: Record<DeficiencyCategory, string> = {
+  modifier_deficiency: "Modifier deficiency",
+  medical_necessity_deficit: "Medical necessity",
+  unbundling_conflict: "Unbundling conflict",
+  payer_history_risk: "Payer history",
+  documentation_quality: "Documentation quality",
+};
+
+function formatPct(score: number): string {
+  return `${Math.round(score * 100)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Risk gauge — P_denial as a semicircular arc
+// ---------------------------------------------------------------------------
+
+function RiskGauge({ score, disposition }: { score: number; disposition: Disposition }) {
+  // Semicircle of radius 28 → arc length π·28.
+  const ARC = Math.PI * 28;
+  const filled = Math.min(1, Math.max(0, score)) * ARC;
+  return (
+    <div
+      className="relative shrink-0"
+      role="meter"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(score * 100)}
+      aria-label={`Denial probability ${formatPct(score)}`}
+    >
+      <svg width="76" height="46" viewBox="0 0 76 46" aria-hidden="true">
+        <path
+          d="M 10 42 A 28 28 0 0 1 66 42"
+          fill="none"
+          stroke="var(--surface-muted)"
+          strokeWidth="7"
+          strokeLinecap="round"
+        />
+        <path
+          d="M 10 42 A 28 28 0 0 1 66 42"
+          fill="none"
+          stroke={GAUGE_COLOR[disposition]}
+          strokeWidth="7"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${ARC}`}
+          className="transition-all duration-500 ease-smooth"
+        />
+      </svg>
+      <div className="absolute inset-x-0 bottom-0 text-center">
+        <span className="font-display text-sm text-text tabular-nums">
+          {formatPct(score)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DispositionPill({ disposition }: { disposition: Disposition }) {
+  const pill = DISPOSITION_PILL[disposition];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-medium tracking-wide",
+        pill.className,
+      )}
+    >
+      {pill.label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-row state after a one-click fix
+// ---------------------------------------------------------------------------
+
+interface RowOverride {
+  beforeScore: number;
+  score: number;
+  disposition: Disposition;
+  released: boolean;
+  findings: RootCauseFinding[];
+  cptDisplay: string[];
+}
+
+interface WorklistProps {
+  rows: PreflightRow[];
+  tiles: PreflightTile[];
+}
+
+export function PreflightWorklist({ rows, tiles }: WorklistProps) {
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [overrides, setOverrides] = useState<Record<string, RowOverride>>({});
+  // The riskiest claim starts expanded so the first fix is a single click.
+  const [expandedId, setExpandedId] = useState<string | null>(
+    rows.length > 0 && rows[0].disposition !== "release" ? rows[0].id : null,
+  );
+  const [evidenceOpenId, setEvidenceOpenId] = useState<string | null>(null);
+
+  const remediate = (row: PreflightRow, input: RemediationInput, key: string) => {
+    setPendingKey(key);
+    startTransition(async () => {
+      const result = await applyPreflightRemediation(input);
+      setPendingKey(null);
+      if (!result.ok) {
+        toast({ title: "Couldn't apply the fix", description: result.error, variant: "error" });
+        return;
+      }
+      setOverrides((prev) => ({
+        ...prev,
+        [row.id]: {
+          // Keep the ORIGINAL score across successive fixes on one claim.
+          beforeScore: prev[row.id]?.beforeScore ?? row.score,
+          score: result.afterScore,
+          disposition: result.afterDisposition,
+          released: result.released,
+          findings: result.findings,
+          cptDisplay: result.cptDisplay,
+        },
+      }));
+      toast({
+        title: result.released ? "Released to submission" : "Claim re-scored",
+        description: result.message,
+        variant: result.released ? "success" : "info",
+      });
+    });
+  };
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-6">
+        <TileGrid tiles={tiles} />
+        <EmptyState
+          icon={<Sparkles className="w-8 h-8 text-accent" />}
+          title="Nothing in pre-flight"
+          description="Every pre-submission claim is clear. New drafts and scrubbed claims land here automatically for a denial-risk check before the 837 goes out."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <TileGrid tiles={tiles} />
+
+      <section aria-label="Pre-flight worklist" className="space-y-4">
+        <h2 className="font-display text-lg text-text tracking-tight">
+          Claims, riskiest first
+        </h2>
+
+        {rows.map((row) => {
+          const ov = overrides[row.id];
+          const score = ov?.score ?? row.score;
+          const disposition = ov?.disposition ?? row.disposition;
+          const findings = ov?.findings ?? row.findings;
+          const cptDisplay = ov?.cptDisplay ?? row.cptDisplay;
+          const expanded = expandedId === row.id;
+          const evidenceOpen = evidenceOpenId === row.id;
+
+          return (
+            <Card key={row.id} tone="raised">
+              <CardContent className="p-0">
+                {/* Row header — one click to expand */}
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(expanded ? null : row.id)}
+                  aria-expanded={expanded}
+                  className="w-full flex items-center gap-5 px-6 py-5 text-left rounded-xl hover:bg-surface-muted/50 transition-colors"
+                >
+                  <RiskGauge score={score} disposition={disposition} />
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <span className="font-medium text-text">{row.patientName}</span>
+                      <DispositionPill disposition={disposition} />
+                      {ov && (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-status-positive-bg text-status-positive-fg tabular-nums">
+                          {formatPct(ov.beforeScore)} → {formatPct(ov.score)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-1.5 text-[13px] text-text-muted flex items-center gap-2 flex-wrap">
+                      <span>{row.payerName ?? "No payer"}</span>
+                      <span aria-hidden="true">·</span>
+                      <span>{row.serviceDateLabel}</span>
+                      <span aria-hidden="true">·</span>
+                      <span>{row.billedLabel}</span>
+                      {row.claimNumber && (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span>#{row.claimNumber}</span>
+                        </>
+                      )}
+                    </div>
+                    <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+                      {cptDisplay.map((c) => (
+                        <Badge key={c} tone="neutral">{c}</Badge>
+                      ))}
+                      {row.icdDisplay.map((c) => (
+                        <Badge key={c} tone="accent">{c}</Badge>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-3 shrink-0">
+                    <span className="text-[12px] text-text-muted hidden md:block">
+                      {findings.length === 0
+                        ? "No findings"
+                        : `${findings.length} finding${findings.length === 1 ? "" : "s"}`}
+                    </span>
+                    <ChevronDown
+                      className={cn(
+                        "w-4 h-4 text-text-muted transition-transform duration-200",
+                        expanded && "rotate-180",
+                      )}
+                    />
+                  </div>
+                </button>
+
+                {/* Expanded detail — findings + inline evidence, no pop-ups */}
+                {expanded && (
+                  <div className="px-6 pb-6 pt-1 space-y-4 border-t border-border/60">
+                    {(ov?.released || (disposition === "release" && ov)) && (
+                      <div className="mt-4 flex items-center gap-2 rounded-lg bg-status-positive-bg text-status-positive-fg px-4 py-3 text-sm font-medium">
+                        <Sparkles className="w-4 h-4 shrink-0" />
+                        Released to submission — P(denial) is in the green zone
+                        (&lt; 10%). The 837 compiler will pick it up.
+                      </div>
+                    )}
+
+                    {findings.length === 0 ? (
+                      <p className="mt-4 text-sm text-text-muted">
+                        No root-cause findings — this claim scores{" "}
+                        {formatPct(score)} on payer history and documentation
+                        signals alone.
+                      </p>
+                    ) : (
+                      <ol className="mt-4 space-y-3" aria-label="Ranked root causes">
+                        {findings.map((finding, idx) => (
+                          <li
+                            key={`${finding.category}-${idx}`}
+                            className="rounded-lg border border-border/70 bg-surface px-5 py-4"
+                          >
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="text-[11px] font-medium text-text-muted tabular-nums">
+                                #{idx + 1}
+                              </span>
+                              <Badge tone={finding.category === "unbundling_conflict" || finding.category === "modifier_deficiency" ? "warning" : "neutral"}>
+                                {CATEGORY_LABEL[finding.category]}
+                              </Badge>
+                              <span className="text-[11px] text-text-muted tabular-nums">
+                                +{finding.contribution.toFixed(2)} logits
+                              </span>
+                            </div>
+                            <p className="mt-2 text-sm text-text leading-relaxed">
+                              {finding.summary}
+                            </p>
+                            <p className="mt-1.5 text-[13px] text-text-muted leading-relaxed">
+                              {finding.remediation}
+                            </p>
+                            <RemediationButton
+                              row={row}
+                              finding={finding}
+                              index={idx}
+                              pendingKey={pendingKey}
+                              isPending={isPending}
+                              onRemediate={remediate}
+                            />
+                          </li>
+                        ))}
+                      </ol>
+                    )}
+
+                    {/* Context-aware evidence — inline expanding section */}
+                    <div className="rounded-lg border border-border/70 bg-surface">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setEvidenceOpenId(evidenceOpen ? null : row.id)
+                        }
+                        aria-expanded={evidenceOpen}
+                        className="w-full flex items-center gap-2 px-5 py-3.5 text-left text-sm font-medium text-text hover:bg-surface-muted/50 transition-colors rounded-lg"
+                      >
+                        <FileText className="w-4 h-4 text-text-muted shrink-0" />
+                        Review narrative note context
+                        <ChevronDown
+                          className={cn(
+                            "w-4 h-4 text-text-muted ml-auto transition-transform duration-200",
+                            evidenceOpen && "rotate-180",
+                          )}
+                        />
+                      </button>
+                      {evidenceOpen && (
+                        <div className="px-5 pb-5 pt-1">
+                          {row.evidence.length === 0 ? (
+                            <p className="text-[13px] text-text-muted leading-relaxed">
+                              No narrative note is attached to this encounter —
+                              the documentation features scored it as thin.
+                            </p>
+                          ) : (
+                            <p className="text-[13px] text-text leading-[1.9]">
+                              {row.evidence.map((sentence, i) => (
+                                <React.Fragment key={i}>
+                                  {sentence.highlight ? (
+                                    <mark
+                                      title={`Matches: ${sentence.matchedTerms.join(", ")}`}
+                                      className="bg-status-link-bg text-status-link-fg rounded px-1 py-0.5 box-decoration-clone"
+                                    >
+                                      {sentence.text}
+                                    </mark>
+                                  ) : (
+                                    <span className="text-text-muted">
+                                      {sentence.text}
+                                    </span>
+                                  )}{" "}
+                                </React.Fragment>
+                              ))}
+                            </p>
+                          )}
+                          {row.payerSampleSize > 0 && (
+                            <p className="mt-3 text-[11px] text-text-muted">
+                              Payer history: {row.payerSampleSize} adjudicated
+                              outcome{row.payerSampleSize === 1 ? "" : "s"} for
+                              the riskiest CPT in the last 180 days.
+                            </p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// One-click remediation button (machine-applicable actions only)
+// ---------------------------------------------------------------------------
+
+function RemediationButton({
+  row,
+  finding,
+  index,
+  pendingKey,
+  isPending,
+  onRemediate,
+}: {
+  row: PreflightRow;
+  finding: RootCauseFinding;
+  index: number;
+  pendingKey: string | null;
+  isPending: boolean;
+  onRemediate: (row: PreflightRow, input: RemediationInput, key: string) => void;
+}) {
+  const action = finding.action;
+  let input: RemediationInput | null = null;
+  let label = "";
+
+  if (action.kind === "append_modifier") {
+    input = {
+      kind: "append_modifier",
+      claimId: row.id,
+      targetCode: action.targetCode,
+      modifier: action.modifier,
+    };
+    label = `Append Modifier-${action.modifier} to ${action.targetCode}`;
+  } else if (action.kind === "remove_line") {
+    input = {
+      kind: "remove_line",
+      claimId: row.id,
+      componentCode: action.componentCode,
+    };
+    label = `Remove ${action.componentCode} line item`;
+  }
+
+  if (!input) {
+    // augment_documentation / manual_review stay human-in-the-loop — the
+    // remediation text above tells the biller exactly what to document.
+    return (
+      <p className="mt-3 text-[11px] text-text-muted inline-flex items-center gap-1.5">
+        <Wrench className="w-3 h-3" />
+        Manual step — apply in the chart, then re-open Pre-Flight.
+      </p>
+    );
+  }
+
+  const key = `${row.id}:${index}`;
+  const busy = isPending && pendingKey === key;
+  const frozen = input; // narrow for the closure
+
+  return (
+    <div className="mt-3">
+      <Button
+        size="sm"
+        variant="primary"
+        disabled={isPending}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemediate(row, frozen, key);
+        }}
+        leadingIcon={<Wrench className="w-3.5 h-3.5" />}
+      >
+        {busy ? "Re-scoring…" : label}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function TileGrid({ tiles }: { tiles: PreflightTile[] }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {tiles.map((t) => (
+        <StatCard
+          key={t.label}
+          label={t.label}
+          value={t.value}
+          hint={t.hint}
+          tone={t.tone}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/api/webhooks/sms-inbound/route.ts
+++ b/src/app/api/webhooks/sms-inbound/route.ts
@@ -1,0 +1,175 @@
+import { timingSafeEqual, createHash } from "node:crypto";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { normalizePhoneDigits } from "@/lib/onboarding/phone";
+import {
+  ingestInboundMessage,
+  normalizeInboundMessage,
+} from "@/lib/triage/gateway";
+
+/**
+ * Inbound SMS webhook (EMR-1145 — Asynchronous Triage Phase 1 + 4.1).
+ *
+ * Accepts a Twilio-shaped payload (JSON or application/x-www-form-urlencoded):
+ *   From       — sender phone (E.164 or US 10-digit)
+ *   Body       — message text
+ *   MessageSid — provider message id (idempotency key; Twilio retries)
+ *
+ * Verification (fail-closed, mirroring webhooks/payabli):
+ *   - SMS_WEBHOOK_SECRET env var MUST be set, or the route refuses (503).
+ *   - The `x-sms-webhook-secret` header MUST match (timing-safe), or 401.
+ *
+ * Patient matching: `From` is reduced to its 10 significant digits via the
+ * shared onboarding/phone normalizer (same digits-only matching philosophy
+ * as the EMR-646 universal patient search), then compared against
+ * Patient.phone digits-for-digits. Exactly one match → verified sender.
+ * Zero or ambiguous matches → the gateway quarantines to the AuditLog
+ * dead-letter (never silently dropped) and we still return 200 so the
+ * provider doesn't retry forever.
+ */
+
+const SECRET_HEADER = "x-sms-webhook-secret";
+
+function secretMatches(provided: string, expected: string): boolean {
+  // Hash both sides so timingSafeEqual gets equal-length buffers regardless
+  // of attacker-controlled input length.
+  const a = createHash("sha256").update(provided).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+interface SmsPayload {
+  from: string;
+  body: string;
+  messageSid: string | null;
+}
+
+async function parsePayload(req: Request): Promise<SmsPayload | null> {
+  const contentType = req.headers.get("content-type") ?? "";
+  let raw: Record<string, unknown> = {};
+  try {
+    if (contentType.includes("application/json")) {
+      raw = (await req.json()) as Record<string, unknown>;
+    } else {
+      // Twilio default: application/x-www-form-urlencoded
+      const params = new URLSearchParams(await req.text());
+      raw = Object.fromEntries(params.entries());
+    }
+  } catch {
+    return null;
+  }
+  const from = typeof raw.From === "string" ? raw.From.trim() : "";
+  const body = typeof raw.Body === "string" ? raw.Body : "";
+  const messageSid =
+    typeof raw.MessageSid === "string" && raw.MessageSid.trim()
+      ? raw.MessageSid.trim()
+      : null;
+  if (!from || !body.trim()) return null;
+  return { from, body, messageSid };
+}
+
+/** Exact digits-for-digits patient match on the sender phone. */
+async function matchPatientByPhone(
+  from: string,
+): Promise<{ patientId: string | null; reason: string | null }> {
+  const digits = normalizePhoneDigits(from);
+  if (digits.length !== 10) {
+    return { patientId: null, reason: "unparseable_phone" };
+  }
+
+  // Prisma can't strip separators in SQL, so narrow with a cheap `contains`
+  // on the last four digits, then do the exact normalized comparison in
+  // memory — the same digits-only matching the universal patient search uses.
+  const candidates = await prisma.patient.findMany({
+    where: { phone: { contains: digits.slice(-4) } },
+    select: { id: true, phone: true },
+    take: 50,
+  });
+
+  const exact = candidates.filter(
+    (p) => p.phone && normalizePhoneDigits(p.phone) === digits,
+  );
+  if (exact.length === 1) return { patientId: exact[0].id, reason: null };
+  if (exact.length === 0) return { patientId: null, reason: "no_patient_match" };
+  // Two patients sharing a phone (household): never guess whose chart to write.
+  return { patientId: null, reason: "ambiguous_phone_match" };
+}
+
+export async function POST(req: Request) {
+  // ── Shared-secret verification (fail-closed) ──────────────────────
+  const expected = process.env.SMS_WEBHOOK_SECRET;
+  if (!expected) {
+    console.error(
+      "[webhook/sms-inbound] refusing webhook — SMS_WEBHOOK_SECRET is not configured",
+    );
+    return NextResponse.json(
+      { ok: false, error: "webhook_not_configured" },
+      { status: 503 },
+    );
+  }
+  const provided = req.headers.get(SECRET_HEADER) ?? "";
+  if (!provided || !secretMatches(provided, expected)) {
+    console.warn("[webhook/sms-inbound] invalid shared secret", {
+      headerPresent: !!provided,
+    });
+    return NextResponse.json(
+      { ok: false, error: "invalid_secret" },
+      { status: 401 },
+    );
+  }
+
+  // ── Payload ───────────────────────────────────────────────────────
+  const payload = await parsePayload(req);
+  if (!payload) {
+    return NextResponse.json(
+      { ok: false, error: "invalid_payload", hint: "From and Body are required" },
+      { status: 400 },
+    );
+  }
+
+  // ── Sender verification by phone match ────────────────────────────
+  const match = await matchPatientByPhone(payload.from);
+
+  const normalized = normalizeInboundMessage({
+    patientId: match.patientId,
+    channel: "sms",
+    rawBody: payload.body,
+    senderVerified: match.patientId !== null,
+    externalId: payload.messageSid,
+  });
+
+  try {
+    const result = await ingestInboundMessage(normalized, {
+      quarantineContext: {
+        // Dead-letter context so staff can follow up with the sender.
+        from: payload.from,
+        matchFailure: match.reason,
+      },
+    });
+
+    // In dev, run the agent queue inline (mirrors the portal send path) so
+    // correspondence drafts + the portal-side safety check appear without a
+    // worker heartbeat.
+    if (result.status === "ingested" && process.env.NODE_ENV !== "production") {
+      try {
+        const { runTick } = await import("@/lib/orchestration/runner");
+        await runTick("inline-dev", 4);
+      } catch {
+        // Dev-only convenience; never fail the webhook for it.
+      }
+    }
+
+    // 200 for quarantine/duplicate too — the message is persisted (dead-letter
+    // or original row); retrying wouldn't change the outcome.
+    return NextResponse.json({ ok: true, status: result.status });
+  } catch (err) {
+    console.error("[webhook/sms-inbound] ingest failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    // 500 so the provider retries — ingest is idempotent on MessageSid.
+    return NextResponse.json(
+      { ok: false, error: "ingest_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -22,6 +22,8 @@ import { prescriptionSafetyAgent } from "./prescription-safety-agent";
 import { diagnosisSafetyAgent } from "./diagnosis-safety-agent";
 import { adherenceDriftDetectorAgent } from "./adherence-drift-detector-agent";
 import { messageUrgencyObserverAgent } from "./message-urgency-observer-agent";
+// EMR-1145 — urgent 911/ED safety auto-reply on inbound messages
+import { safetyAutoResponderAgent } from "./safety-auto-responder-agent";
 import { visitDiscoveryWhispererAgent } from "./visit-discovery-whisperer-agent";
 // Billing agents — Phase 3 of the Revenue Cycle PRD
 import { chargeIntegrityAgent } from "./billing/charge-integrity-agent";
@@ -147,6 +149,7 @@ export const agentRegistry = {
   diagnosisSafety: diagnosisSafetyAgent,
   adherenceDriftDetector: adherenceDriftDetectorAgent,
   messageUrgencyObserver: messageUrgencyObserverAgent,
+  safetyAutoResponder: safetyAutoResponderAgent,
   visitDiscoveryWhisperer: visitDiscoveryWhispererAgent,
   // Billing agents (Phase 3)
   chargeIntegrity: chargeIntegrityAgent,

--- a/src/lib/agents/safety-auto-responder-agent.ts
+++ b/src/lib/agents/safety-auto-responder-agent.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import type { Agent } from "@/lib/orchestration/types";
+import { deriveVulnerabilityFlags, triageMessage } from "@/lib/triage/upi";
+import {
+  dispatchSafetyAutoReply,
+  SAFETY_AUTO_RESPONDER_NAME,
+  SAFETY_AUTO_RESPONDER_VERSION,
+} from "@/lib/triage/gateway/auto-reply";
+
+// ---------------------------------------------------------------------------
+// Safety Auto-Responder (EMR-1145, spec Phase 4.1)
+// ---------------------------------------------------------------------------
+// Fires on every `message.received` and closes the loop the UPI engine
+// (EMR-1146/1147) left open: when an inbound patient message routes
+// URGENT (UPI ≥ 0.75), the pre-configured 911/ED safety reply is actually
+// SENT on the patient's channel — clearly marked automated, audit-logged.
+//
+// Why a dedicated agent instead of widening messageUrgencyObserver?
+// Permissions. The observer deliberately holds only read.patient +
+// write.outcome.reminder (it records, it never speaks). Sending — even a
+// fixed safety template — is a different power, so it lives in its own
+// agent with the explicit `write.message.send` action. This agent NEVER
+// composes text: the body is the deterministic URGENT_AUTO_REPLY template,
+// which is why it is not approval-gated (there is nothing to review, and
+// holding a 911 instruction in an approval queue defeats its purpose).
+//
+// Channels:
+//   - portal: this agent IS the dispatch path (the portal send action only
+//     emits `message.received`; nothing else replies automatically).
+//   - sms: ingestInboundMessage() already replied synchronously; the
+//     dedupe guard inside dispatchSafetyAutoReply makes this run a no-op.
+// ---------------------------------------------------------------------------
+
+const input = z.object({
+  messageId: z.string(),
+  threadId: z.string(),
+  patientId: z.string(),
+});
+
+const output = z.object({
+  route: z.enum(["urgent", "standard"]),
+  upi: z.number(),
+  autoReplySent: z.boolean(),
+  autoReplyMessageId: z.string().nullable(),
+  skippedReason: z.string().nullable(),
+});
+
+export const safetyAutoResponderAgent: Agent<
+  z.infer<typeof input>,
+  z.infer<typeof output>
+> = {
+  name: SAFETY_AUTO_RESPONDER_NAME,
+  version: SAFETY_AUTO_RESPONDER_VERSION,
+  description:
+    "Re-runs the deterministic UPI triage on every inbound patient message " +
+    "and, on an urgent route (UPI ≥ 0.75), sends the pre-configured 911/ED " +
+    "safety auto-reply on the patient's channel. Fixed template only — " +
+    "never composes text.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: ["read.patient", "write.message.send"],
+  requiresApproval: false,
+
+  async run({ messageId, threadId, patientId }, ctx) {
+    ctx.assertCan("read.patient");
+
+    const skip = (reason: string) =>
+      ({
+        route: "standard" as const,
+        upi: 0,
+        autoReplySent: false,
+        autoReplyMessageId: null,
+        skippedReason: reason,
+      });
+
+    const [message, patient] = await Promise.all([
+      prisma.message.findUnique({
+        where: { id: messageId },
+        select: {
+          id: true,
+          threadId: true,
+          body: true,
+          channel: true,
+          senderAgent: true,
+          status: true,
+        },
+      }),
+      prisma.patient.findUnique({
+        where: { id: patientId },
+        select: {
+          id: true,
+          organizationId: true,
+          phone: true,
+          contraindications: true,
+          pastMedicalConditions: {
+            where: { deletedAt: null },
+            select: { condition: true },
+          },
+          pastSurgeries: {
+            where: { deletedAt: null },
+            select: { createdAt: true },
+          },
+        },
+      }),
+    ]);
+
+    if (!message || message.threadId !== threadId) return skip("message_not_found");
+    if (!patient) return skip("patient_not_found");
+    // Only patient-originated, sent messages trigger a safety reply —
+    // never agent drafts or clinician replies.
+    if (message.senderAgent || message.status !== "sent") {
+      return skip("not_patient_originated");
+    }
+
+    // Raw body on purpose: triageMessage normalizes internally for entity
+    // extraction, and the distress scorer needs the original casing.
+    const decision = triageMessage(message.body, {
+      vulnerability: deriveVulnerabilityFlags({
+        conditions: patient.pastMedicalConditions,
+        contraindications: patient.contraindications,
+        surgeries: patient.pastSurgeries,
+      }),
+    });
+
+    if (decision.route !== "urgent") {
+      ctx.log("info", "Message below urgent threshold — no auto-reply", {
+        upi: decision.upi,
+      });
+      return {
+        route: decision.route,
+        upi: decision.upi,
+        autoReplySent: false,
+        autoReplyMessageId: null,
+        skippedReason: null,
+      };
+    }
+
+    ctx.assertCan("write.message.send");
+
+    const reply = await dispatchSafetyAutoReply({
+      threadId,
+      patientId,
+      organizationId: patient.organizationId,
+      channel: message.channel === "sms" ? "sms" : "portal",
+      recipientPhone: patient.phone,
+      triggerMessageId: message.id,
+      upiScore: decision.upi,
+      dispatchedBy: "agent",
+    });
+
+    ctx.log("info", reply.sent ? "Safety auto-reply sent" : "Safety auto-reply skipped", {
+      upi: decision.upi,
+      ...(reply.sent
+        ? { autoReplyMessageId: reply.messageId, delivery: reply.delivery }
+        : { skippedReason: reply.skippedReason }),
+    });
+
+    return {
+      route: "urgent",
+      upi: decision.upi,
+      autoReplySent: reply.sent,
+      autoReplyMessageId: reply.sent ? reply.messageId : null,
+      skippedReason: reply.sent ? null : reply.skippedReason,
+    };
+  },
+};

--- a/src/lib/clinical/rx-safety/__tests__/profile.test.ts
+++ b/src/lib/clinical/rx-safety/__tests__/profile.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from "vitest";
+import {
+  ageFromDateOfBirth,
+  botanicalExposuresFromRows,
+  buildPatientRxProfile,
+  labsFromLabResults,
+  markerToLoinc,
+  sexFromIntake,
+  taggedProductName,
+  CONCENTRATED_CBD_THRESHOLD,
+  type RegimenProductInput,
+} from "../profile";
+import { evaluateRxSafety } from "../evaluate";
+import { LOINC } from "../types";
+
+const NOW = new Date("2026-06-12T00:00:00Z");
+function daysAgo(d: number): Date {
+  return new Date(NOW.getTime() - d * 86400000);
+}
+
+function product(over: Partial<RegimenProductInput> = {}): RegimenProductInput {
+  return {
+    name: "Relief Tincture",
+    thcConcentration: null,
+    cbdConcentration: null,
+    cbnConcentration: null,
+    cbgConcentration: null,
+    ...over,
+  };
+}
+
+/* ── markerToLoinc ───────────────────────────────────────────────────── */
+
+describe("markerToLoinc", () => {
+  it("maps creatinine aliases", () => {
+    for (const m of ["Cr", "Creatinine", "Serum Creatinine", "SCr", "creat"]) {
+      expect(markerToLoinc(m)).toBe(LOINC.SERUM_CREATININE);
+    }
+  });
+
+  it("maps bilirubin / albumin / INR aliases", () => {
+    expect(markerToLoinc("Total Bilirubin")).toBe(LOINC.TOTAL_BILIRUBIN);
+    expect(markerToLoinc("TBili")).toBe(LOINC.TOTAL_BILIRUBIN);
+    expect(markerToLoinc("bilirubin, total")).toBe(LOINC.TOTAL_BILIRUBIN);
+    expect(markerToLoinc("Albumin")).toBe(LOINC.ALBUMIN);
+    expect(markerToLoinc("ALB")).toBe(LOINC.ALBUMIN);
+    expect(markerToLoinc("INR")).toBe(LOINC.INR);
+    expect(markerToLoinc("PT/INR")).toBe(LOINC.INR);
+  });
+
+  it("never matches lookalike markers (exact-token, not substring)", () => {
+    expect(markerToLoinc("eGFR")).toBeNull();
+    expect(markerToLoinc("CrCl")).toBeNull();
+    expect(markerToLoinc("Microalbumin")).toBeNull();
+    expect(markerToLoinc("Urine albumin/creatinine")).toBeNull();
+    expect(markerToLoinc("")).toBeNull();
+  });
+});
+
+/* ── labsFromLabResults ──────────────────────────────────────────────── */
+
+describe("labsFromLabResults", () => {
+  it("extracts LOINC-coded labs with observation dates from panel JSON", () => {
+    const labs = labsFromLabResults([
+      {
+        receivedAt: daysAgo(10),
+        results: {
+          Cr: { value: 1.4, unit: "mg/dL", refLow: 0.6, refHigh: 1.2 },
+          eGFR: { value: 52, unit: "mL/min" }, // not a guardrail marker
+          Na: { value: 140, unit: "mEq/L" },
+        },
+      },
+      {
+        receivedAt: daysAgo(200),
+        results: {
+          "Total Bilirubin": { value: 2.4, unit: "mg/dL" },
+          Albumin: { value: 2.6, unit: "g/dL" },
+          INR: { value: 1.9 },
+        },
+      },
+    ]);
+
+    expect(labs).toHaveLength(4);
+    const cr = labs.find((l) => l.loinc === LOINC.SERUM_CREATININE)!;
+    expect(cr.value).toBe(1.4);
+    expect(cr.unit).toBe("mg/dL");
+    expect(new Date(cr.observedAt).toISOString()).toBe(
+      daysAgo(10).toISOString()
+    );
+    const inr = labs.find((l) => l.loinc === LOINC.INR)!;
+    expect(inr.value).toBe(1.9);
+    expect(inr.unit).toBeUndefined();
+    expect(new Date(inr.observedAt).toISOString()).toBe(
+      daysAgo(200).toISOString()
+    );
+  });
+
+  it("keeps every dated occurrence so the engine can pick the freshest", () => {
+    const labs = labsFromLabResults([
+      { receivedAt: daysAgo(1), results: { Cr: { value: 1.1 } } },
+      { receivedAt: daysAgo(180), results: { Cr: { value: 1.0 } } },
+    ]);
+    expect(labs.map((l) => l.value).sort()).toEqual([1.0, 1.1]);
+  });
+
+  it("ignores malformed rows and non-numeric values", () => {
+    const labs = labsFromLabResults([
+      { receivedAt: daysAgo(1), results: null },
+      { receivedAt: daysAgo(1), results: "corrupt" },
+      {
+        receivedAt: daysAgo(1),
+        results: {
+          Cr: { value: "1.2" }, // string value → skipped
+          INR: { value: Number.NaN }, // non-finite → skipped
+          Albumin: null,
+        },
+      },
+    ]);
+    expect(labs).toHaveLength(0);
+  });
+});
+
+/* ── botanical exposures ─────────────────────────────────────────────── */
+
+describe("botanicalExposuresFromRows", () => {
+  it("maps cannabis + supplement medications, skips Rx/OTC and inactive rows", () => {
+    const exposures = botanicalExposuresFromRows({
+      medications: [
+        { name: "St. John's Wort", type: "supplement", active: true },
+        { name: "CBD oil 1000mg", type: "cannabis", active: true },
+        { name: "Warfarin", type: "prescription", active: true },
+        { name: "Melatonin", type: "supplement", active: false },
+      ],
+      dosingRegimens: [],
+      doseLogs: [],
+    });
+
+    expect(exposures).toHaveLength(2);
+    const sjw = exposures.find((e) => e.name === "St. John's Wort")!;
+    expect(sjw.kind).toBe("supplement");
+    expect(sjw.source).toBe("medication_list");
+    const cbd = exposures.find((e) => e.name === "CBD oil 1000mg")!;
+    expect(cbd.kind).toBe("cannabinoid");
+  });
+
+  it("tags product names with their structured cannabinoid content", () => {
+    expect(
+      taggedProductName(product({ thcConcentration: 5, cbnConcentration: 1 }))
+    ).toBe("Relief Tincture [THC, CBN]");
+    expect(taggedProductName(product())).toBe("Relief Tincture");
+  });
+
+  it("derives exposures from active regimens and recent dose logs", () => {
+    const exposures = botanicalExposuresFromRows({
+      medications: [],
+      dosingRegimens: [
+        { active: true, product: product({ thcConcentration: 10 }) },
+        { active: false, product: product({ name: "Old Vape", thcConcentration: 80 }) },
+      ],
+      doseLogs: [
+        {
+          estimatedThcMg: null,
+          estimatedCbdMg: null,
+          regimen: {
+            product: product({
+              name: "Isolate Drops",
+              cbdConcentration: CONCENTRATED_CBD_THRESHOLD,
+            }),
+          },
+        },
+      ],
+    });
+
+    expect(exposures.map((e) => e.name)).toEqual([
+      "Relief Tincture [THC]",
+      "Isolate Drops [CBD]",
+    ]);
+    const regimenExposure = exposures[0];
+    expect(regimenExposure.source).toBe("product_log");
+    expect(regimenExposure.concentrated).toBeUndefined();
+    const logExposure = exposures[1];
+    expect(logExposure.source).toBe("dosing_log");
+    expect(logExposure.concentrated).toBe(true);
+    expect(logExposure.kind).toBe("cannabinoid");
+  });
+
+  it("falls back to estimated mg fields for ad-hoc logs without a regimen", () => {
+    const exposures = botanicalExposuresFromRows({
+      medications: [],
+      dosingRegimens: [],
+      doseLogs: [
+        { estimatedThcMg: 2.5, estimatedCbdMg: 0, regimen: null },
+        { estimatedThcMg: null, estimatedCbdMg: null, regimen: null }, // nothing known
+      ],
+    });
+    expect(exposures).toHaveLength(1);
+    expect(exposures[0].name).toBe("Patient dose log [THC]");
+    expect(exposures[0].source).toBe("dosing_log");
+  });
+
+  it("dedupes by name and preserves a concentrated flag from any source", () => {
+    const concentrated = product({
+      name: "Isolate Drops",
+      cbdConcentration: 100,
+    });
+    const exposures = botanicalExposuresFromRows({
+      medications: [],
+      dosingRegimens: [
+        { active: true, product: product({ name: "Isolate Drops", cbdConcentration: 10 }) },
+      ],
+      doseLogs: [
+        { estimatedThcMg: null, estimatedCbdMg: null, regimen: { product: concentrated } },
+        { estimatedThcMg: null, estimatedCbdMg: null, regimen: { product: concentrated } },
+      ],
+    });
+    expect(exposures).toHaveLength(1);
+    expect(exposures[0].concentrated).toBe(true);
+  });
+});
+
+/* ── demographics ────────────────────────────────────────────────────── */
+
+describe("sexFromIntake", () => {
+  it("reads sex/gender from the intake blob", () => {
+    expect(sexFromIntake({ sex: "Male" })).toBe("male");
+    expect(sexFromIntake({ gender: "F" })).toBe("female");
+  });
+
+  it("reads sex from the demographics detail editor sections", () => {
+    expect(
+      sexFromIntake({
+        demographicsDetail: {
+          identity: { fields: { pronouns: "he/him", sex: "male" } },
+        },
+      })
+    ).toBe("male");
+  });
+
+  it("defaults to female (lower CKD-EPI eGFR → conservative) when unknown", () => {
+    expect(sexFromIntake(null)).toBe("female");
+    expect(sexFromIntake({})).toBe("female");
+    expect(sexFromIntake({ sex: "non-binary" })).toBe("female");
+    expect(sexFromIntake("corrupt")).toBe("female");
+  });
+});
+
+describe("ageFromDateOfBirth", () => {
+  it("computes whole years, honoring the birthday boundary", () => {
+    expect(ageFromDateOfBirth(new Date("1976-06-12"), NOW)).toBe(50);
+    expect(ageFromDateOfBirth(new Date("1976-06-13"), NOW)).toBe(49);
+  });
+
+  it("returns 0 for unknown or invalid DOB", () => {
+    expect(ageFromDateOfBirth(null, NOW)).toBe(0);
+    expect(ageFromDateOfBirth("not-a-date", NOW)).toBe(0);
+  });
+});
+
+/* ── buildPatientRxProfile end-to-end (mocked rows) ──────────────────── */
+
+describe("buildPatientRxProfile", () => {
+  const rows = {
+    patient: {
+      dateOfBirth: new Date("1956-01-15"),
+      intakeAnswers: { sex: "male" },
+    },
+    labResults: [
+      {
+        receivedAt: daysAgo(14),
+        results: { Cr: { value: 2.1, unit: "mg/dL" } },
+      },
+    ],
+    medications: [
+      { name: "Warfarin", type: "prescription", active: true },
+      { name: "St. John's Wort", type: "supplement", active: true },
+      { name: "Lisinopril", type: "prescription", active: false },
+    ],
+    dosingRegimens: [
+      {
+        active: true,
+        product: product({
+          name: "Isolate Drops",
+          cbdConcentration: 100,
+        }),
+      },
+    ],
+    doseLogs: [],
+  };
+
+  it("assembles the full profile from row shapes", () => {
+    const profile = buildPatientRxProfile(rows, NOW);
+
+    expect(profile.sex).toBe("male");
+    expect(profile.age).toBe(70);
+    expect(profile.pgxVariants).toEqual([]); // no PGx storage in schema yet
+    expect(profile.activeMeds).toEqual(["Warfarin", "St. John's Wort"]);
+    expect(profile.labs).toEqual([
+      {
+        loinc: LOINC.SERUM_CREATININE,
+        value: 2.1,
+        unit: "mg/dL",
+        observedAt: daysAgo(14).toISOString(),
+      },
+    ]);
+    expect(profile.botanicalExposures).toEqual([
+      {
+        name: "St. John's Wort",
+        kind: "supplement",
+        source: "medication_list",
+      },
+      {
+        name: "Isolate Drops [CBD]",
+        kind: "cannabinoid",
+        concentrated: true,
+        source: "product_log",
+      },
+    ]);
+  });
+
+  it("assembled profile drives the engine: CBD exposure × warfarin fires the anticoagulant optimization", async () => {
+    const profile = buildPatientRxProfile(rows, NOW);
+    const r = await evaluateRxSafety(
+      { drugName: "Warfarin 5mg", dose: "5 mg", frequency: "1x per day" },
+      profile,
+      NOW
+    );
+    const finding = r.findings.find(
+      (f) => f.ruleId === "botanical.cbd.anticoagulant"
+    );
+    expect(finding).toBeDefined();
+    expect(finding!.requiredFollowUp).toEqual([
+      { labLoinc: LOINC.INR, timing: "immediate" },
+    ]);
+  });
+
+  it("assembled labs drive the organ layer: reduced eGFR flags metformin", async () => {
+    const profile = buildPatientRxProfile(rows, NOW);
+    const r = await evaluateRxSafety(
+      { drugName: "Metformin 500mg", dailyDoseMg: 1000 },
+      profile,
+      NOW
+    );
+    const finding = r.findings.find(
+      (f) => f.ruleId === "organ.renal.dose_adjust"
+    );
+    expect(finding).toBeDefined();
+    expect(finding!.lowConfidence).toBeUndefined(); // labs are 14 days old
+  });
+});

--- a/src/lib/clinical/rx-safety/evaluate.ts
+++ b/src/lib/clinical/rx-safety/evaluate.ts
@@ -1,3 +1,4 @@
+// SAFE: dead-export-allowed reason="Entry point for the rx-safety engine, called by future clinical order workflows"
 // ---------------------------------------------------------------------------
 // evaluateRxSafety — top-level entry point for the prescription-safety
 // guardrail engine. Runs the three layers (PGx, organ clearance, botanical)

--- a/src/lib/clinical/rx-safety/profile.ts
+++ b/src/lib/clinical/rx-safety/profile.ts
@@ -1,0 +1,354 @@
+// ---------------------------------------------------------------------------
+// PatientRxProfile assembler — Phase 1.2 "Distributed Multi-Domain Ingestion"
+// (Linear EMR-1131/EMR-1135, epic EMR-1119).
+//
+// Pure mapping layer: takes already-fetched Prisma row shapes and assembles
+// the PatientRxProfile that evaluateRxSafety() consumes. No I/O here — the
+// Prisma reads live in the server action next to the prescribe form
+// (src/app/(clinician)/clinic/patients/[id]/prescribe/rx-safety-actions.ts)
+// so this module stays unit-testable with mocked rows.
+//
+// Data sources mapped:
+//   - The Organ Clearance Vault ... LabResult.results JSON (marker-name keyed;
+//     see prisma seed "CMP" rows) → LOINC-coded LabResult[] for creatinine,
+//     bilirubin, albumin, INR — with observation dates for freshness checks.
+//   - The PGx Registry ............ no PGx column exists in the schema today,
+//     so the assembler emits an empty array (the engine treats absence of
+//     genomic data as a silent pass, never a warning).
+//   - The Botanical & Xenobiotic Manifest ... active PatientMedication rows
+//     (cannabis / supplement types), active DosingRegimens and recent DoseLogs
+//     (product names tagged with their structured cannabinoid content so
+//     inferCannabinoidsFromName() resolves the right compounds).
+//   - Demographics ................ sex from intakeAnswers (intake +
+//     demographics detail editor both write there), age from dateOfBirth.
+// ---------------------------------------------------------------------------
+
+import {
+  type BotanicalExposure,
+  type LabResult,
+  type PatientRxProfile,
+  type PgxVariant,
+  LOINC,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Row shapes (structural subsets of the Prisma models — keep in sync by hand;
+// the server action selects exactly these fields).
+// ---------------------------------------------------------------------------
+
+export interface PatientRowInput {
+  dateOfBirth: Date | string | null;
+  /** Patient.intakeAnswers JSON blob (sex/gender live in here). */
+  intakeAnswers: unknown;
+}
+
+export interface LabResultRowInput {
+  receivedAt: Date | string;
+  /** LabResult.results JSON: { [marker]: { value, unit?, ... } } */
+  results: unknown;
+}
+
+export interface MedicationRowInput {
+  name: string;
+  /** Prisma MedicationType: prescription | otc | supplement | cannabis */
+  type: string;
+  active: boolean;
+}
+
+export interface RegimenProductInput {
+  name: string;
+  thcConcentration: number | null;
+  cbdConcentration: number | null;
+  cbnConcentration: number | null;
+  cbgConcentration: number | null;
+}
+
+export interface DosingRegimenRowInput {
+  active: boolean;
+  product: RegimenProductInput | null;
+}
+
+export interface DoseLogRowInput {
+  estimatedThcMg: number | null;
+  estimatedCbdMg: number | null;
+  regimen: { product: RegimenProductInput | null } | null;
+}
+
+export interface PatientRxProfileRows {
+  patient: PatientRowInput;
+  labResults: LabResultRowInput[];
+  medications: MedicationRowInput[];
+  dosingRegimens: DosingRegimenRowInput[];
+  doseLogs: DoseLogRowInput[];
+}
+
+// ---------------------------------------------------------------------------
+// Lab marker → LOINC mapping (Organ Clearance Vault)
+// ---------------------------------------------------------------------------
+
+/**
+ * Alias table for the four organ-clearance markers. LabResult.results is
+ * keyed by free-form marker names ("Cr", "Creatinine", "TBili", "INR"…), so
+ * matching is exact on a normalized token — substring matching would wrongly
+ * capture e.g. "CrCl", "Urine albumin/creatinine", or "Microalbumin".
+ */
+const MARKER_ALIASES: Record<string, string[]> = {
+  [LOINC.SERUM_CREATININE]: ["cr", "creatinine", "serum creatinine", "scr", "creat"],
+  [LOINC.TOTAL_BILIRUBIN]: [
+    "total bilirubin",
+    "bilirubin total",
+    "bilirubin",
+    "tbili",
+    "t bili",
+    "bili total",
+  ],
+  [LOINC.ALBUMIN]: ["albumin", "alb", "serum albumin"],
+  [LOINC.INR]: ["inr", "international normalized ratio", "pt inr", "pt/inr"],
+};
+
+function normalizeMarker(marker: string): string {
+  return marker
+    .toLowerCase()
+    .replace(/[._,]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Resolve a free-form lab marker name to one of the four guardrail LOINCs. */
+export function markerToLoinc(marker: string): string | null {
+  const norm = normalizeMarker(marker);
+  if (!norm) return null;
+  for (const [loinc, aliases] of Object.entries(MARKER_ALIASES)) {
+    if (aliases.includes(norm)) return loinc;
+  }
+  return null;
+}
+
+/**
+ * Extract LOINC-coded labs from LabResult rows. Each row's `results` JSON is
+ * marker-name keyed; every marker that maps to a guardrail LOINC and carries a
+ * finite numeric value becomes one LabResult, stamped with the panel's
+ * receivedAt so the engine can apply the 180-day freshness window.
+ */
+export function labsFromLabResults(rows: LabResultRowInput[]): LabResult[] {
+  const out: LabResult[] = [];
+  for (const row of rows) {
+    if (!row?.results || typeof row.results !== "object") continue;
+    const observedAt =
+      row.receivedAt instanceof Date
+        ? row.receivedAt.toISOString()
+        : String(row.receivedAt);
+    for (const [marker, raw] of Object.entries(
+      row.results as Record<string, unknown>
+    )) {
+      const loinc = markerToLoinc(marker);
+      if (!loinc) continue;
+      if (!raw || typeof raw !== "object") continue;
+      const value = (raw as { value?: unknown }).value;
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      const unit = (raw as { unit?: unknown }).unit;
+      out.push({
+        loinc,
+        value,
+        unit: typeof unit === "string" ? unit : undefined,
+        observedAt,
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Botanical & Xenobiotic Manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * CBD concentration (mg/mL or mg/unit) at or above which a product counts as
+ * a "concentrated CBD extract" for the CYP2C9 anticoagulant guardrail.
+ */
+export const CONCENTRATED_CBD_THRESHOLD = 50;
+
+/**
+ * Tag a cannabis product name with its structured cannabinoid content, e.g.
+ * "Midnight Tincture [THC, CBN]". inferCannabinoidsFromName() (which the
+ * botanical layer reuses) falls back to assuming THC+CBD for unrecognizable
+ * names — tagging keeps the inference faithful to the product's actual
+ * concentrations instead.
+ */
+export function taggedProductName(product: RegimenProductInput): string {
+  const tokens: string[] = [];
+  if ((product.thcConcentration ?? 0) > 0) tokens.push("THC");
+  if ((product.cbdConcentration ?? 0) > 0) tokens.push("CBD");
+  if ((product.cbnConcentration ?? 0) > 0) tokens.push("CBN");
+  if ((product.cbgConcentration ?? 0) > 0) tokens.push("CBG");
+  if (tokens.length === 0) return product.name;
+  return `${product.name} [${tokens.join(", ")}]`;
+}
+
+function productExposure(
+  product: RegimenProductInput,
+  source: string
+): BotanicalExposure {
+  return {
+    name: taggedProductName(product),
+    kind: "cannabinoid",
+    concentrated:
+      (product.cbdConcentration ?? 0) >= CONCENTRATED_CBD_THRESHOLD ||
+      undefined,
+    source,
+  };
+}
+
+/**
+ * Assemble the botanical/cannabinoid exposure manifest from the medication
+ * list (cannabis + supplement rows), active dosing regimens (product log) and
+ * recent dose logs. De-duplicated by normalized name; the earliest source in
+ * the order medication_list → product_log → dosing_log wins.
+ */
+export function botanicalExposuresFromRows(input: {
+  medications: MedicationRowInput[];
+  dosingRegimens: DosingRegimenRowInput[];
+  doseLogs: DoseLogRowInput[];
+}): BotanicalExposure[] {
+  const byName = new Map<string, BotanicalExposure>();
+  const add = (e: BotanicalExposure) => {
+    const key = e.name.toLowerCase().trim();
+    if (!key) return;
+    const existing = byName.get(key);
+    if (existing) {
+      // keep the first occurrence, but never lose a concentrated flag.
+      if (e.concentrated && !existing.concentrated) existing.concentrated = true;
+      return;
+    }
+    byName.set(key, e);
+  };
+
+  for (const med of input.medications) {
+    if (!med.active) continue;
+    if (med.type === "cannabis") {
+      add({ name: med.name, kind: "cannabinoid", source: "medication_list" });
+    } else if (med.type === "supplement") {
+      add({ name: med.name, kind: "supplement", source: "medication_list" });
+    }
+    // prescription / otc rows belong in activeMeds, not the botanical manifest.
+  }
+
+  for (const regimen of input.dosingRegimens) {
+    if (!regimen.active || !regimen.product) continue;
+    add(productExposure(regimen.product, "product_log"));
+  }
+
+  for (const log of input.doseLogs) {
+    if (log.regimen?.product) {
+      add(productExposure(log.regimen.product, "dosing_log"));
+      continue;
+    }
+    // Ad-hoc log without a regimen — fall back to the estimated mg fields.
+    const tokens: string[] = [];
+    if ((log.estimatedThcMg ?? 0) > 0) tokens.push("THC");
+    if ((log.estimatedCbdMg ?? 0) > 0) tokens.push("CBD");
+    if (tokens.length > 0) {
+      add({
+        name: `Patient dose log [${tokens.join(", ")}]`,
+        kind: "cannabinoid",
+        source: "dosing_log",
+      });
+    }
+  }
+
+  return Array.from(byName.values());
+}
+
+// ---------------------------------------------------------------------------
+// Demographics
+// ---------------------------------------------------------------------------
+
+/** Normalize a free-text sex/gender string to the engine's binary input. */
+function normalizeSex(raw: unknown): "female" | "male" | null {
+  if (typeof raw !== "string") return null;
+  const v = raw.trim().toLowerCase();
+  if (v === "f" || v === "female" || v === "woman") return "female";
+  if (v === "m" || v === "male" || v === "man") return "male";
+  return null;
+}
+
+/**
+ * Resolve biological sex from the intakeAnswers blob. Checks the top-level
+ * intake keys first, then every demographicsDetail section the detail editor
+ * persists (FO-B3 writes fields under intake.demographicsDetail[section]).
+ *
+ * Defaults to "female" when undocumented: for a given creatinine the CKD-EPI
+ * 2021 female parameters yield the LOWER eGFR estimate, so the renal
+ * guardrail errs toward surfacing rather than suppressing a dose flag.
+ */
+export function sexFromIntake(intakeAnswers: unknown): "female" | "male" {
+  if (intakeAnswers && typeof intakeAnswers === "object") {
+    const intake = intakeAnswers as Record<string, unknown>;
+    const direct = normalizeSex(intake.sex) ?? normalizeSex(intake.gender);
+    if (direct) return direct;
+
+    const detail = intake.demographicsDetail;
+    if (detail && typeof detail === "object") {
+      for (const section of Object.values(detail as Record<string, unknown>)) {
+        if (!section || typeof section !== "object") continue;
+        const fields = (section as { fields?: unknown }).fields;
+        if (!fields || typeof fields !== "object") continue;
+        const f = fields as Record<string, unknown>;
+        const fromSection = normalizeSex(f.sex) ?? normalizeSex(f.gender);
+        if (fromSection) return fromSection;
+      }
+    }
+  }
+  return "female";
+}
+
+/** Whole years between dateOfBirth and `now`. Unknown DOB → 0 (engine treats
+ *  age only as a CKD-EPI parameter; 0 disables no rules). */
+export function ageFromDateOfBirth(
+  dateOfBirth: Date | string | null,
+  now: Date = new Date()
+): number {
+  if (!dateOfBirth) return 0;
+  const dob = dateOfBirth instanceof Date ? dateOfBirth : new Date(dateOfBirth);
+  if (Number.isNaN(dob.getTime())) return 0;
+  let age = now.getFullYear() - dob.getFullYear();
+  const m = now.getMonth() - dob.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--;
+  return Math.max(0, age);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level assembler
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the PatientRxProfile from pre-fetched rows. Pure — inject `now` for
+ * deterministic age computation in tests.
+ *
+ * PGx: the schema has no pharmacogenomic storage today, so pgxVariants is
+ * always [] (silent pass in the engine). When a PGx column/model lands, wire
+ * it here and the PGx layer activates with zero engine changes.
+ */
+export function buildPatientRxProfile(
+  rows: PatientRxProfileRows,
+  now: Date = new Date()
+): PatientRxProfile {
+  const pgxVariants: PgxVariant[] = [];
+
+  const activeMeds = rows.medications
+    .filter((m) => m.active && m.name.trim().length > 0)
+    .map((m) => m.name.trim());
+
+  return {
+    sex: sexFromIntake(rows.patient.intakeAnswers),
+    age: ageFromDateOfBirth(rows.patient.dateOfBirth, now),
+    pgxVariants,
+    labs: labsFromLabResults(rows.labResults),
+    activeMeds,
+    botanicalExposures: botanicalExposuresFromRows({
+      medications: rows.medications,
+      dosingRegimens: rows.dosingRegimens,
+      doseLogs: rows.doseLogs,
+    }),
+  };
+}

--- a/src/lib/orchestration/types.ts
+++ b/src/lib/orchestration/types.ts
@@ -25,6 +25,10 @@ export type AllowedAction =
   | "write.document.metadata"
   | "write.note.draft"
   | "write.message.draft"
+  // EMR-1145 — held ONLY by safetyAutoResponder: sends the deterministic,
+  // pre-configured 911/ED safety copy on urgent UPI routes. Agents that
+  // compose free-form text stay approval-gated behind write.message.draft.
+  | "write.message.send"
   | "write.task"
   | "write.coding"
   | "write.qualification"

--- a/src/lib/orchestration/workflows.ts
+++ b/src/lib/orchestration/workflows.ts
@@ -514,6 +514,27 @@ export const workflows: WorkflowDefinition[] = [
       },
     ],
   },
+  // EMR-1145 — spec Phase 4.1: when an inbound message routes urgent
+  // (UPI ≥ 0.75), actually SEND the pre-configured 911/ED safety reply on
+  // the patient's channel. Fixed template, so not approval-gated — a 911
+  // instruction held in an approval queue is no safety net at all. The SMS
+  // webhook path replies synchronously in ingestInboundMessage(); the
+  // dedupe guard in dispatchSafetyAutoReply makes this step idempotent.
+  {
+    name: "safety-auto-reply",
+    on: ["message.received"],
+    steps: [
+      {
+        agent: "safetyAutoResponder",
+        input: (e) => ({
+          messageId: (e as any).messageId,
+          threadId: (e as any).threadId,
+          patientId: (e as any).patientId,
+        }),
+        requiresApproval: false,
+      },
+    ],
+  },
   {
     name: "visit-discovery-whisper",
     on: ["note.finalized"],

--- a/src/lib/triage/gateway/__tests__/ingest.test.ts
+++ b/src/lib/triage/gateway/__tests__/ingest.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock prisma + the orchestration dispatcher (vi.hoisted runs before the
+// module-under-test imports them) — same pattern as messaging/deliver.test.ts.
+const hoisted = vi.hoisted(() => {
+  const prisma = {
+    patient: { findUnique: vi.fn() },
+    messageThread: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    message: { create: vi.fn(), findFirst: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  const dispatch = vi.fn();
+  return { prisma, dispatch };
+});
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.prisma }));
+vi.mock("@/lib/orchestration/dispatch", () => ({ dispatch: hoisted.dispatch }));
+
+import { ingestInboundMessage } from "../ingest";
+import { normalizeInboundMessage } from "../normalize";
+import {
+  buildSafetyAutoReplyBody,
+  SAFETY_AUTO_REPLY_SENDER,
+} from "../auto-reply";
+
+const { prisma, dispatch } = hoisted;
+
+const PATIENT = {
+  id: "pat_1",
+  userId: "user_1",
+  organizationId: "org_1",
+  phone: "(303) 555-1212",
+  contraindications: [] as string[],
+  pastMedicalConditions: [] as Array<{ condition: string }>,
+  pastSurgeries: [] as Array<{ createdAt: Date }>,
+};
+
+function smsInput(body: string, overrides?: Partial<Parameters<typeof normalizeInboundMessage>[0]>) {
+  return normalizeInboundMessage({
+    patientId: PATIENT.id,
+    channel: "sms",
+    rawBody: body,
+    senderVerified: true,
+    externalId: "SM_abc123",
+    receivedAt: new Date("2026-06-12T08:00:00Z"),
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // No Twilio env → attemptDelivery uses the mock SMS adapter ("recorded").
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_FROM_NUMBER;
+
+  prisma.patient.findUnique.mockResolvedValue(PATIENT);
+  prisma.messageThread.findFirst.mockResolvedValue({ id: "thread_1" });
+  prisma.messageThread.create.mockResolvedValue({ id: "thread_new" });
+  prisma.messageThread.update.mockResolvedValue({});
+  prisma.auditLog.create.mockImplementation(async () => ({ id: "audit_1" }));
+  // findFirst serves two queries: SMS dedupe (deliveryDetail) and the
+  // auto-reply guard (senderAgent). Default: neither exists.
+  prisma.message.findFirst.mockResolvedValue(null);
+  let n = 0;
+  prisma.message.create.mockImplementation(async ({ data }: any) => ({
+    id: data.senderAgent ? "msg_reply" : `msg_${++n}`,
+  }));
+  dispatch.mockResolvedValue(["job_1"]);
+});
+
+describe("ingestInboundMessage — quarantine (dead-letter, never dropped)", () => {
+  it("unverified sender → AuditLog dead-letter row, no thread/message/dispatch", async () => {
+    const result = await ingestInboundMessage(
+      smsInput("who dis", { patientId: null, senderVerified: false }),
+      { quarantineContext: { from: "+15550001111", matchFailure: "no_patient_match" } },
+    );
+
+    expect(result).toEqual({
+      status: "quarantined",
+      reason: "unverified_sender",
+      auditLogId: "audit_1",
+    });
+
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+    const audit = prisma.auditLog.create.mock.calls[0][0].data;
+    expect(audit.action).toBe("message.inbound.quarantined");
+    expect(audit.metadata.rawBody).toBe("who dis"); // recoverable, not dropped
+    expect(audit.metadata.from).toBe("+15550001111");
+
+    expect(prisma.message.create).not.toHaveBeenCalled();
+    expect(prisma.messageThread.create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("verified flag but no patient match → quarantined as unmatched_patient", async () => {
+    const result = await ingestInboundMessage(
+      smsInput("hello", { patientId: null, senderVerified: true }),
+    );
+    expect(result.status).toBe("quarantined");
+    expect((result as any).reason).toBe("unmatched_patient");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("patientId that no longer resolves → quarantined as patient_not_found", async () => {
+    prisma.patient.findUnique.mockResolvedValue(null);
+    const result = await ingestInboundMessage(smsInput("hello"));
+    expect(result.status).toBe("quarantined");
+    expect((result as any).reason).toBe("patient_not_found");
+    expect(prisma.message.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("ingestInboundMessage — happy path (benign message)", () => {
+  it("persists into the existing thread and dispatches message.received", async () => {
+    const result = await ingestInboundMessage(
+      smsInput("Can I reschedule my appt for next week?"),
+    );
+
+    expect(result.status).toBe("ingested");
+    if (result.status !== "ingested") return;
+    expect(result.threadId).toBe("thread_1");
+    expect(result.route).toBe("standard");
+    expect(result.autoReplyMessageId).toBeNull();
+
+    // Exactly one message row — the inbound one. No auto-reply for benign.
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+    const data = prisma.message.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      threadId: "thread_1",
+      senderUserId: "user_1",
+      status: "sent",
+      channel: "sms",
+      deliveryDetail: "twilio-inbound:SM_abc123",
+      body: "Can I reschedule my appt for next week?",
+    });
+
+    // Same event the portal send path dispatches.
+    expect(dispatch).toHaveBeenCalledWith({
+      name: "message.received",
+      messageId: "msg_1",
+      threadId: "thread_1",
+      patientId: "pat_1",
+      organizationId: "org_1",
+    });
+
+    expect(prisma.messageThread.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "thread_1" } }),
+    );
+  });
+
+  it("creates a fresh thread when the patient has no unresolved thread", async () => {
+    prisma.messageThread.findFirst.mockResolvedValue(null);
+    const result = await ingestInboundMessage(smsInput("refill please"));
+    expect(result.status).toBe("ingested");
+    expect(prisma.messageThread.create).toHaveBeenCalledTimes(1);
+    expect(prisma.messageThread.create.mock.calls[0][0].data.subject).toBe(
+      "Text message from patient",
+    );
+    if (result.status === "ingested") expect(result.threadId).toBe("thread_new");
+  });
+
+  it("agent dispatch failure never blocks the patient's message (Art. VI §1)", async () => {
+    dispatch.mockRejectedValue(new Error("queue down"));
+    const result = await ingestInboundMessage(smsInput("just saying thanks!"));
+    expect(result.status).toBe("ingested");
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ingestInboundMessage — idempotency", () => {
+  it("duplicate MessageSid → no second message row, no dispatch", async () => {
+    prisma.message.findFirst.mockImplementation(async ({ where }: any) =>
+      where.deliveryDetail ? { id: "msg_existing" } : null,
+    );
+    const result = await ingestInboundMessage(smsInput("hello again"));
+    expect(result).toEqual({ status: "duplicate", messageId: "msg_existing" });
+    expect(prisma.message.create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("ingestInboundMessage — urgent route dispatches the 911/ED auto-reply", () => {
+  const URGENT_BODY = "I have crushing chest pain RIGHT NOW, please help";
+
+  it("creates the automated safety reply in the same thread, marked as agent-sent", async () => {
+    const result = await ingestInboundMessage(smsInput(URGENT_BODY));
+
+    expect(result.status).toBe("ingested");
+    if (result.status !== "ingested") return;
+    expect(result.route).toBe("urgent");
+    expect(result.upi).toBeGreaterThanOrEqual(0.75);
+    expect(result.autoReplyMessageId).toBe("msg_reply");
+
+    // Two message rows: the inbound message + the auto-reply.
+    expect(prisma.message.create).toHaveBeenCalledTimes(2);
+    const reply = prisma.message.create.mock.calls[1][0].data;
+    expect(reply).toMatchObject({
+      threadId: "thread_1",
+      senderUserId: null,
+      senderAgent: SAFETY_AUTO_REPLY_SENDER,
+      status: "sent",
+      channel: "sms",
+      recipient: PATIENT.phone,
+      body: buildSafetyAutoReplyBody(),
+    });
+    // Clearly marked automated + carries the 911/ED instruction.
+    expect(reply.body).toMatch(/automated safety message/i);
+    expect(reply.body).toMatch(/911/);
+    expect(reply.body).toMatch(/emergency department/i);
+
+    // Audit-logged, PHI-safe.
+    const auditActions = prisma.auditLog.create.mock.calls.map(
+      (c) => c[0].data.action,
+    );
+    expect(auditActions).toContain("message.safety_auto_reply.sent");
+    const auditRow = prisma.auditLog.create.mock.calls.find(
+      (c) => c[0].data.action === "message.safety_auto_reply.sent",
+    )![0].data;
+    expect(auditRow.subjectId).toBe("msg_reply");
+    expect(auditRow.metadata).toMatchObject({
+      threadId: "thread_1",
+      patientId: "pat_1",
+      channel: "sms",
+      dispatchedBy: "ingest",
+    });
+    expect(JSON.stringify(auditRow.metadata)).not.toContain("chest pain");
+
+    // The normal agent pipeline still fires (nurse draft + observer).
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the auto-reply when one was already sent in the dedupe window", async () => {
+    prisma.message.findFirst.mockImplementation(async ({ where }: any) =>
+      where.senderAgent ? { id: "msg_prior_reply" } : null,
+    );
+    const result = await ingestInboundMessage(smsInput(URGENT_BODY));
+    expect(result.status).toBe("ingested");
+    if (result.status !== "ingested") return;
+    expect(result.route).toBe("urgent");
+    expect(result.autoReplyMessageId).toBeNull();
+    expect(prisma.message.create).toHaveBeenCalledTimes(1); // inbound only
+    const auditActions = prisma.auditLog.create.mock.calls.map(
+      (c) => c[0].data.action,
+    );
+    expect(auditActions).not.toContain("message.safety_auto_reply.sent");
+  });
+
+  it("auto-reply failure is loud (audit row) but does not lose the inbound message", async () => {
+    let call = 0;
+    prisma.message.create.mockImplementation(async ({ data }: any) => {
+      call += 1;
+      if (data.senderAgent) throw new Error("db write failed");
+      return { id: `msg_${call}` };
+    });
+    const result = await ingestInboundMessage(smsInput(URGENT_BODY));
+    expect(result.status).toBe("ingested");
+    if (result.status !== "ingested") return;
+    expect(result.autoReplyMessageId).toBeNull();
+    const auditActions = prisma.auditLog.create.mock.calls.map(
+      (c) => c[0].data.action,
+    );
+    expect(auditActions).toContain("message.safety_auto_reply.failed");
+  });
+
+  it("negated symptoms do not trigger the auto-reply (no over-triage)", async () => {
+    const result = await ingestInboundMessage(
+      smsInput("Good news - no chest pain since the new dose. Can I get a refill?"),
+    );
+    expect(result.status).toBe("ingested");
+    if (result.status !== "ingested") return;
+    expect(result.route).toBe("standard");
+    expect(prisma.message.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/triage/gateway/__tests__/normalize.test.ts
+++ b/src/lib/triage/gateway/__tests__/normalize.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeInboundMessage,
+  stripMessagingArtifacts,
+} from "../normalize";
+
+describe("stripMessagingArtifacts", () => {
+  it("removes zero-width characters and BOMs smuggled in by SMS clients", () => {
+    expect(
+      stripMessagingArtifacts("chest\u200Bpain\uFEFF now\u2060"),
+    ).toBe("chestpain now");
+  });
+
+  it("removes control characters but keeps the patient's words intact", () => {
+    expect(stripMessagingArtifacts("hi\u0007there\u0000 friend")).toBe(
+      "hithere friend",
+    );
+  });
+
+  it("collapses duplicate whitespace, newlines, and tabs", () => {
+    expect(stripMessagingArtifacts("  I   can't\n\nbreathe\t\tat all  ")).toBe(
+      "I can't breathe at all",
+    );
+  });
+
+  it("converts curly quotes to straight quotes", () => {
+    expect(stripMessagingArtifacts("I’m “fine”")).toBe(
+      `I'm "fine"`,
+    );
+  });
+
+  it("preserves case and punctuation (distress signal lives there)", () => {
+    expect(stripMessagingArtifacts("HELP!!! Chest pain, NOW.")).toBe(
+      "HELP!!! Chest pain, NOW.",
+    );
+  });
+
+  it("tolerates null-ish input", () => {
+    expect(stripMessagingArtifacts(undefined as unknown as string)).toBe("");
+  });
+});
+
+describe("normalizeInboundMessage", () => {
+  it("produces the channel-agnostic normalized shape", () => {
+    const receivedAt = new Date("2026-06-12T08:00:00Z");
+    const out = normalizeInboundMessage({
+      patientId: "p1",
+      channel: "sms",
+      rawBody: "  Having  sob ​and my chest hurts  ",
+      senderVerified: true,
+      receivedAt,
+      externalId: "SM123",
+    });
+
+    expect(out).toEqual({
+      patientId: "p1",
+      channel: "sms",
+      receivedAt,
+      rawBody: "Having sob and my chest hurts",
+      // Lowercased + UPI abbreviation expansion ("sob" → "shortness of breath")
+      normalizedBody: "having shortness of breath and my chest hurts",
+      senderVerified: true,
+      externalId: "SM123",
+    });
+  });
+
+  it("reuses the UPI engine's abbreviation dictionary (no gateway copy)", () => {
+    const out = normalizeInboundMessage({
+      patientId: "p1",
+      channel: "portal",
+      rawBody: "need a new rx and an appt, also n/v since yesterday",
+      senderVerified: true,
+    });
+    expect(out.normalizedBody).toBe(
+      "need a new prescription and an appointment, also nausea and vomiting since yesterday",
+    );
+  });
+
+  it("keeps the case-preserved body separate from the triage-normalized body", () => {
+    const out = normalizeInboundMessage({
+      patientId: null,
+      channel: "sms",
+      rawBody: "CANT BREATHE",
+      senderVerified: false,
+    });
+    expect(out.rawBody).toBe("CANT BREATHE");
+    expect(out.normalizedBody).toBe("can't breathe");
+  });
+
+  it("defaults receivedAt to now and externalId to null", () => {
+    const before = Date.now();
+    const out = normalizeInboundMessage({
+      patientId: "p1",
+      channel: "portal",
+      rawBody: "hello",
+      senderVerified: true,
+    });
+    expect(out.receivedAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(out.externalId).toBeNull();
+  });
+});

--- a/src/lib/triage/gateway/auto-reply.ts
+++ b/src/lib/triage/gateway/auto-reply.ts
@@ -1,0 +1,139 @@
+// Inbound Message Gateway — urgent 911/ED safety auto-reply (EMR-1145,
+// closes the dispatch TODO left in messageUrgencyObserver from EMR-1147).
+//
+// Spec Phase 4.1: the moment a message routes urgent (UPI ≥ 0.75), an
+// automated red-flag response goes back on the patient's channel. This
+// module is the single dispatcher both channels share:
+//
+//   - SMS: called synchronously from ingestInboundMessage() — a patient
+//     texting "crushing chest pain" must not wait on the agent queue.
+//   - Portal: called by the safetyAutoResponder agent on `message.received`
+//     (the same event the SMS path dispatches, so the idempotency guard
+//     below is what prevents a double reply on the SMS path).
+//
+// The reply is clearly marked as automated (EMR-784 disclaimer spirit:
+// the patient must always know when no human wrote the message), carries
+// the agent sender identity, and is audit-logged PHI-safe.
+
+import { prisma } from "@/lib/db/prisma";
+import { attemptDelivery } from "@/lib/messaging/deliver";
+import { URGENT_AUTO_REPLY } from "@/lib/triage/upi";
+import type { InboundChannel } from "./normalize";
+
+export const SAFETY_AUTO_RESPONDER_NAME = "safetyAutoResponder";
+export const SAFETY_AUTO_RESPONDER_VERSION = "1.0.0";
+
+/** `Message.senderAgent` value — also the idempotency key for the guard. */
+export const SAFETY_AUTO_REPLY_SENDER = `${SAFETY_AUTO_RESPONDER_NAME}:${SAFETY_AUTO_RESPONDER_VERSION}`;
+
+/** Don't send a second safety auto-reply to the same thread within this window. */
+export const AUTO_REPLY_DEDUPE_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Full auto-reply body: explicit automation disclaimer (EMR-784 spirit —
+ * never let an automated message masquerade as the care team) wrapped
+ * around the pre-configured 911/ED copy from the UPI engine.
+ */
+export function buildSafetyAutoReplyBody(): string {
+  return (
+    "[Automated safety message — no human has read your message yet] " +
+    URGENT_AUTO_REPLY
+  );
+}
+
+export interface SafetyAutoReplyInput {
+  threadId: string;
+  patientId: string;
+  organizationId: string | null;
+  channel: InboundChannel;
+  /** Patient phone for the SMS channel; ignored for portal. */
+  recipientPhone?: string | null;
+  /** The inbound message that triaged urgent (audit linkage). */
+  triggerMessageId: string;
+  /** Final UPI score, recorded in the audit row. */
+  upiScore: number;
+  /** Who is dispatching — "ingest" (webhook path) or "agent" (portal path). */
+  dispatchedBy: "ingest" | "agent";
+}
+
+export type SafetyAutoReplyResult =
+  | { sent: true; messageId: string; delivery: string }
+  | { sent: false; skippedReason: "recent_auto_reply_exists" };
+
+/**
+ * Create the automated 911/ED reply in the patient's thread and attempt
+ * real external delivery for SMS. Idempotent per thread within
+ * AUTO_REPLY_DEDUPE_WINDOW_MS — the `message.received` agent path and the
+ * synchronous SMS ingest path can both call this without double-texting
+ * a patient who is having an emergency.
+ */
+export async function dispatchSafetyAutoReply(
+  input: SafetyAutoReplyInput,
+): Promise<SafetyAutoReplyResult> {
+  const now = new Date();
+
+  // Idempotency guard — one safety reply per thread per window.
+  const existing = await prisma.message.findFirst({
+    where: {
+      threadId: input.threadId,
+      senderAgent: SAFETY_AUTO_REPLY_SENDER,
+      createdAt: { gte: new Date(now.getTime() - AUTO_REPLY_DEDUPE_WINDOW_MS) },
+    },
+    select: { id: true },
+  });
+  if (existing) {
+    return { sent: false, skippedReason: "recent_auto_reply_exists" };
+  }
+
+  const body = buildSafetyAutoReplyBody();
+  const recipient = input.channel === "sms" ? input.recipientPhone ?? null : null;
+
+  // Truthful delivery state, reusing the EMR-808 choke point's pure helper:
+  // a real Twilio send for SMS, "delivered" for portal (persisting IS
+  // delivery in-app), honest "recorded" when no provider is configured.
+  const outcome = await attemptDelivery(input.channel, { recipient, body });
+
+  const message = await prisma.message.create({
+    data: {
+      threadId: input.threadId,
+      senderUserId: null,
+      senderAgent: SAFETY_AUTO_REPLY_SENDER,
+      aiDrafted: false, // deterministic template, not LLM-drafted
+      status: "sent",
+      channel: input.channel,
+      delivery: outcome.delivery,
+      deliveryDetail: outcome.detail,
+      recipient,
+      body,
+      sentAt: now,
+    },
+    select: { id: true },
+  });
+
+  await prisma.messageThread.update({
+    where: { id: input.threadId },
+    data: { lastMessageAt: now },
+  });
+
+  // PHI-safe audit: ids, score, delivery state — never the body/recipient.
+  await prisma.auditLog.create({
+    data: {
+      organizationId: input.organizationId ?? undefined,
+      actorAgent: `agent:${SAFETY_AUTO_REPLY_SENDER.replace(":", "@")}`,
+      action: "message.safety_auto_reply.sent",
+      subjectType: "Message",
+      subjectId: message.id,
+      metadata: {
+        threadId: input.threadId,
+        patientId: input.patientId,
+        triggerMessageId: input.triggerMessageId,
+        channel: input.channel,
+        delivery: outcome.delivery,
+        upiScore: input.upiScore,
+        dispatchedBy: input.dispatchedBy,
+      },
+    },
+  });
+
+  return { sent: true, messageId: message.id, delivery: outcome.delivery };
+}

--- a/src/lib/triage/gateway/index.ts
+++ b/src/lib/triage/gateway/index.ts
@@ -1,0 +1,7 @@
+// Inbound Message Gateway (EMR-1145) — multi-channel funnel into the UPI
+// triage engine. See ./normalize.ts (shape), ./ingest.ts (pipeline) and
+// ./auto-reply.ts (urgent 911/ED safety reply, spec Phase 4.1).
+
+export * from "./normalize";
+export * from "./ingest";
+export * from "./auto-reply";

--- a/src/lib/triage/gateway/ingest.ts
+++ b/src/lib/triage/gateway/ingest.ts
@@ -1,0 +1,274 @@
+// Inbound Message Gateway — ingest pipeline (EMR-1145, epic EMR-1122).
+//
+// One funnel for inbound patient messages that do NOT arrive through an
+// authenticated portal session (today: the Twilio SMS webhook; tomorrow:
+// email, voice transcripts). The pipeline mirrors what the portal send
+// path (src/app/(patient)/portal/messages/actions.ts) does for portal
+// messages, so the Smart Inbox, correspondenceNurse and
+// messageUrgencyObserver agents see SMS messages exactly like portal ones:
+//
+//   verify sender → persist Message into the patient's MessageThread →
+//   dispatch `message.received` → UPI triage → urgent? dispatch the
+//   911/ED safety auto-reply on the same channel (spec Phase 4.1).
+//
+// Unverified senders are NEVER silently dropped: they quarantine into an
+// AuditLog dead-letter row (action `message.inbound.quarantined`) that
+// preserves the payload for staff follow-up, and no thread is created.
+
+import { prisma } from "@/lib/db/prisma";
+import { dispatch } from "@/lib/orchestration/dispatch";
+import { deriveVulnerabilityFlags, triageMessage } from "@/lib/triage/upi";
+import { dispatchSafetyAutoReply } from "./auto-reply";
+import type { NormalizedInboundMessage } from "./normalize";
+
+/** Audit actor for gateway-level rows (quarantine, ingest receipts). */
+export const INBOUND_GATEWAY_ACTOR = "agent:inboundGateway@1.0.0";
+
+/** deliveryDetail prefix used as the idempotency key for SMS provider ids. */
+export const SMS_INBOUND_DETAIL_PREFIX = "twilio-inbound:";
+
+export type IngestResult =
+  | {
+      status: "quarantined";
+      reason: "unverified_sender" | "unmatched_patient" | "patient_not_found";
+      auditLogId: string;
+    }
+  | { status: "duplicate"; messageId: string }
+  | {
+      status: "ingested";
+      messageId: string;
+      threadId: string;
+      route: "urgent" | "standard";
+      upi: number;
+      /** Set when the urgent safety auto-reply was created. */
+      autoReplyMessageId: string | null;
+    };
+
+export interface IngestOptions {
+  /** Extra dead-letter context (e.g. the raw From number) for quarantine rows. */
+  quarantineContext?: Record<string, unknown>;
+}
+
+/**
+ * Dead-letter an inbound message we cannot attribute to a verified patient.
+ * The AuditLog row IS the persistence — staff can recover the message from
+ * the metadata, so nothing is silently dropped. No thread, no Message row,
+ * no agent dispatch: an unverified sender must not be able to inject
+ * content into a patient's chart.
+ */
+async function quarantine(
+  input: NormalizedInboundMessage,
+  reason: "unverified_sender" | "unmatched_patient" | "patient_not_found",
+  context?: Record<string, unknown>,
+): Promise<Extract<IngestResult, { status: "quarantined" }>> {
+  const row = await prisma.auditLog.create({
+    data: {
+      actorAgent: INBOUND_GATEWAY_ACTOR,
+      action: "message.inbound.quarantined",
+      subjectType: "InboundMessage",
+      subjectId: input.externalId ?? null,
+      metadata: {
+        reason,
+        channel: input.channel,
+        receivedAt: input.receivedAt.toISOString(),
+        externalId: input.externalId ?? null,
+        // Dead-letter payload: kept so the message is recoverable by staff.
+        // The sender is unverified, so this is treated as untrusted input,
+        // not chart content.
+        rawBody: input.rawBody.slice(0, 2000),
+        ...(context ?? {}),
+      },
+    },
+    select: { id: true },
+  });
+  return { status: "quarantined", reason, auditLogId: row.id };
+}
+
+/**
+ * Ingest one normalized inbound message. See module header for the pipeline.
+ *
+ * Mirrors the portal send path's failure philosophy (Constitution Art. VI §1):
+ * agent dispatch failures never block the message from landing in the
+ * thread — but the safety auto-reply is NOT best-effort fluff; failures
+ * there are audit-logged loudly so a missed 911 instruction is visible.
+ */
+export async function ingestInboundMessage(
+  input: NormalizedInboundMessage,
+  options?: IngestOptions,
+): Promise<IngestResult> {
+  // ── 1. Sender verification gate ─────────────────────────────────────
+  if (!input.senderVerified || !input.patientId) {
+    return quarantine(
+      input,
+      !input.senderVerified ? "unverified_sender" : "unmatched_patient",
+      options?.quarantineContext,
+    );
+  }
+
+  // ── 2. Idempotency — providers (Twilio) retry webhooks ──────────────
+  if (input.channel === "sms" && input.externalId) {
+    const dupe = await prisma.message.findFirst({
+      where: { deliveryDetail: `${SMS_INBOUND_DETAIL_PREFIX}${input.externalId}` },
+      select: { id: true },
+    });
+    if (dupe) return { status: "duplicate", messageId: dupe.id };
+  }
+
+  // ── 3. Load the patient + the chart context the UPI engine needs ────
+  const patient = await prisma.patient.findUnique({
+    where: { id: input.patientId },
+    select: {
+      id: true,
+      userId: true,
+      organizationId: true,
+      phone: true,
+      contraindications: true,
+      pastMedicalConditions: {
+        where: { deletedAt: null },
+        select: { condition: true },
+      },
+      pastSurgeries: {
+        where: { deletedAt: null },
+        select: { createdAt: true },
+      },
+    },
+  });
+  if (!patient) {
+    return quarantine(input, "patient_not_found", options?.quarantineContext);
+  }
+
+  // ── 4. Persist into the existing thread model ───────────────────────
+  // Reuse the patient's most recent unresolved thread (an SMS reply is
+  // almost always a continuation of the active conversation); start a
+  // fresh one otherwise — same shape the portal path creates.
+  let thread = await prisma.messageThread.findFirst({
+    where: { patientId: patient.id, resolvedAt: null },
+    orderBy: { lastMessageAt: "desc" },
+    select: { id: true },
+  });
+  if (!thread) {
+    thread = await prisma.messageThread.create({
+      data: {
+        patientId: patient.id,
+        subject:
+          input.channel === "sms" ? "Text message from patient" : "Patient message",
+        lastMessageAt: input.receivedAt,
+      },
+      select: { id: true },
+    });
+  }
+
+  const message = await prisma.message.create({
+    data: {
+      threadId: thread.id,
+      // SMS patients may pre-date their portal account; null senderUserId +
+      // null senderAgent still reads as patient-originated everywhere
+      // (smart-inbox + observer treat that pair as the patient).
+      senderUserId: patient.userId ?? null,
+      status: "sent",
+      channel: input.channel,
+      // `recipient` doubles as the verified sender address on inbound rows.
+      recipient: input.channel === "sms" ? patient.phone ?? null : null,
+      deliveryDetail:
+        input.channel === "sms" && input.externalId
+          ? `${SMS_INBOUND_DETAIL_PREFIX}${input.externalId}`
+          : null,
+      body: input.rawBody,
+      sentAt: input.receivedAt,
+    },
+    select: { id: true },
+  });
+
+  await prisma.messageThread.update({
+    where: { id: thread.id },
+    data: { lastMessageAt: input.receivedAt },
+  });
+
+  // ── 5. Dispatch the SAME event the portal path dispatches ───────────
+  // correspondenceNurse drafts a reply, messageUrgencyObserver records the
+  // durable observation, safetyAutoResponder double-checks the auto-reply.
+  // Wrapped in try/catch per Constitution Art. VI §1 — a dead agent queue
+  // must not silence a patient.
+  try {
+    await dispatch({
+      name: "message.received",
+      messageId: message.id,
+      threadId: thread.id,
+      patientId: patient.id,
+      organizationId: patient.organizationId,
+    });
+  } catch (err) {
+    console.warn("[triage/gateway] failed to dispatch message.received", {
+      messageId: message.id,
+      threadId: thread.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // ── 6. UPI triage (deterministic, synchronous) ──────────────────────
+  // Triage runs on the artifact-stripped but CASE-PRESERVED body: the
+  // engine normalizes internally for entity extraction, while the distress
+  // scorer reads casing/punctuation as signal (ALL-CAPS panic). Feeding it
+  // `normalizedBody` (lowercased) would erase that signal.
+  const decision = triageMessage(input.rawBody, {
+    vulnerability: deriveVulnerabilityFlags({
+      conditions: patient.pastMedicalConditions,
+      contraindications: patient.contraindications,
+      surgeries: patient.pastSurgeries,
+    }),
+  });
+
+  // ── 7. Urgent → 911/ED safety auto-reply on the same channel ────────
+  // Synchronous on purpose: a patient texting red-flag symptoms gets the
+  // 911 instruction now, not when a worker next ticks the queue.
+  let autoReplyMessageId: string | null = null;
+  if (decision.route === "urgent") {
+    try {
+      const reply = await dispatchSafetyAutoReply({
+        threadId: thread.id,
+        patientId: patient.id,
+        organizationId: patient.organizationId,
+        channel: input.channel,
+        recipientPhone: patient.phone,
+        triggerMessageId: message.id,
+        upiScore: decision.upi,
+        dispatchedBy: "ingest",
+      });
+      if (reply.sent) autoReplyMessageId = reply.messageId;
+    } catch (err) {
+      // Loud failure: a missed 911 instruction must be visible to staff.
+      console.error("[triage/gateway] safety auto-reply dispatch FAILED", {
+        messageId: message.id,
+        threadId: thread.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await prisma.auditLog
+        .create({
+          data: {
+            organizationId: patient.organizationId,
+            actorAgent: INBOUND_GATEWAY_ACTOR,
+            action: "message.safety_auto_reply.failed",
+            subjectType: "Message",
+            subjectId: message.id,
+            metadata: {
+              threadId: thread.id,
+              patientId: patient.id,
+              channel: input.channel,
+              upiScore: decision.upi,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          },
+        })
+        .catch(() => undefined);
+    }
+  }
+
+  return {
+    status: "ingested",
+    messageId: message.id,
+    threadId: thread.id,
+    route: decision.route,
+    upi: decision.upi,
+    autoReplyMessageId,
+  };
+}

--- a/src/lib/triage/gateway/normalize.ts
+++ b/src/lib/triage/gateway/normalize.ts
@@ -1,0 +1,95 @@
+// Inbound Message Gateway — channel-agnostic normalization (EMR-1145).
+//
+// Phase 1 of the "Asynchronous Triage & Smart Check-ins" red-text spec
+// (docs/product-feedback/2026-06-12_workflows-revisions-red-text.md):
+// every inbound patient message — SMS webhook or portal — is reduced to ONE
+// normalized shape before triage/ingest, so the UPI engine and the Smart
+// Inbox see identical input regardless of transport.
+//
+// The clinical normalization (lowercase, artifact stripping, whitespace
+// collapse, abbreviation expansion: "sob" → "shortness of breath") is NOT
+// re-implemented here — it is the UPI engine's `normalizeMessageText`
+// (src/lib/triage/upi/entities.ts), reused so the gateway and the triage
+// engine can never drift apart on what "normalized" means.
+
+import { normalizeMessageText } from "@/lib/triage/upi";
+
+/** Transports the gateway accepts today. */
+export type InboundChannel = "sms" | "portal";
+
+/** The one normalized inbound-message shape every channel funnels into. */
+export interface NormalizedInboundMessage {
+  /** Matched patient — null when the sender could not be identified. */
+  patientId: string | null;
+  channel: InboundChannel;
+  receivedAt: Date;
+  /**
+   * What the patient actually wrote, minus transport junk (zero-width
+   * characters, stray control chars, duplicate whitespace). Case and
+   * punctuation are preserved — this is what gets stored on the thread.
+   */
+  rawBody: string;
+  /**
+   * UPI-normalized text (lowercased, artifacts stripped, clinical
+   * shorthand expanded). This is what gets triaged — never stored as the
+   * patient's message.
+   */
+  normalizedBody: string;
+  /** True only when the transport authenticated the sender (shared-secret
+   *  webhook + exact phone match, or an authenticated portal session). */
+  senderVerified: boolean;
+  /** Provider message id (e.g. Twilio MessageSid) for idempotency. */
+  externalId?: string | null;
+}
+
+/**
+ * Strip messaging-transport artifacts while preserving the patient's own
+ * words: zero-width/invisible Unicode, control characters, and duplicated
+ * whitespace. Unlike `normalizeMessageText` this keeps case + punctuation,
+ * so the stored message reads exactly as the patient typed it.
+ */
+export function stripMessagingArtifacts(raw: string): string {
+  return (raw ?? "")
+    // Zero-width + BOM + word-joiner characters smuggled in by SMS clients.
+    .replace(/[\u200B-\u200F\u2060\uFEFF]/g, "")
+    // Control characters except \n and \t (kept, then collapsed below).
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    // Curly quotes \u2192 straight, mirroring the UPI normalizer.
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    // Duplicate whitespace (incl. newlines/tabs) \u2192 single space.
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export interface NormalizeInboundInput {
+  patientId: string | null;
+  channel: InboundChannel;
+  rawBody: string;
+  senderVerified: boolean;
+  receivedAt?: Date;
+  externalId?: string | null;
+}
+
+/**
+ * Build the channel-agnostic normalized inbound-message shape.
+ * Pure — no I/O; callers (webhook route, portal path) verify the sender
+ * BEFORE setting `senderVerified`.
+ */
+export function normalizeInboundMessage(
+  input: NormalizeInboundInput,
+): NormalizedInboundMessage {
+  const rawBody = stripMessagingArtifacts(input.rawBody);
+  return {
+    patientId: input.patientId,
+    channel: input.channel,
+    receivedAt: input.receivedAt ?? new Date(),
+    rawBody,
+    // Abbreviation expansion + clinical normalization come from the UPI
+    // engine — one dictionary, owned in one place.
+    normalizedBody: normalizeMessageText(rawBody),
+    senderVerified: input.senderVerified,
+    externalId: input.externalId ?? null,
+  };
+}


### PR DESCRIPTION
Follow-up to #649 (merged with the wave-1 engines). This wave turns those engines into user-facing features, plus the QA bot's `no-orphan-components` allowlist fix. Tracked in the Linear project **WorkFlows Revisions — Zero-Click Ambient Intelligence (June 2026)**.

## What's in here

### 💰 Pre-Flight Claims Dashboard — `/ops/preflight` (EMR-1139)
Operator worklist running the preflight engine server-side per claim: semicircular P_denial risk gauge, disposition pills on the new status tokens, ranked findings with per-feature contributions, inline expanding narrative-evidence highlighting (no modals; riskiest row pre-expanded → 2 clicks to fix), and one-click remediation via a zod-validated server action that re-validates the fix server-side, updates `Claim.cptCodes` transactionally, promotes to ready at < 0.10, and writes an append-only AuditLog row. Documentation-deficit fixes stay guidance-only — the system never injects text into clinical notes. Nav entry under "Scrub and Auths".

### 💊 Ambient Optimization Canvas — inline Rx safety card in the prescribe form (EMR-1131 / EMR-1135)
`PrescribeFormV2` now runs a 400ms-debounced, sequence-guarded safety evaluation as the drug/dose/frequency settle: org-scoped profile assembly (labs→LOINC with alias/lookalike guards, cannabinoid exposures from meds/regimens/dose logs, conservative sex default) → `evaluateRxSafety` → inline card with ranked findings, citations ("CPIC Level A", "CKD-EPI 2021 — creatinine drawn 2026-05-29"), follow-up lab chips, and stale-lab notes. The Sign button recolors on blocking findings and disables on unresolved hard stops. One-click accept mutates the draft only (molecule swaps, −25% anticoagulant reduction, hepatic caps) and audit-logs `rxSafety.recommendation.accepted`.

### 📱 Inbound message gateway + urgent safety auto-reply (EMR-1145; closes the EMR-1147 dispatch TODO)
Twilio-shaped SMS webhook (`/api/webhooks/sms-inbound`: shared-secret header, `timingSafeEqual`, fail-closed 503, registered as `auth: webhook` in route-auth.yaml), channel-agnostic normalization reusing the UPI abbreviation dictionary, MessageSid dedupe, and phone-matched patient identification that quarantines unmatched/ambiguous senders to AuditLog dead-letter rows rather than guessing whose chart to write. Urgent messages (UPI ≥ 0.75) now receive the 911/ED safety auto-reply on both SMS (synchronous) and portal (new `safetyAutoResponder` agent on `message.received`, idempotent per thread per 60 min) — disclaimer-tagged and audit-logged. New scoped `write.message.send` AllowedAction held only by the safety responder.

## Verification
- New tests this wave: 17 (dashboard helpers) + 19 (rx profile) + 21 (gateway) — all green; triage suite 63/63, rx-safety 56/56, preflight 23/23
- `tsc --noEmit` clean, eslint clean on touched files, route-auth manifest checker green (248 routes)
- `node scripts/check-no-orphan-components.mjs` passes on this head (the #649 failure was pre-allowlist-fix)

https://claude.ai/code/session_01CM9Fun5gNmNSvt7TwxW15J

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM9Fun5gNmNSvt7TwxW15J)_