### PR TITLE
fix(metadata): drop doubled '· Leafjourney' suffix from 3 page titles

### DIFF
--- a/src/app/(clinician)/onboarding-legacy/page.tsx
+++ b/src/app/(clinician)/onboarding-legacy/page.tsx
@@ -5,7 +5,7 @@ import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { OnboardingWizard } from "./OnboardingWizard";
 
 export const metadata = {
-  title: "Clinic onboarding · Leafjourney",
+  title: "Clinic onboarding",
   description:
     "Set up your clinic on Leafjourney — basic info, NPI numbers, and state cannabis registries.",
 };

--- a/src/app/(operator)/ops/cfo/page.tsx
+++ b/src/app/(operator)/ops/cfo/page.tsx
@@ -10,7 +10,7 @@ import { CfoTabs, KpiTile, AnomaliesPanel, GenerateReportButton } from "./compon
 import { TrendLine } from "@/components/charts";
 import { MetricBoxGroup } from "@/components/ops/master";
 
-export const metadata = { title: "CFO · Leafjourney" };
+export const metadata = { title: "CFO" };
 export const dynamic = "force-dynamic";
 
 export default async function CfoOverviewPage({

--- a/src/app/(operator)/ops/pricing/page.tsx
+++ b/src/app/(operator)/ops/pricing/page.tsx
@@ -22,7 +22,7 @@ import {
   type FeatureMatrixRow,
 } from "./feature-matrix-table";
 
-export const metadata = { title: "Pricing · Leafjourney" };
+export const metadata = { title: "Pricing" };
 
 export default async function OpsPricingPage() {
   await requireUser();


### PR DESCRIPTION
## What
The root layout defines a title template (`%s · Leafjourney`), but three pages hardcoded the suffix in their own `metadata.title`, so the template appended a second one — e.g. the `/ops/cfo` browser tab read **"CFO · Leafjourney · Leafjourney."**

## Fix — drop the redundant suffix
| Page | Before | After (rendered) |
|---|---|---|
| `/ops/cfo` | `"CFO · Leafjourney"` | CFO · Leafjourney |
| `/ops/pricing` | `"Pricing · Leafjourney"` | Pricing · Leafjourney |
| `onboarding-legacy` | `"Clinic onboarding · Leafjourney"` | Clinic onboarding · Leafjourney |

A repo-wide grep confirms these were the only 3 occurrences.

## Context
Found during a broad operator-surface reliability sweep: **all 123 static `/ops` routes returned 200** (no broken pages), and the key demo pages (Mission Control, CFO, Financial Cockpit, Billing, Analytics) are console-clean. This title bug was the only concrete defect surfaced.

eslint clean on all 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)