### PR TITLE
feat(compounding): Cannabis Compound & Botanical Order Builder (EMR-1163) + Workflows directive digest

### DIFF
--- a/docs/directives/leafjourney-workflows/2026-06-10.txt
+++ b/docs/directives/leafjourney-workflows/2026-06-10.txt
@@ -1,0 +1,2294 @@
+LeafJourney WorkFlows
+
+Prompt: as LeafJourney is starting to develop into a fully stand alone and functioning EMR, it is imperative that all AI agents are skilled and adept at being able to understand every workflow that is needed and having the ability and intelligence to execute, communicate amongst other AI agents and work collaboratively and collectively to make sure all workflows are smooth, efficient, and with as few glitches as possible. It is crucial that the EMR has all of these current workflows in place and to include all workflows from all of the revision word documents that have been sent already. Make sure to study and analyze these workflows in great detail and test drive it to make sure it actually works in real time. Now the bottom information is a detailed outline, but the AI agents must have the individual intellectual capacity to scour the internet for any issues and glitches that occur once the workflows are implemented and then test them. All errors and issues that occur should be documented and be filed into a PDF report that is then sent to the owners’ emails at: neal@leafjourney.com and scott@leafjourney.com. To clarify, LeafJourney should be a beautiful, aesthetically pleasing, exciting, and engaging platform and experience that the patient, clinician, and practice managers want to participate in. If any workflows can be improved from an efficiency standpoint, then the AI agents shall make those changes and report them as well. Just to clarify, the other word documents and revision documents have already been working on the workflows for different aspects. The goal is for the AI agents to use ALL data and aggregate it, remove all repetitive and superfluous data and prompts, and to merge and synchronize all of the recommendations to provider a very robust, task oriented workflow for every part of our EMR. Make sure the AI agents study and review all workflows down here along with the other documents to compile the data succinctly. Remember, the ultimate goal is to make all workflows to be with as few scrolls and as few clicks as possible for anyone using it. Make sure the AI agents have fun with this project and really use their creativity to make LeafJourney stand out and be a revolutionary new EMR.
+
+
+Administrative & Patient Access Workflows (Front Desk)
+	•	These workflows handle the patient’s entry into the practice ecosystem, focusing on identity, scheduling, and financial clearing.
+
+	•	Patient Registration & Onboarding: Capturing demographics, contact info, emergency contacts, and social determinants of health (SDOH). Includes scanning/uploading driver's licenses and insurance cards.
+	•	Phase 1: Omnichannel Digital Self-Onboarding (Pre-Arrival)
+	•	This phase occurs via the patient portal, web application, or a secure link sent via SMS/email upon booking.
+	•	[Patient Device] ──(OCR/Vision Engine)──> AI Extracts ID/Insurance ──> Populates FHIR Resources
+	•	1.1 Secure Identity & Demographics Capture
+	•	The Action: The patient takes a photo of their government-issued ID (Driver's License/Passport) using their smartphone camera.
+	•	The AI Layer: An integrated Computer Vision/OCR engine processes the image locally or securely in transit. It extracts the full name, date of birth, biological sex, addresses, and ID expiration date.
+	•	The Data Write: The AI cross-checks the extracted data against the initial appointment booking info to catch typos, then maps the verified attributes directly into a FHIR “Patient” resource.
+	•	1.2 Multi-Modal Insurance & Coverage Intake
+	•	The Action: The patient takes photos of the front and back of their commercial, Medicare, or supplemental insurance cards.
+	•	The AI Layer: The vision engine extracts the Payer Name, Payer ID, Policy ID, Group Number, RxBIN, and customer service contact numbers. It simultaneously validates the photo quality, automatically alerting the patient to re-take the photo if it detects blurring or obscured text.
+	•	The Data Write: Instantly instantiates a FHIR “Coverage” resource linked to the “Patient” resource.
+	•	1.3 Dynamic, Context-Aware Intake Forms
+	•	The Action: The patient completes digital health history questionnaires (Past Medical History, Surgical, Family, Social, Lifestyle, and Active Symptoms).
+	•	The AI Layer: Instead of a static PDF-style form, the questionnaire behaves dynamically. If a patient selects "History of metabolic syndrome" or "Chronic Pain," the AI dynamically injects highly specific sub-modules (e.g., dietary patterns, sleep architecture tracking, or prior botanical therapies used) while pruning irrelevant fields to prevent form fatigue.
+	•	The Data Write: Answers are structured into a FHIR “QuestionnaireResponse” resource, which the AI pre-parses into discrete candidate clinical items (such as “Condition” or “Procedure” resources) flagged with an “unverified” status code, awaiting clinical reconciliation.
+	•	Phase 2: Unstructured Record Ingestion & Legacy Harmonization
+	•	If the onboarding patient has historical medical records (PDFs, scanned charts, C-CDA files) from external facilities, they upload them during onboarding.
+	•	2.1 The Data Extraction Pipeline
+	•	Step 1 (Ingestion): Files are uploaded via the portal or an HIE endpoint and categorized as a FHIR “DocumentReference.”
+	•	Step 2 (Medical NLP/LLM Extraction): A medical-grade LLM ingests the raw text or OCRed layout of the PDFs. It parses unstructured narrative text to isolate:
+	•	Active problems and historical diagnoses (mapped to ICD-10-CM / SNOMED-CT).
+	•	Prior laboratory, pathology, and imaging reports (mapped to LOINC).
+	•	Historical allergy listings with reaction severity levels (mapped to RxNorm).
+	•	Step 3 (Deduplication & Timeline Building): The AI cross-references the extracted data against the patient's self-reported intake forms. It builds a consolidated, chronological "Patient Knowledge Graph" rather than a chaotic file folder. Duplicated lab values or overlapping diagnoses are automatically merged into a single timeline view.
+	•	Phase 3: Automated Real-Time Clearing & Pre-Auth Check
+	•	This backend automated step runs completely in the background without requiring front-desk intervention.
+	•	[FHIR Coverage Details] ──> EDI 270 Engine ──> [Payer Clear] ──> AI Cost Matrix Generation
+	•	3.1 Real-Time Eligibility (RTE) Routing
+	•	The EMR automatically extracts the Payer ID and Policy details from the FHIR “Coverage” resource.
+	•	It packages this into a secure EDI 270 (Eligibility, Coverage, or Benefit Inquiry) transaction and transmits it directly to the clearinghouse/payer gateway.
+	•	Within seconds, the payer returns an EDI 271 response.
+	•	3.2 AI Benefit Synthesis
+	•	The AI ingests the raw EDI 271 response and translates it into a highly scannable Cost Matrix for the practice and the patient.
+	•	Calculated Output: Active/Inactive status, exact specialist co-pay, remaining calendar-year deductible, and active co-insurance splits.
+	•	Pre-Auth Flagging: The AI analyzes the scheduled appointment reason code (CPT) against known payer coverage guidelines. If a service or anticipated order requires a prior authorization, the system tags the appointment record: “Prior-Auth Required - Pending Documentation.”
+	•	Phase 4: Day-of-Visit Arrival & Check-In Workflow
+	•	This covers the interface and execution when the patient enters the physical clinic or initiates a virtual encounter.
+	•	4.1 Geofenced or Contactless Arrival Verification
+	•	Digital Arrival: If the patient uses the mobile portal app, a geofence trigger or the scanning of an in-clinic QR code flags the patient's appointment status in the EMR from “Scheduled to Arrived.”
+	•	Front Desk Dashboard: The administrative kiosk or receptionist's dashboard updates instantly. A clear visual indicator shows a Green/Clear Checkmark if Phase 1, 2, and 3 are complete (all signatures captured, identity verified, insurance active).
+	•	4.2 Exception & Discrepancy Resolution (The Administrative Queue)
+	•	If the AI detects an issue during the automated pre-arrival phases, the front desk is presented with a targeted action card rather than a blank slate:
+	•	Scenario A (Insurance mismatch): "Payer returned 'Member Not Found'. AI scan indicates a possible typo in Policy ID on card photo. Click here to verify highlighted digits."
+	•	Scenario B (Missing signature): "HIPAA Notice of Privacy Practices unsigned. Prompting patient tablet now."
+	•	4.3 Co-Pay and Outstanding Balance Processing
+	•	The EMR calculates the exact balance owed based on the EDI 271 real-time synthesis.
+	•	The checkout or check-in system prompts card-on-file execution or pushes a tap-to-pay link to the patient's phone, executing a secure PCI-compliant transaction and auto-posting the payment to the internal ledger (EDI 835 parsing preview).
+	•	Phase 5: The Autonomous Clinical Hand-off
+	•	Once check-in is finalized, the EMR transitions the patient asset seamlessly from the front office to the clinical clinical queue.
+	•	[Finalized Check-In] ──> AI Pre-Visit Briefing Engine ──> Populates Provider's Intake Interface
+	•	•  Rooming Queue Injection: The patient’s record moves to the Ready for Intake / Vitals lane on the medical assistant's dashboard, accompanied by an calculated wait-time clock.
+	•	The AI Pre-Visit Brief: The EMR generates a bulleted, highly specific summary of the incoming patient for the provider, accessible instantly on hover or sidebar preview.
+	•	Example Output: "62yo Male presenting for metabolic follow-up. Self-reported adherence to 16:8 intermittent fasting. AI parsed outside records from 2025: history of elevated fasting insulin (24mg/mL) and an NMR lipoprofile showing high Small Dense LDL. All intake forms, consents, and insurance verification cleared."
+
+	•	Insurance Eligibility Verification: Real-time Eligibility (RTE) checks via EDI 270/271 transactions to verify active coverage, copays, deductibles, and co-insurance before the patient is seen.
+	•	Phase 1: Omnichannel Digital Self-Onboarding (Pre-Arrival)
+	•	This phase occurs via the patient portal, web application, or a secure link sent via SMS/email upon booking.
+	•	[Patient Device] ──(OCR/Vision Engine)──> AI Extracts ID/Insurance ──> Populates FHIR Resources
+	•	1.1 Secure Identity & Demographics Capture
+	•	The Action: The patient takes a photo of their government-issued ID (Driver's License/Passport) using their smartphone camera.
+	•	The AI Layer: An integrated Computer Vision/OCR engine processes the image locally or securely in transit. It extracts the full name, date of birth, biological sex, addresses, and ID expiration date.
+	•	The Data Write: The AI cross-checks the extracted data against the initial appointment booking info to catch typos, then maps the verified attributes directly into a FHIR Patient resource.
+	•	1.2 Multi-Modal Insurance & Coverage Intake
+	•	The Action: The patient takes photos of the front and back of their commercial, Medicare, or supplemental insurance cards.
+	•	The AI Layer: The vision engine extracts the Payer Name, Payer ID, Policy ID, Group Number, RxBIN, and customer service contact numbers. It simultaneously validates the photo quality, automatically alerting the patient to re-take the photo if it detects blurring or obscured text.
+	•	The Data Write: Instantly instantiates a FHIR Coverage resource linked to the Patient resource.
+	•	1.3 Dynamic, Context-Aware Intake Forms
+	•	The Action: The patient completes digital health history questionnaires (Past Medical History, Surgical, Family, Social, Lifestyle, and Active Symptoms).
+	•	The AI Layer: Instead of a static PDF-style form, the questionnaire behaves dynamically. If a patient selects "History of metabolic syndrome" or "Chronic Pain," the AI dynamically injects highly specific sub-modules (e.g., dietary patterns, sleep architecture tracking, or prior botanical therapies used) while pruning irrelevant fields to prevent form fatigue.
+	•	The Data Write: Answers are structured into a FHIR “QuestionnaireResponse” resource, which the AI pre-parses into discrete candidate clinical items (such as “Condition” or “Procedure” resources) flagged with an “unverified” status code, awaiting clinical reconciliation.
+	•	Phase 2: Unstructured Record Ingestion & Legacy Harmonization
+	•	If the onboarding patient has historical medical records (PDFs, scanned charts, C-CDA files) from external facilities, they upload them during onboarding.
+	•	2.1 The Data Extraction Pipeline
+	•	Step 1 (Ingestion): Files are uploaded via the portal or an HIE endpoint and categorized as a FHIR “DocumentReference.”
+	•	Step 2 (Medical NLP/LLM Extraction): A medical-grade LLM ingests the raw text or OCRed layout of the PDFs. It parses unstructured narrative text to isolate:
+	•	Active problems and historical diagnoses (mapped to ICD-10-CM / SNOMED-CT).
+	•	Prior laboratory, pathology, and imaging reports (mapped to LOINC).
+	•	Historical allergy listings with reaction severity levels (mapped to RxNorm).
+	•	Step 3 (Deduplication & Timeline Building): The AI cross-references the extracted data against the patient's self-reported intake forms. It builds a consolidated, chronological "Patient Knowledge Graph" rather than a chaotic file folder. Duplicated lab values or overlapping diagnoses are automatically merged into a single timeline view.
+	•	Phase 3: Automated Real-Time Clearing & Pre-Auth Check
+	•	This backend automated step runs completely in the background without requiring front-desk intervention.
+	•	[FHIR Coverage Details] ──> EDI 270 Engine ──> [Payer Clear] ──> AI Cost Matrix Generation
+	•	3.1 Real-Time Eligibility (RTE) Routing
+	•	The EMR automatically extracts the Payer ID and Policy details from the FHIR Coverage resource.
+	•	It packages this into a secure EDI 270 (Eligibility, Coverage, or Benefit Inquiry) transaction and transmits it directly to the clearinghouse/payer gateway.
+	•	Within seconds, the payer returns an EDI 271 response.
+	•	3.2 AI Benefit Synthesis
+	•	The AI ingests the raw EDI 271 response and translates it into a highly scannable Cost Matrix for the practice and the patient.
+	•	Calculated Output: Active/Inactive status, exact specialist co-pay, remaining calendar-year deductible, and active co-insurance splits.
+	•	Pre-Auth Flagging: The AI analyzes the scheduled appointment reason code (CPT) against known payer coverage guidelines. If a service or anticipated order requires a prior authorization, the system tags the appointment record: Prior-Auth Required - Pending Documentation.
+	•	Phase 4: Day-of-Visit Arrival & Check-In Workflow
+	•	This covers the interface and execution when the patient enters the physical clinic or initiates a virtual encounter.
+	•	4.1 Geofenced or Contactless Arrival Verification
+	•	Digital Arrival: If the patient uses the mobile portal app, a geofence trigger or the scanning of an in-clinic QR code flags the patient's appointment status in the EMR from Scheduled to Arrived.
+	•	Front Desk Dashboard: The administrative kiosk or receptionist's dashboard updates instantly. A clear visual indicator shows a Green/Clear Checkmark if Phase 1, 2, and 3 are complete (all signatures captured, identity verified, insurance active).
+	•	4.2 Exception & Discrepancy Resolution (The Administrative Queue)
+	•	If the AI detects an issue during the automated pre-arrival phases, the front desk is presented with a targeted action card rather than a blank slate:
+	•	Scenario A (Insurance mismatch): "Payer returned 'Member Not Found'. AI scan indicates a possible typo in Policy ID on card photo. Click here to verify highlighted digits."
+	•	Scenario B (Missing signature): "HIPAA Notice of Privacy Practices unsigned. Prompting patient tablet now."
+	•	4.3 Co-Pay and Outstanding Balance Processing
+	•	The EMR calculates the exact balance owed based on the EDI 271 real-time synthesis.
+	•	The checkout or check-in system prompts card-on-file execution or pushes a tap-to-pay link to the patient's phone, executing a secure PCI-compliant transaction and auto-posting the payment to the internal ledger (EDI 835 parsing preview).
+	•	Phase 5: The Autonomous Clinical Hand-off
+	•	Once check-in is finalized, the EMR transitions the patient asset seamlessly from the front office to the clinical queue.
+	•	[Finalized Check-In] ──> AI Pre-Visit Briefing Engine ──> Populates Provider's Intake Interface
+	•	Rooming Queue Injection: The patient’s record moves to the Ready for Intake / Vitals lane on the medical assistant's dashboard, accompanied by an calculated wait-time clock.
+	•	The AI Pre-Visit Brief: The EMR generates a bulleted, highly specific summary of the incoming patient for the provider, accessible instantly on hover or sidebar preview.
+	•	Example Output: "62yo Male presenting for metabolic follow-up. Self-reported adherence to 16:8 intermittent fasting. AI parsed outside records from 2025: history of elevated fasting insulin (24U/mL) and an NMR lipoprofile showing high Small Dense LDL. All intake forms, consents, and insurance verification cleared."
+
+	•	Intake & Digital Consents: Patient completion of HIPAA privacy notices, financial responsibility forms, and history questionnaires (via a patient portal or in-clinic tablet) that automatically parse into the discrete data fields of the EMR.
+	•	Phase 1: Contextual Logic & Dynamic Package Generation
+	•	The system must present the exact right documents to the patient based on their demographic profile, scheduled appointment type, and geographic location.
+	•	1.1 The Rule-Engine Trigger
+	•	The Action: An appointment is booked or a new patient record is initiated.
+	•	The AI Layer: The EMR’s workflow engine analyzes the appointment metadata. It queries the practice profile and regional compliance rules to automatically assemble a customized "Intake & Consent Packet."
+	•	The Execution Matrix:
+	•	Standard Legal Core: HIPAA Privacy Notice, Practice Financial Responsibility Policy, Consent to Treat.
+	•	Conditional Additions: Telehealth Consent (if appointment modal is virtual), State-Specific Controlled Substance/Botanical Disclosure (if booking contains targeted primary care/specialty codes), Medicare Secondary Payer Questionnaire (MSP-Q) (if age > 65)
+	•	1.2 Dynamic Layout Ingestion
+	•	Rather than rendering a static PDF, the EMR compiles these forms as dynamic, web-responsive UI modules powered by a FHIR “Questionnaire” schema. This allows for layout scaling across smartphones, tablets, or in-clinic kiosks.
+	•	Phase 2: Secure Digital Consent Execution & Regulatory Cryptography
+	•	A digital signature must be legally binding, fully auditable, and immutable.
+	•	[Patient UI Signature] ──> Cryptographic Hash (SHA-256) ──> Appended to FHIR Consent Resource ──> Immutable Audit Log
+	•	2.1 Identity Verification & Signature Capture
+	•	The Action: The patient reviews the legal disclosures. To sign, they utilize a touchscreen vector-drawn signature, typed legal name authentication, or biometric validation (FaceID/TouchID on personal mobile devices).
+	•	The Security Layer: The EMR captures the metadata of the signing event: IP address, precise timestamp, device identifier, and a cryptographic hash of the document text at the exact millisecond of the signature.
+	•	2.2 FHIR-Native Consent Serialization
+	•	The finalized transaction does not just output a flat image file. It generates a fully populated FHIR “Consent” Resource:
+	•	“.status = active”
+	•	“.scope = patient-privacy or treatment”
+	•	“.category = Mapped to standard LOINC codes for medical/legal consents.”
+	•	“.patient = Reference to Patient/123”
+	•	“.provision” = Explicit data layout outlining exactly what data permissions the patient has authorized (e.g., opt-in/opt-out of HIE data sharing).
+	•	The Hard Copy: A tamper-evident PDF containing the embedded cryptographic signature certificate is compiled and saved as a FHIR “DocumentReference” for external insurance audits.
+	•	Phase 3: Conversational Intake & Intelligent Clinical Ingestion
+	•	Instead of forcing patients to check 50 distinct boxes, the AI-native intake allows patients to input their medical history via natural language or highly adaptive guided workflows.
+	•	3.1 Adaptive Review of Systems (ROS) & History
+	•	The Interaction: The patient is presented with a conversational text interface or a smart symptom-mapping tree.
+	•	Example Input: Patient types: "I'm constantly exhausted, my joints ache, and I've been experimenting with a strict 18:6 fasting schedule to fix my gut issues."
+	•	The AI Layer (Medical NLP & Entity Extraction): The EMR’s clinical LLM parses this unstructured narrative in real time. It extracts discrete clinical entities and maps them immediately to standardized terminologies:
+	•	"Constantly exhausted”   Fatigue (SNOMED-CT: 84229001)
+	•	"Joints ache"  Arthralgia (SNOMED-CT: 57676002)
+	•	"18:6 fasting schedule”  Intermittent Fasting (Mapped to customized practice-level Lifestyle/Protocol codes or SNOMED lifestyle tracking).
+	•	3.2 Automated Allergy & Medication Ingestion
+	•	When entering current medications, as the patient types "Advil" or "Metformin", the AI autocompletes using RxNorm concepts.
+	•	If a patient inputs an unknown brand name or an artisanal therapeutic substance, the AI flags it, extracts the stated dosage/frequency, and creates a structured candidate item labeled “Unverified Substance” for the provider's intake queue.
+	•	Phase 4: Real-Time Validation & Exception Handling
+	•	This layer prevents incomplete, corrupted, or contradictory intake information from making it to the clinical floor.
+	•	4.1 Automated Conflict Detection
+	•	The AI Layer: As the data is generated, a background validation loop checks for absolute contradictions.
+	•	Example: If a patient checks "No known medical conditions" in a checkbox, but types "I take medication for my high blood pressure" in the text narrative, the AI triggers an inline, gentle validation prompt: "It looks like you mentioned taking blood pressure medication. Would you like to add Hypertension to your medical history?"
+	•	4.2 Completeness Guardrails
+	•	The patient cannot click "Submit Packet" if mandatory fields or legal signatures are missing. The UI dynamically collapses completed sections and highlights unexecuted fields with clear, actionable items (e.g., "Missing Signature on Page 3: Financial Responsibility").
+	•	Phase 5: Downstream Clinical Liquidity & Pre-Population
+	•	5.1 Administrative Ledger Clearance
+	•	The check-in kiosk or front-desk dashboard updates the patient status indicator to “Intake Complete”.
+	•	Signed financial authorizations are routed to the billing module, unlocking the patient record for subsequent clean claim generation (EDI 837 prerequisite verification).
+	•	5.2 Clinical Chart Hydration
+	•	The unverified clinical concepts extracted by the AI are staged within the patient's longitudinal chart.
+	•	They are injected directly into a Draft Encounter Note under the Subjective / History section as pending items.
+	•	When the Medical Assistant or Provider opens the chart, they are presented with a clean, pre-populated text block and a simple interactive list: "AI extracted 3 new conditions from patient intake. Click checkmark to accept into permanent Problem List, or 'X' to discard."
+
+	•	Scheduling & Appointment Management: Multi-provider, multi-location calendar views supporting booking, rescheduling, cancellations, waitlist automation, and appointment status tracking (e.g., Scheduled, Confirmed, Arrived, In Room, Checked Out).
+	•	Phase 1: Ingestion Pipelines & Context-Aware Slot Matching
+	•	Appointments enter the system via three main vectors: patient self-service (portal), AI voice/text agents (asynchronous conversational entry), or internal clinic staff routing.
+	•	1.1 The Dynamic Slot-Duration Engine
+	•	The Action: An appointment is requested for a specific encounter type (e.g., "Metabolic Consultation" or "Routine Lab Follow-up").
+	•	The AI Layer: Instead of assigning a fixed 15-minute or 30-minute block, the scheduling engine calculates a personalized, variable slot duration. The AI evaluates:
+	•	The patient's historical complexity (number of active conditions in their Condition list).
+	•	The volume of external unstructured documents uploaded during onboarding that require chart review.
+	•	The provider's real-time operational velocity (average charting time for similar ICD-10 sets).
+	•	The Output: A bespoke time allocation (e.g., 22 minutes instead of a arbitrary 15-minute standard block), maximizing clinic throughput while protecting the provider from scheduling backlogs.
+	•	Phase 2: The Core Scheduling Graph (FHIR Resource Mapping)
+	•	To guarantee native interoperability and lightning-fast API performance, the calendar cannot rely on standard relational database tables. It must map natively to the FHIR scheduling framework.
+	•	2.1 The Interlocking Resource Matrix
+	•	Every calendar event is compiled by linking discrete FHIR entities in real time:
+FHIR Resource
+Operational Role
+Key Attributes Captured
+Schedule
+The master timeline container for a specific asset.
+actor (Provider, Room, or Device), serviceCategory
+Slot
+Individual segments of time within a master schedule.
+start, end, status (free, busy, busy-tentative)
+Appointment
+The formal booking transaction binding resources together.
+status, specialty, reasonCode (ICD-10/SNOMED)
+Participant
+The specific entities required to execute the appointment.
+actor (Reference to Patient, Practitioner, or Location)
+	•	Phase 3: Machine Learning Predictive Optimization
+	•	The scheduling system acts defensively against lost operational revenue caused by late cancellations and no-shows.
+	•	3.1 Predictive No-Show Modeling
+	•	The AI Layer: For every booked appointment, a lightweight machine learning classification model calculates a continuous no-show probability score (“P = No-Show”) upon booking and refreshes it 48 hours prior to the encounter.
+	•	The Feature Set: The model evaluates seasonal weather patterns, traffic data, patient transit distance, historical adherence behavior, and insurance type.
+	•	Strategic Double-Booking Optimization: If (“P = No-Show”) > 0.78, the EMR flags the slot internally and automatically overrides standard guardrails to allow a soft double-booking or triggers an aggressive automated confirmation sequence.
+	•	3.2 Asynchronous Autonomous Waitlist Liquidation
+	•	The Action: A slot becomes available due to a cancellation or rescheduled event.
+	•	The AI Layer: The EMR does not send a mass email blast to the entire waitlist. It analyzes the waitlist pool using an algorithmic matching matrix:
+	•	Clinical Urgency: Prioritizes high-risk patients needing metabolic or medication titration checks.
+	•	Behavioral Match: Matches patients whose geographical proximity or historical appointment patterns indicate a high likelihood of accepting a short-notice slot.
+	•	Execution: Pushes a targeted SMS text prompt to the top 3 matched candidates: "A slot opened tomorrow at 10:15 AM with Dr. X. Reply YES to claim it instantly." The first to respond secures the slot, and the system automatically updates the FHIR Slot and Appointment payloads without human staff intervention.
+	•	Phase 4: Lifecycle State-Machine Tracking
+	•	The system monitors and drives the continuous status transitions of an appointment throughout the operational day.
+	•	[Proposed] ──> [Booked] ──> [Arrived] ──> [In-Room] ──> [Fulfilled] │ └──> [No-Show] ──> (Auto-Trigger Rebook Pipeline)
+	•	“proposed / pending”: The slot is temporarily locked (busy-tentative) while Phase 3 of Onboarding (Real-Time Insurance Eligibility Checking) executes. If eligibility clears, status changes to booked.
+	•	“arrived”: Triggered via geofencing or digital kiosk check-in. The system records the precise arrival timestamp, instantly changing the visual token color on the clinic coordinator's tracking board.
+	•	“arrived  in room”: Transitioned when the Medical Assistant updates the location parameter to a specific exam room. A background clock tracks room-utilization metrics.
+	•	“fulfilled”: Triggered automatically the exact millisecond the provider signs and cryptographically locks the clinical encounter note.
+	•	Phase 5: The Post-Appointment Continuity Loop
+	•	5.1 Care Plan to Appointment Pipeline
+	•	The Action: The provider notes in the care plan: "Return to clinic in 6 weeks for a repeat fasting insulin draw and metabolic review."
+	•	The AI Layer: The clinical LLM extracts this unstructured plan parameter and generates a persistent, actionable tracking item labeled Pending Appointment Order.
+	•	Automated Outreach: 5 weeks later, the system automatically checks the availability matrix, identifies optimal open slots matching the patient's typical day-of-week preference, and delivers an interactive booking menu directly to their mobile device, completing the patient retention and care orchestration loop.
+
+Pre-Encounter & Clinical Intake Workflows (Nursing / Medical Assistant)
+	•	These steps transition the patient from the waiting room to the exam room, establishing the clinical baseline for the visit.
+	•	Patient Rooming & Intake Queue: A digital dashboard tracking which patient is in which exam room and which staff member is assigned to them.
+	•	Phase 1: Real-Time Room Allocation & Passive Tracking
+	•	This phase shifts the patient state from the waiting room to a designated physical asset (Exam Room), coordinating staff logistics.
+	•	1.1 The Intelligent Tracking Matrix
+	•	The Action: The front desk updates the patient status to Arrived (or the system auto-triggers via geofencing). The Intake Queue Dashboard automatically assigns an optimal exam room based on current provider velocity, equipment requirements specified in the appointment metadata (e.g., ultrasound access), and cleaning cycles.
+	•	The Integration Layer: Utilizing Bluetooth Low Energy (BLE) or RFID room beacons, the system passively detects when an assigned MA badge and the patient’s registration token cross the threshold of Exam Room 3.
+	•	The Data Write: The EMR automatically transitions the FHIR Appointment.status from arrived to in-room and generates a new FHIR Encounter resource:
+	•	.status = in-progress
+	•	.location = Reference to Location/ExamRoom3
+	•	.location.status = active
+	•	A background timer begins counting Room Time, visible on the master tracking board to flag bottlenecks.
+	•	Phase 2: Autonomous IoT Vitals Capture & FHIR Serialization
+	•	Rather than an MA manually typing physiological metrics into a grid—which introduces transcription errors—vitals are captured directly from connected hardware.
+	•	[IoT Vitals Monitor] ──(Bluetooth / Wi-Fi Hub)──> JSON Payload Validation ──> FHIR Observation Stream
+	•	2.1 The Ingestion Pipeline
+	•	The Execution: The MA deploys smart, cellular or Wi-Fi-connected biometric cuffs and sensors (e.g., Welch Allyn, Welch Allyn Connex, or equivalent IoT arrays).
+	•	The Automated Stream: As measurements lock on the device, the hardware transmits a secure payload via webhooks or an internal MQTT broker directly to the EMR API gateway.
+	•	Data Parsing: The EMR validates the incoming JSON packet, extracts the metrics, and instantiates separate FHIR Observation resources nested inside the parent Encounter.
+	•	2.2 Standardized Clinical Mappings
+	•	Every metric is natively bound to its exact LOINC and UCUM (Unified Code for Units of Measure) definitions:
+Metric
+LOINC Code
+UCUM Unit
+Data Structure Handling
+Systolic BP
+8480-6
+mm[Hg]
+Appended to a multi-component Blood Pressure Observation resource.
+Diastolic BP
+8462-4
+mm[Hg]
+Appended to a multi-component Blood Pressure Observation resource.
+Heart Rate
+8867-4
+/min
+Instantiates a single pulse metric. Flags tachycardia alerts if $>100\text{ bpm}$.
+Oxygen Saturation
+2708-6
+%
+Captures fractional $\text{O}_2$ saturation via pulse oximetry.
+Body Temperature
+8310-5
+Cel or [degF]
+Maps oral, tympanic, or temporal data.
+Body Weight
+29463-7
+kg or [lb_av]
+Triggers automated metric conversions on the backend.
+	•	2.3 Automated Anthropometric Logic
+	•	The moment weight and height are validated, an automated serverless function executes the Body Mass Index formula:
+	•	
+	•	The result is saved as a distinct FHIR Observation (LOinc: 39156-5) and written directly to the chart timeline.
+	•	Phase 3: AI-Guided MA Reconciliation (The Intake Engine)
+	•	With vitals passively logged, the MA uses a single-pane interface to reconcile patient-reported pre-arrival data.
+	•	3.1 Unverified Asset Clearance
+	•	The Interaction: The screen displays a side-by-side comparison matrix. On the left: Data parsed by the AI from the patient’s digital pre-intake (medications, allergies, and lifestyle habits like fasting intervals or botanical usage). On the right: The active legacy chart.
+	•	The AI Prompt Layer: The system highlights discrepancies or items requiring physical human confirmation.
+	•	Example Inline Alert: "Patient reported starting Metformin 500mg BID 3 weeks ago. Legacy chart notes Metformin 500mg daily. Please confirm active dosage."
+	•	One-Click Commitment: The MA reads the list to the patient, verifies accuracy, and clicks "Confirm All." The EMR changes the status tag of these candidate FHIR resources (MedicationStatement, AllergyIntolerance) from unverified to active.
+	•	Phase 4: Automated Clinical Screening Execution & Scoring
+	•	Based on the parsed Chief Complaint and historical conditions, the AI determines if clinical screening protocols must be executed prior to the physician entering the room.
+	•	Dynamic Screening Assessment: If the patient has a history of anxiety or depression, or if the ambient AI extracts subjective symptoms of mood changes from the intake narrative, the EMR automatically injects a digital screening interface (e.g., PHQ-9 or GAD-7) into the MA's intake tablet.
+	•	The Computational Logic: As the choices are logged, a deterministic coding layer aggregates the score.
+	•	Downstream Signaling: A score >10 on a PHQ-9 automatically injects an immediate clinical safety alert into the provider's overview dashboard, logs a FHIR Observation for clinical depression screening risk, and prepends a "Suicide Risk Assessment / Safety Plan" module to the upcoming provider encounter documentation.
+	•	Phase 5: The Autonomous Provider Handoff (Pre-Visit Insight Synthesis)
+	•	The final step of the rooming workflow changes the system status to notify the provider and construct their immediate clinical cognitive framework.
+	•	┌──> UI: Room Map changes color (Orange -> Blue: "Provider Ready")
+	•	[MA Clicks "Intake Done"] ─┤
+	•	                          └──> Engine: Aggregates Vitals + Screening + History into Core Brief
+	•	5.1 Status Transition
+	•	The MA clicks a single "Finalize Rooming" button. The EMR automatically executes a state transition across the platform:
+	•	The physical exam room block on the clinic floor map turns blue, signaling Provider Ready.
+	•	The Encounter participant states are updated: the MA status is closed out as completed, and the attending Practitioner status switches to active-alert.
+	•	5.2 The "Handoff Synthesis Card"
+	•	The EMR generates a highly condensed, clinically prioritized briefing block anchored at the top of the provider's entry screen. It maps data points into a narrative structure designed to be ingested by a physician in under 15 seconds:
+	•	Intake Briefing: Exam Room 3
+	•	Vitals: 138/84 mmHG (Elevated from baseline $122/78$), $\text{HR } 72\text{ bpm}$, $\text{BMI } 26.4$.
+	•	Chief Complaint: Routine metabolic follow-up and evaluation of prolonged water fasting tolerability.
+	•	Reconciliation Notes: Patient successfully verified adherence to an automated 16:8 intermittent fasting regimen. Checked and confirmed active botanical/cannabinoid profile (CBD:THC 20:1 oil at bedtime).
+	•	Screenings: PHQ-9 administered; score: $3$ (Minimal/Normal).
+	•	AI Action Item: Last HbA1c was 6 months ago ($5.8\%$). Pre-drafted lab order for HbA1c and Fasting Insulin is staged in your checkout queue.
+
+	•	Vitals & Anthropometric Data Capture: Entry of blood pressure, heart rate, respiratory rate, temperature, $\text{O}_2$ saturation, height, weight, and automated calculation of BMI. Support for tracking pediatric growth charts.
+	•	Phase 1: Device Session Binding & Secure Pairing
+	•	To prevent data corruption or cross-mapping (assigning Patient A’s vitals to Patient B), the EMR handles device orchestration via an ephemeral hardware-to-encounter handshake.
+	•	The Trigger: The Medical Assistant (MA) opens the intake dashboard inside the active FHIR Encounter interface.
+	•	The Pairing Mechanism: The MA scans a QR code on the vitals monitor or uses an NFC-tap on a tablet. This action securely binds the physical device ID to the unique FHIR Encounter.id for a single, time-delimited session.
+	•	The Protocol: The EMR opens a secure WebSocket or MQTT connection to the clinic's local hardware integration hub (supporting protocols like IEEE 11073 or proprietary device APIs such as Welch Allyn Connex, Hillrom, or Withings Pro).
+	•	Still allow for manual entering of data using manual tools such as BP cuff, thermometer, etc
+	•	Phase 2: Real-Time Physiological Stream & Data Standardization
+	•	As sensors stabilize on the patient's body, data is transmitted to the EMR app interface in real time before formal commitment to the permanent health record.
+	•	2.1 The Ingestion and Visualization Layer
+	•	The UI displays a live, ambient streaming state (e.g., watching the pulse rate stabilize).
+	•	Once the peripheral device confirms a stable physiological read, the hardware locks the metrics and transmits a structured JSON payload to the EMR edge API.
+	•	2.2 Core Vitals Normalization Matrix
+	•	The backend instantly parses the incoming payload, mapping every metric to its exact clinical ontology via LOINC and UCUM syntax:
+Vital Sign Parameter
+Mapped LOINC Code
+UCUM Unit
+Clinical Data Type
+Systolic Blood Pressure
+8480-6
+mm[Hg]
+quantity (Component 1)
+Diastolic Blood Pressure
+8462-4
+mm[Hg]
+quantity (Component 2)
+Heart Rate (Pulse)
+8867-4
+/min
+quantity
+Respiratory Rate
+9279-1
+/min
+quantity
+Body Temperature
+8310-5
+[degF] or Cel
+quantity (Includes site attribute)
+Oxygen Saturation ($\text{O}_2$ Sat)
+2708-6
+%
+quantity (Via pulse oximetry)
+	•	Phase 3: Anthropometric Metrics & Computational Engine
+	•	Anthropometric data capture expands beyond basic height and weight to include modern metabolic markers like visceral tissue distribution and body composition.
+	•	3.1 Advanced Anthropometric Ingestion
+	•	Weight (LOINC: 29463-7): Captured from a connected digital scale or smart impedance floor plate.
+	•	Height (LOINC: 8302-2): Captured via a digital wall stadiometer or manual input with automated unit validation.
+	•	Waist Circumference (LOINC: 56115-9): Input manually or via an ergonomic digital tape measure to track central adiposity.
+	•	Body Fat Percentage (LOINC: 41594-3): Ingested directly from bioelectrical impedance analysis (BIA) hardware payloads.
+	•	3.2 Real-Time Deterministic Calculations
+	•	The moment the core values are locked, the EMR's math engine calculates critical physiological indices using LaTeX-specified formulas:
+	•	Body Mass Index (BMI) (LOINC: 39156-5):
+	•	
+	•	Waist-to-Height Ratio (WHtR) (LOINC: 92243-5):
+	•	
+	•	Clinical Utility Note: Calculating WHtR provides the physician with an immediate structural metric for visceral fat distribution and long-term metabolic risk stratification, completely independent of total body mass indices.
+	•	Phase 4: AI Edge Validation & Artifact Rejection
+	•	Before any data is written into the permanent FHIR datastore, an AI validation agent evaluates the payload to eliminate transcription mistakes, device malfunctions, and data-entry errors.
+	•	[Incoming Payload] ──> AI Statistical Sanity Check ──> Passes? ──> [Write to FHIR] │ └──> Fails (Outlier) ──> Inline UI Alert (Prompt Re-Read)
+	•	Statistical Outlier Detection: The AI checks incoming metrics against standard physiological limits and the patient's individual historical baseline using a rolling Z-score model ($Z = \frac{x - \mu}{\sigma}$).
+	•	Automated Typo Mitigation: If an operator accidentally enters a weight of 180 kg instead of 180 lbs, or a blood pressure of 1200/80 mmHg, the validation layer flags the anomaly instantly.
+	•	The Execution Action: The UI prevents the user from finalizing intake and presents an explicit inline action card:
+	•	Outlier Warning: > * Weight detected is $42\%$ higher than the patient's 30-day baseline ($181 \text{ kg}$ vs $127 \text{ kg}$).
+	•	Action required: Please confirm if units were inadvertently toggled from pounds to kilograms, or click "Override & Re-Read" to clear.
+	•	Phase 5: FHIR Serialization & Longitudinal Write-Back
+	•	5.1 The Vital Signs Panel Structure
+	•	To maintain semantic clarity, individual vitals are encapsulated inside a parent Vital Signs Panel resource (LOINC: 8716-3). This ensures that a single clinical event (the intake session) links all concurrent observations together.
+	•	5.2 Downstream System Hydration
+	•	The successful HTTP 201 Created database response triggers two asynchronous background processes:
+	•	The Flowsheet Pipeline: The longitudinal flowsheets are instantly populated, adding new coordinates to the provider's data trend graphs (e.g., charting the patient's metabolic trajectory over time).
+	•	The Clinical Alerting Router: If a metric crosses an operational emergency threshold (e.g., Systolic BP $>180\text{ mmHg}$ or $\text{O}_2 \text{ Sat} <88\%$), the EMR bypasses standard review queues and pushes an active, persistent high-priority notification to the assigned physician’s workspace panel.
+
+	•	Chief Complaint (CC) & History Gathering: Documenting the primary reason for the visit and reviewing Past Medical History (PMH), Past Surgical History (PSH), Family History (FH), and Social History (SH).
+	•	Phase 1: Multi-Modal Capture Activation
+	•	The workflow accommodates both pre-encounter patient entries and synchronous, in-room conversations.
+	•	Vector A: Asynchronous Portal/Kiosk Intake: Ingests the patient’s raw text responses from the digital intake module (e.g., "My lower back has been throbbing for three days, and the pain shoots down my right leg").
+	•	Vector B: Synchronous Ambient AI Scribe: * The provider enters the room and taps "Start Encounter" on their mobile device or workstation.
+	•	The EMR initiates a secure, encrypted audio stream (using TLS 1.3 encryption and WebSocket protocols) to the HIPAA-compliant Medical Speech-to-Text and NLP pipeline.
+	•	The system runs real-time speaker diarization to separate the voices of the Provider, the Patient, and any family members present.
+	•	Phase 2: AI Parsing, Entity Extraction, and the OLDCARTS Framework
+	•	As the conversation progresses or the text is processed, a clinical LLM orchestrates the extraction of unstructured text into a structured, multi-dimensional clinical history.
+	•	[Audio / Text Stream] ──> Medical LLM ──> Concept Extractor ──> OLDCARTS Structural Array
+	•	2.1 Clinical Entity Extraction
+	•	The NLP pipeline utilizes Named Entity Recognition and Relation Extraction (NER+RE) trained on clinical corpuses to isolate core medical concepts. It breaks down the History of Present Illness (HPI) using the standardized OLDCARTS framework:
+	•	Onset (O): Determines when the symptom began (e.g., "3 days ago" $\rightarrow$ Relative date parsing converts this to an absolute timestamp).
+	•	Location (L): Isolates the precise anatomical region (e.g., "Anatomical structure of lower back", "Right leg").
+	•	Duration (D): Identifies the temporal behavior (e.g., "Continuous", "Intermittent").
+	•	Characteristics (C): Extracts descriptive qualitative terms (e.g., "Throbbing", "Shooting").
+	•	Aggravating / Alleviating factors (A): Captures what modifies the symptom (e.g., "Worse with sitting", "Better when lying flat").
+	•	Radiation (R): Establishes directional paths (e.g., "Radiating from lumbar region to right lower extremity").
+	•	Treatment (T): Evaluates prior self-treatment interventions (e.g., "Took 400mg Ibuprofen with mild relief").
+	•	Severity (S): Parses quantitative or qualitative metrics (e.g., "Pain is a 7/10").
+	•	Phase 3: Ontological Mapping and Normalization
+	•	To ensure data interoperability, extracted entities are passed through a terminology normalization microservice that maps natural language synonyms to official clinical ontologies.
+	•	
+	•	Phase 4: FHIR-Native Serialization
+	•	The EMR does not write this data to a flat, unsearchable text block in a traditional relational database. It instantly serializes the data into standard FHIR resources to preserve structural semantics.
+	•	4.1 Resource Allocation Matrix
+	•	Chief Complaint Entry: Maps directly to the root Encounter.reasonCode or Encounter.reasonReference.
+	•	Presenting Symptoms: Serialized as provisional Condition resources with a clinical status of provisional or tentative.
+	•	Historical Subjective Data: Serialized into separate Observation or Procedure history resources.
+	•	Phase 5: Real-Time UI Synthesis & Clinical Verification
+	•	While the consultation occurs, the provider’s screen dynamically visualizes the structured output without requiring them to glance away from the patient.
+	•	5.1 The Split-Screen Workspace Interface
+	•	Left Pane (The Conversation): Displays a minimalist, real-time streaming transcript or ambient AI processing token indicator confirming audio ingestion is active.
+	•	Right Pane (The Structured Chart Preview): The AI continuously hydrates a clean, readable preview of the standard clinical note sections:
+	•	Chief Complaint: Low back pain radiating to the right leg.
+	•	History of Present Illness (HPI): A beautifully structured narrative block generated by the clinical LLM using the extracted OLDCARTS parameters.
+	•	Past Medical/Lifestyle History Cross-Reference: If the patient mentions an existing condition (e.g., "This feels completely different from my usual metabolic neuropathy"), the AI scans the patient's historical FHIR Condition graph, highlights the existing diagnosis of Neuropathy, and displays an inline comparison indicator.
+	•	5.2 Provider Review, Modification, and Affirmation
+	•	Before finalizing the section, the provider can edit any generated narrative using voice commands (e.g., "Change pain level to 8/10") or simple keyboard inputs.
+	•	The provider clicks a single confirmation element (or uses an ambient verbal trigger like "Accept history"). This switches the verification status of the provisional FHIR Condition resources to confirmed, automatically embedding the final, structured text into the active SOAP progress note or APSO progress note payload.
+
+	•	Allergy & Medication Reconciliation: * Reviewing existing allergies with reaction severity levels.
+	•	Pulling external prescription history (via Surescripts or a health information exchange) and reconciling it with the patient's self-reported current medications to create an accurate active medication list.
+	•	Phase 1: Omnichannel Network Query & Data Ingestion
+	•	The workflow initiates automatically the moment a patient’s appointment status transitions to Arrived or In-Room, executing asynchronous backend data-gathering queries.
+	•	[Trigger: Arrived Status] ──> API Gateway Query ──> [Surescripts / HIE / Portal] ──> Consolidated Ingestion Bucket
+	•	1.1 Automated HIE Gateway Extraction
+	•	The Action: The EMR’s integration broker issues automated, encrypted queries via Carequality, CommonWell, and Surescripts network endpoints using the patient’s verified FHIR demographic traits.
+	•	The Ingestion Payload: The system extracts historical pharmacy fill data, insurance pharmacy benefit manager (PBM) claims, and external hospital discharge Summaries (C-CDAs) spanning the past 12 months.
+	•	Data Formatting: The incoming raw files (HL7 v2, C-CDA XML, or JSON) are normalized into a staging data bucket as unverified FHIR resources (MedicationRequest, MedicationDispense, and AllergyIntolerance).
+	•	Phase 2: AI-Driven Clustering, Normalization, and Deduplication
+	•	Raw data from multiple external networks is messy, full of duplicates, and contains free-text variations (e.g., "Metformin", "Glucophage 500mg", "METFORMIN HCL").
+	•	2.1 Ontological Alignment Engine
+	•	The AI Layer: A clinical Natural Language Processing (NLP) pipeline parses every raw medication and allergy string. It resolves them to their exact concept identifiers within national medical vocabularies:
+	•	Medications: Mapped to RxNorm Concept Unique Identifiers (RXCUIs) at the Semantic Clinical Drug (SCD) or Ingredient (IN) level.
+	•	Allergies/Intolerances: Mapped to RxNorm (for drug ingredients), UNII (Unique Ingredient Identifier for chemical substances/excipients), or SNOMED-CT (for environmental/food substances and physical manifestations).
+	•	2.2 Semantic Graph De-duplication
+	•	Clustering Logic: Instead of listing the same active ingredient multiple times because a patient filled it at different pharmacies, the AI clusters matching RXCUIs into a single logical group.
+	•	Example: If Source A shows Metformin 500mg Oral Tablet (Prescribed) and Source B shows Metformin Hydrochloride 500mg (Dispensed), the AI merges them into a single proposed reconciliation row labeled: Metformin 500mg Oral Tablet. It flags the frequency and last-fill dates as metadata layers.
+	•	Phase 3: The Interactive Reconciliation Workspace Interface
+	•	The clinical user interface (UI) must give the Medical Assistant or Provider a comprehensive, single-pane reconciliation interface.
+	•	3.1 The Split-Screen Reconciliation Grid
+	•	The workspace displays three data pillars in a structured interactive table:
+	•	The Legacy Chart: What this specific clinic has on file historically.
+	•	The External/Patient Stream: What the AI extracted from HIE networks, pharmacy fills, and pre-arrival digital intake.
+	•	The Reconciled Target List: The definitive real-time list being generated for the current encounter.
+	•	3.2 Action State Handlers
+	•	For every unique substance or medication entry, the user executes an explicit lifecycle command via one-click interactions:
+	•	
+	•	Phase 4: Real-Time AI Safety Analytics (The Drug Interaction Matrix)
+	•	As items are committed to the reconciled list, an asynchronous validation engine runs deterministic safety checks against the entire patient graph.
+	•	[Draft Reconciled List] ──> AI Knowledge Graph Evaluator ──> Checks: Drug-Drug, Drug-Allergy, Drug-Lifestyle │ Inline Clinical Alert
+	•	Drug-Allergy Cross-Reactivity: If a patient is marked as allergic to Penicillin G (RxNorm: 7980), and the user attempts to keep Amoxicillin active, the system flags the cross-reactivity instantly via class-level mapping (NDF-RT / MED-RT).
+	•	Advanced Multi-Omic & Lifestyle Screenings: Moving beyond simple drug-drug interactions, the system flags interactions with a patient's documented lifestyle or botanical protocols:
+	•	Example: If a patient's reconciled active list includes high-dose artisanal CBD or Cannabinoid extracts (noted during intake), the AI surfaces a low-profile inline warning identifying potential cytochrome P450 (specifically CYP3A4 / CYP2C19) competitive inhibition risks with pharmaceuticals like anticoagulants or anticonvulsants on their list.
+	•	Phase 5: FHIR Serialization & Data Provenance Logging
+	•	Once the clinician completes the reconciliation review and clicks "Finalize Medication & Allergy List," the staging bucket is committed to the permanent transaction layer.
+	•	5.1 Documenting the Source of Truth (Provenance)
+	•	To comply with strict data integrity standards, every single reconciled medication or allergy resource must contain a explicit FHIR Provenance record. This tracks who verified the data, when it was verified, and where the original data component came from.
+	•	5.2 Serialized FHIR Resource Payload Examples
+	•	Reconciled Allergy Asset (AllergyIntolerance):
+	•	Reconciled Active Medication Asset (MedicationStatement):
+	•	Upon finalization, the previous historical records are assigned an end-date timestamp, the newly verified FHIR resources are injected into the active longitudinal flowsheet, and a clean, reconciled medication block is instantly written into the subjective portion of the active encounter's SOAP note structure.
+	•	Clinical Screenings: Administering standardized, age-appropriate screenings (e.g., PHQ-9 for depression, GAD-7 for anxiety, falls risk, or cognitive assessments) that score automatically within the chart.
+	•	Phase 1: Context-Aware Automated Trigger Engine
+	•	Screenings are executed dynamically based on clinical guardrails, demographic algorithms, or real-time insights derived from the patient's record, rather than manual staff selection.
+	•	1.1 The Rule-Engine Matrix
+	•	The EMR’s event router scans the patient graph the moment an appointment transitions to Booked or Arrived. It evaluates three criteria tiers to build the screening packet:
+	•	Tier A (Regulatory & Preventive Gaps): Checks the patient’s age, sex, and date of last screening against USPSTF guidelines and MIPS quality actions (e.g., Annual Depression Screening for patients aged $\ge 12$, Fall Risk Assessment for patients aged $\ge 65$).
+	•	Tier B (Clinical Pathway Ingestion): Triggers specific deep-dive screenings based on the scheduled appointment metadata or active problem lists (e.g., mapping a metabolic consult to a structured Lifestyle/Nutrition Assessment, or a chronic pain consult to a DAST-10/Opiate Risk Screener).
+	•	Tier C (AI-Generated Alerts): If the ambient AI scribe or portal communication pipeline extracts concepts of progressive fatigue, cognitive changes, or shifting sleep latency over recent weeks, the EMR flags and prepends the corresponding assessment tool (e.g., GAD-7, Epworth Sleepiness Scale) to the intake pipeline.
+	•	Phase 2: Multimodal Delivery & Data Collection Interface
+	•	The screening must support seamless omnichannel interfaces to eliminate manual data ingestion by the clinical staff.
+	•	Asynchronous Execution (Patient-Facing Portal/Kiosk): The screening is rendered as an interactive, accessible UI element. Progressive disclosure logic is applied: if a patient answers "0 - Not at all" to the first two questions of a PHQ-9 (the PHQ-2 pre-screener), the system cleanly bypasses the remaining 7 questions, logging a negative screening event to save patient time.
+	•	Synchronous Execution (MA-Guided/Conversational): If completed in-clinic, the MA can read questions from an intake dashboard. Alternatively, if the provider reviews screening parameters naturally during the encounter, the ambient AI scribe extracts the spoken answers and fills the digital screening card in the background.
+	•	Phase 3: Computational Scoring & Clinical Ontology Alignment
+	•	Every screening tool must map to standard clinical terminologies down to the individual question and answer choice level to preserve semantic meaning across health networks.
+	•	3.1 Ontological Architecture mapping
+	•	Screening Identity & Panels: Mapped via unique LOINC codes.
+	•	Individual Questions: Mapped to designated LOINC child property codes.
+	•	Patient Responses: Mapped using LOINC answer lists (LL) or SNOMED-CT concept codes for standardized qualitative findings.
+	•	3.2 Standardized Screening Computational Matrix
+Screening Tool
+LOINC Panel Code
+Scoring Calculation Method
+Clinical Interpretation Logic
+PHQ-9 (Depression)
+44249-1
+Sum of ordinal values: $\sum_{i=1}^{9} x_i$ where $x \in [0, 3]$
+$0\text{–}4$: Minimal; $5\text{–}9$: Mild; $10\text{–}14$: Moderate; $\ge 15$: Severe.
+GAD-7 (Anxiety)
+69737-5
+Sum of ordinal values: $\sum_{i=1}^{7} x_i$ where $x \in [0, 3]$
+$5\text{–}9$: Mild; $10\text{–}14$: Moderate; $\ge 15$: Severe anxiety.
+AUDIT (Alcohol Use)
+81223-0
+Combined score across 10 behavioral vector inputs.
+$\ge 8$: Hazardous consumption patterns.
+Mini-Mental (MMSE)
+72107-6
+Total points aggregated out of 30 discrete cognitive tasks.
+$\le 23$: Cognitive impairment indicator.
+	•	Phase 4: AI Risk Stratification & CDS Hooks Execution
+	•	The calculation of a high-risk screening score automatically triggers synchronous, real-time clinical workflows, changing the screening from a passive document to an active care catalyst.
+	•	[Screening Score Calculated] ──> AI CDS Hooks Evaluator ──> Scores Split ──> [Low]: Passive FHIR Log └──> [High]: Active Alert + Care Plan Injected
+	•	4.1 Automated Clinical Direction Handlers
+	•	When a screening score crosses a designated severity threshold, the EMR triggers specialized background processes:
+	•	The Emergency Safety Loop (e.g., PHQ-9 Question 9 > 0): If a patient scores $>0$ on Question 9 (suicidal ideation), the system locks a persistent red banner at the top of the Encounter workspace. It automatically appends a Columbia-Suicide Severity Rating Scale (C-SSRS) module to the provider's active view and restricts note-locking until a documented Safety Plan is completed.
+	•	Metabolic/Lifestyle Optimization Trajectories: If a proprietary or advanced metabolic lifestyle screening calculates a high score indicating progressive insulin resistance or severe sleep architecture fragmentation, the AI inline engine triggers a workflow recommending diagnostic testing profiles (e.g., Fasting Insulin, NMR Lipoprofile) or suggests lifestyle protocols matching the clinic's therapeutic frameworks.
+	•	Phase 5: FHIR Serialization & Quality Metric Export
+	•	Once a screening is confirmed, it is written to the datastore using two interlocking FHIR models: a QuestionnaireResponse (preserving the raw, question-by-question layout) and an Observation (storing the final calculated clinical interpretation).
+	•	5.1 Serialized FHIR Total Score Mapping (Observation)
+	•	5.2 Regulatory Aggregation Pipeline
+	•	The generation of this finalized FHIR payload automatically triggers a background event that satisfies regulatory reporting frameworks. The structure updates the clinic's MIPS Dashboard for specific electronic Clinical Quality Measures (eCQMs), such as CMS2v12 (Screening for Depression and Follow-Up Plan).
+	•	The system confirms that both the screening observation code and the matching downstream intervention plan code are present in the encounter timeline, guaranteeing maximum reimbursement performance during automated payer reporting audits.
+
+The Clinical Encounter Workflows (Provider / Physician)
+	•	The core interface where the physician evaluates, diagnoses, and formulates the treatment plan.
+	•	Chart Review / Longitudinal View: A high-level, easily customizable dashboard showing the patient's problem list, recent lab results, recent specialist notes, and upcoming preventive care gaps.
+	•	Phase 1: The Patient Knowledge Graph & Semantic Ingestion
+	•	The backend structure does not treat data points as isolated table rows. It continuously builds a web of interconnected clinical elements anchored to a time-series vector database.
+	•	[Labs (LOINC)] ───┐ [Notes (SNOMED)] ─┼─> AI Vector Embeddings Engine ──> Unified Patient Knowledge Graph [Wearables] ──────┘
+	•	1.1 Multi-Source Semantic Indexing
+	•	The Engine: When a chart is opened, a background execution layer aggregates every structural component tied to the patient's ID—spanning encounters, diagnostic results, medication timelines, lifestyle interventions, and external HIE data.
+	•	Vector Embeddings Mapping: Unstructured items (like older clinical narratives or text from specialty letters) are assigned vector embeddings alongside discrete codes (ICD-10, SNOMED-CT, RxNorm, LOINC). This allows the EMR to establish semantic links across disparate concepts (e.g., linking a note mentioning "severe insulin resistance" directly to a historical fasting insulin lab value of $26 \ \mu\text{IU/mL}$).
+	•	Phase 2: Synthesis-First Conversational Interface (Semantic Search)
+	•	Instead of manually expanding dozens of historical encounter notes to find a specific clinical detail, the provider interrogates the chart using a secure, real-time clinical query engine.
+	•	2.1 The Conversational Chart Layer
+	•	The Interaction: A persistent AI query bar sits at the top of the longitudinal workspace. The provider can type or speak commands naturally:
+	•	Provider Input: "Summarize her metabolic marker trends over the last two years alongside her intermittent fasting adherence."
+	•	The AI Processing Action: A localized, highly secure Medical LLM parses the query using semantic search parameters across the Patient Knowledge Graph.
+	•	The Generated Output: The system instantly compiles a structured, referenced summary in the side panel:
+	•	AI Chart Synthesis:
+	•	Metabolic Trajectory: HbA1c has declined linearly from $5.9\%$ (June 2024) to $5.4\%$ (Current). Fasting Insulin concurrently fell from $18 \ \mu\text{IU/mL}$ to $7.2 \ \mu\text{IU/mL}$.
+	•	Protocol Alignment: Corresponds chronologically with the patient initiating a documented 16:8 intermittent fasting regimen in October 2024 (verified via portal tracking logs and intake summaries).
+	•	References: Click to highlight: [Encounter Note 10/12/24], [Lab Report 03/15/25], [Wearable Sync Stream].
+	•	Phase 3: The Multi-Dimensional Visual Timeline (Stacked Flowsheets)
+	•	The core UI of the longitudinal view is an interactive, stacked time-series dashboard. It visually pairs standard biometric markers with lifestyle data, revealing deep clinical correlations at a single glance.
+	•	3.1 Stacked Time-Series Harmonization
+	•	The EMR aligns completely different data classes onto a single synchronized horizontal time-axis (ranging from a 72-hour macro view to a 5-year longitudinal trend). To display wildly different scales (e.g., tracking a total cholesterol value of 220 alongside a sleep duration of 7.5 hours), the UI applies a normalized scale or uses independent, stacked vertical track layers:
+	•	Track 1: Metabolic & Advanced Labs: Plots LOINC-coded laboratory markers (e.g., HbA1c, ApoB, Triglycerides, Fasting Insulin).
+	•	Track 2: Lifestyle & Protocol Tracking: Displays documented therapeutic interventions (e.g., specific windows of prolonged water fasting, structured ketogenic protocols, or specialized botanical/supplementation schedules).
+	•	Track 3: Continuous Wearable Aggregation: Visualizes continuous streams pulled via health APIs (e.g., mean glycemic variability from CGMs, daily resting heart rate trends, or deep sleep architecture durations).
+	•	3.2 Statistical Anomaly and Trend Overlay
+	•	The visualization engine automatically calculates and displays a low-profile trendline using a rolling average formula.
+	•	Statistical outliers or periods of significant behavioral variance are automatically flagged with an AI insight marker (e.g., a small clickable node indicating: "This spike in fasting blood glucose aligns with a documented 48-hour period of sleep deprivation ($<4.5\text{ hours/night}$).").
+	•	Phase 4: External Document Synthesis & Ingestion Timeline
+	•	A critical bottleneck in chart review is handling unstructured documents sent from outside health systems (e.g., specialist PDFs or faxed reports).
+	•	4.1 Automated OCR and Extraction Pipeline
+	•	Ingestion: When an outside document is uploaded, it is assigned a FHIR DocumentReference status of preliminary.
+	•	The Extraction Layer: An integrated Optical Character Recognition (OCR) and Medical NLP pipeline breaks down the document. It extracts all clinical entities, maps them to standard codes, and identifies the performing facility and clinician.
+	•	Timeline Pinning: Instead of burying the document in a static folder, the EMR drops a specialized token onto the unified visual timeline matching the exact date the service was originally performed (not the date it was received).
+	•	The Hover Preview: Hovering over the timeline node displays an AI-generated 3-bullet summary of the document, with an inline link to open the original verified source PDF in a side-by-side view.
+	•	Phase 5: FHIR Technical Architecture & Data Mapping
+	•	To maintain strict compliance and perfect data liquidity, the longitudinal view acts as a composite layout engine that dynamically resolves and renders an array of distinct FHIR resources.
+	•	5.1 Backing FHIR Resource Matrix
+	•	
+	•	5.2 JSON Payload Mapping: Unified Query Response
+	•	When the longitudinal dashboard compiles, instead of making dozens of independent API roundtrips, the UI hits a specialized Graph GraphQL or FHIR $everything batch endpoint, returning a beautifully sequenced time-series payload:
+	•	5.3 Permanent Context Synchronization
+	•	As the provider clicks through various elements on the longitudinal timeline, the active context is mirrored into the Draft Encounter Note Workspace. If a provider notices an interesting historical trend (e.g., an ApoB drop following a lifestyle modification) and clicks a small "Pin to Note" icon, the EMR automatically inserts a structured text and graphical link directly into the Objective / Assessment narrative of the active chart note, drastically speeding up the synthesis process for the active encounter.
+
+	•	Clinical Charting & Note Generation: Support for multiple documentation styles (SOAP notes, template-driven charting, quick-text/macros, and integration with ambient AI scribes or voice-to-text dictation tools).
+	•	Phase 1: Ambient Audio Stream & Real-Time Contextualization
+	•	1.1 The Ephemeral Audio Pipeline
+	•	The Action: The provider taps "Start Encounter" on an EMR-linked mobile app, tablet, or workstation microphone array.
+	•	The Streaming Architecture: The device opens an encrypted, outbound-only WebSocket stream (protected via TLS 1.3 and AES-256 encryption at rest) directly to a secure, HIPAA-compliant Medical Speech-to-Text and Natural Language Processing (NLP) pipeline.
+	•	Speaker Diarization: The acoustic model runs local speaker diarization to isolate distinct vocal signatures, labeling the transcript tokens dynamically: [Clinician], [Patient], and [Caregiver].
+	•	1.2 Context-Aware Priming
+	•	Rather than listening blindly, the ambient AI engine is "primed" with the patient’s active longitudinal chart graph prior to processing audio.
+	•	By reading the active Condition list, current MedicationStatement profile, recent DiagnosticReport codes, and the pre-encounter intake summary, the vocabulary model reduces transcription errors for complex, patient-specific medical terms (e.g., correctly distinguishing between standard pharmaceutical protocols, specialized metabolic/fasting intervals, or advanced cannabinoid ratios).
+	•	Phase 2: Semantic Scribing & SOAP Note Architecture
+	•	As the clinical conversation flows naturally, a medical-grade LLM orchestrates the unstructured transcript into a beautifully formatted, structured SOAP (Subjective, Objective, Assessment, Plan) progress note.
+	•	[Natural In-Room Dialogue] ──> Ambient Stream ──> Medical LLM Parser ──> Segmented SOAP Matrix Computerized Physician Order Entry (CPOE):
+	•	2.1 The Subjective Segment
+	•	HPI & ROS Generation: The AI processes the dialogue, filtering out casual pleasantries and synthesizing the narrative into a crisp History of Present Illness (HPI) using the OLDCARTS framework.
+	•	It automatically builds a comprehensive Review of Systems (ROS) based on positive and negative symptoms explicitly voiced or denied during the encounter.
+	•	2.2 The Objective Segment
+	•	Vitals & Physical Exam Extraction: The system automatically injects the verified Vitals & Anthropometric Panel (LOINC: 8716-3) captured during the rooming phase.
+	•	Verbal Physical Exam Scribing: As the provider performs the physical examination and vocalizes findings aloud to the patient, the AI catches and organizes the structural physical exam text block.
+	•	Example Dialogue: "Your lungs are completely clear to auscultation bilaterally, good air movement, no wheezing. Heart has a regular rate and rhythm, normal S1 and S2, no murmurs detected."
+	•	AI Generated Output: Respiratory: Clear to auscultation bilaterally. Normal respiratory effort. No wheezes, rales, or rhonchi. Cardiovascular: Regular rate and rhythm. Normal S1 and S2. No murmurs, rubs, or gallops.
+	•	2.3 The Assessment & Plan (A&P) Segment
+	•	Clinical Synthesis: The AI links discussed symptoms to specific clinical assessment narratives, sorting the plan into a prioritized, problem-oriented list. It details diagnostic steps, therapeutic modifications, lifestyle adjustments, and follow-up intervals discussed with the patient.
+	•	Phase 3: Interactive Verification Workspace & Cognitive Sync
+	•	The user interface provides a single-pane workspace designed to minimize cognitive load, allowing the physician to review, modify, and authorize the generated note.
+	•	3.1 The Split-Screen Dashboard
+	•	Left Pane (Live Transcript Preview): Displays an optional, low-profile indicator confirming active processing and a scrolling text log of the conversation.
+	•	Right Pane (The Interactive Note Canvas): The structured SOAP note is dynamically drafted here in real time. Items requiring clinician verification are highlighted in yellow.
+	•	3.2 Dynamic In-Line Editing & Voice Macros
+	•	Providers can edit any text block traditionally via keyboard, or use direct Voice Command Additions to manipulate the text without clicking away.
+	•	Example Command: "AI, append to the metabolic plan: Patient instructed to begin a supervised 16-hour daily fasting window for 4 weeks with repeat fasting insulin draw."
+	•	The Action: The EMR immediately parses the instruction, converts it to structured text, and appends it to the correct "Plan" node under the metabolic condition tracking block.
+	•	Phase 4: Ontological Standardization & FHIR Serialization
+	•	A finalized note cannot remain as a flat text document. To achieve true interoperability and drive downstream clinical decision support, the text must be translated into structured data objects.
+	•	4.1 Automated Coding Layer
+	•	Upon note generation, the semantic engine runs automated clinical coding across the document, linking text phrases to the standard terminologies required for billing and interoperability:
+	•	
+	•	4.2 The Interoperable FHIR Resource Envelope
+	•	The entire note is wrapped inside a master FHIR Composition Resource, which acts as the structured framework for the encounter documentation. This resource maintains direct, semantic pointers to individual clinical resource fragments generated during the session.
+	•	Phase 5: Cryptographic Finalization & Downstream Action Triggers
+	•	The final step securely locks the note into the legal medical record and launches automated administrative workflows.
+	•	5.1 The Sign-Off Protocol
+	•	The Action: The provider reviews the final draft and triggers the sign-off sequence via biometric confirmation (e.g., FaceID/TouchID) or entering an encrypted PIN.
+	•	Cryptographic Hashing: The system calculates a secure SHA-256 cryptographic hash of the complete Composition payload and embeds it alongside a digital signature certificate.
+	•	State Transition: The EMR transitions the Composition.status and the parent Encounter.status to final / finished. The data payload becomes immutable, permanently protecting it against unauthorized tampering or retroactive modifications.
+	•	5.2 Downstream Care & Operational Orchestration
+	•	The exact millisecond the note is cryptographically signed, the EMR emits a system-wide event notification that triggers four asynchronous actions:
+	•	E-Prescribing (EPCS Verification): Transmits any drafted MedicationRequest payloads directly through Surescripts or specialized pharmacy networks.
+	•	Computerized Physician Order Entry (CPOE): Dispatches LOINC-coded laboratory and imaging orders directly to the designated lab information system (LIS) or radiology partner.
+	•	Administrative & Billing Compiled Loop: The system analyzes the documented medical complexity and finalized codes, automatically generating the optimal Evaluation and Management (E&M) charge tier (e.g., 99214). It packages the codes into a clean EDI 837 claim transaction, ready for immediate clearinghouse processing without requiring manual billing intervention.
+	•	Patient CarePlan Release: Translates the clinical plan into clear, patient-facing language and delivers an interactive summary directly to the patient’s portal application, ensuring continuity of care.
+
+	•	Laboratory & Imaging Orders: Selecting codes (LOINC/CPT) and routing them electronically to internal or external diagnostic facilities.
+	•	Phase 1: Dynamic Order Generation & Protocol Assembly
+	•	Orders are drafted effortlessly through conversational text extraction, clinical macros, or automated disease-state protocols.
+	•	1.1 The Ambient Harvesting Layer
+	•	The Action: The provider discusses diagnostic planning during the encounter or documents it in the Assessment & Plan section of the note (e.g., "Let's order a metabolic safety panel including fasting insulin, an NMR lipoprofile, and an MRI of the lumbar spine without contrast").
+	•	The AI Extraction Engine: The clinical NLP pipeline monitors the documentation stream in real time. It isolates diagnostic intent, distinguishes between laboratory and diagnostic imaging modalities, and drops candidate orders into the Staged Checkout Queue at the bottom of the provider's screen.
+	•	The Clinical Mapping Layer: The text strings are immediately paired with standardized vocabularies:
+	•	"Fasting Insulin" $\rightarrow$ LOINC: 30122-6
+	•	“NMR Lipoprofile" $\rightarrow$ LOINC: 74218-9 (Lipoprotein biomarkers panel)
+	•	"MRI Lumbar Spine w/o Contrast" $\rightarrow$ RadLex: RPID2255 / CPT: 72148
+	•	1.2 Multi-Variant Custom Protocol Engines
+	•	For specialty or longevity clinics, the system supports compound clinical macros. Selecting a proprietary routine like a "Metabolic Optimization Profile" instantly hydrates an immutable bundle of distinct LOINC codes, preventing the physician from hunting for separate metabolic, lipidomic, or endocrine markers.
+	•	Phase 2: Autonomous Insurance Validation & Clinical Guidance (CDS)
+	•	Before an order leaves the EMR boundary, a dual-layer confirmation loop checks regulatory alignment and financial coverage to prevent retroactive rejections or unexpected patient billing.
+	•	2.1 Medical Necessity Validation (NCD/LCD Checking)
+	•	Execution: The EMR runs the staged order bundle against regional Local Coverage Determinations (LCD) and National Coverage Determinations (NCD) policies using an integrated rules engine.
+	•	The Cross-Check: The engine ensures that the patient's documented problem list contains an ICD-10-CM code that justifies the order (e.g., verifying that a Fasting Insulin order is bound to an active diagnosis code like E88.81 [Metabolic Syndrome] or E11.9 [Type 2 Diabetes Mellitus without complications]).
+	•	Advance Beneficiary Notice (ABN) Autogen: If the diagnosis code does not satisfy payer logic, the system does not block the provider; instead, it injects a digital, auto-populated ABN form into the patient's checkout tablet for instantaneous e-signature.
+	•	2.2 Prior Authorization Predictive Ingestion
+	•	For Advanced Imaging (MRI/CT/PET): The system triggers an asynchronous HL7 Da Vinci CRD (Coverage Requirements Discovery) query directly to the patient's insurance portal.
+	•	The Prior-Auth Resolver: If prior authorization is mandatory, an AI agent compiles the necessary clinical data directly from the active encounter note (extracting required trial failures, conservative therapy durations, and physical exam findings) and populates the PAS (Prior Authorization Support) FHIR workflow, bypassing manual portal questionnaire documentation.
+	•	Phase 3: FHIR Technical Architecture & Order Serialization
+	•	Every discrete laboratory biomarker and imaging request is instantiated as an independent, interoperable transaction layer inside the database.
+	•	3.1 The Order Resource Matrix
+	•	The engine constructs the order by building tight relational bonds between three distinct core FHIR components:
+	•	
+	•	Phase 4: Bidirectional Interface Ingestion & LIS/RIS Routing
+	•	The system routes orders through standard network protocols and monitors the execution status across external systems.
+	•	4.1 Interface Transmission Routing
+	•	Upon physician signature, the order payload is converted by an interface broker into a standard HL7 v2.5.1 ORM (Order Message) or transmitted directly via a RESTful secure FHIR endpoint to the destination Laboratory Information System (LIS) or Radiology Information System (RIS) (e.g., Quest Diagnostics, Labcorp, or local hospital imaging networks).
+	•	The EMR assigns a unique, cryptographically generated Placer Order Number (Universal Order ID) that serves as the tracking anchor across the entire diagnostic lifecycle.
+	•	4.2 State Machine Tracking Lifecycle
+	•	The EMR tracking dashboard shifts the order token color dynamically based on incoming event acknowledgments from the testing network:
+	•	ordered: Message dispatched and received by vendor LIS/RIS.
+	•	collected / accepted: Phlebotomy executed; specimen logged or imaging slot verified.
+	•	in-lab / scheduled: Specimen under analysis or patient positioned for scanning.
+	•	amended / finalized: Preliminary or complete data payload delivered back to the provider.
+	•	Phase 5: Automated Result Triage, Trend Mapping & Calculation Guardrails
+	•	When results arrive via an inbound HL7 v2 ORU (Observation Report Unstructured/Structured) payload, the EMR processes, indexes, and triages the metrics automatically.
+	•	5.1 Discrete Ingestion & Advanced Calculators
+	•	Data points are unpacked into distinct FHIR Observation sub-nodes.
+	•	If a laboratory result package includes raw values for Fasting Insulin and Fasting Glucose, the EMR's computational layer automatically triggers an active metabolic index formula:
+	•	
+	•	The system injects this calculated Homeostatic Model Assessment for Insulin Resistance directly into the patient's flowsheet as a secondary derived observation (LOINC: 93385-3), tracking insulin sensitivity trends independent of standard glycation metrics.
+	•	5.2 Intelligent Result Triage Grid & Patient Translation
+	•	Normal Results: Marked as stable, immediately mapped onto the longitudinal trend view, and forwarded to the patient portal alongside an optional, automated AI-generated summary written in friendly, plain language.
+	•	Abnormal Non-Critical Results: Highlighted in yellow on the provider's central workspace, prompting an entry in the review queue for manual signature or one-click care-plan adjustments.
+	•	The Critical Value Alarm Loop: If an incoming laboratory value violates safety margins (e.g., Potassium $<2.5\text{ mEq/L}$ or a critical imaging finding like acute appendicitis flagged via a prioritized diagnostic text payload), the EMR overrides standard review queues. It locks an immutable high-priority banner across the provider’s interface, dispatches an urgent SMS pager notification, and flags the incident in the clinical operations workspace to guarantee safe, rapid patient intervention.
+	•	Referrals: Outbound referral generation to specialists, including attaching relevant clinical notes and C-CDA documents.
+	•	Phase 1: Contextual Referral Generation & Intelligent Provider Matching
+	•	The workflow begins the moment a referral need is identified during an active encounter, replacing manual data reentry with automated contextual discovery.
+	•	1.1 The Ambient Harvesting Layer
+	•	The Action: The provider notes in the Assessment & Plan section or vocalizes during the session: "I am referring you to cardiology for an evaluation of your atypical chest pain and elevated cardiovascular risk markers."
+	•	The AI Extraction Engine: The clinical NLP pipeline parses the transaction, identifies the referral intent, and drops a candidate referral token into the checkout interface.
+	•	The Ontological Mapping Layer: The text is instantly mapped to standardized vocabularies:
+	•	Referral Type: Mapped via SNOMED-CT (e.g., Cardiology referral $\rightarrow$ 416315003).
+	•	Clinical Reason: Bound directly to the active encounter diagnosis via ICD-10-CM (e.g., R07.89 [Other chest pain] or E88.81 [Metabolic syndrome]).
+	•	1.2 Algorithmic Specialist Matching Matrix
+	•	Before dispatching the request, the EMR evaluates an internal graph database to identify the optimal recipient. The matching engine evaluates four discrete parameters:
+	•	Insurance Network Compatibility: Queries payer APIs in real time to guarantee the specialist is an active, in-network provider for the patient's specific health plan.
+	•	Clinical Sub-Specialization: Matches complex clinical profiles (e.g., if the chart contains data on metabolic optimization or longevity markers, it prioritizes cardiologists with specialized training in preventive lipidology or metabolic health).
+	•	Operational Velocity: Checks historical access logs and scheduling APIs to rank specialists by their average time-to-appointment wait intervals.
+	•	Geographical/Patient Proximity: Ranks specialists by travel distance from the patient's verified home coordinate geometry.
+	•	Phase 2: Automated Clinical Packet Assembly & Data Minimization
+	•	Sending an entire 500-page historical medical chart violates HIPAA data minimization standards and increases administrative overhead for the receiving clinician.
+	•	[Master Patient Graph] ──> AI Filtering Engine ──> Context-Relevant Payload ──> FHIR Document Bundle
+	•	2.1 Context-Sensitive Data Filtering
+	•	The Execution: An AI data aggregation agent reads the target referral specialty (Cardiology) and automatically compiles a contextually relevant, minimal clinical summary.
+	•	The Inclusion Filter: It extracts the last 3 encounter notes, current active MedicationStatement resources, active AllergyIntolerance sets, and relevant diagnostic datasets (e.g., lipid panels, ApoB levels, ECG reports, and home biometric tracking history). It intentionally excludes unrelated historical text (e.g., older dermatological checks or unrelated minor procedures) to maintain clinical focus.
+	•	The Packaging Standard: The compiled data is prepared simultaneously as an interoperable HL7 C-CDA (Consultation Note XML) payload and a native FHIR Document Bundle, ready for cross-platform delivery.
+	•	Phase 3: Automated Authorization Clearance (Da Vinci Network)
+	•	Before routing the referral to the target facility, the system completes payment authorization to guarantee the care is covered.
+	•	The Step: The EMR launches an asynchronous background transaction using the HL7 Da Vinci CRD (Coverage Requirements Discovery) protocol.
+	•	Prior Auth Verification: The system determines if the patient's plan requires explicit insurance authorization for the specialty consultation code (e.g., CPT: 99244).
+	•	The Prior-Auth Solver (PAS): If prior authorization is mandatory, the EMR extracts the clinical narrative from the active chart note to build the HL7 Da Vinci PAS (Prior Authorization Support / 278) request payload. It submits this directly to the payer's gateway, avoiding manual insurance portal workflows and tracking the status directly on the scheduling tracking board.
+	•	Phase 4: B2B Transport Architecture & Task State Machine Tracking
+	•	Referrals are treated as active distributed database transactions tracked via the FHIR Task Resource Framework.
+	•	4.1 The Referral Technical Architecture
+	•	To maintain absolute data integrity across external clinic boundaries, the referral is built using two interlocking resource records:
+	•	The ServiceRequest: Defines what is being asked for (e.g., the cardiology consultation order).
+	•	The Task: Tracks the operational lifecycle of the request (e.g., tracking the status from proposed to received, scheduled, and completed).
+	•	4.2 Multi-Protocol Transmission Layer
+	•	The EMR sends the clinical packet and tracking tokens using the best available communication protocol for the receiving facility:
+	•	
+	•	Phase 5: The Loop Closure Architecture & Inbound Document Ingestion
+	•	A referral is not complete when it is sent; it is only complete when the loop is fully closed by capturing the specialist's findings back into the primary care record.	
+	•	5.1 The Inbound Ingestion Loop
+	•	The Tracking State: The EMR monitors the outbound queue, keeping the Task.status marked as in-progress while waiting for external schedule alerts or receipt updates from the recipient network.
+	•	The Consultation Arrival: When the specialist signs their clinical note, their system transmits an inbound consultation payload back to the primary clinic (delivered as an HL7 v2 ORU, a C-CDA Document, or a direct FHIR REST payload).
+	•	5.2 Algorithmic Reconciliation & State Resolution
+	•	The Matching Engine: The EMR reads the incoming document’s metadata, parses the embedded tracking tokens, and matches it directly to the open outbound ServiceRequest and Task IDs.
+	•	The AI Extraction & Ingestion Step: * An AI extraction service processes the specialist's document, highlighting their core assessment conclusions, active diagnostic changes, and medication adjustments.
+	•	The system updates the Task.status to completed.
+	•	It links the new specialist report directly into the Longitudinal Chart Review Timeline and surfaces an alert card in the primary provider's workspace workspace:
+	•	🔄 Referral Loop Closed: Cardiology
+	•	Status: Completed. Inbound Consultation Report ingested from Dr. Specialist.
+	•	Key Findings: Confirmed atypical chest pain secondary to suspected microvascular spasms; structural echocardiogram normal.
+	•	Therapeutic Updates: Initiated Diltiazem 120mg daily.
+	•	Action Required: Click "Accept & Sync Chart" to import the new medication into the active patient graph and clear the tracking task.
+	•	E-Prescribing (eRx) & Medication Management:
+	•	Phase 1: Contextual Intent & Intelligent Clinical Decision Support (CDS)
+	•	The prescription lifecycle initiates seamlessly during note generation or through direct workspace interaction, immediately triggering deterministic patient safety calculations.
+	•	1.1 Ambient Intent Extraction
+	•	The Action: The provider updates the plan narrative or voices an order during the encounter (e.g., "Let's start Metformin XR 500mg daily with dinner, and we will adjust the dosage based on renal clearance").
+	•	The Parser: The clinical NLP engine translates the unstructured text string into an active prescription draft, extracting the drug name, formulation, strength, dose, route, and frequency.
+	•	Ontological Standardization: The drug is instantly mapped to its exact RxNorm Semantic Clinical Drug (SCD) identifier.
+	•	1.2 Real-Time Multi-Omic & Metabolic Safety Filters
+	•	Before a medication is staged for signing, an asynchronous validation engine evaluates the order against the complete patient graph using an integrated CDS Hooks architecture:
+	•	Dynamic Renal Dosing Calculations: For medications requiring renal adjustments, the system reads the patient's most recent creatinine lab values and physical parameters, calculating the estimated Glutamerular Filtration Rate or Creatinine Clearance ($CrCl$) using the Cockcroft-Gault equation:
+	•	
+	•	Clinical Guardrail Exception: If the computed $CrCl$ drops below safety parameters for the selected pharmaceutical (e.g., $<30\text{ mL/min}$ for Metformin), the UI shifts the input field to a warning state, offering one-click renal dose reductions or alternative therapeutic suggestions.
+	•	Hepatic Pathway & Botanical Screenings: The system checks the patient's active reconciled list—including historical, lifestyle, or botanical therapies (such as concentrated cannabinoid extracts)—against a competitive enzyme inhibition database. It flags high-probability CYP3A4 or CYP2C19 metabolic path overlaps to prevent altered systemic exposure or drug toxicity.
+	•	Phase 2: Real-Time Benefit Check (RTBC) & Electronic Prior Authorization
+	•	The EMR completely eliminates pharmacy call-backs by resolving financial coverage, out-of-pocket costs, and coverage restrictions before transmission.
+	•	2.1 Formulary Transparency Ingestion
+	•	The Network Query: The EMR issues a real-time transaction using the NCPDP SCRIPT standard over Surescripts or directly to the patient's Pharmacy Benefit Manager (PBM) gateway.
+	•	The Data Display: The provider is presented with an inline financial matrix: the patient’s exact out-of-pocket cost at their designated pharmacy, their deductible balance status, and a list of therapeutic alternatives that would lower the patient's financial burden.
+	•	2.2 Automated Electronic Prior Authorization (ePA)
+	•	If the selected drug triggers a restrictive PBM flag (e.g., step-therapy required or prior auth mandatory), the EMR fires an automated NCPDP ePA wizard.
+	•	An AI agent parses the patient's current active record, extracts the necessary clinical justifications (such as historical trial failures, diagnostic labs, and active ICD-10 indication codes), and populates the insurance questionnaire in the background, securing immediate approval before the order is finalized.
+	•	Phase 3: Controlled Substances (EPCS) & Cryptographic Handshake
+	•	For regulated compound prescriptions, the workflow switches to a strict, audit-ready operational framework that complies with DEA Electronic Prescribing of Controlled Substances (EPCS) mandates.
+	•	Identity Proofing Verification: The system requires the ordering clinician to be verified at NIST Special Publication 800-63 Digital Identity Assurance Level 3 (IAL3) through federated credentialing.
+	•	The Dual-Factor Cryptographic Token: Signing a controlled substance executes a dual-factor cryptographic challenge. The provider must approve the action using two separate factors:
+	•	Something You Knowledge Base: An encrypted high-entropy PIN.
+	•	Something You Are / Have: A biometric signature (e.g., local hardware FaceID/TouchID) linked to a FIPS 140-2 compliant cryptographic key container.
+	•	Audit Trail Generation: The system appends an immutable, read-only transaction log containing the provider's NPI, DEA registration number, timestamp, IP address, and the cryptographic hash value of the electronic signature payload.
+	•	Phase 4: FHIR Technical Architecture & Order Serialization
+	•	Every prescription order is modeled as an interoperable, discrete data asset. It is instantiated inside the database layer as a validated FHIR MedicationRequest resource.
+	•	4.1 The Medication Resource Architecture
+	•	To ensure high-fidelity data structures across external pharmacy networks, the order splits details into explicit structured attributes:
+	•	
+	•	Phase 5: Direct Pharmacy Transmission & Longitudinal Adherence Tracking
+	•	Once authorized, the script is converted and dispatched across public utility pharmacy switches, establishing an active tracking cycle that monitors patient compliance.
+	•	5.1 Surescripts Network Routing
+	•	The finalized FHIR payload is compiled into an industry-standard NCPDP SCRIPT v2017071 XML message.
+	•	The payload is securely transmitted over the Surescripts routing network directly to the patient's chosen destination pharmacy endpoint, generating an instantaneous technical NEWRX Message Acknowledgment (ACK).
+	•	5.2 The Closed-Loop Adherence Engine (RxFill Event Tracking)
+	•	Moving beyond basic transactional delivery, the system actively monitors whether a patient actually picks up their prescribed therapy using inbound network callbacks.
+	•	The Callback Tracking Mechanism: When the patient collects their medication or if the prescription remains abandoned on the pharmacy shelf after 10 days, the dispensing pharmacy transmits an inbound NCPDP SCRIPT RxFill Notification message back to the clinic's EMR gateway.
+	•	The Automated Record Reconciliation: The system matches the incoming tracking data with the original MedicationRequest.id.
+	•	The AI Triage Action: * If marked as Dispensed, the EMR automatically switches the tracking state to confirmed compliance, updating the longitudinal medication flowsheet.
+	•	If marked as Not Picked Up / Returned to Stock, the EMR flags a primary non-adherence event. It surfaces an active care-coordination action card within the patient’s chart view, prompting the clinic team to proactively reach out, evaluate barriers to care, manage potential side-effect concerns, or optimize the treatment protocol before clinical regression occurs.
+
+	•	Formulary & Real-Time Benefit Check (RTBC): Displaying insurance formulary status and out-of-pocket costs at the point of care.
+	•	Phase 1: Contextual Trigger & Eligibility Extraction
+	•	The verification engine runs silently in the background, executing the moment a medication intent is registered by the system.
+	•	1.1 The Transactional Trigger Matrix
+	•	Vector A (Ambient/Documentation Trigger): As the provider discusses therapy or drafts the Assessment & Plan section, the clinical NLP pipeline isolates the drug intent (e.g., "Let's add Jardiance 10mg daily").
+	•	Vector B (CPOE Interactive Search): The user actively searches for or clicks on a drug formulation in the order entry panel.
+	•	The Action: The EMR triggers an asynchronous background API request to the routing gateway, bypassing the traditional need to click a manual "Check Coverage" button.
+	•	1.2 Multi-Tier Coverage Matching
+	•	Before executing an external network call, the system extracts the patient's real-time payment context:
+	•	The engine reads the active FHIR Coverage Resource linked to the patient record.
+	•	It parses the core electronic routing identifiers: the RxBIN (Processor Identification Number), RxPCN (Processor Control Number), RxGroup ID, and member identifier token.
+	•	If a valid insurance plan is missing or expired, the EMR initiates an automated ASC X12 270/271 (Eligibility Benefit Inquiry/Response) clearinghouse sweep or leverages digital PBM demographic matching to extract active commercial, Medicare, or Medicaid coverage data.
+	•	Phase 2: NCPDP SCRIPT Transaction Routing & Multi-Threading
+	•	The system translates internal clinical requests into national pharmacy exchange standards to interrogate Pharmacy Benefit Managers (PBMs) or health plan adjudicators directly.
+	•	[Internal RxNorm Order] ──> EMR Gateway ──(NCPDP SCRIPT Request)──> PBM Clearinghouse ──> Live Adjudication
+	•	2.1 Technical Request Composition
+	•	The EMR packages a live coverage request using the NCPDP SCRIPT standard (v2023011 / current version) or real-time RESTful network APIs. The payload transmits a structured array containing:
+	•	The Prescriber Profile: National Provider Identifier (NPI), state license, and active DEA credentials.
+	•	The Core Drug Target: RxNorm Concept Unique Identifier (RxCUI) mapping to the specific ingredient, strength, and form.
+	•	The Proposed Fulfillment Window: Explicit values for quantity (e.g., 30) and days supply (e.g., 30 or 90).
+	•	The Multi-Pharmacy Destination Array: The system cross-references the patient's preferred retail pharmacy identifier alongside the clinic’s preferred mail-order hub to return concurrent pricing models.
+	•	2.2 Asynchronous Multi-Threading Broker
+	•	To prevent interface lag, the RTBC broker operates as an asynchronous worker process. It isolates network requests into a separate processing thread, maintaining a system responsiveness goal of under 1.8 seconds for the complete external data roundtrip.
+	•	Phase 3: The Integrated RTBC Decision Panel (UI/UX)
+	•	The response data drops cleanly into an intuitive, actionable split-screen interface within the active prescription workflow, avoiding pop-up alerts or navigation disruptions.
+	•	3.1 The Copay Transparency Matrix
+	•	The UI presents a structured, dynamically sorted comparison layout detailing the exact financial obligations for the requested item:
+	•	
+	•	3.2 The Therapeutic Alternatives Stream
+	•	If the primary requested drug is flagged as costly or highly restricted, an AI optimization panel displays therapeutic alternatives recommended by the PBM's formulary rules engine.
+	•	Example: If Jardiance triggers a Tier 3 cost flag, the system renders an alternative row: Farxiga (Dapagliflozin) 10mg Oral Tablet – Mapped to Tier 1 (Preferred), showing an out-of-pocket cost of $15.00 and a status indicator of No Prior Authorization Required.
+	•	Clicking the alternative choice swaps out the active order, updates the RxNorm identity properties, and rewrites the clinical documentation parameters instantly.
+	•	Phase 4: Usage Restrictions & Automated Electronic Prior Authorization (ePA)
+	•	Beyond calculating financial metrics, the RTBC payload flags operational guardrails and clinical rules enforced by the payer.
+	•	4.1 Utilization Control Identifiers
+	•	The system parses and highlights three distinct restriction classes using standard icons:
+	•	Quantity Limits ($QL$): Indicates maximum allowable dosing bounds (e.g., Max 30 tablets per 30 days).
+	•	Age Restrictions ($AR$): Flags plan-specific clinical rules based on demographics.
+	•	Step Therapy ($ST$): Outlines required prerequisite medication courses. The clinical engine evaluates the patient’s longitudinal chart graph to find matching historical events; if the record proves the patient already failed the required step medications, it automatically appends the historical dates to the transmission payload to bypass the restriction.
+	•	4.2 Instant ePA Transition
+	•	If a prior authorization ($PA$) barrier is unavoidable, a one-click button appears next to the drug entry. Selecting it takes the compiled insurance diagnostic rules and routes them directly into the dedicated Electronic Prior Authorization (ePA) workflow engine without requiring the user to open an external insurance portal.
+	•	Phase 5: FHIR Serialization & Financial Data Ingestion
+	•	To preserve the clinical and administrative lineage of the transaction, the benefit response is modeled as an interoperable, queryable data structure.
+	•	5.1 Resource Ingestion Blueprint
+	•	The formulary and cost data are map-serialized into two primary framework objects:
+	•	CoverageEligibilityResponse: Captures plan verification metadata, deductible metrics, and general financial adjustments.
+	•	MedicationKnowledge: Profiles the explicit structural traits of the pharmaceutical, including its formal tier ranking, step-therapy text properties, and cost-constraint arrays.
+	•	5.2 Permanent Audit Trail Logging
+	•	Upon final prescription sign-off, the verified benefit payload, the target pharmacy choice, and the checked cost estimates are securely logged inside a metadata sub-node of the active MedicationRequest. This provides clinical operations staff with complete audit visibility into plan-selection logic, helps track adherence drop-offs caused by medication costs, and protects the practice with comprehensive compliance documentation during downstream insurance disputes or performance audits.
+
+	•	Diagnostics & Results Review Queue: An inbox for providers to review, sign off on, comment on, and route incoming lab results, imaging reports, and pathology.
+	•	Phase 1: Inbound Interface Parsing, Normalization & Demographic Matching
+	•	Diagnostic results enter the system continuously from external commercial laboratories, imaging centers, and internal hospital pathology platforms.
+	•	1.1 The Ingestion Protocol Gateway
+	•	The Network Interface: The EMR integration gateway exposes highly secure endpoints listening for inbound HL7 v2.5.1 ORU_R01 (Observation Report Unstructured/Structured) message clusters or RESTful FHIR Bundle payloads over TLS 1.3.
+	•	Deterministic Patient Resolution: To prevent misallocation, the ingestion engine passes the message through a multi-tiered matching matrix. It evaluates a patient's primary identifiers across three distinct fields: National Master Patient Index (MPI) token, matching First/Last Name tokens, Date of Birth (DOB), and assigned biological sex.
+	•	If a minor discrepancy occurs (e.g., an abbreviated first name like "Chris" vs "Christopher"), the system routes the message to an internal Administrative Reconciliation Desk as unassigned, protecting the production database from mismatched charting errors.
+	•	1.2 Multi-Terminology Ontological Mapping
+	•	As the data stream parses successfully, the system maps the incoming clinical markers into unified national vocabularies:
+	•	Laboratory Markers: Evaluated and mapped using unique LOINC identifiers at the discrete analyte level.
+	•	Imaging Modalities & Anatomical Locations: Translated into RadLex concept codes or mapped to definitive SNOMED-CT structural entities.
+	•	Phase 2: Unstructured Data Extraction & Semantic Ingestion
+	•	When diagnostic vendors transmit unstructured documents (e.g., scanned pathology narratives or faxed radiology PDF reports), the EMR activates its integrated document extraction pipeline.
+	•	2.1 Optical Character Recognition (OCR) & Document Layout Analysis
+	•	The Parser: The document is routed through a specialized Medical OCR framework that preserves reading hierarchies across dense tables and multi-column clinical notes.
+	•	Entity Extraction: A localized Clinical NLP model reads the extracted text strings, focusing heavily on sections labeled IMPRESSION, FINDINGS, or DIAGNOSIS. It isolates significant diagnostic keywords (e.g., "suspicious pulmonary nodule measuring 8mm", "acute cholecystitis signs") and maps them directly to corresponding ICD-10-CM or SNOMED-CT codes in the staging layer.
+	•	2.2 Time-Series Flowsheet Alignment
+	•	Rather than keeping results locked inside a static attachment window, any discovered discrete numeric value is extracted, paired with its parent LOINC code, and pinned directly into the patient's Longitudinal Flowsheet Timeline. This guarantees the item appears instantly alongside historical values for real-time trend plotting.
+	•	Phase 3: Automated Risk Triage & Secondary Calculators
+	•	Before a result is delivered to the provider's active workspace, a validation layer calculates clinical indexes and assigns severity tiers to optimize processing speed.
+	•	3.1 Dynamic Clinical Index Generation
+	•	The receipt of new diagnostic markers automatically prompts the execution of secondary algorithmic computations to assess progression or recovery curves:
+	•	Non-Invasive Liver Fibrosis Scoring ($FIB\text{-}4$): If an inbound laboratory payload updates values for Platelet Count, AST, and ALT, the system auto-calculates the $FIB\text{-}4$ score using the patient's chronological age:
+	•	
+	•	Kinetic Delta Flags: The engine checks the current value against historical baselines. If a value changes drastically despite remaining technically within normal reference limits (e.g., a 25% linear drop in a patient’s baseline Hemoglobin over a 14-day window), the system generates a custom "Kinetic Delta" warning flag.
+	•	3.2 The Urgency Escalation Matrix
+	•	The system filters incoming documents into three prioritized triage buckets based on reference ranges and clinical severity thresholds:
+	•	
+	•	Phase 4: The Interactive Results Workspace Interface
+	•	The provider's central review hub is configured to minimize clicks, optimize cognitive processing, and maximize patient safety.
+	•	4.1 The Single-Pane Interactive Dashboard
+	•	The queue is organized as a dynamic matrix, allowing the provider to view text narratives, look at historical data trends, and authorize follow-up care actions from a single screen.
+	•	Inline Mini-Sparklines: Moving the mouse cursor over any lab marker exposes a 2-year horizontal graph showing the patient's metric trajectory, immediately contextualizing whether a finding is chronic or an acute deviation.
+	•	The One-Click Action Suite: For every diagnostic entry, the clinician can execute rapid follow-up commands via interactive buttons.
+	•	Phase 5: FHIR Technical Architecture & Closed-Loop Notification Sign-Off
+	•	When a provider finalizes a diagnostic record, the staging data transitions into an unalterable component of the patient’s permanent chart history.
+	•	5.1 Interoperable FHIR Schema Modeling
+	•	The operational architecture manages results by linking a parent FHIR DiagnosticReport envelope directly to an array of specific, granular FHIR Observation components.
+	•	5.2 Cryptographic Digital Signatures & Provenance Generation
+	•	Sign-Off Authentication: To complete review verification, the clinician validates their session via localized biometrics or a PIN handshake.
+	•	The Provenance Seal: The EMR system generates a permanent FHIR Provenance Resource tied to the transaction. This immutable record logs the provider's identity code, an absolute timestamp, and a cryptographic hash value of the reviewed file.
+	•	This verification sequence removes the item from the active review desk, marks the record status as verified, and satisfies MIPS Quality Measure ID: 122 (Closing the Referral Loop: Receipt of Specialist Report), ensuring clean compliance records for institutional performance audits.
+
+Post-Encounter & Care Coordination Workflows
+	•	Ensuring continuity of care, legal compliance, and clear communication after the provider leaves the room.
+
+	•	Patient Discharge & Clinical Summaries: Generating the After-Visit Summary (AVS) or Patient Clinical Summary containing instructions, changes to medications, and follow-up intervals, available print-side or pushed to the patient portal.
+	•	Phase 1: Automated Clinical Graph Harvesting
+	•	The discharge engine executes the moment a provider shifts an encounter status to Discharge Staged or signs the core chart note. Instead of requiring the clinician to manually copy and paste details into a discharge form, a background broker gathers data from four distinct areas of the active encounter:
+	•	Medication Changes Matrix: Pulls all MedicationRequest objects created, modified, or explicitly deprecated (discontinued) during the session.
+	•	Pending Diagnostics Tracking: Extracts all open ServiceRequest records (laboratory and diagnostic imaging orders) that require outpatient fulfillment.
+	•	Therapeutic Protocol Ingestion: Captures active CarePlan nodes, focusing on non-pharmacological interventions, lifestyle protocols, or structured nutritional/fasting intervals.
+	•	Follow-Up Scheduling Windows: Identifies scheduling orders and follow-up intervals explicitly stated in the plan text or encounter metadata.
+	•	Phase 2: The AI Health Literacy & Translation Layer
+	•	Patients rarely understand raw clinical instructions. The EMR runs the compiled technical clinical graph through an automated health-literacy translation pipeline to adjust the reading level to an accessible layout.
+	•	2.1 Medical Jargon Deconstruction
+	•	The NLP engine targets complex phrasing and Latin sig codes, replacing them with clear, actionable sentences:
+	•	"Metformin XR 500mg PO QHS w/ meal" $\rightarrow$ "Take 1 tablet (500mg) of Metformin Extended-Release by mouth every night at bedtime. Always take this pill with food to protect your stomach."
+	•	"Hyperlipidemia management optimization" $\rightarrow$ "Protecting and optimizing your cholesterol markers."
+	•	2.2 Visual Medication Reconciliation Grid
+	•	To eliminate post-discharge medication errors, the system builds a high-contrast, color-coded table grouping medications by their operational status.
+	•	
+	•	Phase 3: Interactive AVS UI Canvas & Provider Guardrails
+	•	Before publication, the draft AVS drops into a streamlined validation workspace, allowing the care team to review and customize the layout.
+	•	3.1 The One-Pane Layout Preview
+	•	The Warning Center: The interface scans the narrative for high-risk actions. If a dangerous medication is stopped (e.g., an anticoagulant or insulin adjustment), the system highlights that row in red, requiring a single-click verification confirming the patient was verbally instructed on the change.
+	•	
+	•	Custom Dietary & Protocol Extensions: Providers can append pre-built lifestyle cards directly into the instructions. For instance, if a metabolic protocol is initiated, the provider can click a macro button to embed a structured chart outlining hydration rules, electrolyte replacement guides, and safety parameters for a prescribed intermittent fasting window.
+	•	Phase 4: Omnichannel Delivery Matrix (Print vs. Portal)
+	•	Once the clinical team authorizes the summary, the EMR coordinates two concurrent deployment streams.
+	•	4.1 Print-Side Optimization (Physical Output)
+	•	Accessibility Formatting: The print subsystem renders a clean, high-contrast PDF using large, legible typefaces. The layout prioritizes scannability, placing emergency warning signs ("When to seek immediate emergency care") in a bold box at the top of page one.
+	•	Localization Parsing: The formatting engine reads the patient's preferred language code from their profile. If the language is set to Spanish, Mandarin, or Vietnamese, the PDF prints side-by-side translated instructional blocks automatically.
+	•	4.2 Patient Portal Digital Ingestion
+	•	Real-Time Push Notifications: The document is uploaded securely to the patient mobile application via an encrypted endpoint, triggering an immediate notification on the patient's mobile device.
+	•	Interactive Tasks & Loop Closures: The portal does not display the summary as a flat PDF. It unpacks the data into interactive dashboard widgets:
+	•	One-Click Scheduling: Tapping the "Follow up in 4 weeks" section launches an automated appointment booking module pre-loaded with the provider's template availability.
+	•	Diagnostic Reminders: Lab orders generate calendar items that remind the patient when to complete fasting blood draws based on their upcoming clinical milestones.
+	•	Phase 5: FHIR Technical Architecture & Regulatory Audit Tracking
+	•	The generation and delivery of an AVS are modeled as an immutable transactional event inside the data layer, utilizing a structured FHIR DocumentReference wrapper.
+	•	5.1 Backing FHIR Resource Relationships
+	•	The summary acts as a master document index, utilizing explicit relational links to point directly to the discrete source objects that built it:
+	•	
+	•	5.3 Automated Quality Metric and MIPS Attestation
+	•	The cryptographic logging of this DocumentReference payload to the database layer fires a web hook to the analytics engine. This completes the technical compliance verification loop for MIPS Promoting Interoperability (PI) Objective: Provider to Patient Exchange.
+	•	By automatically tracking the exact timestamp the summary is written relative to the encounter closing event, the EMR validates that the clinical summary was delivered within the mandated 24-hour compliance window, maximizing the practice's regulatory performance scores without adding manual administrative burdens.
+
+	•	Encounter Sign-off & Locking: A formal cryptographic or electronic signature mechanism that locks the legal medical record post-encounter, preventing unauthorized retroactive changes.
+	•	Phase 1: Pre-Sign-off Validation & Clinical Guardrails (The Pre-Flight Check)
+	•	The sign-off process begins when the provider initiates the encounter finalization sequence. Before running cryptographic operations, the EMR validates that the record meets all clinical, billing, and regulatory criteria.
+	•	1.1 The Automated Integrity Engine
+	•	The system runs an asynchronous validation loop across the encounter context to check for omissions or clinical inconsistencies:
+	•	Coding Integrity Check: Verifies that every active MedicationRequest, ServiceRequest (labs/imaging), and Procedure initiated during the encounter is mapped to at least one justifying ICD-10-CM diagnosis code.
+	•	Ambient Workspace Attestation: Scans the text note to ensure that any temporary AI draft blocks or placeholder tokens (e.g., unresolved yellow text highlights or [Insert Lab Value Here] tags) are cleared.
+	•	Co-Signature Triage Engine: Evaluates the provider's credentials. If the encounter was conducted by a resident or advanced practice provider requiring a co-signature, the system routes the note to the designated attending physician's queue, preventing final cryptographic locking until the supervisor completes an identical validation check.
+	•	Phase 2: Cryptographic Handshake & Identity Verification
+	•	Once structural validation clears, the EMR transitions from data collection to a secure signing framework compliant with NIST SP 800-63-3 Authenticator Assurance Level 3 (AAL3) guidelines.
+	•	[Finalized Clinical Graph] ──> SHA-256 Hashing ──> Hardware Secure Enclave (Passcode/Biometrics) ──> Cryptographic Signature Envelope
+	•	2.1 Multi-Factor Hardware Authentication
+	•	The Handshake Request: The provider selects "Sign and Lock Encounter."
+	•	The Cryptographic Challenge: The system presents a cryptographic challenge string. The provider completes this signature using a localized hardware token or built-in hardware security module (such as a device's Secure Enclave).
+	•	The Dual-Factor Check: The user passes this challenge by entering an encrypted high-entropy PIN alongside a biometric signature (e.g., local FaceID or TouchID verification), verifying that the credential holder is physically present at the moment of signing.
+	•	2.2 Public Key Infrastructure (PKI) Digital Signature
+	•	Payload Hashing: The system gathers the entire clinical dataset for the encounter—the note narratives, discrete diagnoses, vitals, prescriptions, and orders—and creates a single SHA-256 cryptographic hash representation of the records.
+	•	Asymmetric Encryption Encryption: The hardware module uses the provider’s distinct, securely provisioned private key (utilizing an asymmetric algorithm such as ECDSA secp256r1 or RSA-2048) to encrypt the calculated SHA-256 hash.
+	•	This operation yields a unique digital signature that is structurally bound to that specific block of patient records. If even a single character or code is altered later by an unauthorized database operation, the document hash will fail verification, exposing the tampering event instantly.
+	•	Phase 3: Immutable State Transition & Database Freezing
+	•	After generating the digital signature, the system modifies the database access rights and resource states to isolate the encounter data.
+	•	3.1 Immutable Status Transitions
+	•	The system runs a transactional database update to switch all related FHIR resource nodes to their final, unalterable states:
+	•	Encounter.status transitions to finished.
+	•	Composition.status transitions to final.
+	•	DocumentReference.docStatus transitions to final.
+	•	3.2 Database Access Control List (ACL) Lockdown
+	•	The Write Lock: The database engine adjusts access control lists for the row IDs associated with the encounter, converting permissions from Read/Write to Read-Only for all standard provider and administrator accounts.
+	•	WORM Storage Routing: The finalized JSON payload, the digital signature string, and the accompanying public key certificate are copied to a Write Once, Read Many (WORM) storage vault, creating an unalterable archive of the record.
+	•	Phase 4: Downstream Event Distribution
+	•	Finalizing the encounter triggers a system-wide event message that completes secondary care delivery and administrative workflows.
+	•	Automated Billing Loop: The system packages the validated ICD-10-CM and CPT codes, automatically generating the optimal Evaluation and Management (E&M) code matrix. It formats these details into an EDI 837 claim file for direct clearinghouse dispatch, reducing billing delays.
+	•	Clinical Data Exchange Integration: The system converts the finalized dataset into an interoperable HL7 C-CDA Continuity of Care Document or direct FHIR stream, securely distributing it to regional Health Information Exchanges (HIEs) or the patient's verified primary care network.
+	•	Patient Engagement Portal Delivery: Translates the clinical plan details into patient-facing terminology and delivers the interactive After-Visit Summary (AVS) to the patient’s portal application.
+	•	Compliance Auditing Check: Appends the signature event to the system's permanent access logs to support future organizational audits or quality reviews.
+	•	Phase 5: FHIR Technical Architecture & Cryptographic Signature Serialization
+	•	The system tracks and represents electronic signatures using a dedicated FHIR Provenance Resource that points directly to the underlying signed clinical components.
+	•	
+	•	Phase 6: The Exception Path (Amendments & Addenda Architecture)
+	•	Clinical realities sometimes require corrections to a chart after an encounter has been officially locked. To handle this without invalidating the original data, the system runs an explicit correction protocol.
+	•	6.1 The Non-Destructive Correction Framework
+	•	The Original Record Remains Intact: The cryptographically locked record is never edited, modified, or overwritten directly.
+	•	The Addendum Mechanism: The provider generates a separate, distinct Addendum Composition Resource to document additions or corrections.
+	•	The Relationship Link: This new record utilizes a structural relatesTo attribute array, pointing explicitly to the original signed document ID:
+	•	6.2 The Combined Historical Render View
+	•	When a user reviews the record via the Longitudinal Chart Review Dashboard, the rendering engine resolves the relatesTo pointers. It loads the original historical note pristine, but dynamically appends the verified addendum block directly underneath it in a clearly marked workspace. This provides reviewers with full clinical visibility while preserving an unalterable, legally compliant medical record.
+
+	•	Care Tracking & Task Management: An internal messaging and task-routing engine allowing providers to delegate tasks (e.g., "Call patient to discuss normal labs," "Schedule 2-week follow-up") to MAs, nurses, or coordinators.
+	•	Phase 1: Context-Aware Generation & Ambient Task Harvesting
+	•	Task tracking integrates seamlessly into clinical workflows by extracting directives automatically from documentation or using structured protocol engines.
+	•	1.1 The Ambient Task Extraction Layer
+	•	The Action: The provider updates the plan narrative or logs an order during the session (e.g., "Medical Assistant to call the patient to discuss their normal metabolic labs and confirm they are maintaining their fasting routine, then have scheduling book a 2-week follow-up").
+	•	The Parser: The clinical NLP pipeline parses the syntax of the entry, isolates the specific administrative and clinical directives, and breaks them out into distinct, structured tasks.
+	•	Ontological Standardization: Every generated task is tagged with a defined activity type using national clinical code systems:
+	•	"Call patient to discuss labs" $\rightarrow$ SNOMED-CT: 408542008 (Patient telephone triage)
+	•	"Schedule follow-up" $\rightarrow$ SNOMED-CT: 308291005 (Arranging appointments)
+	•	1.2 Protocol-Driven Compound Task Bundles
+	•	The engine links directly to automated care pathways. For example, triggering a specialized diagnostic evaluation automatically deploys an underlying cascade of synchronized tasks: an administrative check for insurance pre-authorization, a laboratory sample tracking token, and a placeholder scheduling request for a follow-up review.
+	•	Phase 2: Intelligent Routing Matrix & Queue Triage Engine
+	•	Once generated, tasks enter an active routing broker that manages assignments using structural roles and workload metrics rather than static, unmonitored user inboxes.
+	•	[Harvested Core Task] ──> Triage Engine ──> Evaluates Rules & Balance ──> Role-Based Queue
+	•	2.1 Multi-Variant Allocation Logic
+	•	The tracking engine routes tasks across the organization by evaluating four dynamic parameters:
+	•	Structural Role Routing: Tasks map to functional role queues (e.g., Medical Assistants MA, Registered Nurses RN, Care Coordinators, or Billing Specialists) based on structural safety profiles and required licensing levels.
+	•	Workload Load-Balancing: If a task targets an individual provider or sub-team, the engine reviews active queues across the clinic and balances new items to prevent administrative bottlenecks.
+	•	Cross-Boundary Handoff Tracking: When a task requires inputs from multiple teams (e.g., a complex authorization requiring documentation from an RN followed by a sub-mission by a biller), the platform manages the cross-department handoff automatically, updating tracking flags as each sub-task clears.
+	•	2.2 Critical Urgency Classifications
+	•	The system applies discrete triage levels to prioritize incoming team tasks:
+	•	
+	•	Phase 3: The Actionable Clinical Workspace (UI/UX)
+	•	The tracking engine changes task items from passive text reminders into actionable workflow cards that provide staff with all required clinical context directly within the item container.
+	•	Zero-Search Context Integration: Opening a task card displays all supporting patient data inline. For a "Call patient to discuss normal labs" assignment, the card embeds the patient's verified telephone number, a secure click-to-call dialer link, and the exact normal lab observations, preventing staff from hunting through the chart for basic metrics.
+	•	Dynamic Action Tools: The workspace includes embedded operational macros. Selecting "Log Call & Close Loop" records the session details directly to the patient's chart history, generates a FHIR Communication record, and marks the parent task complete with a single action.
+	•	Phase 4: FHIR Technical Architecture & Task Resource Lifecycle
+	•	Tasks operate as structured, auditable data assets modeled via the FHIR Task Resource framework, maintaining tight links between the requesting clinician, the owner, and the context.
+	•	
+	•	Phase 5: Automated Loop Closure & Escalation Governance
+	•	To prevent clinical details from dropping off tracking queues, the task engine enforces strict Service Level Agreements (SLAs) through an active tracking pipeline.
+	•	5.1 Automated Escalation Triggers
+	•	The Baseline Tracker: Every task carries a strict time-to-completion requirement based on its triage level.
+	•	The Escalation Path: If a Tier 2 task (e.g., scheduling a 2-week follow-up for an abnormal lab review) stays unaddressed or in an unread state past its target window, the engine runs an escalation macro:
+	•	It modifies the .priority attribute path from routine to urgent.
+	•	It changes the .owner pointer, moving the item out of individual queues and routing it to the supervising nurse's tracking workspace.
+	•	It logs an operational warning event to prevent gaps in patient follow-up care.
+	•	5.2 Quality Performance Metric Ingestion
+	•	When a team member marks a task complete, the platform captures the operational data—tracking the initiation timestamp against the final resolution event. This logging provides clean visibility for internal practice management analytics and satisfies clinical tracking metrics under regional risk-sharing agreements. It streamlines audit workflows, keeping quality reporting smooth and friction-free.
+
+Revenue Cycle Management (RCM) & Billing Workflows
+	•	Turning clinical documentation into clean, reimbursable claims.
+
+	•	Charge Capture & Superbill Generation: Automatically mapping documented diagnoses and procedures to ICD-10-CM, CPT, and HCPCS codes during the encounter.
+	•	Phase 1: Real-Time Semantic Ingestion & Tri-Vocabulary Mapping
+	•	The billing capture architecture acts as a background auditor that monitors the encounter documentation space, instantly converting clinical concepts into their required alphanumeric codes.
+	•	1.1 The Ambient Coding Layer
+	•	The Action: The provider finalizes documentation statements inside the encounter canvas (e.g., "Exposed a patient with long-standing metabolic syndrome to a therapeutic trigger point injection using 10mg of Kenalog to address acute myofascial pain.").
+	•	The Extraction Protocol: The localized clinical NLP model identifies distinct medical entities, separating them into indications, interventions, and supplies.
+	•	The Tri-Vocabulary Alignment Matrix: The entities are simultaneously cross-referenced with national code registries:
+	•	Clinical Diagnoses: Mapped to ICD-10-CM (e.g., E88.81 [Metabolic syndrome] and M79.18 [Myofascial pain syndrome, billing site]).
+	•	Procedural Interventions: Mapped to CPT codes (e.g., 20552 [Injection(s); single or multiple trigger point(s), 1 or 2 muscle(s)]).
+	•	Supplies & Pharmaceuticals: Mapped to HCPCS Level II codes (e.g., J3301 [Injection, triamcinolone acetonide, not otherwise specified, Janus/Kenalog, per 10 mg])
+	•	Phase 2: Algorithmic Evaluation & Management (E&M) Leveling Engine
+	•	To secure accurate reimbursement without adding administrative overhead, the platform calculates office visit codes (CPT 99202–99215) by applying deterministic AMA coding frameworks.
+	•	2.1 The Two-Path Selection Model
+	•	The billing calculator tracks documentation metrics across two concurrent parameters, automatically selecting whichever framework results in the most compliant and justifiable code:
+	•	2.2 Medical Decision Making (MDM) Scoring Matrix
+	•	If the provider selects MDM-based leveling, the platform evaluates three distinct structural elements to determine the appropriate service tier:
+E&M CPT Code (Established Patient)
+Element 1: Number & Complexity of Problems Addressed
+Element 2: Amount or Complexity of Clinical Data Reviewed
+Element 3: Risk of Complications or Management Interventions
+99213 (Low MDM)
+2 or more minor problems, OR 1 stable chronic illness.
+Minimal or no data tracking required.
+Low risk from additional diagnostics or standard over-the-counter therapies.
+99214 (Moderate MDM)
+1 or more chronic illnesses with mild progression, OR 2 or more stable chronic conditions.
+Moderate data tracking (e.g., reconciling independent test panels, ordering new LOINC panels).
+Moderate risk (e.g., initiating prescription medications like Metformin or SGLT2 inhibitors).
+99215 (High MDM)
+1 or more chronic illnesses severe enough to cause life-threatening exacerbations.
+Extensive data tracking (e.g., analyzing complex biometric records, historical review synthesis).
+High risk (e.g., intensive drug monitoring, emergency hospitalization determinations).
+	•	Phase 3: Automated Compliance Scrubbing & NCCI Edit Validation
+	•	Before a digital superbill is presented to the care team, it passes through an automated validation gateway to eliminate coding conflicts and reduce insurance denials.
+	•	3.1 National Correct Coding Initiative (NCCI) Verification
+	•	Procedure-to-Procedure (PTP) Bundling: The system checks the code list against CMS PTP tables to identify mutually exclusive codes. If a clinician adds an extensive procedure code alongside a minor component code that is already included in the main service, the system flags the overlap and drops the minor component to prevent double-billing rejections.
+	•	Automated Modifier Optimization: If the system detects an evaluation service alongside a distinct procedure performed on the same day, it prompts the application of validation indicators:
+	•	Appends Modifier 25 to the E&M code (e.g., 99214-25) to prove the evaluation was significant and separately identifiable.
+	•	Appends Modifier 59 or XS to procedural pairs to confirm interventions were executed on distinct anatomical structures.
+	•	3.2 Medically Unlikely Edits (MUE) Safety Guards
+	•	The calculation engine checks HCPCS units against verified billing safety thresholds. If a provider documents an injectable volume that exceeds standard single-day limits, the system catches the entry error, alerts the team to review the documentation, and updates the billable units before compilation.
+	•	Phase 4: FHIR Technical Architecture & Data Serialization
+	•	The generated superbill is modeled inside the data layer as an interoperable financial network, anchoring billing data directly to the originating clinical events.
+	•	4.1 Financial Resource Relationships
+	•	The architecture preserves data lineage by avoiding isolated spreadsheet tracking, using explicit relational links across four main FHIR objects:
+	•	
+	•	Phase 5: Interactive Superbill Interface & Financial Dispatch
+	•	The finalized superbill drops cleanly into a single-page authorization dashboard presented to the provider at the moment of encounter sign-off.
+	•	5.1 The Provider Checkout Interface
+	•	The dashboard presents the provider with a clear, pre-scored breakdown of the encounter's financial entries:
+	•	The Code Validation Panel: Displays paired diagnoses and procedures clearly side-by-side. If a code pair lacks clear justification, a small yellow warning marker appears, allowing the provider to attach a supporting diagnosis from the chart with a single click.
+	•	One-Click Authorization: Selecting "Approve & Routing Dispatch" locks the financial records, synchronizes the updates with the parent patient ledger, and routes the validated entries to the administrative billing queue.
+	•	5.2 Clearinghouse Transmission (Loop Closure)
+	•	The approved superbill bypasses manual re-entry pipelines entirely. The revenue management module ingests the raw FHIR ChargeItem array and compiles it into an industry-standard ASC X12 837P (Professional Claim) Transaction File.
+	•	This file is securely dispatched over a live EDI link to the regional clearinghouse network, closing the encounter-to-billing loop, minimizing processing delays, and ensuring clean claims delivery.
+
+	•	Coding & Claim Scrubbing: A billing interface where coders review claims against local coverage determinations (LCDs) and National Correct Coding Initiative (NCCI) edits to catch errors prior to submission.
+	•	Phase 1: Claim Ingestion & Rule-Set Engine Synchronization
+	•	The claim scrubbing pipeline initiates the moment an encounter is cryptographically locked and the associated ChargeItem components are generated.
+	•	1.1 Automated Claim Generation & Lifecycle Binding
+	•	The Trigger: The system ingests the approved billing codes from the encounter and automatically instantiates a structured draft claim object.
+	•	Demographic & Insurance Orchestration: The engine queries the patient graph to bind active insurance policies, verifying the payer routing details via the RxBIN/PCN or standard commercial payer IDs.
+	•	1.2 Live Regulation Lake Synchronization
+	•	Before rendering the claim to a medical coder, the background scrubbing engine routes the dataset through a real-time compliance database updated to match current federal and commercial payer rules:
+	•	The NCCI Database: Queries active National Correct Coding Initiative tables (including Procedure-to-Procedure edits and unit limits) distributed quarterly by CMS.
+	•	The LCD/NCD Mapping Engine: Evaluates regional policies enforced by the local Medicare Administrative Contractor (MAC) based on the provider's physical practice location, alongside national coverage guidelines.
+	•	Phase 2: Automated Rules Engine & Edit Matching (The Scrubbing Layer)
+	•	The system passes the compiled claim codes through a multi-tiered validation matrix to detect compliance issues before any user interaction occurs.
+	•	2.1 The Four-Tier Scrubbing Matrix
+	•	NCCI Procedure-to-Procedure (PTP) Edits: Scans the CPT/HCPCS code array to see if a comprehensive code and a component code have been billed together. If an unbundled pair is identified, the system tags the violation and determines if a structural modifier (e.g., Modifier 59) is allowed under the current CMS guidelines.
+	•	Medically Unlikely Edits (MUE): Compares the billed units for each line item against the maximum units of service that a provider would typically deliver to a single patient on the same calendar day.
+	•	LCD/NCD Clinical Medical Necessity Verification: Cross-references each procedural CPT code against the allowed diagnostic ICD-10-CM codes specified in the MAC's active LCD documentation. If a procedure (e.g., a complex metabolic panel or therapeutic injection) lacks a supporting diagnostic code on the claim, it triggers a medical necessity exception.
+	•	Commercial Payer Rule Sets: Evaluates custom compliance rules unique to specific commercial health plans, checking for strict global surgery windows, demographic age constraints, and mandatory prior authorization reference formatting.
+	•	Phase 3: The Coder Command Center UI/UX Workspace
+	•	Claims that trigger compliance alerts are held in a secure staging queue and presented within an interactive, single-page Coder Command Center designed to minimize administrative friction.
+	•	3.1 The Split-Screen Interactive Workspace
+	•	The interface provides a clean, unified view that combines the billing codes, compliance alerts, and original documentation sources on a single screen:
+	•	Left Panel (The Original Clinical Proof): Renders a read-only view of the cryptographically locked encounter note. This allows the coder to quickly review the provider's narrative and verify clinical details without leaving the workspace.
+	•	Right Panel (The Active Interactive Claim): Displays the diagnostic codes, procedural line items, modifiers, charges, and service units in an editable grid.
+	•	3.2 Visual Alert Hierarchy & One-Click Corrections
+	•	Alerts are organized by severity to help coders prioritize their review queue:
+	•	
+	•	Phase 4: FHIR Technical Architecture & Data Serialization
+	•	The system models the entire scrubbing and correction lifecycle using interoperable data standards, anchoring claims to an auditable timeline via the FHIR Claim Resource.
+	•	4.1 Financial Data Lineage Mapping
+	•	To preserve traceability across administrative workflows, the architecture manages data changes using interconnected FHIR objects:
+	•	
+	•	Phase 5: Clearinghouse Compilation & Dispatch (Loop Closure)
+	•	Once a coder resolves any outstanding flags and signs off on the layout, the claim shifts from a staging state to external transmission.
+	•	5.1 ASC X12 837P Transaction Packaging
+	•	The EDI Compiler: The revenue management module ingests the verified FHIR Claim resource graph and maps it directly into an industry-standard ASC X12 837P (Professional Claim) Transaction File.
+	•	Cryptographic Envelope Securing: The transmission file is secured with a SHA-256 cryptographic checksum and routed over an encrypted HTTPS connection to the practice's designated clearinghouse gateway.
+	•	5.2 Dynamic Acknowledgment Tracking (999 and 277 Ingestion)
+	•	The platform manages the claim lifecycle after submission by continuously monitoring inbound network acknowledgments:
+	•	The 999 Functional Acknowledgment: The clearinghouse issues an immediate 999 transaction file. The system parses this file to confirm that the EDI file structure was successfully processed without transmission corruption.
+	•	The 277 Claim Status Notification: Once the medical insurance payer receives the claim, they issue a 277 transaction file. The EMR gateway parses this file to verify that the claim has successfully cleared the payer's initial validation filters and entered the active adjudication pool.
+	•	This complete process provides billing teams with continuous visibility from initial coding through final adjudication, ensuring clean claim tracking and predictable revenue cycles.
+
+	•	Claims EDI Transmission: Packaging encounters into EDI 837 claim files to be sent to a clearinghouse or payer, and receiving EDI 277 claim status responses.
+	•	Phase 1: The FHIR-to-EDI 837 Crosswalk Mapping Engine
+	•	When a medical coder approves a draft claim, the transaction engine extracts the rich clinical graph from the EMR database and maps it directly into standard ASC X12 837 Professional (837P) v5010 data structures.
+	•	1.1 Structural Relational Crosswalk Matrix
+	•	The system avoids flat-file conversions by executing a direct schema transformation from multi-relational FHIR objects to hierarchical X12 data segments:
+FHIR Data Resource & Field Path
+Target X12 837P Loop
+Target X12 Segment & Data Element
+Operational Business Function
+Organization.identifier (Tax ID/EIN)
+Loop 2010AA
+REF*EI*951234567~
+Identifies the Billing Provider Corporate entity.
+Practitioner.identifier (NPI)
+Loop 2310B
+NM1*82*1*WALI*VIJAY***XX*1234567890~
+Identifies the Rendering Clinician.
+Patient.name & Patient.identifier
+Loop 2010CA
+NM1*IL*1*DOE*JOHN****MI*SUB998271A~
+Identifies the Patient/Subscriber Member Card ID.
+Claim.item.productOrService (CPT/HCPCS)
+Loop 2400
+SV1*HC:20552*150.00*UN*1***1:2~
+Service Line: Code, Charge, Units, Diagnosis Pointers.
+Claim.diagnosis.sequence (ICD-10-CM)
+Loop 2300
+HI*BK:M7918*BF:E8881~
+Principal (BK) and Secondary (BF) Diagnosis mapping.
+Claim.item.detail.referencing (PA ID)
+Loop 2300
+REF*G1*PA-99201A-X2~
+Prior Authorization Approval Tracking Key.
+	•	Phase 2: The EDI Compilation & Syntactic Validation Engine
+	•	Before the data moves to the outbound transport gateway, the compiled segments are assembled into standard ANSI ASCII text packages and subjected to deep syntactic validation checks.
+	•	2.1 WEDI SNIP Edits Validation Framework
+	•	The transformation broker subjects the raw EDI string to an automated five-tier Strategic National Implementation Process (SNIP) assessment:
+	•	SNIP Level 1 (Integrity Testing): Validates data segment structures, checks for missing trailing delimiters (~), and verifies balance controls between internal structural controls.
+	•	SNIP Level 2 (Requirement Testing): Flags omitted conditional segments (e.g., verifying that if an accident diagnosis is present, the corresponding accident date segment is populated).
+	•	SNIP Level 3 (Balance Testing): Verifies that the sum of line-item charges matches the total claim amount specified in the CLM02 segment.
+	•	SNIP Level 4 (Situational Testing): Checks fields governed by explicit environmental constraints, such as ensuring rendering provider segments are omitted if they match the billing provider details.
+	•	2.2 Compressed Output Sample: Validated Outbound 837P Segment
+	•	Phase 3: Secure Transmission & Clearinghouse Communication Gateway
+	•	The EMR bypasses manual file operations by using an automated background queue manager to securely route outbound billing packets.
+	•	3.1 Transport Layer Protocol Stack
+	•	AS2 Secure Handshake: The system transfers the transaction files over an active Applicability Statement 2 (AS2) connection encrypted with TLS 1.3. It requires SHA-256 Message Disposition Notifications (MDN) from the recipient to confirm receipt.
+	•	Asynchronous Queue Management: Claims are transferred using a dedicated background worker system. If an external connection drops, the system places the file back into a retry queue, executing controlled exponential back-off attempts while preserving complete transaction tracking.
+	•	Phase 4: Inbound Acknowledgment Parsing & Lifecycle Processing (EDI 999 & 277)
+	•	As external systems process the claim, the EMR ingest engine captures and acts upon inbound acknowledgments to maintain a real-time audit history of the billing lifecycle.
+	•	4.1 The Two-Stage Inbound Reconciliation Pipeline
+	•	The EDI 999 Functional Acknowledgment: The clearinghouse evaluates the basic file structure and returns a 999 response within minutes. The EMR parses this file to verify syntactic acceptance (IK501=A). If it contains structural errors (IK501=R), the system changes the claim status to Syntactic Rejection and notifies the billing team.
+	•	The EDI 277 Claim Status Notification: The payer or clearinghouse evaluates the billing fields against initial adjudication rules and returns a 277 file. The EMR uses this response to update the administrative state engine.
+	•	4.2 The 277 Status Code Translation Engine
+	•	The parsing engine inspects the Claim Status Category Codes (CSCC) and Claim Status Codes (CSC) in the 277 response to update the internal claim lifecycle state.
+	•	Phase 5: FHIR Serialization & State Machine Reconciliation
+	•	Once an inbound 277 status notification is parsed, the system records the transaction history by instantiating a tracking record modeled as a FHIR ClaimResponse Resource.
+	•	5.1 System State Synchronization
+	•	The system links the new status record back to the original Claim data model using explicit resource references.
+	•	It sets the internal status attributes of the parent claim object to match the translated 277 category rules, ensuring the tracking indicators update automatically across all financial and billing dashboard views.
+	•	5.3 Automated Audit Logs & Performance Tracking
+	•	When the ClaimResponse resource is saved, the platform triggers an internal database event that calculates the exact time difference between the initial claim submission and the acknowledgment receipt. This tracking provides billing management with clear analytics on clearinghouse performance, ensures compliance with prompt-payment standards under active regional payer agreements, and keeps claims tracking transparent and auditable.
+
+	•	Payment Posting & Denial Management: Automated processing of Electronic Remittance Advices (EDI 835 ERA) to post payments and route denied claims into an active appeals queue for billing staff.
+	•	Phase 1: Inbound ERA Ingestion & Transaction Reconciliation
+	•	The financial posting workflow activates the moment an inbound ASC X12 835 v5010 Electronic Remittance Advice (ERA) payload is delivered over a secure AS2 endpoint or pulled from a clearinghouse SFTP repository.
+	•	
+	•	1.1 Envelope Decoupling & Batch Splitting
+	•	The Parser: The system reads the interchange control header (ISA) and functional group header (GS), validating the integrity of the transmission envelope.
+	•	BPR-to-Bank Matching: The system extracts the Financial Ingestion Segment (BPR). It matches the payment method code (BPR04), transaction amount (BPR02), and EFT/Check trace number (BPR07) against the clinic's real-time banking ledger feeds via an automated Treasury Reconciliation API.
+	•	1.2 Deterministic Claim Line Resolution
+	•	The processing engine opens the Loop 2100 (Claim Payment Information) block and processes each individual Claim Payment segment (CLP) to locate its parent tracking entity within the EMR graph:
+	•	Identifier Matching: The system extracts the Payer Control Number (CLP01), matching it directly against the internal unique identifier stored in the EMR financial ledger layer.
+	•	Secondary Verification: To prevent false positives from recycled billing numbers, the system cross-references the patient’s Unique Master Patient Index (MPI) token, the specific date of service (DTM*472~), and the billing provider's NPI. If any parameter mismatches, the transaction status shifts to Unreconciled Staging for manual supervisor review.
+	•	Phase 2: Automated Payment Posting State Engine
+	•	Once a claim is securely matched to an open record, the system iterates through each service line within Loop 2110 (Service Payment Information) to balance the clinical ledger.
+	•	2.1 The Service Line Financial Equation
+	•	For every Service Information segment (SVC), the billing engine reads the submitted charge, the paid amount, and the accompanying Claim Adjustment segments (CAS). The engine enforces a strict mathematical validation rule before updating the account balance:
+	•	
+	•	2.2 Balance Allocation Logic
+	•	The posting engine automatically updates the transaction fields based on the X12 Group Codes parsed from the CAS segment:
+	•	Phase 3: The Denial Extraction & Categorization Matrix
+	•	If a claim line indicates a partial payment or zero allowance due to a processing exception, the engine stops automated posting for that line item and activates the automated denial triage protocol.
+	•	3.1 CARC and RARC Structural Parsing
+	•	The engine reads the Claim Adjustment Reason Codes (CARC) and Remittance Advice Remark Codes (RARC) embedded within the service loops. Rather than treating these codes as raw strings, the platform runs them through an ontological translation matrix to determine the underlying reason for the denial.
+	•	3.2 Automated Task-Routing Triage Matrix
+	•	Based on the parsed CARC/RARC combinations, the system assigns the record to specific workflow queues, bypassing manual sorting steps:
+Parsed CARC / RARC Patterns
+Categorized Root Cause
+Immediate EMR Action State
+Target Operational Destination Queue
+CARC 197 (No prior auth)
+ 
+RARC N755 (Auth missing)
+Missing Prior Authorization
+Updates claim tracking to Denied - Prior Auth; extracts auth token logs.
+Prior Authorization Appeals Team
+CARC 50 (Not medically necessary)
+ 
+RARC N115 (LCD guidelines)
+Medical Necessity Violation
+Updates claim tracking to Denied - Clinical; auto-extracts relevant LCD rule sheet.
+Clinical Review Queue (Escalated to Provider/RN)
+CARC 22 (Coordination of Benefits)
+ 
+RARC N83 (Primary payer active)
+Coordination of Benefits (COB)
+Updates claim tracking to Pending Patient Action; suspends commercial billing clocks.
+Front Desk / Patient Portal Engagement Queue
+CARC 16 (Lack of information)
+ 
+RARC M125 (Missing modifier)
+Coding / Modifier Error
+Updates claim tracking to Scrubbing Failure; unbinds current claim line states.
+Certified Medical Coder Revision Queue
+	•	Phase 4: Coder Workflow & Interactive Appeals Canvas
+	•	When an item hits a user queue, it is presented within an integrated dashboard that displays all context, documentation, and communication tools on a single screen.
+	•	Zero-Search Appeal Packaging: The workspace dynamically assembles the supporting clinical documentation. For a medical necessity denial, it opens a side-by-side view showing the original locked note, the relevant Local Coverage Determination (LCD) policy text, and pre-selected chart elements (e.g., historical clinic notes or diagnostic profiles) that can be appended to the appeal with a single click.
+	•	One-Click Appeal Generation: Clicking "Attach Chart & Appeal" compiles the selected records into a secure outbox packet, automatically drafts a formal, payer-formatted appeal cover letter, updates the tracking state, and queues the packet for electronic delivery or digital fax dispatch.
+	•	Phase 5: FHIR Technical Architecture & Data Serialization
+	•	The remittance history, adjustments, and denial categories are modeled using interoperable standards, recorded within the FHIR ExplanationOfBenefit (EOB) framework, and linked back to the parent records.
+	•	
+	•	Phase 6: Closed-Loop Appeal Automation & Resubmission
+	•	When an appeal or a corrected claim is approved for resubmission within the workspace, the system closes the lifecycle loop by packaging the transaction for external routing.
+	•	6.1 Corrected Claim Generation (837 Type 7)
+	•	The Refactoring Engine: If a claim was denied due to an incorrect modifier or a typing error, the platform creates a clean instance of the transaction while maintaining links to the original file history.
+	•	X12 Resubmission Indicators: The system updates the claim frequency code within the CLM05-3 segment, setting it to "7" (Replacement of Prior Claim), and appends the unique payer reference number to Loop 2300 (REF*F8~). This alerts the payer's adjudication system to replace the original file rather than rejecting the submission as a duplicate charge.
+	•	6.2 Electronic Tracking & Operational Visibility
+	•	The system tracks the newly generated transaction through the outbound AS2 channel, matching it against inbound 999 and 277 acknowledgments. This provides billing management with real-time lifecycle visibility, prevents unresolved rejections from falling out of the active workflow, and ensures predictable, clean collection cycles.
+
+Interoperability & Platform Administration Workflows
+	•	The under-the-hood ecosystem required to maintain security, compliance, and seamless data exchange.
+	•	[System Admin] ──> RBAC / Audit Logs ──> HIPAA Compliance
+	•	[Data Exchange] ──> FHIR APIs / C-CDA ──> HIE Interoperability
+	•	Role-Based Access Control (RBAC): Granular permission management ensuring users (Physicians, MAs, Billers, Scribes, Admins) only see data relevant to their scope of practice.
+	•	Phase 1: Zero-Trust Cryptographic Identity & Session Ingestion
+	•	Access control begins outside the presentation layer, enforcing identity validation and context verification before loading any patient data.
+	•	1.1 Federated Identity & Token Architecture
+	•	The Handshake: The system integrates with enterprise identity providers via OpenID Connect (OIDC) and OAuth 2.0 mutual TLS (mTLS).
+	•	The Claim Payload: Upon successful authentication, the server generates a cryptographically signed JSON Web Token (JWT). This token contains immutable claims outlining the user’s organization ID, national provider identifier (NPI), verified role profile, and granular SMART on FHIR access permissions.
+	•	1.2 Interactive Session Scoping
+	•	The API gateway intercepts every incoming request, decoding the JWT to evaluate context parameters:
+	•	The Network Boundary: Verifies the user's current IP address or hardware cryptographic key.
+	•	The Active Encounter Context: If a user requests a patient record, the engine checks to see if an active encounter or an open task links that user to the patient, preventing unauthorized chart browsing.
+	•	Phase 2: The Granular Permission Matrix & Role Scopes
+	•	The system manages visibility rules by decoupling technical identities from clinical actions. Users are assigned functional profiles that map explicitly to standard SMART on FHIR v2 Scopes.
+User Role
+Primary Functional Scope
+Authorized FHIR Resource Scopes
+UI Visibility Layer Constraint
+Physician / MD
+Full clinical decision-making, care plan design, and legally binding sign-offs.
+user/Patient.*, user/Encounter.*, user/Observation.*, user/MedicationRequest.*, user/Composition.*
+Unrestricted read/write access to all clinical layers. Single-click cryptographic note execution.
+Medical Assistant (MA)
+Intake orchestration, objective metric capturing, and workflow task routing.
+user/Patient.read, user/Observation.write, user/Condition.read, user/Task.*
+Can view charts and document vitals/intake data. Cannot sign core chart notes or authorize medication requests.
+Scribe
+Parallel clinical documentation generation on behalf of a supervising physician.
+user/Patient.read, user/Encounter.read, user/Composition.write
+Can generate draft text narratives. Cannot change medication lists independently or final-sign any medical records.
+Medical Biller
+Financial ledger audits, compliance scrubbing, and claims clearinghouse management.
+user/Patient.read, user/Encounter.read, user/ChargeItem.*, user/Claim.*, user/ExplanationOfBenefit.*
+Complete financial and demographic workspace visibility. Completely blocks access to underlying text progress notes or sensitive clinical narratives.
+System Administrator
+Identity registry lifecycle tracking, database maintenance, and security log reviews.
+system/Practitioner.*, system/AuditEvent.read, system/StructureDefinition.*
+Access to core structural configurations, backend dictionaries, and system logs. Completely blocked from viewing patient-identifiable clinical records.
+	•	Phase 3: Attribute-Based Access Control (ABAC) Extensions
+	•	Static roles are often insufficient for managing complex clinical realities. The engine supplements the core RBAC matrix with an automated Attribute-Based Access Control (ABAC) evaluation layer to manage edge cases.
+	•	3.1 Sensitive Record Isolation (The Privacy Shield)
+	•	The Rule: Patient records matching specific vulnerability parameters (e.g., employee files, high-profile individuals, or explicit behavioral health categories) are stamped with an HL7 Security Label token (SecurityLabel = V).
+	•	The Override Enforcement: When a provider attempts to query this file, the engine bypasses standard RBAC profiles. It blocks the query unless the user passes a secondary validation check confirming they are explicitly listed as the primary provider on the patient's active care team.
+	•	3.2 Dynamic "Break the Glass" (BTG) Protocol
+	•	The Emergency Exception: In critical emergent scenarios where an unassigned clinician must access a locked or restricted record, the user interface displays a "Break the Glass" override action.
+	•	The Verification Lifecycle: Selecting this option grants immediate, temporary read permissions for a 4-hour window. The system requires the user to enter a text justification from a standardized list, immediately flags the override event, and routes an alert to the organizational compliance officer's workspace.
+	•	Phase 4: FHIR Technical Architecture & Data Serialization
+	•	The access control model is maintained using native healthcare standards, tracking active provider permissions through the FHIR PractitionerRole Resource and tracking data requests via structural data models.
+	•	
+	•	Phase 5: Real-Time Data Filtering & Audit Governance
+	•	To protect data privacy without introducing latency, authorization processing runs directly within the database query execution layer.
+	•	5.1 Inline Database Filter Modification
+	•	The API pipeline does not fetch entire records and strip fields downstream. Instead, the authorization layer intercepts data requests and updates query constraints in real time before execution:
+	•	If a Medical Biller runs a query to load an encounter record, the system intercepts the database call and restricts the field selections to demographic and structural billing entries, completely excluding narrative assessment blocks from the returned database cursor.
+	•	5.2 Immutable Security Auditing (HIPAA & HITECH Alignment)
+	•	Every data query, modification, view, or failed attempt triggers an immediate, asynchronous write to an encrypted audit database. The transaction logs an unalterable FHIR AuditEvent object detailing the exact timestamp, user NPI, client device fingerprint, targeted resource ID, and the authorization outcome. This provides compliance managers with complete visibility and ensures the organization satisfies strict data protection standards.
+
+	•	Break-the-Glass Emergency Access: A secure override workflow that allows providers to access restricted records in a clinical emergency, triggering an immediate, high-priority audit log entries.
+	•	Phase 1: Security Interception & Restriction Detection
+	•	The emergency access pipeline activates when a provider attempts to query a chart, order a medication, or load a historical note that carries a strict privacy restriction flag.
+	•	1.1 Structural Data Classification
+	•	The API gateway evaluates records using native HL7 Security Labels. If a resource contains data elements designated with high-sensitivity codes, standard role-based access tokens are immediately deflected:
+	•	ETH (Substance use disorder data protection)
+	•	PSY (Behavioral health / psychiatric documentation isolation)
+	•	VIP (High-profile individual or staff member anonymity protections)
+	•	R / V (Restricted or Very Restricted structural designations)
+	•	1.2 Access Deflection and Context Evaluation
+	•	When an unassigned user calls an endpoint matching these labels, the system intercepts the request and evaluates the context graph. If no active appointment, scheduled task, or direct care team assignment links that clinician to the patient, the data payload is withheld, and the user interface shifts to the Break-the-Glass Intercept Window.
+	•	Phase 2: The Emergency Override Interface & Justification Canvas
+	•	To eliminate accidental or unauthorized overrides while preserving precious seconds in an acute scenario, the EMR presents a high-contrast, zero-latency verification modal.
+	•	2.1 The Two-Click Emergency Override Workspace
+	•	The interface displays a modal detailing the legal and organizational implications of an emergency override, requiring two immediate verification inputs:
+	•	Standardized Justification Selection: The provider must select a valid clinical reason from a constrained dropdown list mapped to national data standards:
+	•	"Acute life-threatening emergency; patient unable to consent." (SNOMED-CT: 427081008)
+	•	"Unconscious or cognitively compromised patient requiring immediate medication reconciliation." (SNOMED-CT: 418191006)
+	•	"Emergent trauma triage with missing historical records." (SNOMED-CT: 225358003)
+	•	Re-Authentication Handshake: The provider passes a localized hardware validation challenge—either verifying an integrated biometric signature (e.g., local FaceID/TouchID) or re-entering their primary high-entropy security PIN. This satisfies federal NIST SP 800-63-3 AAL3 requirements, confirming the authorized identity holder is physically present.
+	•	Phase 3: Ephemeral Privilege Escalation & Session Isolation
+	•	Once identity and intent are validated, the authentication server executes a controlled, time-bound expansion of the user's operational scopes without changing their permanent system permissions.
+	•	[Biometric/PIN Cleared] ──> OAuth2 Server Issues Ephemeral JWT ──> Scopes Restricted to Active Session ──> Automated 4-Hour Countdown
+	•	3.1 Short-Lived Token Generation
+	•	The Ephemeral Token: The system generates a distinct, short-lived JSON Web Token (JWT) specifically bound to the requesting provider's session and the target patient's unique identifier.
+	•	Granular Scope Extensions: The token injects transient permission parameters utilizing strict SMART on FHIR patterns:
+	•	patient/Consent.write (To log the override signature context)
+	•	patient/Patient.read, patient/Observation.read, patient/MedicationRequest.read
+	•	The 4-Hour Security Countdown: The token is hardcoded with an explicit expiration window of 4 hours. Once this timeframe closes, the temporary access token self-destructs, and any subsequent data queries default back to standard restricted access rules.
+	•	Phase 4: High-Priority Notification & SIEM Ingestion Pipeline
+	•	To maintain accountability, executing a Break-the-Glass action triggers an automated, high-priority notification sequence that alerts organizational compliance networks.
+	•	Real-Time SIEM Stream: The system generates a JSON log packet and pushes it via an encrypted webhook directly to the clinic's SIEM (Security Information and Event Management) platform, placing it at the top of the high-risk activity queue.
+	•	Direct Pager Protocol: Sends automated, encrypted SMS alerts and high-priority emails directly to the clinic's Privacy Officers and Chief Information Security Officer (CISO), identifying the provider, the patient, and the stated clinical reason.
+	•	Visual UI Indicator: Displays a high-contrast tracking banner at the top of the patient's chart workspace while the override session is active, reminding the clinician and any co-signers that their data access is under live compliance review.
+	•	Compliance Task Routing: Automatically drops a mandatory post-event justification task into the provider's administrative inbox to collect a detailed narrative once the clinical emergency concludes.
+	•	Phase 5: FHIR Technical Architecture & Access Event Serialization
+	•	The system logs the override event using native interoperability resources, generating a permanent, tamper-evident audit ledger within the database layer using the FHIR AuditEvent framework.
+	•	
+	•	Phase 6: Session Teardown & Post-Event Compliance Reconciliation
+	•	To close the emergency lifecycle completely, the system coordinates automated teardown and reconciliation tasks once the time window expires.
+	•	6.1 Automated Boundary Enforcement
+	•	Active Token Revocation: When the internal 4-hour token countdown clears, the authorization broker runs an automated token revocation script.
+	•	UI Workspace Eviction: The system clear-wipes cached data elements from the client terminal memory and returns the active view to a blank search dashboard, preventing unauthorized data exposure on unattended workstations.
+	•	6.2 The Post-Override Verification Loop
+	•	The Task Trigger: As the session closes, the task management engine activates the compliance request generated during Phase 4.
+	•	The Reconciliation Form: The provider is required to log a brief narrative detail within 24 hours to explain the emergency context.
+	•	The Legal Audit Package: Once signed, this narrative is cryptographically bound to the initial AuditEvent log. This creates a clear, unified compliance package ready for immediate review during federal data privacy reviews, institutional safety assessments, or external security audits.
+
+	•	Interoperability & Data Portability: Seamless generation, export, and parsing of Continuity of Care Documents (CCDs) and HL7/FHIR-based API data endpoints for external health system queries.
+	•	Phase 1: Inbound Data Ingestion & C-CDA XML Parsing Engine
+	•	When an external clinical document (e.g., a Continuity of Care Document / CCD) enters the platform network boundary via the Direct Project secure email framework or a regional Health Information Exchange (HIE), the inbound data ingestion pipeline transforms the raw file into structured data.
+	•	1.1 Structural Ingestion & Sharding
+	•	The Ingestion Pipeline: The engine unpackages the MIME envelope of the inbound message, isolates the primary payload, and confirms that the XML complies with HL7 C-CDA R2.1 schema rules using localized Schematron validation engines.
+	•	Document Sharding: The parser scans the XML tree to isolate individual section templates via their standardized Object Identifiers (OIDs).
+	•	1.2 Semantic Normalization & Ontological Mapping
+	•	As the processor reads data elements within each section, it maps local or narrative data strings to standard national medical terminologies:
+	•	Medications: Maps text nodes and National Drug Codes (NDC) to explicit RxNorm semantic clinical drug codes.
+	•	Laboratory Results: Normalizes diverse local clinical analytes to unified LOINC observation attributes.
+	•	Problems & Diagnoses: Resolves ICD-9/10 expressions into definitive SNOMED-CT clinical concept codes.
+	•	1.3 Deterministic Reconciliation & Deduplication
+	•	To prevent duplicate records within the longitudinal patient chart, parsed data passes through an automated clinical matching filter before entering the active database layer:
+	•	The Check: If the parsed document contains an active condition (e.g., Essential Hypertension, SNOMED: 38341003), the engine checks the patient's existing Condition graph.
+	•	The Action: If a matching active condition code is already recorded, the system skips duplicate resource generation and instead appends the new external document source to the provenance tracking logs of the existing resource.
+	•	Phase 2: SMART on FHIR RESTful API Gateway (External Queries)
+	•	The EMR deploys a secure, outward-facing endpoint infrastructure that complies with ONC Health IT Certification mandates, allowing authorized external networks to query real-time patient records using structured APIs.
+	•	2.1 Authorized Protocol Handshake
+	•	Identity Verification: External requests pass through an API gateway protected by the SMART App Launch v2 framework.
+	•	Token Verification: The requester presents an asymmetric, cryptographically signed OAuth2 access token issued by an enterprise identity provider, containing explicit clinical permission parameters (e.g., patient/Patient.read, patient/Observation.read).
+	•	2.2 Operational Search Framework
+	•	The server parses inbound RESTful parameter streams and targets indexing keys inside the database layer, enforcing structural configurations defined by the US Core Implementation Guide (v3.1.1 / v6.1.0):
+	•	Targeted Queries: Handles high-volume search parameters cleanly (e.g., GET https://api.clinic.org/fhir/Observation?patient=749201&category=laboratory).
+	•	Bulk Export Infrastructure: Supports the FHIR Bulk Data Access specification ($export) for population-level health reporting. It compiles large-scale datasets asynchronously into NDJSON (Newtonsoft/Newline-delimited JSON) batches and hosts them within a secure cloud storage environment protected by expiring SAS tokens.
+	•	Phase 3: Outbound C-CDA Generation & Export Protocol
+	•	When a patient requests a chart transfer or a provider coordinates care with an external facility that does not support native FHIR endpoints, the system assembles an on-demand, legally valid C-CDA Continuity of Care Document (CCD).
+	•	3.1 Real-Time Record Synthesis
+	•	The Aggregator: The export coordinator queries the patient data graph to extract active patient records across core clinical categories: allergies, medications, active problems, recent immunizations, and vital signs.
+	•	
+	•	XML Template Assembly: The system maps these structured JSON records into a valid XML tree using standard C-CDA document templates. It generates a readable narrative block for each clinical section alongside corresponding structured data elements to satisfy medical-legal documentation standards.
+	•	3.2 Cryptographic Signing & Network Distribution
+	•	The Hash Check: The compiled XML document is stamped with a unique SHA-256 validation hash.
+	•	Secure Delivery: The document is bundled inside an encrypted payload container and transferred to external systems using automated clinical exchange networks
+	•	Phase 4: National Network Integration & Trust Frameworks
+	•	To facilitate automatic data sharing across different healthcare organizations, the EMR integrates directly with national interoperability frameworks, including Carequality, CommonWell Health Alliance, and the eHealth Exchange.
+	•	4.1 IHE Transaction Protocol Mapping
+	•	The system uses automated background workflows to respond to lookups from national directory networks by running standard Integrating the Healthcare Enterprise (IHE) web service transactions:
+	•	Patient Identity Resolution (ITI-55 / Cross-Gateway Patient Discovery): Processes inbound demographic search fields (e.g., Name, Date of Birth, Gender, Zip Code) against an internal deterministic Master Patient Index (MPI) algorithm to confirm match confidence scores.
+	•	Document Metadata Queries (ITI-38 / Cross-Gateway Query): Returns a clean directory list of available clinical documents, summaries, and encounter notes for a confirmed patient match.
+	•	Secure Document Delivery (ITI-39 / Cross-Gateway Retrieve): Transfers selected C-CDA files securely across healthcare networks via MTOM/XOP encoded SOAP streams, verifying communication endpoints using mutual TLS (mTLS) certificate exchanges.
+	•	Phase 5: Technical Mapping Schema & JSON Serialization
+	•	The interoperability layer coordinates data translations by running real-time mappings between C-CDA XML section templates and corresponding native FHIR data resources.
+Clinical Domain Section
+Standard C-CDA R2.1 Section Template OID
+Target FHIR Resource Destination
+Core Structural Target Codes
+Allergies & Adverse Reactions
+2.16.840.1.113883.10.20.22.2.6.1
+AllergyIntolerance
+UNII, RxNorm, SNOMED-CT
+Medication History
+2.16.840.1.113883.10.20.22.2.1.1
+MedicationStatement / MedicationRequest
+RxNorm, NDC
+Active Problem List
+2.16.840.1.113883.10.20.22.2.5.1
+Condition
+SNOMED-CT, ICD-10-CM
+Diagnostic & Lab Results
+2.16.840.1.113883.10.20.22.2.3.1
+Observation (Laboratory)
+LOINC, UCUM (Units)
+Vital Signs Tracking
+2.16.840.1.113883.10.20.22.2.4.1
+Observation (Vitals)
+LOINC, UCUM (e.g., mm[Hg], Cel)
+Immunization History
+2.16.840.1.113883.10.20.22.2.2.1
+Immunization
+CVX, MVX
+	•	Phase 6: Continuous Compliance & Interoperability Auditing
+	•	To maintain secure data exchanges and fulfill federal reporting requirements, the interoperability module runs automated data audits on all inbound and outbound transactions.
+	•	6.1 Real-Time Data Lineage Tracking
+	•	Every data modification or query maps to an immutable FHIR Provenance Resource that details the originating organization, the authorizing provider's cryptographic token, and the exact software system that facilitated the transaction.
+	•	6.2 Information Blocking Guardrails
+	•	The Safety Policy: The engine monitors outgoing API traffic to prevent unauthorized data restriction events, ensuring compliance with 21st Century Cures Act Information Blocking regulations.
+	•	The Enforcement Check: If a user or rule set blocks a valid external data query that passed identity checks, the system pauses the restriction, generates a compliance exception flag, and routes the transaction event to the organizational risk management dashboard for immediate safety review. This maintains open data pathways across health networks while keeping patient data secure, auditable, and compliant.
+	•	MIPS / MACRA & Quality Reporting: Dashboards that aggregate clinical data across the entire practice panel to track, calculate, and export regulatory quality metrics (e.g., eCQMs).
+	•	Phase 1: Real-Time Data Harvesting & Demographic Panel Processing
+	•	1.1 Ingestion Handshake & Event-Driven Processing
+	•	The Trigger: The event coordinator listens for state change modifications across core clinical databases—specifically tracking new entries in Encounter, Observation, Condition, and Procedure logs.
+	•	The Normalization Layer: Before data reaches the quality calculation broker, the system confirms that all documentation strings match standardized value sets maintained by the National Library of Medicine (NLM) Value Set Authority Center (VSAC). This translates text phrases into distinct, regulatory-compliant terminologies: LOINC for laboratory results, SNOMED-CT for clinical diagnoses, RxNorm for active prescription ingredients, and CPT/HCPCS for procedural operations.
+	•	Phase 2: The eCQM Algorithmic Calculation Engine (CQL Evaluation)
+	•	The platform evaluates clinical status arrays using decoupled Clinical Quality Language (CQL) processing kernels, ensuring compliance with specifications mandated by CMS and the Office of the National Coordinator (ONC).
+	•	2.1 Standard Measure Logic Hierarchy
+	•	For each specific Electronic Clinical Quality Measure (eCQM), the processor runs patient data records through an evaluation sequence to assign appropriate reporting category states:
+	•	2.2 Mathematical Quality Performance Equations
+	•	The registry engine processes individual patient category assignments across the collective panel to calculate the practice’s official performance metrics. The calculation executes a strict deterministic equation to evaluate the final compliance rate:
+	•	
+	•	Phase 3: The MIPS Quality Dashboard Interface & Care-Gap Management
+	•	The aggregated panel calculations drop directly into a high-visibility, interactive dashboard engineered to track performance data against active CMS benchmark deciles.
+	•	3.1 Common Ambulatory eCQM Configuration Profiles
+CMS Measure ID
+Quality Measure Title
+Target Denominator Rules Criteria
+Target Numerator Rules Criteria
+CMS122v14
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9.0%)
+Patients age 18–75 with an active diagnosis of Diabetes mellitus (SNOMED-CT) and at least one outpatient encounter.
+Patients whose most recent HbA1c laboratory evaluation value is > 9.0%, or who had no HbA1c panel executed during the performance year. (Note: Lower rate denotes superior performance)
+CMS165v14
+Controlling High Blood Pressure
+Patients age 18–85 with an active diagnosis of Essential Hypertension initiated before or within the first six months of the performance window.
+Patients whose most recent blood pressure measurement reading is securely documented as < 140/90 mmHg.
+CMS138v14
+Preventive Care & Screening: Tobacco Use: Screening and Cessation
+Patients age 18 and older with at least one validated encounter during the active measurement year.
+Patients screened for tobacco use within the past 12 months AND who received tobacco cessation counseling interventions if identified as a user.
+	•	3.2 Real-Time Care-Gap Notification Interventions
+	•	Decile Analysis: The dashboard charts the practice's active compliance percentages directly alongside current-year CMS point deciles, highlighting how much MIPS incentive points each category contributes to the corporate bottom line.
+	•	Inline Care-Gap Prompts: If a patient matching a measure's denominator checks into the clinic and lacks a compliant numerator event, a care-gap warning banner renders within the clinical charting view (e.g., "Patient requires a repeat Blood Pressure evaluation to satisfy CMS165v14 criteria"). This allows the care team to resolve outstanding gaps before closing the patient encounter.
+	•	Phase 4: FHIR Technical Architecture & Clinical Reasoning Serialization
+	•	The quality measurement structures, calculation rules, and output results are modeled using native healthcare standards, utilizing the FHIR Clinical Reasoning Framework to manage compliance tracking.
+	•	4.1 Underlying Core Structural Resource Components
+	•	
+	•	Phase 5: QRDA Compilation & CMS QPP Registry Submission (Loop Closure)
+	•	At the close of the tracking cycle, the platform aggregates the finalized clinical data into authorized regulatory reporting structures to complete the submission process.
+	•	5.1 Quality Reporting Document Architecture (QRDA) Formatting
+	•	The export pipeline reads the calculated MeasureReport dataset and transforms it into required federal reporting formats:
+	•	QRDA Category I: High-fidelity clinical files containing detailed data points for every individual patient tracked within the reporting cohort.
+	•	QRDA Category III: Aggregated reporting files summarizing collective numerator and denominator counts across the entire organization, mapped explicitly to the practice's Corporate Tax ID (TIN) and individual clinician National Provider Identifiers (NPI).
+	•	5.2 Direct Registry REST API Transmission
+	•	Instead of requiring manual uploads through external websites, the EMR integrates directly with federal infrastructure endpoints. The system uses secure webhooks to transform QRDA data arrays into standard JSON request structures and dispatches them directly via the CMS QPP Submission REST API Gateway.
+	•	The API connection handles the submission data over a secure TLS 1.3 session authenticated with custom developer tokens issued by CMS. The system processes the incoming server responses, verifies data acceptance status, logs the transaction keys, and updates the compliance dashboard status to Officially Submitted & Accepted. This workflow ensures transparent data verification and wraps up the practice's MIPS regulatory reporting cycle with minimal administrative friction.
+
+Advanced Clinical & Documentation Automations
+	•	Native Ambient AI Scribe Workflow: Instead of forcing providers to use third-party plugins, integrate an ambient AI listening engine directly into the charting interface.
+	•	The Workflow: The provider triggers "Listen" during the encounter. The AI captures the natural conversation, filters out small talk, and structures it seamlessly into a customizable SOAP note. Crucially, it should auto-suggest billing codes and order entries based on the conversation text, leaving the provider to simply review and sign off.
+	•	Phase 1: Native Stream Initiation & Cryptographic Consent Enforcement
+	•	The ambient recording pipeline is bound directly to the active patient workspace, preventing audio data from drifting outside the verified clinical context.
+	•	1.1 Digital Consent Guardrails
+	•	The Enforcement Check: Before enabling the system microphone, the interface checks for an active FHIR Consent Resource confirming the patient has approved ambient recording.
+	•	The Override Workflow: If consent is missing, the scribe activation toggle is grayed out, displaying a link to an inline digital signature capture workspace. Once the patient signs, the status updates immediately.
+	•	1.2 Hardware & Session Handshake
+	•	The Initialization Capture: Clicking the recording button activates a secure session via the browser's native HTML5 Web Audio API.
+	•	The Network Pipe: The system opens a secure, low-latency binary WebSocket or gRPC stream directly from the local device to the EMR application server, using TLS 1.3 to protect the data in transit.
+	•	Phase 2: High-Fidelity Audio Streaming & Acoustic Diarization Pipeline
+	•	The ingestion pipeline converts conversational audio into structured, clean textual streams while isolating the specific speakers in the room.
+	•	2.1 Audio Processing & Acoustic Conditioning
+	•	The Raw Input: The system captures audio as a raw 16kHz linear PCM single-channel stream to provide optimal speech-to-text accuracy while minimizing required network bandwidth.
+	•	Acoustic Conditioning: Acoustic echo cancellation and background noise filtering blocks run natively within the client browser layer, stripping out medical device hums, keyboard clicks, and HVAC interference.
+	•	2.2 Neural Speaker Diarization
+	•	The incoming stream passes through a specialized acoustic segmentation model that tracks distinct vocal characteristics to distinguish speakers without requiring directional multi-microphone arrays:
+	•	Speaker 0 (The Clinician): Matched against the provider's stored voiceprint profile verified during login.
+	•	Speaker 1 (The Patient): Identified by contrastive acoustic features.
+	•	Speaker 2+ (Family Members / Interpreters): Segmented into auxiliary dialogue nodes.
+	•	Phase 3: Semantic Enrichment & Structural Clinical Synthesis
+	•	Once the audio converts to text, the platform's clinical language models parse the raw conversation into structured, regulatory-compliant medical documentation.
+	•	3.1 Structural SOAP Transformation
+	•	A specialized clinical language model analyzes the dialogue to map unstructured conversational segments into standard documentation sections:
+	•	3.2 Medical Entity Coding & Ontological Normalization
+	•	The engine processes clinical concepts mentioned in the text and links them directly to standardized medical terminologies:
+	•	Diagnoses: Maps clinical descriptions directly to SNOMED-CT or ICD-10-CM codes.
+	•	Prescriptions: Normalizes medication names, forms, and dosages to unique RxNorm concepts.
+	•	Diagnostics: Links ordered tests or evaluations to LOINC or CPT codes.
+	•	Phase 4: The Native UI/UX Interactive Charting Canvas
+	•	The parsed clinical note drops into a single-screen, highly interactive charting dashboard designed to minimize cognitive friction for the reviewer.
+	•	4.1 Side-by-Side Verification Screen
+	•	The Document Interface: Renders a clean split-screen workspace within the core chart view. The left pane shows the streaming text transcript, while the right pane displays the auto-populating structured SOAP draft notes.
+	•	Inline Confidence Mapping: Portions of the note generated with lower AI confidence levels or containing conflicting historical values are highlighted with a soft background color tint. Hovering over a highlighted phrase displays the exact audio transcript snippet that triggered the text generation.
+	•	4.2 Single-Click Data Binding
+	•	The Structural Injections: Next to each auto-extracted data element (such as an altered medication dosage or a new diagnostic order), the UI displays an inline validation checkbox.
+	•	The Action: Selecting the checkbox validates the element, automatically queueing the corresponding structured prescription or laboratory order request in the backend EMR database without requiring manual text entry.
+	•	Phase 5: FHIR Technical Architecture & Lineage Serialization
+	•	The finalized document text, the original conversational transcript data, and the associated AI model metadata are recorded as interoperable data elements.
+	•	
+	•	Phase 6: Clinical Validation, Attestation, & Cryptographic Locking
+	•	To complete the workflow cycle, the generated draft note passes through a strict clinical validation loop before it is committed to the patient's permanent record.
+	•	6.1 Interactive Modification Audits
+	•	If the provider manually changes text generated by the ambient model (e.g., editing a physical exam finding), the system logs the original text alongside the modification.
+	•	These text changes are stored within local configuration tracking logs to provide a transparent history of edits, helping compliance teams track documentation accuracy across the clinic network.
+	•	6.2 Legal Attestation Signature
+	•	The Final Sign-off: Clicking "Sign Note" prompts the provider for their digital signature credential, certifying they have reviewed and approved the documentation.
+	•	The Immutable Lock: The system applies a SHA-256 cryptographic signature block over the finalized Composition resource, locking the encounter record. The background ambient workers then clear all localized audio buffer arrays from the workstation's memory, ensuring compliance with strict data security regulations and concluding the encounter workflow.
+
+	•	Dynamic, Context-Aware Charting Templates: Traditional templates are static and rigid. A standout feature is predictive charting, where the template morphs based on the patient's age, chief complaint, and past history. If a patient presents for a metabolic follow-up, the chart dynamically surfaces relevant historical lab trends (e.g., HbA1c, fasting insulin) and specific lifestyle tracking fields right next to the active note.
+	•	Phase 1: Context Aggregation & Structural Token Extraction
+	•	The polymorphic pipeline initializes the moment a patient encounter is opened or marked as active by the clinical team.
+	•	1.1 Multi-Dimensional Context Harvester
+	•	An event listener captures the initialization event and builds a temporary runtime data structure containing four core parameters:
+	•	Demographics: Resolves age and physiological markers from the Patient resource.
+	•	Presenting Problem (Chief Complaint): Parses unstructured triage text or structured input fields from the active Encounter.reasonCode.
+	•	Longitudinal Problem List: Scans the patient's record for active Condition entries with a verification status of confirmed.
+	•	Biomarker History: Queries the data service layer for specific labs, vital records, and lifestyle flowsheets recorded over the preceding 36 months.
+	•	1.2 Clinical Context Scenario Example
+	•	When evaluating an appointment record, the context harvester extracts the following parameters:
+	•	Age/Gender: 46-year-old male.
+	•	Chief Complaint: "Metabolic follow-up, reviewing recent lifestyle shifts and energy variations."
+	•	Active Problems: Type 2 Diabetes Mellitus (ICD-10: E11.9), Hyperlipidemia (ICD-10: E78.5).
+	•	Historical Payload Status: Existing lab history for Fasting Insulin, Hemoglobin HbA1c, and continuous biomarker streams.
+	•	Phase 2: The Polymorphic UI Morphing Engine
+	•	The application server passes the extracted context payload into a rules-based layout compiler. This layer evaluates the parameters to structurally morph the document canvas before it renders on screen.
+	•	2.1 Dynamic Layout Transformation Logic Pipeline
+	•	Instead of loading a fixed string container, the interface is assembled dynamically using modular data blocks governed by conditional display rules
+	•	2.2 Adaptive Field Invalidation Matrix
+	•	The template engine hides non-contributory charting sections based on the active encounter context, optimizing screen space and reducing visual clutter:
+	•	
+	•	Phase 3: The Integrated Split-Canvas Workspace UI/UX
+	•	The front-end rendering layer displays a side-by-side workspace that combines narrative text generation with historical data visualization on a single screen.
+	•	3.1 Dual-Pane Interactive Interface Layout
+	•	The Progressive Left Pane (The Active SOAP Canvas): A clean text workspace configured with semantic Markdown processing. As the clinician type-documents or acts upon ambient AI text blocks, the engine scans the text to continuously adapt the right-hand panel.
+	•	The Analytical Right Pane (The Clinical Intelligence Inset): A dynamic analytics panel locked directly adjacent to the progress note text area.
+	•	3.2 High-Density Metabolic Visualization Components
+	•	When a metabolic follow-up is triggered, the right-hand panel activates targeted analytics features:
+	•	Live Biomarker Trend Lines: Displays high-density line charts tracking specific clinical values (e.g., HbA1c, Fasting Insulin, ApoB, High-Sensitivity CRP) over time, eliminating the need to search through separate laboratory data tabs.
+	•	The Lifestyle Tracking Flowsheet: Embeds discrete documentation fields right next to the active note text to capture key metabolic health habits:
+	•	Fasting Window Duration (Hours)
+	•	Zone 2 Cardiovascular Exercise Volumetrics (Minutes/Week)
+	•	Average Deep/REM Sleep Duration Metrics
+	•	Phase 4: FHIR Technical Architecture & Data Schema
+	•	Dynamic templates are structured using native SMART on FHIR Clinical Reasoning frameworks. Layout behavior is controlled by nesting expressions within the structural templates.
+	•	4.1 Structural Interoperability Components
+	•	
+	•	Phase 5: Predictive Ordering & Inline Decision Support
+	•	The context engine does more than adapt layout fields—it runs real-time data calculations to provide context-appropriate clinical insights directly inside the charting workspace.
+	•	5.1 Dynamic Mathematical Clinical Calculations
+	•	If the database populates the right-hand trend window with concurrent values for fasting glucose and fasting insulin, the template engine automatically runs a background calculation to assess insulin resistance:
+	•	
+	•	If the resulting value exceeds 2.5 (indicating significant insulin resistance), the template inserts an inline alert banner: Alert: HOMA-IR calculated at 3.4. Consider adjusting metabolic management protocols.
+	•	5.2 Automated Order Recommendations (Closing the Loop)
+	•	The Evaluation Check: The engine evaluates the timestamps of the patient's existing lab records. If the patient has an active diagnosis of Type 2 Diabetes but has not had an HbA1c or fasting lipid panel executed within the past 180 days, the template takes proactive action.
+	•	The Action: It adds a pre-populated "Suggested Orders" action sheet directly beneath the active progress note section
+	•	Single-Click Sign-off: Checking an item updates the database immediately, adding a pending ServiceRequest to the active encounter. This allows the provider to authorize required follow-up labs without leaving the primary charting view, ensuring efficient documentation workflows and personalized, data-driven patient care.
+
+Lifestyle, Metabolic, and Wearable Data Aggregation
+	•	Legacy EMRs are completely blind to what happens to a patient between clinic visits. Bridging this gap is a massive competitive differentiator.
+	•	[Wearables / CGMs] ──> PGHD Ingestion Pipeline ──> Clinical Trend Dashboard │ (AI Flags Anomalies)
+	•	Patient-Generated Health Data (PGHD) Ingestion: A workflow that securely pulls data from consumer wearables, continuous glucose monitors (CGMs), smart scales, and sleep trackers via Apple HealthKit, Google Fit, or dedicated APIs.
+	•	Phase 1: Multi-Platform Authorization & OAuth2 Consent Framework
+	•	To securely ingest data from diverse consumer endpoints, the system implements a unified OAuth 2.0 and native mobile security handshake.
+	•	1.1 Edge Capture: Apple HealthKit & Google Health Connect
+	•	The iOS Architecture: The EMR’s native mobile application establishes a background execution thread using the HKHealthStore framework. The user signs an on-screen consent form, prompting the native iOS security layer to grant granular read permissions for explicit types (HKQuantityTypeIdentifierNumberOfTimesFalling, HKQuantityTypeIdentifierBloodGlucose, HKCategoryTypeIdentifierSleepAnalysis).
+	•	The Android Architecture: The EMR utilizes the Android Health Connect SDK to access the local on-device encrypted data repository. This allows the application to query native data records without relying on legacy cloud polling behaviors.
+	•	1.2 Cloud-to-Cloud Integration (Dexcom, Oura, Withings)
+	•	For devices that sync directly to independent cloud architectures, the system utilizes the OAuth 2.0 Authorization Code Flow with PKCE (Proof Key for Code Exchange):
+	•	[EMR Patient Portal] ──> Redirects to Device Auth (e.g., Dexcom) ──> User Grants Scopes ──> Server Returns Auth Code ──> EMR Exchanges Code for Cryptographic Access & Refresh Token Pairs via mTLS
+	•	Scopes Matrix: Request boundaries are strictly confined to required scopes (e.g., dexcom.glucose.read, oura.v2.sleep.read, withings.metrics.read). Refresh tokens are encrypted and held securely within an HSM (Hardware Security Module) vault.
+	•	Phase 2: Inbound Data Ingestion & Stream Processing Engine
+	•	The ingestion infrastructure manages data streams through two parallel ingestion pathways optimized for battery preservation and system load balancing.
+	•	2.1 Parallel Ingestion Mechanisms
+	•	Asynchronous Webhook Receivers: Used for cloud APIs (e.g., Dexcom/Oura). When a device server pushes a payload alert (e.g., App-Ready / New CGM Data Available), a lightweight, serverless webhook receiver processes the notification, validates the cryptographic signature header, and pushes the event into an ingestion message queue.
+	•	Delta Anchor Syncing: Used for mobile frameworks. The mobile app runs a background task using an incremental syncing strategy (HKAnchoredObjectQuery). Instead of pulling historical data arrays during every execution cycle, the application reads data added or modified since the last recorded anchor token, reducing data usage and processing overhead.
+	•	2.2 Deduplication & Rate Limiting Guardrails
+	•	The Collision Check: Because patients often cross-link accounts (e.g., syncing a smart scale to both Apple Health and Withings Cloud), the ingestion layer pipes incoming JSON payloads into a caching buffer layer.
+	•	The Resolution Rule: Elements are evaluated based on their unique hardware manufacturer identifier, universal tracking index, and explicit measurement timestamp. If an inbound record matches an existing data point within a $\pm 10\text{-second}$ window, the duplicate entry is dropped, and a merge event is noted in the data lineage system.
+	•	Phase 3: Semantic Normalization & Clinical Unit Standardization
+	•	Raw telemetry from consumer hardware is unstructured and inconsistent, using variable text labels and unit standards. The normalization engine translates these incoming strings into uniform, clinically sound terminologies.
+	•	3.1 Mapping Transformation Pipeline
+	•	The stream transformer parses incoming data arrays and translates local device payload labels to match national medical standards, mapping them to LOINC codes for clinical concepts and UCUM codes for structural measurement units:
+Consumer Device Type
+Source Payload Attribute
+Target Normalized LOINC Code
+Target Standard UCUM Unit
+Continuous Glucose Monitor
+glucose_value, interstitial_glucose
+99501-9
+ 
+(Glucose [Mass/vol] in Interstitial fluid)
+mg/dL or mmol/L
+Smart Scale
+body_weight, weight_kg
+29463-7
+ 
+(Body weight)
+kg
+Smart Scale
+skeletal_muscle_mass_percentage
+93358-0
+ 
+(Skeletal muscle mass/Body weight)
+%
+Sleep Tracker
+sleep_duration_total_seconds
+74220-5
+ 
+(Sleep duration)
+h or min
+Wearable Activity Tracker
+resting_heart_rate_bpm
+8867-4
+ 
+(Heart rate resting)
+/min
+	•	Phase 4: Embedded Clinical Intelligence & Provider Workspace UI/UX
+	•	Rather than requiring clinicians to navigate out of the charting workflow, normalized PGHD populates interactive panels directly adjacent to the active documentation canvas.
+	•	High-Density Data Visualizations: The telemetry panel displays smooth line charts tracking interstitial glucose movements, complete with shaded bands indicating target glycemic zones ($70 - 180\text{ mg/dL}$). It surfaces key sleep architecture metrics (Deep, REM, and Light sleep percentages) stacked alongside resting heart rate trends.
+	•	Single-Click Narrative Synthesis: Providers can click an inline action token ("Populate Trend Into Note") to run an internal text macro. This parses the preceding 14 days of telemetry data and inserts a structured summary directly into the progress note text area (e.g., "Ambulatory glucose metrics reviewed: 14-day Time-in-Range (TIR) calculated at 82%, mean interstitial glucose value: 114 mg/dL, average nocturnal sleep duration: 7.2 hours with a 22% deep sleep fraction.").
+	•	Phase 5: FHIR Technical Architecture & Resource Serialization
+	•	Ingested data streams are written to the database layer as native FHIR Observation Resources, maintaining distinct associations with the originating patient identifier and hardware source component.
+	•	5.1 Data Layer Architecture
+	•	The Patient Association: Binds individual observation entries to the unique internal Patient graph identifier.
+	•	The Hardware Provenance: References a core Device Resource that logs the explicit device parameters (e.g., Manufacturer: Dexcom, Model: G7, Unique Device Identifier: UDI), maintaining complete data audit records.
+	•	Phase 6: Clinical Boundary Alerts & Automated Decision Support
+	•	To prevent data fatigue while ensuring clinical responsiveness, incoming PGHD runs through an algorithmic evaluation layer to flag urgent out-of-bounds variations.
+	•	6.1 Clinical Boundary Metrics & Scoring Strategy
+	•	The platform avoids firing simple threshold triggers on single noisy data points by running time-series evaluation rules over rolling data windows:
+	•	
+	•	6.2 The Escalation Decision Matrix
+	•	Based on the results of the evaluation loops, the system classifies events and routes appropriate responses:
+	•	Urgent Critical Event (Severe Acute Excursion): If an inbound CGM value records at $< 55\text{ mg/dL}$ or $> 300\text{ mg/dL}$ for more than 20 consecutive minutes, the system triggers an emergency workflow loop. It generates an urgent task banner across active clinic displays, distributes secure push alerts to the designated on-call triage provider, and notes the event within the patient portal network.
+	•	Non-Urgent Trend Event (Longitudinal Care Gap): If the calculated 14-day Time-in-Range percentage drops below $70\%$, the engine flags a long-term care trend variation. It logs a low-priority task entry within the primary care team's panel-management workspace, prompting them to review the patient's lifestyle management plan or adjust their active medication schedule during their next follow-up. This methodology keeps providers informed of significant data shifts without overloading them with alerts for transient data spikes.
+	•	Biometric Trend Dashboards: Instead of dumping raw data points into a chart, aggregate this information into clean, actionable visual trends. Providers can instantly see a patient’s average resting heart rate, sleep architecture, or glycemic variability over the last 90 days, allowing for highly personalized, preventive, and metabolic-focused care.
+	•	Phase 1: High-Volume Time-Series Data Stream Ingestion & Caching
+	•	The visualization pipeline acts as an analytics layer on top of raw clinical and wearable data infrastructures, isolating high-volume telemetry queries from active transactional databases.
+	•	1.1 Read-Optimized Data Ingestion
+	•	The Ingestion Pipeline: Continuous data streams from wearable hardware integrations and clinical encounters (e.g., blood pressure checks, point-of-care labs) pass through an event router into a specialized time-series data storage layer.
+	•	The 90-Day Rolling Cache: The system maintains a read-optimized cache that groups patient telemetry into indexed 90-day blocks. This architecture allows the application to load complex visual trends instantly without causing performance lag on primary electronic records databases.
+	•	Phase 2: Algorithmic Aggregation & Advanced Mathematical Metric Extraction
+	•	To prevent data noise from obscuring genuine clinical changes, raw data packets run through localized mathematical processors. This layer transforms point-in-time entries into validated markers of metabolic and autonomic health.
+	•	2.1 Glycemic Variability Integration
+	•	Rather than relying solely on mean glucose measurements, the system evaluates the stability of the patient's glycemic curves. The processor runs rolling data vectors through a standard Coefficient of Variation equation to gauge variability:
+	•	
+	•	Where $\sigma$ represents the standard deviation of all blood glucose readings over the past 90 days, and $\mu$ represents the true mathematical mean of those same values.
+	•	Clinical Target Boundary: The engine marks a calculated output of $\le 36\%$ as stable metabolic boundary performance. Values higher than this threshold point to elevated glycemic variability, triggering automated tracking markers within the workspace.
+	•	2.2 Sleep Architecture & Efficiency Compilations
+	•	The processing blocks parse daily sleep phase arrays into aggregated longitudinal metrics:
+	•	Sleep Efficiency Calculation: Calculates true systemic rest intervals by comparing recorded sleep durations directly against total time spent in bed:
+	•	
+	•	Structural Phase Partitioning: Computes the true 90-day rolling averages for distinct sleep states, flagging individuals whose Deep (N3) or REM sleep cycles fall below targeted health boundaries (e.g., Deep Sleep Fraction $< 20\%$ of total sleep architecture).
+	•	2.3 Cardiovascular Autonomic Tracking
+	•	Resting Heart Rate (RHR) Stabilization: Applies a 7-day moving average filter to nocturnal heart rate recordings to smooth out transient spikes caused by late-night meals, alcohol consumption, or short-term training fatigue, isolating the true baseline resting heart rate.
+	•	Heart Rate Variability (HRV) Trends: Aggregates nocturnal root mean square of successive differences (rMSSD) data streams, tracking long-term changes in autonomic resilience and sympathetic-parasympathetic balance.
+	•	Phase 3: The 90-Day Metabolic Dashboard Interface UI/UX Design
+	•	The aggregated biometric indices serve an interactive, single-view visual terminal designed to display clear baseline shifts at a glance.
+	•	3.1 High-Contrast Trend Element Visualizer
+	•	Baseline Overlay Views: The interactive timeline display charts raw data points as a translucent background layer behind a solid, high-visibility trend line. This approach makes longitudinal changes clear without hiding underlying acute variations.
+	•	Delta ($\Delta$) Indicator Modules: Each data panel displays a clear variance metric comparing the patient's performance over the most recent 30-day window against their initial 90-day baseline data (e.g., Avg Resting HR: 54 bpm $\Delta$ -4 bpm over prior 60 days).
+	•	Phase 4: FHIR Technical Architecture & Data Schema
+	•	Longitudinal aggregations and summary metrics are structured as native FHIR Observation Resources that use specific statistical codes to ensure seamless data portability across compliant networks.
+	•	4.1 Structural Interoperability Components
+	•	
+	•	Phase 5: Clinical Correlation, Trend Analysis & Decision Support Injections
+	•	Behind the visual interface, an advanced clinical evaluation engine monitors moving data streams to highlight underlying metabolic shifts and alert providers to potential health trends.
+	•	5.1 Multi-Variant Pattern Detection
+	•	Instead of evaluating single data metrics in isolation, the engine runs continuous cross-variable assessments to spot early signs of shifting metabolic or autonomic function
+	•	5.2 Inline Insights Delivery
+	•	When the pattern detection engine identifies a multi-variable trend, it surfaces an actionable insight banner directly at the top of the provider's active charting interface:
+	•	⚠️ Clinical Metric Correlation Alert: Over the last 45 days, the patient's rolling resting heart rate has dropped by 5 bpm, corresponding with a 20% increase in deep sleep duration and improved glycemic stability (Coefficient of Variation dropped from 34% to 28%). This pattern indicates positive metabolic adaptation and enhanced autonomic resilience.
+	•	Phase 6: Workflow Automation, Panel Management & Actionable Interventions
+	•	To translate clinical insights into practical patient care, the biometric trend engine connects straight to operational task queues and panel management tools.
+	•	6.1 Closing the Care Loop from the Dashboard Layout
+	•	The interface features actionable management options embedded directly inside the trend panels, letting providers execute follow-up tasks with a single click:
+	•	Automated Dashboard Injections: Clicking "Export Trend Summary" runs an internal macro that inserts a clean markdown summary of the 90-day biometric data straight into the active encounter note text area, providing clear documentation of the patient's physiological progress.
+	•	Proactive Laboratory Assessment: If the 90-day data shows rising glycemic variability or an increasing average glucose baseline, the system automatically surfaces a tailored follow-up action card.
+	•	6.2 Population Health Panel Orchestration
+	•	Risk Stratification Queries: Care managers can filter patient panels using collective trend markers rather than relying on static diagnosis codes (e.g., "Identify all clinic patients with an active diagnosis of Prediabetes whose 90-day Glycemic Coefficient of Variation has risen above 38% over the past 30 days").
+	•	Targeted Care Outreach: The resulting patient lists map straight into automated communication streams. This allows clinical teams to deploy proactive scheduling links or coordinate lifestyle intervention follow-ups for rising-risk cohorts before acute metabolic complications emerge, maximizing the impact of preventative care strategies.
+	•	Data synchronization for patients tracking biomarker metrics via external wearable APIs
+	•	Phase 1: Distributed Webhook Subscription & Multi-Tenant API Hub
+	•	Rather than polling external API endpoints every few minutes—which runs into strict rate limits—the synchronization engine uses a reactive webhook framework.
+	•	1.1 Webhook Lifecycle Orchestration
+	•	When a patient links their device via the patient portal, the EMR registers an active subscription with the external vendor’s developer gateway.
+	•	The Handshake Registration: The system sends an outbound payload containing the EMR’s secure webhook listener URL, an auto-generated subscription UUID, and a shared cryptographic secret key.
+	•	The Verification Challenge: The engine responds to verification checks (such as Dexcom's or Oura's GET challenge requests) by hashing the incoming token strings and returning the required signature to activate the webhook pipeline.
+	•	1.2 Multi-Tenant Multi-Vendor Event Router
+	•	A single gateway listener processes all incoming vendor data traffic, operating on an asynchronous event-driven layout
+	•	Phase 2: Asynchronous Ingestion & Idempotent Processing Queue
+	•	To prevent high-volume data streams (like continuous glucose data arriving every 5 minutes across an entire patient population) from slowing down the primary EMR app servers, data collection is decoupled from data processing.
+	•	2.1 The Event-Streaming Architecture
+	•	Ingestion Worker Layer: When a valid webhook triggers, the gateway places the raw JSON body straight into an ingestion queue (e.g., Apache Kafka or Redis Streams) and immediately returns an HTTP 202 Accepted status to the external vendor. This keeps the network connection window open for less than 50 milliseconds.
+	•	Downstream Processing Thread: Background processing workers pull messages from the queue asynchronously, handling heavy computing tasks like data parsing, user profile matching, and clinical unit normalization out of the main application thread.
+	•	2.2 Idempotency Guardrails & Deduplication
+	•	To prevent duplicate records from inflating clinical data trends when vendors send duplicate webhook payloads, the engine applies two structural checks:
+	•	The Deterministic Idempotency Key: The processor generates a unique tracking hash for every incoming data point by combining the hardware's source identifier, the patient's internal ID, and the explicit event timestamp:
+	•	
+	•	The Cache Check: Before running database updates, the worker checks this hash against a fast, in-memory Redis Cache (configured with a rolling 72-hour expiration window). If the key already exists, the payload is dropped as a duplicate, preventing unnecessary database writes.
+	•	Phase 3: Token Lifecycle Management & HSM Secret Isolation
+	•	Because consumer API connections rely on short-lived OAuth 2.0 access credentials, maintaining continuous data synchronization requires an automated, secure token refresh infrastructure.
+	•	3.1 Secure Vault Architecture
+	•	All authorization attributes, including client secrets, access tokens, and refresh tokens, are stored in an encrypted Hardware Security Module (HSM) vault using AES-256 encryption.
+	•	The application database holds only non-sensitive reference markers linking back to the secure vault keys.
+	•	3.2 Automated Background Token Refresh Pipeline
+	•	A background scheduling worker runs continuous synchronization health checks across the credential database
+	•	Phase 4: Semantic Normalization & Multi-Variant Biomarker Mapping
+	•	Raw JSON payloads pushed from external wearable APIs vary significantly in structural taxonomy. The synchronization engine uses an architectural translation matrix to normalize incoming data strings into unified clinical structures.
+	•	4.1 Cross-Vendor Translation Matrix
+	•	
+	•	Phase 5: Historical Backfilling & Chronological Reconciliation
+	•	When a device reconnects after an extended offline period (e.g., a patient traveling in remote areas or keeping their mobile sync disabled for days), the external API drops a large batch of historical data points during the next sync cycle.
+	•	5.1 Deep Backfill Window Management
+	•	When a backfill notification arrives, the system sets up a dedicated data-catching loop instead of processing the entries inline.
+	•	The system checks the earliest timestamp in the incoming batch and queries the internal database for that time window. It extracts existing data points for that period to establish a baseline for deduplication.
+	•	5.2 Real-Time Merging & Re-indexing
+	•	The Chronological Insert Loop: The processor walks through the historical records chronologically, using bulk database operations to insert missing entries while skipping points that match existing records.
+	•	Downstream Aggregation Triggers: Once the backfill operation completes successfully, the system fires an internal event message to notify down-stream analytics workers. This prompts the trend dashboard engines to recalculate rolling 30, 60, and 90-day metabolic averages using the updated data points, ensuring all clinical charts display fully accurate trend timelines.
+	•	Phase 6: FHIR Technical Architecture & Continuous Stream Serialization
+	•	Every data synchronization event, update cycle, and structural observation matches native SMART on FHIR Interoperability Specifications, writing clean records straight to the permanent clinical database layer.
+	•	6.1 Transaction Bundle Composition
+	•	Large-scale multi-point updates or backfills are processed using a FHIR Bundle Resource configured with a .type parameter of transaction. This ensures that all observations within the package execute as a single atomic operation—if any component fails validation, the entire transaction rolls back to preserve data consistency.
+
+Complex and Non-Traditional Prescribing Workflows
+	•	Standard e-prescribing handles commercial pharmaceuticals well, but completely stumbles when it comes to personalized, compound, or botanical medicine.
+
+	•	Custom Compound & Botanical Order Builder: Create a workflow dedicated to prescribing non-standard therapies—such as tailored compounding formulas, specific nutritional supplements, or medicinal botanicals/cannabinoids.
+	•	The Workflow: Allow providers to build and save custom titration schedules, specify precise component ratios (e.g., custom peptide blends or specific CBD:THC ratios), generate compliant PDF scripts for specialized pharmacies, or route them directly to integrated e-commerce/dispensary platforms.
+	•	Phase 1: The Multi-Component Ratio Matrix Builder (Formulation Engine)
+	•	The core order builder replaces single-selection dropdown fields with a dynamic constituent-nesting ledger. This allows clinicians to build custom formulas from raw chemical elements, peptides, supplements, or botanical distillates.
+	•	1.1 Dynamic Ingredient Apportionment
+	•	The Ingredient Catalog: The engine operates on an independent database of base compounds mapped to standardized terminologies (RxNorm extension codes for raw materials or SNOMED-CT for botanical extracts).
+	•	Ratio Binding Modality: Providers can toggle the compounding matrix input fields to build formulations based on absolute mass ratios, volumetric splits, or target absolute milligram concentration deliverables per dose unit.
+	•	1.2 Concentration Yield Calculations
+	•	When designing a fluid suspension or oil-based sublingual tincture, the engine executes real-time density and fluid mass balance operations to verify batch concentrations. The mathematical yield equation evaluates each constituent's exact volume and weight contribution:
+	•	
+	•	For a customized cannabinoid tincture specifying a 20:1:2 ratio (CBD to THC to CBN) aimed at a target delivery concentration of $50\text{ mg/mL}$ total active cannabinoids in a $30\text{ mL}$ amber glass bottle, the engine automatically calculates the required raw ingredient volumes:
+	•	CBD Isolated Distillate: $1,304.3\text{ mg}$ total ($43.48\text{ mg/mL}$)
+	•	Delta-9-THC Distillate: $65.2\text{ mg}$ total ($2.17\text{ mg/mL}$)
+	•	CBN Isolate: $130.4\text{ mg}$ total ($4.35\text{ mg/mL}$)
+	•	MCT Oil Carrier Base: Quantity Sufficient (QS) to reach exactly $30.0\text{ mL}$
+	•	Phase 2: Programmatic Titration & Taper Schedule Orchestrator
+	•	To manage patient responses to active botanicals, adaptogens, or customized peptide therapies safely, the system replaces standard static text instructions with an active, multi-phase scheduling engine.
+	•	2.1 Multi-Phase Step-Dosing Arrays
+	•	Clinicians can design custom, sequential execution blocks directly within the order builder interface, defining explicit phase intervals, daily dosing times, and step adjustments
+	•	2.2 Template Blueprints Repository
+	•	The Blueprint Architecture: Providers can save configured matrix calculations and titration schedules as reusable "Formulation Blueprints" (e.g., Metabolic Sleep Support Protocol - High CBN).
+	•	One-Click Ordering: When selected for a new patient encounter, the blueprint automatically imports the complete ratio matrix and schedule, checks for allergies against active ingredients, and populates the ordering terminal.
+	•	Phase 3: Jurisdictional Regulatory Guardrails & Controlled Substance Controls
+	•	Because non-standard botanical formulations and medical cannabinoids navigate complex state and federal legal requirements, the order engine runs automatic compliance checks behind the scenes.
+	•	3.1 Adaptive Threshold Enforcement
+	•	THC Mass Accumulation Checks: If a formulation includes Delta-9-THC, the system calculates the absolute dry-weight percentage and total milligram mass per container to ensure compliance with state-specific medical cannabis program restrictions.
+	•	Daily Supply Auditing: The engine checks the total compound volume against the calculated daily use from the titration schedule to verify that the final amount stays within allowable regional single-dispensation limits (e.g., confirming compliance with California's maximum daily medical allocation rules).
+	•	Phase 4: Dual-Channel Delivery Pipeline (PDF Synthesis vs. Webhook API Routing)
+	•	Once an order is validated and authorized, the EMR processes the data payload through a dispatch channel based on the type of medication and pharmacy destination.
+	•	4.1 Channel A: Specialized Compounding Pharmacy PDF Generation
+	•	For traditional specialized compounding pharmacies that do not use automated data networks, the system builds an audit-ready PDF document containing:
+	•	Security Assets: High-resolution 2D data-matrices, verified NPI and DEA registration credentials, and an immutable SHA-256 transaction hash.
+	•	Detailed Composition Layouts: Clear tables breaking down every raw component, batch amount, specific carrier vehicle, precise step-by-step titration instructions, and authorized refill parameters.
+	•	Secure Delivery: Dispatched directly via secure, encrypted digital fax connections (eFax over TLS) straight to the pharmacy's ingestion terminal.
+	•	4.2 Channel B: Direct E-Commerce & Dispensary API Despatch
+	•	For modern botanical distribution hubs, supplement suppliers, or specialized dispensaries, the system skips manual document transmission entirely and sends structured payloads via secure APIs:
+	•	The Connection Handshake: Outbound webhook integrations transform the verified order into a direct API request (e.g., structured JSON format routed via authenticated mTLS sessions) sent straight to endpoints like Shopify Plus, specialized ERP systems, or medical supplier gateways.
+	•	The Clinical E-Commerce Flow: The API request pushes the precise formulation details, patient delivery demographics, and order references straight into the supplier's fulfillment queue. The supplier's system automatically builds a custom checkout link and sends it to the patient via SMS or secure portal message, allowing them to complete fulfillment seamlessly while keeping the provider updated on the order status.
+	•	Phase 5: FHIR Technical Architecture & Data Schema
+	•	Because standard FHIR resources are typically built around pre-packaged factory medications, customized compounds use nested Medication resource links to maintain precise data definitions.
+	•	5.1 Architecture Mapping Matrix
+	•	
+	•	Phase 6: Patient-Facing Visio-Timeline & Telemetry Feedback Loops
+	•	To complete the order cycle, the system extends tracking features down to the patient-facing application layer to support compliance and safety monitoring.
+	•	6.1 Graphical Titration Guides
+	•	Visual Guides: Rather than requiring patients to decipher complex text directions, the patient portal translates multi-phase dosage instructions into highly scannable, interactive visual timelines.
+	•	Dynamic Checklists: The application surfaces clear daily checklists tailored to the patient's active schedule phase (e.g., displaying an interactive prompt: Morning Dose: Take 0.25 mL sublingually).
+	•	6.2 Patient-Reported Outcome Measures (PROMs) & Symptom Tracking
+	•	Automated Pulse Surveys: The system deploys quick micro-surveys via the patient portal at key titration changes (e.g., on day 4, day 8, and day 15) to track subjective responses and tolerance levels.
+	•	Targeted Clinical Feedback Metrics: The tracking surveys capture core metrics optimized around the specific therapy target:
+	•	Sleep Disruptions & Latency Scores
+	•	Subjective Energy & Focus Levels
+	•	Gastrointestinal/Systemic Tolerance Metrics
+	•	Provider Alert Dashboards: Collected survey metrics pass back into the care management dashboard. If a patient records an adverse trend line (such as a significant spike in daytime fatigue during an escalation phase), the platform flags the trend and places a high-priority review task into the clinical team's workspace, supporting proactive care adjustments and optimized therapeutic monitoring.
+
+	•	Lifestyle & Protocol Prescribing: Treat lifestyle interventions with the same clinical weight as pharmaceuticals. Allow providers to "prescribe" structured protocols—such as specific dietary frameworks, therapeutic fasting regimens, or targeted mindfulness/stress-reduction routines—complete with patient-facing educational modules pushed automatically to their portal.
+	•	Phase 1: The Structured Protocol Prescription Canvas
+	•	The protocol engine replaces standard, open-ended text fields with a discrete order-entry workspace. This setup allows clinicians to prescribe multi-variable lifestyle protocols with clear, trackable parameters.
+	•	1.1 Digital Order Interface Structure
+	•	Every lifestyle order operates with identical structural properties to an electronic drug prescription, containing an active identifier, clear duration bounds, authorization signatures, and explicit contraindication screening loops (e.g., flagging a prolonged fasting prescription for a patient with a documented history of an eating disorder or an active pregnancy).
+	•	1.2 Protocol Templates Blueprint Repository
+	•	Clinicians can access a central repository of validated protocols or save customized configurations as personal clinical blueprints:
+	•	The Metabolic Longevity Protocol: Combines a plant-forward, whole-food Mediterranean dietary model with specific time-restricted eating parameters.
+	•	The Autonomic Restoration Blueprint: Combines structured breathwork with daily mindfulness schedules to support stress reduction and cardiovascular autonomic health.
+	•	Phase 2: Metabolic & Nutritional Architecture (Fasting & Dietary Vectors)
+	•	The nutritional module converts broad dietary advice into specific, quantifiable targets that allow for precise metabolic tracking.
+	•	2.1 Programmatic Fasting Regimens
+	•	The fasting configuration panel allows providers to construct step-by-step fasting regimens with clear liquid-intake rules and refeeding guidelines:
+	•	Time-Restricted Feeding (TRF): Specifies daily fasting and eating windows (e.g., an 18-hour fast paired with a 6-hour nutritional window).
+	•	Prolonged Therapeutic Water Fasting: Defines extended multi-day intervals (e.g., 72 to 120 hours) with strict, trackable tracking targets:
+	•	Hydration Requirements: Prescribed electrolyte fluid volumes (e.g., specifying sodium, potassium, and magnesium additions to water inputs).
+	•	Refeeding Protocols: Programmatic, post-fast reintroduction schedules to prevent refeeding complications, defining exact macronutrient sequences (e.g., breaking a fast with bone broth or clean fats before introducing carbohydrates).
+	•	2.2 Dietary Framework Configurations
+	•	Rather than simply recommending a "healthy diet," the system defines explicit nutritional boundaries:
+	•	Macronutrient Apportionment: Defines precise percentage or absolute mass boundaries (e.g., limiting carbohydrates to $<50\text{ grams/day}$ for ketogenic induction, or setting a minimum protein target of $1.6\text{ g/kg/day}$).
+	•	Glycemic & Ingredient Quality Exclusions: Embeds rule sets that flag processed sugar variations, refined starches, or inflammatory oils, prioritizing scratch-cooked, whole-food ingredient tracking.
+	•	Phase 3: Autonomic & Neurochemical Regulation Protocols (Mindfulness & Stress Management)
+	•	To treat stress reduction with clinical rigor, the platform supports the formal prescription of non-pharmacological down-regulation tools designed to optimize autonomic balance.
+	•	3.1 Autonomic Conditioning Parameters
+	•	The behavioral prescription workspace tracks stress management techniques using specific dosing variables:
+Intervention Type
+Specified Modulation Mechanics
+Clinical Frequency Target
+Objective Biometric Core Metric
+Resonant Coherent Breathing
+5.5-second inhalation paired with a 5.5-second exhalation vector.
+10 minutes, twice daily (BID).
+Nocturnal Heart Rate Variability (rMSSD) Elevation.
+Somatic Meditation & Yoga Nidra
+Non-Sleep Deep Rest (NSDR) guided acoustic sensory sweeps.
+20 minutes, post-encounter or QHS (nightly).
+Mean Daytime Resting Heart Rate Suppression.
+Mindfulness-Based Stress Reduction
+Fixed structured focus or non-dual awareness sitting sessions.
+15 minutes, ante-meridiem (morning).
+Real-Time Tonic Skin Conductance / Cortisol Curve Normalization.
+	•	3.2 Visual Protocol Flow Builder
+	•	Clinicians can use an interactive visual designer to link these exercises together into a unified daily routine (e.g., scheduling a 10-minute breathwork session at 08:00 to ease morning sympathetic spikes, followed by a 20-minute restorative somatic tracking session at 21:30 to promote deep sleep architecture).
+	•	Phase 4: Multi-Channel Patient Portal Delivery & Interactive Educational Ingestion
+	•	Once a lifestyle protocol is signed, the EMR coordinates content delivery to the patient portal, ensuring educational modules deploy in lockstep with the active prescription phase.
+	•	[Provider Signs Protocol] ──> System Generates CarePlan ──> Triggers LMS Hook ──> Pushes Phase 1 Video & Text Modules to Portal ──> Locks Next Modules Until Engagement Verification
+	•	4.1 Phase-Locked Content Automation
+	•	The Enrollment Hook: The system registers the active protocol and automatically enrolls the patient in corresponding educational paths within the native Learning Management System (LMS).
+	•	Dynamic Content Releasing: Educational modules unlock based on the patient's current stage in the prescription timeline. For an extended water fast, the portal delivers a "Pre-Fast Ingestion Prep" video 48 hours before day 1, switches to daily "Fasting Management Guides" during the active fast, and surfaces "Safe Refeeding Protocols" 12 hours before the fast concludes.
+	•	4.2 Interactive Verification Check-Ins
+	•	The Patient Feedback Loop: To ensure safety and track engagement, the system requires the patient to complete quick verification steps inside the portal before progressing through the protocol phases.
+	•	Knowledge Check Assessments: Short, interactive prompts confirm the patient understands key instructions (e.g., confirming they know how to mix their electrolyte solution or can identify signs that indicate they should safely stop an extended fast).
+	•	Phase 5: FHIR Technical Architecture & CarePlan Serialization
+	•	Lifestyle protocols are recorded using the SMART on FHIR Clinical Reasoning framework, combining CarePlan, Goal, and ServiceRequest resources into a single interoperable data structure.
+	•	5.1 Data Model Architecture
+	•	The Master Plan Core: A CarePlan Resource acts as the central hub, defining the overall lifecycle, category definitions, and authorization status.
+	•	The Metric Goals: Embedded Goal Resources map out target endpoints for the patient (e.g., tracking a specific target for fasting glucose variability or target sleep efficiency metrics).
+	•	The Prescribed Actions: Individual ServiceRequest Resources represent the specific components of the protocol, tracking the explicit dosing, frequency parameters, and associated educational content references.
+	•	Phase 6: Telemetry Integration & Objective Adherence Scoring
+	•	To close the loop, the system uses integrated wearable data pipelines to calculate an objective adherence score, moving beyond a reliance on self-reported patient compliance logs.
+	•	6.1 Multi-Variant Adherence Engine
+	•	The background analytics platform aggregates wearable streams to verify that the patient's physiological data aligns with their active lifestyle prescription:
+	•	
+	•	Where $\mathbf{B}_{\text{sync}}$ represents objective biometric verification (e.g., CGM tracking data validating that caloric ingestion stays strictly within the prescribed 6-hour window), $\mathbf{E}_{\text{portal}}$ tracks educational module completion, and $\mathbf{S}_{\text{check}}$ measures subjective survey check-ins. The variables $w_1, w_2, w_3$ represent assigned structural balancing weights.
+	•	6.2 Provider Workspace Intervention Triggers
+	•	Adherence scores feed straight back into the provider's care management dashboards, prioritizing follow-up tasks based on real-time trends:
+	•	The High-Adherence Trend Banner: When a patient maintains high adherence and demonstrates positive physiological changes, the system surfaces a confirmation badge next to their record (e.g., Metabolic Adherence: 94%. 90-day telemetry shows a 15% increase in nocturnal HRV and stabilized glycemic variability. Protocol objectives achieved.).
+	•	The Proactive Drop-off Flag: If a patient's calculated adherence index drops below $60\%$ over a 7-day period, the system logs an automated alert within the care team's outreach queue. This prompts a care manager or health coach to contact the patient, resolve any barriers to compliance, and adjust the lifestyle intervention plan before the patient disengages from the protocol entirely.
+
+Proactive Care Management & Asynchronous Workflows
+	•	Automated Post-Encounter "Check-ins": A workflow that automates follow-up engagement based on clinical actions. If a provider starts a patient on a new medication or a strict metabolic protocol, the EMR automatically sends a secure, text-based check-in 3, 7, or 14 days later asking about side effects or adherence.
+	•	The Value: Normal responses are filed quietly in the chart; abnormal responses or red flags trigger a high-priority task in the clinical queue for an MA or nurse to intervene.
+	•	Phase 1: Event-Driven Trigger Extraction & Enrollment Engine
+	•	The orchestration loop monitors the database transaction log, bypassing manual entry workflows by evaluating structured clinical state alterations instantly upon encounter sign-off.
+	•	1.1 Automated State-Change Interception
+	•	A transactional database trigger listens for two explicit lifecycle state changes:
+	•	MedicationRequest.status changing to active where the intent is order.
+	•	CarePlan.status changing to active where a specific tracking category is assigned.
+	•	1.2 Clinical Risk Mapping and Filtering
+	•	The pipeline evaluates the newly generated resources against an internal routing matrix to determine if enrollment is required:
+	•	Exclusionary Filtering Engine: The enrollment engine checks the patient's record for active exclusion variables—such as cognitive impairment flags or opt-out status parameters—before building an automated queue tracking profile.
+	•	Clinical Target Matching: The mechanism isolates high-visibility clinical additions (e.g., starting an advanced metabolic medication or deploying a strict prolonged water fasting regimen) to match them with a corresponding conversational sequence.
+	•	Phase 2: Dynamic Timeline Configuration & Delivery Matrix
+	•	Once enrolled, the pipeline computes a custom conversational roadmap based on the specific drug profile or protocol complexity.
+	•	2.1 Contextual Outreach Schedules
+	•	The tracking engine sets up structured message loops configured for specific clinical validation windows
+Triggering Clinical Action
+Targeted Outreach Cadence
+Primary Conversational Investigation Target
+New Metabolic Medication Initiation
+Day 3: Acute Tolerance Check
+ 
+Day 7: Adherence Verification
+ 
+Day 14: Titration Evaluation
+Evaluates common gastrointestinal side effects (e.g., nausea, satiety shifts) and confirms the patient successfully obtained the medication from their pharmacy.
+Strict Therapeutic Fasting Protocol
+Day 1: Fasting Launch Verification
+ 
+Day 3: Metabolic Transition Safety
+ 
+Day 5: Post-Fast Refeeding Audit
+Assesses hydration levels, screens for severe electrolyte imbalances (e.g., lightheadedness, syncope symptoms), and reinforces the safe refeeding guide sequence.
+Custom Tincture / Cannabinoid Order
+Day 3: Initial Induction Audit
+ 
+Day 14: Steady-State Target Audit
+Tracks baseline somnolence variations, registers micro-dose titration compliance, and screens for unexpected cognitive or physiological responses.
+	•	2.2 Date Serialization Architecture
+	•	The system calculates absolute delivery target windows using timestamp offsets from the initial encounter execution time:
+	•	
+	•	The engine applies standard delivery boundaries, adjusting calculated timestamps to fall between 10:00 AM and 2:00 PM local patient time to optimize response rates and ensure a reliable communications interface.
+	•	Phase 3: Conversational Processing Layer & Natural Language Understanding (NLU)
+	•	When a patient responds via a secure SMS gateway, the incoming unstructured text stream passes through a specialized clinical processing module.
+	•	[Inbound Patient SMS Text] ──> Normalization (Regex/Spell) ──> Medical Entity Extraction ──> Sentiment & Urgency Scoring ──> Triage Routing
+	•	3.1 Medical Intent Extraction
+	•	The text engine normalizes the text response and extracts semantic concepts by cross-referencing values against standard vocabularies (SNOMED-CT for clinical symptoms and SIDER for established drug side effect matrices):
+	•	Patient Input: "I'm throwing up and feel super dizzy since starting the new metabolic shots."
+	•	Extracted Tokens: Vomiting (SNOMED: 422400008), Dizziness (SNOMED: 404640003).
+	•	3.2 Automated Urgency Classification
+	•	The NLP classifier computes an objective urgency score ($U_s$) ranging from $0.0$ to $1.0$. The value is derived by calculating the cumulative severity weights ($w_i$) of the extracted symptom tokens ($S_i$) alongside an analytical evaluation of the response sentiment ($S_{\text{mag}}$):
+	•	
+	•	Class 0: Benign / Asymptomatic ($U_s < 0.35$): Reflects statements indicating standard adherence without notable issues (e.g., "Doing well, no issues with the new routine").
+	•	Class 1: Low Adherence / Minor Symptom ($0.35 \le U_s < 0.70$): Points to manageable side effects or minor adherence friction (e.g., "A bit of mild nausea, but managing ok").
+	•	Class 2: Severe Red Flag ($U_s \ge 0.70$): Signals severe toxicities, intractable adverse events, or complete treatment discontinuation (e.g., "Uncontrollable vomiting, stopped taking it yesterday").
+	•	Phase 4: Smart Routing & Clinical Task Queue Orchestration
+	•	The system processes the computed Urgency Classification through a dual-channel routing matrix to ensure appropriate clinical visibility.
+	•	4.1 Channel A: Silent Charting (Class 0 Responses)
+	•	Operational Flow: The engine processes the message automatically without routing it to a live inbox.
+	•	
+	•	Action: The text log is written straight to the permanent patient record as an updated communication entry. The engine closes the active follow-up loop, notes a successful milestone completion, and maintains a clean clinical dashboard environment.
+	•	4.2 Channel B: Care Team Escalation (Class 1 & 2 Responses)
+	•	Operational Flow: Class 1 items generate low-priority care tasks, while Class 2 items trigger immediate system-wide escalation.
+	•	Action: The engine injects a high-priority tracking entry into the clinical work queue assigned to the clinic's Medical Assistants (MAs) and Nurses
+	•	Phase 5: FHIR Technical Architecture & Data Schema
+	•	The workflow uses native SMART on FHIR Scheduling and Workflow resources to log and manage tracking tasks across compliant healthcare networks.
+	•	5.1 Data Component Interoperability
+	•	CommunicationRequest: Tracks the initial automated delivery instructions, including planned execution dates, target recipients, and linked encounter contexts.
+	•	Communication: Stores individual outbound SMS questions and inbound text responses.
+	•	Task: Manages escalated clinical tasks generated by Class 1 or 2 events, tracking assignment status, owners, and resolution notes.
+	•	Phase 6: Clinical Governance, Audit Logging, and Loop Closing
+	•	To ensure safety and data integrity, the pipeline implements strict fail-safe parameters and systematic auditing workflows.
+	•	6.1 Interactive Emergency Deflection Protocols
+	•	The NLU layer scans incoming text streams for severe life-safety trigger words (e.g., "chest pain", "shortness of breath", "suicidal thoughts"). If a matching emergency token is identified, the engine immediately halts standard routing loops and executes an automated, high-priority safety response:
+	•	⚠️ CRITICAL ALERT: Your response indicates potential emergency symptoms. Please call 911 or go to the nearest emergency room immediately. Do not wait for a clinic reply. This automated line is not monitored for emergency medical responses.
+	•	6.2 Non-Response Escalation Timeouts
+	•	If a patient fails to respond to an automated check-in text, the engine executes a structured retry and safety escalation sequence.
+	•	This systematic tracking architecture ensures that if a patient remains silent after starting a high-risk therapy or complex protocol, the system drops a fallback task into the clinical team's queue. This allows staff to perform a proactive wellness check, maintaining closed-loop clinical safety throughout the care cycle.
+
+	•	Asynchronous Care Pipelines: Move beyond standard video telehealth. Build secure, structured messaging workflows where patients can submit specific photo or text updates (e.g., a skin lesion tracking update or a week of blood pressure logs) that providers can review and sign off on during administrative blocks, utilizing asynchronous billing codes.
+	•	Phase 1: Patient-Facing Structured Intake & Secure Media Capture Framework
+	•	To ensure that asynchronous updates provide high-quality, clinically sound information, the portal drops open-ended chat inputs in favor of structured, condition-specific intake pipelines.
+	•	1.1 Guided Clinical Ingestion Modules
+	•	The Dermatological Asset Pipeline: When a patient tracks a skin lesion update, the portal launches a dedicated camera interface. It runs an on-device computer vision check to verify illumination uniformity, sharpness, and framing before allowing submission. The system enforces a mandatory dual-capture protocol: one wide-angle contextual image for anatomical orientation and one macro-focused close-up with a calibrated reference object (e.g., a physical coin or standard diagnostic sticker) for size verification.
+	•	The Physiological Log Uploader: For tracking cardiovascular or metabolic metrics (e.g., home blood pressure sweeps, continuous temperature tracks), the user interfaces with a validated tabular sheet or an integrated peripheral. The engine extracts these inputs and instantly strips out non-standard delimiters or invalid keystrokes.
+	•	1.2 Metadata Enrichment & Security Isolation
+	•	All uploaded binary objects pass through a backend security broker before hitting the EMR storage engine:
+	•	EXIF Scrubbing: The ingestion layer strips out raw consumer EXIF metadata (e.g., GPS coordinates, smartphone device model strings) to ensure privacy.
+	•	Clinical Tagging Insertion: The system appends an encrypted cryptographic header containing the patient's internal identifier, an explicit anatomical location code (using SNOMED-CT body site modifiers), a standardized timestamp, and the image resolution scaling factors, converting raw photos into auditable clinical media assets.
+	•	Phase 2: Asynchronous Queuing, Triaging, & Automated Routing Engine
+	•	Asynchronous care submissions bypass standard real-time chat boxes, populating a dedicated, centralized administrative review pipeline.
+	•	2.1 The Store-and-Forward Triage Topology
+	•	Submissions are sorted by clinical priority rather than arrival time. Incoming physiological logs are run through mathematical processors to detect significant clinical variations before a human provider reviews them.
+	•	For home blood pressure logs, the processor extracts the Mean Arterial Pressure (MAP) for each entry to flag hypertensive trends over the tracking period:
+	•	
+	•	2.2 Automated Queue Stratification Matrix
+	•	Based on the results of the ingestion algorithms and short intake screening questionnaires, submissions are assigned to clear triage tiers within the administrative workspace:
+Calculated Severity Tier
+Algorithmic Trigger Metric
+Targeted System SLA
+Core Queue Target Action
+Tier 3: Stable Review
+Interstitial glucose or BP metrics sit within $\pm 10\%$ of established baseline; no subjective symptoms noted.
+72 Business Hours
+Route to standard administrative asynchronous care review dashboard.
+Tier 2: Variant Drift
+$\text{MAP} \ge 110\text{ mmHg}$ or skin lesion boundary displays asymmetrical extension over 30 days.
+24 Business Hours
+Move to front of administrative queue; flag record with yellow variance token.
+Tier 1: Acute Excursion
+Acute red-flag symptoms noted (e.g., sudden chest pressure, vision changes, or severe localized pain).
+Immediate ($< 15\text{ Mins}$)
+Halt async pipeline. Generate an automated patient warning redirecting to urgent care/911 and text an urgent alert to the on-call nursing supervisor.
+	•	Phase 3: The Unified Asymmetric Provider Review Workspace UI/UX
+	•	The provider terminal is designed to maximize clinical efficiency during administrative blocks, allowing doctors to sign off on comprehensive case reviews in seconds.
+	•	High-Density Comparative Canvas: The workspace features a split-screen media layout. For dermatological updates, it renders past baseline images alongside the latest upload, complete with a synchronization lens that scales, aligns, and color-balances both captures to make shifts clear at a glance. For metric tracking logs, it charts raw points as a thin background trend line behind a solid, clean, moving-average overlay.
+	•	Single-Click Sign-Off Documentation Macros: Providers can use built-in text macros to compile clinical findings instantly. Selecting a resolution action auto-populates the assessment text area, drafts the patient's portal advice message, queues the required billing codes, and readies the encounter for a single, final cryptographic signature.
+	•	Phase 4: Asynchronous CPT Billing Automation & Cumulative Time-Tracking
+	•	To ensure proper financial validation for non-face-to-face care delivery, the pipeline implements an automated background audit tracker that measures interaction times and maps them to appropriate billing codes.
+	•	4.1 Automated Stopwatch Ledger
+	•	The Verification Clock: When a provider opens a Tier 2 or Tier 3 asynchronous submission, a localized session counter begins logging active focus time.
+	•	Cumulative Review Grouping: If a review requires reviewing historical data sets or cross-referencing previous lab panels, the engine aggregates these interaction intervals over a rolling 7-day period. This ensures that all time spent on the case contributes toward the billing threshold.
+	•	4.2 Asynchronous Billing Code Engine
+	•	Once the provider completes and signs the review, the billing selector applies strict rules to choose the appropriate billing codes based on total tracked time and the specific service type
+	•	Phase 5: FHIR Technical Architecture & Data Schema Serialization
+	•	Every asynchronous submission, provider evaluation note, and associated digital asset is structured using native, interoperable HL7 FHIR resources.
+	•	5.1 Resource Interoperability Grid
+	•	DiagnosticReport: Serves as the primary clinical shell tracking the overall status, time limits, and conclusions of the asynchronous encounter.
+	•	Media: Stores the high-resolution, metadata-enriched image captures or physical documents uploaded by the patient.
+	•	Observation: Represents discrete biometric data trends extracted from home tracking logs, such as systolic/diastolic blood pressure pairs or average interstitial glucose values.
+	•	Phase 6: Closed-Loop Communication & Dynamic Escalation Triggers
+	•	An asynchronous interaction concludes only when the patient has been safely updated and clear follow-up steps are logged.
+	•	6.1 Automated Portal Dispatch
+	•	The Patient Notification: Signing off on the review immediately triggers a secure mobile notification and email alert to the patient portal (e.g., "Dr. Wali has completed the clinical review of your blood pressure logs. Click here to view your updated care plan updates and lifestyle adjustments.").
+	•	Patient Acknowledgement Receipts: The portal enforces a mandatory verification click when the patient opens the review details, logging an auditable confirmation timestamp within the EMR metadata to document compliance and close the communication loop.
+	•	6.2 Synchronous Escalation Bypass Rails
+	•	If a provider runs into significant diagnostic uncertainty during an asynchronous review, or if a submission reveals an alarming clinical change, the interface allows them to pivot immediately to synchronous care
+	•	This integrated escalation rail ensures that if an asynchronous case requires real-time clinical intervention, the platform rapidly transitions the patient into a high-touch care setting without losing any of the collected data.
+
+Developer-First Architecture & App Marketplace
+	•	FHIR-Native Data Pipeline: Do not just build a legacy SQL database and slap a FHIR converter on top of it for compliance. If you architect the core database schema to be inherently FHIR-native, data exchange becomes lightning-fast and perfectly structured.
+	•	Phase 1: Storage Layer Architecture & Schema Topology (FHIR-as-the-Model)
+	•	The system uses a document-relational hybrid database engine (such as PostgreSQL with optimized binary JSON storage, JSONB) or a distributed NoSQL document tier. This design ensures complete ACID transaction reliability while handling polymorphic FHIR resources natively.
+	•	1.1 Core Resource Table Topology
+	•	Instead of maintaining separate tables for every clinical concept, the system consolidates storage into a unified, high-performance table engine. This layout optimizes storage by managing resources through metadata columns alongside a highly indexable payload field.
+	•	1.2 Multi-Version Concurrency Control (History Tracking)
+	•	To ensure compliance with strict medical audit trail requirements and maintain a complete data history, updates do not overwrite existing table records. Instead, a database trigger automatically clones the current document state into a history tracking table (fhir_resources_history) before applying any modifications to the primary engine.
+	•	Phase 2: In-Memory Structural Validation & Schematron Engine
+	•	Every incoming data payload (whether from an external API, an integrated medical device, or user input within the EMR) must pass through a strict, multi-tiered pipeline validation gate before hitting the storage tier.
+	•	Step 1: Structural Validation: Verifies the inbound payload is a well-formed JSON object and parses the mandatory resourceType and id keys.
+	•	Step 2: Base FHIR R4/R5 Schema Verification: Validates the resource properties against core specification schemas, confirming that required attributes (e.g., Observation.status or Patient.name) are present and conform to specified formats.
+	•	Step 3: Profile & Extension Constraint Processing: Evaluates custom clinical profile declarations listed inside the payload's meta.profile array. The engine uses in-memory compilation libraries to cross-reference and enforce strict constraints (such as validating that a continuous glucose monitoring payload contains required device-specific extension attributes).
+	•	Phase 3: High-Performance Search Parameter Indexing & Query Optimization
+	•	Querying unstructured binary documents can lead to slow, resource-intensive sequential scans. To maintain fast query responses across millions of patient records, the platform extracts key tracking variables into highly optimized relational index patterns.
+	•	3.1 GIN (Generalized Inverted Index) Expression Matrices
+	•	To allow fast searches across deeply nested arrays within the native payload (such as querying by patient identifiers or specific clinical codes), the engine applies optimized inverted indexing overlays
+	•	3.2 Automated SearchParameter Mapping Pipeline
+	•	The EMR abstracts these database-specific indexes into standard FHIR SearchParameter Specifications. When a provider runs a query within the workspace, the query engine matches the parameters directly to pre-indexed fields, bypassing slow pattern-matching loops:
+	•	
+	•	Phase 4: Atomic Mutation Pipelines & Distributed Bundle Resolvers
+	•	When dealing with interconnected clinical resources, the system must process data inputs using strict transactional rules to prevent partial writes, broken records, or orphaned reference pointers.
+	•	4.1 Atomicity Enforcement for Complex Bundles
+	•	When a transaction bundle arrives containing multiple interdependent resources (e.g., a new clinical encounter along with associated lab findings and follow-up care plans), the pipeline executes the entire package as a single database transaction. If any individual resource fails validation or runs into a constraint conflict, the platform rolls back the complete sequence to preserve data integrity.
+	•	4.2 Graph-Based Dependency Resolution Loop
+	•	Before committing a transaction package to disk, an internal graph processing module scans the payload components to organize and sequence the database updates safely
+	•	Phase 5: Reactive Subscription Architecture & Stream Export Pipelines
+	•	An inherently FHIR-native storage tier allows the system to implement a reactive data pipeline, streaming updates to external systems and client applications as data changes occur.
+	•	5.1 Native FHIR Subscription Integration
+	•	Instead of relying on batch export routines or heavy polling loops, developers can register native Subscription Resources directly within the platform. The pipeline evaluates the subscription parameters against data updates in real time
+	•	5.2 Real-Time Event Routing Matrix
+	•	When a resource is updated, the change engine processes the event through a reactive streaming pipeline to notify downstream integrations instantly
+	•	Phase 6: System Performance Benchmarking & Automated Compliance Auditing
+	•	By building the data pipeline to be inherently FHIR-native, the platform eliminates translation layers entirely. This architecture delivers dramatic speed improvements and simplified audit tracking compared to traditional legacy facade models.
+	•	6.1 Data Pipeline Latency Comparison
+	•	
+	•	6.2 Immutable Provenance & Security Auditing
+	•	Every data change event automatically builds a companion FHIR AuditEvent Resource in lockstep with the primary database transaction.
+	•	This tracking document records the complete lifecycle history of the data modification—capturing the unique user identifier, active network location parameters, the triggering application context, and references to the specific data modifications made. This automated audit trail provides absolute transparency, establishing clear, permanent accountability for every asset transformation across the entire platform.
+
+	•	Open API & Plug-and-Play Integration: Build a secure, developer-friendly API wrapper around your system. This allows practices to easily plug in their own proprietary tools, third-party analytics platforms, or niche CRM systems without needing a six-figure custom integration budget.
+	•	Phase 1: Self-Service Developer Portal & App Onboarding Lifecycle
+	•	To eliminate manual administrative bottlenecks when onboarding new applications, the architecture includes a self-service developer gateway that manages the entire application lifecycle.
+	•	1.1 Automated Developer Workspace
+	•	App Registration Hub: External developers can register their applications independently, generate cryptographic sandbox keys, and configure target redirect URLs.
+	•	Granular Scope Selector: Access permissions use explicit SMART on FHIR OAuth scope taxonomies rather than broad all-or-nothing system access (e.g., patient/Patient.read, user/Encounter.write, system/Observation.read).
+	•	1.2 OAuth 2.0, OIDC, and PKCE Authentication Infrastructure
+	•	The wrapper secures all client authentication paths using an OpenID Connect (OIDC) overlay on top of an asynchronous OAuth 2.0 framework:
+	•	The Access Key Paradigm: Server-side services connect using standard Client Credentials flows, while client-facing web applications or mobile apps are required to use the Authorization Code Flow paired with PKCE (Proof Key for Code Exchange) to prevent token interception.
+	•	Token Architecture: Access credentials issue as short-lived (15-minute expiration) JSON Web Tokens (JWT), cryptographically signed using asymmetric RS256 keys. The signature verification relies on a public JSON Web Key Set (JWKS) endpoint hosted at the gateway edge.
+	•	Phase 2: Edge API Gateway Layer, Rate Limiting, & Traffic Shaping
+	•	To safeguard system stability and isolate core electronic health record operations from high-volume third-party query traffic, an intelligent edge proxy layer (such as Envoy or Kong) manages all inbound requests.
+	•	2.1 Token Bucket Traffic Isolation
+	•	Rate limiting is managed at the edge using an asynchronous Token Bucket architecture. This system tracks application IDs and incoming client IP addresses to process requests without overloading the main database engines.
+	•	The remaining bucket balance $B_t$ for any active client token at time $t$ is calculated dynamically using the replenishment rate $r$, the maximum allowed burst capacity $B_{\text{max}}$, and the time delta $\Delta t$ since the last request event:
+	•	
+	•	2.2 Tiered Rate-Limiting Matrices
+Developer Access Level Tier
+Allotted Baseline Rate Limit
+Permitted Maximum Burst Capacity
+Ideal Production Integration Target Use Case
+Sandbox Environment
+5 requests / second
+20 requests
+Sandbox testing and initial app configuration.
+Standard Practice Application
+60 requests / minute
+120 requests
+Niche CRMs, patient intake forms, local scheduling tools.
+Enterprise Analytics Pipeline
+3,000 requests / hour
+5,000 requests
+Real-time population health data platforms and BI tools.
+	•	Phase 3: Reactive Webhook Hub & Event Streaming Framework
+	•	To prevent external applications from constantly polling the system for changes—which degrades performance—the integration engine includes a reactive, event-driven webhooks system.
+	•	3.1 Event Router Infrastructure
+	•	When important actions occur within the EMR (such as scheduling an encounter, updating a lab result, or modifying patient demographic data), a transactional trigger routes the event data straight to a high-speed messaging queue (e.g., Apache Kafka or AWS EventBridge).
+	•	3.2 Secure Delivery Protocol
+	•	[Internal Event Triggered] ──> Fetch Subscribed Webhook Target URLs ──> Compute HMAC-SHA256 Signature Header ──> Deliver JSON Content Payload Outbound ──> Track HTTP 2xx Acknowledgment
+	•	The Cryptographic Signature: To allow receiving systems to verify that a payload originated from the authorized EMR instance, every webhook dispatch includes a specialized header: X-Hub-Signature-256. This value contains an explicit HMAC-SHA256 hash of the JSON payload body calculated using the app's unique client secret key.
+	•	Automated Retry Policies: If a target integration endpoint drops offline or returns a non-2xx status code, the delivery workers execute a 5-step exponential backoff retry policy before marking the integration channel as degraded.
+	•	Phase 4: Mock Sandbox Environments & Interactive Specification Engine
+	•	To lower development costs for practices, the platform provides comprehensive testing environments that allow developers to build and validate integrations without needing live engineering support.
+	•	4.1 OpenAPI 3.1 Interactive Engine
+	•	Self-Documenting Blueprints: The entire API wrapper surface maps to an interactive, version-controlled OpenAPI 3.1 Specification dashboard.
+	•	Live Try-It-Out Terminals: Authenticated developers can run test requests against live documentation endpoints, view exact header definitions, and inspect realistic JSON responses directly within their web browser.
+	•	4.2 Non-PHI Synthetic Data Sandbox
+	•	The Sandbox Environment: The developer portal links out to an isolated, mock execution workspace running a mirror of the core API engine.
+	•	Synthesized Clinical Records: The sandbox contains no real patient data (Protected Health Information). Instead, it populates responses using fully randomized, mathematically coherent synthetic patient distributions that simulate realistic vital sign variations, demographic profiles, and historical medication records, allowing for safe and thorough app validation.
+	•	Phase 5: FHIR-Aligned Extension Scoping & Custom Metadata Payload Schemas
+	•	To maintain clean data structures across the platform, third-party applications must interact using standard FHIR structures. When specialized apps require custom fields, the wrapper stores them inside standard FHIR extension arrays, keeping the base database clean.
+	•	5.1 JSON Payload Example: Custom Third-Party CRM Tags in a FHIR Patient Patch
+	•	This payload shows how an external CRM app can write its own tracking attributes (e.g., automated attribution markers and custom outreach preferences) into a patient record by using the native FHIR extension layout
+	•	Phase 6: Automated Security Auditing & Real-Time Threat Revocation
+	•	To ensure complete accountability and protect patient data, the platform continuously monitors integration behaviors and enforces automated security guardrails.
+	•	6.1 Anomaly Monitoring and Circuit Breaking
+	•	The API gateway evaluates inbound data flows against behavioral baselines. If an application displays a suspicious transaction profile (e.g., an external CRM suddenly downloading thousands of distinct patient profiles outside of standard business hours), the security engine fires an automated protection response
+	•	6.2 Audit Log Serialization
+	•	Every API transaction—including the authenticated app ID, requesting IP address, target resource parameters, and exact data actions performed—is instantly logged to an immutable tracking repository. These records generate native FHIR AuditEvent Resources that run in parallel with all primary API events, ensuring full HIPAA compliance and comprehensive visibility for system administrators.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Synthesis-First Chart Review (The "Patient Graph")
+	•	Physicians waste hours digging through decades of poorly organized external PDFs, C-CDAs, and old specialist notes. AI should summarize this instantly.
+
+	•	Semantic Search & Longitudinal Synthesis: Replace the static "chart review" tab with an intelligent, conversational interface. A provider should be able to ask the chart: "Show me the historical trend of this patient's metabolic markers alongside their lifestyle changes over the last two years." The AI dynamically pulls data from separate lab PDFs, wearable data streams, and past progress notes to present a unified, visual timeline.
+	•	Phase 1: Multi-Modal Data Extraction, Normalization, & Stream Ingestion
+	•	To feed the synthesis loop, heterogeneous data sources must be parsed and structured into an interoperable ingestion pipeline before hitting the vectorization layer.
+	•	1.1 Unstructured Narrative Processing (Progress Notes)
+	•	Section-Aware Chunking: Free-text progress notes are run through a structural layout parser that segments the text based on template headings (such as SOAP—Subjective, Objective, Assessment, Plan).
+	•	Sliding Context Window: Rather than using rigid character cutoffs, documents are divided into overlapping sliding windows of 512 tokens. This method splits text at natural paragraph boundaries to preserve the clinical context of narrative descriptions.
+	•	1.2 Semi-Structured Data Extraction (Lab PDFs)
+	•	Layout-Aware OCR Parsing: Scanned lab results pass through a vision-based layout parsing engine. This model extracts structural table arrays, identifying row relationships to capture the analyte name, measured value, unit, reference range, and collection timestamp.
+	•	Controlled Vocabulary Standardization: Extracted strings are processed by a fuzzy mapping engine that links local text labels to standard terminologies, binding lab results directly to verified LOINC codes (e.g., mapping "Hemoglobin A1c" or "A1C" to LOINC: 4548-4).
+	•	1.3 Structured Real-Time Telemetry (Wearable Streams)
+	•	Time-Series Metric Resampling: High-frequency metrics from consumer wearables and medical devices (e.g., continuous glucose monitors, heart rate variability trackers, sleep duration logs) are processed through data streaming pipelines.
+	•	Downsampling Matrix: To prevent raw time-series data from overwhelming the system, metrics are aggregated into uniform daily telemetry windows (calculating means, medians, and maximum variances). This reduces data density while preserving long-term physiological trends.
+	•	Phase 2: Hybrid Knowledge Retrieval & Vector Search Architecture
+	•	Once normalized, the data is indexed using a dual-vector representation strategy that supports both precise text matching and contextual, semantic queries.
+	•	2.1 Clinical Domain Vector Encoding
+	•	High-Dimensional Embeddings: Chunks extracted from narrative notes and structured summaries are passed to a domain-specific clinical embedding model to generate dense, 1536-dimensional vector representations.
+	•	Persistence Layer Vector Indexing: Vector representations are written to a document-relational hybrid database engine utilizing an HNSW (Hierarchical Navigable Small World) index graph. This setup ensures fast vector lookups under heavy concurrent query workloads.
+	•	2.2 Dual-Stream Hybrid Search Blending
+	•	To maximize retrieval accuracy, incoming user queries are processed concurrently through two independent search paths:
+	•	Dense Semantic Routing: The system vectorizes the user's natural language question to surface contextually relevant matches (e.g., mapping a query about "lifestyle changes" to narrative text discussing "caloric restriction protocols" or "high-intensity interval training").
+	•	Sparse Lexical Indexing: In parallel, a sparse keyword index (BM25) processes explicit search terms to quickly isolate exact medical names, drug formulations, or unique alphanumeric identifiers.
+	•	The results of both retrieval streams are combined into a final, unified results set using a Reciprocal Rank Fusion (RRF) scoring algorithm:
+	•	
+	•	where $M$ represents the search retrieval strategies, $r_m(d)$ is the ordinal rank of document $d$ within strategy $m$, and $k$ is a standard smoothing constant (set to 60).
+	•	Phase 3: Cross-Domain Longitudinal Timeline Synthesis & Data Alignment Matrix
+	•	Models often struggle to maintain temporal accuracy when processing raw, unstructured text strings. To solve this, the engine organizes retrieved data into a structured Temporal Data Alignment Matrix before generating clinical summaries.
+	•	The system dynamically aligns disparate clinical events across a unified timeline, anchoring multi-modal inputs to the patient's record:
+Relative Target Timestamp
+Data Domain Category
+Source Origin Entity Identifier
+Normalized Clinical Metadata Values / Extracted Tokens
+Encounter: T - 720 Days
+Clinical Narrative
+DocumentReference/note-102
+Provider initiates a strict 5-day prolonged therapeutic fasting protocol; patient goals established.
+Encounter: T - 710 Days
+Lab Biomarker PDF
+Observation/lab-val-5921
+LOINC 4548-4 (HbA1c): 6.4% (High Risk Zone); Fasting Insulin: 18 uIU/mL.
+Interval: T - 600 to T - 300 Days
+Wearable Telemetry
+Observation/stream-agg-04
+Mean daily steps increase from 4,200 to 9,800; Interstitial CGM mean glucose drops by 14 mg/dL.
+Encounter: T - 14 Days
+Clinical Narrative
+DocumentReference/note-394
+Patient reports sustained adherence to a low-carbohydrate vegetarian diet; notes improved daytime energy levels.
+Encounter: T - 3 Days
+Lab Biomarker PDF
+Observation/lab-val-9831
+LOINC 4548-4 (HbA1c): 5.4% (Optimal Range Normalization); Fasting Insulin: 6 uIU/mL.
+	•	Phase 4: Conversational Clinical Reasoning and Intent-Routing Engine
+	•	When a provider queries the patient chart, an orchestrator processes the natural language input through a structured inference execution path.
+	•	[Provider Input Query] ──> Entity Extraction ──> Parameter Mapping ──> Context Synthesis ──> UI Display
+	•	Step 1: Clinical Intent Extraction: The system parses the query—such as "Show me the historical trend of this patient's metabolic markers alongside their lifestyle changes over the last two years"—extracting key search parameters and structural constraints.
+	•	Step 2: Deterministic Parameter Mapping: The intent router converts natural language terms into structured query variables:
+	•	Temporal Bounds: Restricts the database search to the requested window ($[T_{\text{current}} - 730\text{ Days}, T_{\text{current}}]$).
+	•	Concept Extraction: Maps "metabolic markers" to specific LOINC clusters (e.g., HbA1c, Fasting Insulin, Lipid Panels) and matches "lifestyle changes" to semantic categories like physical activity summaries, dietary notes, and fasting records.
+	•	Step 3: Context-Guided Synthesis: The aligned data matrix and retrieved text chunks are fed to a specialized clinical reasoning model. The model generates a concise narrative summary detailing the patient's health trajectory, directly linking every claim to its source data profile.
+	•	Phase 5: Interoperable FHIR Technical Architecture & Serialized Context Document
+	•	The synthesized output is stored as a native, interoperable FHIR ClinicalImpression Resource, allowing external systems to query the results of the conversational analysis.
+	•	5.1 Resource Interoperability Grid
+	•	ClinicalImpression: Act-as the primary clinical shell tracking the summary statement, evaluation interval, and diagnostic conclusions.
+	•	Evidence: Provides a structured validation array linking the clinical summaries directly to the underlying source data records.
+	•	Phase 6: Clinical Factual Grounding, Verification Layers, & Hallucination Countermeasures
+	•	To guarantee safety and absolute data truth in high-stakes clinical settings, the synthesis engine passes all generated summaries through a strict, multi-stage validation check before displaying them to providers.
+	•	[Generated Narrative Draft] ──> Token Citation Parser ──> Source Verification Cross-Check ──> Final Grounded Response
+	•	6.1 Factual Reconciliation Protocol
+	•	Token Verification Mapping: The system parses the draft narrative text to isolate every numeric measurement, date, and trend statement.
+	•	Source Validation Rule: Each identified value is cross-referenced directly with the retrieved raw clinical records. For example, if the text statement asserts "HbA1c dropped to 5.4%", the reconciliation layer verifies that an Observation resource containing the value 5.4 and the code LOINC: 4548-4 exists within the retrieved data set.
+	•	6.2 Strict Erasure Guardrails
+	•	If the reconciliation layer encounters a value or narrative claim that cannot be verified against the source records, the system applies an automated correction response:
+	•	[Unverifiable Value Detected] ──> Halt Processing ──> Erase Unverified Sentence ──> Log Error to Audit History
+	•	This strict verification layer filters out the typical hallucination vulnerabilities associated with general-purpose large language models. By ensuring that every output line is anchored to an auditable clinical event, the platform provides clinicians with a highly accurate, trustworthy conversational workspace for longitudinal chart review.
+
+	•	External Document Ingestion: When a 50-page medical record is uploaded from an outside facility, an OCR + Medical LLM pipeline immediately ingests it, extracts key data points (procedures, specialist impressions, rare diagnoses), reconciles them against the current chart, and flags discrepancies for provider review.
+	•	Phase 1: Document Processing, Visual Segmentation, & Multi-Modal OCR
+	•	Large, multi-page PDFs from external facilities frequently contain mixed layouts, including structural tables, computer-generated text, and handwritten notes. The ingestion layer processes these documents using a multi-modal visual segmentation pipeline.
+	•	1.1 Visual Layout Analysis
+	•	The document is first decomposed into single-page images and evaluated by a vision-based layout transformer. This model classifies distinct structural bounding boxes before text extraction begins, segmenting pages into:
+	•	Unstructured text blocks (e.g., narrative progress notes).
+	•	Structured data blocks (e.g., laboratory panels, vital sign tables).
+	•	Artifact markers (e.g., fax headers, page numbers, duplicate facility stamps).
+	•	1.2 Dual OCR/ICR Extraction Stream
+	•	Text extraction adapts dynamically based on the identified layout properties within each bounding box:
+	•	Printed Narrative Blocks: Processed via a deep learning text-recognition engine optimized for dense medical prose and complex clinical terminology.
+	•	Tabular & Handwritten Regions: Routed through an Intelligent Character Recognition (ICR) transformer to extract multi-axis table columns and decode low-legibility handwritten clinical notes or signatures.
+	•	Unified Output Synthesis: The system aggregates coordinates, layout regions, and recognized text strings into a structured hierarchical text schema (such as hOCR), preserving reading order and spatial relationships across all 50 pages.
+	•	Phase 2: Hierarchical LLM Routing, Sectioning, & Entity Extraction
+	•	A 50-page chart often exceeds the practical dense processing limits of standard real-time extraction models. To maximize accuracy and avoid context-window dilution, the pipeline uses a structured divide-and-conquer processing strategy.
+	•	2.1 Chronological & Section-Based Document Partitioning
+	•	A lightweight, high-throughput clinical classification model reads the unified text stream to identify structural document boundaries. It breaks the combined document down into distinct clinical sub-documents
+	•	2.2 Domain-Specific Extraction Frameworks
+	•	Each isolated clinical segment is processed in parallel using targeted extraction templates designed to extract specific data classes:
+	•	Surgical & Procedural Logs: Extracts explicit surgical events, implant details, intraoperative milestones, and specialized anesthesia techniques.
+	•	Specialist Impressions & Clinical Reasoning: Analyzes narrative consult conclusions to capture diagnostic reasoning, rule-out strategies, and direct clinical recommendations.
+	•	Phenotypic Variance & Rare Conditions: Uses specialized entity-recognition patterns to detect low-frequency clinical terms, unusual symptom constellations, and rare genetic or metabolic diagnoses.
+	•	Phase 3: Clinical Entity Mapping & Vocabulary Standardization
+	•	Extracted text strings must be converted into standardized medical codes to allow for automated clinical decision support and accurate cross-chart reconciliation.
+	•	The system evaluates text tokens against an in-memory terminology backend to bind unstructured language to standardized identifiers:
+	•	Context-Aware Disambiguation: The pipeline uses surrounding sentence tokens to resolve ambiguous acronyms correctly based on the clinical context (e.g., ensuring "MS" resolves to Multiple Sclerosis SNOMED: 42503003 within a neurology consult, but maps to Mitral Stenosis SNOMED: 79619009 within a cardiology report).
+	•	Negation & History Filtering: The engine runs assertion analysis on every identified entity to filter out non-active conditions. Elements flagged as negated (e.g., "Patient denies any chest pain") or assigned to family members (e.g., "Mother has history of breast cancer") are excluded from active problem matching.
+	•	Phase 4: Cross-Chart Reconciliation & Discrepancy Detection Engine
+	•	Once the external data is standardized, the reconciliation engine compares the incoming clinical entities against the patient's existing active EMR chart (e.g., their native Condition, Procedure, and MedicationStatement FHIR lists).
+	•	4.1 Multi-Factor Clinical Match Profiling
+	•	The system computes a multi-factor Match Confidence Score ($C_m$) to determine whether an external clinical entity ($E_{\text{ext}}$) matches an existing record in the internal chart ($E_{\text{int}}$):
+	•	
+	•	Where $\mathbf{Sim}_{\text{semantic}}$ measures the vector cosine similarity between narrative descriptions, $\mathbf{Match}_{\text{ontology}}$ evaluates hierarchical code relationships (e.g., recognizing parent-child or equivalent terms within SNOMED-CT hierarchies), and $\mathbf{Prox}_{\text{temporal}}$ scores the proximity of the associated event dates. The terms $w_1, w_2, w_3$ represent normalized balancing weights.
+	•	4.2 Automated Discrepancy Stratification
+	•	If the Match Confidence Score falls below a specific threshold, or if clear clinical contradictions are identified, the item is categorized into a structured discrepancy queue:
+Discrepancy Variant
+Underlying Logical Metric
+Clinical Example Configuration
+Urgent Triage Action
+The Unrecorded Omission
+$C_m < 0.15$ across all active internal chart records.
+External record details a confirmed diagnosis of Celiac Disease (SNOMED: 39633005); native chart lacks any related gastrointestinal entries.
+Flag as a new clinical insight; queue for validation entry.
+The Anatomical Laterality Conflict
+$C_m \ge 0.80$, but structural laterality modifiers contain directly opposing values.
+External report documents an Arthroplasty of Left Knee, while the internal chart logs the procedure on the Right Knee.
+High-Priority Alert: Block automated merging and trigger a hard data conflict flag.
+The Positional Status Shift
+High ontology match, but active resolution status attributes contradict.
+Internal problem list tracks Essential Hypertension as an active issue, whereas an external nephrology consult flags the condition as Resolved/Controlled via lifestyle mod.
+Present status update validation toggle to the provider.
+	•	Phase 5: FHIR Technical Architecture & Data Schema Serialization
+	•	To prevent data pollution from unverified sources, external clinical insights are stored using staging structures rather than writing them directly to the patient's master problem list. The system uses a FHIR Bundle transaction that groups a DocumentReference shell with a series of DetectedIssue resources.
+	•	Phase 6: Interactive Provider Reconciliation Workspace & Human-in-the-Loop Triage
+	•	External insights remain in an unverified state until a licensed provider reviews and signs off on the data changes. This verification happens inside a specialized "Chart Reconciliation" interface within the EMR workspace.
+	•	Contextual Visual Verification: Clicking the "View Source PDF" button opens a split-screen viewer that goes directly to the matching page and highlights the exact sentence where the clinical entity was found. This setup allows the clinician to instantly confirm the context of the extraction without manually scrolling through the 50-page document.
+	•	One-Click Ledger Updating: * Accepting an Omission automatically updates the staging DetectedIssue status to resolved, creates a new verified Condition or Procedure resource, and appends it to the patient's active master problem list.
+	•	Rejecting an entry archives the recommendation permanently, logging a placeholder token within the audit metadata to prevent the system from re-extracting and flagging the same duplicate entry during future document upload cycles.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Proactive, Context-Aware Clinical Intelligence
+	•	Legacy Clinical Decision Support (CDS) is hated because it relies on annoying, rigid pop-ups that cause alert fatigue. AI-driven CDS is subtle, predictive, and highly contextual.
+	•	[Continuous Wearable/Lab Stream] ──> Predictive AI Engine ──> Subtle Inline Insight (No Pop-ups)
+	•	Inline Clinical Insights: Rather than flashing an interruptive alert, the AI subtly highlights text or displays sidebar insights. For example, if a provider is reviewing a metabolic panel, the AI might cross-reference historical glycemic trends and wearable data to calculate a predictive risk score for insulin resistance, offering a recommended intervention protocol tailored to the practice's philosophy.
+	•	Prescription Safety & Optimization Guardrails: The AI evaluates a drafted prescription against the patient’s complete multi-omic profile—including genomic data if available, liver/kidney function labs, and potential botanical or drug interactions—proactively suggesting dosage adjustments or safer alternatives.
+
+Autonomous Revenue Cycle Management (RCM)
+	•	The billing department shouldn't be a separate silo; it should be a continuous feedback loop driven by machine learning.
+	•	Predictive Denial Auditing: Before a claim is ever submitted via EDI 837, an AI model trained on historical payer behavior and local coverage determinations "scrubs" the claim. It assigns a precise probability score for rejection or denial. If the risk is high, it flags the exact missing clinical documentation or modifier required to fix it.
+	•	Automated Prior Authorization Routing: The moment an advanced diagnostic test or specialized therapy is ordered, the AI extracts the necessary clinical justifications from the chart, auto-populates the payer’s specific prior authorization forms, and submits them electronically, reducing a 20-minute manual process to seconds.
+
+Intelligent Patient Remote Orchestration
+	•	An AI-driven EMR extends the clinic's reach into the patient's daily life, acting as an automated care coordinator.
+	•	Asynchronous Triage & Smart Check-ins: The system automatically analyzes patient communication (via portal messages or SMS). It uses clinical NLP to triage messages based on urgency, drafting responses for the clinical team to review, or escalating critical symptoms directly to the provider's urgent task queue.
+	•	Dynamic Patient-Facing Summaries: The After-Visit Summary (AVS) is typically generic and hard for patients to understand. The AI should instantly translate the clinical note into highly personalized, conversational instructions matching the patient's literacy level and language preference, clearly detailing their medication titration schedules, nutritional protocols, and lifestyle goals.
+
+The "Zero-Click" Clinical Encounter Pipeline
+	•	Instead of the provider acting as an expensive data-entry clerk, the AI should handle the heavy lifting of documentation, order drafting, and coding simultaneously.
+	•	Ambient Synthesis to Structured Schema: The ambient AI doesn't just generate a block of text for a SOAP note. It parses the conversation in real time and automatically populates discrete fields in your FHIR-native database (e.g., extracting specific vitals mentioned, updating the allergy list, or adding a new diagnosis to the problem list).
+	•	Autonomous Order & Script Drafting: If the provider says to the patient, "Let's check your fasting insulin and NMR lipoprofile next week, and I want you to start a 14:10 intermittent fasting schedule," the AI automatically drafts the laboratory orders, flags the appropriate LOINC codes, and creates a structured lifestyle prescription in the checkout queue. The provider only needs to review and click "Authorize."
+	•	Real-Time Code Justification: As the provider speaks or edits the note, the AI maps the clinical narrative to the highest appropriate hierarchical condition category (HCC) and ICD-10 codes, ensuring the documentation legally supports the billing complexity before the note is locked.
+

--- a/docs/plans/leafjourney-workflows-2026-06-10-digest.md
+++ b/docs/plans/leafjourney-workflows-2026-06-10-digest.md
@@ -1,0 +1,224 @@
+# LeafJourney WorkFlows — Owner Directive Digest (2026-06-10)
+
+> **Status:** Documented (repo digest complete). Gap-verification + net-new Linear
+> filing in progress — see [Gap Analysis](#gap-analysis) (scaffold below).
+>
+> This is a **read/aggregate digest**, not a build order. The owner prompt is
+> explicitly an *aggregation* directive ("use ALL data… remove all repetitive
+> and superfluous data… merge and synchronize"), so most of what it describes
+> overlaps work already shipped or already ingested (Patel chart revisions,
+> Owner Portal revisions, the megasprint tracks). Treat every line as **gap-verify
+> against `main` first**, not greenfield. See `MEMORY.md` for the prior-work map.
+
+## Source & baseline
+
+| Field | Value |
+|---|---|
+| Title | **LeafJourney WorkFlows** ("…Workflows Revisions") |
+| Received | 2026-06-10 (iMessage attachment) |
+| Original file | `LeafJourney Workflows Revisions.docx` (~2.07 MB, embedded diagram images) |
+| Source md5 | `b25512d9129cb6182868adeaf9e1be9d` |
+| Extracted text (canonical) | `docs/directives/leafjourney-workflows/2026-06-10.txt` (2,294 lines, ~38k words) |
+| From | Owners — Neal & Scott (`neal@leafjourney.com`, `scott@leafjourney.com`) |
+
+Extraction: `textutil -convert txt`. Note the `.docx` embeds ASCII flow diagrams
+and several formula/table figures rendered as images; a few `[blank]` bullets in
+the text correspond to images/figures that did not survive plain-text conversion
+(formulas, FHIR-mapping tables, the compounding yield equation, etc.).
+
+## The owner directive (verbatim prompt)
+
+> as LeafJourney is starting to develop into a fully stand alone and functioning
+> EMR, it is imperative that all AI agents are skilled and adept at being able to
+> understand every workflow that is needed and having the ability and intelligence
+> to execute, communicate amongst other AI agents and work collaboratively and
+> collectively to make sure all workflows are smooth, efficient, and with as few
+> glitches as possible. It is crucial that the EMR has all of these current
+> workflows in place and to include all workflows from all of the revision word
+> documents that have been sent already. Make sure to study and analyze these
+> workflows in great detail and test drive it to make sure it actually works in
+> real time. Now the bottom information is a detailed outline, but the AI agents
+> must have the individual intellectual capacity to scour the internet for any
+> issues and glitches that occur once the workflows are implemented and then test
+> them. All errors and issues that occur should be documented and be filed into a
+> PDF report that is then sent to the owners' emails at: neal@leafjourney.com and
+> scott@leafjourney.com. … LeafJourney should be a beautiful, aesthetically
+> pleasing, exciting, and engaging platform … If any workflows can be improved
+> from an efficiency standpoint, then the AI agents shall make those changes and
+> report them as well. … the other word documents and revision documents have
+> already been working on the workflows for different aspects. The goal is for the
+> AI agents to use ALL data and aggregate it, remove all repetitive and
+> superfluous data and prompts, and to merge and synchronize all of the
+> recommendations to provide a very robust, task oriented workflow for every part
+> of our EMR. … the ultimate goal is to make all workflows to be with as few
+> scrolls and as few clicks as possible for anyone using it. Make sure the AI
+> agents have fun with this project and really use their creativity to make
+> LeafJourney stand out and be a revolutionary new EMR.
+
+### Standing instructions extracted from the prompt
+1. **Aggregate, don't duplicate** — merge this with all prior revision docs; strip repeats. (Aligns with our gap-verify discipline.)
+2. **Test-drive each workflow in real time** — verify behavior, not just code presence.
+3. **Error-report obligation** — implementation issues should be compiled into a **PDF report emailed to neal@ + scott@leafjourney.com.** ⚠️ This is an outward-facing send; do **not** auto-email — surface findings to Scott for review/approval first.
+4. **Efficiency mandate** — "as few scrolls and as few clicks as possible"; improvements are in-scope and should be reported.
+5. **Aesthetic mandate** — Apple-grade, delightful (consistent with CLAUDE.md Dr. Patel directive).
+
+---
+
+## The 8 workflow domains
+
+The body specs eight end-to-end domains. Each named sub-workflow below is
+described in the doc as a 5–6 "Phase" pipeline with FHIR resource mappings,
+terminology code bindings (ICD-10-CM / SNOMED-CT / LOINC / RxNorm / HCPCS),
+EDI/X12 + NCPDP transactions, AI/NLP extraction layers, and cryptographic
+sign-off. Line numbers reference the canonical extracted text.
+
+### 1. Administrative & Patient Access (Front Desk) — line 6
+Patient entry: identity, scheduling, financial clearing.
+- **Patient Registration & Onboarding** (9) — OCR/vision ID + insurance-card capture → FHIR `Patient`/`Coverage`; dynamic context-aware intake → `QuestionnaireResponse`; unstructured legacy-record ingestion (PDF/C-CDA → NLP → ICD-10/SNOMED/LOINC/RxNorm) → dedup "Patient Knowledge Graph"; background RTE clearing; geofenced/QR arrival → AI pre-visit brief.
+- **Insurance Eligibility Verification** (64) — EDI 270/271 RTE → AI "Cost Matrix" (copay/deductible/coinsurance); CPT-vs-payer pre-auth flagging. *(Largely a repeat of Reg phases 1–5.)*
+- **Intake & Digital Consents** (119) — rule-engine consent-packet generation; SHA-256 signed FHIR `Consent`; conversational ROS intake; real-time conflict/completeness guardrails; chart hydration into draft note.
+- **Scheduling & Appointment Management** (172) — dynamic variable slot-duration engine; FHIR `Schedule`/`Slot`/`Appointment` matrix; ML no-show scoring + soft double-booking; autonomous waitlist liquidation (top-3 SMS); lifecycle state machine; care-plan→appointment continuity loop.
+
+### 2. Pre-Encounter & Clinical Intake (Nursing / MA) — line 226
+Waiting room → exam room baseline.
+- **Patient Rooming & Intake Queue** (228) — BLE/RFID room allocation; auto FHIR `Encounter` (in-progress); room-time timers.
+- **Vitals & Anthropometric Capture** (310) — IoT cuff pairing (QR/NFC, IEEE 11073 / Welch Allyn Connex) → FHIR `Observation` stream w/ LOINC+UCUM; BMI/WHtR calc; Z-score outlier detection; critical-threshold alert router.
+- **Allergy & Medication Reconciliation** (423) — PBM/HIE fill ingestion → RxNorm/UNII/SNOMED; RXCUI clustering; 3-pillar reconcile table; drug-allergy cross-reactivity (NDF-RT/MED-RT); botanical/lifestyle interaction screening.
+- **Clinical Screenings** (465) — auto-injected PHQ-9 / GAD-7 / AUDIT / MMSE, LOINC-coded, auto-scored; PHQ-9 >10 → safety alert + prepended suicide-risk module.
+
+### 3. The Clinical Encounter (Provider / Physician) — line 518
+- **Chart Review / Longitudinal View** (520) — vector-embedding knowledge graph; natural-language chart query → cited AI synthesis; external-doc timeline pinning w/ hover summaries.
+- **Clinical Charting & Note Generation** (564) — ambient AI scribe (TLS1.3 WebSocket, speaker diarization), OLDCARTS HPI/ROS, verbal-exam scribing; SHA-256 sign+lock → `Composition.final`; auto E&M (e.g., 99214) → EDI 837; patient CarePlan release.
+- **Laboratory & Imaging Orders** (615) — ambient order extraction → LOINC/CPT staged checkout; ICD-10 medical-necessity cross-check (LCD/NCD); prior-auth resolver; order state-machine tracking; results triage (normal/abnormal/critical-value alarm loop).
+- **Referrals** (663) — ambient referral harvest → SNOMED; in-network/sub-specialty/velocity/proximity matching; HIPAA-minimized C-CDA/FHIR packet; Da Vinci CRD/PAS auth; `ServiceRequest`+`Task` state machine; inbound loop-closure ingestion.
+- **E-Prescribing (eRx) & Medication Management** (714) — ambient → RxNorm SCD; CDS Hooks renal (Cockcroft-Gault) + hepatic/CYP botanical filters; RTBC (NCPDP/Surescripts) + ePA; EPCS (IAL3, dual-factor, FIPS 140-2); FHIR `MedicationRequest`; RxFill closed-loop adherence.
+- **Formulary & RTBC** (759) — async <1.8s benefit broker; copay transparency matrix; therapeutic-alternative swaps; QL/AR/ST utilization flags + step-therapy auto-bypass; `CoverageEligibilityResponse`/`MedicationKnowledge` logging. *(Heavy overlap with eRx Phase 2.)*
+- **Diagnostics & Results Review Queue** (809) — HL7 ORU/FHIR ingestion + deterministic MPI matching; OCR/NLP of unstructured reports; FIB-4 & kinetic-delta calculators; urgency escalation matrix; single-pane sparkline workspace; FHIR `Provenance` sign-off (MIPS #122).
+
+### 4. Post-Encounter & Care Coordination — line 852
+- **Patient Discharge & Clinical Summaries (AVS)** (855) — auto-harvest med-changes/pending-dx/careplan/follow-ups; health-literacy translation (sig→plain language); color-coded med-recon grid; print + portal omnichannel; localization; FHIR `DocumentReference`; MIPS PI 24-hr attestation.
+- **Encounter Sign-off & Locking** (896) — pre-flight integrity/coding/co-sign checks; AAL3 dual-factor; PKI (ECDSA/RSA) SHA-256 signature; immutable state transition + ACL/WORM lockdown; downstream event fan-out; non-destructive addenda (`relatesTo`).
+- **Care Tracking & Task Management** (943) — ambient task extraction → SNOMED activity codes; protocol compound-task bundles; role/workload routing matrix; zero-search context cards; FHIR `Task` lifecycle; SLA escalation governance.
+
+### 5. Revenue Cycle Management (RCM) & Billing — line 983
+- **Charge Capture & Superbill Generation** (986) — ambient tri-vocabulary mapping (ICD-10-CM/CPT/HCPCS); MDM-based E&M leveling (99202–99215); NCCI PTP bundling + modifier optimization; FHIR `Claim` linkage; one-click authorize→billing queue.
+- **Coding & Claim Scrubbing** (1042) — draft `Claim` instantiation; NCCI/LCD/NCD/MUE + commercial payer rule scrub; severity-sorted coder workspace; FHIR object lineage.
+- **Claims EDI Transmission** (1084) — FHIR `Claim` → X12 837P compile; SHA-256 envelope → clearinghouse; 5-tier SNIP validation; async retry queue w/ exponential backoff; 277 status tracking.
+- **Payment Posting & Denial Management** (1146) — 835 ERA parse; BPR-to-bank treasury reconciliation; CLP/MPI/DOS/NPI identifier matching; CARC/RARC denial routing → appeals queue; one-click appeal packet; clean-claim refactoring.
+
+### 6. Interoperability & Platform Administration — line 1213
+- **Role-Based Access Control (RBAC)** (1217) — JWT context eval; active-encounter relationship gating; HL7 sensitivity labels (e.g., behavioral-health) w/ care-team override.
+- **Break-the-Glass Emergency Access** (1272) — standardized justification + AAL3 re-auth; ephemeral SMART-on-FHIR scoped JWT; CISO/privacy-officer paging; 4-hr auto-revoke + UI eviction; 24-hr reconciliation form.
+- **Interoperability & Data Portability** (1320) — C-CDA R2.1 Schematron parse + OID sharding; NDC→RxNorm / LOINC / SNOMED normalization; dedup filter; SMART-on-FHIR OAuth2 scoped API; FHIR Bulk `$export` (NDJSON).
+- **Patient-Generated Health Data (PGHD) Ingestion** (1547) — HealthKit/Google Fit/CGM/smart-scale/sleep pulls; downsampling; FHIR `Observation` trends.
+
+*(The back third of this domain blends in platform-architecture recommendations:
+**FHIR-Native Data Pipeline** (~1978) and **Open API & Plug-and-Play Integration**
+(~2017, developer hub / sandbox keys / live "try-it-out" terminals / retry policies).)*
+
+### 7. Complex & Non-Traditional Prescribing — line 1710  ⭐ cannabis-specific
+Where standard eRx "stumbles": compound/botanical/cannabinoid medicine.
+- **Custom Compound & Botanical Order Builder** (1713) — constituent-nesting ratio matrix (e.g., CBD:THC:CBN 20:1:2 @ 50 mg/mL/30 mL with auto raw-ingredient yield calc); multi-phase titration/taper orchestrator; reusable "Formulation Blueprints"; **jurisdictional THC mass / daily-supply guardrails**; dual-channel delivery (compounding-pharmacy eFax PDF **vs.** dispensary/e-commerce webhook API → Shopify Plus/ERP, SMS checkout link); nested FHIR `Medication`; patient visio-timeline + PROMs pulse surveys.
+- **Lifestyle & Protocol Prescribing** (1768) — "prescribe" structured fasting/diet/mindfulness protocols with contraindication screening (e.g., block prolonged fast for ED/pregnancy history); programmatic fasting regimens (TRF, prolonged water fast w/ electrolyte + refeeding rules); macronutrient apportionment; autonomic/breathwork dosing table; phase-locked LMS content + knowledge-check gating; FHIR `CarePlan`+`Goal`+`ServiceRequest`; wearable-driven objective adherence score → drop-off flags.
+
+### 8. Proactive Care Management & Asynchronous — line 1837
+- **Automated Post-Encounter "Check-ins"** (1838) — DB-trigger enrollment on `MedicationRequest`/`CarePlan` active; per-therapy cadence (metabolic med day 3/7/14; fasting day 1/3/5; tincture day 3/14); SMS NLU → SNOMED/SIDER extraction → urgency score `Us` (Class 0 silent-chart / Class 1 low-pri / Class 2 red-flag escalation); FHIR `CommunicationRequest`/`Communication`/`Task`.
+- **Asynchronous Care Pipelines** (1917) — store-and-forward photo/text submissions (skin lesion, home BP logs → MAP extraction); security broker; triage tiers; single-click sign-off macros; cumulative time-grouping for async billing; FHIR `DiagnosticReport`/`Media`/`Observation`.
+- **External Document Ingestion** (2180) — 50-page outside-record OCR+LLM; layout-aware ICR; parallel templated extraction (surgical/specialist-impression/rare-condition); confidence-scored discrepancy queue → one-click ledger update (`DetectedIssue`→resolved).
+- *(Also folds in a clinical **RAG / semantic-retrieval** pipeline — section-aware chunking, 512-token sliding windows, 1536-dim embeddings, hybrid dense+BM25 retrieval, source-validation reconciliation → `ClinicalImpression`/`Evidence`.)*
+
+---
+
+## Capstone future-state vision (doc tail)
+
+A closing "north-star" section restates the AI thesis as four clusters (these are
+re-summaries of the domains above, not new workflows):
+1. **The Cognitive Clinical Co-Pilot** — inline non-interruptive insights (predictive insulin-resistance scoring from labs+wearables); prescription safety/optimization against multi-omic profile.
+2. **Autonomous Revenue Cycle Management** — predictive denial auditing pre-837; automated prior-auth routing.
+3. **Intelligent Patient Remote Orchestration** — async triage / smart check-ins w/ drafted responses; dynamic patient-facing AVS at the patient's literacy level + language.
+4. **The "Zero-Click" Clinical Encounter Pipeline** — ambient synthesis to structured FHIR fields; autonomous order/script drafting (review-and-authorize only); real-time HCC/ICD-10 code justification.
+
+---
+
+## Cross-cutting technical themes (recurring across all 8 domains)
+- **FHIR-native** resource modeling (Patient, Coverage, Encounter, Observation, MedicationRequest, ServiceRequest, Task, Consent, Composition, DocumentReference, Provenance, CarePlan, Claim).
+- **Terminology binding** everywhere: ICD-10-CM, SNOMED-CT, LOINC, UCUM, RxNorm, HCPCS, RadLex, NDC, CARC/RARC.
+- **Transactions:** EDI X12 270/271, 837P, 277, 835; NCPDP SCRIPT/RTBC/ePA; Surescripts RxFill; HL7 v2 ORU; C-CDA R2.1; Da Vinci CRD/PAS.
+- **Ambient AI extraction → staged "unverified" candidates → one-click clinician reconcile** is the single most repeated pattern.
+- **Cryptographic sign-off:** SHA-256 hash + AAL3/IAL3 dual-factor + PKI (ECDSA/RSA) + WORM/immutability + addenda-not-edits.
+- **Closed loops:** referral loop, RxFill adherence, results sign-off, task SLA escalation, check-in escalation.
+- **UX north star:** fewest scrolls/clicks; single-pane workspaces; no pop-ups.
+
+---
+
+## Gap Analysis
+
+**Headline finding (gap-verified 2026-06-11 via 8 parallel code-search sweeps):**
+the codebase already implements an estimated **~70–80%** of this doc. Every domain
+has shipped engines/UI; the doc is a re-statement of largely-built work, exactly as
+its "aggregate, don't duplicate" prompt implies. Genuine net-new work clusters into
+(a) **Domain 7 cannabis/botanical compounding + lifestyle-protocol prescribing**,
+(b) **stub→real integrations** (270/271, RTBC, Surescripts/EPCS, SMART-on-FHIR,
+break-the-glass), and (c) **a clinical RAG/semantic layer**.
+
+Verdict legend: ✅ DONE · 🟡 PARTIAL · ❌ MISSING. Evidence paths in the per-domain
+sub-sections below the table.
+
+| # | Domain | Sub-workflow verdicts | Net-new gaps (candidate work) |
+|---|---|---|---|
+| 1 | Front Desk | Registration ✅ · Eligibility 🟡 · Consents ✅ · Scheduling ✅ | **270/271 is mocked** (`eligibility-client.ts` simulates); no multi-provider calendar render; SHA-256 consent hashing not wired; no legacy PDF/C-CDA ingest executor; ID-card vision not production-wired |
+| 2 | Pre-Encounter Intake | Rooming ✅ · Vitals 🟡 · Med/Allergy Recon 🟡 · Screenings ✅ | Vitals **LOINC/UCUM coding + adult BMI/WHtR + Z-score outliers + critical-vital CDS**; no height field; PBM/HIE med ingestion + RxNorm/UNII mapping + dedup clustering; PHQ-9>10 safety alert |
+| 3 | Clinical Encounter | Charting ✅ · Chart Review 🟡 · Lab/Img Orders ✅ · Referrals 🟡 · eRx 🟡 · RTBC ❌ · Results ✅ | **RTBC real benefit check** (stub only); eRx **CDS renal/hepatic/CYP-cannabis** safety; **EPCS** controlled-substance signing; **ePA**; **Da Vinci CRD/PAS** + C-CDA referral packet + inbound loop closure; ambient continuous scribe; semantic chart query (RAG); LCD/NCD necessity check; FIB-4/kinetic-delta calculators |
+| 4 | Post-Encounter | AVS 🟡 · Sign-off/Lock 🟡 · Task mgmt 🟡 | AVS **med-recon grid + auto portal delivery + MIPS 24-hr attestation** (+ localization); clinician-note **PKI signature + AAL3 step-up at sign**; WORM/addenda(`relatesTo`) model; task **SLA escalation** + ambient extraction |
+| 5 | RCM & Billing | Charge capture ✅ · Scrubbing ✅ · EDI tx ✅ · Payment/Denial ✅ | (most mature domain) **LCD/NCD commercial-payer scrub** (only Medicare-CBD today); **coder workspace UI**; **algorithmic MDM E&M leveling**; FHIR `Claim` export; 999 AK9 auto-retry |
+| 6 | Interop & Platform Admin | RBAC ✅ · Privacy/sensitivity ✅ · FHIR R4 ✅ · PGHD ✅ · Dev hub/webhooks ✅ · Break-glass 🟡 · SMART-on-FHIR ❌ · Bulk $export 🟡 · C-CDA 🟡 | **Break-the-Glass full workflow** (justification + re-auth + ephemeral token + CISO alert); **SMART-on-FHIR OAuth2 launch**; **C-CDA generate + parse** (Schematron); bulk `$export` beyond Patient/sync; NDC→RxNorm lookup; live API "try-it-out" console |
+| 7 | Complex/Non-Traditional Rx ⭐ | Compound builder ❌ · Ratio/yield 🟡 · Titration 🟡(stub EMR-272) · Blueprints ❌ · THC guardrails 🟡 · Dual-channel 🟡 · Lifestyle Rx 🟡 | **THE BIG NET-NEW.** `CompoundFormulation`/`FormulationBlueprint` models + ratio builder UI (CBD:THC:CBN) + yield calc; **finish `TitrationScheduleItem` (EMR-272 is an empty stub)**; `LifestyleProtocol` model + FHIR `CarePlan`/`Goal`/`ServiceRequest`; `CompoundingPharmacyOrder` eFax + dispensary/Shopify webhook; jurisdictional THC-mass limit enforcement; adherence PROM + wearable scoring |
+| 8 | Proactive/Async | Check-ins 🟡 · SMS NLU 🟡 · Escalation ✅ · Async pipelines ❌ · Ext-doc ingest ✅ · RAG ❌ · Async billing ❌ | **Async care pipeline** (patient photo/BP submission + image broker + review macros + cumulative-time async billing codes); **Clinical RAG/semantic retrieval** (embeddings + hybrid dense/BM25 + source-validation → `ClinicalImpression`/`Evidence`); med/CarePlan-triggered check-in enrollment + SNOMED/SIDER NLU; `DetectedIssue` reconcile queue |
+
+### Per-domain evidence (selected)
+- **D1:** `eligibility-client.ts:41` mock 800ms; `EligibilitySnapshot` schema ✓; `registration-packet.tsx`, `consent-view.tsx` ✓; `scheduling/{no-show-model,waitlist,intake-gate,previsit-readiness}.ts` ✓; `domain/ensure-encounter.ts` ✓.
+- **D2:** `domain/queue-board.ts`+`visit-state.ts` ✓; `clinical/vitals-catalog.ts` (no LOINC/height); `clinical/allergy-profile.ts` (8-family keyword cross-react only); `intake/{phq9,gad7,cudit}-screener.tsx` + `assessment-catalog.ts` ✓ (no >10 alert in `cds/alerts.ts`).
+- **D3:** `notes/[noteId]/note-editor.tsx` + `agents/scribe-agent.ts` + `clinical/voice-dictation.ts` ✓; `api/integrations/rtpb/route.ts` skeleton; `api/integrations/surescripts/transmit/route.ts` stub; `domain/referral-packet.ts` ✓ (no Da Vinci); `clinical/result-signoff.ts` ✓.
+- **D4:** `leaflet/{page,actions}.tsx` + `domain/plain-language.ts` ✓ (no med-recon grid / auto-send); `NoteStatus` lock ✓ but `auth/mfa-gate.ts` not tied to sign; `ops/tasks` + `Task` model ✓ (no SLA auto-escalation).
+- **D5:** `billing/{scrub,ncci-mue,edi/edi-837p,era-parser,remittance,appeal-tracker}.ts` + `clearinghouse/gateway.ts` ✓; `medicare-cbd-rules.ts` only (no commercial LCD/NCD).
+- **D6:** `rbac/permissions.ts` (6+ roles, chart-restriction, sensitivity) ✓; `platform/fhir.ts` (5 resources) ✓; `integrations/{healthkit-normalizer,dexcom-client,libre-api,eversense-parser}.ts` ✓; `developer/*` hub ✓; `api/emergency/[token]/route.ts` partial break-glass; `api/integrations/fhir-bulk/route.ts` Patient-only.
+- **D7:** `CannabisRx`(THC+CBD only)/`DosingRegimen`/`DoseLog` schema; `agents/titration-scheduler-agent.ts` = stub (EMR-272); `cannabis-dosing-protocols.ts` hardcoded; **no** `CompoundFormulation`/`FormulationBlueprint`/`LifestyleProtocol` models; FHIR `CarePlan`/`Goal`/`ServiceRequest` mappers absent.
+- **D8:** `api/cron/post-op-checker/route.ts` + `scheduling/send-reminders.ts` ✓; `domain/smart-inbox.ts` keyword triage; `agents/message-urgency-observer-agent.ts` ✓; `clinical/ocr-extract.ts` ✓; **no** vector/embedding/BM25/RAG anywhere; **no** patient async photo/BP submission API.
+
+### Standing-instruction status (from owner prompt)
+- **Error→PDF→email owners:** mechanism not built; and it's an outward-facing auto-send — recommend a *reviewed* report, not an automated email. ❌ (by design — hold for Scott's call)
+- **"Few scrolls/few clicks" efficiency + Apple aesthetic:** ongoing program (Owner Portal Slice-2 copy/color sweep, doc cockpit). 🟡
+
+## Net-new gap register → candidate Linear issues
+
+> **Filing discipline (task #4):** before creating ANY issue, search Linear for an
+> existing ticket/project. Several gaps map to existing tickets — enrich those, don't
+> duplicate. **No bulk auto-creation** — confirm the filing list with Scott first
+> (outward-facing).
+>
+> **Linear recon (2026-06-11) — existing tickets that net-new gaps must dedup against:**
+> - **EMR-146** "BIG: Cannabis Pharmacology + Prescription Module" — *Done*; natural **parent** for Domain-7 compounding work.
+> - **EMR-272** "Cannabis Pharmacology Fleet (12 agents)" — *Done*; its `titrationScheduler` is a **stub agent** (so a real titration/taper orchestrator = net-new, relates to EMR-272/146).
+> - **EMR-10** (EMR-154) "FDA Rx + Cannabis Rx + Supplement modules" — *Backlog*; relates to compound builder.
+> - **EMR-37** "Multi-Medication Prescribing + Double-Check" — *Backlog*.
+> - **EMR-664** "/clinic/sign-off/refills split-pane + e-sign" — *Done*.
+> - **EMR-396** "Three-tier AI treatment: lifestyle / OTC / Rx" + **EMR-5** "LIFESTYLE module" (*Done*) — relate to **Lifestyle/Protocol Prescribing** gap.
+> - **EMR-840 / EMR-841 / EMR-846** (`patel-directive`) — clinical interaction/risk-flag/Cindy pipeline; overlap Domain-2/3 CDS gaps.
+> - **EMR-192** ambient prescription-safety agent — *Done*; relates to eRx CDS gap.
+>
+> **Labels:** `patel-directive` exists (Patel doc pattern); no `owner-portal`/`workflows-directive` label surfaced — would create `workflows-directive` to match the established per-directive label convention.
+> **Projects:** issues live in **Clinician Workflow Streamline v1**, **Marketplace v1**, web-polish, etc. Per prior pattern a dedicated **"LeafJourney Workflows Revisions"** project + label is the clean home for net-new gap tickets — but since the user chose *gap-only*, an alternative is to file gaps into the existing relevant projects linked to the parents above.
+
+Ranked clusters (highest net-new value first):
+1. **Cannabis Compounding & Botanical Rx (Domain 7)** — compound formulation/ratio builder + blueprints + yield calc; finish titration (EMR-272); jurisdictional THC guardrails; dual-channel delivery (eFax + dispensary/Shopify webhook). *Most net-new; aligns with CLAUDE.md product thesis.*
+2. **Lifestyle / Protocol Prescribing (Domain 7)** — `LifestyleProtocol` model, fasting/diet/mindfulness builder, phase-locked LMS, FHIR CarePlan/Goal/ServiceRequest, wearable adherence score.
+3. **Stub→real integrations** — live 270/271 eligibility; RTBC; Surescripts/EPCS/ePA; SMART-on-FHIR OAuth2; full break-the-glass workflow; C-CDA generate+parse.
+4. **Clinical safety/CDS gaps** — eRx renal/hepatic/CYP-cannabis checks; vitals LOINC + critical-vital alerts; PHQ-9>10 safety alert; LCD/NCD medical-necessity.
+5. **Clinical RAG / semantic layer (Domain 8)** — embeddings + hybrid retrieval + source-validated synthesis (powers chart-query + ambient + denial-prediction).
+6. **Async care pipeline (Domain 8)** — patient photo/BP store-and-forward + review macros + cumulative-time async billing.
+7. **Post-encounter polish** — AVS med-recon grid + auto portal delivery + 24-hr attestation; clinician-note PKI signature + AAL3 step-up; task SLA escalation.
+
+### Prior directive ingestions this overlaps (do not re-file)
+- **Patel chart revisions** — `docs/plans/patel-chart-revisions-buildout.md` (525-directive gap map).
+- **Owner Portal revisions** — `docs/plans/owner-portal-revisions-2026-06-10-diff-analysis.md` + `docs/directives/owner-portal/2026-06-10.txt`.
+- **Megasprint tracks** (clinical chart kit, billing/EDI, scheduling, infra) — see `MEMORY.md`.

--- a/docs/plans/leafjourney-workflows-2026-06-10-digest.md
+++ b/docs/plans/leafjourney-workflows-2026-06-10-digest.md
@@ -1,7 +1,12 @@
 # LeafJourney WorkFlows — Owner Directive Digest (2026-06-10)
 
-> **Status:** Documented (repo digest complete). Gap-verification + net-new Linear
-> filing in progress — see [Gap Analysis](#gap-analysis) (scaffold below).
+> **Status:** Documented (repo digest complete). **Linear filing resolved (2026-06-11):**
+> reconciled into the existing **"WorkFlows Revisions — Zero-Click Ambient Intelligence"**
+> project — its 6 greenfield capstone epics (`EMR-1118..1123`) were annotated with
+> gap-verify-vs-`main` comments, and the two omitted net-new clusters were added as
+> `EMR-1163` (Cannabis Compounding & Botanical Order Builder ⭐) and `EMR-1164`
+> (Lifestyle & Protocol Prescribing). No duplicate project was created. The ranked
+> clusters below are the backlog map for those epics' children. See [Gap Analysis](#gap-analysis).
 >
 > This is a **read/aggregate digest**, not a build order. The owner prompt is
 > explicitly an *aggregation* directive ("use ALL data… remove all repetitive

--- a/src/app/(clinician)/clinic/library/compounding/compounding-builder.tsx
+++ b/src/app/(clinician)/clinic/library/compounding/compounding-builder.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+// Cannabis Compound & Botanical Order Builder — EMR-1163 (Domain 7).
+//
+// Clinician-facing builder over the pure engine in
+// @/lib/domain/cannabis-compounding. Enter a target ratio + concentration +
+// batch size; see the per-constituent breakdown, the raw-ingredient yield
+// (grams of each isolate + carrier oil), and a policy THC guardrail. Save
+// reusable Formulation Blueprints (localStorage-interim until the
+// CompoundFormulation model lands — see the EMR-1163 epic).
+
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input, Label, FieldGroup } from "@/components/ui/input";
+import { LeafSprig } from "@/components/ui/ornament";
+import { cn } from "@/lib/utils/cn";
+import {
+  CANNABINOIDS,
+  parseRatio,
+  computeFormulation,
+  computeYield,
+  checkThcGuardrail,
+  type Cannabinoid,
+  type RawIngredient,
+} from "@/lib/domain/cannabis-compounding";
+
+const BLUEPRINTS_KEY = "lj.compounding.blueprints.v1";
+
+interface IngredientRow {
+  id: string;
+  label: string;
+  cannabinoid: Cannabinoid;
+  potencyMgPerGram: number;
+}
+
+interface Blueprint {
+  name: string;
+  ratioSpec: string;
+  totalMgPerMl: number;
+  batchMl: number;
+  savedAt: string;
+}
+
+// Smart defaults (Dr. Patel directive: auto-populate everywhere). A typical
+// sublingual-oil inventory — clinician edits to match their compounding stock.
+const DEFAULT_INGREDIENTS: IngredientRow[] = [
+  { id: "cbd-iso", label: "CBD isolate", cannabinoid: "CBD", potencyMgPerGram: 990 },
+  { id: "thc-dist", label: "THC distillate", cannabinoid: "THC", potencyMgPerGram: 880 },
+  { id: "cbn-iso", label: "CBN isolate", cannabinoid: "CBN", potencyMgPerGram: 980 },
+  { id: "cbg-iso", label: "CBG isolate", cannabinoid: "CBG", potencyMgPerGram: 980 },
+];
+
+function fmt(n: number, digits = 1): string {
+  if (!Number.isFinite(n)) return "—";
+  return n.toLocaleString(undefined, { maximumFractionDigits: digits });
+}
+
+const selectClass =
+  "h-10 rounded-md border border-border-strong bg-surface px-2 text-sm text-text " +
+  "focus:outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/30";
+
+export function CompoundingBuilder() {
+  const [ratioSpec, setRatioSpec] = useState("CBD:THC:CBN = 20:1:2");
+  const [totalMgPerMl, setTotalMgPerMl] = useState("50");
+  const [batchMl, setBatchMl] = useState("30");
+  const [ingredients, setIngredients] = useState<IngredientRow[]>(DEFAULT_INGREDIENTS);
+
+  const [thcEnabled, setThcEnabled] = useState(true);
+  const [thcMaxBatch, setThcMaxBatch] = useState("100");
+  const [thcPolicyLabel, setThcPolicyLabel] = useState("Clinic policy");
+
+  const [blueprints, setBlueprints] = useState<Blueprint[]>([]);
+  const [blueprintName, setBlueprintName] = useState("");
+
+  // Load saved blueprints once on mount.
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(BLUEPRINTS_KEY);
+      if (raw) setBlueprints(JSON.parse(raw) as Blueprint[]);
+    } catch {
+      /* corrupt/absent storage — start empty */
+    }
+  }, []);
+
+  function persistBlueprints(next: Blueprint[]) {
+    setBlueprints(next);
+    try {
+      window.localStorage.setItem(BLUEPRINTS_KEY, JSON.stringify(next));
+    } catch {
+      /* storage full/blocked — keep in-memory */
+    }
+  }
+
+  const computed = useMemo(() => {
+    try {
+      const ratio = parseRatio(ratioSpec);
+      const formulation = computeFormulation({
+        ratio,
+        totalCannabinoidMgPerMl: Number(totalMgPerMl),
+        batchVolumeMl: Number(batchMl),
+      });
+      const raw: RawIngredient[] = ingredients
+        .filter((i) => i.label.trim() && i.potencyMgPerGram > 0)
+        .map((i) => ({
+          id: i.id,
+          label: i.label,
+          potencyMgPerGram: { [i.cannabinoid]: i.potencyMgPerGram },
+        }));
+      const yieldResult = computeYield(formulation, raw);
+      const guardrail =
+        thcEnabled && Number(thcMaxBatch) > 0
+          ? checkThcGuardrail(formulation, {
+              maxThcMgPerBatch: Number(thcMaxBatch),
+              label: thcPolicyLabel.trim() || undefined,
+            })
+          : null;
+      return { formulation, yieldResult, guardrail, error: null as string | null };
+    } catch (e) {
+      return { formulation: null, yieldResult: null, guardrail: null, error: (e as Error).message };
+    }
+  }, [ratioSpec, totalMgPerMl, batchMl, ingredients, thcEnabled, thcMaxBatch, thcPolicyLabel]);
+
+  function updateIngredient(id: string, patch: Partial<IngredientRow>) {
+    setIngredients((rows) => rows.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  }
+  function addIngredient() {
+    setIngredients((rows) => [
+      ...rows,
+      { id: `ing-${rows.length}-${rows.reduce((a, r) => a + r.label.length, 0)}`, label: "", cannabinoid: "CBD", potencyMgPerGram: 900 },
+    ]);
+  }
+  function removeIngredient(id: string) {
+    setIngredients((rows) => rows.filter((r) => r.id !== id));
+  }
+
+  function saveBlueprint() {
+    const name = blueprintName.trim();
+    if (!name) return;
+    const bp: Blueprint = {
+      name,
+      ratioSpec,
+      totalMgPerMl: Number(totalMgPerMl),
+      batchMl: Number(batchMl),
+      savedAt: new Date().toISOString(),
+    };
+    persistBlueprints([bp, ...blueprints.filter((b) => b.name !== name)]);
+    setBlueprintName("");
+  }
+  function loadBlueprint(bp: Blueprint) {
+    setRatioSpec(bp.ratioSpec);
+    setTotalMgPerMl(String(bp.totalMgPerMl));
+    setBatchMl(String(bp.batchMl));
+  }
+  function deleteBlueprint(name: string) {
+    persistBlueprints(blueprints.filter((b) => b.name !== name));
+  }
+
+  const { formulation, yieldResult, guardrail, error } = computed;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+      {/* ── Inputs ─────────────────────────────────────────── */}
+      <div className="space-y-6">
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span aria-hidden>⚗️</span> Target formulation
+            </CardTitle>
+            <CardDescription>Define the cannabinoid ratio and the batch you want to compound.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FieldGroup
+              label="Cannabinoid ratio"
+              hint='e.g. "CBD:THC:CBN = 20:1:2" or "CBD 20, THC 1"'
+              error={error ?? undefined}
+            >
+              <Input value={ratioSpec} onChange={(e) => setRatioSpec(e.target.value)} />
+            </FieldGroup>
+            <div className="grid grid-cols-2 gap-4">
+              <FieldGroup label="Total cannabinoid (mg/mL)">
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  value={totalMgPerMl}
+                  onChange={(e) => setTotalMgPerMl(e.target.value)}
+                />
+              </FieldGroup>
+              <FieldGroup label="Batch volume (mL)">
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  value={batchMl}
+                  onChange={(e) => setBatchMl(e.target.value)}
+                />
+              </FieldGroup>
+            </div>
+            {formulation && (
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <Badge tone="highlight">{formulation.ratioLabel}</Badge>
+                <Badge tone="neutral">{fmt(formulation.totalCannabinoidMg)} mg total cannabinoid</Badge>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span aria-hidden>🧪</span> Raw ingredient inventory
+            </CardTitle>
+            <CardDescription>Potency of each isolate/distillate on hand (mg active per gram).</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {ingredients.map((ing) => (
+              <div key={ing.id} className="flex items-end gap-2">
+                <div className="flex-1">
+                  <Label htmlFor={`lbl-${ing.id}`}>Ingredient</Label>
+                  <Input
+                    id={`lbl-${ing.id}`}
+                    value={ing.label}
+                    placeholder="CBD isolate"
+                    onChange={(e) => updateIngredient(ing.id, { label: e.target.value })}
+                  />
+                </div>
+                <div className="w-24">
+                  <Label htmlFor={`cb-${ing.id}`}>Cannabinoid</Label>
+                  <select
+                    id={`cb-${ing.id}`}
+                    className={cn(selectClass, "w-full")}
+                    value={ing.cannabinoid}
+                    onChange={(e) => updateIngredient(ing.id, { cannabinoid: e.target.value as Cannabinoid })}
+                  >
+                    {CANNABINOIDS.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="w-24">
+                  <Label htmlFor={`p-${ing.id}`}>mg/g</Label>
+                  <Input
+                    id={`p-${ing.id}`}
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={ing.potencyMgPerGram}
+                    onChange={(e) => updateIngredient(ing.id, { potencyMgPerGram: Number(e.target.value) })}
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Remove ${ing.label || "ingredient"}`}
+                  onClick={() => removeIngredient(ing.id)}
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+            <Button type="button" variant="secondary" size="sm" onClick={addIngredient}>
+              + Add ingredient
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span aria-hidden>🛡️</span> Jurisdictional THC guardrail
+            </CardTitle>
+            <CardDescription>Policy-owned limit — the builder flags, the clinician decides.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <label className="flex items-center gap-2 text-sm text-text">
+              <input type="checkbox" checked={thcEnabled} onChange={(e) => setThcEnabled(e.target.checked)} />
+              Enforce a per-batch THC mass limit
+            </label>
+            {thcEnabled && (
+              <div className="grid grid-cols-2 gap-4">
+                <FieldGroup label="Max THC per batch (mg)">
+                  <Input
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={thcMaxBatch}
+                    onChange={(e) => setThcMaxBatch(e.target.value)}
+                  />
+                </FieldGroup>
+                <FieldGroup label="Policy source">
+                  <Input value={thcPolicyLabel} onChange={(e) => setThcPolicyLabel(e.target.value)} />
+                </FieldGroup>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── Results ────────────────────────────────────────── */}
+      <div className="space-y-6">
+        {guardrail && (
+          <div
+            className={cn(
+              "rounded-lg border px-4 py-3 text-sm",
+              guardrail.ok
+                ? "border-success/40 bg-success/5 text-success"
+                : "border-danger/40 bg-danger/5 text-danger",
+            )}
+            role={guardrail.ok ? undefined : "alert"}
+          >
+            {guardrail.ok ? (
+              <span>✅ Within the {thcPolicyLabel || "policy"} THC limit.</span>
+            ) : (
+              <ul className="space-y-1">
+                {guardrail.violations.map((v) => (
+                  <li key={v}>⚠️ {v}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle>Constituent breakdown</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {formulation ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-subtle">
+                    <th className="py-2 pr-4 font-medium">Cannabinoid</th>
+                    <th className="py-2 pr-4 font-medium">Parts</th>
+                    <th className="py-2 pr-4 font-medium">mg/mL</th>
+                    <th className="py-2 font-medium">mg / batch</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/40">
+                  {formulation.constituents.map((c) => (
+                    <tr key={c.cannabinoid}>
+                      <td className="py-2 pr-4 font-medium text-text">{c.cannabinoid}</td>
+                      <td className="py-2 pr-4 text-text-muted">{c.parts}</td>
+                      <td className="py-2 pr-4 text-text-muted">{fmt(c.mgPerMl, 2)}</td>
+                      <td className="py-2 text-text-muted">{fmt(c.mgTotal)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className="text-sm text-text-subtle">Enter a valid ratio to see the breakdown.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <LeafSprig size={16} className="text-accent/80" /> Compounding yield
+            </CardTitle>
+            <CardDescription>What to weigh out for a {fmt(Number(batchMl))} mL batch.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {yieldResult ? (
+              <>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-subtle">
+                      <th className="py-2 pr-4 font-medium">Ingredient</th>
+                      <th className="py-2 pr-4 font-medium">Weigh (g)</th>
+                      <th className="py-2 font-medium">≈ Volume (mL)</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/40">
+                    {yieldResult.ingredients.map((i) => (
+                      <tr key={i.id}>
+                        <td className="py-2 pr-4 font-medium text-text">{i.label}</td>
+                        <td className="py-2 pr-4 text-text-muted">{fmt(i.grams, 3)}</td>
+                        <td className="py-2 text-text-muted">{fmt(i.volumeMl, 2)}</td>
+                      </tr>
+                    ))}
+                    <tr>
+                      <td className="py-2 pr-4 font-medium text-text">Carrier oil (q.s.)</td>
+                      <td className="py-2 pr-4 text-text-subtle">—</td>
+                      <td className="py-2 text-text-muted">{fmt(yieldResult.carrierVolumeMl, 2)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                {yieldResult.warnings.length > 0 && (
+                  <ul className="space-y-1 rounded-md bg-warning/5 px-3 py-2 text-xs text-warning">
+                    {yieldResult.warnings.map((w) => (
+                      <li key={w}>⚠️ {w}</li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            ) : (
+              <p className="text-sm text-text-subtle">Add at least one matching ingredient to compute the yield.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card tone="raised">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span aria-hidden>📐</span> Formulation blueprints
+            </CardTitle>
+            <CardDescription>Save this recipe to reuse across patients.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Label htmlFor="bp-name">Blueprint name</Label>
+                <Input
+                  id="bp-name"
+                  value={blueprintName}
+                  placeholder="20:1:2 sleep tincture"
+                  onChange={(e) => setBlueprintName(e.target.value)}
+                />
+              </div>
+              <Button type="button" onClick={saveBlueprint} disabled={!blueprintName.trim() || !formulation}>
+                Save
+              </Button>
+            </div>
+            {blueprints.length > 0 ? (
+              <ul className="divide-y divide-border/40">
+                {blueprints.map((bp) => (
+                  <li key={bp.name} className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="text-sm font-medium text-text">{bp.name}</p>
+                      <p className="text-xs text-text-subtle">
+                        {bp.ratioSpec} · {fmt(bp.totalMgPerMl)} mg/mL · {fmt(bp.batchMl)} mL
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button type="button" variant="ghost" size="sm" onClick={() => loadBlueprint(bp)}>
+                        Load
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`Delete ${bp.name}`}
+                        onClick={() => deleteBlueprint(bp.name)}
+                      >
+                        ✕
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-text-subtle">No saved blueprints yet.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(clinician)/clinic/library/compounding/page.tsx
+++ b/src/app/(clinician)/clinic/library/compounding/page.tsx
@@ -1,0 +1,24 @@
+// Cannabis Compound & Botanical Order Builder — EMR-1163 (Domain 7).
+//
+// Net-new compounding surface: the single-product models (CannabisProduct /
+// DosingRegimen) describe finished products and one-patient dosing, but a
+// compound formulation is a clinician-defined recipe at a target cannabinoid
+// ratio. This page drives the pure engine in @/lib/domain/cannabis-compounding.
+
+import { PageShell, PageHeader } from "@/components/shell/PageHeader";
+import { CompoundingBuilder } from "./compounding-builder";
+
+export const metadata = { title: "Compound & Botanical Order Builder" };
+
+export default function CompoundingPage() {
+  return (
+    <PageShell maxWidth="max-w-[1100px]">
+      <PageHeader
+        eyebrow="Compounding"
+        title="Compound & Botanical Order Builder"
+        description="Design a multi-cannabinoid formulation by target ratio, see the raw-ingredient yield, and check it against your jurisdictional THC limit."
+      />
+      <CompoundingBuilder />
+    </PageShell>
+  );
+}

--- a/src/app/(clinician)/clinic/library/page.tsx
+++ b/src/app/(clinician)/clinic/library/page.tsx
@@ -27,6 +27,22 @@ export default async function LibraryPage() {
         actions={<PdfExportButton />}
       />
 
+      {/* Compounding tool (EMR-1163) */}
+      <Link href="/clinic/library/compounding" className="block mb-6 group">
+        <Card tone="raised" className="transition-colors group-hover:border-accent/40">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span aria-hidden>⚗️</span> Compound &amp; Botanical Order Builder
+              <Badge tone="highlight">New</Badge>
+            </CardTitle>
+            <CardDescription>
+              Design a multi-cannabinoid formulation by target ratio (e.g. CBD:THC:CBN 20:1:2), get the
+              raw-ingredient yield, and check it against your jurisdictional THC limit.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </Link>
+
       {/* Cannabinoid pharmacology */}
       <Card tone="raised" className="mb-6">
         <CardHeader>

--- a/src/lib/domain/cannabis-compounding.test.ts
+++ b/src/lib/domain/cannabis-compounding.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  batchThcMg,
+  checkThcGuardrail,
+  computeFormulation,
+  computeYield,
+  dailyThcMg,
+  parseRatio,
+  type RawIngredient,
+} from "./cannabis-compounding";
+
+describe("parseRatio", () => {
+  it("parses the names-then-values form", () => {
+    expect(parseRatio("CBD:THC:CBN = 20:1:2")).toEqual({ CBD: 20, THC: 1, CBN: 2 });
+  });
+
+  it("parses inline name+number pairs in either order", () => {
+    expect(parseRatio("CBD 20, THC 1, CBN 2")).toEqual({ CBD: 20, THC: 1, CBN: 2 });
+    expect(parseRatio("20 CBD : 1 THC : 2 CBN")).toEqual({ CBD: 20, THC: 1, CBN: 2 });
+    expect(parseRatio("CBD20 THC1")).toEqual({ CBD: 20, THC: 1 });
+  });
+
+  it("is case-insensitive and supports decimals", () => {
+    expect(parseRatio("cbd 1 : thc 0.5")).toEqual({ CBD: 1, THC: 0.5 });
+  });
+
+  it("throws on an unparseable spec", () => {
+    expect(() => parseRatio("no cannabinoids here")).toThrow(/Unparseable/);
+  });
+});
+
+describe("computeFormulation", () => {
+  const f = computeFormulation({
+    ratio: { CBD: 20, THC: 1, CBN: 2 },
+    totalCannabinoidMgPerMl: 50,
+    batchVolumeMl: 30,
+  });
+
+  it("splits total concentration across constituents by ratio", () => {
+    const cbd = f.constituents.find((c) => c.cannabinoid === "CBD")!;
+    const thc = f.constituents.find((c) => c.cannabinoid === "THC")!;
+    const cbn = f.constituents.find((c) => c.cannabinoid === "CBN")!;
+    expect(f.totalParts).toBe(23);
+    expect(cbd.mgPerMl).toBeCloseTo((50 * 20) / 23, 6);
+    expect(thc.mgPerMl).toBeCloseTo((50 * 1) / 23, 6);
+    expect(cbn.mgPerMl).toBeCloseTo((50 * 2) / 23, 6);
+  });
+
+  it("conserves total mass: sum of constituents = total mg/mL × batch", () => {
+    const sum = f.constituents.reduce((s, c) => s + c.mgTotal, 0);
+    expect(sum).toBeCloseTo(50 * 30, 6);
+    expect(f.totalCannabinoidMg).toBeCloseTo(1500, 6);
+  });
+
+  it("reduces the ratio label by gcd", () => {
+    const g = computeFormulation({
+      ratio: { CBD: 40, THC: 2, CBN: 4 },
+      totalCannabinoidMgPerMl: 50,
+      batchVolumeMl: 30,
+    });
+    expect(g.ratioLabel).toBe("CBD:THC:CBN 20:1:2");
+  });
+
+  it("rejects degenerate targets", () => {
+    expect(() => computeFormulation({ ratio: {}, totalCannabinoidMgPerMl: 50, batchVolumeMl: 30 })).toThrow();
+    expect(() => computeFormulation({ ratio: { CBD: 1 }, totalCannabinoidMgPerMl: 0, batchVolumeMl: 30 })).toThrow();
+    expect(() => computeFormulation({ ratio: { CBD: 1 }, totalCannabinoidMgPerMl: 50, batchVolumeMl: 0 })).toThrow();
+  });
+});
+
+describe("computeYield", () => {
+  const f = computeFormulation({
+    ratio: { CBD: 20, THC: 1, CBN: 2 },
+    totalCannabinoidMgPerMl: 50,
+    batchVolumeMl: 30,
+  });
+
+  const isolates: RawIngredient[] = [
+    { id: "cbd-iso", label: "CBD isolate", potencyMgPerGram: { CBD: 990 } },
+    { id: "thc-dist", label: "THC distillate", potencyMgPerGram: { THC: 900 } },
+    { id: "cbn-iso", label: "CBN isolate", potencyMgPerGram: { CBN: 980 } },
+  ];
+
+  it("computes grams of each isolate from required mg", () => {
+    const y = computeYield(f, isolates);
+    const cbd = y.ingredients.find((i) => i.id === "cbd-iso")!;
+    const thc = y.ingredients.find((i) => i.id === "thc-dist")!;
+    // CBD mgTotal = 50 * 20/23 * 30
+    expect(cbd.grams).toBeCloseTo(((50 * 20) / 23) * 30 / 990, 5);
+    expect(thc.grams).toBeCloseTo(((50 * 1) / 23) * 30 / 900, 5);
+    expect(y.unmet).toEqual([]);
+    expect(y.warnings).toEqual([]);
+  });
+
+  it("sizes carrier as batch minus active volume", () => {
+    const y = computeYield(f, isolates);
+    const activeMl = y.ingredients.reduce((s, i) => s + i.volumeMl, 0);
+    expect(y.carrierVolumeMl).toBeCloseTo(30 - activeMl, 6);
+    expect(y.carrierVolumeMl).toBeGreaterThan(0);
+    expect(y.totalVolumeMl).toBe(30);
+  });
+
+  it("flags a cannabinoid no ingredient can supply", () => {
+    const g = computeFormulation({ ratio: { CBD: 1, CBG: 1 }, totalCannabinoidMgPerMl: 20, batchVolumeMl: 10 });
+    const y = computeYield(g, [{ id: "cbd-iso", label: "CBD isolate", potencyMgPerGram: { CBD: 990 } }]);
+    expect(y.unmet).toEqual(["CBG"]);
+    expect(y.warnings.some((w) => w.includes("CBG"))).toBe(true);
+  });
+
+  it("warns when an incidental-content ingredient overshoots another constituent", () => {
+    const g = computeFormulation({ ratio: { CBD: 1, THC: 1 }, totalCannabinoidMgPerMl: 100, batchVolumeMl: 10 });
+    // "dirty" distillate that drags 400 mg/g of CBD along with the THC
+    const ings: RawIngredient[] = [
+      { id: "cbd-iso", label: "CBD isolate", potencyMgPerGram: { CBD: 990 } },
+      { id: "dirty-thc", label: "Crude THC distillate", potencyMgPerGram: { THC: 500, CBD: 400 } },
+    ];
+    const y = computeYield(g, ings);
+    const cbdDelta = y.deltas.find((d) => d.cannabinoid === "CBD")!;
+    expect(cbdDelta.achievedMg).toBeGreaterThan(cbdDelta.targetMg);
+    expect(cbdDelta.withinTolerance).toBe(false);
+    expect(y.warnings.some((w) => w.includes("CBD overshoots"))).toBe(true);
+  });
+
+  it("warns when actives cannot fit the batch volume", () => {
+    const g = computeFormulation({ ratio: { CBD: 1 }, totalCannabinoidMgPerMl: 200, batchVolumeMl: 5 });
+    const weak: RawIngredient[] = [{ id: "weak", label: "Weak pre-mix", potencyMgPerGram: { CBD: 100 } }];
+    const y = computeYield(g, weak);
+    expect(y.warnings.some((w) => w.includes("exceed"))).toBe(true);
+    expect(y.carrierVolumeMl).toBe(0);
+  });
+
+  it("honors a pinned source over the most-concentrated default", () => {
+    const g = computeFormulation({ ratio: { CBD: 1 }, totalCannabinoidMgPerMl: 20, batchVolumeMl: 10 });
+    const ings: RawIngredient[] = [
+      { id: "strong", label: "CBD isolate", potencyMgPerGram: { CBD: 990 } },
+      { id: "weak", label: "CBD oil", potencyMgPerGram: { CBD: 100 } },
+    ];
+    const def = computeYield(g, ings);
+    expect(def.ingredients[0].id).toBe("strong");
+    const pinned = computeYield(g, ings, { sourceByCannabinoid: { CBD: "weak" } });
+    expect(pinned.ingredients[0].id).toBe("weak");
+  });
+});
+
+describe("THC guardrail", () => {
+  const f = computeFormulation({
+    ratio: { CBD: 20, THC: 1, CBN: 2 },
+    totalCannabinoidMgPerMl: 50,
+    batchVolumeMl: 30,
+  });
+
+  it("computes batch and daily THC mass", () => {
+    expect(batchThcMg(f)).toBeCloseTo(((50 * 1) / 23) * 30, 6);
+    expect(dailyThcMg(f, { mlPerDose: 1, dosesPerDay: 2 })).toBeCloseTo(((50 * 1) / 23) * 2, 6);
+  });
+
+  it("flags a per-batch THC violation", () => {
+    const r = checkThcGuardrail(f, { maxThcMgPerBatch: 50, label: "Demo State 2026" });
+    expect(r.ok).toBe(false);
+    expect(r.violations[0]).toMatch(/per-batch limit \(Demo State 2026\)/);
+  });
+
+  it("flags a per-day THC violation only with a dose spec", () => {
+    const dose = { mlPerDose: 1, dosesPerDay: 2 };
+    expect(checkThcGuardrail(f, { maxThcMgPerDay: 4 }, dose).ok).toBe(false);
+    expect(checkThcGuardrail(f, { maxThcMgPerDay: 4 }).ok).toBe(true); // no dose ⇒ daily not evaluated
+  });
+
+  it("passes when within limits", () => {
+    const r = checkThcGuardrail(f, { maxThcMgPerBatch: 100, maxThcMgPerDay: 10 }, { mlPerDose: 1, dosesPerDay: 2 });
+    expect(r.ok).toBe(true);
+    expect(r.violations).toEqual([]);
+  });
+});

--- a/src/lib/domain/cannabis-compounding.ts
+++ b/src/lib/domain/cannabis-compounding.ts
@@ -1,0 +1,373 @@
+// Cannabis Compounding & Botanical Order Builder — EMR-1163 (Domain 7)
+//
+// Pure, side-effect-free engine for the *multi-constituent* compound workflow
+// that the existing single-product models can't express:
+//   - CannabisProduct      → one finished product (thc/cbd/cbn concentrations)
+//   - DosingRegimen        → one patient dosing one product
+//   - DOSING_PROTOCOLS     → hardcoded titration templates (cannabis-dosing-protocols.ts)
+//
+// A compound formulation is a clinician-defined *recipe*: a target cannabinoid
+// ratio (e.g. CBD:THC:CBN = 20:1:2) at a target total concentration, compounded
+// into a batch from raw ingredients (isolates / distillates) + a carrier oil.
+// This module computes the per-constituent breakdown, the raw-ingredient YIELD
+// (how many grams of each isolate + how much carrier), and checks the batch
+// against a *caller-supplied* jurisdictional THC limit.
+//
+// Governance: this engine never hardcodes legal limits or makes the prescribing
+// decision. Limits are passed in by policy (see feedback: clinical-governance);
+// it computes and flags, the clinician decides.
+
+export type Cannabinoid = "THC" | "CBD" | "CBN" | "CBG" | "CBC" | "THCV";
+
+export const CANNABINOIDS: readonly Cannabinoid[] = ["THC", "CBD", "CBN", "CBG", "CBC", "THCV"];
+
+const CANNABINOID_SET = new Set<string>(CANNABINOIDS);
+
+function isCannabinoid(x: string): x is Cannabinoid {
+  return CANNABINOID_SET.has(x.toUpperCase());
+}
+
+export type Ratio = Partial<Record<Cannabinoid, number>>;
+
+export interface FormulationTarget {
+  /** Relative parts per cannabinoid, e.g. { CBD: 20, THC: 1, CBN: 2 }. */
+  ratio: Ratio;
+  /** Target TOTAL cannabinoid concentration across all constituents (mg/mL). */
+  totalCannabinoidMgPerMl: number;
+  /** Total batch volume to compound (mL). */
+  batchVolumeMl: number;
+}
+
+export interface ConstituentBreakdown {
+  cannabinoid: Cannabinoid;
+  parts: number;
+  /** parts / totalParts (0–1). */
+  fraction: number;
+  mgPerMl: number;
+  /** mgPerMl × batchVolumeMl. */
+  mgTotal: number;
+}
+
+export interface Formulation {
+  target: FormulationTarget;
+  constituents: ConstituentBreakdown[];
+  totalParts: number;
+  /** Sum of constituent mg/mL — equals target.totalCannabinoidMgPerMl. */
+  totalMgPerMl: number;
+  /** Sum of constituent mg over the batch. */
+  totalCannabinoidMg: number;
+  /** Normalized human label, e.g. "CBD:THC:CBN 20:1:2". */
+  ratioLabel: string;
+}
+
+// ── Ratio parsing ──────────────────────────────────────────────────────────
+
+// One alternation, scanned globally: a cannabinoid adjacent to a number in
+// EITHER order. Because the regex finds the leftmost match, a leading number
+// ("20 CBD") is consumed by the number-first arm before "CBD" can be misread as
+// pairing with the *next* segment's number.
+const PAIR = /(THC|CBD|CBN|CBG|CBC|THCV)\s*[:=]?\s*([0-9]*\.?[0-9]+)|([0-9]*\.?[0-9]+)\s*[:=]?\s*(THC|CBD|CBN|CBG|CBC|THCV)/gi;
+
+/**
+ * Parse a free-form ratio spec into a normalized {cannabinoid: parts} map.
+ * Accepts, among others:
+ *   "CBD:THC:CBN = 20:1:2"      (names then values, positional)
+ *   "CBD 20, THC 1, CBN 2"
+ *   "20 CBD : 1 THC : 2 CBN"
+ *   "CBD20 THC1 CBN2"
+ */
+export function parseRatio(spec: string): Ratio {
+  const trimmed = spec.trim();
+
+  const out: Ratio = {};
+  const add = (name: string, val: number) => {
+    const c = name.toUpperCase() as Cannabinoid;
+    out[c] = (out[c] ?? 0) + val;
+  };
+
+  // Form: "<names> = <values>" — a single '=' splitting all-names from
+  // all-values, paired positionally (e.g. "CBD:THC:CBN = 20:1:2").
+  const halves = trimmed.split("=");
+  if (halves.length === 2) {
+    const names = (halves[0].match(/[A-Za-z]+/g) ?? []).filter(isCannabinoid) as Cannabinoid[];
+    const values = (halves[1].match(/[0-9]*\.?[0-9]+/g) ?? []).map(Number);
+    if (names.length > 0 && names.length === values.length && !/[A-Za-z]/.test(halves[1])) {
+      names.forEach((n, i) => add(n, values[i]));
+      return out;
+    }
+  }
+
+  // Form: adjacent name+number (either order) pairs anywhere in the string.
+  for (const m of trimmed.matchAll(PAIR)) {
+    if (m[1] != null) add(m[1], Number(m[2]));
+    else add(m[4], Number(m[3]));
+  }
+
+  if (Object.keys(out).length === 0) {
+    throw new Error(`Unparseable cannabinoid ratio: "${spec}"`);
+  }
+  return out;
+}
+
+// ── Formulation math ───────────────────────────────────────────────────────
+
+function reduceParts(parts: number[]): number[] {
+  // Reduce to small integers when the parts are whole numbers; otherwise leave as-is.
+  if (!parts.every((p) => Number.isInteger(p) && p > 0)) return parts;
+  const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+  const g = parts.reduce((acc, p) => gcd(acc, p), parts[0]);
+  return g > 1 ? parts.map((p) => p / g) : parts;
+}
+
+/**
+ * Expand a target ratio + concentration + batch size into a full per-constituent
+ * formulation. Throws on a degenerate target (empty/negative ratio, non-positive
+ * concentration or volume).
+ */
+export function computeFormulation(target: FormulationTarget): Formulation {
+  const { ratio, totalCannabinoidMgPerMl, batchVolumeMl } = target;
+  const entries = (Object.entries(ratio) as [Cannabinoid, number][]).filter(([, p]) => p > 0);
+
+  if (entries.length === 0) throw new Error("Formulation ratio must have at least one positive part");
+  if (entries.some(([, p]) => p < 0)) throw new Error("Ratio parts cannot be negative");
+  if (!(totalCannabinoidMgPerMl > 0)) throw new Error("totalCannabinoidMgPerMl must be > 0");
+  if (!(batchVolumeMl > 0)) throw new Error("batchVolumeMl must be > 0");
+
+  const totalParts = entries.reduce((sum, [, p]) => sum + p, 0);
+
+  const constituents: ConstituentBreakdown[] = entries.map(([cannabinoid, parts]) => {
+    const fraction = parts / totalParts;
+    const mgPerMl = totalCannabinoidMgPerMl * fraction;
+    return {
+      cannabinoid,
+      parts,
+      fraction,
+      mgPerMl,
+      mgTotal: mgPerMl * batchVolumeMl,
+    };
+  });
+
+  const reduced = reduceParts(entries.map(([, p]) => p));
+  const ratioLabel = `${entries.map(([c]) => c).join(":")} ${reduced.join(":")}`;
+
+  return {
+    target,
+    constituents,
+    totalParts,
+    totalMgPerMl: totalCannabinoidMgPerMl,
+    totalCannabinoidMg: totalCannabinoidMgPerMl * batchVolumeMl,
+    ratioLabel,
+  };
+}
+
+// ── Raw-ingredient yield ───────────────────────────────────────────────────
+
+export interface RawIngredient {
+  id: string;
+  label: string;
+  /**
+   * mg of each cannabinoid delivered per GRAM of this raw ingredient.
+   *   CBD isolate ≈ { CBD: 990 }
+   *   THC distillate ≈ { THC: 880, CBD: 20 }
+   *   broad-spectrum ≈ { CBD: 700, CBN: 40, CBG: 30 }
+   */
+  potencyMgPerGram: Partial<Record<Cannabinoid, number>>;
+  /** g/mL, used to size the carrier. Cannabis oils ≈ 0.90–0.95. Default 0.95. */
+  densityGPerMl?: number;
+}
+
+const DEFAULT_DENSITY = 0.95;
+const DEFAULT_TOLERANCE = 0.05; // 5% — incidental-cannabinoid overshoot warning threshold
+
+export interface YieldIngredientLine {
+  id: string;
+  label: string;
+  grams: number;
+  volumeMl: number;
+  contributesMg: Partial<Record<Cannabinoid, number>>;
+}
+
+export interface YieldDelta {
+  cannabinoid: Cannabinoid;
+  targetMg: number;
+  achievedMg: number;
+  deltaMg: number;
+  withinTolerance: boolean;
+}
+
+export interface YieldResult {
+  ingredients: YieldIngredientLine[];
+  carrierVolumeMl: number;
+  totalVolumeMl: number;
+  achievedTotalMg: Partial<Record<Cannabinoid, number>>;
+  deltas: YieldDelta[];
+  /** Target cannabinoids no raw ingredient supplies. */
+  unmet: Cannabinoid[];
+  warnings: string[];
+}
+
+export interface YieldOptions {
+  /** Pin a specific ingredient (by id) as the source for a cannabinoid. */
+  sourceByCannabinoid?: Partial<Record<Cannabinoid, string>>;
+  carrierLabel?: string;
+  /** Relative overshoot beyond which an incidental-contribution warning fires. */
+  tolerance?: number;
+}
+
+function chooseSource(
+  c: Cannabinoid,
+  ingredients: RawIngredient[],
+  pin?: string,
+): RawIngredient | undefined {
+  if (pin) {
+    const pinned = ingredients.find((i) => i.id === pin && (i.potencyMgPerGram[c] ?? 0) > 0);
+    if (pinned) return pinned;
+  }
+  // Most concentrated source for this cannabinoid wins.
+  return ingredients
+    .filter((i) => (i.potencyMgPerGram[c] ?? 0) > 0)
+    .sort((a, b) => (b.potencyMgPerGram[c] ?? 0) - (a.potencyMgPerGram[c] ?? 0))[0];
+}
+
+/**
+ * Compute how much of each raw ingredient + carrier is needed to compound a
+ * formulation. Uses a greedy one-source-per-cannabinoid assignment: each target
+ * cannabinoid is sourced from its most concentrated ingredient, then incidental
+ * cross-contributions (e.g. the CBD that rides along in a THC distillate) are
+ * netted out and flagged when they push a constituent past tolerance.
+ */
+export function computeYield(
+  formulation: Formulation,
+  ingredients: RawIngredient[],
+  opts: YieldOptions = {},
+): YieldResult {
+  const tolerance = opts.tolerance ?? DEFAULT_TOLERANCE;
+  const warnings: string[] = [];
+  const unmet: Cannabinoid[] = [];
+  const gramsById = new Map<string, number>();
+  const used = new Map<string, RawIngredient>();
+
+  for (const con of formulation.constituents) {
+    if (con.mgTotal <= 0) continue;
+    const source = chooseSource(con.cannabinoid, ingredients, opts.sourceByCannabinoid?.[con.cannabinoid]);
+    if (!source) {
+      unmet.push(con.cannabinoid);
+      warnings.push(`No raw ingredient supplies ${con.cannabinoid}.`);
+      continue;
+    }
+    const potency = source.potencyMgPerGram[con.cannabinoid] as number;
+    const grams = con.mgTotal / potency;
+    gramsById.set(source.id, (gramsById.get(source.id) ?? 0) + grams);
+    used.set(source.id, source);
+  }
+
+  const lines: YieldIngredientLine[] = [];
+  let activesVolumeMl = 0;
+  const achievedTotalMg: Partial<Record<Cannabinoid, number>> = {};
+
+  for (const [id, grams] of gramsById) {
+    const ing = used.get(id) as RawIngredient;
+    const density = ing.densityGPerMl ?? DEFAULT_DENSITY;
+    const volumeMl = grams / density;
+    activesVolumeMl += volumeMl;
+    const contributesMg: Partial<Record<Cannabinoid, number>> = {};
+    for (const c of CANNABINOIDS) {
+      const p = ing.potencyMgPerGram[c] ?? 0;
+      if (p > 0) {
+        const mg = grams * p;
+        contributesMg[c] = mg;
+        achievedTotalMg[c] = (achievedTotalMg[c] ?? 0) + mg;
+      }
+    }
+    lines.push({ id, label: ing.label, grams, volumeMl, contributesMg });
+  }
+
+  const deltas: YieldDelta[] = formulation.constituents.map((con) => {
+    const achievedMg = achievedTotalMg[con.cannabinoid] ?? 0;
+    const deltaMg = achievedMg - con.mgTotal;
+    const withinTolerance = con.mgTotal === 0 ? deltaMg === 0 : Math.abs(deltaMg) / con.mgTotal <= tolerance;
+    if (!withinTolerance && achievedMg > con.mgTotal) {
+      warnings.push(
+        `${con.cannabinoid} overshoots target by ${(deltaMg).toFixed(1)} mg (incidental content in another ingredient).`,
+      );
+    }
+    return { cannabinoid: con.cannabinoid, targetMg: con.mgTotal, achievedMg, deltaMg, withinTolerance };
+  });
+
+  const carrierVolumeMl = formulation.target.batchVolumeMl - activesVolumeMl;
+  if (carrierVolumeMl < 0) {
+    warnings.push(
+      `Active ingredients (${activesVolumeMl.toFixed(1)} mL) exceed the ${formulation.target.batchVolumeMl} mL batch — raise batch volume or lower concentration.`,
+    );
+  }
+
+  return {
+    ingredients: lines,
+    carrierVolumeMl: Math.max(0, carrierVolumeMl),
+    totalVolumeMl: formulation.target.batchVolumeMl,
+    achievedTotalMg,
+    deltas,
+    unmet,
+    warnings,
+  };
+}
+
+// ── Jurisdictional THC guardrail (parametric — policy supplies the limit) ────
+
+export interface ThcLimit {
+  maxThcMgPerBatch?: number;
+  maxThcMgPerDay?: number;
+  /** Free-text policy source, surfaced in violation messages. */
+  label?: string;
+}
+
+export interface DoseSpec {
+  mlPerDose: number;
+  dosesPerDay: number;
+}
+
+function thcConstituent(f: Formulation): ConstituentBreakdown | undefined {
+  return f.constituents.find((c) => c.cannabinoid === "THC");
+}
+
+export function batchThcMg(f: Formulation): number {
+  return thcConstituent(f)?.mgTotal ?? 0;
+}
+
+export function dailyThcMg(f: Formulation, dose: DoseSpec): number {
+  const mgPerMl = thcConstituent(f)?.mgPerMl ?? 0;
+  return mgPerMl * dose.mlPerDose * dose.dosesPerDay;
+}
+
+export interface GuardrailResult {
+  ok: boolean;
+  violations: string[];
+}
+
+/**
+ * Check a formulation against a caller-supplied THC limit. Returns the list of
+ * violations (empty ⇒ ok). The limit is owned by clinic/jurisdiction policy,
+ * not this module.
+ */
+export function checkThcGuardrail(f: Formulation, limit: ThcLimit, dose?: DoseSpec): GuardrailResult {
+  const violations: string[] = [];
+  const src = limit.label ? ` (${limit.label})` : "";
+
+  if (limit.maxThcMgPerBatch != null) {
+    const batch = batchThcMg(f);
+    if (batch > limit.maxThcMgPerBatch) {
+      violations.push(
+        `Batch THC ${batch.toFixed(1)} mg exceeds the ${limit.maxThcMgPerBatch} mg per-batch limit${src}.`,
+      );
+    }
+  }
+  if (limit.maxThcMgPerDay != null && dose) {
+    const daily = dailyThcMg(f, dose);
+    if (daily > limit.maxThcMgPerDay) {
+      violations.push(
+        `Daily THC ${daily.toFixed(1)} mg exceeds the ${limit.maxThcMgPerDay} mg/day limit${src}.`,
+      );
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}


### PR DESCRIPTION
## What
Lands the #1 net-new gap from the **LeafJourney Workflows Revisions** directive (Domain 7): a *multi-constituent* cannabis compound formulation workflow the existing single-product models (`CannabisProduct` / `DosingRegimen`) can't express. Plus the directive's repo digest + gap analysis.

## Changes
**Compounding engine** — `src/lib/domain/cannabis-compounding.ts` (pure, no I/O)
- `parseRatio`: free-form specs (`"CBD:THC:CBN = 20:1:2"`) → normalized parts
- `computeFormulation`: ratio + target mg/mL + batch → per-constituent mg/mL & mg (mass-conserving, gcd-reduced label)
- `computeYield`: raw-ingredient (isolate/distillate) grams + carrier q.s.; greedy one-source-per-cannabinoid with incidental-overshoot & can't-fit-batch warnings
- `checkThcGuardrail`: parametric per-batch / per-day THC limit — **policy supplies the limit, the engine flags, the clinician decides** (clinical-governance principle)
- 18 vitest cases

**Order Builder UI** — `/clinic/library/compounding`
- Live constituent breakdown + weigh-out yield + guardrail banner
- Editable raw-ingredient inventory with smart defaults
- Formulation Blueprints (localStorage-interim — deliberately no schema migration; the `CompoundFormulation` / `FormulationBlueprint` Prisma models are tracked as EMR-1163 follow-up to avoid the dev-DB migration-drift hazard)
- Discoverable "New" card on the clinical library index

**Docs** — `docs/directives/leafjourney-workflows/2026-06-10.txt` (canonical extract) + `docs/plans/leafjourney-workflows-2026-06-10-digest.md` (8-domain gap analysis: ~70–80% of the directive already shipped on `main`).

## Verification
- ✅ 18/18 vitest · ✅ whole-repo typecheck (0 errors) · ✅ eslint clean
- ✅ Rendered authed on the dev server with correct engine output (`20:1:2 @ 50 mg/mL / 30 mL` → 1,500 mg total, CBD 1,304.3 mg/batch); 0 console errors

## Linear
EMR-1163 (epic). Reconciled into the existing "WorkFlows Revisions — Zero-Click Ambient Intelligence" project rather than duplicating it; this is the first shipped slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)