### PR TITLE
Owner Portal Revisions — G3: 7-result autocomplete primitive + /ops adoption

### DIFF
--- a/src/app/(operator)/ops/feedback/feedback-view.tsx
+++ b/src/app/(operator)/ops/feedback/feedback-view.tsx
@@ -13,6 +13,7 @@ import {
   SortMenu,
   type ActiveChip,
 } from "@/components/ui/filter-bar";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { LinkifiedText } from "@/components/ui/linkified-text";
 import { cn } from "@/lib/utils/cn";
 
@@ -131,6 +132,20 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
       }
     });
   }, [items, state]);
+
+  // MASTER-prompt G3 — top-7 page-specific matches: patient name (label),
+  // also searchable by the feedback excerpt (keyword), mirroring the
+  // name-or-excerpt filter above.
+  const feedbackOptions: AutocompleteOption[] = useMemo(
+    () =>
+      items.map((i) => ({
+        value: i.patientName,
+        label: i.patientName,
+        sublabel: i.excerpt,
+        keywords: [i.excerpt],
+      })),
+    [items],
+  );
 
   const chips: ActiveChip[] = [];
   if (state.tab !== "all") {
@@ -261,12 +276,16 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        <Input
-          type="search"
-          placeholder="Search by name or excerpt…"
+        <AutocompleteInput
+          options={feedbackOptions}
           value={state.query}
-          onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
-          className="md:w-64 h-9"
+          onValueChange={(text) => setState((s) => ({ ...s, query: text }))}
+          onSelect={(opt) => setState((s) => ({ ...s, query: opt.value }))}
+          placeholder="Search by name or excerpt…"
+          emptyMessage="No feedback matches"
+          aria-label="Search feedback by name or excerpt"
+          className="md:w-64"
+          inputClassName="h-9"
         />
         <MultiSelectFilter
           label="NPS (Net Promoter Score) band"

--- a/src/app/(operator)/ops/inventory/inventory-view.tsx
+++ b/src/app/(operator)/ops/inventory/inventory-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input, FieldGroup, Textarea } from "@/components/ui/input";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import {
   classifyStatus,
   STATUS_STYLES,
@@ -57,6 +58,20 @@ export function InventoryView({ initialItems }: { initialItems: InventoryItem[] 
         );
       });
   }, [items, filter, query]);
+
+  // MASTER-prompt G3 — the directive's "AI SKU search": top-7 matches on
+  // product name (label) plus brand / SKU / UPC (keywords), mirroring the
+  // filter above.
+  const productOptions: AutocompleteOption[] = useMemo(
+    () =>
+      items.map((i) => ({
+        value: i.productName,
+        label: i.productName,
+        sublabel: [i.brand, i.sku].filter(Boolean).join(" · "),
+        keywords: [i.brand, i.sku, i.upc].filter((s): s is string => !!s),
+      })),
+    [items],
+  );
 
   function applyRestock() {
     if (!restockTarget || restockQty <= 0) return;
@@ -162,11 +177,14 @@ export function InventoryView({ initialItems }: { initialItems: InventoryItem[] 
           })}
         </div>
         <div className="flex items-center gap-2">
-          <Input
-            type="search"
-            placeholder="Search product, SKU, UPC…"
+          <AutocompleteInput
+            options={productOptions}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onValueChange={setQuery}
+            onSelect={(opt) => setQuery(opt.value)}
+            placeholder="Search product, SKU, UPC…"
+            emptyMessage="No products match"
+            aria-label="Search products by name, SKU, or UPC"
             className="md:w-64"
           />
           <Button onClick={() => setShowAdd((v) => !v)} size="sm">

