### PR TITLE
Owner Portal Revisions — MASTER-prompt primitives G2/G3/G4/G8 + adoptions (consolidated)

### DIFF
--- a/src/app/(clinician)/layout.tsx
+++ b/src/app/(clinician)/layout.tsx
@@ -11,6 +11,7 @@ import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { BreathingBreak } from "@/components/clinical/BreathingBreak";
 import { KeyboardShortcuts } from "@/components/ui/keyboard-shortcuts";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { GlobalSearchButton } from "@/components/ui/global-search-button";
 import { ConsciousnessOverlay } from "@/components/ui/consciousness-overlay";
 import { ClinicianTour } from "@/components/onboarding/clinician-tour";
 import { InstallPrompt } from "@/components/pwa/install-prompt";
@@ -256,6 +257,7 @@ export default async function ClinicianLayout({
       <BreathingBreak />
       <KeyboardShortcuts />
       <CommandPalette role="clinician" userId={user.id} />
+      <GlobalSearchButton />
       <ConsciousnessOverlay />
       <ClinicianTour autoStart={!isDemoSurface} />
       <InstallPrompt />

--- a/src/app/(operator)/layout.tsx
+++ b/src/app/(operator)/layout.tsx
@@ -4,6 +4,7 @@ import { getCurrentUser } from "@/lib/auth/session";
 export const dynamic = "force-dynamic";
 import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { GlobalSearchButton } from "@/components/ui/global-search-button";
 import { SystemBannerRail } from "@/components/ui/system-banner";
 import { homeForRoles } from "@/lib/rbac/roles";
 import { prisma } from "@/lib/db/prisma";
@@ -265,6 +266,7 @@ export default async function OperatorLayout({
         showNavPrefs={false}
       >
         <CommandPalette role="operator" userId={user.id} />
+        <GlobalSearchButton />
         {children}
       </AppShell>
     </>

--- a/src/app/(operator)/ops/announcements/announcements-view.tsx
+++ b/src/app/(operator)/ops/announcements/announcements-view.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input, Textarea } from "@/components/ui/input";
 import { LinkifiedText } from "@/components/ui/linkified-text";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 export type AnnouncementCategory = "Clinical" | "Ops" | "Celebrations" | "Reminders";
@@ -48,6 +53,8 @@ export function AnnouncementsView({
 }) {
   const [items, setItems] = useState<Announcement[]>(initialAnnouncements);
   const [filter, setFilter] = useState<"all" | AnnouncementCategory>("all");
+  // MASTER-prompt G8 — per-section date/keyword filter for the feed below.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
   const [composeOpen, setComposeOpen] = useState(false);
   const [draft, setDraft] = useState({
     title: "",
@@ -59,11 +66,17 @@ export function AnnouncementsView({
 
   const visible = useMemo(() => {
     const filtered = filter === "all" ? items : items.filter((i) => i.category === filter);
-    return [...filtered].sort((a, b) => {
+    const searched = sectionQuery
+      ? applySectionQuery(filtered, sectionQuery, {
+          getDate: (a) => a.createdAt,
+          getText: (a) => `${a.title} ${a.body} ${a.category}`,
+        })
+      : filtered;
+    return [...searched].sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
       return b.createdAt.localeCompare(a.createdAt);
     });
-  }, [items, filter]);
+  }, [items, filter, sectionQuery]);
 
   function react(id: string, emoji: string) {
     setItems((prev) =>
@@ -136,6 +149,15 @@ export function AnnouncementsView({
         <Button size="sm" onClick={() => setComposeOpen(true)}>
           Post announcement
         </Button>
+      </div>
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h2 className="text-sm font-semibold text-text">Announcements</h2>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Filter — “last 30 days”, “reminder”…"
+          aria-label="Filter announcements by date or keyword"
+        />
       </div>
 
       <div className="space-y-4">

--- a/src/app/(operator)/ops/feedback/feedback-view.tsx
+++ b/src/app/(operator)/ops/feedback/feedback-view.tsx
@@ -13,6 +13,7 @@ import {
   SortMenu,
   type ActiveChip,
 } from "@/components/ui/filter-bar";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { LinkifiedText } from "@/components/ui/linkified-text";
 import { cn } from "@/lib/utils/cn";
 
@@ -131,6 +132,20 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
       }
     });
   }, [items, state]);
+
+  // MASTER-prompt G3 — top-7 page-specific matches: patient name (label),
+  // also searchable by the feedback excerpt (keyword), mirroring the
+  // name-or-excerpt filter above.
+  const feedbackOptions: AutocompleteOption[] = useMemo(
+    () =>
+      items.map((i) => ({
+        value: i.patientName,
+        label: i.patientName,
+        sublabel: i.excerpt,
+        keywords: [i.excerpt],
+      })),
+    [items],
+  );
 
   const chips: ActiveChip[] = [];
   if (state.tab !== "all") {
@@ -261,12 +276,16 @@ export function FeedbackView({ initialFeedback }: { initialFeedback: FeedbackIte
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        <Input
-          type="search"
-          placeholder="Search by name or excerpt…"
+        <AutocompleteInput
+          options={feedbackOptions}
           value={state.query}
-          onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
-          className="md:w-64 h-9"
+          onValueChange={(text) => setState((s) => ({ ...s, query: text }))}
+          onSelect={(opt) => setState((s) => ({ ...s, query: opt.value }))}
+          placeholder="Search by name or excerpt…"
+          emptyMessage="No feedback matches"
+          aria-label="Search feedback by name or excerpt"
+          className="md:w-64"
+          inputClassName="h-9"
         />
         <MultiSelectFilter
           label="NPS (Net Promoter Score) band"

--- a/src/app/(operator)/ops/incidents/incidents-view.tsx
+++ b/src/app/(operator)/ops/incidents/incidents-view.tsx
@@ -14,6 +14,11 @@ import {
   type ActiveChip,
 } from "@/components/ui/filter-bar";
 import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
+import {
   INCIDENT_CATEGORY_LABELS,
   type IncidentCategory,
   type IncidentReport,
@@ -83,6 +88,8 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
   const [formOpen, setFormOpen] = useState(false);
   const [resolving, setResolving] = useState<IncidentReport | null>(null);
   const [resolutionNotes, setResolutionNotes] = useState("");
+  // MASTER-prompt G8 — per-section date/param/keyword filter for the log below.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
   const [draft, setDraft] = useState({
     severity: "low" as IncidentSeverity,
     category: "safety" as IncidentCategory,
@@ -106,7 +113,14 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
       if (state.patientAffectedOnly && !i.patientAffected) return false;
       return true;
     });
-    return list.sort((a, b) => {
+    const searched = sectionQuery
+      ? applySectionQuery(list, sectionQuery, {
+          getDate: (i) => i.reportedAt,
+          getText: (i) =>
+            `${i.title} ${i.description} ${INCIDENT_CATEGORY_LABELS[i.category]} ${SEVERITY_LABELS[i.severity]}`,
+        })
+      : list;
+    return searched.sort((a, b) => {
       switch (state.sort) {
         case "newest":
           return b.reportedAt.localeCompare(a.reportedAt);
@@ -118,7 +132,7 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
           return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
       }
     });
-  }, [incidents, state]);
+  }, [incidents, state, sectionQuery]);
 
   const chips: ActiveChip[] = [];
   if (state.severities.length > 0) {
@@ -281,6 +295,15 @@ export function IncidentsView({ initialIncidents }: { initialIncidents: Incident
       </div>
 
       <FilterChips chips={chips} onRemove={removeChip} onClearAll={clearAll} />
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h2 className="text-sm font-semibold text-text">Incident log</h2>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Filter log — “last 30 days”, “critical”…"
+          aria-label="Filter incident log by date or keyword"
+        />
+      </div>
 
       <Card tone="raised">
         <div className="overflow-x-auto">

--- a/src/app/(operator)/ops/inventory/inventory-view.tsx
+++ b/src/app/(operator)/ops/inventory/inventory-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input, FieldGroup, Textarea } from "@/components/ui/input";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import {
   classifyStatus,
   STATUS_STYLES,
@@ -57,6 +58,20 @@ export function InventoryView({ initialItems }: { initialItems: InventoryItem[] 
         );
       });
   }, [items, filter, query]);
+
+  // MASTER-prompt G3 — the directive's "AI SKU search": top-7 matches on
+  // product name (label) plus brand / SKU / UPC (keywords), mirroring the
+  // filter above.
+  const productOptions: AutocompleteOption[] = useMemo(
+    () =>
+      items.map((i) => ({
+        value: i.productName,
+        label: i.productName,
+        sublabel: [i.brand, i.sku].filter(Boolean).join(" · "),
+        keywords: [i.brand, i.sku, i.upc].filter((s): s is string => !!s),
+      })),
+    [items],
+  );
 
   function applyRestock() {
     if (!restockTarget || restockQty <= 0) return;
@@ -162,11 +177,14 @@ export function InventoryView({ initialItems }: { initialItems: InventoryItem[] 
           })}
         </div>
         <div className="flex items-center gap-2">
-          <Input
-            type="search"
-            placeholder="Search product, SKU, UPC…"
+          <AutocompleteInput
+            options={productOptions}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onValueChange={setQuery}
+            onSelect={(opt) => setQuery(opt.value)}
+            placeholder="Search product, SKU, UPC…"
+            emptyMessage="No products match"
+            aria-label="Search products by name, SKU, or UPC"
             className="md:w-64"
           />
           <Button onClick={() => setShowAdd((v) => !v)} size="sm">

--- a/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
+++ b/src/app/(operator)/ops/mail-fax/mail-fax-client.tsx
@@ -30,6 +30,7 @@ import { StatCard } from "@/components/ui/stat-card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ModalShell } from "@/components/ui/modal-shell";
 import { Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 import {
   crossCheckCoverage,
@@ -317,6 +318,17 @@ export function MailFaxClient({
   const [editDob, setEditDob] = useState("");
   const [editCategory, setEditCategory] = useState<string>(CHART_DOC_CATEGORIES[0]);
   const [editDocDate, setEditDocDate] = useState("");
+
+  // MASTER-prompt G3 — turn the blind "search patient by name" field into a
+  // top-7 autocomplete over the practice's own patients.
+  const patientOptions: AutocompleteOption[] = useMemo(
+    () =>
+      dbPatients.map((p) => ({
+        value: `${p.firstName} ${p.lastName}`,
+        label: `${p.firstName} ${p.lastName}`,
+      })),
+    [dbPatients],
+  );
 
   // Resolve a DB patient id from a scanned patient name. Returns null when there
   // is no CONFIDENT match (EMR-983: do NOT fall back to dbPatients[0]).
@@ -1365,10 +1377,14 @@ export function MailFaxClient({
         <form onSubmit={handleRouteEdit} className="space-y-4 px-6 py-5">
           <div className="space-y-1.5">
             <label className="text-xs font-semibold text-text-subtle uppercase">Patient name or DOB</label>
-            <Input
+            <AutocompleteInput
+              options={patientOptions}
               value={editPatientQuery}
-              onChange={(e) => setEditPatientQuery(e.target.value)}
+              onValueChange={setEditPatientQuery}
+              onSelect={(opt) => setEditPatientQuery(opt.value)}
               placeholder="Search patient by name"
+              emptyMessage="No matching patients"
+              aria-label="Search patient by name"
             />
             <Input
               value={editDob}

--- a/src/app/(operator)/ops/policies/policies-view.tsx
+++ b/src/app/(operator)/ops/policies/policies-view.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 export type PolicyCategory = "Clinical" | "HIPAA" | "Safety" | "Operations" | "Emergency";
@@ -89,6 +90,20 @@ export function PoliciesView({ policies: initialPolicies }: { policies: Policy[]
     [filtered, selectedId],
   );
 
+  // MASTER-prompt G3 — top-7 page-specific matches: policy titles (label),
+  // searchable by category + body text (keywords), mirroring the title-or-body
+  // filter below.
+  const policyOptions: AutocompleteOption[] = useMemo(
+    () =>
+      policies.map((p) => ({
+        value: p.title,
+        label: p.title,
+        sublabel: p.category,
+        keywords: [p.category, p.body],
+      })),
+    [policies],
+  );
+
   function acknowledge(id: string) {
     const next = { ...acks, [id]: new Date().toISOString() };
     setAcks(next);
@@ -98,11 +113,14 @@ export function PoliciesView({ policies: initialPolicies }: { policies: Policy[]
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Input
-          type="search"
-          placeholder="Search policies…"
+        <AutocompleteInput
+          options={policyOptions}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onValueChange={setQuery}
+          onSelect={(opt) => setQuery(opt.value)}
+          placeholder="Search policies…"
+          emptyMessage="No policies match"
+          aria-label="Search policies"
           className="md:w-80"
         />
         <Button size="sm" variant="secondary" onClick={openCreate}>

--- a/src/app/(operator)/ops/supplies/supplies-view.tsx
+++ b/src/app/(operator)/ops/supplies/supplies-view.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 import { AgentDraftedCard } from "@/components/supplies/agent-drafted-card";
 import type { SupplyOrderRow, SupplyOrderStatus } from "./_placeholder-types";
@@ -64,15 +69,27 @@ export function SuppliesInbox({ initialRows }: { initialRows: SupplyOrderRow[] }
     }
     return map;
   }, [initialRows]);
-  const rows = rowsByTab[active];
+  // MASTER-prompt G8 — date / amount / supplier search over the active tab.
+  const [sectionQuery, setSectionQuery] = useState<SectionQuery | null>(null);
+  const rows = useMemo(() => {
+    const base = rowsByTab[active];
+    return sectionQuery
+      ? applySectionQuery(base, sectionQuery, {
+          getDate: (r) => r.createdAt,
+          getAmount: (r) => r.totalCents / 100,
+          getText: (r) => `${r.supplyName} ${r.supplierName ?? ""}`,
+        })
+      : base;
+  }, [rowsByTab, active, sectionQuery]);
 
   return (
     <div className="space-y-6">
-      <nav
-        role="tablist"
-        aria-label="Supply order status"
-        className="flex flex-wrap gap-1 p-1 rounded-xl bg-surface-muted/60 border border-border/60 w-fit"
-      >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <nav
+          role="tablist"
+          aria-label="Supply order status"
+          className="flex flex-wrap gap-1 p-1 rounded-xl bg-surface-muted/60 border border-border/60 w-fit"
+        >
         {TABS.map((tab) => {
           const count = rowsByTab[tab.key].length;
           const isActive = active === tab.key;
@@ -99,7 +116,13 @@ export function SuppliesInbox({ initialRows }: { initialRows: SupplyOrderRow[] }
             </button>
           );
         })}
-      </nav>
+        </nav>
+        <SectionSearchBar
+          onChange={setSectionQuery}
+          placeholder="Search — “last 30 days”, “> 100”, supplier…"
+          aria-label="Search supply orders by date, amount, or name"
+        />
+      </div>
 
       {rows.length === 0 ? (
         <EmptyState title={EMPTY[active].title} description={EMPTY[active].description} />

--- a/src/app/(operator)/ops/time-clock/timeclock-view.tsx
+++ b/src/app/(operator)/ops/time-clock/timeclock-view.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  SectionSearchBar,
+  applySectionQuery,
+  type SectionQuery,
+} from "@/components/ops/master";
 import { cn } from "@/lib/utils/cn";
 
 interface ClockEntry {
@@ -135,7 +140,19 @@ export function TimeclockView({ userName }: { userName: string }) {
     [entries, now],
   );
 
-  const recent = [...entries].reverse().slice(0, 10);
+  // MASTER-prompt G8 — calendar/keyword search over the recent-activity log.
+  const [activityQuery, setActivityQuery] = useState<SectionQuery | null>(null);
+  const filteredEntries = useMemo(
+    () =>
+      activityQuery
+        ? applySectionQuery(entries, activityQuery, {
+            getDate: (e) => e.timestamp,
+            getText: (e) => `clock ${e.type} clocked ${e.type}`,
+          })
+        : entries,
+    [entries, activityQuery],
+  );
+  const recent = [...filteredEntries].reverse().slice(0, 10);
 
   function exportTimesheet() {
     const header = "timestamp,type\n";
@@ -205,11 +222,18 @@ export function TimeclockView({ userName }: { userName: string }) {
 
       <Card tone="raised">
         <CardContent className="py-5">
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
             <p className="text-sm font-medium text-text">Recent activity</p>
-            <Button size="sm" variant="secondary" onClick={exportTimesheet} disabled={entries.length === 0}>
-              Export timesheet
-            </Button>
+            <div className="flex items-end gap-2">
+              <SectionSearchBar
+                onChange={setActivityQuery}
+                placeholder="Search — “last 7 days”, “clock out”…"
+                aria-label="Search clock activity by date or type"
+              />
+              <Button size="sm" variant="secondary" onClick={exportTimesheet} disabled={entries.length === 0}>
+                Export timesheet
+              </Button>
+            </div>
           </div>
           {recent.length === 0 ? (
             <p className="text-xs text-text-subtle">No clock activity yet.</p>

--- a/src/app/(operator)/ops/vendors/vendors-view.tsx
+++ b/src/app/(operator)/ops/vendors/vendors-view.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { FieldGroup, Input } from "@/components/ui/input";
+import { AutocompleteInput, type AutocompleteOption } from "@/components/ops/master";
 import {
   EmptyFilterState,
   FilterChips,
@@ -130,6 +131,22 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
     [vendors],
   );
 
+  // MASTER-prompt G3 — the search field's own page-specific options: every
+  // vendor, matchable by name (label) plus contact / email / category
+  // (keywords). rankAutocomplete surfaces the top 7 as you type.
+  const vendorOptions: AutocompleteOption[] = useMemo(
+    () =>
+      vendors.map((v) => ({
+        value: v.name,
+        label: v.name,
+        sublabel: [v.category, v.contactName].filter(Boolean).join(" · "),
+        keywords: [v.contactName, v.email, v.category].filter(
+          (s): s is string => !!s,
+        ),
+      })),
+    [vendors],
+  );
+
   const chips: ActiveChip[] = [];
   if (state.query.trim()) {
     chips.push({ id: "query", label: "Search", value: state.query.trim() });
@@ -230,12 +247,16 @@ export function VendorsView({ initialVendors }: { initialVendors: Vendor[] }) {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2 flex-wrap">
-          <Input
-            type="search"
-            placeholder="Search vendors…"
+          <AutocompleteInput
+            options={vendorOptions}
             value={state.query}
-            onChange={(e) => setState((s) => ({ ...s, query: e.target.value }))}
-            className="md:w-64 h-9"
+            onValueChange={(text) => setState((s) => ({ ...s, query: text }))}
+            onSelect={(opt) => setState((s) => ({ ...s, query: opt.value }))}
+            placeholder="Search vendors…"
+            emptyMessage="No vendors match"
+            aria-label="Search vendors"
+            className="md:w-64"
+            inputClassName="h-9"
           />
           <MultiSelectFilter
             label="Category"

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -7,6 +7,7 @@ import { AppShell, type NavSection } from "@/components/shell/AppShell";
 import { homeForRoles } from "@/lib/rbac/roles";
 import { QuoteWelcomeModal } from "@/components/ui/quote-of-the-day";
 import { CommandPalette } from "@/components/ui/command-palette";
+import { GlobalSearchButton } from "@/components/ui/global-search-button";
 import { ChatCBInterface } from "@/components/ask-cindy/ChatCBInterface";
 import { PortalCustomizationProvider } from "@/components/portal/portal-customization-provider";
 import { ConfettiCanvas } from "@/components/portal/confetti-canvas";
@@ -165,6 +166,7 @@ export default async function PatientLayout({
       >
         <QuoteWelcomeModal userName={user.firstName} />
         <CommandPalette role="patient" userId={user.id} />
+        <GlobalSearchButton />
         <ChatCBInterface />
         <ConfettiCanvas />
         <InstallPrompt />

--- a/src/components/error-pages/open-command-palette-button.tsx
+++ b/src/components/error-pages/open-command-palette-button.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { openCommandPalette } from "@/components/ui/command-palette";
 
 /**
  * Tiny client-side CTA used inside error / not-found screens to surface
- * the global command palette. Synthesises a ⌘K KeyboardEvent so we don't
- * have to plumb a context through every error boundary — the palette
- * already listens for that hotkey globally.
+ * the global command palette. Delegates to the shared `openCommandPalette()`
+ * helper (which re-dispatches the global ⌘K hotkey) so the open path is
+ * identical to the G4 bottom-left affordance.
  *
  * Detects platform and shows ⌘K vs Ctrl+K accordingly.
  */
@@ -27,19 +28,7 @@ export function OpenCommandPaletteButton({
       variant="secondary"
       size="lg"
       className={className}
-      onClick={() => {
-        // Re-use the palette's own hotkey handler instead of reaching into
-        // its internals. Works in every route group, including ones where
-        // the palette mounts conditionally.
-        const evt = new KeyboardEvent("keydown", {
-          key: "k",
-          code: "KeyK",
-          metaKey: isMac,
-          ctrlKey: !isMac,
-          bubbles: true,
-        });
-        window.dispatchEvent(evt);
-      }}
+      onClick={openCommandPalette}
       trailingIcon={
         <kbd
           className="ml-1 inline-flex items-center rounded border border-border-strong/70 bg-surface-muted px-1.5 py-0.5 font-mono text-[10px] tracking-tight text-text-muted"

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -9,15 +9,32 @@
 //   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
 //   G6 Table send/print/download   → <DataTable exportable> + table-export utils
 //   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
+//   G8 Per-section date/param search → <SectionSearchBar> (+ parseSectionQuery)
 //   G9 Compare mode               → <MetricBoxGroup> (select ≥2 → overlay chart)
 //   G10 "click a box → popup"      → <MetricBox> (history popup + feather cycle)
 //   G11 Hover tooltips on charts   → <MetricBox> drill-in (branded chart hover)
 //
+// G4 (global "search everything") ships as the layout-mounted
+// <GlobalSearchButton> (bottom-left affordance opening the ⌘K command palette),
+// not a per-page import — see src/components/ui/global-search-button.tsx.
+//
 // Still to build (tracked, not yet shipped): global sidebar overlay/autohide
-// (G2 layered/autohide half remains; in-page-click re-open fixed via PR #648)
-// and the per-section AI search bar (G8).
+// (G2 layered/autohide half remains; in-page-click re-open fixed via PR #648).
 
 export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  SectionSearchBar,
+  type SectionSearchBarProps,
+} from "@/components/ui/section-search-bar";
+
+export {
+  parseSectionQuery,
+  applySectionQuery,
+  type SectionQuery,
+  type SectionDateRange,
+  type SectionAmountFilter,
+} from "@/lib/ui/section-query";
 
 export {
   AutocompleteInput,

--- a/src/components/ops/master/index.ts
+++ b/src/components/ops/master/index.ts
@@ -5,6 +5,7 @@
 //
 // Coverage of the MASTER-prompt "layout law":
 //   G1 Collapsible sections        → <Collapsible>
+//   G3 7-result page autocomplete  → <AutocompleteInput> (+ rankAutocomplete core)
 //   G5 Sortable table columns      → <DataTable> (tri-state header sort, built-in)
 //   G6 Table send/print/download   → <DataTable exportable> + table-export utils
 //   G7 Movable / rearrangeable     → <SortableList> / <KanbanBoard> / reorder()
@@ -17,6 +18,18 @@
 // and the per-section AI search bar (G8).
 
 export { Collapsible } from "@/components/ui/collapsible";
+
+export {
+  AutocompleteInput,
+  type AutocompleteInputProps,
+} from "@/components/ui/autocomplete-input";
+
+export {
+  rankAutocomplete,
+  scoreOption,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "@/lib/ui/autocomplete-match";
 
 export {
   MetricBox,

--- a/src/components/shell/ContextDrawer.tsx
+++ b/src/components/shell/ContextDrawer.tsx
@@ -11,10 +11,12 @@ export interface ContextDrawerProps {
   pathname: string;
   onClose: () => void;
   pinned: boolean;
+  /** True when overlay is forced by a narrow viewport (G2) — pinning is N/A. */
+  narrow?: boolean;
   onTogglePin: () => void;
 }
 
-export function ContextDrawer({ section, pathname, onClose, pinned, onTogglePin }: ContextDrawerProps) {
+export function ContextDrawer({ section, pathname, onClose, pinned, narrow = false, onTogglePin }: ContextDrawerProps) {
   const open = section !== null;
   const ref = React.useRef<HTMLDivElement | null>(null);
 
@@ -103,25 +105,29 @@ export function ContextDrawer({ section, pathname, onClose, pinned, onTogglePin 
             </ul>
           </nav>
           
-          {/* Monday.com-style Pin Footer */}
-          <div className="mt-auto border-t border-border/80 p-3">
-            <button
-              type="button"
-              onClick={onTogglePin}
-              className="flex w-full items-center justify-center gap-2 rounded-md bg-surface-muted/50 py-2 text-xs font-medium text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className={cn("transition-transform duration-200", !pinned && "rotate-45")}
+          {/* Monday.com-style Pin Footer. Hidden when a narrow viewport forces
+              overlay mode (G2) — pinning the drawer into the layout isn't an
+              option until the window widens again. */}
+          {!narrow && (
+            <div className="mt-auto border-t border-border/80 p-3">
+              <button
+                type="button"
+                onClick={onTogglePin}
+                className="flex w-full items-center justify-center gap-2 rounded-md bg-surface-muted/50 py-2 text-xs font-medium text-text-subtle hover:bg-surface-muted hover:text-text transition-colors"
               >
-                <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
-              </svg>
-              {pinned ? "Collapse sidebar" : "Pin sidebar"}
-            </button>
-          </div>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className={cn("transition-transform duration-200", !pinned && "rotate-45")}
+                >
+                  <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
+                </svg>
+                {pinned ? "Collapse sidebar" : "Pin sidebar"}
+              </button>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/shell/MobileNav.tsx
+++ b/src/components/shell/MobileNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 import { NavSections } from "./NavSections";
 import type { NavItem, NavSection } from "./nav-sections";
@@ -17,6 +18,7 @@ interface MobileNavProps {
 
 export function MobileNav({ sections, nav }: MobileNavProps) {
   const [open, setOpen] = React.useState(false);
+  const pathname = usePathname();
 
   const resolved: NavSection[] = React.useMemo(() => {
     if (sections && sections.length > 0) return sections;
@@ -26,6 +28,18 @@ export function MobileNav({ sections, nav }: MobileNavProps) {
 
   // Close drawer on route change (link click)
   const closeDrawer = () => setOpen(false);
+
+  // MASTER-prompt G2 — autohide on EVERY navigation, including browser
+  // back/forward, which a link-click handler alone wouldn't catch. usePathname
+  // updates on all of them, so collapse whenever the route changes.
+  const firstPath = React.useRef(true);
+  React.useEffect(() => {
+    if (firstPath.current) {
+      firstPath.current = false;
+      return;
+    }
+    setOpen(false);
+  }, [pathname]);
 
   // Lock body scroll when drawer is open
   React.useEffect(() => {

--- a/src/components/shell/PillarNav.tsx
+++ b/src/components/shell/PillarNav.tsx
@@ -54,19 +54,48 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
     }
   };
 
-  // Open the active pillar's drawer ONLY when the route's pillar actually
-  // changes (a real navigation). A same-route re-render — e.g. a server action
-  // revalidating the page, which hands PillarNav a fresh `sections` array
-  // reference — must NOT re-open a drawer the user just collapsed. That was the
-  // "sidebar pops back open when I click Log / Add / Delete / Generate" bug
-  // (Owner Portal Revisions, MASTER prompt G2).
+  // MASTER-prompt G2 — when the viewport is narrowed / split to half-screen the
+  // sidebar must OVERLAY content (float above it) instead of squeezing it into
+  // a column, regardless of the pin preference. Below `lg` we force the
+  // drawer's existing unpinned/overlay mode; at `lg`+ the stored pin choice is
+  // respected, so wide-screen layout is byte-for-byte unchanged.
+  const [narrow, setNarrow] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(min-width: 768px) and (max-width: 1023.98px)");
+    const update = () => setNarrow(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  const effectivePinned = pinned && !narrow;
+
+  // Wide + pinned: follow the route — open the drawer for the pillar you
+  // navigated into, but ONLY when the route's pillar actually CHANGES (a real
+  // navigation). A same-route re-render — e.g. a server action revalidating the
+  // page, which hands PillarNav a fresh `sections` array reference — must NOT
+  // re-open a drawer the user just collapsed. That was the "sidebar pops back
+  // open when I click Log / Add / Delete / Generate" bug (MASTER prompt G2, PR #648).
   const prevPathPillar = React.useRef<string | null>(pathPillar);
   React.useEffect(() => {
-    if (pathPillar && pathPillar !== prevPathPillar.current) {
+    if (effectivePinned && pathPillar && pathPillar !== prevPathPillar.current) {
       setActivePillar(pathPillar);
     }
     prevPathPillar.current = pathPillar;
-  }, [pathPillar]);
+  }, [pathPillar, effectivePinned]);
+
+  // Overlay mode (narrow or unpinned): autohide on EVERY navigation, including
+  // browser back/forward (both surface as a pathname change). Keyed on
+  // `pathname`, not `pathPillar`, so even same-pillar navigation collapses the
+  // floating drawer. A same-route revalidation leaves `pathname` unchanged, so
+  // this never fires spuriously — PR #648 stays fixed in overlay mode too.
+  const prevPathname = React.useRef<string>(pathname);
+  React.useEffect(() => {
+    if (!effectivePinned && pathname !== prevPathname.current) {
+      setActivePillar(null);
+    }
+    prevPathname.current = pathname;
+  }, [pathname, effectivePinned]);
 
   // On mount only: if the current route isn't under any pillar, restore the
   // last-used pillar so the drawer isn't empty on a neutral landing page.
@@ -132,7 +161,8 @@ export function PillarNav({ sections, header, footer }: PillarNavProps) {
         section={activeSection}
         pathname={pathname}
         onClose={() => setActivePillar(null)}
-        pinned={pinned}
+        pinned={effectivePinned}
+        narrow={narrow}
         onTogglePin={handleTogglePin}
       />
     </div>

--- a/src/components/ui/autocomplete-input.tsx
+++ b/src/components/ui/autocomplete-input.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+// MASTER-prompt G3 — the shared "type-ahead with the top page-specific
+// matches" field for /ops. Every search bar / dropdown / searchable input is
+// meant to surface up to 7 of *this page's own* options as you type (the
+// directive is explicit that it's site-specific, not a global search — that's
+// G4). Pages pass their own `options`; ranking is delegated to the pure
+// rankAutocomplete() core so behavior is identical and testable everywhere.
+//
+// Accessibility: implements the ARIA 1.2 combobox-with-listbox pattern —
+// role="combobox" input, aria-expanded / aria-controls / aria-activedescendant,
+// a role="listbox" popup with role="option" rows, full keyboard nav
+// (↑/↓ to move, Enter to choose, Esc to close), and click-outside dismissal.
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import {
+  rankAutocomplete,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "@/lib/ui/autocomplete-match";
+
+export type { AutocompleteOption } from "@/lib/ui/autocomplete-match";
+
+export interface AutocompleteInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "defaultValue" | "onChange" | "onSelect"
+  > {
+  /** This page's own options — the directive's "page-specific" set. */
+  options: readonly AutocompleteOption[];
+  /** Fired when the user commits an option (click or Enter on a row). */
+  onSelect: (option: AutocompleteOption) => void;
+  /** Controlled query text. Omit for uncontrolled. */
+  value?: string;
+  /** Initial query text when uncontrolled. */
+  defaultValue?: string;
+  /** Notified on every keystroke (controlled or not). */
+  onValueChange?: (text: string) => void;
+  /** When set, Enter with no highlighted row commits the typed text as its own
+   *  option ({ value, label } both = the raw text). For free-form fields. */
+  allowFreeText?: boolean;
+  /** Max rows to show. Defaults to the MASTER-prompt count of 7. */
+  limit?: number;
+  /** Shown when the query matches nothing. Hidden if omitted. */
+  emptyMessage?: string;
+  /** Custom row renderer; defaults to label + dimmed sublabel. */
+  renderOption?: (option: AutocompleteOption, active: boolean) => React.ReactNode;
+  /** Extra classes on the wrapping element. */
+  className?: string;
+  /** Extra classes on the <input>. */
+  inputClassName?: string;
+}
+
+export const AutocompleteInput = forwardRef<
+  HTMLInputElement,
+  AutocompleteInputProps
+>(function AutocompleteInput(
+  {
+    options,
+    onSelect,
+    value,
+    defaultValue = "",
+    onValueChange,
+    allowFreeText = false,
+    limit = AUTOCOMPLETE_DEFAULT_LIMIT,
+    emptyMessage,
+    renderOption,
+    className,
+    inputClassName,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    disabled,
+    ...inputProps
+  },
+  ref,
+) {
+  const reactId = useId();
+  const listboxId = `${reactId}-listbox`;
+  const optionId = (i: number) => `${reactId}-opt-${i}`;
+
+  const isControlled = value !== undefined;
+  const [innerText, setInnerText] = useState(defaultValue);
+  const text = isControlled ? value : innerText;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const matches = useMemo(
+    () => rankAutocomplete(options, text, limit),
+    [options, text, limit],
+  );
+
+  // First non-disabled row, used as the keyboard landing spot on open.
+  const firstEnabled = useMemo(
+    () => matches.findIndex((m) => !m.disabled),
+    [matches],
+  );
+
+  const setText = useCallback(
+    (next: string) => {
+      if (!isControlled) setInnerText(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setActiveIndex(-1);
+  }, []);
+
+  const commit = useCallback(
+    (option: AutocompleteOption) => {
+      if (option.disabled) return;
+      onSelect(option);
+      setText(option.label);
+      close();
+    },
+    [onSelect, setText, close],
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+    setOpen(true);
+    setActiveIndex(-1);
+  };
+
+  const moveActive = useCallback(
+    (dir: 1 | -1) => {
+      if (matches.length === 0) return;
+      setActiveIndex((prev) => {
+        let i = prev;
+        for (let step = 0; step < matches.length; step++) {
+          i = (i + dir + matches.length) % matches.length;
+          if (!matches[i]?.disabled) return i;
+        }
+        return prev;
+      });
+    },
+    [matches],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(e);
+    if (e.defaultPrevented) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(firstEnabled);
+        } else {
+          moveActive(1);
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (open) moveActive(-1);
+        break;
+      case "Enter": {
+        const picked = activeIndex >= 0 ? matches[activeIndex] : undefined;
+        if (picked) {
+          e.preventDefault();
+          commit(picked);
+        } else if (allowFreeText && text.trim()) {
+          e.preventDefault();
+          const raw = text.trim();
+          onSelect({ value: raw, label: raw });
+          close();
+        }
+        break;
+      }
+      case "Escape":
+        if (open) {
+          e.preventDefault();
+          close();
+        }
+        break;
+      case "Tab":
+        close();
+        break;
+    }
+  };
+
+  // Keep the active row scrolled into view.
+  useEffect(() => {
+    if (!open || activeIndex < 0) return;
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `#${CSS.escape(optionId(activeIndex))}`,
+    );
+    el?.scrollIntoView({ block: "nearest" });
+    // optionId is stable per render; activeIndex/open drive this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, activeIndex]);
+
+  // Click / focus outside closes the popup.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) close();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open, close]);
+
+  const showList = open && (matches.length > 0 || !!emptyMessage);
+
+  return (
+    <div ref={wrapperRef} className={cn("relative", className)}>
+      <Input
+        ref={ref}
+        type="text"
+        role="combobox"
+        aria-expanded={showList}
+        aria-controls={showList ? listboxId : undefined}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && activeIndex >= 0 ? optionId(activeIndex) : undefined
+        }
+        autoComplete="off"
+        value={text}
+        disabled={disabled}
+        onChange={handleChange}
+        onFocus={(e) => {
+          setOpen(true);
+          onFocus?.(e);
+        }}
+        onBlur={onBlur}
+        onKeyDown={handleKeyDown}
+        className={inputClassName}
+        {...inputProps}
+      />
+
+      {showList && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className={cn(
+            "absolute z-50 mt-1 max-h-72 w-full overflow-auto rounded-xl border border-border-strong",
+            "bg-surface py-1 shadow-lg shadow-black/5",
+          )}
+        >
+          {matches.length === 0 && emptyMessage ? (
+            <li
+              role="presentation"
+              className="px-3 py-2 text-sm text-text-muted"
+            >
+              {emptyMessage}
+            </li>
+          ) : (
+            matches.map((option, i) => {
+              const active = i === activeIndex;
+              return (
+                <li
+                  key={`${option.value}-${i}`}
+                  id={optionId(i)}
+                  role="option"
+                  aria-selected={active}
+                  aria-disabled={option.disabled || undefined}
+                  // onMouseDown (not onClick) so the pick lands before the
+                  // input's blur tears the popup down.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    commit(option);
+                  }}
+                  onMouseEnter={() => !option.disabled && setActiveIndex(i)}
+                  className={cn(
+                    "flex cursor-pointer flex-col px-3 py-2 text-sm",
+                    option.disabled && "cursor-not-allowed opacity-50",
+                    active && !option.disabled && "bg-accent/10",
+                  )}
+                >
+                  {renderOption ? (
+                    renderOption(option, active)
+                  ) : (
+                    <>
+                      <span className="truncate text-text">{option.label}</span>
+                      {option.sublabel && (
+                        <span className="truncate text-xs text-text-muted">
+                          {option.sublabel}
+                        </span>
+                      )}
+                    </>
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+});

--- a/src/components/ui/command-palette.tsx
+++ b/src/components/ui/command-palette.tsx
@@ -393,6 +393,28 @@ export interface CommandPaletteProps {
   userId?: string;
 }
 
+/**
+ * Programmatically open (toggle) the global command palette from anywhere —
+ * no context plumbing. Re-dispatches the ⌘K / Ctrl+K hotkey the palette
+ * already listens for globally, so it works in every route group regardless
+ * of where the palette mounts. Used by the MASTER-prompt G4 bottom-left
+ * "search everything" affordance and the error-page CTA.
+ */
+export function openCommandPalette(): void {
+  if (typeof window === "undefined") return;
+  const isMac =
+    typeof navigator !== "undefined" && /mac|iphone|ipad|ipod/i.test(navigator.platform);
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      bubbles: true,
+    }),
+  );
+}
+
 export function CommandPalette({ role, userId }: CommandPaletteProps = {}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);

--- a/src/components/ui/global-search-button.tsx
+++ b/src/components/ui/global-search-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+// MASTER-prompt G4 — "a search icon at the bottom-left of every page = a
+// full-directory query (search the whole 'computer', not just one 'folder')."
+// This is the always-present visible affordance for the global ⌘K command
+// palette, deliberately distinct from the page-specific G3 autocomplete.
+// It opens the palette the operator shell already mounts.
+
+import { Search } from "lucide-react";
+import { openCommandPalette } from "@/components/ui/command-palette";
+import { cn } from "@/lib/utils/cn";
+
+export function GlobalSearchButton({ className }: { className?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={openCommandPalette}
+      aria-label="Search everything"
+      title="Search everything (⌘K)"
+      className={cn(
+        // Fixed bottom-left, beneath the palette modal (z-50) but above page
+        // chrome. Round icon target sized for comfortable clicking.
+        "fixed bottom-4 left-4 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full",
+        "border border-border-strong bg-surface text-text-muted shadow-lg shadow-black/10",
+        "transition-colors hover:bg-surface-muted hover:text-text",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+        // Hidden on small screens — the doc scopes this pass to desktop.
+        "hidden md:inline-flex",
+        className,
+      )}
+    >
+      <Search className="h-5 w-5" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/components/ui/section-search-bar.tsx
+++ b/src/components/ui/section-search-bar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// MASTER-prompt G8 — the compact "search bar across from each section header"
+// that does chronological / parameter filtering of that section's rows. The
+// directive frames it as AI-driven (Cindy); under the hood it's the
+// deterministic parseSectionQuery() core (honest — no LLM call), so typing
+// "last 30 days > 1000 denied" filters by date AND amount AND keyword. Pair it
+// with applySectionQuery() in the consuming section.
+
+import { useMemo, useState } from "react";
+import { Sparkles, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils/cn";
+import { parseSectionQuery, type SectionQuery } from "@/lib/ui/section-query";
+
+export interface SectionSearchBarProps {
+  /** Called with the parsed query on every keystroke. */
+  onChange: (query: SectionQuery) => void;
+  /** Reference "now" for relative ranges; captured once if omitted. */
+  now?: Date;
+  placeholder?: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function SectionSearchBar({
+  onChange,
+  now: nowProp,
+  placeholder = "Filter — try “last 30 days” or “> 1000”",
+  className,
+  "aria-label": ariaLabel = "Filter this section by date, amount, or keyword",
+}: SectionSearchBarProps) {
+  const [text, setText] = useState("");
+  // Stable reference instant so relative windows don't drift each keystroke.
+  const [now] = useState(() => nowProp ?? new Date());
+
+  const query = useMemo(() => parseSectionQuery(text, now), [text, now]);
+
+  const update = (value: string) => {
+    setText(value);
+    onChange(parseSectionQuery(value, now));
+  };
+
+  const chips: string[] = [];
+  if (query.dateRange) chips.push(query.dateRange.label);
+  if (query.amount) chips.push(`${query.amount.op} ${query.amount.value}`);
+
+  return (
+    <div className={cn("flex flex-col items-end gap-1", className)}>
+      <div className="relative w-full sm:w-64">
+        <Sparkles
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-accent/70"
+          aria-hidden="true"
+        />
+        <Input
+          type="text"
+          value={text}
+          onChange={(e) => update(e.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className="h-9 pl-8 pr-8 text-sm"
+        />
+        {text && (
+          <button
+            type="button"
+            onClick={() => update("")}
+            aria-label="Clear section filter"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-text-subtle hover:text-text"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      {chips.length > 0 && (
+        <div className="flex flex-wrap justify-end gap-1">
+          {chips.map((c) => (
+            <span
+              key={c}
+              className="inline-flex items-center rounded-full bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ui/autocomplete-match.test.ts
+++ b/src/lib/ui/autocomplete-match.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  rankAutocomplete,
+  scoreOption,
+  AUTOCOMPLETE_DEFAULT_LIMIT,
+  type AutocompleteOption,
+} from "./autocomplete-match";
+
+const opt = (
+  label: string,
+  extra: Partial<AutocompleteOption> = {},
+): AutocompleteOption => ({ value: label, label, ...extra });
+
+const labels = (rows: AutocompleteOption[]) => rows.map((r) => r.label);
+
+describe("scoreOption", () => {
+  it("returns 0 for an empty query (no ranking signal)", () => {
+    expect(scoreOption(opt("Anything"), "")).toBe(0);
+    expect(scoreOption(opt("Anything"), "   ")).toBe(0);
+  });
+
+  it("returns -1 when the query does not match", () => {
+    expect(scoreOption(opt("Aetna"), "cigna")).toBe(-1);
+  });
+
+  it("ranks exact ▸ prefix ▸ word-start ▸ substring", () => {
+    const exact = scoreOption(opt("pain"), "pain");
+    const prefix = scoreOption(opt("painful"), "pain");
+    const wordStart = scoreOption(opt("Low back pain"), "back");
+    const substring = scoreOption(opt("complaint"), "plai");
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(wordStart);
+    expect(wordStart).toBeGreaterThan(substring);
+    expect(substring).toBeGreaterThan(0);
+  });
+
+  it("matches against keywords but ranks them below a label hit", () => {
+    const labelHit = scoreOption(opt("Aetna"), "aet");
+    const keywordHit = scoreOption(
+      opt("Anthem", { keywords: ["BCBS", "blue cross"] }),
+      "bcbs",
+    );
+    expect(keywordHit).toBeGreaterThan(0);
+    expect(labelHit).toBeGreaterThan(keywordHit);
+  });
+
+  it("treats word boundaries in codes/paths (M54.5, low-back, A/R)", () => {
+    expect(scoreOption(opt("M54.5 Low back pain"), "54")).toBeGreaterThan(0);
+    expect(scoreOption(opt("low-back"), "back")).toBeGreaterThan(0);
+    expect(scoreOption(opt("A/R aging"), "aging")).toBeGreaterThan(0);
+  });
+
+  it("ANDs multi-word queries — every token must appear", () => {
+    expect(scoreOption(opt("Low back pain"), "low pain")).toBeGreaterThan(0);
+    expect(scoreOption(opt("Low back pain"), "low knee")).toBe(-1);
+  });
+});
+
+describe("rankAutocomplete", () => {
+  const payers = [
+    opt("Aetna"),
+    opt("Anthem BCBS", { keywords: ["blue cross", "blue shield"] }),
+    opt("Cigna"),
+    opt("Humana"),
+    opt("UnitedHealthcare", { keywords: ["UHC"] }),
+  ];
+
+  it("returns the first N options verbatim for an empty query", () => {
+    const out = rankAutocomplete(payers, "", 3);
+    expect(labels(out)).toEqual(["Aetna", "Anthem BCBS", "Cigna"]);
+  });
+
+  it("defaults to the MASTER-prompt limit of 7", () => {
+    expect(AUTOCOMPLETE_DEFAULT_LIMIT).toBe(7);
+    const many = Array.from({ length: 20 }, (_, i) => opt(`Option ${i}`));
+    expect(rankAutocomplete(many, "")).toHaveLength(7);
+    expect(rankAutocomplete(many, "option")).toHaveLength(7);
+  });
+
+  it("filters to matches and caps at the limit", () => {
+    // query "an": "Anthem BCBS" (prefix) + "Humana" (substring) match;
+    // Aetna / Cigna / UnitedHealthcare have no "an".
+    const out = rankAutocomplete(payers, "an", 10);
+    expect(labels(out)).toEqual(["Anthem BCBS", "Humana"]);
+  });
+
+  it("orders a prefix match ahead of a substring match", () => {
+    // "Aging" is a label prefix of "ag"; "Repackaging" only contains it
+    // mid-word — prefix must win.
+    const out = rankAutocomplete([opt("Repackaging"), opt("Aging")], "ag");
+    expect(out[0].label).toBe("Aging");
+  });
+
+  it("breaks score ties by shorter label, then alphabetically", () => {
+    const out = rankAutocomplete(
+      [opt("Painkiller log"), opt("Pain"), opt("Painful")],
+      "pain",
+    );
+    // exact "Pain" first; remaining two are both prefix matches -> shorter
+    // ("Painful", 7) before longer ("Painkiller log", 14).
+    expect(labels(out)).toEqual(["Pain", "Painful", "Painkiller log"]);
+  });
+
+  it("never throws on an empty option list", () => {
+    expect(rankAutocomplete([], "anything")).toEqual([]);
+    expect(rankAutocomplete([], "")).toEqual([]);
+  });
+
+  it("treats limit 0 as an empty result", () => {
+    expect(rankAutocomplete(payers, "a", 0)).toEqual([]);
+  });
+});

--- a/src/lib/ui/autocomplete-match.ts
+++ b/src/lib/ui/autocomplete-match.ts
@@ -1,0 +1,124 @@
+// MASTER-prompt G3 — "every search bar / dropdown / searchable field
+// auto-populates the top page-specific matches as you type; site-specific,
+// not global." This is the pure ranking core behind <AutocompleteInput>:
+// given a page's own option list and the live query, return the best N
+// matches (default 7, per the directive). Kept framework-free and
+// side-effect-free so it is trivially unit-testable, exactly like the
+// table-export core that backs G6.
+
+export interface AutocompleteOption {
+  /** Stable value handed back to the consumer on selection. */
+  value: string;
+  /** Human-readable text shown in the field + list row. */
+  label: string;
+  /** Optional dimmer second line (e.g. a code, category, or hint). */
+  sublabel?: string;
+  /** Extra match terms that should surface the option but aren't displayed
+   *  (e.g. synonyms, an SKU, a payer id). */
+  keywords?: string[];
+  /** Rendered but not selectable / skipped by keyboard nav. */
+  disabled?: boolean;
+}
+
+/** Default match count mandated by the MASTER prompt ("top 7 matches"). */
+export const AUTOCOMPLETE_DEFAULT_LIMIT = 7;
+
+// Score tiers — higher is a stronger match. Ordering matters more than the
+// exact magnitudes; the gaps are wide so a better placement always wins
+// before length/alpha tie-breakers come into play.
+const SCORE_EXACT = 1000;
+const SCORE_LABEL_PREFIX = 500;
+const SCORE_WORD_PREFIX = 300;
+const SCORE_LABEL_SUBSTRING = 150;
+const SCORE_SUBLABEL_PREFIX = 90;
+const SCORE_KEYWORD_PREFIX = 80;
+const SCORE_SCATTERED = 40;
+
+const norm = (s: string | undefined): string =>
+  (s ?? "").toLowerCase().trim();
+
+// Split on whitespace and common label punctuation so word-boundary prefix
+// matching works against codes/paths like "M54.5", "low-back", "A/R aging".
+const WORD_SPLIT = /[\s\-/.,()[\]_]+/;
+
+function wordStartsWith(hay: string, needle: string): boolean {
+  return hay.split(WORD_SPLIT).some((w) => w.length > 0 && w.startsWith(needle));
+}
+
+function haystacks(option: AutocompleteOption): string[] {
+  return [
+    norm(option.label),
+    norm(option.sublabel),
+    ...(option.keywords ?? []).map(norm),
+  ].filter((h) => h.length > 0);
+}
+
+/**
+ * Score one option against a normalized, non-empty query.
+ * Returns a positive score for a match, or -1 for no match.
+ *
+ * A multi-word query is an AND: every token must appear somewhere in the
+ * option's text (label, sublabel, or a keyword). The headline score comes
+ * from how the *whole* query lands in the label (exact ▸ prefix ▸ word-start
+ * ▸ substring), with weaker tiers for sublabel/keyword-only and scattered
+ * token hits — so "low back" ranks "Low back pain" above a row that merely
+ * mentions "back" and "low" in separate keywords.
+ */
+export function scoreOption(option: AutocompleteOption, query: string): number {
+  const q = norm(query);
+  if (q === "") return 0;
+
+  const hays = haystacks(option);
+  const label = hays[0] ?? "";
+
+  // AND across query tokens — each must land somewhere.
+  const tokens = q.split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    if (!hays.some((h) => h.includes(token))) return -1;
+  }
+
+  if (label === q) return SCORE_EXACT;
+  if (label.startsWith(q)) return SCORE_LABEL_PREFIX;
+  if (wordStartsWith(label, q)) return SCORE_WORD_PREFIX;
+  if (label.includes(q)) return SCORE_LABEL_SUBSTRING;
+
+  const rest = hays.slice(1);
+  if (rest.some((h) => h.startsWith(q) || wordStartsWith(h, q))) {
+    return SCORE_SUBLABEL_PREFIX > SCORE_KEYWORD_PREFIX
+      ? SCORE_SUBLABEL_PREFIX
+      : SCORE_KEYWORD_PREFIX;
+  }
+  // Every token matched, but not as one contiguous run anywhere.
+  return SCORE_SCATTERED;
+}
+
+/**
+ * Rank a page's options against the live query and return the top `limit`.
+ *
+ * Empty query → the first `limit` options verbatim (the "top page-specific
+ * defaults" the field shows before the user types), preserving the caller's
+ * own ordering. Non-empty query → matches only, sorted by score, then by
+ * shorter label (more specific), then alphabetically for a stable order.
+ */
+export function rankAutocomplete(
+  options: readonly AutocompleteOption[],
+  query: string,
+  limit: number = AUTOCOMPLETE_DEFAULT_LIMIT,
+): AutocompleteOption[] {
+  const cap = Math.max(0, limit);
+  if (norm(query) === "") return options.slice(0, cap);
+
+  const scored = options
+    .map((option) => ({ option, score: scoreOption(option, query) }))
+    .filter((s) => s.score >= 0);
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const la = a.option.label.length;
+    const lb = b.option.label.length;
+    if (la !== lb) return la - lb;
+    return a.option.label.localeCompare(b.option.label);
+  });
+
+  return scored.slice(0, cap).map((s) => s.option);
+}

--- a/src/lib/ui/section-query.test.ts
+++ b/src/lib/ui/section-query.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSectionQuery,
+  applySectionQuery,
+  type SectionQuery,
+} from "./section-query";
+
+// Fixed reference point for deterministic relative-date parsing.
+// 2026-06-12 is a Friday.
+const NOW = new Date(2026, 5, 12, 14, 30, 0);
+
+// Format using LOCAL components — the parser builds local-midnight dates, so
+// toISOString() (UTC) would roll end-of-day across the date line on machines
+// behind UTC.
+const pad = (n: number) => String(n).padStart(2, "0");
+const iso = (d?: Date) =>
+  d ? `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` : undefined;
+
+describe("parseSectionQuery — amounts", () => {
+  it("parses comparators with optional $ and commas", () => {
+    expect(parseSectionQuery("> 1000").amount).toEqual({ op: ">", value: 1000 });
+    expect(parseSectionQuery("<= $1,250.50").amount).toEqual({ op: "<=", value: 1250.5 });
+    expect(parseSectionQuery("= 0").amount).toEqual({ op: "=", value: 0 });
+  });
+
+  it("leaves remaining words as terms", () => {
+    const q = parseSectionQuery("denied > 1000");
+    expect(q.amount).toEqual({ op: ">", value: 1000 });
+    expect(q.terms).toEqual(["denied"]);
+  });
+});
+
+describe("parseSectionQuery — relative dates", () => {
+  it("'last 30 days' spans 30 days back through end of today", () => {
+    const q = parseSectionQuery("last 30 days", NOW);
+    expect(q.dateRange?.label).toBe("last 30 days");
+    expect(iso(q.dateRange?.from)).toBe("2026-05-13");
+    expect(q.dateRange?.to?.getDate()).toBe(12);
+  });
+
+  it("'today' and 'yesterday' resolve to single days", () => {
+    expect(iso(parseSectionQuery("today", NOW).dateRange?.from)).toBe("2026-06-12");
+    expect(iso(parseSectionQuery("yesterday", NOW).dateRange?.from)).toBe("2026-06-11");
+    expect(iso(parseSectionQuery("yesterday", NOW).dateRange?.to)).toBe("2026-06-11");
+  });
+
+  it("'this month' / 'this year' / 'ytd' start at the period boundary", () => {
+    expect(iso(parseSectionQuery("this month", NOW).dateRange?.from)).toBe("2026-06-01");
+    expect(iso(parseSectionQuery("this year", NOW).dateRange?.from)).toBe("2026-01-01");
+    expect(parseSectionQuery("ytd", NOW).dateRange?.label).toBe("year to date");
+    expect(iso(parseSectionQuery("ytd", NOW).dateRange?.from)).toBe("2026-01-01");
+  });
+
+  it("'this quarter' starts at the quarter boundary (Q2 for June)", () => {
+    expect(iso(parseSectionQuery("this quarter", NOW).dateRange?.from)).toBe("2026-04-01");
+  });
+
+  it("shorthand 'last month' = 30-day window", () => {
+    expect(iso(parseSectionQuery("last month", NOW).dateRange?.from)).toBe("2026-05-13");
+  });
+});
+
+describe("parseSectionQuery — explicit dates", () => {
+  it("after / since / before set open-ended bounds", () => {
+    const after = parseSectionQuery("since 2026-03-01", NOW);
+    expect(iso(after.dateRange?.from)).toBe("2026-03-01");
+    expect(after.dateRange?.to).toBeUndefined();
+
+    const before = parseSectionQuery("before 2026-03-01", NOW);
+    expect(before.dateRange?.to && iso(before.dateRange.to)).toBe("2026-03-01");
+    expect(before.dateRange?.from).toBeUndefined();
+  });
+
+  it("an explicit range binds both ends", () => {
+    const q = parseSectionQuery("2026-01-01 to 2026-02-15", NOW);
+    expect(iso(q.dateRange?.from)).toBe("2026-01-01");
+    expect(iso(q.dateRange?.to)).toBe("2026-02-15");
+  });
+
+  it("a bare ISO date filters that single day", () => {
+    const q = parseSectionQuery("2026-04-09", NOW);
+    expect(iso(q.dateRange?.from)).toBe("2026-04-09");
+    expect(iso(q.dateRange?.to)).toBe("2026-04-09");
+  });
+});
+
+describe("parseSectionQuery — composition & empties", () => {
+  it("combines date + amount + terms", () => {
+    const q = parseSectionQuery("aetna denied last 7 days > 500", NOW);
+    expect(q.amount).toEqual({ op: ">", value: 500 });
+    expect(q.dateRange?.label).toBe("last 7 days");
+    expect(q.terms.sort()).toEqual(["aetna", "denied"]);
+    expect(q.isEmpty).toBe(false);
+  });
+
+  it("flags an empty query", () => {
+    expect(parseSectionQuery("   ", NOW).isEmpty).toBe(true);
+    expect(parseSectionQuery("", NOW).terms).toEqual([]);
+  });
+});
+
+interface Row {
+  payer: string;
+  date: string;
+  amount: number;
+}
+const rows: Row[] = [
+  { payer: "Aetna", date: "2026-06-10", amount: 1200 },
+  { payer: "Cigna", date: "2026-05-01", amount: 300 },
+  { payer: "Aetna", date: "2026-01-15", amount: 50 },
+];
+const accessors = {
+  getDate: (r: Row) => r.date,
+  getAmount: (r: Row) => r.amount,
+  getText: (r: Row) => r.payer,
+};
+
+describe("applySectionQuery", () => {
+  const run = (raw: string): Row[] =>
+    applySectionQuery(rows, parseSectionQuery(raw, NOW), accessors);
+
+  it("returns all rows for an empty query", () => {
+    expect(run("")).toHaveLength(3);
+  });
+
+  it("filters by term", () => {
+    expect(run("aetna").map((r) => r.amount).sort((a, b) => a - b)).toEqual([50, 1200]);
+  });
+
+  it("filters by amount comparator", () => {
+    expect(run("> 500")).toEqual([rows[0]]);
+  });
+
+  it("filters by date range (last 60 days excludes the January row)", () => {
+    const out = run("last 60 days");
+    expect(out.map((r) => r.date)).toEqual(["2026-06-10", "2026-05-01"]);
+  });
+
+  it("ANDs all facets together", () => {
+    expect(run("aetna last 60 days > 500")).toEqual([rows[0]]);
+  });
+
+  it("excludes rows missing the facet data", () => {
+    const q: SectionQuery = parseSectionQuery("> 100", NOW);
+    const out = applySectionQuery(rows, q, { getAmount: () => null });
+    expect(out).toHaveLength(0);
+  });
+});

--- a/src/lib/ui/section-query.ts
+++ b/src/lib/ui/section-query.ts
@@ -1,0 +1,245 @@
+// MASTER-prompt G8 — the per-section search bar "across from each section
+// header" that does chronological / parameter filtering. The directive frames
+// it as "AI-driven (Cindy)", but the honest, deterministic core is a small
+// natural-language parser: it turns a typed phrase like
+//   "last 30 days denied > 1000"
+// into a structured { dateRange, amount, terms } filter the section applies to
+// its own rows. No LLM call — predictable, testable, and offline. (Kept pure
+// and framework-free, like the G3 rankAutocomplete / G6 table-export cores.)
+
+export type AmountOp = ">" | ">=" | "<" | "<=" | "=";
+
+export interface SectionAmountFilter {
+  op: AmountOp;
+  value: number;
+}
+
+export interface SectionDateRange {
+  /** Inclusive lower bound (undefined = open). */
+  from?: Date;
+  /** Inclusive upper bound (undefined = open). */
+  to?: Date;
+  /** Human-readable chip label, e.g. "last 30 days". */
+  label: string;
+}
+
+export interface SectionQuery {
+  raw: string;
+  /** Free-text words left after date/amount phrases are removed. */
+  terms: string[];
+  dateRange?: SectionDateRange;
+  amount?: SectionAmountFilter;
+  /** True when nothing meaningful was parsed (no date, amount, or terms). */
+  isEmpty: boolean;
+}
+
+const DAY_MS = 86_400_000;
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function endOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+function daysBefore(now: Date, n: number): Date {
+  return new Date(startOfDay(now).getTime() - n * DAY_MS);
+}
+function startOfWeek(d: Date): Date {
+  // Week starts Monday.
+  const x = startOfDay(d);
+  const diff = (x.getDay() + 6) % 7;
+  return new Date(x.getTime() - diff * DAY_MS);
+}
+function isoToLocalDate(iso: string): Date {
+  // Parse YYYY-MM-DD as a LOCAL date (not UTC) so day boundaries match what
+  // the user sees in the section.
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// Relative "last/past <N> <unit>" and shorthand windows → day counts.
+const NAMED_WINDOW_DAYS: Record<string, number> = {
+  week: 7,
+  month: 30,
+  quarter: 90,
+  year: 365,
+};
+
+/**
+ * Parse a section search phrase into a structured filter. `now` is injected so
+ * relative ranges ("last 30 days") are deterministic and testable.
+ */
+export function parseSectionQuery(raw: string, now: Date = new Date()): SectionQuery {
+  let work = ` ${raw.toLowerCase()} `;
+  let dateRange: SectionDateRange | undefined;
+  let amount: SectionAmountFilter | undefined;
+
+  const consume = (re: RegExp): RegExpMatchArray | null => {
+    const m = work.match(re);
+    if (m) work = work.replace(m[0], " ");
+    return m;
+  };
+
+  // --- amount comparator: > 1000, <= $50, = 0 ------------------------------
+  const amt = consume(/([<>]=?|=)\s*\$?\s*([\d,]+(?:\.\d+)?)/);
+  if (amt) {
+    amount = { op: amt[1] as AmountOp, value: Number(amt[2].replace(/,/g, "")) };
+  }
+
+  // --- explicit ISO range: 2026-01-01..2026-02-01 / "A to B" ---------------
+  let m = consume(/(\d{4}-\d{2}-\d{2})\s*(?:\.\.|to|–|-)\s*(\d{4}-\d{2}-\d{2})/);
+  if (m) {
+    dateRange = {
+      from: startOfDay(isoToLocalDate(m[1])),
+      to: endOfDay(isoToLocalDate(m[2])),
+      label: `${m[1]} → ${m[2]}`,
+    };
+  }
+
+  // --- after / since / from DATE ------------------------------------------
+  if (!dateRange && (m = consume(/(?:after|since|from)\s+(\d{4}-\d{2}-\d{2})/))) {
+    dateRange = { from: startOfDay(isoToLocalDate(m[1])), label: `since ${m[1]}` };
+  }
+  // --- before / until DATE -------------------------------------------------
+  if (!dateRange && (m = consume(/(?:before|until)\s+(\d{4}-\d{2}-\d{2})/))) {
+    dateRange = { to: endOfDay(isoToLocalDate(m[1])), label: `before ${m[1]}` };
+  }
+
+  // --- relative "last/past N days|weeks|months|years" ----------------------
+  if (!dateRange && (m = consume(/(?:last|past)\s+(\d+)\s+(day|week|month|year)s?/))) {
+    const n = Number(m[1]);
+    const unitDays = m[2] === "day" ? 1 : NAMED_WINDOW_DAYS[m[2]];
+    dateRange = {
+      from: daysBefore(now, n * unitDays),
+      to: endOfDay(now),
+      label: `last ${n} ${m[2]}${n === 1 ? "" : "s"}`,
+    };
+  }
+
+  // --- "today" / "yesterday" ----------------------------------------------
+  if (!dateRange && consume(/\byesterday\b/)) {
+    const y = daysBefore(now, 1);
+    dateRange = { from: y, to: endOfDay(y), label: "yesterday" };
+  }
+  if (!dateRange && consume(/\btoday\b/)) {
+    dateRange = { from: startOfDay(now), to: endOfDay(now), label: "today" };
+  }
+
+  // --- "this week|month|quarter|year" / "ytd" ------------------------------
+  if (!dateRange && consume(/\bthis\s+week\b/)) {
+    dateRange = { from: startOfWeek(now), to: endOfDay(now), label: "this week" };
+  }
+  if (!dateRange && consume(/\bthis\s+month\b/)) {
+    dateRange = {
+      from: new Date(now.getFullYear(), now.getMonth(), 1),
+      to: endOfDay(now),
+      label: "this month",
+    };
+  }
+  if (!dateRange && consume(/\bthis\s+quarter\b/)) {
+    const q = Math.floor(now.getMonth() / 3);
+    dateRange = {
+      from: new Date(now.getFullYear(), q * 3, 1),
+      to: endOfDay(now),
+      label: "this quarter",
+    };
+  }
+  if (!dateRange && consume(/\b(?:this\s+year|ytd)\b/)) {
+    dateRange = {
+      from: new Date(now.getFullYear(), 0, 1),
+      to: endOfDay(now),
+      label: "year to date",
+    };
+  }
+
+  // --- shorthand "last week|month|quarter|year" ----------------------------
+  if (!dateRange && (m = consume(/(?:last|past)\s+(week|month|quarter|year)\b/))) {
+    const days = NAMED_WINDOW_DAYS[m[1]];
+    dateRange = { from: daysBefore(now, days), to: endOfDay(now), label: `last ${m[1]}` };
+  }
+
+  // --- bare ISO date → that single day ------------------------------------
+  if (!dateRange && (m = consume(/(\d{4}-\d{2}-\d{2})/))) {
+    const d = isoToLocalDate(m[1]);
+    dateRange = { from: startOfDay(d), to: endOfDay(d), label: m[1] };
+  }
+
+  const terms = work
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
+  return {
+    raw,
+    terms,
+    dateRange,
+    amount,
+    isEmpty: !dateRange && !amount && terms.length === 0,
+  };
+}
+
+export interface SectionQueryAccessors<T> {
+  /** Row's date for chronological filtering. Return null to never match a range. */
+  getDate?: (row: T) => Date | string | null | undefined;
+  /** Row's numeric value for amount comparators. */
+  getAmount?: (row: T) => number | null | undefined;
+  /** Row's searchable text for the free terms (joined, lower-cased internally). */
+  getText?: (row: T) => string;
+}
+
+function inRange(date: Date, range: SectionDateRange): boolean {
+  if (range.from && date < range.from) return false;
+  if (range.to && date > range.to) return false;
+  return true;
+}
+
+function compareAmount(value: number, f: SectionAmountFilter): boolean {
+  switch (f.op) {
+    case ">":
+      return value > f.value;
+    case ">=":
+      return value >= f.value;
+    case "<":
+      return value < f.value;
+    case "<=":
+      return value <= f.value;
+    case "=":
+      return value === f.value;
+  }
+}
+
+/**
+ * Apply a parsed SectionQuery to a row list. Each active facet (date, amount,
+ * terms) is an AND; terms themselves are an AND across the row's text. Rows
+ * missing the data a facet needs are excluded from that facet.
+ */
+export function applySectionQuery<T>(
+  rows: readonly T[],
+  query: SectionQuery,
+  accessors: SectionQueryAccessors<T>,
+): T[] {
+  if (query.isEmpty) return [...rows];
+  const { getDate, getAmount, getText } = accessors;
+
+  return rows.filter((row) => {
+    if (query.dateRange && getDate) {
+      const raw = getDate(row);
+      if (raw == null) return false;
+      const d = raw instanceof Date ? raw : new Date(raw);
+      if (Number.isNaN(d.getTime()) || !inRange(d, query.dateRange)) return false;
+    }
+    if (query.amount && getAmount) {
+      const v = getAmount(row);
+      if (v == null || !compareAmount(v, query.amount)) return false;
+    }
+    if (query.terms.length > 0 && getText) {
+      const hay = getText(row).toLowerCase();
+      if (!query.terms.every((t) => hay.includes(t))) return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
Consolidates all completed MASTER-prompt UI-law work onto `main` (now that the Slice-1 kit + MetricBox have merged). **Supersedes the base-at-parent staging PRs #659 / #660 / #661 / #665 / #668** — same commits, but rebased cleanly onto `main` so they're directly mergeable. 7 commits, conflict-free cherry-pick.

## What's in here
- **G3 — 7-result autocomplete** (`91e66085`): pure `rankAutocomplete` core (13 tests) + ARIA-1.2 `<AutocompleteInput>`; adopted on vendors / policies / feedback / inventory / mail-fax patient picker.
- **G4 — global "search everything"** (`488fadc7` + `7aa74cc2`): `<GlobalSearchButton>` (bottom-left) surfacing the existing ⌘K palette via a shared `openCommandPalette()` helper; mounted in operator + clinician + patient shells.
- **G8 — per-section date/param search** (`bdbb4499` + `a29b52c1` + `c533e323`): deterministic `parseSectionQuery` NL parser (18 tests) + `<SectionSearchBar>`; adopted on incidents, announcements, time-clock (the directive's "calendar search"), and supplies.
- **G2 — sidebar overlay-when-narrowed + autohide-on-nav** (`de7c015e`): closes the two halves deferred from #648 by *gating* the drawer's existing overlay mode to narrow viewports + autohiding on navigation/back-forward. **Wide-screen layout unchanged** (zero regression); resolves the route-following-vs-autohide tension by viewport.

This completes the shared MASTER-prompt primitive set **G1–G11**.

## Verified against `main`
`tsc --noEmit` **0 errors** · `eslint` clean · `vitest` **39/39** (autocomplete 13 + section-query 18 + table-export 8). *(A stale generated Prisma client showed 7 unrelated patient-portal errors until `prisma generate` — not from this change.)*

## Notes
- G2/G4 are client/DOM behavior; the repo has no jsdom, so they're tsc/eslint-verified — a brief live pass at narrow widths is worth doing before/after merge.
- Once merged, the 5 staging PRs above can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)