### PR TITLE
Patient UX flawless pass (batch 3) — responsive/loading polish + data-honesty

### DIFF
--- a/src/app/(patient)/portal/billing/statements/page.tsx
+++ b/src/app/(patient)/portal/billing/statements/page.tsx
@@ -158,7 +158,8 @@ export default async function PatientStatementsPage() {
         ) : (
           <Card tone="raised">
             <CardContent className="py-4">
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto -mx-4 px-4">
+              <table className="w-full text-sm min-w-[26rem]">
                 <thead>
                   <tr className="text-left text-text-subtle text-[11px] uppercase tracking-wider border-b border-border/60">
                     <th className="py-2">Date</th>
@@ -191,6 +192,7 @@ export default async function PatientStatementsPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </CardContent>
           </Card>
         )}

--- a/src/app/(patient)/portal/billing/tax-summary/page.tsx
+++ b/src/app/(patient)/portal/billing/tax-summary/page.tsx
@@ -134,7 +134,7 @@ export default async function TaxSummaryPage() {
                 </p>
               </div>
 
-              <div className="grid grid-cols-3 gap-6 pt-6 border-t border-border">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 pt-6 border-t border-border">
                 <div className="text-center">
                   <p className="text-xs text-text-subtle uppercase tracking-wider mb-1">Total billed</p>
                   <p className="text-lg font-semibold text-text">{formatMoney(totalCharged)}</p>

--- a/src/app/(patient)/portal/dose-calendar/calendar-view.tsx
+++ b/src/app/(patient)/portal/dose-calendar/calendar-view.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useMemo, useCallback } from "react";
 import {
-  generateDemoMonth,
+  buildMonthEntries,
   getAdherenceLevel,
   ADHERENCE_COLORS,
   type DoseCalendarEntry,
+  type DoseLogLite,
 } from "@/lib/domain/dose-calendar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -13,18 +14,24 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils/cn";
 
 const DAYS_OF_WEEK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const REGIMEN_NAME = "Charlotte's Web 1:1 Tincture";
-const DOSES_PER_DAY = 3;
 
