### PR TITLE
fix(roster): hide reserved System CalendarBlock pseudo-patient from the clinician roster

### DIFF
--- a/src/app/(clinician)/clinic/patients/actions.ts
+++ b/src/app/(clinician)/clinic/patients/actions.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { ForbiddenError, requirePermission } from "@/lib/rbac/permissions";
 import { patientMatchesQuery } from "@/lib/search/patient-search";
+import { EXCLUDE_SYSTEM_PATIENT } from "@/lib/domain/system-patient";
 
 const emergencyContactSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -120,7 +121,7 @@ export async function searchPatientsAction(query: string) {
       deletedAt: null,
       // Exclude the reserved internal record that anchors calendar blocks —
       // it is not a real patient and must never be selectable in patient search.
-      NOT: { firstName: "System", lastName: "CalendarBlock" },
+      ...EXCLUDE_SYSTEM_PATIENT,
     },
     include: {
       appointments: {

--- a/src/app/(clinician)/clinic/patients/page.tsx
+++ b/src/app/(clinician)/clinic/patients/page.tsx
@@ -7,6 +7,7 @@ import { NewPatientModal } from "@/components/clinic/NewPatientModal";
 import { RosterExportMenu } from "./roster-export-menu";
 import { RouterRefreshFreshness } from "@/components/ui/freshness-indicator.client";
 import { logger } from "@/lib/observability/log";
+import { EXCLUDE_SYSTEM_PATIENT } from "@/lib/domain/system-patient";
 
 export const metadata = { title: "Patient Roster" };
 
@@ -26,7 +27,11 @@ export default async function PatientsPage({
   // pagination + filter UI.
   const PATIENT_ROSTER_CAP = 500;
   const patients = await prisma.patient.findMany({
-    where: { organizationId: orgId, deletedAt: null },
+    // The reserved "System CalendarBlock" record is not a real patient and must
+    // not appear in the roster. searchPatientsAction already excludes it; this
+    // keeps the initial server render consistent so it can't flash in then
+    // vanish on refresh. See @/lib/domain/system-patient.
+    where: { organizationId: orgId, deletedAt: null, ...EXCLUDE_SYSTEM_PATIENT },
     include: { chartSummary: true },
     orderBy: { lastName: "asc" },
     take: PATIENT_ROSTER_CAP,

--- a/src/lib/domain/system-patient.ts
+++ b/src/lib/domain/system-patient.ts
@@ -1,0 +1,16 @@
+// The reserved internal Patient record that anchors calendar blocks (provider
+// time-off, meetings, do-not-book windows). It is NOT a real patient: it must
+// never surface in clinical patient lists (roster, search, pickers) or be
+// selectable / bulk-actionable.
+//
+// It is identified by the reserved name pair below — the same convention the
+// schedule block writer uses. Centralized here so the exclusion can't drift
+// between query sites. That drift is exactly what let the record leak into the
+// roster's first server render while search/refresh hid it (fixed 2026-06-13).
+
+export const SYSTEM_PATIENT_NAME = { firstName: "System", lastName: "CalendarBlock" };
+
+/** Prisma `where` fragment that excludes the reserved system pseudo-patient. */
+export const EXCLUDE_SYSTEM_PATIENT = {
+  NOT: { firstName: SYSTEM_PATIENT_NAME.firstName, lastName: SYSTEM_PATIENT_NAME.lastName },
+};


### PR DESCRIPTION
## What
During a live Dr-Live reliability smoke of the clinical encounter flow (roster → chart → prescribe), the clinician **patient roster** rendered the reserved internal **`System CalendarBlock`** record as if it were a patient. It then disappeared on refresh/search — because `searchPatientsAction` *does* filter it but the roster page query did not. That flash-then-vanish inconsistency reads as unreliable in a live demo.

## Root cause
**Filter drift.** Two query sites listed org patients; only one excluded the reserved record. `src/app/(clinician)/clinic/patients/page.tsx` used `where: { organizationId, deletedAt: null }` with no exclusion.

## Fix
- New `src/lib/domain/system-patient.ts` exporting `EXCLUDE_SYSTEM_PATIENT` (and `SYSTEM_PATIENT_NAME`).
- Roster page and `searchPatientsAction` both spread the shared fragment, so they can't drift again.

Name-match is the existing convention (the schedule block writer creates the record with the same reserved name); a dedicated flag would need a schema migration and is out of scope here.

## Verification
- eslint clean on all 3 changed files.
- Local whole-repo typecheck was run; the only errors were pre-existing `portal/*` (`treatmentGoal`/`sideEffects`) noise from a stale generated Prisma client in this worktree's symlinked node_modules — **none in the changed files**. CI runs `prisma generate` fresh, so it's the authoritative typecheck here.

## Context
The broader smoke was reassuring: roster, patient chart, and the v2 prescribe form all render with **0 console errors** — the encounter flow is in much better shape than the original "deplorable" report. Found one other minor item (a "Leafmart Customer" record also shows in the roster; lower priority, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)