### PR TITLE
Patient UX bug squash — 16 verified fixes (crashes, fabricated stats, dead controls, a11y)

### DIFF
--- a/src/app/(patient)/portal/assessments/[slug]/assessment-form.tsx
+++ b/src/app/(patient)/portal/assessments/[slug]/assessment-form.tsx
@@ -91,7 +91,15 @@ export function AssessmentForm({ template }: { template: AssessmentTemplate }) {
               {state.score}
             </span>
             <span className="text-lg text-text-muted ml-2">
-              / {template.slug === "pain-vas" ? "10" : template.questions.length * 3}
+              {/* Max score = sum of each question's highest option value (scales
+                  differ: PHQ-9/GAD-7 cap at 3, ISI/AUDIT-C/CUDIT-R at 4,
+                  PROMIS-Pain at 5), not a flat ×3. */}
+              / {template.slug === "pain-vas"
+                ? "10"
+                : template.questions.reduce(
+                    (sum, q) => sum + Math.max(...q.options.map((o) => o.value)),
+                    0,
+                  )}
             </span>
           </div>
         </CardHeader>

--- a/src/app/(patient)/portal/billing/disputes/actions.ts
+++ b/src/app/(patient)/portal/billing/disputes/actions.ts
@@ -18,9 +18,13 @@ export async function fileDispute(formData: FormData) {
   const reason = String(formData.get("reason") ?? "") as DisputeReason;
   const narrative = String(formData.get("narrative") ?? "").trim();
   const disputedAmountStr = String(formData.get("disputedAmount") ?? "").trim();
-  const disputedAmountCents = disputedAmountStr
-    ? Math.round(parseFloat(disputedAmountStr) * 100)
-    : null;
+  const parsedAmount = parseFloat(disputedAmountStr);
+  // Guard against NaN (non-numeric input) and negative amounts — otherwise a
+  // NaN or negative cents value gets persisted and rendered as e.g. "-$50.00".
+  const disputedAmountCents =
+    Number.isFinite(parsedAmount) && parsedAmount > 0
+      ? Math.round(parsedAmount * 100)
+      : null;
 
   if (!statementId || !reason || narrative.length < 4) return;
 

--- a/src/app/(patient)/portal/billing/tax-summary/page.tsx
+++ b/src/app/(patient)/portal/billing/tax-summary/page.tsx
@@ -36,8 +36,8 @@ export default async function TaxSummaryPage() {
       where: {
         claim: { patientId: patient.id },
         paymentDate: {
-          gte: new Date(`${selectedYear}-01-01`),
-          lte: new Date(`${selectedYear}-12-31T23:59:59`),
+          gte: new Date(`${selectedYear}-01-01T00:00:00.000Z`),
+          lte: new Date(`${selectedYear}-12-31T23:59:59.999Z`),
         },
         source: "patient",
       },
@@ -57,8 +57,8 @@ export default async function TaxSummaryPage() {
       where: {
         patientId: patient.id,
         serviceDate: {
-          gte: new Date(`${selectedYear}-01-01`),
-          lte: new Date(`${selectedYear}-12-31T23:59:59`),
+          gte: new Date(`${selectedYear}-01-01T00:00:00.000Z`),
+          lte: new Date(`${selectedYear}-12-31T23:59:59.999Z`),
         },
       },
       orderBy: { serviceDate: "asc" },

--- a/src/app/(patient)/portal/billing/tax-summary/page.tsx
+++ b/src/app/(patient)/portal/billing/tax-summary/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow } from "@/components/ui/ornament";
 import { formatMoney } from "@/lib/domain/billing";
+import { PrintButton } from "./print-button";
 
 export const metadata = { title: "Year-End Tax Summary" };
 
@@ -108,16 +109,9 @@ export default async function TaxSummaryPage() {
           <Badge tone="accent">{selectedYear}</Badge>
           <span className="text-sm text-text-muted">Tax year</span>
         </div>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={undefined}
-          className="print:hidden"
-        >
-          <span className="print:hidden" suppressHydrationWarning>
-            Print summary
-          </span>
-        </Button>
+        <PrintButton variant="primary" size="sm" className="print:hidden">
+          Print summary
+        </PrintButton>
       </div>
 
       {totalPatientPaid === 0 && visitCount === 0 ? (
@@ -257,24 +251,12 @@ export default async function TaxSummaryPage() {
 
           {/* Print button (bottom) */}
           <div className="text-center print:hidden">
-            <PrintButton />
+            <PrintButton variant="ghost" size="sm">
+              Print or save as PDF
+            </PrintButton>
           </div>
         </div>
       )}
     </PageShell>
-  );
-}
-
-function PrintButton() {
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        if (typeof window !== "undefined") window.print();
-      }}
-      className="inline-flex items-center gap-2 text-sm text-accent hover:text-accent/80 transition-colors font-medium"
-    >
-      Print or save as PDF
-    </button>
   );
 }

