### PR TITLE
ops/waitlist — branded ConfirmDialog for Remove (replace native confirm)

### DIFF
--- a/src/app/(operator)/ops/waitlist/waitlist-table.tsx
+++ b/src/app/(operator)/ops/waitlist/waitlist-table.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useTransition } from "react";
 import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils/cn";
 import { offerSlotAction, removeFromWaitlistAction } from "./actions";
 
@@ -93,6 +94,7 @@ function Row({ row, stripe }: { row: WaitlistRow; stripe: boolean }) {
   const [pending, startTransition] = useTransition();
   const [feedback, setFeedback] = useState<string | null>(null);
 
+  const confirm = useConfirm();
   const handleOffer = () => {
     setFeedback(null);
     startTransition(async () => {
@@ -100,8 +102,15 @@ function Row({ row, stripe }: { row: WaitlistRow; stripe: boolean }) {
       setFeedback(r.ok ? `Offer sent (${r.batchSize} in this stagger)` : r.error);
     });
   };
-  const handleRemove = () => {
-    if (!confirm(`Remove ${row.name} from the waitlist?`)) return;
+  const handleRemove = async () => {
+    const ok = await confirm({
+      title: `Remove ${row.name} from the waitlist?`,
+      description:
+        "They'll be taken off the waitlist. You can re-add them later if needed.",
+      severity: "danger",
+      confirmLabel: "Remove",
+    });
+    if (!ok) return;
     startTransition(async () => {
       const r = await removeFromWaitlistAction({ patientId: row.id });
       if (!r.ok) setFeedback(r.error);


### PR DESCRIPTION
## What

`ops/waitlist` — replace the native `window.confirm()` on the "Remove from waitlist" action with the branded `ConfirmDialog` (`useConfirm`).

`handleRemove` now `await confirm({ severity: "danger", confirmLabel: "Remove", … })` — focus-trapped, Esc/backdrop-cancellable, theme-consistent — before firing `removeFromWaitlistAction`.

This was the **only remaining native `confirm()` in `/ops`**; `queue-board` and `mission-control` already use `useConfirm`, so this brings the waitlist in line. The `ConfirmDialog` primitive exists precisely to replace inaccessible/unthemed `window.confirm`.

## Dependencies

None on the `ops/master` kit — targets `main` directly (cherry-picked from `a4f615dd`, zero conflicts).

## Verified

`tsc --noEmit` + `eslint` clean. **Could not exercise the dialog live** — the dev seed has an empty waitlist ("Nobody on the waitlist yet"), so no Remove button renders. The change mirrors the already-shipped `useConfirm` danger pattern in `queue-board.tsx` / `mission-control-client.tsx` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