-export function CalendarView() {
-  const today = new Date();
+export function CalendarView({
+  logs,
+  scheduledPerDay,
+  regimenName,
+}: {
+  logs: DoseLogLite[];
+  scheduledPerDay: number;
+  regimenName: string;
+}) {
+  const today = useMemo(() => new Date(), []);
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
   const entries = useMemo(
-    () => generateDemoMonth(year, month, REGIMEN_NAME, DOSES_PER_DAY),
-    [year, month],
+    () => buildMonthEntries(logs, scheduledPerDay, regimenName, year, month),
+    [logs, scheduledPerDay, regimenName, year, month],
   );
 
   const entryMap = useMemo(() => {
@@ -72,6 +79,11 @@ export function CalendarView() {
     return total > 0 ? Math.round((taken / total) * 100) : 0;
   }, [entries]);
 
+  const totalTaken = useMemo(
+    () => entries.reduce((sum, e) => sum + e.takenDoses, 0),
+    [entries],
+  );
+
   const isFutureDay = useCallback(
     (day: number) => {
       const date = new Date(year, month, day);
@@ -90,13 +102,15 @@ export function CalendarView() {
         <CardContent className="py-4 px-6 flex items-center justify-between">
           <div>
             <p className="text-xs font-medium uppercase tracking-wider text-text-subtle">
-              Current regimen
+              {scheduledPerDay > 0 ? "Current regimen" : "Tracking"}
             </p>
             <p className="text-sm font-medium text-text mt-0.5">
-              {REGIMEN_NAME}
+              {scheduledPerDay > 0 ? regimenName : "Your logged doses"}
             </p>
           </div>
-          <Badge tone="accent">{DOSES_PER_DAY}x daily</Badge>
+          {scheduledPerDay > 0 && (
+            <Badge tone="accent">{scheduledPerDay}x daily</Badge>
+          )}
         </CardContent>
       </Card>
 
@@ -212,42 +226,58 @@ export function CalendarView() {
 
         {/* Right panel: detail or monthly summary */}
         <div className="space-y-6">
-          {/* Monthly adherence ring */}
+          {/* Monthly summary — real adherence when scheduled, else a logged count */}
           <Card>
             <CardContent className="py-6 flex flex-col items-center">
-              <div className="relative h-28 w-28 mb-4">
-                <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
-                  <circle
-                    cx="50"
-                    cy="50"
-                    r="42"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="8"
-                    className="text-surface-muted"
-                  />
-                  <circle
-                    cx="50"
-                    cy="50"
-                    r="42"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="8"
-                    strokeLinecap="round"
-                    strokeDasharray={`${(adherencePercent / 100) * 264} 264`}
-                    className="text-emerald-600 transition-all duration-700"
-                  />
-                </svg>
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <span className="font-display text-2xl text-text tabular-nums">
-                    {adherencePercent}%
+              {scheduledPerDay > 0 ? (
+                <>
+                  <div className="relative h-28 w-28 mb-4">
+                    <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
+                      <circle
+                        cx="50"
+                        cy="50"
+                        r="42"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="8"
+                        className="text-surface-muted"
+                      />
+                      <circle
+                        cx="50"
+                        cy="50"
+                        r="42"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="8"
+                        strokeLinecap="round"
+                        strokeDasharray={`${(adherencePercent / 100) * 264} 264`}
+                        className="text-emerald-600 transition-all duration-700"
+                      />
+                    </svg>
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <span className="font-display text-2xl text-text tabular-nums">
+                        {adherencePercent}%
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-sm text-text-muted text-center leading-relaxed">
+                    You took{" "}
+                    <span className="font-medium text-text">{adherencePercent}%</span> of your
+                    scheduled doses this month
+                  </p>
+                </>
+              ) : (
+                <>
+                  <span className="font-display text-4xl text-text tabular-nums mb-1">
+                    {totalTaken}
                   </span>
-                </div>
-              </div>
-              <p className="text-sm text-text-muted text-center leading-relaxed">
-                You took <span className="font-medium text-text">{adherencePercent}%</span> of
-                your doses this month
-              </p>
+                  <p className="text-sm text-text-muted text-center leading-relaxed">
+                    {totalTaken === 0
+                      ? "No doses logged this month yet."
+                      : `dose${totalTaken === 1 ? "" : "s"} logged this month`}
+                  </p>
+                </>
+              )}
             </CardContent>
           </Card>
 

--- a/src/app/(patient)/portal/dose-calendar/page.tsx
+++ b/src/app/(patient)/portal/dose-calendar/page.tsx
@@ -1,13 +1,50 @@
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import { requireRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
 import { PageShell } from "@/components/shell/PageHeader";
 import { Eyebrow } from "@/components/ui/ornament";
 import { CalendarView } from "./calendar-view";
+import type { DoseLogLite } from "@/lib/domain/dose-calendar";
 
 export const metadata = { title: "Dose Calendar" };
 
 export default async function DoseCalendarPage() {
-  await requireRole("patient");
+  const user = await requireRole("patient");
+  const patient = await prisma.patient.findUnique({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+
+  let logs: DoseLogLite[] = [];
+  let scheduledPerDay = 0;
+  let regimenName = "Your doses";
+
+  if (patient) {
+    const since = new Date();
+    since.setFullYear(since.getFullYear() - 1);
+    const [doseRows, regimens] = await Promise.all([
+      prisma.doseLog.findMany({
+        where: { patientId: patient.id, loggedAt: { gte: since } },
+        select: { loggedAt: true, actualVolume: true, volumeUnit: true },
+        orderBy: { loggedAt: "desc" },
+      }),
+      prisma.dosingRegimen.findMany({
+        where: { patientId: patient.id, active: true },
+        select: { frequencyPerDay: true, product: { select: { name: true } } },
+      }),
+    ]);
+    logs = doseRows.map((d) => ({
+      loggedAt: d.loggedAt.toISOString(),
+      actualVolume: d.actualVolume,
+      volumeUnit: d.volumeUnit,
+    }));
+    scheduledPerDay = regimens.reduce((sum, r) => sum + r.frequencyPerDay, 0);
+    if (regimens.length === 1 && regimens[0].product?.name) {
+      regimenName = regimens[0].product.name;
+    } else if (regimens.length > 1) {
+      regimenName = `${regimens.length} active regimens`;
+    }
+  }
 
   return (
     <PageShell maxWidth="max-w-[960px]">
@@ -18,12 +55,17 @@ export default async function DoseCalendarPage() {
           Dose calendar
         </h1>
         <p className="text-sm text-text-muted mt-3 max-w-md mx-auto leading-relaxed">
-          Track your daily medication adherence. Each day shows whether you took
-          your scheduled doses on time.
+          {scheduledPerDay > 0
+            ? "Each day shows the doses you logged against your schedule."
+            : "Each day shows the doses you logged."}
         </p>
       </div>
 
-      <CalendarView />
+      <CalendarView
+        logs={logs}
+        scheduledPerDay={scheduledPerDay}
+        regimenName={regimenName}
+      />
     </PageShell>
   );
 }

--- a/src/app/(patient)/portal/journal/page.tsx
+++ b/src/app/(patient)/portal/journal/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/db/prisma";
 import { PageShell, PageHeader } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import { JournalView } from "./journal-view";
+import { SampleBadge } from "@/components/patient/sample-badge";
 import type { JournalEntry } from "@/lib/domain/journal-community";
 
 export const metadata = { title: "Wellness Journal" };
@@ -74,6 +75,12 @@ export default async function JournalPage() {
         description="A quiet, private space to reflect on how cannabis is fitting into your life."
       />
       <PatientSectionNav section="journey" />
+      <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+        <SampleBadge />
+        <p className="text-xs text-text-muted">
+          These example entries show how journaling works — they aren&apos;t saved yet.
+        </p>
+      </div>
       <JournalView initialEntries={entries} patientId={patient.id} />
     </PageShell>
   );

--- a/src/app/(patient)/portal/learn/page.tsx
+++ b/src/app/(patient)/portal/learn/page.tsx
@@ -279,7 +279,7 @@ export default function LearnPage() {
                   </div>
                 </div>
 
-                <div className="grid grid-cols-3 gap-3 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
                   <div className="rounded-lg bg-accent-soft/40 border border-accent/10 px-3 py-2 text-center">
                     <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-accent mb-0.5">Onset</p>
                     <p className="text-sm font-display text-text">{d.onset}</p>

--- a/src/app/(patient)/portal/lifestyle/page.tsx
+++ b/src/app/(patient)/portal/lifestyle/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/domain/achievements";
 import { computePlantHealth } from "@/lib/domain/plant-health";
 import { WearableRings } from "@/components/gamification/wearable-rings";
+import { SampleBadge } from "@/components/patient/sample-badge";
 import { MindfulnessCheckIn } from "@/components/portal/mindfulness-check-in";
 import { LifestyleToolkit } from "./lifestyle-toolkit";
 import { LifestyleTrends, type LifestyleTrendPoint } from "./lifestyle-trends";
@@ -186,9 +187,12 @@ export default async function LifestylePage() {
         <Card tone="raised">
           <CardContent className="py-6">
             <div className="flex items-center justify-between mb-4">
-              <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-accent">
-                Today from {DEMO_WEARABLE_SUMMARY.source}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-accent">
+                  Wearable snapshot
+                </p>
+                <SampleBadge />
+              </div>
               <span className="text-2xl" aria-hidden="true">
                 {DEMO_WEARABLE_SUMMARY.emoji}
               </span>

--- a/src/app/(patient)/portal/log-dose/quick-dose-logger.tsx
+++ b/src/app/(patient)/portal/log-dose/quick-dose-logger.tsx
@@ -380,7 +380,7 @@ export function QuickDoseLogger({ patientId, products }: Props) {
             Tap all that apply (optional)
           </p>
 
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
             {SIDE_EFFECT_OPTIONS.map((eff) => (
               <button
                 key={eff.id}
@@ -673,7 +673,7 @@ function FollowUpHost() {
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
-      <Card className="rounded-2xl w-full max-w-md shadow-2xl animate-in fade-in slide-in-from-bottom-4">
+      <Card className="rounded-2xl w-full max-w-md max-h-[85vh] overflow-y-auto shadow-2xl animate-in fade-in slide-in-from-bottom-4">
         <CardContent className="pt-8 pb-8">
           <div className="text-center mb-6">
             <p className="text-4xl mb-3">👋</p>

--- a/src/app/(patient)/portal/medications/page.tsx
+++ b/src/app/(patient)/portal/medications/page.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
 import { formatDate } from "@/lib/utils/format";
 import { DosingDisplay } from "@/components/prescription/dosing-display";
+import { SampleBadge } from "@/components/patient/sample-badge";
 import { detectSubstitution } from "@/lib/domain/medication-substitution";
 import {
   RefillRequestPanel,
@@ -486,9 +487,12 @@ export default async function MedicationsPage() {
 
       {/* ==================== Dosing plan (merged from /portal/dosing) ==================== */}
       <section id="dosing-plan" className="mb-10 scroll-mt-24">
-        <h2 className="font-display text-2xl text-text tracking-tight mb-6">
-          Your dosing plan
-        </h2>
+        <div className="mb-6 flex items-center gap-2">
+          <h2 className="font-display text-2xl text-text tracking-tight">
+            Your dosing plan
+          </h2>
+          <SampleBadge />
+        </div>
         <p className="text-sm text-text-muted mb-6 max-w-xl leading-relaxed">
           A personalized dosing recommendation built from your health profile,
           current medications, and outcome trends. Your care team will review

--- a/src/app/(patient)/portal/messages/thread-view.tsx
+++ b/src/app/(patient)/portal/messages/thread-view.tsx
@@ -166,7 +166,7 @@ function ThreadRow({
           <div className="flex items-center justify-between gap-3">
             <p
               className={cn(
-                "text-sm truncate",
+                "text-sm line-clamp-2 break-words",
                 isOpen ? "font-semibold text-text" : "font-medium text-text",
               )}
             >

--- a/src/app/(patient)/portal/page.tsx
+++ b/src/app/(patient)/portal/page.tsx
@@ -12,6 +12,7 @@ import { WellnessTipWidget } from "@/components/ui/wellness-tip-widget";
 import { QuickSymptomFab } from "@/components/ui/quick-symptom-fab";
 import { VitalsCard } from "@/components/patient/vitals-card";
 import { HealthRoadmap } from "@/components/patient/health-roadmap";
+import { SampleBadge } from "@/components/patient/sample-badge";
 import { PositiveInputPrompt } from "@/components/patient/positive-input-prompt";
 import { DicomViewer } from "@/components/dicom/dicom-viewer";
 import { ContinuePanel } from "@/components/portal/continue-panel";
@@ -216,9 +217,13 @@ export default async function PatientHome() {
         <SparklinesWidget userId={user.id} />
       </Suspense>
 
-      {/* ── Daily Vitals ── */}
+      {/* ── Daily Vitals (illustrative — no vitals capture model yet) ── */}
       <div className="mb-6 md:mb-8">
-        <VitalsCard vitals={{ heartRate: 72, bloodPressureSys: 120, bloodPressureDia: 80, respiratoryRate: 16, oxygenSaturation: 98, temperature: 98.6, lastUpdated: "Today at 9:00 AM" }} />
+        <div className="mb-2 flex items-center gap-2">
+          <Eyebrow>Daily Vitals</Eyebrow>
+          <SampleBadge />
+        </div>
+        <VitalsCard vitals={{ heartRate: 72, bloodPressureSys: 120, bloodPressureDia: 80, respiratoryRate: 16, oxygenSaturation: 98, temperature: 98.6, lastUpdated: "Sample data" }} />
       </div>
 
       {/* ── Top row: Health grade + Lifestyle bars + AI tips ── */}
@@ -241,15 +246,22 @@ export default async function PatientHome() {
         <PlantTasksWidget userId={user.id} />
       </Suspense>
 
-      {/* ── High-Level Health Roadmap ── */}
+      {/* ── High-Level Health Roadmap (illustrative until care-plan milestones exist) ── */}
       <div className="mb-6 md:mb-8">
+        <div className="mb-2 flex items-center gap-2">
+          <Eyebrow>Health Roadmap</Eyebrow>
+          <SampleBadge />
+        </div>
         <HealthRoadmap />
       </div>
 
-      {/* ── Recent Imaging (DICOM Viewer) ── */}
+      {/* ── Recent Imaging (DICOM Viewer) — illustrative sample study ── */}
       <div className="mb-6 md:mb-8">
-        <Eyebrow className="mb-3">Recent Scan</Eyebrow>
-        <DicomViewer 
+        <div className="mb-3 flex items-center gap-2">
+          <Eyebrow>Recent Scan</Eyebrow>
+          <SampleBadge />
+        </div>
+        <DicomViewer
           image={{
             id: "scan-123",
             name: "LUMBAR SPINE MRI",

--- a/src/app/(patient)/portal/records/upload-form.tsx
+++ b/src/app/(patient)/portal/records/upload-form.tsx
@@ -9,7 +9,7 @@
  * aborts the rest.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   FileUpload,
@@ -21,7 +21,6 @@ import { Button } from "@/components/ui/button";
 
 export function UploadForm({ onClose }: { onClose?: () => void }) {
   const router = useRouter();
-  const [completedCount, setCompletedCount] = useState(0);
 
   const handler: FileUploadHandler = useCallback(async (file): Promise<UploadedFile> => {
     const fd = new FormData();
@@ -32,12 +31,6 @@ export function UploadForm({ onClose }: { onClose?: () => void }) {
     }
     return { id: result.documentId, name: file.name };
   }, []);
-
-  if (completedCount > 0 && !onClose) {
-    // Page-mounted variant — refresh in place so the records list picks
-    // up the new entries.
-    router.refresh();
-  }
 
   return (
     <div className="space-y-4">
@@ -51,7 +44,6 @@ export function UploadForm({ onClose }: { onClose?: () => void }) {
         onUpload={handler}
         onComplete={(items) => {
           const ok = items.filter((i) => i.status === "uploaded").length;
-          setCompletedCount(ok);
           if (ok > 0) router.refresh();
         }}
       />

--- a/src/app/(patient)/portal/schedule/booking-calendar.tsx
+++ b/src/app/(patient)/portal/schedule/booking-calendar.tsx
@@ -535,7 +535,7 @@ export function BookingCalendar({ providers, patientId, upcoming }: BookingCalen
                 Available times for {formatDateLabel(selectedDate)}
               </p>
               {availableSlots.length > 0 ? (
-                <div className="grid grid-cols-3 gap-2">
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                   {availableSlots.map((slot) => (
                     <button
                       key={slot.id}

--- a/src/app/(patient)/portal/shop/checkout/checkout-form.tsx
+++ b/src/app/(patient)/portal/shop/checkout/checkout-form.tsx
@@ -209,7 +209,7 @@ export function CheckoutForm({ items, subtotal, tax, total, onSuccess }: Checkou
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div>
               <label htmlFor="city" className="block text-xs font-semibold text-text-muted mb-1">
                 City

--- a/src/app/(patient)/portal/strains/page.tsx
+++ b/src/app/(patient)/portal/strains/page.tsx
@@ -158,6 +158,11 @@ export default async function StrainFinderPage({
           : `Showing ${display.length} popular strains. Add a symptom to refine.`}
       </p>
 
+      {display.length === 0 && (
+        <p className="text-sm text-text-muted text-center py-10">
+          No strains match your filter. Try removing a symptom or classification.
+        </p>
+      )}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {display.map(({ strain, score, matchedSymptoms }) => (
           <Card key={strain.id} tone="raised">

--- a/src/app/(patient)/portal/tutorials/page.tsx
+++ b/src/app/(patient)/portal/tutorials/page.tsx
@@ -221,7 +221,7 @@ function PlayerModal({
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={() => onClose(false)}
       />
-      <div className="relative z-10 w-full max-w-2xl rounded-3xl border border-border bg-surface-raised shadow-2xl overflow-hidden">
+      <div className="relative z-10 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-3xl border border-border bg-surface-raised shadow-2xl">
         <div
           className={`${video.thumbnailBg} flex aspect-video items-center justify-center`}
         >

--- a/src/app/(patient)/portal/volunteer/volunteer-view.tsx
+++ b/src/app/(patient)/portal/volunteer/volunteer-view.tsx
@@ -373,7 +373,7 @@ function Modal({ children, onClose }: { children: React.ReactNode; onClose: () =
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
       onClick={onClose}
     >
-      <Card tone="raised" className="w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
+      <Card tone="raised" className="w-full max-w-lg max-h-[85vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         {children}
       </Card>
     </div>

--- a/src/app/(patient)/portal/wellness/page.tsx
+++ b/src/app/(patient)/portal/wellness/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Sparkline } from "@/components/ui/sparkline";
 import { Eyebrow, EditorialRule, LeafSprig } from "@/components/ui/ornament";
+import { SampleBadge } from "@/components/patient/sample-badge";
 import {
   buildAchievements,
   consecutiveDayStreak,
@@ -186,7 +187,7 @@ export default async function WellnessHubPage() {
       {/* Today from your devices */}
       <section className="mb-10">
         <div className="flex items-baseline justify-between mb-3">
-          <Eyebrow>Today from your devices</Eyebrow>
+          <Eyebrow>From your devices</Eyebrow>
           <Link
             href="/portal/integrations"
             className="text-xs text-accent hover:underline"
@@ -208,7 +209,7 @@ export default async function WellnessHubPage() {
                     </p>
                   </div>
                   {src.summary ? (
-                    <Badge tone="success">Connected</Badge>
+                    <SampleBadge />
                   ) : (
                     <Badge tone="neutral">Not connected</Badge>
                   )}

--- a/src/components/ask-cindy/ChatCBInterface.tsx
+++ b/src/components/ask-cindy/ChatCBInterface.tsx
@@ -76,7 +76,7 @@ export function ChatCBInterface() {
             exit={{ scale: 0, opacity: 0 }}
             transition={{ duration: 0.2 }}
             onClick={() => setIsOpen(true)}
-            className="fixed bottom-[88px] right-6 z-[85] h-14 w-14 rounded-full bg-accent text-white shadow-xl flex items-center justify-center hover:scale-105 active:scale-95 transition-all"
+            className="fixed bottom-[120px] right-6 sm:bottom-[88px] z-[85] h-14 w-14 rounded-full bg-accent text-white shadow-xl flex items-center justify-center hover:scale-105 active:scale-95 transition-all"
             aria-label="Open ChatCB"
           >
             <Bot size={24} />

--- a/src/components/patient/sample-badge.tsx
+++ b/src/components/patient/sample-badge.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Honest "Sample data" marker. Placed on patient-facing surfaces that show
+ * illustrative/demo content rather than the patient's own records, so nothing
+ * fabricated is presented as real clinical data. (Hybrid honesty pass — used
+ * where there is no real data source yet to gate behind an empty state.)
+ */
+export function SampleBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5",
+        "text-[10px] font-semibold uppercase tracking-wide text-amber-700",
+        className,
+      )}
+    >
+      Sample data
+    </span>
+  );
+}

--- a/src/lib/domain/dose-calendar.ts
+++ b/src/lib/domain/dose-calendar.ts
@@ -32,43 +32,79 @@ export const ADHERENCE_COLORS: Record<AdherenceLevel, { bg: string; text: string
   missed: { bg: "bg-red-100", text: "text-red-700", ring: "ring-red-200" },
 };
 
+/** A patient's real dose-log row, trimmed to what the calendar needs. */
+export interface DoseLogLite {
+  loggedAt: string; // ISO
+  actualVolume: number;
+  volumeUnit: string;
+}
+
+function localDayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`;
+}
+
 /**
- * Generate a month of demo calendar data.
+ * Build a month of REAL calendar entries from the patient's dose logs.
+ *
+ * `scheduledPerDay` is the active regimen's frequency (0 when there's no active
+ * regimen). With a schedule, adherence = logged ÷ scheduled and past days with
+ * no logs show as "missed". Without a schedule we can't define adherence, so we
+ * only surface the days the patient actually logged (no fabricated baseline).
  */
-export function generateDemoMonth(year: number, month: number, regimenName: string, dosesPerDay: number): DoseCalendarEntry[] {
-  const entries: DoseCalendarEntry[] = [];
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
+export function buildMonthEntries(
+  logs: DoseLogLite[],
+  scheduledPerDay: number,
+  regimenName: string,
+  year: number,
+  month: number,
+): DoseCalendarEntry[] {
+  const byDay = new Map<string, DoseLogLite[]>();
+  for (const log of logs) {
+    const key = localDayKey(new Date(log.loggedAt));
+    const bucket = byDay.get(key);
+    if (bucket) bucket.push(log);
+    else byDay.set(key, [log]);
+  }
+
   const today = new Date();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const entries: DoseCalendarEntry[] = [];
 
   for (let day = 1; day <= daysInMonth; day++) {
     const date = new Date(year, month, day);
-    if (date > today) break; // Don't generate future entries
+    if (date > today) break;
 
-    const dateStr = date.toISOString().slice(0, 10);
-    // Simulate realistic adherence (85% overall, some missed days)
-    const rand = Math.random();
-    let takenDoses: number;
-    if (rand > 0.85) takenDoses = 0; // 15% chance fully missed
-    else if (rand > 0.70) takenDoses = Math.max(1, dosesPerDay - 1); // partial
-    else takenDoses = dosesPerDay; // taken all
+    const key = localDayKey(date);
+    const dayLogs = byDay.get(key) ?? [];
+    // No schedule and nothing logged → leave the day blank rather than invent one.
+    if (scheduledPerDay === 0 && dayLogs.length === 0) continue;
 
-    const times = Array.from({ length: dosesPerDay }, (_, i) => {
-      const hour = 8 + Math.floor((12 / dosesPerDay) * i);
-      return `${hour.toString().padStart(2, "0")}:00`;
-    });
+    const takenDoses = dayLogs.length;
+    const scheduledDoses = scheduledPerDay > 0 ? scheduledPerDay : takenDoses;
 
     entries.push({
-      date: dateStr,
+      date: key,
       regimen: regimenName,
-      scheduledDoses: dosesPerDay,
+      scheduledDoses,
       takenDoses,
-      adherencePercent: Math.round((takenDoses / dosesPerDay) * 100),
-      doses: times.map((time, i) => ({
-        time,
-        taken: i < takenDoses,
-        amount: 10,
-        unit: "mg",
-      })),
+      adherencePercent:
+        scheduledDoses > 0
+          ? Math.min(100, Math.round((takenDoses / scheduledDoses) * 100))
+          : 0,
+      doses: dayLogs
+        .slice()
+        .sort((a, b) => new Date(a.loggedAt).getTime() - new Date(b.loggedAt).getTime())
+        .map((log) => ({
+          time: new Date(log.loggedAt).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          }),
+          taken: true,
+          amount: log.actualVolume,
+          unit: log.volumeUnit,
+        })),
     });
   }
 


### PR DESCRIPTION
A deeper QA sweep (3 parallel hunters: responsive, loading/empty/error, data-fabrication). Loading/empty/error came back clean (portal is very well-defended). Two workstreams here:

## 1. Responsive / loading polish (13 fixes)
- Modals that clipped off-screen on short viewports → `max-h` + scroll (tutorials, log-dose follow-up, volunteer).
- `statements` payments table wrapped in `overflow-x-auto`; non-responsive `grid-cols-3` rows now stack (checkout, tax-summary, learn, log-dose side-effects, booking slots).
- `messages` thread subject `truncate` → `line-clamp-2`; ChatCB FAB lifted above the mobile install banner.
- `records` upload-form: `router.refresh()` moved out of the render body; `strains` empty-state.

## 2. Data-honesty (hybrid) — stop showing fabricated data as the patient's own
The fabrication hunter found ~10 surfaces rendering hardcoded data as the patient's real records. Per the agreed hybrid:

**Sourced from REAL data:**
- **dose-calendar** — was `Math.random()` adherence + a hardcoded regimen. Now built from the patient's actual `DoseLog`: true adherence (logged ÷ active-regimen `frequencyPerDay`) when a regimen exists, else an honest "doses logged" count; empty/zero handled.

**Honest "Sample data" labels** (no real source yet; new `<SampleBadge>`):
- home: Daily Vitals (dropped false "captured Today 9:00 AM"), Health Roadmap, Recent Scan.
- lifestyle + wellness wearables (dropped false "Today from Apple Health" / "Connected").
- medications "Your dosing plan"; journal seeded entries ("not saved yet").

(Caregivers + the streaks `Math.max` floor the hunter also flagged were already fixed in #674/#672.)

Still illustrative, lower priority (non-clinical): community / philanthropy / volunteer / seed-trove demo feeds.

## Verified
`tsc --noEmit` **0 errors** · `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)