### PR TITLE
fix(banners): /admin/banners 500 — move pure filter out of the 'use client' module

### DIFF
--- a/src/app/(super-admin)/admin/banners/page.tsx
+++ b/src/app/(super-admin)/admin/banners/page.tsx
@@ -13,7 +13,10 @@ import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
 import { Breadcrumbs } from "@/components/super-admin/breadcrumbs";
 import { SYSTEM_BANNERS } from "@/lib/banners/config";
-import { getActiveSystemBanners } from "@/lib/banners/system-banner-source";
+// Server-safe module (NOT the "use client" hook file) — a Server Component
+// calling a fn exported from a "use client" module gets a client-reference
+// proxy and 500s. See ./active-banners.
+import { getActiveSystemBanners } from "@/lib/banners/active-banners";
 
 export const metadata: Metadata = {
   title: "System banners — LeafJourney",

--- a/src/lib/banners/active-banners.ts
+++ b/src/lib/banners/active-banners.ts
@@ -1,0 +1,53 @@
+/**
+ * active-banners.ts — pure, server- AND client-safe resolver for the set of
+ * active system banners. NO "use client" directive: this must be importable
+ * from server components (e.g. the /admin/banners viewer) and server actions.
+ *
+ * The React hook wrapper lives in ./system-banner-source ("use client") and
+ * delegates to getActiveSystemBanners here. Keeping the filter logic in this
+ * server-safe module is what lets a Server Component call it directly — a
+ * Server Component calling a function exported from a "use client" module gets
+ * a client-reference proxy and throws at request time (that was the
+ * /admin/banners 500).
+ */
+
+import { SYSTEM_BANNERS, type SystemBannerConfig } from "./config";
+
+export type ActiveBannerSurface = "clinician" | "operator" | "super-admin";
+
+export interface ActiveSystemBannersOptions {
+  /** Which mount surface is asking. Used to gate `surfaces` allowlists. */
+  surface: ActiveBannerSurface;
+  /** Optional clock override for testing. Defaults to `Date.now()`. */
+  now?: number;
+}
+
+function isWithinWindow(b: SystemBannerConfig, now: number): boolean {
+  if (b.startsAt) {
+    const start = Date.parse(b.startsAt);
+    if (Number.isFinite(start) && now < start) return false;
+  }
+  if (b.endsAt) {
+    const end = Date.parse(b.endsAt);
+    if (Number.isFinite(end) && now > end) return false;
+  }
+  return true;
+}
+
+function matchesSurface(b: SystemBannerConfig, surface: ActiveBannerSurface): boolean {
+  if (!b.surfaces || b.surfaces.length === 0) return true;
+  return b.surfaces.includes(surface);
+}
+
+/**
+ * Returns the banners that should render right now for `surface`.
+ * Pure — safe to call from server or client.
+ */
+export function getActiveSystemBanners(
+  options: ActiveSystemBannersOptions,
+): readonly SystemBannerConfig[] {
+  const ts = options.now ?? Date.now();
+  return SYSTEM_BANNERS.filter(
+    (b) => b.enabled && matchesSurface(b, options.surface) && isWithinWindow(b, ts),
+  );
+}

--- a/src/lib/banners/system-banner-source.ts
+++ b/src/lib/banners/system-banner-source.ts
@@ -1,61 +1,28 @@
 "use client";
 
 /**
- * system-banner-source.ts — single hook that resolves the set of active
- * system banners for the current surface.
+ * system-banner-source.ts — React hook that resolves the set of active system
+ * banners for the current surface. Client-only.
  *
- * v1 derives strictly from `src/lib/banners/config.ts`. The hook is shaped
- * around a future swap to `/api/status` (PR #479 follow-up):
+ * The pure filter logic lives in ./active-banners (server-safe, no "use
+ * client") so Server Components can call getActiveSystemBanners directly. This
+ * file is just the `useMemo` hook wrapper for client components.
  *
- *   useActiveSystemBanners({ surface }) ->
- *     1. Filter SYSTEM_BANNERS by `enabled`.
- *     2. Filter by surface (if a banner declares a `surfaces` allowlist).
- *     3. Filter by active time window (`startsAt` / `endsAt`).
- *     4. TODO(PR #479 follow-up): merge in system-health banners
- *        derived from `/api/status` when overall state !== "operational".
- *
- * The hook is intentionally synchronous + dependency-free for v1 so it
- * can render in any client component without a Suspense boundary.
+ * v1 derives strictly from `src/lib/banners/config.ts`. Future swap to
+ * `/api/status` (PR #479 follow-up) slots into ./active-banners without
+ * touching call sites.
  */
 
 import { useMemo } from "react";
+import { type SystemBannerConfig } from "./config";
 import {
-  SYSTEM_BANNERS,
-  type SystemBannerConfig,
-} from "./config";
+  getActiveSystemBanners,
+  type ActiveBannerSurface,
+  type ActiveSystemBannersOptions,
+} from "./active-banners";
 
