### PR TITLE
EMR-662: /clinic/sign-off split-pane layout + Sign-Off tree restructure

### DIFF
--- a/src/app/(clinician)/clinic/sign-off/layout.tsx
+++ b/src/app/(clinician)/clinic/sign-off/layout.tsx
@@ -90,9 +90,16 @@ export default async function SignOffLayout({
     <div className="flex h-full min-h-[calc(100vh-4rem)]">
       {/* Left sidebar — Sign-Off tree navigation */}
       <div className="w-56 shrink-0 border-r border-border bg-surface flex flex-col p-3">
-        <p className="text-[11px] font-semibold text-text-subtle uppercase tracking-[0.12em] mb-3 px-2">
-          Sign-off
-        </p>
+        <div className="flex items-center justify-between mb-3 px-2">
+          <p className="text-[11px] font-semibold text-text-subtle uppercase tracking-[0.12em]">
+            Sign-off
+          </p>
+          {total > 0 && (
+            <span className="text-[10px] font-semibold tabular-nums rounded-full bg-surface-muted px-1.5 py-0.5 text-text-subtle">
+              {total}
+            </span>
+          )}
+        </div>
         <SignOffNav sections={sections} />
       </div>
 

--- a/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
+++ b/src/app/(clinician)/clinic/sign-off/sign-off-tree-view.tsx
@@ -23,7 +23,7 @@ export type SignOffRow = {
   title: string;
   patientName: string;
   patientId: string;
-  receivedAt: string; // ISO string — Date is not serialisable across the server→client boundary
+  receivedAt: string; // ISO — Date is not serialisable across the server→client boundary
   urgency: "high" | "normal" | "low";
   hint: string;
   href: string;
@@ -57,7 +57,17 @@ const KIND_ICON_COLOR: Record<SignOffRow["kind"], string> = {
   message: "text-accent",
 };
 
+// Left accent bar color per kind — appears on selected / hovered tree items.
+const KIND_BAR: Record<SignOffRow["kind"], string> = {
+  lab: "bg-info",
+  refill: "bg-success",
+  note: "bg-[color:var(--highlight-hover)]",
+  message: "bg-accent",
+};
+
 const KIND_ORDER: SignOffRow["kind"][] = ["lab", "refill", "note", "message"];
+
+type FilterMode = "all" | "urgent" | "today";
 
 function formatRelative(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
@@ -67,6 +77,16 @@ function formatRelative(iso: string): string {
   const hr = Math.floor(min / 60);
   if (hr < 24) return `${hr}h ago`;
   return `${Math.floor(hr / 24)}d ago`;
+}
+
+function isToday(iso: string): boolean {
+  const d = new Date(iso);
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
 }
 
 function PatientInitials({ name }: { name: string }) {
@@ -99,45 +119,159 @@ function TreeItem({
         type="button"
         onClick={onSelect}
         className={cn(
-          "w-full text-left px-3 py-2 border-b border-border/30 transition-colors flex items-start gap-2.5",
+          "group w-full text-left border-b border-border/30 transition-colors flex items-stretch relative",
           selected ? "bg-accent/10" : "hover:bg-surface-muted/60"
         )}
       >
-        <Icon
-          className={cn("mt-[3px] h-3.5 w-3.5 shrink-0", KIND_ICON_COLOR[item.kind])}
+        {/* Left kind-accent bar */}
+        <span
+          className={cn(
+            "w-[3px] shrink-0 rounded-r-full transition-opacity",
+            KIND_BAR[item.kind],
+            selected ? "opacity-100" : "opacity-0 group-hover:opacity-40"
+          )}
           aria-hidden
         />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            {item.urgency === "high" && (
-              <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" aria-label="urgent" />
-            )}
-            <p className="text-[13px] font-medium text-text truncate leading-snug">
-              {item.title}
+
+        <div className="flex items-start gap-2.5 px-3 py-2.5 min-w-0 flex-1">
+          <Icon
+            className={cn("mt-[3px] h-3.5 w-3.5 shrink-0", KIND_ICON_COLOR[item.kind])}
+            aria-hidden
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              {item.urgency === "high" && (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-danger shrink-0"
+                  aria-label="urgent"
+                />
+              )}
+              <p className="text-[13px] font-medium text-text truncate leading-snug">
+                {item.title}
+              </p>
+            </div>
+            <p className="text-[11px] text-text-subtle mt-0.5 truncate">
+              {item.patientName} · {formatRelative(item.receivedAt)}
             </p>
+            {item.hint && (
+              <p className="text-[11px] text-text-subtle/70 mt-0.5 truncate italic">
+                {item.hint}
+              </p>
+            )}
           </div>
-          <p className="text-[11px] text-text-subtle mt-0.5 truncate">
-            {item.patientName} · {formatRelative(item.receivedAt)}
-          </p>
         </div>
       </button>
     </li>
   );
 }
 
+function SectionHeader({
+  label,
+  groupKey,
+  urgentCount,
+  itemCount,
+  icon: Icon,
+  isCollapsed,
+  onToggle,
+}: {
+  label: string;
+  groupKey: string;
+  urgentCount?: number;
+  itemCount: number;
+  icon?: LucideIcon;
+  isCollapsed: boolean;
+  onToggle: () => void;
+}) {
+  const Chevron = isCollapsed ? ChevronRight : ChevronDown;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full flex items-center justify-between px-3 py-2 bg-surface-muted/40 border-b border-border/60 hover:bg-surface-muted transition-colors sticky top-0 z-10"
+      aria-expanded={!isCollapsed}
+    >
+      <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
+        {Icon && <Icon className="h-3 w-3" aria-hidden />}
+        {(urgentCount ?? 0) > 0 && (
+          <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
+        )}
+        {label}
+      </span>
+      <span className="flex items-center gap-2">
+        <span className="text-[10px] text-text-subtle tabular-nums">{itemCount}</span>
+        <Chevron className="h-3 w-3 text-text-subtle" />
+      </span>
+    </button>
+  );
+}
+
+function FilterTabs({
+  active,
+  onChange,
+  counts,
+}: {
+  active: FilterMode;
+  onChange: (m: FilterMode) => void;
+  counts: Record<FilterMode, number>;
+}) {
+  const tabs: { key: FilterMode; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "urgent", label: "Urgent" },
+    { key: "today", label: "Today" },
+  ];
+  return (
+    <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border/60 bg-surface">
+      {tabs.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onChange(key)}
+          className={cn(
+            "flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors",
+            active === key
+              ? "bg-accent/15 text-accent"
+              : "text-text-subtle hover:text-text hover:bg-surface-muted"
+          )}
+        >
+          {label}
+          {counts[key] > 0 && (
+            <span
+              className={cn(
+                "tabular-nums text-[10px] min-w-[14px] text-center",
+                key === "urgent" && counts[key] > 0 ? "text-danger" : ""
+              )}
+            >
+              {counts[key]}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState<FilterMode>("all");
 
   const selected = rows.find((r) => r.id === selectedId) ?? null;
 
-  const urgentItems = rows.filter((r) => r.urgency === "high");
+  // Filter rows for the tree display
+  const visibleRows = rows.filter((r) => {
+    if (filter === "urgent") return r.urgency === "high";
+    if (filter === "today") return isToday(r.receivedAt);
+    return true;
+  });
 
+  const urgentItems = visibleRows.filter((r) => r.urgency === "high");
+
+  // Kind groups only include non-urgent items so items appear exactly once.
   const groups = KIND_ORDER.map((kind) => ({
     kind,
     label: KIND_LABEL[kind],
-    items: rows.filter((r) => r.kind === kind),
-    urgentCount: rows.filter((r) => r.kind === kind && r.urgency === "high").length,
+    items: visibleRows.filter((r) => r.kind === kind && r.urgency !== "high"),
+    urgentCount: visibleRows.filter((r) => r.kind === kind && r.urgency === "high").length,
   })).filter((g) => g.items.length > 0);
 
   const toggleCollapse = (key: string) => {
@@ -148,114 +282,131 @@ export function SignOffTreeView({ rows }: { rows: SignOffRow[] }) {
     });
   };
 
-  function SectionHeader({
-    label,
-    groupKey,
-    urgentCount,
-    itemCount,
-    icon: Icon,
-  }: {
-    label: string;
-    groupKey: string;
-    urgentCount?: number;
-    itemCount: number;
-    icon?: LucideIcon;
-  }) {
-    const isCollapsed = collapsed.has(groupKey);
-    const Chevron = isCollapsed ? ChevronRight : ChevronDown;
-    return (
-      <button
-        type="button"
-        onClick={() => toggleCollapse(groupKey)}
-        className="w-full flex items-center justify-between px-3 py-2 bg-surface-muted/40 border-b border-border/60 hover:bg-surface-muted transition-colors sticky top-0 z-10"
-        aria-expanded={!isCollapsed}
-      >
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-subtle">
-          {Icon && <Icon className="h-3 w-3" aria-hidden />}
-          {(urgentCount ?? 0) > 0 && (
-            <span className="h-1.5 w-1.5 rounded-full bg-danger shrink-0" />
-          )}
-          {label}
-        </span>
-        <span className="flex items-center gap-2">
-          <span className="text-[10px] text-text-subtle tabular-nums">{itemCount}</span>
-          <Chevron className="h-3 w-3 text-text-subtle" />
-        </span>
-      </button>
-    );
-  }
+  const filterCounts: Record<FilterMode, number> = {
+    all: rows.length,
+    urgent: rows.filter((r) => r.urgency === "high").length,
+    today: rows.filter((r) => isToday(r.receivedAt)).length,
+  };
+
+  const handleSelect = (id: string) => {
+    setSelectedId((prev: string | null) => (prev === id ? null : id));
+  };
 
   return (
     <SplitPane
       orientation="horizontal"
-      defaultSize={288}
+      defaultSize={300}
       minSize={220}
       maxSize={520}
       storageKey="sign-off-tree"
       ariaLabel="Resize sign-off queue"
     >
       {/* Tree panel */}
-      <div className="h-full overflow-y-auto bg-surface border-r border-border">
-        {/* Urgent group — shown only when urgent items exist */}
-        {urgentItems.length > 0 && (
-          <div>
-            <SectionHeader
-              label="Urgent"
-              groupKey="urgent"
-              urgentCount={urgentItems.length}
-              itemCount={urgentItems.length}
-              icon={AlertTriangle}
-            />
-            {!collapsed.has("urgent") && (
-              <ul>
-                {urgentItems.map((item) => (
-                  <TreeItem
-                    key={`urgent-${item.id}`}
-                    item={item}
-                    selected={selectedId === item.id}
-                    onSelect={() => { setSelectedId(item.id === selectedId ? null : item.id); }}
-                  />
-                ))}
-              </ul>
+      <div className="h-full overflow-hidden bg-surface border-r border-border flex flex-col">
+        {/* Sticky panel header */}
+        <div className="sticky top-0 z-20 flex items-center justify-between px-3 py-2.5 bg-surface border-b border-border/60">
+          <span className="text-[13px] font-semibold text-text">Sign-Off Queue</span>
+          <div className="flex items-center gap-1.5">
+            {urgentItems.length > 0 && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-white bg-danger rounded-full px-1.5 py-0.5 tabular-nums">
+                <AlertTriangle className="h-2.5 w-2.5" aria-hidden />
+                {urgentItems.length}
+              </span>
             )}
+            <span className="text-[11px] text-text-subtle tabular-nums">
+              {visibleRows.length} pending
+            </span>
           </div>
-        )}
+        </div>
 
-        {/* Kind groups */}
-        {groups.map((group) => {
-          const Icon = KIND_ICON[group.kind];
-          return (
-            <div key={group.kind}>
+        {/* Filter tabs */}
+        <FilterTabs active={filter} onChange={setFilter} counts={filterCounts} />
+
+        {/* Tree content */}
+        <div className="flex-1 overflow-y-auto">
+          {/* Urgent group — only when urgent items exist */}
+          {urgentItems.length > 0 && (
+            <div>
               <SectionHeader
-                label={group.label}
-                groupKey={group.kind}
-                urgentCount={group.urgentCount}
-                itemCount={group.items.length}
-                icon={Icon}
+                label="Urgent"
+                groupKey="urgent"
+                urgentCount={urgentItems.length}
+                itemCount={urgentItems.length}
+                icon={AlertTriangle}
+                isCollapsed={collapsed.has("urgent")}
+                onToggle={() => toggleCollapse("urgent")}
               />
-              {!collapsed.has(group.kind) && (
+              {!collapsed.has("urgent") && (
                 <ul>
-                  {group.items.map((item) => (
+                  {urgentItems.map((item) => (
                     <TreeItem
-                      key={item.id}
+                      key={`urgent-${item.id}`}
                       item={item}
                       selected={selectedId === item.id}
-                      onSelect={() => { setSelectedId(item.id === selectedId ? null : item.id); }}
+                      onSelect={() => handleSelect(item.id)}
                     />
                   ))}
                 </ul>
               )}
             </div>
-          );
-        })}
+          )}
 
-        {groups.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-            <span className="text-3xl mb-3">✅</span>
-            <p className="text-sm font-medium text-text">Queue clear</p>
-            <p className="text-[12px] text-text-subtle mt-1">Nothing waiting on a signature</p>
-          </div>
-        )}
+          {/* Kind groups (non-urgent items only) */}
+          {groups.map((group) => {
+            const Icon = KIND_ICON[group.kind];
+            return (
+              <div key={group.kind}>
+                <SectionHeader
+                  label={group.label}
+                  groupKey={group.kind}
+                  urgentCount={group.urgentCount}
+                  itemCount={group.items.length}
+                  icon={Icon}
+                  isCollapsed={collapsed.has(group.kind)}
+                  onToggle={() => toggleCollapse(group.kind)}
+                />
+                {!collapsed.has(group.kind) && (
+                  <ul>
+                    {group.items.map((item) => (
+                      <TreeItem
+                        key={item.id}
+                        item={item}
+                        selected={selectedId === item.id}
+                        onSelect={() => handleSelect(item.id)}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+
+          {visibleRows.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+              {filter === "all" ? (
+                <>
+                  <span className="text-3xl mb-3">✅</span>
+                  <p className="text-sm font-medium text-text">Queue clear</p>
+                  <p className="text-[12px] text-text-subtle mt-1">
+                    Nothing waiting on a signature
+                  </p>
+                </>
+              ) : (
+                <>
+                  <span className="text-3xl mb-3">🔍</span>
+                  <p className="text-sm font-medium text-text">No items match</p>
+                  <button
+                    type="button"
+                    onClick={() => setFilter("all")}
+                    className="text-[12px] text-accent mt-2 hover:underline"
+                  >
+                    Show all items
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Detail panel */}
@@ -316,6 +467,7 @@ function SignOffDetail({ row }: { row: SignOffRow }) {
         {row.hint}
       </div>
 
+      {/* CTA */}
       <Link
         href={row.href}
         className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition-colors"


### PR DESCRIPTION
Implements EMR-662.

## What changed

- **`sign-off-tree-view.tsx`** — Full restructure of the `SignOffTreeView` component:
  - **De-duplicated item rendering**: Kind groups (Labs, Refills, etc.) now exclude items already shown in the Urgent section — every pending item appears exactly once in the tree.
  - **Sticky panel header**: New "Sign-Off Queue" title bar above the tree with a live pending count and a red urgent-count pill when abnormal/flagged items are present.
  - **Filter tabs** (All / Urgent / Today): One-click narrow view, with item counts per tab. "Today" uses a local date compare so the tab is always current. Selecting a filter that returns no results shows a recovery CTA ("Show all items").
  - **Kind-colored left accent bar** on `TreeItem`: A 3 px rounded bar in each kind's brand color fades in on hover and stays solid when the row is selected, replacing the plain-background selection signal.
  - **Hint text preview**: Each tree row now renders the `hint` string as a third truncated italic line — clinicians see context ("Abnormal — review and route", "Low confidence 48%") before clicking through.
  - `SectionHeader` is extracted to a top-level function (was nested inside `SignOffTreeView`); it now receives `isCollapsed` / `onToggle` as props instead of closing over outer state.
  - Fixed `overflow-hidden` on the tree panel container so the flex header + inner scroll div work correctly (was `overflow-y-auto` which fought the inner `flex-1 overflow-y-auto`).

- **`layout.tsx`** — Minor: sidebar header now shows the aggregate pending count as a badge next to the "Sign-off" label, so the total is visible from every sign-off sub-route (labs, refills, notes, messages).

## How to verify

1. Navigate to `/clinic/sign-off`.
2. Confirm the left tree panel has a "Sign-Off Queue" header with a pending count.
3. If any abnormal labs or flagged refills exist, confirm they appear under **Urgent** only — not duplicated in their kind section.
4. Click **Urgent** / **Today** filter tabs and confirm the tree filters correctly; confirm the "Show all items" recovery link appears when a filter returns zero rows.
5. Hover a tree item — the left accent bar should fade in in the item's kind color (blue for labs, green for refills, etc.).
6. Select an item — accent bar stays solid, row is highlighted, detail panel populates.
7. Navigate to `/clinic/sign-off/labs` and confirm the layout sidebar shows the aggregate count badge next to "Sign-off".

## Notes

- The `next lint` command cannot run in this environment (ESLint v10 flat-config mismatch with the project's `.eslintrc.json`) — this is pre-existing infra state, not introduced here.
- Pre-existing TS env errors (`Cannot find module 'react'`, `JSX.IntrinsicElements` etc.) are unchanged — typecheck diff shows zero new errors.
- Follow-up tickets (EMR-663 Labs modal, EMR-664 Refills e-signature) will build detail-panel actions on top of this tree structure.

---
_Generated by [Claude Code](https://claude.ai/code/session_019n7dA8hAh7HcnNj3UCUPTE)_