--- a/src/app/(patient)/portal/billing/tax-summary/print-button.tsx
+++ b/src/app/(patient)/portal/billing/tax-summary/print-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Button } from "@/components/ui/button";
+
+// The tax-summary page is a Server Component (it runs Prisma queries), so the
+// window.print() handler can't live there — passing an onClick to a button from
+// a Server Component throws "Event handlers cannot be passed to Client Component
+// props" at render. This tiny client island carries the handler.
+type PrintButtonProps = Omit<ComponentProps<typeof Button>, "onClick">;
+
+export function PrintButton({ children = "Print or save as PDF", ...props }: PrintButtonProps) {
+  return (
+    <Button
+      {...props}
+      onClick={() => {
+        if (typeof window !== "undefined") window.print();
+      }}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/app/(patient)/portal/consent/consent-view.tsx
+++ b/src/app/(patient)/portal/consent/consent-view.tsx
@@ -401,10 +401,14 @@ export function ConsentView({
                           Completed
                         </p>
                         <p className="text-[10px] text-text-subtle">
-                          {new Date(
-                            signedConsents.find((s) => s.templateId === template.id)
-                              ?.signedAt ?? ""
-                          ).toLocaleDateString()}
+                          {(() => {
+                            const signedAt = signedConsents.find(
+                              (s) => s.templateId === template.id,
+                            )?.signedAt;
+                            return signedAt
+                              ? new Date(signedAt).toLocaleDateString()
+                              : "";
+                          })()}
                         </p>
                       </div>
                     </div>

--- a/src/app/(patient)/portal/medications/page.tsx
+++ b/src/app/(patient)/portal/medications/page.tsx
@@ -433,9 +433,11 @@ export default async function MedicationsPage() {
 
                     {/* ── Actions ────────────────────────────── */}
                     <div className="pt-2 flex items-center gap-3 flex-wrap">
-                      <Button variant="highlight" size="md">
-                        Log a dose
-                      </Button>
+                      <a href="/portal/log-dose">
+                        <Button variant="highlight" size="md">
+                          Log a dose
+                        </Button>
+                      </a>
                       <a href="/portal/medications/explainer">
                         <Button variant="ghost" size="md">
                           How does this work?
@@ -534,19 +536,6 @@ export default async function MedicationsPage() {
         </Card>
       </section>
 
-      {/* ==================== Dosing recommendation (merged from /portal/dosing) ==================== */}
-      <EditorialRule className="my-10" />
-      <section id="dosing-plan" className="scroll-mt-24 mb-4">
-        <Eyebrow className="mb-3">Dosing plan</Eyebrow>
-        <h2 className="font-display text-2xl md:text-3xl text-text tracking-tight">
-          AI-assisted dosing recommendation
-        </h2>
-        <p className="text-sm text-text-muted mt-3 max-w-md leading-relaxed mb-6">
-          Built from your health profile, current medications, and outcome
-          trends. Your care team will review and finalize.
-        </p>
-        <DosingDisplay />
-      </section>
     </PageShell>
   );
 }

--- a/src/app/(patient)/portal/notifications/notification-center.tsx
+++ b/src/app/(patient)/portal/notifications/notification-center.tsx
@@ -318,6 +318,10 @@ export function NotificationCenter({
                     {/* Enabled toggle */}
                     <div className="flex justify-center w-16">
                       <button
+                        type="button"
+                        role="switch"
+                        aria-checked={pref.enabled}
+                        aria-label={`Enable ${config.label} notifications`}
                         onClick={() => toggleEnabled(pref.type)}
                         className={cn(
                           "h-5 w-9 rounded-full transition-colors duration-200 relative",
@@ -338,6 +342,10 @@ export function NotificationCenter({
                       (channel) => (
                         <div key={channel} className="flex justify-center w-16">
                           <button
+                            type="button"
+                            role="checkbox"
+                            aria-checked={pref.channels.includes(channel)}
+                            aria-label={`${config.label} via ${channel.replace("_", " ")}`}
                             disabled={!pref.enabled}
                             onClick={() => toggleChannel(pref.type, channel)}
                             className={cn(

--- a/src/app/(patient)/portal/nutrition/nutrition-logger.tsx
+++ b/src/app/(patient)/portal/nutrition/nutrition-logger.tsx
@@ -101,7 +101,7 @@ export function NutritionLogger() {
   function handleBarcodeLookup() {
     const found = resolveBarcode(barcode.trim());
     if (!found) {
-      setPhotoStatus(null);
+      setPhotoStatus("No match for that barcode — type the food name below.");
       setDraft((d) => ({ ...d, source: "barcode", name: "" }));
       return;
     }
@@ -370,6 +370,7 @@ function MacroRing({
             stroke="var(--accent)"
             strokeWidth="3"
             strokeLinecap="round"
+            pathLength={100}
             strokeDasharray={`${pct} 100`}
             transform="rotate(-90 18 18)"
           />

--- a/src/app/(patient)/portal/outcomes/page.tsx
+++ b/src/app/(patient)/portal/outcomes/page.tsx
@@ -169,7 +169,7 @@ export default async function OutcomesPage() {
                   )}
                 </div>
                 <Sparkline
-                  data={series.length > 1 ? series : [0, 0]}
+                  data={series}
                   width={200}
                   height={40}
                 />

--- a/src/app/(patient)/portal/qa/qa-view.tsx
+++ b/src/app/(patient)/portal/qa/qa-view.tsx
@@ -34,10 +34,12 @@ function QACard({
   entry,
   isOpen,
   onToggle,
+  onOpen,
 }: {
   entry: QAEntry;
   isOpen: boolean;
   onToggle: () => void;
+  onOpen: (id: string) => void;
 }) {
   const tone = CATEGORY_TONES[entry.category] || "neutral";
 
@@ -128,7 +130,8 @@ function QACard({
                       key={related.id}
                       onClick={(e) => {
                         e.stopPropagation();
-                        // Scroll to and open the related question
+                        // Open the related question's accordion, then scroll to it.
+                        onOpen(related.id);
                         const el = document.getElementById(`qa-${related.id}`);
                         if (el) {
                           el.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -178,6 +181,8 @@ export function QAView() {
     }
     return groups;
   }, [query, activeCategory, results]);
+
+  const openOne = (id: string) => setOpenIds((prev) => new Set(prev).add(id));
 
   function toggleOpen(id: string) {
     setOpenIds((prev) => {
@@ -317,6 +322,7 @@ export function QAView() {
                       entry={entry}
                       isOpen={openIds.has(entry.id)}
                       onToggle={() => toggleOpen(entry.id)}
+                      onOpen={openOne}
                     />
                   </div>
                 ))}
@@ -335,6 +341,7 @@ export function QAView() {
                 entry={entry}
                 isOpen={openIds.has(entry.id)}
                 onToggle={() => toggleOpen(entry.id)}
+                onOpen={openOne}
               />
             </div>
           ))}

--- a/src/app/(patient)/portal/registration/registration-packet.tsx
+++ b/src/app/(patient)/portal/registration/registration-packet.tsx
@@ -273,14 +273,17 @@ function Field({
   required?: boolean;
   children: React.ReactNode;
 }) {
+  // Wrap the control inside the <label> so it's programmatically associated
+  // (clicking the label focuses the field; screen readers announce it) without
+  // threading ids through every call site.
   return (
-    <div>
-      <label className="text-[10px] font-medium uppercase tracking-wider text-text-subtle block mb-1">
+    <label className="block">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-text-subtle block mb-1">
         {label}
         {required && <span className="text-danger"> *</span>}
-      </label>
+      </span>
       {children}
-    </div>
+    </label>
   );
 }
 

--- a/src/app/(patient)/portal/seed-trove/wallet-view.tsx
+++ b/src/app/(patient)/portal/seed-trove/wallet-view.tsx
@@ -89,10 +89,9 @@ export function TroveWalletView({
 }
 
 function TierStrip({ snapshot, balance }: { snapshot: SeedTroveSnapshot; balance: number }) {
-  const progress =
-    snapshot.seedsToNextTier == null || snapshot.seedsToNextTier === 0
-      ? 100
-      : Math.min(99, Math.floor(((balance - (balance - snapshot.seedsToNextTier - 1)) / (snapshot.seedsToNextTier + 1)) * 100));
+  // Actual progress through the current tier (0–100), computed in the loyalty
+  // builder where the tier floors are known.
+  const progress = snapshot.tierProgressPct;
   return (
     <Card tone="ambient">
       <CardContent className="py-7">
@@ -125,7 +124,7 @@ function TierStrip({ snapshot, balance }: { snapshot: SeedTroveSnapshot; balance
             <div className="h-1.5 mt-1.5 rounded-full bg-surface-muted overflow-hidden">
               <div
                 className="h-full bg-emerald-600 transition-all"
-                style={{ width: `${100 - progress}%` }}
+                style={{ width: `${progress}%` }}
               />
             </div>
           </div>

--- a/src/app/(patient)/portal/streaks/page.tsx
+++ b/src/app/(patient)/portal/streaks/page.tsx
@@ -9,6 +9,21 @@ import { StreaksView, type StreaksData } from "./streaks-view";
 
 export const metadata = { title: "Your Streak" };
 
+/** Longest run of consecutive calendar days in a set of "YYYY-MM-DD" keys. */
+function longestRun(dayKeys: Set<string>): number {
+  const sorted = [...dayKeys].sort();
+  let longest = 0;
+  let run = 0;
+  let prev: number | null = null;
+  for (const key of sorted) {
+    const t = new Date(`${key}T00:00:00`).getTime();
+    run = prev !== null && t - prev === 86_400_000 ? run + 1 : 1;
+    if (run > longest) longest = run;
+    prev = t;
+  }
+  return longest;
+}
+
 export default async function StreaksPage() {
   const user = await requireRole("patient");
   const patient = await prisma.patient.findUnique({
@@ -42,7 +57,8 @@ export default async function StreaksPage() {
 
   const data: StreaksData = {
     currentStreak: showDemo ? 12 : realCurrent,
-    longestStreak: showDemo ? 23 : Math.max(realCurrent, 23),
+    // Real longest run of consecutive logged days — not a fabricated floor of 23.
+    longestStreak: showDemo ? 23 : longestRun(loggedKeys),
     totalDaysLogged: showDemo ? 47 : loggedKeys.size,
     last30: days,
   };

--- a/src/components/store/affiliate-product-card.tsx
+++ b/src/components/store/affiliate-product-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { ExternalLink, Tag, ShoppingBag } from "lucide-react";
 import { LeafIcon } from "@/components/leafmart/LeafIcon";

--- a/src/lib/domain/seed-trove-loyalty.ts
+++ b/src/lib/domain/seed-trove-loyalty.ts
@@ -138,6 +138,8 @@ export interface SeedTroveSnapshot {
   tierHue: string;
   seedsToNextTier: number | null;   // null when at the top tier
   nextTierLabel: string | null;
+  /** 0–100 progress through the current tier toward the next (100 at top tier). */
+  tierProgressPct: number;
   recentEntries: SeedLedgerEntry[]; // newest first, capped to 10
 }
 
@@ -168,6 +170,15 @@ export function snapshotFromLedger(userId: string, ledger: SeedLedgerEntry[]): S
     tierHue: tier.hue,
     seedsToNextTier: next ? Math.max(0, next.minSeeds - balance) : null,
     nextTierLabel: next?.label ?? null,
+    tierProgressPct: next
+      ? Math.min(
+          100,
+          Math.max(
+            0,
+            Math.round(((balance - tier.minSeeds) / (next.minSeeds - tier.minSeeds)) * 100),
+          ),
+        )
+      : 100,
     recentEntries: recent,
   };
 }

--- a/src/lib/domain/treatment-goals.ts
+++ b/src/lib/domain/treatment-goals.ts
@@ -38,9 +38,12 @@ export const GOAL_METRIC_LABELS: Record<GoalMetric, { label: string; emoji: stri
  * Calculate progress toward a goal.
  */
 export function calculateGoalProgress(goal: TreatmentGoal, currentValue: number): GoalProgress {
-  const range = Math.abs(goal.target - goal.baseline);
-  const progress = Math.abs(currentValue - goal.baseline);
-  const percentComplete = range === 0 ? 100 : Math.min(100, Math.round((progress / range) * 100));
+  // Signed, so moving the WRONG way from baseline counts as 0% — not progress.
+  // (e.g. a "less pain" goal of 7→3 with a current of 9 is 0%, not |9-7|/|3-7|=50%.)
+  const range = goal.target - goal.baseline;
+  const moved = currentValue - goal.baseline;
+  const percentComplete =
+    range === 0 ? 100 : Math.min(100, Math.max(0, Math.round((moved / range) * 100)));
 
   let trend: GoalProgress["trend"] = "steady";
   if (goal.direction === "decrease") {


### PR DESCRIPTION
Output of a comprehensive patient-experience QA sweep (6 parallel hunters across all 90 `/portal/*` pages + the shell). These are the **high-confidence, verified** fixes; larger "feature not wired to persistence" findings and orphaned-page nav are listed at the bottom for a product call (not included here).

## Render crashes (Server Component passing `onClick` → Next throws at render)
- `store/affiliate-product-card` — added `"use client"` (was crashing the `/portal/shop` "Partner Deals" section).
- `billing/tax-summary` — extracted the `window.print()` handler into a `"use client"` island (`print-button.tsx`); also replaced the top dead `onClick={undefined}` button.

## Fabricated / incorrect data shown to patients
- **goals** (`treatment-goals.calculateGoalProgress`) — was `Math.abs`, so moving the **wrong** way counted as progress (a "less pain" 7→3 goal at current 9 showed "50% there"). Now signed + clamped → **0% when moving away**.
- **streaks** — `Math.max(realCurrent, 23)` fabricated "Longest ever: 23 days" for every real patient → compute the **real** longest consecutive run.
- **seed-trove** — tier-progress expression algebraically reduced to a constant (bar stuck at 1%) → added a correct `tierProgressPct` to the snapshot.
- **assessments** — denominator hardcoded `questions.length * 3`, wrong for ISI/AUDIT-C/PROMIS (showed impossible "28 / 21") → sum of each question's max option value.
- **outcomes** — `[0,0]` sparkline fallback drew a false flat-zero line for a single data point → let Sparkline's "Not enough data" show.

## Dead controls / interaction & a11y
- **medications** — dead "Log a dose" button → links to `/portal/log-dose`; removed a duplicated dosing section (rendered `DosingDisplay` twice + duplicate `id="dosing-plan"`).
- **registration** — whole packet's labels weren't associated with inputs → wrap control in `<label>`.
- **notifications** — enable switch + channel checkboxes had no accessible name → `role`/`aria-checked`/`aria-label`/`type`.
- **qa** — "Related questions" now opens the target accordion before scrolling (was landing on a collapsed card).
- **consent** — guard "Invalid Date" when a signed row isn't found.
- **billing/disputes** — guard NaN/negative disputed amounts.
- **nutrition** — MacroRing geometry (`pathLength={100}`, was filling ~97% at "100%"); barcode-not-found now shows a message.
- **billing/tax-summary** — year-range query was UTC/local asymmetric → both bounds explicit UTC.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean on all touched files · no test breakage. (Two commits: crashes/data batch 1, a11y/interaction batch 2.)

## Deliberately NOT in this PR (need a product decision — larger work)
- **Flows that only mutate client state / sessionStorage and silently don't persist:** journal entries, survey responses, caregivers invite/revoke, device integrations, HIPAA record-release request, "email my story/records to doctor". These show false success and need real server actions (+ possibly schema). Privacy-sensitive ones (caregivers, record-release) are the priority.
- **Hardcoded demo data presented as the patient's own:** dose-calendar adherence, portal-home "Daily Vitals" + "Recent Scan".
- **12 orphaned pages** (exist but unreachable from any nav/link): companion, care-pathway, bookmarks, dispensary-locator, advocacy, tutorials, orders, philanthropy, my-story, survey, schedule-viz, wellness-toolkit.

Happy to take any of these as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)