### PR TITLE
EMR-921 /ops/schedule — clickable stat ribbon retitles + filters the Week View

### DIFF
--- a/src/app/(operator)/ops/schedule/ScheduleClient.tsx
+++ b/src/app/(operator)/ops/schedule/ScheduleClient.tsx
@@ -47,6 +47,23 @@ const MODALITY_TONE: Record<string, "accent" | "info" | "neutral"> = {
 // EMR-919 — stable display order for the clickable modality KPI chips.
 const MODALITY_ORDER = ["in_person", "video", "phone"];
 
+// EMR-921 — clickable stat-ribbon scopes. Clicking a box retitles the Week View
+// and filters the grid to that scope ("today" = appts dated today; the rest
+// match appointment status). "In range" clears the scope.
+type ScopeKey = "today" | "confirmed" | "requested" | "completed";
+const SCOPES: { key: ScopeKey; label: string; tone: "accent" | "success" | "warning" | "neutral" }[] = [
+  { key: "today", label: "Today", tone: "accent" },
+  { key: "confirmed", label: "Confirmed", tone: "success" },
+  { key: "requested", label: "Requested", tone: "warning" },
+  { key: "completed", label: "Completed", tone: "neutral" },
+];
+const SCOPE_DOT: Record<ScopeKey, string> = {
+  today: "bg-accent",
+  confirmed: "bg-[color:var(--success,theme(colors.emerald.500))]",
+  requested: "bg-highlight",
+  completed: "bg-border-strong",
+};
+
 const STATUS_TONE: Record<
   string,
   "success" | "warning" | "danger" | "neutral" | "accent"
@@ -119,6 +136,8 @@ export function ScheduleClient({
   );
   // EMR-919 / EMR-930 — modality filter driven by the clickable KPI chips.
   const [selectedModality, setSelectedModality] = useState<string | null>(null);
+  // EMR-921 — stat-ribbon scope filter (Today / Confirmed / Requested / Completed).
+  const [selectedScope, setSelectedScope] = useState<ScopeKey | null>(null);
 
   const selectedProvider = useMemo(
     () => providers.find((p) => p.id === selectedProviderId) ?? null,
@@ -134,19 +153,37 @@ export function ScheduleClient({
     return counts;
   }, [appointments]);
 
+  // EMR-921 — scope counts for the clickable stat ribbon.
+  const scopeCounts = useMemo(() => {
+    const todayStr = new Date().toDateString();
+    return {
+      today: appointments.filter(
+        (a) => new Date(a.startAt).toDateString() === todayStr,
+      ).length,
+      confirmed: appointments.filter((a) => a.status === "confirmed").length,
+      requested: appointments.filter((a) => a.status === "requested").length,
+      completed: appointments.filter((a) => a.status === "completed").length,
+    };
+  }, [appointments]);
+
   // Restrict the day buckets by the active provider + modality filters so the
   // Week View grid reflects only the matching schedule.
   const visibleDays = useMemo(() => {
-    if (!selectedProviderId && !selectedModality) return days;
+    if (!selectedProviderId && !selectedModality && !selectedScope) return days;
+    const todayStr = new Date().toDateString();
     return days.map((d) => ({
       ...d,
       appointments: d.appointments.filter(
         (a) =>
           (!selectedProviderId || a.providerId === selectedProviderId) &&
-          (!selectedModality || a.modality === selectedModality),
+          (!selectedModality || a.modality === selectedModality) &&
+          (!selectedScope ||
+            (selectedScope === "today"
+              ? new Date(a.startAt).toDateString() === todayStr
+              : a.status === selectedScope)),
       ),
     }));
-  }, [days, selectedProviderId, selectedModality]);
+  }, [days, selectedProviderId, selectedModality, selectedScope]);
 
   // Snapshot stats for the selected provider, computed from loaded data.
   const snapshot = useMemo(() => {
@@ -166,12 +203,64 @@ export function ScheduleClient({
     };
   }, [appointments, selectedProviderId]);
 
+  const scopeLabel = selectedScope
+    ? SCOPES.find((s) => s.key === selectedScope)!.label
+    : null;
   const boxTitle = selectedProvider
     ? `${selectedProvider.user.firstName} ${selectedProvider.user.lastName}`
-    : "Week view";
+    : scopeLabel ?? "Week view";
 
   return (
     <>
+      {/* EMR-921 — clickable stat ribbon: a click retitles the Week View below
+          and filters its grid to that scope; "In range" clears the filter. */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-8">
+        {[
+          { key: null as ScopeKey | null, label: "In range", value: totalThisWeek, dotClass: "" },
+          ...SCOPES.map((s) => ({
+            key: s.key as ScopeKey | null,
+            label: s.label,
+            value: scopeCounts[s.key],
+            dotClass: SCOPE_DOT[s.key],
+          })),
+        ].map((box) => {
+          const active =
+            box.key === null ? !selectedScope : selectedScope === box.key;
+          return (
+            <button
+              key={box.label}
+              type="button"
+              aria-pressed={active}
+              onClick={() =>
+                setSelectedScope(
+                  box.key === null || selectedScope === box.key ? null : box.key,
+                )
+              }
+              className={cn(
+                "rounded-2xl border bg-surface-raised px-4 py-3 text-left shadow-sm transition-all",
+                "hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                active
+                  ? "border-accent/60 ring-1 ring-accent/40"
+                  : "border-border/80 hover:border-border-strong",
+              )}
+            >
+              <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-text-subtle">
+                {box.dotClass && (
+                  <span
+                    className={cn("h-1.5 w-1.5 rounded-full", box.dotClass)}
+                    aria-hidden
+                  />
+                )}
+                {box.label}
+              </span>
+              <span className="mt-1 block font-display text-2xl text-text tabular-nums">
+                {box.value}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
       {/* Week view header — title (swaps to provider name) + range filter */}
       <div className="mb-4 flex items-center justify-between gap-3">
         <div className="flex items-baseline gap-3 min-w-0">
@@ -183,6 +272,15 @@ export function ScheduleClient({
             <button
               type="button"
               onClick={() => setSelectedProviderId(null)}
+              className="text-[11px] font-medium text-accent hover:underline shrink-0"
+            >
+              Back to all
+            </button>
+          )}
+          {!selectedProvider && selectedScope && (
+            <button
+              type="button"
+              onClick={() => setSelectedScope(null)}
               className="text-[11px] font-medium text-accent hover:underline shrink-0"
             >
               Back to all

--- a/src/app/(operator)/ops/schedule/page.tsx
+++ b/src/app/(operator)/ops/schedule/page.tsx
@@ -1,7 +1,6 @@
 import { prisma } from "@/lib/db/prisma";
 import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
-import { Card, CardContent } from "@/components/ui/card";
 import { computeAppointmentRisk } from "@/lib/scheduling/appointment-risk";
 import type { RiskTier } from "@/lib/scheduling/no-show-model";
 import {
@@ -274,19 +273,6 @@ export default async function SchedulePage({
     user: { firstName: p.user.firstName, lastName: p.user.lastName },
   }));
 
-  // Stats (reflect the chosen window).
-  const totalThisWeek = appointments.length;
-  const confirmedCount = appointments.filter(
-    (a) => a.status === "confirmed",
-  ).length;
-  const requestedCount = appointments.filter(
-    (a) => a.status === "requested",
-  ).length;
-  const completedCount = appointments.filter(
-    (a) => a.status === "completed",
-  ).length;
-  const todayCount = appointments.filter((a) => isSameDay(a.startAt, now)).length;
-
   const spanLabel = rangeSpanLabel(start, end);
 
   return (
@@ -296,15 +282,6 @@ export default async function SchedulePage({
         title="Schedule"
         description={spanLabel}
       />
-
-      {/* Stats strip */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-8">
-        <StatCard label="In range" value={totalThisWeek} />
-        <StatCard label="Today" value={todayCount} tone="accent" />
-        <StatCard label="Confirmed" value={confirmedCount} tone="success" />
-        <StatCard label="Requested" value={requestedCount} tone="warning" />
-        <StatCard label="Completed" value={completedCount} tone="neutral" />
-      </div>
 
       <ScheduleClient
         rangeLabel={spanLabel}
@@ -353,33 +330,3 @@ function serializeAppointment(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Stat card
-// ---------------------------------------------------------------------------
-
-function StatCard({
-  label,
-  value,
-  tone = "neutral",
-}: {
-  label: string;
-  value: number;
-  tone?: "accent" | "success" | "warning" | "neutral";
-}) {
-  const colors = {
-    accent: "text-accent",
-    success: "text-success",
-    warning: "text-[color:var(--warning)]",
-    neutral: "text-text",
-  };
-  return (
-    <Card tone="raised">
-      <CardContent className="pt-5 pb-5">
-        <p className={`font-display text-3xl tabular-nums ${colors[tone]}`}>
-          {value}
-        </p>
-        <p className="text-xs text-text-muted mt-1">{label}</p>
-      </CardContent>
-    </Card>
-  );
-}


### PR DESCRIPTION
## What

`/ops/schedule` — implements EMR-921 (Dr. Patel Owner Portal Revisions): clicking a stat-ribbon box retitles the Week View and filters its grid to that scope.

- The ribbon (In range / Today / Confirmed / Requested / Completed) moves into `ScheduleClient` as **clickable cards**. Clicking one sets a `selectedScope`: the Week View title retitles to that box's label, the day grid filters to matching appointments (`today` = dated today; the rest match appointment status), and a **"Back to all"** affordance clears it. "In range" clears the scope. Scope composes with the existing provider + modality filters.
- `page.tsx` drops the static `StatCard` strip, the now-unused per-scope counts, the local `StatCard` component, and the now-unused `Card` import; `ScheduleClient` derives the counts from the appointments it already holds.

## Dependencies

None on the `ops/master` kit — targets `main` directly. Cherry-picked from the integration branch (`8521507f`) onto current `main` with zero conflicts.

## Verified

`tsc --noEmit` + `eslint` clean (0 errors in the schedule files); live as `owner@demo.health` — clicking "Confirmed" retitles the section to "Confirmed" and filters the grid to exactly the 5 confirmed visits (other days show "No visits"); "Back to all" restores the full week. 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