-export type ActiveBannerSurface = "clinician" | "operator" | "super-admin";
-
-export interface UseActiveSystemBannersOptions {
-  /** Which mount surface is asking. Used to gate `surfaces` allowlists. */
-  surface: ActiveBannerSurface;
-  /**
-   * Optional clock override for testing. Defaults to `Date.now()`. The
-   * hook does not subscribe to a clock tick — banners cross their
-   * start/end window on the next render rather than on the wall clock.
-   */
-  now?: number;
-}
-
-function isWithinWindow(b: SystemBannerConfig, now: number): boolean {
-  if (b.startsAt) {
-    const start = Date.parse(b.startsAt);
-    if (Number.isFinite(start) && now < start) return false;
-  }
-  if (b.endsAt) {
-    const end = Date.parse(b.endsAt);
-    if (Number.isFinite(end) && now > end) return false;
-  }
-  return true;
-}
-
-function matchesSurface(
-  b: SystemBannerConfig,
-  surface: ActiveBannerSurface,
-): boolean {
-  if (!b.surfaces || b.surfaces.length === 0) return true;
-  return b.surfaces.includes(surface);
-}
+export type { ActiveBannerSurface };
+export type UseActiveSystemBannersOptions = ActiveSystemBannersOptions;
 
 /**
  * Returns the banners that should render right now for `surface`.
@@ -65,25 +32,5 @@ export function useActiveSystemBanners({
   surface,
   now,
 }: UseActiveSystemBannersOptions): readonly SystemBannerConfig[] {
-  return useMemo(() => {
-    const ts = now ?? Date.now();
-    return SYSTEM_BANNERS.filter(
-      (b) => b.enabled && matchesSurface(b, surface) && isWithinWindow(b, ts),
-    );
-  }, [surface, now]);
-}
-
-/**
- * Server-friendly variant — same filter logic, but callable from a server
- * component or a server action. Mirrors the hook signature so a future
- * swap to `/api/status` can be slotted in here without touching callers.
- */
-export function getActiveSystemBanners(
-  options: UseActiveSystemBannersOptions,
-): readonly SystemBannerConfig[] {
-  const ts = options.now ?? Date.now();
-  return SYSTEM_BANNERS.filter(
-    (b) =>
-      b.enabled && matchesSurface(b, options.surface) && isWithinWindow(b, ts),
-  );
+  return useMemo(() => getActiveSystemBanners({ surface, now }), [surface, now]);
 }


### PR DESCRIPTION
## The bug (real 500, found by live sweep)
`/admin/banners` returned a **stable HTTP 500**. The Server Component called `getActiveSystemBanners`, which was exported from `system-banner-source.ts` — a **`"use client"`** module (it also exports the `useActiveSystemBanners` React hook). In the App Router, a Server Component calling a function exported from a `"use client"` module receives a **client-reference proxy** and throws at request time.

**Why CI didn't catch it:** `next build` compiles the module fine — this is a *runtime* RSC boundary error, not a build error. It only shows up when the route is actually requested. Surfaced by a live authed route sweep of the super-admin surface.

## Fix
Extract the pure, server-safe filter into a new **non-client** module `src/lib/banners/active-banners.ts` (`getActiveSystemBanners` + `isWithinWindow` + `matchesSurface` + types).
- `system-banner-source.ts` (`"use client"`) keeps only the `useActiveSystemBanners` hook, now delegating to the pure function.
- `admin/banners/page.tsx` imports `getActiveSystemBanners` from the server-safe module.

The client hook (`useActiveSystemBanners`, used by `components/ui/system-banner.tsx`) is unchanged in behavior.

## Verification
- eslint clean; whole-repo typecheck **0 errors**.
- Structural fix — removes the client→server call boundary that caused the throw. (Runtime confirmation pending a stable server; the shared dev box is currently CPU-saturated by parallel swarms, load avg ~40.)

Found during an intensive reliability sweep: across super-admin + public + storefront, this was the **only** real defect — every other route returned 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)