### PR TITLE
Owner Portal Revisions — G8 adoption sweep #2: time-clock + supplies

### DIFF
--- a/src/app/(operator)/ops/supplies/supplies-view.tsx
+++ b/src/app/(operator)/ops/supplies/supplies-view.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 import { AgentDraftedCard } from "@/components/supplies/agent-drafted-card";
 import type { SupplyOrderRow, SupplyOrderStatus } from "./_placeholder-types";
@@ -64,15 +69,27 @@ export function SuppliesInbox({ initialRows }: { initialRows: SupplyOrderRow[] }
     }
     return map;
   }, [initialRows]);
-  const rows = rowsByTab[active];
+  // MASTER-prompt G8 — date / amount / supplier search over the active tab.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
+  const rows = useMemo(() => {
+    const base = rowsByTab[active];
+    return sectionQuery
+      ? applySectionQuery(base, sectionQuery, {
+          getDate: (r) => r.createdAt,
+          getAmount: (r) => r.totalCents / 100,
+          getText: (r) => `${r.supplyName} ${r.supplierName ?? ""}`,
+        })
+      : base;
+  }, [rowsByTab, active, sectionQuery]);
 
   return (
     <div className="space-y-6">
-      <nav
-        role="tablist"
-        aria-label="Supply order status"
-        className="flex flex-wrap gap-1 p-1 rounded-xl bg-surface-muted/60 border border-border/60 w-fit"
-      >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <nav
+          role="tablist"
+          aria-label="Supply order status"
+          className="flex flex-wrap gap-1 p-1 rounded-xl bg-surface-muted/60 border border-border/60 w-fit"
+        >
         {TABS.map((tab) => {
           const count = rowsByTab[tab.key].length;
           const isActive = active === tab.key;
@@ -99,7 +116,13 @@ export function SuppliesInbox({ initialRows }: { initialRows: SupplyOrderRow[] }
             </button>
           );
         })}
-      </nav>
+        </nav>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Search — “last 30 days”, “> 100”, supplier…"
+          aria-label="Search supply orders by date, amount, or name"
+        />
+      </div>
 
       {rows.length === 0 ? (
         <EmptyState title={EMPTY[active].title} description={EMPTY[active].description} />

--- a/src/app/(operator)/ops/time-clock/timeclock-view.tsx
+++ b/src/app/(operator)/ops/time-clock/timeclock-view.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 interface ClockEntry {
@@ -135,7 +140,19 @@ export function TimeclockView({ userName }: { userName: string }) {
     [entries, now],
   );
 
-  const recent = [...entries].reverse().slice(0, 10);
+  // MASTER-prompt G8 — calendar/keyword search over the recent-activity log.
+  const [activityQuery, setActivityQuery] = useState<SectionQuery | null>(null);
+  const filteredEntries = useMemo(
+    () =>
+      activityQuery
+        ? applySectionQuery(entries, activityQuery, {
+            getDate: (e) => e.timestamp,
+            getText: (e) => `clock ${e.type} clocked ${e.type}`,
+          })
+        : entries,
+    [entries, activityQuery],
+  );
+  const recent = [...filteredEntries].reverse().slice(0, 10);
 
   function exportTimesheet() {
     const header = "timestamp,type\n";
@@ -205,11 +222,18 @@ export function TimeclockView({ userName }: { userName: string }) {
 
       <Card tone="raised">
         <CardContent className="py-5">
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
             <p className="text-sm font-medium text-text">Recent activity</p>
-            <Button size="sm" variant="secondary" onClick={exportTimesheet} disabled={entries.length === 0}>
-              Export timesheet
-            </Button>
+            <div className="flex items-end gap-2">
+              <SectionSearchBar
+                onChange={setActivityQuery}
+                placeholder="Search — “last 7 days”, “clock out”…"
+                aria-label="Search clock activity by date or type"
+              />
+              <Button size="sm" variant="secondary" onClick={exportTimesheet} disabled={entries.length === 0}>
+                Export timesheet
+              </Button>
+            </div>
           </div>
           {recent.length === 0 ? (
             <p className="text-xs text-text-subtle">No clock activity yet.</p>


### PR DESCRIPTION
Two more `<SectionSearchBar>` (G8) adoptions, continuing the sweep after `/ops/incidents` (#661) and `/ops/announcements` (#665).

- **time-clock** — the "Recent activity" log gets the directive's explicitly-requested **calendar search**: filter clock entries by date (`timestamp`) + type (`"clock out"`, `"last 7 days"`) via `applySectionQuery`.
- **supplies** — the active status tab's orders filter by `createdAt` (date), `totalCents` (amount, e.g. `"> 100"`), and `supplyName`/`supplierName` (keyword).

Depends on the G8 primitive (`parseSectionQuery` / `<SectionSearchBar>`) from #661.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean.

## Base branch
Base-at-parent (the G8 primitive isn't on `main` yet). Diff = exactly the 2 adoption files. Retarget down the stack once #661 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)