### PR TITLE
chore(infra): delete legacy databases from render manifests

### DIFF
--- a/render-staging.yaml
+++ b/render-staging.yaml
@@ -141,8 +141,3 @@ services:
       - key: RESEND_API_KEY
         sync: false
 
-databases:
-  - name: emr-postgres-staging
-    plan: basic-256mb
-    databaseName: emr
-    user: emr

--- a/render.yaml
+++ b/render.yaml
@@ -156,8 +156,3 @@ services:
       - key: EMAIL_FROM
         sync: false
 
-databases:
-  - name: emr-postgres
-    plan: basic-256mb
-    databaseName: emr
-    user: emr


### PR DESCRIPTION
Removes the legacy emr-postgres and emr-postgres-staging database blocks from render.yaml and render-staging.yaml to prevent any accidental split-brain configuration issues where migrations apply to Supabase but the app reads from legacy Render-hosted databases.