### PR TITLE
Stabilization QA pass: EMR-1113 dev-DB fix + Drawer Escape-handler hardening

### DIFF
--- a/src/components/leafnerd/fhir-intelligence/Drawer.tsx
+++ b/src/components/leafnerd/fhir-intelligence/Drawer.tsx
@@ -142,7 +142,7 @@ export function Drawer({ payload, onClose, toast }: { payload: DrawerPayload; on
     const k = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", k);
     return () => window.removeEventListener("keydown", k);
-  }, []);
+  }, [onClose]);
 
   const tabsFor: [string, string][] = ({
     fhir:    [["summary", "Normalized"], ["raw", "Raw JSON"], ["prov", "Provenance"], ["valid", "Validation"]],


### PR DESCRIPTION
## Summary
Overnight stabilization / bug-crushing QA pass against `main`, run in an isolated worktree (the shared clone has concurrent swarms + a stale Prisma client that produces false typecheck errors). The headline fix was **operational, not code** — this PR carries only the one code delta found.

### 🐛 Biggest find (fixed live, no code change): EMR-1113 dev-DB drift
Migration `20260610090000_emr1113_dose_capture_and_goals` (adds `DoseLog.sideEffects` + `TreatmentGoal`) existed in the repo and on main's schema, but was **never applied to the dev database** (`_prisma_migrations` falsely recorded it as applied, so `migrate status` lied "up to date"). Every query touching those models threw `column DoseLog.sideEffects does not exist`:
- **Clinician patient chart** (`clinic/patients/[id]`) — 21 console errors, degraded render
- Patient portal `/goals`, `/dose-history`, and the `/log-dose` write path

Hidden from HTTP-status sweeps because error boundaries swallow it into a **200 + broken render**. Fixed by applying the idempotent migration via `DIRECT_URL`. Verified read **and** write end-to-end (chart 21→0 console errors; logged a dose with side-effects + created a goal through the real UI, both persisted, test rows cleaned up). `migrate diff` afterward confirms the DB now fully satisfies main's schema — no other drift.

### 🔧 This PR's code change
`Drawer.tsx` (leafnerd FHIR): the Escape-to-close `useEffect` had `[]` deps while closing over `onClose` → potential stale-closure. Added `onClose` to deps (standard react-hooks/exhaustive-deps fix). Latent today, defensive going forward.

## Verification on `main`
- typecheck **0 errors** · **3383 tests pass** · prod build **green** · lint warnings-only
- ~90 routes smoked across operator/clinician/patient/public/role personas — **zero 500s, zero console errors after the DB fix**
- Other 3 exhaustive-deps lint warnings triaged as benign (1 false-positive intentional refresh dep, 1 not-a-bug closure, 1 perf-nit on a demo component) — not fixed by design.

## Advisory (NOT in this PR — on in-flight branches, for those owners)
- **ws-c-prescribing-safety:** high-dose-THC attestation gate never fires for *custom/free-text* products (no structured concentration). Clinical-completeness gap, not a bug — a governance call.
- **ws-a-doc-cockpit:** `tax-summary.ts:summarizeTaxData` buckets quarters by `getUTCMonth()` ignoring year; safe only because the sole caller pre-filters to one year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)