### PR TITLE
EMR-054: Wire up Garmin patient portal integration

### DIFF
--- a/prisma/migrations/20260613221500_add_device_connections/migration.sql
+++ b/prisma/migrations/20260613221500_add_device_connections/migration.sql
@@ -1,0 +1,30 @@
+-- EMR-054 — wearable / health-app device connection persistence.
+--
+-- Backs the patient portal Integrations page (Connect / Disconnect / last
+-- sync) with a real table instead of client-only React state. Garmin
+-- connect/sync additionally drives a real ingestion pass into OutcomeLog
+-- via GarminVitalsClient.
+--
+-- Standalone table with a plain-string patientId (no foreign key), same
+-- pattern as RecordReleaseRequest (20260613120000) and TreatmentGoal
+-- (20260610090000), so it applies cleanly over a db-push-drifted database.
+--
+-- Additive + idempotent (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS "DeviceConnection" (
+    "id" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "connected" BOOLEAN NOT NULL DEFAULT false,
+    "accessToken" TEXT,
+    "lastSyncedAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeviceConnection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "DeviceConnection_patientId_provider_key" ON "DeviceConnection"("patientId", "provider");
+
+CREATE INDEX IF NOT EXISTS "DeviceConnection_patientId_idx" ON "DeviceConnection"("patientId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3082,6 +3082,43 @@ model RecordReleaseRequest {
 }
 
 // --------------------------------------------------------------
+// Wearable / health-app device connections (EMR-054)
+//
+// Persists a patient's connected wearables & health apps (Garmin, Apple
+// Health, Fitbit, Oura, etc.) so the connect/disconnect/last-sync state on
+// the patient portal Integrations page survives a reload instead of living
+// in client-only React state. Garmin specifically drives a real ingestion
+// pass (GarminVitalsClient -> OutcomeLog) on connect/sync.
+//
+// Standalone + additive: plain-string patientId with NO @relation, same
+// pattern as RecordReleaseRequest / TreatmentGoal, so it applies cleanly
+// over a db-push-drifted database and touches no existing model.
+// --------------------------------------------------------------
+model DeviceConnection {
+  id        String  @id @default(cuid())
+  patientId String
+  // Stable provider slug matching the portal UI ids: "garmin",
+  // "apple-health", "fitbit", "oura", "dexcom", "libre", "whoop",
+  // "medtronic", "eversense".
+  provider  String
+  connected Boolean @default(false)
+
+  // Opaque access token from the device OAuth handshake. Mock for now —
+  // the live OAuth flow lands with the provider SDK work. Cleared on
+  // disconnect so a stale token never drives a background sync.
+  accessToken  String?
+  lastSyncedAt DateTime?
+  // Last sync failure message, surfaced in the UI and cleared on success.
+  lastError    String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([patientId, provider])
+  @@index([patientId])
+}
+
+// --------------------------------------------------------------
 // Team / staff invitations (practice lifecycle)
 // Standalone + additive: plain-string ids (organizationId, invitedById,
 // acceptedByUserId) with NO @relation, so this touches no existing model.

--- a/src/app/(patient)/portal/integrations/actions.test.ts
+++ b/src/app/(patient)/portal/integrations/actions.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * EMR-054 — patient portal device connections.
+ *
+ * Pins the connect/disconnect/sync server actions: provider validation,
+ * patient scoping, that Garmin (and only Garmin) drives a real ingestion
+ * pass, token clearing on disconnect, and audit coverage.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  mockPrisma: {
+    patient: { findUnique: vi.fn() },
+    deviceConnection: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      update: vi.fn(),
+    },
+    outcomeLog: { findMany: vi.fn() },
+    clinicalObservation: { findMany: vi.fn() },
+  },
+  requireRoleMock: vi.fn(),
+  garminSyncMock: vi.fn(),
+  createAuditLogMock: vi.fn(),
+  evaluateCDSMock: vi.fn(),
+  routeCDSMock: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: hoisted.mockPrisma }));
+vi.mock("@/lib/auth/session", () => ({
+  requireRole: (role: string) => hoisted.requireRoleMock(role),
+}));
+vi.mock("@/lib/domain/audit-logger", () => ({
+  createAuditLog: (p: unknown) => hoisted.createAuditLogMock(p),
+}));
+vi.mock("@/lib/integrations/garmin-vitals", () => ({
+  garminClient: { syncPatientData: (...a: unknown[]) => hoisted.garminSyncMock(...a) },
+}));
+vi.mock("@/lib/cds/engine", () => ({
+  evaluatePatientCDS: (...a: unknown[]) => hoisted.evaluateCDSMock(...a),
+}));
+vi.mock("@/lib/cds/alerts", () => ({
+  routeCDSTriggers: (...a: unknown[]) => hoisted.routeCDSMock(...a),
+}));
+
+import { connectDevice, disconnectDevice, syncDevice, getDeviceConnections } from "./actions";
+
+const {
+  mockPrisma,
+  requireRoleMock,
+  garminSyncMock,
+  createAuditLogMock,
+  evaluateCDSMock,
+  routeCDSMock,
+} = hoisted;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireRoleMock.mockResolvedValue({ id: "user_1" });
+  mockPrisma.patient.findUnique.mockResolvedValue({
+    id: "patient_1",
+    organizationId: "org_1",
+  });
+  mockPrisma.deviceConnection.upsert.mockImplementation(({ update, create }: any) => ({
+    connected: update?.connected ?? create?.connected ?? false,
+    lastSyncedAt: update?.lastSyncedAt ?? create?.lastSyncedAt ?? null,
+    lastError: update?.lastError ?? create?.lastError ?? null,
+  }));
+  mockPrisma.deviceConnection.update.mockImplementation(({ data }: any) => ({
+    connected: true,
+    lastSyncedAt: data?.lastSyncedAt ?? null,
+    lastError: data?.lastError ?? null,
+  }));
+  mockPrisma.outcomeLog.findMany.mockResolvedValue([]);
+  mockPrisma.clinicalObservation.findMany.mockResolvedValue([]);
+  garminSyncMock.mockResolvedValue(3);
+  evaluateCDSMock.mockReturnValue([]);
+});
+
+describe("connectDevice", () => {
+  it("rejects an unknown provider", async () => {
+    const res = await connectDevice("peloton");
+    expect(res).toEqual({ ok: false, error: "Unknown device." });
+    expect(mockPrisma.deviceConnection.upsert).not.toHaveBeenCalled();
+  });
+
+  it("runs the Garmin ingestion pass and records how many logs synced", async () => {
+    const res = await connectDevice("garmin");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(res.recordsSynced).toBe(3);
+    expect(res.state.connected).toBe(true);
+
+    expect(garminSyncMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = mockPrisma.deviceConnection.upsert.mock.calls[0][0];
+    expect(upsertArgs.where.patientId_provider).toEqual({
+      patientId: "patient_1",
+      provider: "garmin",
+    });
+    expect(upsertArgs.update.connected).toBe(true);
+
+    const audit = createAuditLogMock.mock.calls[0][0];
+    expect(audit.action).toBe("patient.device_connected");
+    expect(audit.metadata).toMatchObject({ provider: "garmin", recordsSynced: 3 });
+  });
+
+  it("connects a non-Garmin provider without an ingestion pass", async () => {
+    const res = await connectDevice("fitbit");
+    expect(res.ok).toBe(true);
+    expect(garminSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("disconnectDevice", () => {
+  it("marks disconnected and clears the stored token", async () => {
+    const res = await disconnectDevice("garmin");
+    expect(res.ok).toBe(true);
+    const upsertArgs = mockPrisma.deviceConnection.upsert.mock.calls[0][0];
+    expect(upsertArgs.update).toEqual({
+      connected: false,
+      accessToken: null,
+      lastError: null,
+    });
+    expect(createAuditLogMock.mock.calls[0][0].action).toBe(
+      "patient.device_disconnected",
+    );
+  });
+});
+
+describe("syncDevice", () => {
+  it("refuses to sync a device that isn't connected", async () => {
+    mockPrisma.deviceConnection.findUnique.mockResolvedValue(null);
+    const res = await syncDevice("garmin");
+    expect(res).toEqual({ ok: false, error: "Connect this device before syncing." });
+    expect(garminSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("re-runs the Garmin ingestion when connected", async () => {
+    mockPrisma.deviceConnection.findUnique.mockResolvedValue({
+      connected: true,
+      accessToken: "mock-garmin-token",
+    });
+    const res = await syncDevice("garmin");
+    expect(res.ok).toBe(true);
+    expect(garminSyncMock).toHaveBeenCalledTimes(1);
+    expect(createAuditLogMock.mock.calls[0][0].action).toBe("patient.device_synced");
+  });
+});
+
+describe("getDeviceConnections", () => {
+  it("maps saved rows keyed by provider slug", async () => {
+    const when = new Date("2026-06-13T10:00:00.000Z");
+    mockPrisma.deviceConnection.findMany.mockResolvedValue([
+      { provider: "garmin", connected: true, lastSyncedAt: when, lastError: null },
+    ]);
+    const out = await getDeviceConnections();
+    expect(out.garmin).toEqual({
+      connected: true,
+      lastSync: when.toISOString(),
+      error: null,
+    });
+  });
+});

--- a/src/app/(patient)/portal/integrations/actions.ts
+++ b/src/app/(patient)/portal/integrations/actions.ts
@@ -1,0 +1,253 @@
+"use server";
+
+// EMR-054 — patient portal device/wearable connections.
+//
+// Replaces the client-only toggle state on the Integrations page with real
+// per-patient persistence (DeviceConnection). Connecting or syncing Garmin
+// additionally runs a live ingestion pass — GarminVitalsClient writes Body
+// Battery / Stress / Sleep into the patient's OutcomeLog series — and then
+// evaluates the wearables CDS rules so a fresh sync can raise a care-team
+// alert, mirroring the cron/sync-wearables daemon.
+
+import { revalidatePath } from "next/cache";
+import { requireRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { createAuditLog } from "@/lib/domain/audit-logger";
+import { garminClient } from "@/lib/integrations/garmin-vitals";
+import { evaluatePatientCDS } from "@/lib/cds/engine";
+import { routeCDSTriggers } from "@/lib/cds/alerts";
+import {
+  isDeviceProvider,
+  type DeviceActionResult,
+  type DeviceConnectionState,
+} from "./providers";
+
+/** How many trailing days of history to pull on a Garmin connect/sync. */
+const GARMIN_BACKFILL_DAYS = 7;
+
+async function requirePatient(): Promise<{
+  id: string;
+  organizationId: string;
+  userId: string;
+}> {
+  const user = await requireRole("patient");
+  const patient = await prisma.patient.findUnique({
+    where: { userId: user.id },
+    select: { id: true, organizationId: true },
+  });
+  if (!patient) throw new Error("FORBIDDEN");
+  return { ...patient, userId: user.id };
+}
+
+function toState(row: {
+  connected: boolean;
+  lastSyncedAt: Date | null;
+  lastError: string | null;
+}): DeviceConnectionState {
+  return {
+    connected: row.connected,
+    lastSync: row.lastSyncedAt ? row.lastSyncedAt.toISOString() : null,
+    error: row.lastError,
+  };
+}
+
+/**
+ * Loads the signed-in patient's saved connections, keyed by provider slug.
+ * Providers with no row yet are simply absent (treated as disconnected by
+ * the UI), so the page never has to backfill rows just to render.
+ */
+export async function getDeviceConnections(): Promise<
+  Record<string, DeviceConnectionState>
+> {
+  const user = await requireRole("patient");
+  const patient = await prisma.patient.findUnique({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+  if (!patient) return {};
+
+  const rows = await prisma.deviceConnection.findMany({
+    where: { patientId: patient.id },
+  });
+
+  const out: Record<string, DeviceConnectionState> = {};
+  for (const row of rows) out[row.provider] = toState(row);
+  return out;
+}
+
+/**
+ * Runs a Garmin ingestion pass for the patient over the backfill window and
+ * fires the wearables CDS rules on the freshly written data. Returns the
+ * number of OutcomeLogs written. CDS failures never fail the sync — the
+ * data is already persisted.
+ */
+async function runGarminSync(
+  patientId: string,
+  accessToken: string,
+): Promise<number> {
+  const end = new Date();
+  const start = new Date(end.getTime() - GARMIN_BACKFILL_DAYS * 86_400_000);
+  const startDate = start.toISOString().split("T")[0];
+  const endDate = end.toISOString().split("T")[0];
+
+  const recordsSynced = await garminClient.syncPatientData(
+    patientId,
+    accessToken,
+    startDate,
+    endDate,
+  );
+
+  try {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const [logs, observations] = await Promise.all([
+      prisma.outcomeLog.findMany({
+        where: { patientId, loggedAt: { gte: since } },
+      }),
+      prisma.clinicalObservation.findMany({
+        where: { patientId, createdAt: { gte: since } },
+      }),
+    ]);
+    const triggers = evaluatePatientCDS(patientId, logs, observations);
+    if (triggers.length > 0) await routeCDSTriggers(triggers);
+  } catch (err) {
+    console.error("[Garmin] CDS evaluation failed (data was persisted):", err);
+  }
+
+  return recordsSynced;
+}
+
+/**
+ * Connects a device for the signed-in patient. For Garmin this also pulls
+ * the trailing week of biometrics into the patient's outcome history.
+ */
+export async function connectDevice(
+  provider: string,
+): Promise<DeviceActionResult> {
+  if (!isDeviceProvider(provider)) return { ok: false, error: "Unknown device." };
+  const patient = await requirePatient();
+
+  // Mock OAuth handshake — the live flow lands with the provider SDK work.
+  const accessToken = `mock-${provider}-token`;
+
+  let recordsSynced = 0;
+  let lastError: string | null = null;
+  let lastSyncedAt: Date | null = null;
+
+  if (provider === "garmin") {
+    try {
+      recordsSynced = await runGarminSync(patient.id, accessToken);
+      lastSyncedAt = new Date();
+    } catch (err) {
+      console.error("[Garmin] connect sync failed:", err);
+      lastError = "We couldn't reach Garmin Connect. Please try again.";
+    }
+  }
+
+  const row = await prisma.deviceConnection.upsert({
+    where: { patientId_provider: { patientId: patient.id, provider } },
+    create: {
+      patientId: patient.id,
+      provider,
+      connected: true,
+      accessToken,
+      lastSyncedAt,
+      lastError,
+    },
+    update: {
+      connected: true,
+      accessToken,
+      ...(lastSyncedAt ? { lastSyncedAt } : {}),
+      lastError,
+    },
+  });
+
+  await createAuditLog({
+    organizationId: patient.organizationId,
+    actorId: patient.userId,
+    targetId: patient.id,
+    action: "patient.device_connected",
+    metadata: { provider, recordsSynced },
+  });
+
+  revalidatePath("/portal/integrations");
+  return { ok: true, state: toState(row), recordsSynced };
+}
+
+/** Disconnects a device and clears its stored access token. */
+export async function disconnectDevice(
+  provider: string,
+): Promise<DeviceActionResult> {
+  if (!isDeviceProvider(provider)) return { ok: false, error: "Unknown device." };
+  const patient = await requirePatient();
+
+  const row = await prisma.deviceConnection.upsert({
+    where: { patientId_provider: { patientId: patient.id, provider } },
+    create: { patientId: patient.id, provider, connected: false },
+    update: { connected: false, accessToken: null, lastError: null },
+  });
+
+  await createAuditLog({
+    organizationId: patient.organizationId,
+    actorId: patient.userId,
+    targetId: patient.id,
+    action: "patient.device_disconnected",
+    metadata: { provider },
+  });
+
+  revalidatePath("/portal/integrations");
+  return { ok: true, state: toState(row) };
+}
+
+/**
+ * Re-runs a sync for an already-connected device. Garmin pulls fresh
+ * biometrics; other providers just stamp the sync time until their own
+ * ingestion pipeline lands.
+ */
+export async function syncDevice(
+  provider: string,
+): Promise<DeviceActionResult> {
+  if (!isDeviceProvider(provider)) return { ok: false, error: "Unknown device." };
+  const patient = await requirePatient();
+
+  const existing = await prisma.deviceConnection.findUnique({
+    where: { patientId_provider: { patientId: patient.id, provider } },
+  });
+  if (!existing || !existing.connected) {
+    return { ok: false, error: "Connect this device before syncing." };
+  }
+
+  let recordsSynced = 0;
+  let lastError: string | null = null;
+
+  if (provider === "garmin") {
+    try {
+      recordsSynced = await runGarminSync(
+        patient.id,
+        existing.accessToken ?? `mock-${provider}-token`,
+      );
+    } catch (err) {
+      console.error("[Garmin] manual sync failed:", err);
+      lastError = "We couldn't reach Garmin Connect. Please try again.";
+    }
+  }
+
+  const row = await prisma.deviceConnection.update({
+    where: { patientId_provider: { patientId: patient.id, provider } },
+    data: {
+      ...(lastError ? {} : { lastSyncedAt: new Date() }),
+      lastError,
+    },
+  });
+
+  await createAuditLog({
+    organizationId: patient.organizationId,
+    actorId: patient.userId,
+    targetId: patient.id,
+    action: "patient.device_synced",
+    metadata: { provider, recordsSynced },
+  });
+
+  revalidatePath("/portal/integrations");
+  if (lastError) return { ok: false, error: lastError };
+  return { ok: true, state: toState(row), recordsSynced };
+}

--- a/src/app/(patient)/portal/integrations/integrations-view.tsx
+++ b/src/app/(patient)/portal/integrations/integrations-view.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { connectDevice, disconnectDevice, syncDevice } from "./actions";
+import type { DeviceConnectionState } from "./providers";
 
 interface Integration {
   id: string;
@@ -89,38 +91,66 @@ const INTEGRATIONS: Integration[] = [
   },
 ];
 
-interface ConnectionState {
-  connected: boolean;
-  lastSync: string | null;
+const DISCONNECTED: DeviceConnectionState = {
+  connected: false,
+  lastSync: null,
+  error: null,
+};
+
+function formatSync(iso: string | null): string {
+  if (!iso) return "Never synced";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Never synced";
+  return `Last sync: ${d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;
 }
 
-export function IntegrationsView() {
-  const [states, setStates] = useState<Record<string, ConnectionState>>({
-    "apple-health": { connected: true, lastSync: "2026-04-16 08:15" },
-    fitbit: { connected: false, lastSync: null },
-    oura: { connected: false, lastSync: null },
-    garmin: { connected: false, lastSync: null },
-    dexcom: { connected: false, lastSync: null },
-    libre: { connected: false, lastSync: null },
-    whoop: { connected: false, lastSync: null },
-    medtronic: { connected: false, lastSync: null },
-    eversense: { connected: false, lastSync: null },
-  });
+interface IntegrationsViewProps {
+  initialStates: Record<string, DeviceConnectionState>;
+}
 
-  const toggle = (id: string) => {
-    setStates((prev) => ({
-      ...prev,
-      [id]: {
-        connected: !prev[id].connected,
-        lastSync: !prev[id].connected ? new Date().toISOString().replace("T", " ").slice(0, 16) : null,
-      },
-    }));
+export function IntegrationsView({ initialStates }: IntegrationsViewProps) {
+  const [states, setStates] = useState<Record<string, DeviceConnectionState>>(
+    initialStates ?? {},
+  );
+  // Per-card pending flag so one card's spinner doesn't block the others.
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [, startTransition] = useTransition();
+
+  const stateFor = (id: string) => states[id] ?? DISCONNECTED;
+
+  const run = (
+    id: string,
+    action: (provider: string) => Promise<
+      | { ok: true; state: DeviceConnectionState }
+      | { ok: false; error: string }
+    >,
+  ) => {
+    setPending((p) => ({ ...p, [id]: true }));
+    startTransition(async () => {
+      try {
+        const result = await action(id);
+        setStates((prev) => ({
+          ...prev,
+          [id]: result.ok
+            ? result.state
+            : { ...stateFor(id), error: result.error },
+        }));
+      } finally {
+        setPending((p) => ({ ...p, [id]: false }));
+      }
+    });
   };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
       {INTEGRATIONS.map((integration) => {
-        const state = states[integration.id];
+        const state = stateFor(integration.id);
+        const busy = !!pending[integration.id];
         return (
           <Card key={integration.id} tone="raised">
             <CardHeader>
@@ -157,18 +187,46 @@ export function IntegrationsView() {
                 </div>
               </div>
 
+              {state.error ? (
+                <div className="text-xs text-danger">{state.error}</div>
+              ) : null}
+
               <div className="flex items-center justify-between pt-2 border-t border-border">
                 <div className="text-xs text-text-subtle">
-                  {state.lastSync ? `Last sync: ${state.lastSync}` : "Never synced"}
+                  {busy ? "Syncing…" : formatSync(state.lastSync)}
                 </div>
                 {integration.available ? (
-                  <Button
-                    variant={state.connected ? "secondary" : "primary"}
-                    size="sm"
-                    onClick={() => toggle(integration.id)}
-                  >
-                    {state.connected ? "Disconnect" : `Connect ${integration.name}`}
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    {state.connected ? (
+                      <>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => run(integration.id, syncDevice)}
+                        >
+                          Sync now
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => run(integration.id, disconnectDevice)}
+                        >
+                          Disconnect
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => run(integration.id, connectDevice)}
+                      >
+                        Connect {integration.name}
+                      </Button>
+                    )}
+                  </div>
                 ) : (
                   <Button variant="secondary" size="sm" disabled>
                     Coming soon

--- a/src/app/(patient)/portal/integrations/page.tsx
+++ b/src/app/(patient)/portal/integrations/page.tsx
@@ -2,11 +2,13 @@ import { requireRole } from "@/lib/auth/session";
 import { PageHeader, PageShell } from "@/components/shell/PageHeader";
 import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
 import { IntegrationsView } from "./integrations-view";
+import { getDeviceConnections } from "./actions";
 
 export const metadata = { title: "Integrations" };
 
 export default async function PatientIntegrationsPage() {
   await requireRole("patient");
+  const connections = await getDeviceConnections();
 
   return (
     <PageShell maxWidth="max-w-[1060px]">
@@ -16,7 +18,7 @@ export default async function PatientIntegrationsPage() {
         title="Connected devices & apps"
         description="Sync data from your wearables and health apps so your care team sees the full picture."
       />
-      <IntegrationsView />
+      <IntegrationsView initialStates={connections} />
     </PageShell>
   );
 }

--- a/src/app/(patient)/portal/integrations/providers.ts
+++ b/src/app/(patient)/portal/integrations/providers.ts
@@ -1,0 +1,32 @@
+// Shared, non-server constants/types for the patient portal Integrations
+// page. Kept out of actions.ts because a "use server" module may only
+// export async functions.
+
+/** Provider slugs that match the Integrations UI card ids. */
+export const DEVICE_PROVIDERS = [
+  "apple-health",
+  "fitbit",
+  "oura",
+  "garmin",
+  "dexcom",
+  "libre",
+  "whoop",
+  "medtronic",
+  "eversense",
+] as const;
+
+export type DeviceProvider = (typeof DEVICE_PROVIDERS)[number];
+
+export function isDeviceProvider(value: string): value is DeviceProvider {
+  return (DEVICE_PROVIDERS as readonly string[]).includes(value);
+}
+
+export interface DeviceConnectionState {
+  connected: boolean;
+  lastSync: string | null;
+  error: string | null;
+}
+
+export type DeviceActionResult =
+  | { ok: true; state: DeviceConnectionState; recordsSynced?: number }
+  | { ok: false; error: string };

--- a/src/lib/domain/audit-logger.ts
+++ b/src/lib/domain/audit-logger.ts
@@ -28,6 +28,9 @@ export type AuditActionType =
   | "patient.chart_exported"
   | "patient.phi_accessed"
   | "patient.engagement_tracked"
+  | "patient.device_connected"
+  | "patient.device_disconnected"
+  | "patient.device_synced"
   | "prescription.issued"
   | "prescription.voided";
 

--- a/src/lib/integrations/garmin-vitals.ts
+++ b/src/lib/integrations/garmin-vitals.ts
@@ -6,6 +6,7 @@
  * into Verdant's OutcomeLog schema.
  */
 
+import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 
 export interface GarminDailySummary {
@@ -67,16 +68,21 @@ export class GarminVitalsClient {
 
   /**
    * Syncs a patient's Garmin payload into the database.
+   *
+   * Idempotent over the [startDate, endDate] window: prior Garmin-sourced
+   * OutcomeLogs in that range are cleared before re-inserting, so repeated
+   * connect/sync presses don't pile up duplicate rows. Returns the number
+   * of OutcomeLogs written.
    */
   async syncPatientData(
     patientId: string,
     accessToken: string,
     startDate: string,
     endDate: string,
-  ): Promise<void> {
+  ): Promise<number> {
     const payload = await this.fetchVitals(accessToken, startDate, endDate);
 
-    const logsToCreate = [];
+    const logsToCreate: Prisma.OutcomeLogCreateManyInput[] = [];
 
     // 1. Process Body Battery -> OutcomeLog (energy)
     for (const daily of payload.dailies) {
@@ -109,13 +115,28 @@ export class GarminVitalsClient {
       });
     }
 
-    // 4. Batch DB insertions
-    if (logsToCreate.length > 0) {
-      await prisma.outcomeLog.createMany({ data: logsToCreate });
-      console.log(
-        `[GarminVitals] Inserted ${logsToCreate.length} OutcomeLogs`,
-      );
-    }
+    if (logsToCreate.length === 0) return 0;
+
+    // 4. Idempotent write: clear prior Garmin logs in this window, then
+    // re-insert. Garmin logs are identified by the "Garmin " note prefix
+    // (no source column on OutcomeLog), scoped to the synced day range so
+    // we never touch a patient's manual check-ins or other integrations.
+    const windowStart = new Date(`${startDate}T00:00:00.000Z`);
+    const windowEnd = new Date(`${endDate}T23:59:59.999Z`);
+    const written = await prisma.$transaction(async (tx) => {
+      await tx.outcomeLog.deleteMany({
+        where: {
+          patientId,
+          note: { startsWith: "Garmin " },
+          loggedAt: { gte: windowStart, lte: windowEnd },
+        },
+      });
+      const result = await tx.outcomeLog.createMany({ data: logsToCreate });
+      return result.count;
+    });
+
+    console.log(`[GarminVitals] Inserted ${written} OutcomeLogs`);
+    return written;
   }
 }
 


### PR DESCRIPTION
## Summary

The patient portal **Integrations** page (`/portal/integrations`) was a client-only mock — Connect/Disconnect flipped React `useState` that vanished on reload and never touched the database or the existing `GarminVitalsClient`. This wires the Garmin integration end to end.

## What changed

- **Persistence** — new `DeviceConnection` model + migration storing each patient's connected wearables and last-sync state. Standalone table with a plain-string `patientId` (no FK), idempotent (`IF NOT EXISTS`), matching the `RecordReleaseRequest` / `TreatmentGoal` convention so it applies cleanly over a db-push-drifted database.
- **Server actions** (`integrations/actions.ts`) — `connectDevice` / `disconnectDevice` / `syncDevice` / `getDeviceConnections`, all scoped to the signed-in patient. Connecting or syncing **Garmin** runs a real ingestion pass via `GarminVitalsClient` (Body Battery / Stress / Sleep → `OutcomeLog`) over the trailing 7 days, then evaluates the wearables CDS rules and routes any triggers — mirroring the `cron/sync-wearables` daemon. Non-Garmin providers persist connection state until their own pipelines land.
- **Idempotency** — `GarminVitalsClient.syncPatientData` now clears prior Garmin-sourced logs in its date window before re-inserting, and returns the number of logs written, so repeated "Sync now" presses don't accumulate duplicates.
- **UI** — the page loads real connection state from the DB; the view drives the actions with per-card pending/error state and adds a "Sync now" control for connected devices.
- **Audit** — connect/disconnect/sync each write an audit row (new `patient.device_connected` / `_disconnected` / `_synced` action types).
- **Tests** — `actions.test.ts` covers provider validation, patient scoping, Garmin-only ingestion, token clearing on disconnect, and state mapping.

## Not in scope

The OAuth handshake is still mocked (`mock-garmin-token`); the live Garmin Connect token exchange is separate work and is marked with a comment at the plug-in point. Data mapping, persistence, CDS, audit, and UI are all real.

## Verification

- `tsc --noEmit` clean
- ESLint clean on all changed files
- `lint:audit` passes
- New device-actions tests (7) and existing vitals-catalog tests (6) pass

https://claude.ai/code/session_0162mD2CpaGXAoi3CeRoumof

---
_Generated by [Claude Code](https://claude.ai/code/session_0162mD2CpaGXAoi3CeRoumof)_