--- a/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
+++ b/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
@@ -30,6 +30,7 @@ import { StatCard } from "@/components/ui/stat-card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ModalShell } from "@/components/ui/modal-shell";
 import { Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 import {
   crossCheckCoverage,
@@ -317,6 +318,17 @@ export function MailFaxClient({
   const [editDob, setEditDob] = useState("");
   const [editCategory, setEditCategory] = useState<string>(CHART_DOC_CATEGORIES[0]);
   const [editDocDate, setEditDocDate] = useState("");
+
+  // MASTER-prompt G3 — turn the blind "search patient by name" field into a
+  // top-7 autocomplete over the practice's own patients.
+  const patientOptions: AutocompleteOption[] = useMemo(
+    () =>
+      dbPatients.map((p) => ({
+        value: `${p.firstName} ${p.lastName}`,
+        label: `${p.firstName} ${p.lastName}`,
+      })),
+    [dbPatients],
+  );
 
   // Resolve a DB patient id from a scanned patient name. Returns null when there
   // is no CONFIDENT match (EMR-983: do NOT fall back to dbPatients[0]).
@@ -1365,10 +1377,14 @@ export function MailFaxClient({
         <form onSubmit={handleRouteEdit} className="space-y-4 px-6 py-5">
           <div className="space-y-1.5">
             <label className="text-xs font-semibold text-text-subtle uppercase">Patient name or DOB</label>
-            <Input
+            <AutocompleteInput
+              options={patientOptions}
               value={editPatientQuery}
-              onChange={(e) => setEditPatientQuery(e.target.value)}
+              onValueChange={setEditPatientQuery}
+              onSelect={(opt) => setEditPatientQuery(opt.value)}
               placeholder="Search patient by name"
+              emptyMessage="No matching patients"
+              aria-label="Search patient by name"
             />
             <Input
               value={editDob}

--- a/src/app/(operator)/ops/policies/policies-view.tsx
+++ b/src/app/(operator)/ops/policies/policies-view.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 export type PolicyCategory = "Clinical" | "HIPAA" | "Safety" | "Operations" | "Emergency";
@@ -89,6 +90,20 @@ export function PoliciesView({ policies: initialPolicies }: { policies: Policy[]
     [filtered, selectedId],
   );
 
+  // MASTER-prompt G3 — top-7 page-specific matches: policy titles (label),
+  // searchable by category + body text (keywords), mirroring the title-or-body
+  // filter below.
+  const policyOptions: AutocompleteOption[] = useMemo(
+    () =>
+      policies.map((p) => ({
+        value: p.title,
+        label: p.title,
+        sublabel: p.category,
+        keywords: [p.category, p.body],
+      })),
+    [policies],
+  );
+
   function acknowledge(id: string) {
     const next = { ...acks, [id]: new Date().toISOString() };
     setAcks(next);
@@ -98,11 +113,14 @@ export function PoliciesView({ policies: initialPolicies }: { policies: Policy[]
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Input
-          type="search"
-          placeholder="Search policies…"
+        <AutocompleteInput
+          options={policyOptions}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onValueChange={setQuery}
+          onSelect={(opt) => setQuery(opt.value)}
+          placeholder="Search policies…"
+          emptyMessage="No policies match"
+          aria-label="Search policies"
           className="md:w-80"
         />
         <Button size="sm" variant="secondary" onClick={openCreate}>

--- a/src/app/(operator)/ops/vendors/vendors-view.tsx
+++ b/src/app/(operator)/ops/vendors/vendors-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import {
   EmptyFilterState,
   FilterChips,
@@ -130,6 +131,22 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     [vendors],
   );
 
+  // MASTER-prompt G3 — the search field's own page-specific options: every
+  // vendor, matchable by name (label) plus contact / email / category
+  // (keywords). rankAutocomplete surfaces the top 7 as you type.
+  const vendorOptions: AutocompleteOption[] = useMemo(
+    () =>
+      vendors.map((v) => ({
+        value: v.name,
+        label: v.name,
+        sublabel: [v.category, v.contactName].filter(Boolean).join(" · "),
+        keywords: [v.contactName, v.email, v.category].filter(
+          (s): s is string => !!s,
+        ),
+      })),
+    [vendors],
+  );
+
   const chips: ActiveChip[] = [];
   if (state.query.trim()) {
     chips.push({ id: "query", label: "Search", value: state.query.trim() });
@@ -230,12 +247,16 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2 flex-wrap">
-          <Input
-            type="search"
-            placeholder="Search vendors…"
+          <AutocompleteInput
+            options={vendorOptions}
             value={state.query}
-            onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
-            className="md:w-64 h-9"
+            onValueChange={(text) => setState((s) => ({ ...s, query: text }))}
+            onSelect={(opt) => setState((s) => ({ ...s, query: opt.value }))}
+            placeholder="Search vendors…"
+            emptyMessage="No vendors match"
+            aria-label="Search vendors"
+            className="md:w-64"
+            inputClassName="h-9"
           />
           <MultiSelectFilter
             label="Category"

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -5,6 +5,7 @@
 //
 // Coverage of the MASTER-prompt "layout law":
 //   G1 Collapsible sections        → <Collapsible>
+//   G3 7-result page autocomplete  → <AutocompleteInput> (+ rankAutocomplete core)
 //   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
 //   G6 Table send/print/download   → <DataTable exportable> + table-export utils
 //   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
@@ -17,6 +18,18 @@
 // and the per-section AI search bar (G8).
 
 export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  AutocompleteInput,
+  type AutocompleteInputProps,
+} from "@/components/ui/autocomplete-input";
+
+export {
+  rankAutocomplete,
+  scoreOption,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "@/lib/ui/autocomplete-match";
 
 export {
   MetricBox,

--- a/src/components/ui/autocomplete-input.tsx
+++ b/src/components/ui/autocomplete-input.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+// MASTER-prompt G3 — the shared "type-ahead with the top page-specific
+// matches" field for /ops. Every search bar / dropdown / searchable input is
+// meant to surface up to 7 of *this page's own* options as you type (the
+// directive is explicit that it's site-specific, not a global search — that's
+// G4). Pages pass their own `options`; ranking is delegated to the pure
+// rankAutocomplete() core so behavior is identical and testable everywhere.
+//
+// Accessibility: implements the ARIA 1.2 combobox-with-listbox pattern —
+// role="combobox" input, aria-expanded / aria-controls / aria-activedescendant,
+// a role="listbox" popup with role="option" rows, full keyboard nav
+// (↑/↓ to move, Enter to choose, Esc to close), and click-outside dismissal.
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import {
+  rankAutocomplete,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "@/lib/ui/autocomplete-match";
+
+export type { AutocompleteOption } from "@/lib/ui/autocomplete-match";
+
+export interface AutocompleteInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "defaultValue" | "onChange" | "onSelect"
+  > {
+  /** This page's own options — the directive's "page-specific" set. */
+  options: readonly AutocompleteOption[];
+  /** Fired when the user commits an option (click or Enter on a row). */
+  onSelect: (option: AutocompleteOption) => void;
+  /** Controlled query text. Omit for uncontrolled. */
+  value?: string;
+  /** Initial query text when uncontrolled. */
+  defaultValue?: string;
+  /** Notified on every keystroke (controlled or not). */
+  onValueChange?: (text: string) => void;
+  /** When set, Enter with no highlighted row commits the typed text as its own
+   *  option ({ value, label } both = the raw text). For free-form fields. */
+  allowFreeText?: boolean;
+  /** Max rows to show. Defaults to the MASTER-prompt count of 7. */
+  limit?: number;
+  /** Shown when the query matches nothing. Hidden if omitted. */
+  emptyMessage?: string;
+  /** Custom row renderer; defaults to label + dimmed sublabel. */
+  renderOption?: (option: AutocompleteOption, active: boolean) => React.ReactNode;
+  /** Extra classes on the wrapping element. */
+  className?: string;
+  /** Extra classes on the <input>. */
+  inputClassName?: string;
+}
+
+export const AutocompleteInput = forwardRef<
+  HTMLInputElement,
+  AutocompleteInputProps
+>(function AutocompleteInput(
+  {
+    options,
+    onSelect,
+    value,
+    defaultValue = "",
+    onValueChange,
+    allowFreeText = false,
+    limit = AUTOCOMPLETE_DEFAULT_LIMIT,
+    emptyMessage,
+    renderOption,
+    className,
+    inputClassName,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    disabled,
+    ...inputProps
+  },
+  ref,
+) {
+  const reactId = useId();
+  const listboxId = `${reactId}-listbox`;
+  const optionId = (i: number) => `${reactId}-opt-${i}`;
+
+  const isControlled = value !== undefined;
+  const [innerText, setInnerText] = useState(defaultValue);
+  const text = isControlled ? value : innerText;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const matches = useMemo(
+    () => rankAutocomplete(options, text, limit),
+    [options, text, limit],
+  );
+
+  // First non-disabled row, used as the keyboard landing spot on open.
+  const firstEnabled = useMemo(
+    () => matches.findIndex((m) => !m.disabled),
+    [matches],
+  );
+
+  const setText = useCallback(
+    (next: string) => {
+      if (!isControlled) setInnerText(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setActiveIndex(-1);
+  }, []);
+
+  const commit = useCallback(
+    (option: AutocompleteOption) => {
+      if (option.disabled) return;
+      onSelect(option);
+      setText(option.label);
+      close();
+    },
+    [onSelect, setText, close],
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+    setOpen(true);
+    setActiveIndex(-1);
+  };
+
+  const moveActive = useCallback(
+    (dir: 1 | -1) => {
+      if (matches.length === 0) return;
+      setActiveIndex((prev) => {
+        let i = prev;
+        for (let step = 0; step < matches.length; step++) {
+          i = (i + dir + matches.length) % matches.length;
+          if (!matches[i]?.disabled) return i;
+        }
+        return prev;
+      });
+    },
+    [matches],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(e);
+    if (e.defaultPrevented) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(firstEnabled);
+        } else {
+          moveActive(1);
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (open) moveActive(-1);
+        break;
+      case "Enter": {
+        const picked = activeIndex >= 0 ? matches[activeIndex] : undefined;
+        if (picked) {
+          e.preventDefault();
+          commit(picked);
+        } else if (allowFreeText && text.trim()) {
+          e.preventDefault();
+          const raw = text.trim();
+          onSelect({ value: raw, label: raw });
+          close();
+        }
+        break;
+      }
+      case "Escape":
+        if (open) {
+          e.preventDefault();
+          close();
+        }
+        break;
+      case "Tab":
+        close();
+        break;
+    }
+  };
+
+  // Keep the active row scrolled into view.
+  useEffect(() => {
+    if (!open || activeIndex < 0) return;
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `#${CSS.escape(optionId(activeIndex))}`,
+    );
+    el?.scrollIntoView({ block: "nearest" });
+    // optionId is stable per render; activeIndex/open drive this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, activeIndex]);
+
+  // Click / focus outside closes the popup.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) close();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open, close]);
+
+  const showList = open && (matches.length > 0 || !!emptyMessage);
+
+  return (
+    <div ref={wrapperRef} className={cn("relative", className)}>
+      <Input
+        ref={ref}
+        type="text"
+        role="combobox"
+        aria-expanded={showList}
+        aria-controls={showList ? listboxId : undefined}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && activeIndex >= 0 ? optionId(activeIndex) : undefined
+        }
+        autoComplete="off"
+        value={text}
+        disabled={disabled}
+        onChange={handleChange}
+        onFocus={(e) => {
+          setOpen(true);
+          onFocus?.(e);
+        }}
+        onBlur={onBlur}
+        onKeyDown={handleKeyDown}
+        className={inputClassName}
+        {...inputProps}
+      />
+
+      {showList && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className={cn(
+            "absolute z-50 mt-1 max-h-72 w-full overflow-auto rounded-xl border border-border-strong",
+            "bg-surface py-1 shadow-lg shadow-black/5",
+          )}
+        >
+          {matches.length === 0 && emptyMessage ? (
+            <li
+              role="presentation"
+              className="px-3 py-2 text-sm text-text-muted"
+            >
+              {emptyMessage}
+            </li>
+          ) : (
+            matches.map((option, i) => {
+              const active = i === activeIndex;
+              return (
+                <li
+                  key={`${option.value}-${i}`}
+                  id={optionId(i)}
+                  role="option"
+                  aria-selected={active}
+                  aria-disabled={option.disabled || undefined}
+                  // onMouseDown (not onClick) so the pick lands before the
+                  // input's blur tears the popup down.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    commit(option);
+                  }}
+                  onMouseEnter={() => !option.disabled && setActiveIndex(i)}
+                  className={cn(
+                    "flex cursor-pointer flex-col px-3 py-2 text-sm",
+                    option.disabled && "cursor-not-allowed opacity-50",
+                    active && !option.disabled && "bg-accent/10",
+                  )}
+                >
+                  {renderOption ? (
+                    renderOption(option, active)
+                  ) : (
+                    <>
+                      <span className="truncate text-text">{option.label}</span>
+                      {option.sublabel && (
+                        <span className="truncate text-xs text-text-muted">
+                          {option.sublabel}
+                        </span>
+                      )}
+                    </>
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+});

--- a/src/lib/ui/autocomplete-match.test.ts
+++ b/src/lib/ui/autocomplete-match.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  rankAutocomplete,
+  scoreOption,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "./autocomplete-match";
+
+const opt = (
+  label: string,
+  extra: Partial<AutocompleteOption> = {},
+): AutocompleteOption => ({ value: label, label, ...extra });
+
+const labels = (rows: AutocompleteOption[]) => rows.map((r) => r.label);
+
+describe("scoreOption", () => {
+  it("returns 0 for an empty query (no ranking signal)", () => {
+    expect(scoreOption(opt("Anything"), "")).toBe(0);
+    expect(scoreOption(opt("Anything"), "   ")).toBe(0);
+  });
+
+  it("returns -1 when the query does not match", () => {
+    expect(scoreOption(opt("Aetna"), "cigna")).toBe(-1);
+  });
+
+  it("ranks exact ▸ prefix ▸ word-start ▸ substring", () => {
+    const exact = scoreOption(opt("pain"), "pain");
+    const prefix = scoreOption(opt("painful"), "pain");
+    const wordStart = scoreOption(opt("Low back pain"), "back");
+    const substring = scoreOption(opt("complaint"), "plai");
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(wordStart);
+    expect(wordStart).toBeGreaterThan(substring);
+    expect(substring).toBeGreaterThan(0);
+  });
+
+  it("matches against keywords but ranks them below a label hit", () => {
+    const labelHit = scoreOption(opt("Aetna"), "aet");
+    const keywordHit = scoreOption(
+      opt("Anthem", { keywords: ["BCBS", "blue cross"] }),
+      "bcbs",
+    );
+    expect(keywordHit).toBeGreaterThan(0);
+    expect(labelHit).toBeGreaterThan(keywordHit);
+  });
+
+  it("treats word boundaries in codes/paths (M54.5, low-back, A/R)", () => {
+    expect(scoreOption(opt("M54.5 Low back pain"), "54")).toBeGreaterThan(0);
+    expect(scoreOption(opt("low-back"), "back")).toBeGreaterThan(0);
+    expect(scoreOption(opt("A/R aging"), "aging")).toBeGreaterThan(0);
+  });
+
+  it("ANDs multi-word queries — every token must appear", () => {
+    expect(scoreOption(opt("Low back pain"), "low pain")).toBeGreaterThan(0);
+    expect(scoreOption(opt("Low back pain"), "low knee")).toBe(-1);
+  });
+});
+
+describe("rankAutocomplete", () => {
+  const payers = [
+    opt("Aetna"),
+    opt("Anthem BCBS", { keywords: ["blue cross", "blue shield"] }),
+    opt("Cigna"),
+    opt("Humana"),
+    opt("UnitedHealthcare", { keywords: ["UHC"] }),
+  ];
+
+  it("returns the first N options verbatim for an empty query", () => {
+    const out = rankAutocomplete(payers, "", 3);
+    expect(labels(out)).toEqual(["Aetna", "Anthem BCBS", "Cigna"]);
+  });
+
+  it("defaults to the MASTER-prompt limit of 7", () => {
+    expect(AUTOCOMPLETE_DEFAULT_LIMIT).toBe(7);
+    const many = Array.from({ length: 20 }, (_, i) => opt(`Option ${i}`));
+    expect(rankAutocomplete(many, "")).toHaveLength(7);
+    expect(rankAutocomplete(many, "option")).toHaveLength(7);
+  });
+
+  it("filters to matches and caps at the limit", () => {
+    // query "an": "Anthem BCBS" (prefix) + "Humana" (substring) match;
+    // Aetna / Cigna / UnitedHealthcare have no "an".
+    const out = rankAutocomplete(payers, "an", 10);
+    expect(labels(out)).toEqual(["Anthem BCBS", "Humana"]);
+  });
+
+  it("orders a prefix match ahead of a substring match", () => {
+    // "Aging" is a label prefix of "ag"; "Repackaging" only contains it
+    // mid-word — prefix must win.
+    const out = rankAutocomplete([opt("Repackaging"), opt("Aging")], "ag");
+    expect(out[0].label).toBe("Aging");
+  });
+
+  it("breaks score ties by shorter label, then alphabetically", () => {
+    const out = rankAutocomplete(
+      [opt("Painkiller log"), opt("Pain"), opt("Painful")],
+      "pain",
+    );
+    // exact "Pain" first; remaining two are both prefix matches -> shorter
+    // ("Painful", 7) before longer ("Painkiller log", 14).
+    expect(labels(out)).toEqual(["Pain", "Painful", "Painkiller log"]);
+  });
+
+  it("never throws on an empty option list", () => {
+    expect(rankAutocomplete([], "anything")).toEqual([]);
+    expect(rankAutocomplete([], "")).toEqual([]);
+  });
+
+  it("treats limit 0 as an empty result", () => {
+    expect(rankAutocomplete(payers, "a", 0)).toEqual([]);
+  });
+});

--- a/src/lib/ui/autocomplete-match.ts
+++ b/src/lib/ui/autocomplete-match.ts
@@ -1,0 +1,124 @@
+// MASTER-prompt G3 — "every search bar / dropdown / searchable field
+// auto-populates the top page-specific matches as you type; site-specific,
+// not global." This is the pure ranking core behind <AutocompleteInput>:
+// given a page's own option list and the live query, return the best N
+// matches (default 7, per the directive). Kept framework-free and
+// side-effect-free so it is trivially unit-testable, exactly like the
+// table-export core that backs G6.
+
+export interface AutocompleteOption {
+  /** Stable value handed back to the consumer on selection. */
+  value: string;
+  /** Human-readable text shown in the field + list row. */
+  label: string;
+  /** Optional dimmer second line (e.g. a code, category, or hint). */
+  sublabel?: string;
+  /** Extra match terms that should surface the option but aren't displayed
+   *  (e.g. synonyms, an SKU, a payer id). */
+  keywords?: string[];
+  /** Rendered but not selectable / skipped by keyboard nav. */
+  disabled?: boolean;
+}
+
+/** Default match count mandated by the MASTER prompt ("top 7 matches"). */
+export const AUTOCOMPLETE_DEFAULT_LIMIT = 7;
+
+// Score tiers — higher is a stronger match. Ordering matters more than the
+// exact magnitudes; the gaps are wide so a better placement always wins
+// before length/alpha tie-breakers come into play.
+const SCORE_EXACT = 1000;
+const SCORE_LABEL_PREFIX = 500;
+const SCORE_WORD_PREFIX = 300;
+const SCORE_LABEL_SUBSTRING = 150;
+const SCORE_SUBLABEL_PREFIX = 90;
+const SCORE_KEYWORD_PREFIX = 80;
+const SCORE_SCATTERED = 40;
+
+const norm = (s: string | undefined): string =>
+  (s ?? "").toLowerCase().trim();
+
+// Split on whitespace and common label punctuation so word-boundary prefix
+// matching works against codes/paths like "M54.5", "low-back", "A/R aging".
+const WORD_SPLIT = /[\s\-/.,()[\]_]+/;
+
+function wordStartsWith(hay: string, needle: string): boolean {
+  return hay.split(WORD_SPLIT).some((w) => w.length > 0 && w.startsWith(needle));
+}
+
+function haystacks(option: AutocompleteOption): string[] {
+  return [
+    norm(option.label),
+    norm(option.sublabel),
+    ...(option.keywords ?? []).map(norm),
+  ].filter((h) => h.length > 0);
+}
+
+/**
+ * Score one option against a normalized, non-empty query.
+ * Returns a positive score for a match, or -1 for no match.
+ *
+ * A multi-word query is an AND: every token must appear somewhere in the
+ * option's text (label, sublabel, or a keyword). The headline score comes
+ * from how the *whole* query lands in the label (exact ▸ prefix ▸ word-start
+ * ▸ substring), with weaker tiers for sublabel/keyword-only and scattered
+ * token hits — so "low back" ranks "Low back pain" above a row that merely
+ * mentions "back" and "low" in separate keywords.
+ */
+export function scoreOption(option: AutocompleteOption, query: string): number {
+  const q = norm(query);
+  if (q === "") return 0;
+
+  const hays = haystacks(option);
+  const label = hays[0] ?? "";
+
+  // AND across query tokens — each must land somewhere.
+  const tokens = q.split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    if (!hays.some((h) => h.includes(token))) return -1;
+  }
+
+  if (label === q) return SCORE_EXACT;
+  if (label.startsWith(q)) return SCORE_LABEL_PREFIX;
+  if (wordStartsWith(label, q)) return SCORE_WORD_PREFIX;
+  if (label.includes(q)) return SCORE_LABEL_SUBSTRING;
+
+  const rest = hays.slice(1);
+  if (rest.some((h) => h.startsWith(q) || wordStartsWith(h, q))) {
+    return SCORE_SUBLABEL_PREFIX > SCORE_KEYWORD_PREFIX
+      ? SCORE_SUBLABEL_PREFIX
+      : SCORE_KEYWORD_PREFIX;
+  }
+  // Every token matched, but not as one contiguous run anywhere.
+  return SCORE_SCATTERED;
+}
+
+/**
+ * Rank a page's options against the live query and return the top `limit`.
+ *
+ * Empty query → the first `limit` options verbatim (the "top page-specific
+ * defaults" the field shows before the user types), preserving the caller's
+ * own ordering. Non-empty query → matches only, sorted by score, then by
+ * shorter label (more specific), then alphabetically for a stable order.
+ */
+export function rankAutocomplete(
+  options: readonly AutocompleteOption[],
+  query: string,
+  limit: number = AUTOCOMPLETE_DEFAULT_LIMIT,
+): AutocompleteOption[] {
+  const cap = Math.max(0, limit);
+  if (norm(query) === "") return options.slice(0, cap);
+
+  const scored = options
+    .map((option) => ({ option, score: scoreOption(option, query) }))
+    .filter((s) => s.score >= 0);
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const la = a.option.label.length;
+    const lb = b.option.label.length;
+    if (la !== lb) return la - lb;
+    return a.option.label.localeCompare(b.option.label);
+  });
+
+  return scored.slice(0, cap).map((s) => s.option);
+}


### PR DESCRIPTION
## What
MASTER-prompt **G3** — _"every search bar / dropdown / searchable field auto-populates the top page-specific matches as you type; site-specific, not global."_ Built as a shared primitive (mirroring the Slice-1 pattern: pure tested core + thin component + barrel), then adopted across the clean client-side `/ops` search fields.

## Primitive
- **`src/lib/ui/autocomplete-match.ts`** — pure `rankAutocomplete(options, query, limit=7)`: exact ▸ label-prefix ▸ word-start ▸ substring ▸ sublabel/keyword, multi-token AND, stable score/length/alpha tie-break. Framework-free, like `table-export.ts`. **13 vitest cases.**
- **`src/components/ui/autocomplete-input.tsx`** — accessible ARIA-1.2 combobox: `role=combobox` + `aria-expanded/controls/activedescendant`, `role=listbox`/`option`, ↑/↓/Enter/Esc, click-outside dismiss; controlled or uncontrolled; optional free-text commit.
- **`src/components/ops/master/index.ts`** — barrel re-export; G3 marked shipped (additive on top of the MetricBox exports).

## Adoption
Each keeps the existing live substring filter via `onValueChange`; the dropdown is **purely additive**, and selecting a row snaps the query to that exact match.

| Page | Surfaces top-7 of… |
|---|---|
| `vendors` | name + contact/email/category |
| `policies` | title, searchable by category + body |
| `feedback` | patient name + excerpt |
| `inventory` | product name + brand/SKU/UPC (the directive's "AI SKU search") |
| `mail-fax` | the **blind** "search patient by name" field → real top-7 patient picker |

**Skipped:** `/ops/education` — server component using a `<form method="get">` round-trip through `searchParams` + server-side `searchEducation()`; a client autocomplete would drop the server-search semantics.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean (touched files) · `vitest` **13/13**. Live browser QA pending (concurrent `next dev` → shared-`.next` 500s).

## Note on the base branch
Base is the integration-branch snapshot **at this commit's parent**, not `main`, **on purpose**: the `components/ops/master` kit + `MetricBox` don't exist on `main` yet (slice-1 PR #645 unmerged) and the shared barrel re-export ties G3 to them, so a `main`-based diff wouldn't build. This base gives an **isolated, buildable** G3 diff (exactly the 9 files). Retarget to `main` once the kit lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)