### PR TITLE
EMR-1031 /ops/cfo/pnl — move statement detail into KPI drill-in popups

### DIFF
--- a/src/app/(operator)/ops/cfo/pnl/page.tsx
+++ b/src/app/(operator)/ops/cfo/pnl/page.tsx
@@ -2,12 +2,12 @@ import { requireUser } from "@/lib/auth/session";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Eyebrow } from "@/components/ui/ornament";
-import { Badge } from "@/components/ui/badge";
 import { rangeForPeriod, priorRange } from "@/lib/finance/period";
 import { buildPnl } from "@/lib/finance/pnl";
 import { fmtMoney, fmtPct, changeBadgeText } from "@/lib/finance/formatting";
-import { CfoTabs, GenerateReportButton, StatementSection } from "../components";
+import { CfoTabs, GenerateReportButton } from "../components";
 import { PnlTable, type PnlRow } from "./pnl-table";
+import { PnlKpiGrid, type PnlKpiView, type PnlSectionView } from "./pnl-kpi-grid";
 
 export const metadata = { title: "P&L · CFO" };
 export const dynamic = "force-dynamic";
@@ -56,6 +56,113 @@ export default async function PnlPage({ searchParams }: { searchParams?: { perio
     };
   });
 
+  // EMR-1031 — the statement detail sections, now surfaced inside each KPI's
+  // drill-in popup rather than as standalone cards on the page.
+  const sectionRevenue: PnlSectionView = {
+    title: "Revenue",
+    totalLabel: "Total revenue",
+    totalCents: pnl.totals.revenueCents,
+    emphasized: true,
+    lines: pnl.sections.revenue.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+      detail: `${l.itemCount} record${l.itemCount !== 1 ? "s" : ""}`,
+    })),
+  };
+  const sectionCogs: PnlSectionView = {
+    title: "Cost of goods & services",
+    totalLabel: "Total COGS",
+    totalCents: pnl.sections.cogs.totalCents,
+    lines: pnl.sections.cogs.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+      detail: `${l.itemCount} expense${l.itemCount !== 1 ? "s" : ""}`,
+    })),
+  };
+  const sectionOpex: PnlSectionView = {
+    title: "Operating expenses",
+    totalLabel: "Total operating expenses",
+    totalCents: pnl.sections.operatingExpenses.totalCents,
+    lines: pnl.sections.operatingExpenses.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+      detail: `${l.itemCount} entr${l.itemCount !== 1 ? "ies" : "y"}`,
+    })),
+  };
+  const sectionDa: PnlSectionView = {
+    title: "Depreciation & amortization",
+    totalLabel: "Total D&A (non-cash)",
+    totalCents: pnl.sections.depreciationAmortization.totalCents,
+    lines: pnl.sections.depreciationAmortization.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+    })),
+  };
+  const sectionInterest: PnlSectionView = {
+    title: "Interest & financing",
+    totalLabel: "Total non-operating",
+    totalCents: pnl.sections.nonOperating.totalCents,
+    lines: pnl.sections.nonOperating.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+    })),
+  };
+  const sectionTaxes: PnlSectionView = {
+    title: "Income & excise tax",
+    totalLabel: "Total tax",
+    totalCents: pnl.sections.taxes.totalCents,
+    lines: pnl.sections.taxes.lines.map((l) => ({
+      label: l.label,
+      amountCents: l.amountCents,
+    })),
+  };
+
+  // Each Headline KPI's popup shows the statement section(s) that drive it.
+  const kpis: PnlKpiView[] = [
+    {
+      id: "revenue",
+      label: "Revenue",
+      valueDisplay: fmtMoney(pnl.totals.revenueCents, { compact: true }),
+      ...kpiChange(pnl.totals.revenueCents, priorPnl.totals.revenueCents),
+      sections: [sectionRevenue],
+    },
+    {
+      id: "gross_margin",
+      label: "Gross margin",
+      valueDisplay: fmtPct(pnl.totals.grossMarginPct),
+      ...kpiChange(pnl.totals.grossMarginPct, priorPnl.totals.grossMarginPct),
+      sections: [sectionRevenue, sectionCogs],
+    },
+    {
+      id: "ebitda",
+      label: "EBITDA",
+      valueDisplay: fmtMoney(pnl.totals.ebitdaCents, { compact: true }),
+      ...kpiChange(pnl.totals.ebitdaCents, priorPnl.totals.ebitdaCents),
+      sections: [sectionOpex],
+    },
+    {
+      id: "net_income",
+      label: "Net income",
+      valueDisplay: fmtMoney(pnl.totals.netIncomeCents, { compact: true }),
+      ...kpiChange(pnl.totals.netIncomeCents, priorPnl.totals.netIncomeCents),
+      sections: [sectionDa, sectionInterest, sectionTaxes],
+    },
+    {
+      id: "net_margin",
+      label: "Net margin",
+      valueDisplay: fmtPct(pnl.totals.netMarginPct),
+      ...kpiChange(pnl.totals.netMarginPct, priorPnl.totals.netMarginPct),
+      sections: [
+        sectionRevenue,
+        sectionCogs,
+        sectionOpex,
+        sectionDa,
+        sectionInterest,
+        sectionTaxes,
+      ],
+    },
+  ];
+
   return (
     <PageShell maxWidth="max-w-[1320px]">
       <PageHeader
@@ -66,76 +173,10 @@ export default async function PnlPage({ searchParams }: { searchParams?: { perio
       />
       <CfoTabs active="pnl" />
 
-      {/* Summary bar */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-10">
-        <SummaryStat label="Revenue" current={pnl.totals.revenueCents} prior={priorPnl.totals.revenueCents} biggerIsBetter />
-        <SummaryStat label="Gross margin" current={pnl.totals.grossMarginPct} prior={priorPnl.totals.grossMarginPct} biggerIsBetter unit="pct" />
-        <SummaryStat label="EBITDA" current={pnl.totals.ebitdaCents} prior={priorPnl.totals.ebitdaCents} biggerIsBetter />
-        <SummaryStat label="Net income" current={pnl.totals.netIncomeCents} prior={priorPnl.totals.netIncomeCents} biggerIsBetter />
-        <SummaryStat label="Net margin" current={pnl.totals.netMarginPct} prior={priorPnl.totals.netMarginPct} biggerIsBetter unit="pct" />
-      </div>
-
-      {/* Detail statement */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-10">
-        <StatementSection
-          title="Revenue"
-          totalCents={pnl.totals.revenueCents}
-          totalLabel="Total revenue"
-          lines={pnl.sections.revenue.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-            detail: `${l.itemCount} record${l.itemCount !== 1 ? "s" : ""}`,
-          }))}
-          emphasized
-        />
-        <StatementSection
-          title="Cost of goods & services"
-          totalCents={pnl.sections.cogs.totalCents}
-          totalLabel="Total COGS"
-          lines={pnl.sections.cogs.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-            detail: `${l.itemCount} expense${l.itemCount !== 1 ? "s" : ""}`,
-          }))}
-        />
-        <StatementSection
-          title="Operating expenses"
-          totalCents={pnl.sections.operatingExpenses.totalCents}
-          totalLabel="Total operating expenses"
-          lines={pnl.sections.operatingExpenses.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-            detail: `${l.itemCount} entr${l.itemCount !== 1 ? "ies" : "y"}`,
-          }))}
-        />
-        <StatementSection
-          title="Depreciation & amortization"
-          totalCents={pnl.sections.depreciationAmortization.totalCents}
-          totalLabel="Total D&A (non-cash)"
-          lines={pnl.sections.depreciationAmortization.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-          }))}
-        />
-        <StatementSection
-          title="Interest & financing"
-          totalCents={pnl.sections.nonOperating.totalCents}
-          totalLabel="Total non-operating"
-          lines={pnl.sections.nonOperating.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-          }))}
-        />
-        <StatementSection
-          title="Income & excise tax"
-          totalCents={pnl.sections.taxes.totalCents}
-          totalLabel="Total tax"
-          lines={pnl.sections.taxes.lines.map((l) => ({
-            label: l.label,
-            amountCents: l.amountCents,
-          }))}
-        />
-      </div>
+      {/* Headline KPIs — click a tile to drill into its statement breakdown.
+          The detail sections (Revenue / COGS / OpEx / D&A / Interest / Tax)
+          now live inside these popups instead of as standalone cards (EMR-1031). */}
+      <PnlKpiGrid kpis={kpis} />
 
       {/* Side by side: this period vs. prior — sortable columns + CSV/print export (MASTER prompt G5/G6) */}
       <div className="mb-10">
