### PR TITLE
fix(clinic): Dr-Live polish — sign-off badge rollup, chart tab title, hide cookie banner in EMR

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/page.tsx
@@ -129,6 +129,11 @@ interface PageProps {
    Page component — server-side data fetch + render
    ═══════════════════════════════════════════════════════════════════ */
 
+// PHI-free tab title — deliberately generic so a patient's name never lands in
+// the browser tab or history. Replaces the default marketing title
+// ("Leafjourney — Modern cannabis care") this route was inheriting.
+export const metadata = { title: "Patient Chart" };
+
 export default async function PatientChartPage({ params, searchParams }: PageProps) {
   const user = await requireUser();
   const tab = (searchParams.tab as TabKey) || "demographics";

--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -101,11 +101,12 @@ export default async function ClinicianLayout({
     labsPendingCount,
     labsAbnormalCount,
     refillsPendingCount,
+    notesPendingCount,
   ] = await (async () => {
     const orgId = user.organizationId;
     // The sign-off badge counts are clinical workload signals — skip the
     // queries entirely for roles that can't see the sign-off queue.
-    if (!orgId || !canReadNotes) return [0, 0, 0, 0, 0] as const;
+    if (!orgId || !canReadNotes) return [0, 0, 0, 0, 0, 0] as const;
     return Promise.all([
       safeCount(() =>
         prisma.message.count({
@@ -147,8 +148,25 @@ export default async function ClinicianLayout({
           },
         })
       ),
+      // Notes awaiting signature — completes the sign-off rollup so the
+      // Inbox-rail badge matches the /clinic/sign-off hub total. Query must
+      // mirror sign-off/layout.tsx (noteTotal).
+      safeCount(() =>
+        prisma.note.count({
+          where: {
+            status: "needs_review",
+            encounter: { patient: { organizationId: orgId } },
+          },
+        })
+      ),
     ]);
   })();
+
+  // Unified sign-off rollup (AI-drafted messages + labs + refills + notes) so
+  // the Inbox-rail "Sign-off" badge matches the /clinic/sign-off hub's "All
+  // items" total. Passing pendingCount (messages only) under-counted it.
+  const signOffPending =
+    pendingCount + labsPendingCount + refillsPendingCount + notesPendingCount;
 
   const sections: NavSection[] = [
     {
@@ -193,7 +211,7 @@ export default async function ClinicianLayout({
               {
                 label: "Sign-off",
                 href: "/clinic/sign-off",
-                badge: computeApprovalsBadge({ pendingCount, emergencyCount }), // Or a combined badge
+                badge: computeApprovalsBadge({ pendingCount: signOffPending, emergencyCount }),
               },
               // EMR-915: kiosk→phone lobby intake/consent waiting to be accepted into the chart.
               { label: "Lobby submissions", href: "/clinic/lobby-submissions" },

--- a/src/components/layout/CookieConsent.tsx
+++ b/src/components/layout/CookieConsent.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 const STORAGE_KEY = "leafjourney-cookie-consent";
 
+// Authenticated app surfaces + the full-bleed Leafnerd SPA. The cookie-consent
+// banner is a public-visitor compliance element; inside the logged-in EMR it
+// just overlays clinical/ops/patient work and looks unprofessional in a live
+// demo. It still shows on public marketing / storefront / education pages.
+const SUPPRESS_PREFIXES = ["/clinic", "/ops", "/portal", "/kiosk", "/leafnerd"];
+
 export function CookieConsent() {
   const [show, setShow] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     // SSR safety: localStorage is only on the client.
@@ -36,6 +44,10 @@ export function CookieConsent() {
     }
     setShow(false);
   };
+
+  if (pathname && SUPPRESS_PREFIXES.some((p) => pathname.startsWith(p))) {
+    return null;
+  }
 
   if (!show) return null;
 


### PR DESCRIPTION
Three small reliability/polish fixes surfaced during the Dr-Live clinical-encounter smoke (the deferred "Also noted" items).

## 1. Sign-off badge under-counted (same drift class as the roster fix)
The Inbox-rail **Sign-off** badge showed only AI-drafted **messages** (e.g. "1 pending"), while the `/clinic/sign-off` hub rolls up labs + refills + notes + messages ("All items 3"). The rail *already fetched* the labs/refills counts but never summed them — the `// Or a combined badge` comment was a literal half-done TODO. **Fix:** add the missing notes count and pass the full total; the query mirrors `sign-off/layout.tsx` so the two views agree.

## 2. Patient-chart tab title
The chart route inherited the default marketing title *"Leafjourney — Modern cannabis care."* **Fix:** `export const metadata = { title: "Patient Chart" }` — deliberately PHI-free so a patient's name never lands in the browser tab/history.

## 3. Cookie banner overlaying the EMR
The cookie-consent banner rendered on every authenticated page (it overlays clinical work and looks unprofessional in a live demo). **Fix:** suppress it on the app surfaces (`/clinic`, `/ops`, `/portal`, `/kiosk`, `/leafnerd`); it still shows on public marketing / storefront / education pages for compliance.

## Verification
- eslint clean on all 3 files.
- Local whole-repo typecheck: the only errors are pre-existing `portal/*` (`treatmentGoal`/`sideEffects`) noise from a stale generated Prisma client in the worktree's symlinked node_modules — **none in the changed files**. CI runs `prisma generate` fresh (authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)