### PR TITLE
Owner Portal Revisions — G8: per-section date/param search bar + incidents proof

### DIFF
--- a/src/app/(operator)/ops/incidents/incidents-view.tsx
+++ b/src/app/(operator)/ops/incidents/incidents-view.tsx
@@ -14,6 +14,11 @@ import {
   type ActiveChip,
 } from "@/components/ui/filter-bar";
 import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
+import {
   INCIDENT_CATEGORY_LABELS,
   type IncidentCategory,
   type IncidentReport,
@@ -83,6 +88,8 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
   const [formOpen, setFormOpen] = useState(false);
   const [resolving, setResolving] = useState<IncidentReport | null>(null);
   const [resolutionNotes, setResolutionNotes] = useState("");
+  // MASTER-prompt G8 — per-section date/param/keyword filter for the log below.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
   const [draft, setDraft] = useState({
     severity: "low" as IncidentSeverity,
     category: "safety" as IncidentCategory,
@@ -106,7 +113,14 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
       if (state.patientAffectedOnly && !i.patientAffected) return false;
       return true;
     });
-    return list.sort((a, b) => {
+    const searched = sectionQuery
+      ? applySectionQuery(list, sectionQuery, {
+          getDate: (i) => i.reportedAt,
+          getText: (i) =>
+            `${i.title} ${i.description} ${INCIDENT_CATEGORY_LABELS[i.category]} ${SEVERITY_LABELS[i.severity]}`,
+        })
+      : list;
+    return searched.sort((a, b) => {
       switch (state.sort) {
         case "newest":
           return b.reportedAt.localeCompare(a.reportedAt);
@@ -118,7 +132,7 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
           return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
       }
     });
-  }, [incidents, state]);
+  }, [incidents, state, sectionQuery]);
 
   const chips: ActiveChip[] = [];
   if (state.severities.length > 0) {
@@ -281,6 +295,15 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
       </div>
 
       <FilterChips chips={chips} onRemove={removeChip} onClearAll={clearAll} />
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h2 className="text-sm font-semibold text-text">Incident log</h2>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Filter log — “last 30 days”, “critical”…"
+          aria-label="Filter incident log by date or keyword"
+        />
+      </div>
 
       <Card tone="raised">
         <div className="overflow-x-auto">

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -9,15 +9,32 @@
 //   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
 //   G6 Table send/print/download   → <DataTable exportable> + table-export utils
 //   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
+//   G8 Per-section date/param search → <SectionSearchBar> (+ parseSectionQuery)
 //   G9 Compare mode               → <MetricBoxGroup> (select ≥2 → overlay chart)
 //   G10 "click a box → popup"      → <MetricBox> (history popup + feather cycle)
 //   G11 Hover tooltips on charts   → <MetricBox> drill-in (branded chart hover)
 //
+// G4 (global "search everything") ships as the layout-mounted
+// <GlobalSearchButton> (bottom-left affordance opening the ⌘K command palette),
+// not a per-page import — see src/components/ui/global-search-button.tsx.
+//
 // Still to build (tracked, not yet shipped): global sidebar overlay/autohide
-// (G2 layered/autohide half remains; in-page-click re-open fixed via PR #648)
-// and the per-section AI search bar (G8).
+// (G2 layered/autohide half remains; in-page-click re-open fixed via PR #648).
 
 export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  SectionSearchBar,
+  type SectionSearchBarProps,
+} from "@/components/ui/section-search-bar";
+
+export {
+  parseSectionQuery,
+  applySectionQuery,
+  type SectionQuery,
+  type SectionDateRange,
+  type SectionAmountFilter,
+} from "@/lib/ui/section-query";
 
 export {
   AutocompleteInput,

--- a/src/components/ui/section-search-bar.tsx
+++ b/src/components/ui/section-search-bar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// MASTER-prompt G8 — the compact "search bar across from each section header"
+// that does chronological / parameter filtering of that section's rows. The
+// directive frames it as AI-driven (Cindy); under the hood it's the
+// deterministic parseSectionQuery() core (honest — no LLM call), so typing
+// "last 30 days > 1000 denied" filters by date AND amount AND keyword. Pair it
+// with applySectionQuery() in the consuming section.
+
+import { useMemo, useState } from "react";
+import { Sparkles, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import { parseSectionQuery, type SectionQuery } from "@/lib/ui/section-query";
+
+export interface SectionSearchBarProps {
+  /** Called with the parsed query on every keystroke. */
+  onChange: (query: SectionQuery) => void;
+  /** Reference "now" for relative ranges; captured once if omitted. */
+  now?: Date;
+  placeholder?: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function SectionSearchBar({
+  onChange,
+  now: nowProp,
+  placeholder = "Filter — try “last 30 days” or “> 1000”",
+  className,
+  "aria-label": ariaLabel = "Filter this section by date, amount, or keyword",
+}: SectionSearchBarProps) {
+  const [text, setText] = useState("");
+  // Stable reference instant so relative windows don't drift each keystroke.
+  const [now] = useState(() => nowProp ?? new Date());
+
+  const query = useMemo(() => parseSectionQuery(text, now), [text, now]);
+
+  const update = (value: string) => {
+    setText(value);
+    onChange(parseSectionQuery(value, now));
+  };
+
+  const chips: string[] = [];
+  if (query.dateRange) chips.push(query.dateRange.label);
+  if (query.amount) chips.push(`${query.amount.op} ${query.amount.value}`);
+
+  return (
+    <div className={cn("flex flex-col items-end gap-1", className)}>
+      <div className="relative w-full sm:w-64">
+        <Sparkles
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-accent/70"
+          aria-hidden="true"
+        />
+        <Input
+          type="text"
+          value={text}
+          onChange={(e) => update(e.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className="h-9 pl-8 pr-8 text-sm"
+        />
+        {text && (
+          <button
+            type="button"
+            onClick={() => update("")}
+            aria-label="Clear section filter"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-text-subtle hover:text-text"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      {chips.length > 0 && (
+        <div className="flex flex-wrap justify-end gap-1">
+          {chips.map((c) => (
+            <span
+              key={c}
+              className="inline-flex items-center rounded-full bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ui/section-query.test.ts
+++ b/src/lib/ui/section-query.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSectionQuery,
+  applySectionQuery,
+  type SectionQuery,
+} from "./section-query";
+
+// Fixed reference point for deterministic relative-date parsing.
+// 2026-06-12 is a Friday.
+const NOW = new Date(2026, 5, 12, 14, 30, 0);
+
+// Format using LOCAL components — the parser builds local-midnight dates, so
+// toISOString() (UTC) would roll end-of-day across the date line on machines
+// behind UTC.
+const pad = (n: number) => String(n).padStart(2, "0");
+const iso = (d?: Date) =>
+  d ? `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` : undefined;
+
+describe("parseSectionQuery — amounts", () => {
+  it("parses comparators with optional $ and commas", () => {
+    expect(parseSectionQuery("> 1000").amount).toEqual({ op: ">", value: 1000 });
+    expect(parseSectionQuery("<= $1,250.50").amount).toEqual({ op: "<=", value: 1250.5 });
+    expect(parseSectionQuery("= 0").amount).toEqual({ op: "=", value: 0 });
+  });
+
+  it("leaves remaining words as terms", () => {
+    const q = parseSectionQuery("denied > 1000");
+    expect(q.amount).toEqual({ op: ">", value: 1000 });
+    expect(q.terms).toEqual(["denied"]);
+  });
+});
+
+describe("parseSectionQuery — relative dates", () => {
+  it("'last 30 days' spans 30 days back through end of today", () => {
+    const q = parseSectionQuery("last 30 days", NOW);
+    expect(q.dateRange?.label).toBe("last 30 days");
+    expect(iso(q.dateRange?.from)).toBe("2026-05-13");
+    expect(q.dateRange?.to?.getDate()).toBe(12);
+  });
+
+  it("'today' and 'yesterday' resolve to single days", () => {
+    expect(iso(parseSectionQuery("today", NOW).dateRange?.from)).toBe("2026-06-12");
+    expect(iso(parseSectionQuery("yesterday", NOW).dateRange?.from)).toBe("2026-06-11");
+    expect(iso(parseSectionQuery("yesterday", NOW).dateRange?.to)).toBe("2026-06-11");
+  });
+
+  it("'this month' / 'this year' / 'ytd' start at the period boundary", () => {
+    expect(iso(parseSectionQuery("this month", NOW).dateRange?.from)).toBe("2026-06-01");
+    expect(iso(parseSectionQuery("this year", NOW).dateRange?.from)).toBe("2026-01-01");
+    expect(parseSectionQuery("ytd", NOW).dateRange?.label).toBe("year to date");
+    expect(iso(parseSectionQuery("ytd", NOW).dateRange?.from)).toBe("2026-01-01");
+  });
+
+  it("'this quarter' starts at the quarter boundary (Q2 for June)", () => {
+    expect(iso(parseSectionQuery("this quarter", NOW).dateRange?.from)).toBe("2026-04-01");
+  });
+
+  it("shorthand 'last month' = 30-day window", () => {
+    expect(iso(parseSectionQuery("last month", NOW).dateRange?.from)).toBe("2026-05-13");
+  });
+});
+
+describe("parseSectionQuery — explicit dates", () => {
+  it("after / since / before set open-ended bounds", () => {
+    const after = parseSectionQuery("since 2026-03-01", NOW);
+    expect(iso(after.dateRange?.from)).toBe("2026-03-01");
+    expect(after.dateRange?.to).toBeUndefined();
+
+    const before = parseSectionQuery("before 2026-03-01", NOW);
+    expect(before.dateRange?.to && iso(before.dateRange.to)).toBe("2026-03-01");
+    expect(before.dateRange?.from).toBeUndefined();
+  });
+
+  it("an explicit range binds both ends", () => {
+    const q = parseSectionQuery("2026-01-01 to 2026-02-15", NOW);
+    expect(iso(q.dateRange?.from)).toBe("2026-01-01");
+    expect(iso(q.dateRange?.to)).toBe("2026-02-15");
+  });
+
+  it("a bare ISO date filters that single day", () => {
+    const q = parseSectionQuery("2026-04-09", NOW);
+    expect(iso(q.dateRange?.from)).toBe("2026-04-09");
+    expect(iso(q.dateRange?.to)).toBe("2026-04-09");
+  });
+});
+
+describe("parseSectionQuery — composition & empties", () => {
+  it("combines date + amount + terms", () => {
+    const q = parseSectionQuery("aetna denied last 7 days > 500", NOW);
+    expect(q.amount).toEqual({ op: ">", value: 500 });
+    expect(q.dateRange?.label).toBe("last 7 days");
+    expect(q.terms.sort()).toEqual(["aetna", "denied"]);
+    expect(q.isEmpty).toBe(false);
+  });
+
+  it("flags an empty query", () => {
+    expect(parseSectionQuery("   ", NOW).isEmpty).toBe(true);
+    expect(parseSectionQuery("", NOW).terms).toEqual([]);
+  });
+});
+
+interface Row {
+  payer: string;
+  date: string;
+  amount: number;
+}
+const rows: Row[] = [
+  { payer: "Aetna", date: "2026-06-10", amount: 1200 },
+  { payer: "Cigna", date: "2026-05-01", amount: 300 },
+  { payer: "Aetna", date: "2026-01-15", amount: 50 },
+];
+const accessors = {
+  getDate: (r: Row) => r.date,
+  getAmount: (r: Row) => r.amount,
+  getText: (r: Row) => r.payer,
+};
+
+describe("applySectionQuery", () => {
+  const run = (raw: string): Row[] =>
+    applySectionQuery(rows, parseSectionQuery(raw, NOW), accessors);
+
+  it("returns all rows for an empty query", () => {
+    expect(run("")).toHaveLength(3);
+  });
+
+  it("filters by term", () => {
+    expect(run("aetna").map((r) => r.amount).sort((a, b) => a - b)).toEqual([50, 1200]);
+  });
+
+  it("filters by amount comparator", () => {
+    expect(run("> 500")).toEqual([rows[0]]);
+  });
+
+  it("filters by date range (last 60 days excludes the January row)", () => {
+    const out = run("last 60 days");
+    expect(out.map((r) => r.date)).toEqual(["2026-06-10", "2026-05-01"]);
+  });
+
+  it("ANDs all facets together", () => {
+    expect(run("aetna last 60 days > 500")).toEqual([rows[0]]);
+  });
+
+  it("excludes rows missing the facet data", () => {
+    const q: SectionQuery = parseSectionQuery("> 100", NOW);
+    const out = applySectionQuery(rows, q, { getAmount: () => null });
+    expect(out).toHaveLength(0);
+  });
+});

--- a/src/lib/ui/section-query.ts
+++ b/src/lib/ui/section-query.ts
@@ -1,0 +1,245 @@
+// MASTER-prompt G8 — the per-section search bar "across from each section
+// header" that does chronological / parameter filtering. The directive frames
+// it as "AI-driven (Cindy)", but the honest, deterministic core is a small
+// natural-language parser: it turns a typed phrase like
+//   "last 30 days denied > 1000"
+// into a structured { dateRange, amount, terms } filter the section applies to
+// its own rows. No LLM call — predictable, testable, and offline. (Kept pure
+// and framework-free, like the G3 rankAutocomplete / G6 table-export cores.)
+
+export type AmountOp = ">" | ">=" | "<" | "<=" | "=";
+
+export interface SectionAmountFilter {
+  op: AmountOp;
+  value: number;
+}
+
+export interface SectionDateRange {
+  /** Inclusive lower bound (undefined = open). */
+  from?: Date;
+  /** Inclusive upper bound (undefined = open). */
+  to?: Date;
+  /** Human-readable chip label, e.g. "last 30 days". */
+  label: string;
+}
+
+export interface SectionQuery {
+  raw: string;
+  /** Free-text words left after date/amount phrases are removed. */
+  terms: string[];
+  dateRange?: SectionDateRange;
+  amount?: SectionAmountFilter;
+  /** True when nothing meaningful was parsed (no date, amount, or terms). */
+  isEmpty: boolean;
+}
+
+const DAY_MS = 86_400_000;
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function endOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+function daysBefore(now: Date, n: number): Date {
+  return new Date(startOfDay(now).getTime() - n * DAY_MS);
+}
+function startOfWeek(d: Date): Date {
+  // Week starts Monday.
+  const x = startOfDay(d);
+  const diff = (x.getDay() + 6) % 7;
+  return new Date(x.getTime() - diff * DAY_MS);
+}
+function isoToLocalDate(iso: string): Date {
+  // Parse YYYY-MM-DD as a LOCAL date (not UTC) so day boundaries match what
+  // the user sees in the section.
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// Relative "last/past <N> <unit>" and shorthand windows → day counts.
+const NAMED_WINDOW_DAYS: Record<string, number> = {
+  week: 7,
+  month: 30,
+  quarter: 90,
+  year: 365,
+};
+
+/**
+ * Parse a section search phrase into a structured filter. `now` is injected so
+ * relative ranges ("last 30 days") are deterministic and testable.
+ */
+export function parseSectionQuery(raw: string, now: Date = new Date()): SectionQuery {
+  let work = ` ${raw.toLowerCase()} `;
+  let dateRange: SectionDateRange | undefined;
+  let amount: SectionAmountFilter | undefined;
+
+  const consume = (re: RegExp): RegExpMatchArray | null => {
+    const m = work.match(re);
+    if (m) work = work.replace(m[0], " ");
+    return m;
+  };
+
+  // --- amount comparator: > 1000, <= $50, = 0 ------------------------------
+  const amt = consume(/([<>]=?|=)\s*\$?\s*([\d,]+(?:\.\d+)?)/);
+  if (amt) {
+    amount = { op: amt[1] as AmountOp, value: Number(amt[2].replace(/,/g, "")) };
+  }
+
+  // --- explicit ISO range: 2026-01-01..2026-02-01 / "A to B" ---------------
+  let m = consume(/(\d{4}-\d{2}-\d{2})\s*(?:\.\.|to|–|-)\s*(\d{4}-\d{2}-\d{2})/);
+  if (m) {
+    dateRange = {
+      from: startOfDay(isoToLocalDate(m[1])),
+      to: endOfDay(isoToLocalDate(m[2])),
+      label: `${m[1]} → ${m[2]}`,
+    };
+  }
+
+  // --- after / since / from DATE ------------------------------------------
+  if (!dateRange && (m = consume(/(?:after|since|from)\s+(\d{4}-\d{2}-\d{2})/))) {
+    dateRange = { from: startOfDay(isoToLocalDate(m[1])), label: `since ${m[1]}` };
+  }
+  // --- before / until DATE -------------------------------------------------
+  if (!dateRange && (m = consume(/(?:before|until)\s+(\d{4}-\d{2}-\d{2})/))) {
+    dateRange = { to: endOfDay(isoToLocalDate(m[1])), label: `before ${m[1]}` };
+  }
+
+  // --- relative "last/past N days|weeks|months|years" ----------------------
+  if (!dateRange && (m = consume(/(?:last|past)\s+(\d+)\s+(day|week|month|year)s?/))) {
+    const n = Number(m[1]);
+    const unitDays = m[2] === "day" ? 1 : NAMED_WINDOW_DAYS[m[2]];
+    dateRange = {
+      from: daysBefore(now, n * unitDays),
+      to: endOfDay(now),
+      label: `last ${n} ${m[2]}${n === 1 ? "" : "s"}`,
+    };
+  }
+
+  // --- "today" / "yesterday" ----------------------------------------------
+  if (!dateRange && consume(/\byesterday\b/)) {
+    const y = daysBefore(now, 1);
+    dateRange = { from: y, to: endOfDay(y), label: "yesterday" };
+  }
+  if (!dateRange && consume(/\btoday\b/)) {
+    dateRange = { from: startOfDay(now), to: endOfDay(now), label: "today" };
+  }
+
+  // --- "this week|month|quarter|year" / "ytd" ------------------------------
+  if (!dateRange && consume(/\bthis\s+week\b/)) {
+    dateRange = { from: startOfWeek(now), to: endOfDay(now), label: "this week" };
+  }
+  if (!dateRange && consume(/\bthis\s+month\b/)) {
+    dateRange = {
+      from: new Date(now.getFullYear(), now.getMonth(), 1),
+      to: endOfDay(now),
+      label: "this month",
+    };
+  }
+  if (!dateRange && consume(/\bthis\s+quarter\b/)) {
+    const q = Math.floor(now.getMonth() / 3);
+    dateRange = {
+      from: new Date(now.getFullYear(), q * 3, 1),
+      to: endOfDay(now),
+      label: "this quarter",
+    };
+  }
+  if (!dateRange && consume(/\b(?:this\s+year|ytd)\b/)) {
+    dateRange = {
+      from: new Date(now.getFullYear(), 0, 1),
+      to: endOfDay(now),
+      label: "year to date",
+    };
+  }
+
+  // --- shorthand "last week|month|quarter|year" ----------------------------
+  if (!dateRange && (m = consume(/(?:last|past)\s+(week|month|quarter|year)\b/))) {
+    const days = NAMED_WINDOW_DAYS[m[1]];
+    dateRange = { from: daysBefore(now, days), to: endOfDay(now), label: `last ${m[1]}` };
+  }
+
+  // --- bare ISO date → that single day ------------------------------------
+  if (!dateRange && (m = consume(/(\d{4}-\d{2}-\d{2})/))) {
+    const d = isoToLocalDate(m[1]);
+    dateRange = { from: startOfDay(d), to: endOfDay(d), label: m[1] };
+  }
+
+  const terms = work
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
+  return {
+    raw,
+    terms,
+    dateRange,
+    amount,
+    isEmpty: !dateRange && !amount && terms.length === 0,
+  };
+}
+
+export interface SectionQueryAccessors<T> {
+  /** Row's date for chronological filtering. Return null to never match a range. */
+  getDate?: (row: T) => Date | string | null | undefined;
+  /** Row's numeric value for amount comparators. */
+  getAmount?: (row: T) => number | null | undefined;
+  /** Row's searchable text for the free terms (joined, lower-cased internally). */
+  getText?: (row: T) => string;
+}
+
+function inRange(date: Date, range: SectionDateRange): boolean {
+  if (range.from && date < range.from) return false;
+  if (range.to && date > range.to) return false;
+  return true;
+}
+
+function compareAmount(value: number, f: SectionAmountFilter): boolean {
+  switch (f.op) {
+    case ">":
+      return value > f.value;
+    case ">=":
+      return value >= f.value;
+    case "<":
+      return value < f.value;
+    case "<=":
+      return value <= f.value;
+    case "=":
+      return value === f.value;
+  }
+}
+
+/**
+ * Apply a parsed SectionQuery to a row list. Each active facet (date, amount,
+ * terms) is an AND; terms themselves are an AND across the row's text. Rows
+ * missing the data a facet needs are excluded from that facet.
+ */
+export function applySectionQuery<T>(
+  rows: readonly T[],
+  query: SectionQuery,
+  accessors: SectionQueryAccessors<T>,
+): T[] {
+  if (query.isEmpty) return [...rows];
+  const { getDate, getAmount, getText } = accessors;
+
+  return rows.filter((row) => {
+    if (query.dateRange && getDate) {
+      const raw = getDate(row);
+      if (raw == null) return false;
+      const d = raw instanceof Date ? raw : new Date(raw);
+      if (Number.isNaN(d.getTime()) || !inRange(d, query.dateRange)) return false;
+    }
+    if (query.amount && getAmount) {
+      const v = getAmount(row);
+      if (v == null || !compareAmount(v, query.amount)) return false;
+    }
+    if (query.terms.length > 0 && getText) {
+      const hay = getText(row).toLowerCase();
+      if (!query.terms.every((t) => hay.includes(t))) return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
## What
MASTER-prompt **G8** — _"a search bar across from each section header; chronological / parameter filtering, AI-driven (Cindy)."_ Built **honestly** — the "AI" is a deterministic NL parser, not an LLM call — mirroring the G3/G6 pure-core pattern.

## Primitive
- **`src/lib/ui/section-query.ts`** — pure `parseSectionQuery(raw, now)` turning a phrase (`"last 30 days denied > 1000"`) into `{ dateRange, amount, terms }`:
  - relative windows (`last N days/weeks/…`, `this week/month/quarter`, `today`, `yesterday`, `ytd`)
  - explicit `after`/`before`/`since` + ISO ranges + bare ISO dates
  - amount comparators (`>` `>=` `<` `<=` `=`)
  - plus generic `applySectionQuery(rows, q, accessors)` (date/amount/terms AND-ed). `now` is injected for determinism. **18 vitest cases.**
- **`src/components/ui/section-search-bar.tsx`** — compact header-right input (Sparkles affordance for "Cindy") that parses on keystroke and renders active-filter chips; captures a stable `now` so relative windows don't drift.
- **`src/components/ops/master/index.ts`** — barrel exports (G8 marked shipped; G4 noted as the layout-mounted affordance).

## Proof adoption
`ops/incidents` — an **"Incident log"** section header with the bar across from it, filtering `reportedAt` (date) + title/description/category/severity (keyword) via `applySectionQuery`.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean · `vitest` **18/18** (31/31 with G3).

## Base branch
Stacked on the **G4** PR branch (#660) — the shared `components/ops/master` barrel ties these slices together and isn't on `main` yet. Diff is exactly the 5 G8 files. Retarget down the stack to `main` as the prior slices merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)