### PR TITLE
Owner Portal Revisions — G2 sidebar overlay/autohide + G4/G8 adoption

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -10,6 +10,7 @@ import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { BreathingBreak } from "@/components/clinical/BreathingBreak";
 import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { GlobalSearchButton } from "@/components/ui/global-search-button";
 import { ConsciousnessOverlay } from "@/components/ui/consciousness-overlay";
 import { ClinicianTour } from "@/components/onboarding/clinician-tour";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
@@ -205,6 +206,7 @@ export default async function ClinicianLayout({
       <BreathingBreak />
       <KeyboardShortcuts />
       <CommandPalette role="clinician" userId={user.id} />
+      <GlobalSearchButton />
       <ConsciousnessOverlay />
       <ClinicianTour autoStart={!isDemoSurface} />
       <InstallPrompt />

--- a/src/app/(operator)/ops/announcements/announcements-view.tsx
+++ b/src/app/(operator)/ops/announcements/announcements-view.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input, Textarea } from "@/components/ui/input";
 import { LinkifiedText } from "@/components/ui/linkified-text";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 export type AnnouncementCategory = "Clinical" | "Ops" | "Celebrations" | "Reminders";
@@ -48,6 +53,8 @@ export function AnnouncementsView({
 }) {
   const [items, setItems] = useState<Announcement[]>(initialAnnouncements);
   const [filter, setFilter] = useState<"all" | AnnouncementCategory>("all");
+  // MASTER-prompt G8 — per-section date/keyword filter for the feed below.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
   const [composeOpen, setComposeOpen] = useState(false);
   const [draft, setDraft] = useState({
     title: "",
@@ -59,11 +66,17 @@ export function AnnouncementsView({
 
   const visible = useMemo(() => {
     const filtered = filter === "all" ? items : items.filter((i) => i.category === filter);
-    return [...filtered].sort((a, b) => {
+    const searched = sectionQuery
+      ? applySectionQuery(filtered, sectionQuery, {
+          getDate: (a) => a.createdAt,
+          getText: (a) => `${a.title} ${a.body} ${a.category}`,
+        })
+      : filtered;
+    return [...searched].sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       return b.createdAt.localeCompare(a.createdAt);
     });
-  }, [items, filter]);
+  }, [items, filter, sectionQuery]);
 
   function react(id: string, emoji: string) {
     setItems((prev) =>
@@ -136,6 +149,15 @@ export function AnnouncementsView({
         <Button size="sm" onClick={() => setComposeOpen(true)}>
           Post announcement
         </Button>
+      </div>
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h2 className="text-sm font-semibold text-text">Announcements</h2>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Filter — “last 30 days”, “reminder”…"
+          aria-label="Filter announcements by date or keyword"
+        />
       </div>
 
       <div className="space-y-4">

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -6,6 +6,7 @@ import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { homeForRoles } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { GlobalSearchButton } from "@/components/ui/global-search-button";
 import { ChatCBInterface } from "@/components/ask-cindy/ChatCBInterface";
 import { PortalCustomizationProvider } from "@/components/portal/portal-customization-provider";
 import { ConfettiCanvas } from "@/components/portal/confetti-canvas";
@@ -133,6 +134,7 @@ export default async function PatientLayout({
       >
         <QuoteWelcomeModal userName={user.firstName} />
         <CommandPalette role="patient" userId={user.id} />
+        <GlobalSearchButton />
         <ChatCBInterface />
         <ConfettiCanvas />
         <InstallPrompt />

--- a/src/components/shell/ContextDrawer.tsx
+++ b/src/components/shell/ContextDrawer.tsx
@@ -11,10 +11,12 @@ export interface ContextDrawerProps {
   pathname: string;
   onClose: () => void;
   pinned: boolean;
+  /** True when overlay is forced by a narrow viewport (G2) — pinning is N/A. */
+  narrow?: boolean;
   onTogglePin: () => void;
 }
 
-export function ContextDrawer({ section, pathname, onClose, pinned, onTogglePin }: ContextDrawerProps) {
+export function ContextDrawer({ section, pathname, onClose, pinned, narrow = false, onTogglePin }: ContextDrawerProps) {
   const open = section !== null;
   const ref = React.useRef<HTMLDivElement | null>(null);
 
@@ -103,25 +105,29 @@ export function ContextDrawer({ section, pathname, onClose, pinned, onTogglePin 
             </ul>
           </nav>
           
-          {/* Monday.com-style Pin Footer */}
-          <div className="mt-auto border-t border-border/80 p-3">
-            <button
-              type="button"
-              onClick={onTogglePin}
-              className="flex w-full items-center justify-center gap-2 rounded-md bg-surface-muted/50 py-2 text-xs font-medium text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className={cn("transition-transform duration-200", !pinned && "rotate-45")}
+          {/* Monday.com-style Pin Footer. Hidden when a narrow viewport forces
+              overlay mode (G2) — pinning the drawer into the layout isn't an
+              option until the window widens again. */}
+          {!narrow && (
+            <div className="mt-auto border-t border-border/80 p-3">
+              <button
+                type="button"
+                onClick={onTogglePin}
+                className="flex w-full items-center justify-center gap-2 rounded-md bg-surface-muted/50 py-2 text-xs font-medium text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
               >
-                <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
-              </svg>
-              {pinned ? "Collapse sidebar" : "Pin sidebar"}
-            </button>
-          </div>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className={cn("transition-transform duration-200", !pinned && "rotate-45")}
+                >
+                  <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
+                </svg>
+                {pinned ? "Collapse sidebar" : "Pin sidebar"}
+              </button>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/shell/MobileNav.tsx
+++ b/src/components/shell/MobileNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 import { NavSections } from "./NavSections";
 import type { NavItem, NavSection } from "./nav-sections";
@@ -17,6 +18,7 @@ interface MobileNavProps {
 
 export function MobileNav({ sections, nav }: MobileNavProps) {
   const [open, setOpen] = React.useState(false);
+  const pathname = usePathname();
 
   const resolved: NavSection[] = React.useMemo(() => {
     if (sections && sections.length > 0) return sections;
@@ -26,6 +28,18 @@ export function MobileNav({ sections, nav }: MobileNavProps) {
 
   // Close drawer on route change (link click)
   const closeDrawer = () => setOpen(false);
+
+  // MASTER-prompt G2 — autohide on EVERY navigation, including browser
+  // back/forward, which a link-click handler alone wouldn't catch. usePathname
+  // updates on all of them, so collapse whenever the route changes.
+  const firstPath = React.useRef(true);
+  React.useEffect(() => {
+    if (firstPath.current) {
+      firstPath.current = false;
+      return;
+    }
+    setOpen(false);
+  }, [pathname]);
 
   // Lock body scroll when drawer is open
   React.useEffect(() => {

--- a/src/components/shell/PillarNav.tsx
+++ b/src/components/shell/PillarNav.tsx
@@ -54,19 +54,48 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
     }
   };
 
-  // Open the active pillar's drawer ONLY when the route's pillar actually
-  // changes (a real navigation). A same-route re-render — e.g. a server action
-  // revalidating the page, which hands PillarNav a fresh `sections` array
-  // reference — must NOT re-open a drawer the user just collapsed. That was the
-  // "sidebar pops back open when I click Log / Add / Delete / Generate" bug
-  // (Owner Portal Revisions, MASTER prompt G2).
+  // MASTER-prompt G2 — when the viewport is narrowed / split to half-screen the
+  // sidebar must OVERLAY content (float above it) instead of squeezing it into
+  // a column, regardless of the pin preference. Below `lg` we force the
+  // drawer's existing unpinned/overlay mode; at `lg`+ the stored pin choice is
+  // respected, so wide-screen layout is byte-for-byte unchanged.
+  const [narrow, setNarrow] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(min-width: 768px) and (max-width: 1023.98px)");
+    const update = () => setNarrow(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  const effectivePinned = pinned && !narrow;
+
+  // Wide + pinned: follow the route — open the drawer for the pillar you
+  // navigated into, but ONLY when the route's pillar actually CHANGES (a real
+  // navigation). A same-route re-render — e.g. a server action revalidating the
+  // page, which hands PillarNav a fresh `sections` array reference — must NOT
+  // re-open a drawer the user just collapsed. That was the "sidebar pops back
+  // open when I click Log / Add / Delete / Generate" bug (MASTER prompt G2, PR #648).
   const prevPathPillar = React.useRef<string | null>(pathPillar);
   React.useEffect(() => {
-    if (pathPillar && pathPillar !== prevPathPillar.current) {
+    if (effectivePinned && pathPillar && pathPillar !== prevPathPillar.current) {
       setActivePillar(pathPillar);
     }
     prevPathPillar.current = pathPillar;
-  }, [pathPillar]);
+  }, [pathPillar, effectivePinned]);
+
+  // Overlay mode (narrow or unpinned): autohide on EVERY navigation, including
+  // browser back/forward (both surface as a pathname change). Keyed on
+  // `pathname`, not `pathPillar`, so even same-pillar navigation collapses the
+  // floating drawer. A same-route revalidation leaves `pathname` unchanged, so
+  // this never fires spuriously — PR #648 stays fixed in overlay mode too.
+  const prevPathname = React.useRef<string>(pathname);
+  React.useEffect(() => {
+    if (!effectivePinned && pathname !== prevPathname.current) {
+      setActivePillar(null);
+    }
+    prevPathname.current = pathname;
+  }, [pathname, effectivePinned]);
 
   // On mount only: if the current route isn't under any pillar, restore the
   // last-used pillar so the drawer isn't empty on a neutral landing page.
@@ -132,7 +161,8 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
         section={activeSection}
         pathname={pathname}
         onClose={() => setActivePillar(null)}
-        pinned={pinned}
+        pinned={effectivePinned}
+        narrow={narrow}
         onTogglePin={handleTogglePin}
       />
     </div>


### PR DESCRIPTION
Three follow-on slices for the MASTER-prompt UI law, bundled (contiguous commits).

## G2 — sidebar overlay-when-narrowed + autohide-on-navigation
Closes the two G2 halves deferred from #648 (which only fixed "don't re-open on in-page button click"), **without changing the intentional wide-screen design**.

Key realization: overlay mode **already exists** — `ContextDrawer` renders `absolute z-50 shadow` (floating over content) when unpinned vs `relative w-60` (in-flow) when pinned. So this is *gating*, not a rebuild:
- **`PillarNav`** — a `matchMedia` for the narrow-desktop band (768–1023px, i.e. a half-screen split) forces overlay mode regardless of the stored pin preference (`effectivePinned = pinned && !narrow`). At `lg`+ the pin choice is respected → **wide-screen layout unchanged**.
- **Autohide on navigation** — the route-following "open the matching pillar" effect now runs only when `effectivePinned`; in overlay mode a second effect collapses the drawer on every `pathname` change, **including browser back/forward**. Keyed on `pathname` (not pillar) so same-pillar nav also autohides. A same-route revalidation leaves `pathname` unchanged → **#648 stays fixed** in overlay mode too.
- **`ContextDrawer`** — new optional `narrow` prop hides the pin toggle when overlay is forced.
- **`MobileNav`** — autohide on every navigation incl. back/forward via `usePathname` (previously only link-click + Escape).

**Product decision encoded:** route-following persists for wide/pinned; overlay+autohide for narrow/unpinned — across all 3 portals (shared shell), but wide-screen is a no-op everywhere. The `lg` threshold is a one-line change.

## G4 adoption — global search in the other two shells
Mounts `<GlobalSearchButton/>` (shipped on operator in #660) into the **clinician** and **patient** layouts, so the bottom-left "search everything" affordance is present on every portal (palette is already role-scoped per layout).

## G8 adoption — announcements feed
Second `<SectionSearchBar>` adoption (after `/ops/incidents` in #661): an "Announcements" header with the bar across from it, filtering the feed by `createdAt` + title/body/category via `applySectionQuery`.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean. G2/G4 are client/DOM behavior (no jsdom in-repo for a unit test) — **visual QA pending**; G8's parser core is covered by the 18 tests in #661.

## Base branch
Base is the integration-branch snapshot at these commits' parent (the kit/shell primitives aren't on `main` yet). Diff = exactly the 6 files. Retarget to `main` once the prior slices land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)