@@ -157,23 +198,22 @@ export default async function PnlPage({ searchParams }: { searchParams?: { perio
   );
 }
 
-function SummaryStat({ label, current, prior, biggerIsBetter, unit = "cents" }: { label: string; current: number; prior: number; biggerIsBetter?: boolean; unit?: "cents" | "pct" }) {
-  const value = unit === "cents" ? fmtMoney(current, { compact: true }) : fmtPct(current);
-  const pct = prior !== 0 ? Math.round(((current - prior) / Math.abs(prior)) * 1000) / 10 : null;
-  const change = changeBadgeText(pct, biggerIsBetter ?? true);
-  return (
-    <Card tone="raised">
-      <CardContent className="pt-5 pb-5">
-        <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">{label}</p>
-        <p className="font-display text-2xl text-text tabular-nums mt-1.5">{value}</p>
-        {pct !== null && (
-          <Badge tone={change.tone === "good" ? "success" : change.tone === "bad" ? "danger" : "neutral"} className="text-[9px] mt-2">
-            {change.text} vs prior
-          </Badge>
-        )}
-      </CardContent>
-    </Card>
-  );
+function kpiChange(
+  current: number,
+  prior: number,
+): { changeText: string | null; badgeTone: "success" | "danger" | "neutral" } {
+  const pct =
+    prior !== 0 ? Math.round(((current - prior) / Math.abs(prior)) * 1000) / 10 : null;
+  const change = changeBadgeText(pct, true);
+  return {
+    changeText: pct !== null ? change.text : null,
+    badgeTone:
+      change.tone === "good"
+        ? "success"
+        : change.tone === "bad"
+          ? "danger"
+          : "neutral",
+  };
 }
 
 function MemoTile({ label, value, hint }: { label: string; value: string; hint: string }) {

--- a/src/app/(operator)/ops/cfo/pnl/pnl-kpi-grid.tsx
+++ b/src/app/(operator)/ops/cfo/pnl/pnl-kpi-grid.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { fmtMoney } from "@/lib/finance/formatting";
+import { cn } from "@/lib/utils/cn";
+
+// EMR-1031 — The P&L "Detail statement" cards (Revenue / COGS / OpEx / D&A /
+// Interest / Tax) used to sit on the main page. This moves each breakdown into
+// the pop-up that opens when its related Headline KPI tile is clicked, so the
+// page leads with the KPIs and the detail is one click away.
+
+export interface PnlSectionView {
+  title: string;
+  totalLabel?: string;
+  totalCents: number;
+  emphasized?: boolean;
+  lines: { label: string; amountCents: number; detail?: string }[];
+}
+
+export interface PnlKpiView {
+  id: string;
+  label: string;
+  valueDisplay: string;
+  /** Change-vs-prior badge text, or null to hide it. */
+  changeText: string | null;
+  badgeTone: "success" | "danger" | "neutral";
+  /** Detail sections shown in this KPI's drill-in popup. */
+  sections: PnlSectionView[];
+}
+
+export function PnlKpiGrid({ kpis }: { kpis: PnlKpiView[] }) {
+  const [openId, setOpenId] = React.useState<string | null>(null);
+  const active = openId ? kpis.find((k) => k.id === openId) ?? null : null;
+
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-10">
+        {kpis.map((k) => (
+          <button
+            key={k.id}
+            type="button"
+            onClick={() => setOpenId(k.id)}
+            aria-haspopup="dialog"
+            aria-label={`${k.label}: ${k.valueDisplay}. View breakdown`}
+            className={cn(
+              "group rounded-2xl border border-border/80 bg-surface-raised px-5 py-5 text-left shadow-sm",
+              "transition-all hover:-translate-y-0.5 hover:shadow-md hover:border-border-strong",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            )}
+          >
+            <p className="text-[10px] uppercase tracking-[0.12em] text-text-subtle">
+              {k.label}
+            </p>
+            <p className="font-display text-2xl text-text tabular-nums mt-1.5">
+              {k.valueDisplay}
+            </p>
+            {k.changeText && (
+              <Badge tone={k.badgeTone} className="text-[9px] mt-2">
+                {k.changeText} vs prior
+              </Badge>
+            )}
+            <span className="mt-2 block text-[10px] font-medium text-accent opacity-0 transition-opacity group-hover:opacity-100">
+              View breakdown →
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <Dialog open={!!active} onOpenChange={(o) => !o && setOpenId(null)}>
+        <DialogContent className="max-w-2xl">
+          {active && (
+            <>
+              <DialogHeader>
+                <DialogTitle>
+                  {active.label} · {active.valueDisplay}
+                </DialogTitle>
+                {active.changeText && (
+                  <p className="text-sm text-text-muted">
+                    {active.changeText} vs prior period
+                  </p>
+                )}
+              </DialogHeader>
+              <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+                {active.sections.map((s, i) => (
+                  <SectionBreakdown key={`${s.title}-${i}`} section={s} />
+                ))}
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// Local mirror of the server-side <StatementSection> presentation, kept inline
+// so this client component doesn't pull the server `../components` module into
+// the client bundle.
+function SectionBreakdown({ section }: { section: PnlSectionView }) {
+  const { title, totalLabel, totalCents, lines, emphasized } = section;
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-surface px-4 py-4",
+        emphasized && "border-l-4 border-l-accent",
+      )}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-display text-base text-text">{title}</h3>
+        <span className="font-display text-base text-text tabular-nums">
+          {fmtMoney(totalCents)}
+        </span>
+      </div>
+      {lines.length > 0 ? (
+        <div className="divide-y divide-border/60">
+          {lines.map((l, i) => (
+            <div
+              key={`${l.label}-${i}`}
+              className="flex items-center justify-between py-2 gap-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-text truncate">{l.label}</p>
+                {l.detail && (
+                  <p className="text-[11px] text-text-subtle truncate">
+                    {l.detail}
+                  </p>
+                )}
+              </div>
+              <span className="text-sm tabular-nums text-text-muted shrink-0">
+                {fmtMoney(l.amountCents)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-text-subtle italic">
+          No items in this period.
+        </p>
+      )}
+      {totalLabel && (
+        <div className="mt-3 pt-3 border-t border-border/60 flex justify-between">
+          <span className="text-sm font-medium text-text">{totalLabel}</span>
+          <span className="font-display text-sm text-text tabular-nums">
+            {fmtMoney(totalCents)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

`/ops/cfo/pnl` — implements EMR-1031 (Dr. Patel Owner Portal Revisions v2): the statement detail sections move off the page and into the Headline-KPI drill-in popups.

- New client component `pnl-kpi-grid.tsx`: the 5 KPI tiles (Revenue / Gross margin / EBITDA / Net income / Net margin) are now **clickable** and open a Dialog showing the statement section(s) that drive that KPI:
  - Revenue → Revenue
  - Gross margin → Revenue + Cost of goods
  - EBITDA → Operating expenses
  - Net income → D&A + Interest & financing + Income & excise tax
  - Net margin → full waterfall (all six)
- `page.tsx` **removes the six inline `StatementSection` detail cards**, builds serializable section + KPI views, and renders `<PnlKpiGrid>`. The local `SummaryStat` component and the now-unused `StatementSection` / `Badge` imports are dropped; change badges come from a small `kpiChange` helper. A self-contained `SectionBreakdown` mirrors the server `StatementSection` so the client bundle doesn't pull in `../components`.

The "This period vs. prior" sortable/exportable table and the Memo tiles are untouched.

## Dependencies

None on the `ops/master` kit — targets `main` directly (cherry-picked from `82cd54c3` with zero conflicts; `pnl-table.tsx` is already on `main`).

## Verified

`tsc --noEmit` + `eslint` clean (0 errors in the pnl files); live as `owner@demo.health` — the detail cards are gone from the page; clicking "Net margin" opens a popup with all six sections (Revenue emphasized, COGS, OpEx, D&A $467.46, Interest, Tax), scrollable. 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
