### PR TITLE
Workflows Revisions wave 3: plain-language After-Visit Summary pipeline (EMR-1149–1152)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6055,3 +6055,48 @@ model MigrationJob {
   @@index([organizationId, status])
   @@index([migrationProfileId])
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// After-Visit Summary (AVS) — Workflows Revisions EMR-1149..1152
+// ───────────────────────────────────────────────────────────────────────────
+// The plain-language, literacy- and language-matched after-visit summary the
+// AVS generation job (EMR-1149) compiles on chart-sign and the provider
+// releases to the patient portal (EMR-1152). One row per signed note
+// (`noteId @unique`) makes generation idempotent. Relation-less by design —
+// same pattern as AgentJob/AuditLog — so it adds zero back-relations to the
+// hot Patient/Encounter/Note/User models. `payload` holds the structured,
+// research-queryable document: decomposed care plan (EMR-1150), titration
+// calendar + lifestyle roadmap (EMR-1152), localized rendering + the
+// source-note text used for the side-by-side verification panel.
+enum AfterVisitSummaryStatus {
+  draft
+  released
+}
+
+model AfterVisitSummary {
+  id               String                  @id @default(cuid())
+  organizationId   String
+  encounterId      String
+  noteId           String                  @unique
+  patientId        String
+  /// ISO 639-1 language the summary was rendered in (defaults to "en").
+  language         String                  @default("en")
+  /// 6th–8th grade readability target band the generator drove toward.
+  targetGradeMin   Float                   @default(6)
+  targetGradeMax   Float                   @default(8)
+  /// Flesch–Kincaid grade actually achieved by the generated prose.
+  readabilityGrade Float?
+  status           AfterVisitSummaryStatus @default(draft)
+  /// Structured AVS document (decomposed plan, calendar, roadmap, localized
+  /// copy, source-note text). Zod-validated by the AVS domain layer.
+  payload          Json
+  generatedAt      DateTime                @default(now())
+  releasedAt       DateTime?
+  releasedById     String?
+  createdAt        DateTime                @default(now())
+  updatedAt        DateTime                @updatedAt
+
+  @@index([patientId, status])
+  @@index([organizationId, status])
+  @@index([encounterId])
+}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/avs-actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/avs-actions.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/rbac/permissions";
+import { createLightContext } from "@/lib/orchestration/context";
+import { avsGeneratorAgent } from "@/lib/agents/avs-generator-agent";
+import { safeParseAvsDocument, type AvsDocument } from "@/lib/domain/avs/types";
+
+// ---------------------------------------------------------------------------
+// EMR-1152 — Provider verification + one-click release of the after-visit
+// summary. Release is BLOCKED until the provider affirms the summary matches
+// the signed note (the `verified` flag); after that it's a single action that
+// flips the draft to released and surfaces it in the patient portal.
+// ---------------------------------------------------------------------------
+
+export interface AvsSummaryData {
+  id: string;
+  status: "draft" | "released";
+  language: string;
+  readabilityGrade: number | null;
+  releasedAt: string | null;
+  doc: AvsDocument;
+}
+
+type LoadResult =
+  | { ok: true; summary: AvsSummaryData | null }
+  | { ok: false; error: string };
+
+async function loadNoteScoped(noteId: string) {
+  const user = await requireUser();
+  const note = await prisma.note.findFirst({
+    where: { id: noteId, encounter: { organizationId: user.organizationId! } },
+    select: { id: true, status: true },
+  });
+  return { user, note };
+}
+
+/** Read the persisted AVS draft/release for a note (org-scoped). */
+export async function getAvsForNote(noteId: string): Promise<LoadResult> {
+  const { note } = await loadNoteScoped(noteId);
+  if (!note) return { ok: false, error: "Note not found" };
+
+  const row = await prisma.afterVisitSummary.findUnique({ where: { noteId } });
+  if (!row) return { ok: true, summary: null };
+
+  const doc = safeParseAvsDocument(row.payload);
+  if (!doc) return { ok: false, error: "Stored summary is unreadable; regenerate it." };
+
+  return {
+    ok: true,
+    summary: {
+      id: row.id,
+      status: row.status,
+      language: row.language,
+      readabilityGrade: row.readabilityGrade,
+      releasedAt: row.releasedAt ? row.releasedAt.toISOString() : null,
+      doc,
+    },
+  };
+}
+
+/** (Re)generate the AVS draft for a signed note via the deterministic agent. */
+export async function regenerateAvsForNote(noteId: string): Promise<LoadResult> {
+  const { user, note } = await loadNoteScoped(noteId);
+  if (!note) return { ok: false, error: "Note not found" };
+  if (!hasPermission(user, "notes.edit")) return { ok: false, error: "Not permitted" };
+
+  const ctx = createLightContext({
+    organizationId: user.organizationId,
+    agentName: "avsGenerator",
+  });
+  const result = await avsGeneratorAgent.run({ noteId }, ctx);
+  if (result.skipped && result.reason === "already_released") {
+    return { ok: false, error: "This summary is already released and cannot be regenerated." };
+  }
+  if (result.skipped) {
+    return { ok: false, error: `Could not generate summary (${result.reason ?? "unknown"}).` };
+  }
+
+  revalidatePath(`/clinic/patients/${(await currentPatientId(noteId)) ?? ""}/notes/${noteId}`);
+  return getAvsForNote(noteId);
+}
+
+/**
+ * Release the verified AVS to the patient. `verified` must be true — the panel
+ * gates the button on the provider's review affirmation.
+ */
+export async function releaseAvsForNote(
+  noteId: string,
+  verified: boolean,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser();
+  if (!hasPermission(user, "notes.edit")) return { ok: false, error: "Not permitted" };
+  if (!verified) return { ok: false, error: "Confirm the summary matches your note before releasing." };
+
+  const row = await prisma.afterVisitSummary.findUnique({
+    where: { noteId },
+    select: { id: true, status: true, organizationId: true, patientId: true },
+  });
+  if (!row) return { ok: false, error: "No summary to release. Generate one first." };
+  if (row.organizationId !== user.organizationId) return { ok: false, error: "Not permitted" };
+  if (row.status === "released") return { ok: true };
+
+  const now = new Date();
+  await prisma.afterVisitSummary.update({
+    where: { id: row.id },
+    data: { status: "released", releasedAt: now, releasedById: user.id },
+  });
+
+  // Surface it in the patient portal immediately (notification + timeline page).
+  const patient = await prisma.patient.findUnique({
+    where: { id: row.patientId },
+    select: { userId: true },
+  });
+  if (patient?.userId) {
+    await prisma.notification.create({
+      data: {
+        userId: patient.userId,
+        type: "avs_ready",
+        priority: "normal",
+        title: "Your visit summary is ready",
+        body: "Read your plain-language after-visit summary, with your plan and next steps.",
+        href: "/portal/visit-summary",
+      },
+    });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: row.organizationId,
+      actorUserId: user.id,
+      action: "avs.released",
+      subjectType: "AfterVisitSummary",
+      subjectId: row.id,
+      metadata: { noteId, patientId: row.patientId },
+    },
+  });
+
+  revalidatePath("/portal/visit-summary");
+  return { ok: true };
+}
+
+async function currentPatientId(noteId: string): Promise<string | null> {
+  const note = await prisma.note.findUnique({
+    where: { id: noteId },
+    select: { encounter: { select: { patientId: true } } },
+  });
+  return note?.encounter.patientId ?? null;
+}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/avs-review-panel.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/avs-review-panel.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AvsSummaryView } from "@/components/avs/AvsSummaryView";
+import {
+  getAvsForNote,
+  regenerateAvsForNote,
+  releaseAvsForNote,
+  type AvsSummaryData,
+} from "./avs-actions";
+
+const LANGUAGE_LABEL: Record<string, string> = { en: "English", es: "Spanish", vi: "Vietnamese" };
+
+// EMR-1152 — inline (no-popup) provider surface: side-by-side source-note vs
+// generated summary, with a release that's blocked until the provider affirms
+// the summary matches the note. One click after that delivers it to the portal.
+export function AvsReviewPanel({ noteId }: { noteId: string }) {
+  const [summary, setSummary] = React.useState<AvsSummaryData | null>(null);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [verified, setVerified] = React.useState(false);
+  const [pending, startTransition] = React.useTransition();
+
+  React.useEffect(() => {
+    let active = true;
+    getAvsForNote(noteId).then((res) => {
+      if (!active) return;
+      if (res.ok) setSummary(res.summary);
+      else setError(res.error);
+      setLoaded(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [noteId]);
+
+  function regenerate() {
+    setError(null);
+    startTransition(async () => {
+      const res = await regenerateAvsForNote(noteId);
+      if (res.ok) {
+        setSummary(res.summary);
+        setVerified(false);
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  function release() {
+    setError(null);
+    startTransition(async () => {
+      const res = await releaseAvsForNote(noteId, verified);
+      if (res.ok) {
+        const reloaded = await getAvsForNote(noteId);
+        if (reloaded.ok) setSummary(reloaded.summary);
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  const isReleased = summary?.status === "released";
+
+  return (
+    <section
+      aria-labelledby="avs-review-heading"
+      className="mt-8 overflow-hidden rounded-lg border border-border bg-surface shadow-sm"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/70 bg-surface-muted/60 px-5 py-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
+            Patient after-visit summary
+          </p>
+          <h2 id="avs-review-heading" className="mt-1 font-display text-xl font-semibold tracking-tight text-text">
+            Plain-language summary
+          </h2>
+        </div>
+        {summary && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone="neutral">{LANGUAGE_LABEL[summary.language] ?? summary.language}</Badge>
+            {summary.readabilityGrade != null && (
+              <Badge tone={summary.doc.readability.meetsTarget ? "success" : "warning"}>
+                Reading level {summary.readabilityGrade.toFixed(1)}
+                {summary.doc.readability.meetsTarget ? " ✓" : " — review"}
+              </Badge>
+            )}
+            <Badge tone={isReleased ? "success" : "highlight"}>{isReleased ? "Released" : "Draft"}</Badge>
+          </div>
+        )}
+      </div>
+
+      <div className="px-5 py-5">
+        {!loaded && <p className="text-sm text-text-muted">Loading summary…</p>}
+
+        {loaded && error && (
+          <div className="rounded-lg border border-danger/30 bg-red-50/40 px-4 py-3 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        {loaded && !summary && !error && (
+          <div className="flex flex-col items-start gap-3 rounded-lg border border-border bg-surface-muted/35 px-4 py-5">
+            <p className="text-sm text-text-muted">
+              No after-visit summary yet. Generate a plain-language summary from this signed note.
+            </p>
+            <Button type="button" size="sm" variant="secondary" onClick={regenerate} disabled={pending}>
+              {pending ? "Generating…" : "Generate summary"}
+            </Button>
+          </div>
+        )}
+
+        {loaded && summary && (
+          <div className="space-y-5">
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <div className="rounded-lg border border-border bg-surface-muted/30 p-4">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                  Your signed note
+                </p>
+                <pre className="max-h-[420px] overflow-auto whitespace-pre-wrap font-sans text-sm leading-relaxed text-text-muted">
+                  {summary.doc.sourceNote || "No note text available."}
+                </pre>
+              </div>
+              <div className="rounded-lg border border-accent/25 bg-surface p-4">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-accent">
+                  Patient will see
+                </p>
+                <div className="max-h-[420px] overflow-auto">
+                  <AvsSummaryView doc={summary.doc} />
+                </div>
+              </div>
+            </div>
+
+            {isReleased ? (
+              <div className="flex items-center justify-between gap-3 rounded-lg border border-highlight/35 bg-highlight-soft px-4 py-3">
+                <p className="text-sm font-medium text-text">
+                  Released to the patient portal
+                  {summary.releasedAt
+                    ? ` on ${new Date(summary.releasedAt).toLocaleDateString("en-US")}`
+                    : ""}
+                  .
+                </p>
+                <Badge tone="success">Delivered</Badge>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3 rounded-lg border border-border bg-surface-muted/35 px-4 py-3 md:flex-row md:items-center md:justify-between">
+                <label className="flex cursor-pointer items-start gap-2 text-sm text-text">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4 rounded border-border text-accent focus:ring-accent"
+                    checked={verified}
+                    onChange={(e) => setVerified(e.target.checked)}
+                  />
+                  <span>I reviewed this summary and it accurately reflects my note.</span>
+                </label>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  <Button type="button" size="sm" variant="ghost" onClick={regenerate} disabled={pending}>
+                    Regenerate
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="primary"
+                    onClick={release}
+                    disabled={!verified || pending}
+                    title={verified ? "Release to patient" : "Confirm review first"}
+                  >
+                    {pending ? "Releasing…" : "Release to patient"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/notes/[noteId]/page.tsx
@@ -15,6 +15,7 @@ import { hasPermission, canDocumentObjective } from "@/lib/rbac/permissions";
 import { coerceVitals } from "@/lib/clinical/objective-vitals";
 import { buildVisitCompletionBundle } from "@/lib/domain/visit-completion";
 import { VisitCompletionPanel } from "./visit-completion-panel";
+import { AvsReviewPanel } from "./avs-review-panel";
 import { noteStatusBadge } from "./note-status";
 import { AgentJobStrip, type AgentJobLite } from "./agent-job-strip";
 
@@ -289,6 +290,11 @@ export default async function NoteDetailPage({ params }: PageProps) {
           releasedPayload={releasedPayload}
           noteId={note.id}
         />
+      )}
+
+      {/* EMR-1152 — plain-language after-visit summary: verify + one-click release */}
+      {(note.status === "finalized" || note.status === "amended") && (
+        <AvsReviewPanel noteId={note.id} />
       )}
 
       {/* Post-finalize downstream-agent status (audit minor #6) */}

--- a/src/app/(patient)/portal/visit-summary/page.tsx
+++ b/src/app/(patient)/portal/visit-summary/page.tsx
@@ -1,0 +1,85 @@
+import { PatientSectionNav } from "@/components/shell/PatientSectionNav";
+import { PageHeader, PageShell } from "@/components/shell/PageHeader";
+import { prisma } from "@/lib/db/prisma";
+import { requireRole } from "@/lib/auth/session";
+import { AvsSummaryView } from "@/components/avs/AvsSummaryView";
+import { safeParseAvsDocument } from "@/lib/domain/avs/types";
+
+export const metadata = { title: "Visit summaries" };
+
+// EMR-1152 — patient-facing after-visit summaries. Released summaries appear
+// here immediately (the release action revalidates this path + sends a portal
+// notification deep-linking here). Latest is expanded; earlier ones collapse
+// into a scannable list. No pop-ups; Zen-Density styling.
+export default async function VisitSummaryPage() {
+  const user = await requireRole("patient");
+  const patient = await prisma.patient.findUnique({ where: { userId: user.id } });
+
+  if (!patient) {
+    return (
+      <PageShell maxWidth="max-w-[880px]">
+        <PageHeader eyebrow="My Health" title="Visit summaries" />
+        <PatientSectionNav section="health" />
+        <p className="text-sm text-text-muted">No patient profile found.</p>
+      </PageShell>
+    );
+  }
+
+  const rows = await prisma.afterVisitSummary.findMany({
+    where: { patientId: patient.id, status: "released" },
+    orderBy: { releasedAt: "desc" },
+    take: 20,
+  });
+
+  const summaries = rows.flatMap((r) => {
+    const doc = safeParseAvsDocument(r.payload);
+    return doc ? [{ id: r.id, releasedAt: r.releasedAt, doc }] : [];
+  });
+
+  const [latest, ...earlier] = summaries;
+
+  return (
+    <PageShell maxWidth="max-w-[880px]">
+      <PageHeader eyebrow="My Health" title="Visit summaries" />
+      <PatientSectionNav section="health" />
+
+      {summaries.length === 0 ? (
+        <div className="mt-6 rounded-xl border border-border bg-surface-muted/40 px-5 py-8 text-center">
+          <p className="text-3xl" aria-hidden>📋</p>
+          <p className="mt-2 text-sm font-medium text-text">No visit summaries yet</p>
+          <p className="mt-1 text-sm text-text-muted">
+            After your next visit, your care team will share a plain-language summary here.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-6 space-y-8">
+          <article className="rounded-2xl border border-border bg-surface p-5 shadow-sm md:p-6">
+            <AvsSummaryView doc={latest.doc} />
+          </article>
+
+          {earlier.length > 0 && (
+            <section className="space-y-3">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-subtle">
+                Earlier summaries
+              </h2>
+              {earlier.map((s) => (
+                <details key={s.id} className="group rounded-xl border border-border bg-surface">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-text">
+                    <span>
+                      {s.doc.visitDate} · {s.doc.provider}
+                    </span>
+                    <span className="text-xs text-text-muted group-open:hidden">View</span>
+                    <span className="hidden text-xs text-text-muted group-open:inline">Hide</span>
+                  </summary>
+                  <div className="border-t border-border/60 px-4 py-4">
+                    <AvsSummaryView doc={s.doc} />
+                  </div>
+                </details>
+              ))}
+            </section>
+          )}
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/src/components/avs/AvsSummaryView.tsx
+++ b/src/components/avs/AvsSummaryView.tsx
@@ -1,0 +1,116 @@
+// Presentational renderer for an AvsDocument (EMR-1152).
+// Used by both the provider verification panel and the patient portal page, so
+// it's a pure server component — no hooks, no data fetching. Zen-Density styling
+// (soft pastel, generous padding, no pop-ups): everything is a scannable,
+// time-ordered component rather than a wall of prose.
+
+import type { AvsDocument, MedicationActionTag } from "@/lib/domain/avs/types";
+
+const ACTION_COPY: Record<MedicationActionTag, { label: string; tone: string; icon: string }> = {
+  INITIATE: { label: "Start", tone: "bg-emerald-50 text-emerald-700 border-emerald-200", icon: "🆕" },
+  TITRATE: { label: "Adjust", tone: "bg-amber-50 text-amber-700 border-amber-200", icon: "📈" },
+  MAINTAIN: { label: "Keep taking", tone: "bg-sky-50 text-sky-700 border-sky-200", icon: "✅" },
+  DISCONTINUE: { label: "Stop", tone: "bg-rose-50 text-rose-700 border-rose-200", icon: "🛑" },
+};
+
+export function AvsSummaryView({ doc }: { doc: AvsDocument }) {
+  return (
+    <div className="space-y-6 text-text">
+      <header className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-accent">
+          After-visit summary
+        </p>
+        <h2 className="font-display text-2xl font-semibold tracking-tight">
+          {doc.visitDate} · {doc.provider}
+        </h2>
+        <p className="text-sm leading-relaxed text-text-muted">{doc.narrative}</p>
+      </header>
+
+      {doc.calendars.length > 0 && (
+        <section aria-labelledby="avs-meds" className="space-y-3">
+          <h3 id="avs-meds" className="text-sm font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            Your medicine schedule
+          </h3>
+          {doc.calendars.map((cal) => (
+            <div key={cal.molecule} className="overflow-hidden rounded-xl border border-border bg-surface">
+              <div className="border-b border-border/70 bg-surface-muted/50 px-4 py-2.5">
+                <p className="text-sm font-semibold">{cal.molecule}</p>
+              </div>
+              <ul className="divide-y divide-border/60">
+                {cal.steps.map((step, i) => (
+                  <li key={i} className="flex flex-col gap-1 px-4 py-3 md:flex-row md:items-center md:gap-4">
+                    <span className="inline-flex w-fit items-center rounded-full bg-accent-soft px-2.5 py-0.5 text-xs font-semibold text-accent">
+                      {step.dayRange}
+                    </span>
+                    <span className="text-sm font-medium">{step.instruction}</span>
+                    <span className="text-xs text-text-muted">{step.timeOfDay}</span>
+                    {step.goal && (
+                      <span className="text-xs font-medium text-emerald-600 md:ml-auto">🎯 {step.goal}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {doc.decomposed.medications.some((m) => m.action === "DISCONTINUE") && (
+        <section className="space-y-2">
+          {doc.decomposed.medications
+            .filter((m) => m.action === "DISCONTINUE")
+            .map((m, i) => (
+              <div
+                key={i}
+                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${ACTION_COPY.DISCONTINUE.tone}`}
+              >
+                <span aria-hidden>{ACTION_COPY.DISCONTINUE.icon}</span>
+                <span className="font-medium">{ACTION_COPY.DISCONTINUE.label} {m.molecule}</span>
+              </div>
+            ))}
+        </section>
+      )}
+
+      {(doc.roadmap.nutrition.length > 0 || doc.roadmap.behavior.length > 0) && (
+        <section aria-labelledby="avs-lifestyle" className="space-y-3">
+          <h3 id="avs-lifestyle" className="text-sm font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            Your everyday plan
+          </h3>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {[...doc.roadmap.nutrition, ...doc.roadmap.behavior].map((item, i) => (
+              <div key={i} className="flex gap-3 rounded-xl border border-border bg-surface px-4 py-3">
+                <span className="text-2xl" aria-hidden>{item.icon}</span>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold">{item.label}</p>
+                  <p className="text-xs leading-relaxed text-text-muted">{item.detail}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {doc.nextSteps.length > 0 && (
+        <section aria-labelledby="avs-next" className="space-y-2">
+          <h3 id="avs-next" className="text-sm font-semibold uppercase tracking-[0.12em] text-text-subtle">
+            What to do next
+          </h3>
+          <ol className="space-y-2">
+            {doc.nextSteps.map((step, i) => (
+              <li key={i} className="flex gap-3 rounded-lg bg-surface-muted/40 px-3 py-2 text-sm">
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent text-xs font-semibold text-white">
+                  {i + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      <section className="rounded-xl border border-highlight/30 bg-highlight-soft px-4 py-3">
+        <p className="text-sm font-medium">{doc.followUp}</p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/shell/PatientSectionNav.tsx
+++ b/src/components/shell/PatientSectionNav.tsx
@@ -48,6 +48,7 @@ const SECTIONS: Record<string, SectionDef> = {
       { label: "Labs", href: "/portal/labs" },
     ],
     secondary: [
+      { label: "Visit summaries", href: "/portal/visit-summary" },
       { label: "Assessments", href: "/portal/assessments" },
       { label: "Check-in history", href: "/portal/outcomes" },
       { label: "Dose history", href: "/portal/dose-history" },

--- a/src/lib/agents/avs-generator-agent.ts
+++ b/src/lib/agents/avs-generator-agent.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import type { Agent } from "@/lib/orchestration/types";
+import { writeAgentAudit } from "@/lib/orchestration/context";
+import { formatDateInZone, formatDateOnly, fullName } from "@/lib/utils/format";
+import { DEFAULT_TIME_ZONE } from "@/lib/utils/timezone";
+import {
+  buildDeterministicNarrative,
+  extractActionItems,
+  extractNoteSection,
+  type LeafletData,
+  type LeafletMedication,
+} from "@/lib/domain/leaflet";
+import { NOTE_BLOCK_LABELS, type NoteBlock } from "@/lib/domain/notes";
+import { buildAvsDocument } from "@/lib/domain/avs/build-avs-document";
+import { resolvePatientLanguage } from "@/lib/domain/avs/localization";
+
+// ---------------------------------------------------------------------------
+// AVS Generator Agent — EMR-1149 (Dynamic Patient-Facing Summaries)
+// ---------------------------------------------------------------------------
+// Fires on `note.finalized` (the chart-sign / encounter-close signal). Compiles
+// the signed note + the patient's language preference + a safe literacy target,
+// runs the deterministic AVS pipeline (decompose → readability → localize →
+// calendar/roadmap), and persists a DRAFT AfterVisitSummary keyed to the note.
+//
+// Idempotent per note (`AfterVisitSummary.noteId @unique`): re-running refreshes
+// a draft but never clobbers one the provider has already RELEASED (EMR-1152).
+// Deterministic — no model call — so it runs unattended on the job queue and is
+// reproducible for the de-identified research datasets the Data Collection
+// Philosophy requires. Generation is read-only to the chart + writes only the
+// summary draft, so no approval gate.
+// ---------------------------------------------------------------------------
+
+const AGENT_NAME = "avsGenerator";
+const AGENT_VERSION = "1.0.0";
+export const AVS_GENERATED_ACTION = "avs.generated";
+
+const input = z.object({
+  noteId: z.string(),
+  encounterId: z.string().optional(),
+});
+
+const output = z.object({
+  skipped: z.boolean(),
+  reason: z.string().optional(),
+  afterVisitSummaryId: z.string().nullable(),
+  language: z.string().nullable(),
+  readabilityGrade: z.number().nullable(),
+});
+
+/** Reassemble the verbatim signed-note text for the verification panel. */
+function renderSourceNote(blocks: NoteBlock[]): string {
+  return blocks
+    .filter((b) => b?.body?.trim())
+    .map((b) => `${NOTE_BLOCK_LABELS[b.type] ?? b.heading}\n${b.body.trim()}`)
+    .join("\n\n");
+}
+
+export const avsGeneratorAgent: Agent<z.infer<typeof input>, z.infer<typeof output>> = {
+  name: AGENT_NAME,
+  version: AGENT_VERSION,
+  description:
+    "Generates the plain-language, literacy- and language-matched after-visit " +
+    "summary on chart-sign and persists it as a draft for provider release. " +
+    "Deterministic; idempotent per note; never overwrites a released summary.",
+  inputSchema: input,
+  outputSchema: output,
+  allowedActions: ["read.note", "read.encounter", "read.patient", "write.chartSummary"],
+  requiresApproval: false,
+
+  async run({ noteId }, ctx) {
+    ctx.assertCan("read.note");
+
+    const note = await prisma.note.findUnique({
+      where: { id: noteId },
+      include: { encounter: { include: { patient: true } } },
+    });
+    if (!note) {
+      ctx.log("warn", "AVS skipped — note not found", { noteId });
+      return { skipped: true, reason: "note_not_found", afterVisitSummaryId: null, language: null, readabilityGrade: null };
+    }
+    if (note.status !== "finalized" && note.status !== "amended") {
+      ctx.log("info", "AVS skipped — note not signed", { noteId, status: note.status });
+      return { skipped: true, reason: "note_not_signed", afterVisitSummaryId: null, language: null, readabilityGrade: null };
+    }
+
+    const encounter = note.encounter;
+    const patient = encounter.patient;
+
+    // Never clobber a summary the provider already released.
+    const existing = await prisma.afterVisitSummary.findUnique({
+      where: { noteId },
+      select: { id: true, status: true },
+    });
+    if (existing?.status === "released") {
+      ctx.log("info", "AVS skipped — already released", { noteId, avsId: existing.id });
+      return { skipped: true, reason: "already_released", afterVisitSummaryId: existing.id, language: null, readabilityGrade: null };
+    }
+
+    ctx.assertCan("read.patient");
+
+    const [orgRow, provider, regimens, meds, appts] = await Promise.all([
+      prisma.organization.findUnique({
+        where: { id: encounter.organizationId },
+        select: { timeZone: true },
+      }),
+      encounter.providerId
+        ? prisma.provider.findUnique({
+            where: { id: encounter.providerId },
+            include: { user: { select: { firstName: true, lastName: true } } },
+          })
+        : Promise.resolve(null),
+      prisma.dosingRegimen.findMany({
+        where: { patientId: patient.id, active: true },
+        include: { product: true },
+      }),
+      prisma.patientMedication.findMany({ where: { patientId: patient.id, active: true } }),
+      prisma.appointment.findMany({
+        where: { patientId: patient.id, status: "confirmed", startAt: { gte: new Date() } },
+        orderBy: { startAt: "asc" },
+        take: 1,
+      }),
+    ]);
+
+    const timeZone = orgRow?.timeZone || DEFAULT_TIME_ZONE;
+    const blocks = (Array.isArray(note.blocks) ? note.blocks : []) as unknown as NoteBlock[];
+
+    const carePlan: LeafletMedication[] = [
+      ...regimens.map((r): LeafletMedication => ({
+        name: (r as { product?: { name?: string } }).product?.name ?? "Cannabis product",
+        dosage: `${r.volumePerDose} ${r.volumeUnit}, ${r.frequencyPerDay}x daily`,
+        instructions: r.patientInstructions,
+        type: "cannabis",
+      })),
+      ...meds.map((m): LeafletMedication => ({
+        name: m.name,
+        dosage: m.dosage ?? "",
+        instructions: null,
+        type: (m.type as LeafletMedication["type"]) ?? "prescription",
+      })),
+    ];
+
+    const assessment = extractNoteSection(blocks, "assessment");
+    const plan = extractNoteSection(blocks, "plan");
+    const subjective = extractNoteSection(blocks, "summary");
+    const followUpSection = extractNoteSection(blocks, "followUp");
+
+    const nextAppt = appts[0];
+    const apptLine = nextAppt ? `Your next appointment is ${formatDateInZone(nextAppt.startAt, timeZone)}.` : "";
+    const followUp =
+      [followUpSection, apptLine].filter(Boolean).join(" ").trim() ||
+      "Please schedule a follow-up visit as advised by your care team.";
+
+    const leafletData: LeafletData = {
+      patientName: fullName(patient.firstName, patient.lastName),
+      patientDOB: patient.dateOfBirth ? formatDateOnly(patient.dateOfBirth) : null,
+      allergies: patient.allergies ?? [],
+      visit: {
+        date: formatDateInZone(encounter.scheduledFor ?? encounter.createdAt, timeZone),
+        provider: provider?.user ? fullName(provider.user.firstName, provider.user.lastName) : "Your care team",
+        modality: encounter.modality,
+        reason: encounter.reason,
+      },
+      discussed: subjective || assessment || "Visit details not yet documented.",
+      carePlan,
+      carePlanNotes: plan || "Care plan will be updated after your next visit.",
+      nextSteps: extractActionItems(plan),
+      followUp,
+      narrativeSource: [assessment, plan, subjective].filter(Boolean).join("\n\n"),
+      generatedAt: new Date().toISOString(),
+    };
+
+    const language = resolvePatientLanguage(patient.intakeAnswers);
+
+    const doc = buildAvsDocument({
+      patientFirstName: patient.firstName,
+      visitDate: leafletData.visit.date,
+      provider: leafletData.visit.provider,
+      planText: plan,
+      baseNarrative: buildDeterministicNarrative(leafletData),
+      nextSteps:
+        leafletData.nextSteps.length > 0
+          ? leafletData.nextSteps
+          : ["Follow the care plan your clinician reviewed with you today.", "Log how you're feeling in the portal."],
+      followUp,
+      language,
+      sourceNote: renderSourceNote(blocks) || leafletData.narrativeSource,
+    });
+
+    const payload = doc as unknown as Prisma.InputJsonValue;
+    const saved = await prisma.afterVisitSummary.upsert({
+      where: { noteId },
+      create: {
+        organizationId: encounter.organizationId,
+        encounterId: encounter.id,
+        noteId,
+        patientId: patient.id,
+        language,
+        readabilityGrade: doc.readability.grade,
+        payload,
+      },
+      update: {
+        language,
+        readabilityGrade: doc.readability.grade,
+        payload,
+        generatedAt: new Date(),
+      },
+      select: { id: true },
+    });
+
+    ctx.assertCan("write.chartSummary");
+    await writeAgentAudit(
+      AGENT_NAME,
+      AGENT_VERSION,
+      encounter.organizationId,
+      AVS_GENERATED_ACTION,
+      { type: "Note", id: noteId },
+      {
+        afterVisitSummaryId: saved.id,
+        language,
+        readabilityGrade: doc.readability.grade,
+        meetsTarget: doc.readability.meetsTarget,
+        medications: doc.decomposed.medications.length,
+        calendars: doc.calendars.length,
+      },
+    );
+
+    ctx.log("info", "AVS draft generated", {
+      noteId,
+      avsId: saved.id,
+      language,
+      grade: doc.readability.grade,
+    });
+
+    return {
+      skipped: false,
+      afterVisitSummaryId: saved.id,
+      language,
+      readabilityGrade: doc.readability.grade,
+    };
+  },
+};

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -25,6 +25,8 @@ import { messageUrgencyObserverAgent } from "./message-urgency-observer-agent";
 // EMR-1145 — urgent 911/ED safety auto-reply on inbound messages
 import { safetyAutoResponderAgent } from "./safety-auto-responder-agent";
 import { visitDiscoveryWhispererAgent } from "./visit-discovery-whisperer-agent";
+// EMR-1149 — plain-language after-visit summary generation on chart-sign
+import { avsGeneratorAgent } from "./avs-generator-agent";
 // Billing agents — Phase 3 of the Revenue Cycle PRD
 import { chargeIntegrityAgent } from "./billing/charge-integrity-agent";
 import { denialTriageAgent } from "./billing/denial-triage-agent";
@@ -151,6 +153,7 @@ export const agentRegistry = {
   messageUrgencyObserver: messageUrgencyObserverAgent,
   safetyAutoResponder: safetyAutoResponderAgent,
   visitDiscoveryWhisperer: visitDiscoveryWhispererAgent,
+  avsGenerator: avsGeneratorAgent,
   // Billing agents (Phase 3)
   chargeIntegrity: chargeIntegrityAgent,
   denialTriage: denialTriageAgent,

--- a/src/lib/domain/avs/build-avs-document.test.ts
+++ b/src/lib/domain/avs/build-avs-document.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildAvsDocument } from "./build-avs-document";
+import { assertDosesUnchanged, localizeAvsDocument } from "./localization";
+import { parseAvsDocument } from "./types";
+
+const baseInput = {
+  patientFirstName: "Maria",
+  visitDate: "June 13, 2026",
+  provider: "Dr. Patel",
+  planText: [
+    "Start metformin 500 mg by mouth twice daily with meals.",
+    "Plan to titrate metformin up to 1000 mg twice daily after two weeks if tolerated.",
+    "Begin a 14:10 intermittent fasting schedule.",
+    "Walk for 30 minutes daily.",
+  ].join("\n"),
+  baseNarrative:
+    "Today Maria had a follow-up visit. We talked about insulin resistance and started a new medicine.",
+  nextSteps: ["Take metformin 500 mg twice daily.", "Log your blood sugar each morning."],
+  followUp: "Follow-up in 4 weeks.",
+  sourceNote: "Plan: start metformin 500 mg BID, titrate to 1000 mg, 14:10 IF, walk 30 min.",
+  now: new Date("2026-06-13T12:00:00.000Z"),
+};
+
+describe("buildAvsDocument (English)", () => {
+  const doc = buildAvsDocument({ ...baseInput, language: "en" });
+
+  it("validates against the persisted-payload schema", () => {
+    expect(() => parseAvsDocument(doc)).not.toThrow();
+  });
+
+  it("composes decomposition, a titration calendar, and a roadmap", () => {
+    expect(doc.decomposed.medications.length).toBeGreaterThanOrEqual(2);
+    expect(doc.calendars).toHaveLength(1);
+    expect(doc.calendars[0].steps).toHaveLength(2);
+    expect(doc.roadmap.nutrition.length).toBe(1);
+    expect(doc.roadmap.behavior.length).toBe(1);
+  });
+
+  it("de-jargons insulin resistance in the narrative", () => {
+    expect(doc.narrative).toContain("how your body cells process energy from your food");
+  });
+
+  it("computes a readability score", () => {
+    expect(doc.readability.grade).toBeGreaterThanOrEqual(0);
+    expect(doc.readability.targetGradeMin).toBe(6);
+    expect(doc.readability.targetGradeMax).toBe(8);
+  });
+
+  it("stamps generatedAt from the injected clock", () => {
+    expect(doc.generatedAt).toBe("2026-06-13T12:00:00.000Z");
+  });
+});
+
+describe("buildAvsDocument (Spanish) preserves doses", () => {
+  const en = buildAvsDocument({ ...baseInput, language: "en" });
+  const es = buildAvsDocument({ ...baseInput, language: "es" });
+
+  it("marks the language and keeps medication doses byte-identical", () => {
+    expect(es.language).toBe("es");
+    expect(assertDosesUnchanged(en, es)).toBe(true);
+    expect(es.nextSteps.join(" ")).toContain("500 mg");
+  });
+
+  it("is equivalent to localizing the English document", () => {
+    const localized = localizeAvsDocument(en, "es");
+    expect(es.decomposed).toEqual(localized.decomposed);
+    expect(es.calendars).toEqual(localized.calendars);
+  });
+});

--- a/src/lib/domain/avs/build-avs-document.ts
+++ b/src/lib/domain/avs/build-avs-document.ts
@@ -1,0 +1,74 @@
+// ───────────────────────────────────────────────────────────────────────────
+// AVS document composition — the pure heart of the generation job (EMR-1149)
+// ───────────────────────────────────────────────────────────────────────────
+// Takes the already-loaded encounter facts and composes the full, structured,
+// readability-checked, localized AvsDocument. Pure + deterministic (a `now` is
+// injectable) so it's unit-testable without a database or model call. The
+// agent does the I/O; this does the thinking.
+
+import {
+  computeReadability,
+  DEFAULT_TARGET_GRADE_MAX,
+  DEFAULT_TARGET_GRADE_MIN,
+  simplifyForReadability,
+} from "./readability";
+import { decomposeCarePlan } from "./care-plan-decomposition";
+import { buildLifestyleRoadmap, buildTitrationCalendars } from "./schedule";
+import { localizeAvsDocument, localizeText } from "./localization";
+import type { AvsDocument, SupportedLanguage } from "./types";
+
+export interface BuildAvsInput {
+  patientFirstName: string;
+  visitDate: string;
+  provider: string;
+  /** The signed Plan block — drives decomposition + calendars + roadmap. */
+  planText: string;
+  /** Deterministic English recap (e.g. leaflet buildDeterministicNarrative). */
+  baseNarrative: string;
+  nextSteps: string[];
+  followUp: string;
+  language: SupportedLanguage;
+  /** Verbatim signed-note text for the provider side-by-side verification. */
+  sourceNote: string;
+  targetGradeMin?: number;
+  targetGradeMax?: number;
+  /** Injected for deterministic tests; defaults to wall-clock. */
+  now?: Date;
+}
+
+export function buildAvsDocument(input: BuildAvsInput): AvsDocument {
+  const decomposed = decomposeCarePlan(input.planText);
+  const calendars = buildTitrationCalendars(decomposed);
+  const roadmap = buildLifestyleRoadmap(decomposed);
+
+  // De-jargon + simplify the English narrative, then score it. Readability is
+  // always measured on the English baseline (the FK math is English-tuned); the
+  // localized prose inherits the same structural simplicity.
+  const englishNarrative = simplifyForReadability(localizeText(input.baseNarrative, "en").text);
+  const readability = computeReadability(englishNarrative, {
+    targetGradeMin: input.targetGradeMin ?? DEFAULT_TARGET_GRADE_MIN,
+    targetGradeMax: input.targetGradeMax ?? DEFAULT_TARGET_GRADE_MAX,
+  });
+
+  const generatedAt = (input.now ?? new Date()).toISOString();
+
+  const baseDoc: AvsDocument = {
+    version: 1,
+    language: "en",
+    patientFirstName: input.patientFirstName,
+    visitDate: input.visitDate,
+    provider: input.provider,
+    narrative: englishNarrative,
+    decomposed,
+    calendars,
+    roadmap,
+    nextSteps: input.nextSteps.map((s) => simplifyForReadability(localizeText(s, "en").text)),
+    followUp: localizeText(input.followUp, "en").text,
+    readability,
+    sourceNote: input.sourceNote,
+    generatedAt,
+  };
+
+  if (input.language === "en") return baseDoc;
+  return localizeAvsDocument(baseDoc, input.language);
+}

--- a/src/lib/domain/avs/care-plan-decomposition.test.ts
+++ b/src/lib/domain/avs/care-plan-decomposition.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyMedicationAction,
+  decomposeCarePlan,
+  extractBehavioralTarget,
+  extractDose,
+  extractFastingWindow,
+  extractMolecule,
+  extractRoute,
+  extractTiming,
+  segmentPlan,
+} from "./care-plan-decomposition";
+
+describe("field extractors", () => {
+  it("extracts dose with unit", () => {
+    expect(extractDose("metformin 500 mg twice daily")).toBe("500 mg");
+    expect(extractDose("CBD oil 0.25 mL under the tongue")).toBe("0.25 mL");
+    expect(extractDose("continue walking")).toBeNull();
+  });
+
+  it("normalizes route to plain language", () => {
+    expect(extractRoute("take PO")).toBe("by mouth");
+    expect(extractRoute("place sublingual")).toBe("under the tongue");
+    expect(extractRoute("2 puffs inhaled")).toBe("inhaled");
+    expect(extractRoute("no route here")).toBeNull();
+  });
+
+  it("normalizes timing to plain language", () => {
+    expect(extractTiming("BID")).toBe("twice daily");
+    expect(extractTiming("take qhs")).toBe("at bedtime");
+    expect(extractTiming("once daily")).toBe("once daily");
+    expect(extractTiming("with food")).toBe("with meals");
+  });
+
+  it("classifies action verbs with correct precedence", () => {
+    expect(classifyMedicationAction("start metformin")).toBe("INITIATE");
+    expect(classifyMedicationAction("discontinue lisinopril")).toBe("DISCONTINUE");
+    expect(classifyMedicationAction("taper off prednisone")).toBe("DISCONTINUE");
+    expect(classifyMedicationAction("increase metformin to 1000 mg")).toBe("TITRATE");
+    expect(classifyMedicationAction("continue atorvastatin")).toBe("MAINTAIN");
+    expect(classifyMedicationAction("patient feels well")).toBeNull();
+  });
+
+  it("extracts molecules from the lexicon and after verbs", () => {
+    expect(extractMolecule("start metformin 500 mg")).toBe("Metformin");
+    expect(extractMolecule("begin CBD oil at night")?.toLowerCase()).toContain("cbd");
+  });
+
+  it("extracts fasting windows and behavioral targets", () => {
+    expect(extractFastingWindow("14:10 intermittent fasting")).toBe("14:10");
+    expect(extractFastingWindow("16/8 eating window")).toBe("16:8");
+    expect(extractBehavioralTarget("walk for 30 minutes")).toBe("30 minutes");
+    expect(extractBehavioralTarget("aim for 7-8 hours of sleep")).toBe("7-8 hours");
+    expect(extractBehavioralTarget("target 10,000 steps")).toBe("10,000 steps");
+  });
+});
+
+describe("segmentPlan", () => {
+  it("splits bulleted plans", () => {
+    const segs = segmentPlan("- Start metformin 500 mg\n- Begin 14:10 IF\n- Walk 30 min daily");
+    expect(segs).toHaveLength(3);
+    expect(segs[0]).toContain("metformin");
+  });
+
+  it("splits prose into sentences", () => {
+    const segs = segmentPlan("Start metformin 500 mg twice daily. Recheck A1c in 3 months.");
+    expect(segs).toHaveLength(2);
+  });
+});
+
+// ── Fixture 1: metformin titration plan ──────────────────────────────────────
+describe("fixture: metformin titration plan", () => {
+  const plan = [
+    "Start metformin 500 mg by mouth twice daily with meals.",
+    "Plan to titrate metformin up to 1000 mg twice daily after two weeks if tolerated.",
+    "Discontinue glipizide.",
+    "Continue lisinopril 10 mg once daily.",
+  ].join("\n");
+
+  const result = decomposeCarePlan(plan);
+
+  it("captures four medication actions and no diet/behavior noise", () => {
+    expect(result.medications).toHaveLength(4);
+    expect(result.dietary).toHaveLength(0);
+    expect(result.behavioral).toHaveLength(0);
+  });
+
+  it("tags the initiate action with dose, route, and timing", () => {
+    const initiate = result.medications.find((m) => m.action === "INITIATE");
+    expect(initiate?.molecule).toBe("Metformin");
+    expect(initiate?.dose).toBe("500 mg");
+    expect(initiate?.route).toBe("by mouth");
+    expect(initiate?.timing).toBe("twice daily");
+  });
+
+  it("tags the titration and discontinuation", () => {
+    expect(result.medications.some((m) => m.action === "TITRATE" && m.dose === "1000 mg")).toBe(true);
+    expect(result.medications.some((m) => m.action === "DISCONTINUE")).toBe(true);
+    expect(result.medications.some((m) => m.action === "MAINTAIN")).toBe(true);
+  });
+});
+
+// ── Fixture 2: 14:10 intermittent-fasting protocol ───────────────────────────
+describe("fixture: 14:10 intermittent fasting protocol", () => {
+  const plan = [
+    "Begin a 14:10 intermittent fasting schedule, eating between 9am and 7pm.",
+    "Aim for a low-carb, whole-food diet.",
+    "Increase water intake to stay well hydrated.",
+  ].join("\n");
+
+  const result = decomposeCarePlan(plan);
+
+  it("classifies all three as dietary, not medication", () => {
+    expect(result.dietary).toHaveLength(3);
+    expect(result.medications).toHaveLength(0);
+  });
+
+  it("captures the eating window and protocol kinds", () => {
+    const tre = result.dietary.find((d) => d.window === "14:10");
+    expect(tre).toBeDefined();
+    expect(result.dietary.some((d) => d.kind === "macronutrient")).toBe(true);
+    expect(result.dietary.some((d) => d.kind === "hydration")).toBe(true);
+  });
+});
+
+// ── Fixture 3: walking + breathing behavioral plan ───────────────────────────
+describe("fixture: walking + breathing behavioral plan", () => {
+  const plan = [
+    "Walk for 30 minutes daily, working up to Zone 2 cardio.",
+    "Practice 10 minutes of breathing exercises each evening for stress reduction.",
+    "Aim for 7-8 hours of sleep with a consistent bedtime routine.",
+    "Log your blood pressure at home each morning.",
+  ].join("\n");
+
+  const result = decomposeCarePlan(plan);
+
+  it("classifies all four as behavioral", () => {
+    expect(result.behavioral).toHaveLength(4);
+    expect(result.medications).toHaveLength(0);
+    expect(result.dietary).toHaveLength(0);
+  });
+
+  it("captures behavioral kinds and quantified targets", () => {
+    expect(result.behavioral.some((b) => b.kind === "activity" && b.target === "30 minutes")).toBe(true);
+    expect(result.behavioral.some((b) => b.kind === "mindfulness")).toBe(true);
+    expect(result.behavioral.some((b) => b.kind === "sleep" && b.target === "7-8 hours")).toBe(true);
+    expect(result.behavioral.some((b) => b.kind === "monitoring")).toBe(true);
+  });
+});
+
+describe("mixed plan + documentation artifacts", () => {
+  it("routes prose with no care change to unclassified", () => {
+    const result = decomposeCarePlan(
+      "Patient is doing well overall. Start metformin 500 mg daily. Discussed goals.",
+    );
+    expect(result.medications).toHaveLength(1);
+    expect(result.unclassified.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns empty buckets for empty input", () => {
+    const result = decomposeCarePlan("");
+    expect(result.medications).toEqual([]);
+    expect(result.dietary).toEqual([]);
+    expect(result.behavioral).toEqual([]);
+    expect(result.unclassified).toEqual([]);
+  });
+});

--- a/src/lib/domain/avs/care-plan-decomposition.ts
+++ b/src/lib/domain/avs/care-plan-decomposition.ts
@@ -1,0 +1,284 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1150 — Care-plan decomposition
+// ───────────────────────────────────────────────────────────────────────────
+// Doc Phase 2: strip documentation artifacts from the signed plan text and
+// isolate the *actual care changes* into structured buckets the calendar /
+// roadmap renderer (EMR-1152) and the patient summary consume:
+//
+//   • medications  — action tag + molecule + dose + route + timing
+//   • dietary      — time-restricted eating / fasting / macros / hydration
+//   • behavioral   — sleep / activity / mindfulness / monitoring / substance
+//
+// Deterministic on purpose: the same plan text must always decompose the same
+// way (testable, auditable, reproducible for the research datasets the Data
+// Collection Philosophy requires). No model calls here.
+
+import type {
+  BehavioralItem,
+  BehavioralKind,
+  DecomposedCarePlan,
+  DietaryKind,
+  DietaryProtocol,
+  MedicationAction,
+  MedicationActionTag,
+} from "./types";
+
+/* -------------------------------------------------------------------------- */
+/* Sentence segmentation                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Split plan prose into candidate care-change sentences. Mirrors the leaflet's
+ * extractActionItems segmentation (bullets first, sentence-split otherwise) so
+ * the AVS and the leaflet agree on what counts as an action line.
+ */
+export function segmentPlan(planText: string): string[] {
+  if (!planText) return [];
+  const hasBullets = /(^|\n)\s*[-•*\d]/.test(planText);
+  const lines = planText
+    .split(/\n+/)
+    .map((line) => line.replace(/^[\s\-•*]+/, "").replace(/^\d+[.)]\s*/, "").trim())
+    .filter(Boolean);
+  const candidates = hasBullets
+    ? lines.flatMap((line) => line.split(/(?<=[.!?])\s+/))
+    : lines.flatMap((line) => line.split(/(?<=[.!?])\s+/));
+  return candidates.map((s) => s.trim()).filter((s) => s.length > 2);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Medication action lexicons                                                  */
+/* -------------------------------------------------------------------------- */
+
+const ACTION_VERBS: Array<{ tag: MedicationActionTag; pattern: RegExp }> = [
+  // Order matters: "taper off" / "stop" must beat the generic "taper" → TITRATE.
+  { tag: "DISCONTINUE", pattern: /\b(discontinue|discontinued|stop|stopping|cease|hold|holding|taper\s+off|d\/?c)\b/i },
+  { tag: "TITRATE", pattern: /\b(titrate|titrating|increase|increasing|decrease|decreasing|up-?titrate|down-?titrate|adjust|adjusting|reduce|reducing|raise|bump|taper(?:\s+(?:up|down|to))?)\b/i },
+  { tag: "INITIATE", pattern: /\b(start|starting|begin|beginning|initiate|initiating|add|adding|prescribe|prescribing|trial\s+of|commence)\b/i },
+  { tag: "MAINTAIN", pattern: /\b(continue|continuing|maintain|maintaining|keep|remain\s+on|stay\s+on|ongoing|no\s+change)\b/i },
+];
+
+/** Known molecule / product names — high-precision anchor for the parser. */
+const MOLECULE_LEXICON = [
+  "metformin", "lisinopril", "atorvastatin", "rosuvastatin", "simvastatin",
+  "sertraline", "escitalopram", "fluoxetine", "albuterol", "omeprazole",
+  "pantoprazole", "amlodipine", "losartan", "hydrochlorothiazide", "hctz",
+  "gabapentin", "pregabalin", "duloxetine", "levothyroxine", "insulin",
+  "semaglutide", "ozempic", "wegovy", "empagliflozin", "jardiance",
+  "melatonin", "trazodone", "naltrexone", "buprenorphine",
+  // Cannabis / botanical — LeafJourney's home turf
+  "cbd", "cannabidiol", "thc", "tetrahydrocannabinol", "cbn", "cbg",
+  "cannabis", "marijuana", "epidiolex", "cannabis oil", "cbd oil", "thc oil",
+];
+
+const ROUTE_MAP: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /\b(by mouth|orally|oral|po|p\.o\.)\b/i, label: "by mouth" },
+  { pattern: /\b(sublingual(?:ly)?|under the tongue|s\/?l)\b/i, label: "under the tongue" },
+  { pattern: /\b(inhal(?:e|ed|ation)|inhaler|puff)\b/i, label: "inhaled" },
+  { pattern: /\b(topical(?:ly)?|on the skin)\b/i, label: "on the skin" },
+  { pattern: /\b(subcutaneous(?:ly)?|sub-?q|subq|sc)\b/i, label: "as an injection under the skin" },
+  { pattern: /\b(intramuscular(?:ly)?|i\.?m\.?)\b/i, label: "as a shot into the muscle" },
+  { pattern: /\b(transdermal|patch)\b/i, label: "as a patch" },
+  { pattern: /\b(rectal(?:ly)?|suppository)\b/i, label: "as a suppository" },
+];
+
+const TIMING_MAP: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /\b(twice (?:a day|daily)|two times (?:a day|daily)|bid|b\.i\.d\.)\b/i, label: "twice daily" },
+  { pattern: /\b(three times (?:a day|daily)|tid|t\.i\.d\.)\b/i, label: "three times daily" },
+  { pattern: /\b(four times (?:a day|daily)|qid|q\.i\.d\.)\b/i, label: "four times daily" },
+  { pattern: /\b(at bedtime|before bed|qhs|nightly|each night|every night)\b/i, label: "at bedtime" },
+  { pattern: /\b(every morning|each morning|in the morning|qam|q\.a\.m\.)\b/i, label: "every morning" },
+  { pattern: /\b(with meals|with food|with breakfast|with dinner)\b/i, label: "with meals" },
+  { pattern: /\b(once (?:a day|daily)|every day|daily|qd|q\.d\.|q24h)\b/i, label: "once daily" },
+  { pattern: /\b(as needed|prn|p\.r\.n\.)\b/i, label: "as needed" },
+  { pattern: /\b(every other day|qod)\b/i, label: "every other day" },
+  { pattern: /\b(weekly|once a week|every week)\b/i, label: "weekly" },
+];
+
+const DOSE_PATTERN =
+  /\b\d+(?:\.\d+)?\s?(?:mg|mcg|µg|g|ml|milliliters?|units?|iu|puffs?|tablets?|tabs?|caps?|capsules?|drops?|sprays?|%)\b/i;
+
+/* -------------------------------------------------------------------------- */
+/* Field extractors (exported for unit tests)                                  */
+/* -------------------------------------------------------------------------- */
+
+export function extractDose(text: string): string | null {
+  const m = text.match(DOSE_PATTERN);
+  if (!m) return null;
+  return m[0].replace(/\s+/g, " ").trim();
+}
+
+export function extractRoute(text: string): string | null {
+  for (const { pattern, label } of ROUTE_MAP) if (pattern.test(text)) return label;
+  return null;
+}
+
+export function extractTiming(text: string): string | null {
+  for (const { pattern, label } of TIMING_MAP) if (pattern.test(text)) return label;
+  return null;
+}
+
+/** Classify a sentence's medication action verb, or null if none present. */
+export function classifyMedicationAction(text: string): MedicationActionTag | null {
+  for (const { tag, pattern } of ACTION_VERBS) if (pattern.test(text)) return tag;
+  return null;
+}
+
+const MOLECULE_STOPWORDS = new Set([
+  "the", "a", "an", "your", "his", "her", "their", "patient", "patient's",
+  "dose", "daily", "to", "of", "on", "with", "and", "for", "by", "at",
+  "mg", "mcg", "ml", "g", "units", "tablet", "tablets", "capsule",
+]);
+
+/** Best-effort molecule extraction: lexicon hit first, else token after verb. */
+export function extractMolecule(text: string): string | null {
+  const lower = text.toLowerCase();
+  // Prefer multi-word lexicon entries (e.g. "cbd oil") over single words.
+  const sorted = [...MOLECULE_LEXICON].sort((a, b) => b.length - a.length);
+  for (const drug of sorted) {
+    if (new RegExp(`\\b${drug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i").test(lower)) {
+      return drug.replace(/\b\w/g, (c) => c.toUpperCase());
+    }
+  }
+  // Fall back to the first meaningful token after the action verb.
+  for (const { pattern } of ACTION_VERBS) {
+    const m = text.match(new RegExp(pattern.source + "\\s+(.+)", "i"));
+    if (m?.[1]) {
+      const token = m[1]
+        .split(/\s+/)
+        .find(
+          (t) =>
+            t.length > 2 &&
+            !MOLECULE_STOPWORDS.has(t.toLowerCase()) &&
+            !DOSE_PATTERN.test(t) &&
+            /[a-z]/i.test(t),
+        );
+      if (token) {
+        return token.replace(/[^\w-]/g, "").replace(/\b\w/g, (c) => c.toUpperCase());
+      }
+    }
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dietary + behavioral lexicons                                               */
+/* -------------------------------------------------------------------------- */
+
+const FASTING_WINDOW_PATTERN = /\b(\d{1,2})\s*[:\/]\s*(\d{1,2})\b/;
+
+const DIETARY_RULES: Array<{ kind: DietaryKind; pattern: RegExp }> = [
+  { kind: "time_restricted_eating", pattern: /\b(time-?restricted eating|tre|eating window|\d{1,2}\s*[:\/]\s*\d{1,2})\b/i },
+  // NB: no bare "if"/"fast" alternatives — they false-match "if tolerated"
+  // and "breakfast". Spelled-out forms only.
+  { kind: "fasting", pattern: /\b(intermittent fasting|fasting|water fast|overnight fast)\b/i },
+  { kind: "macronutrient", pattern: /\b(low-?carb|low-?carbohydrate|keto(?:genic)?|protein|macros?|macronutrients?|carbohydrate|sugar|mediterranean diet|whole-?food|plant-?based)\b/i },
+  { kind: "hydration", pattern: /\b(hydration|water intake|drink water|fluids?|electrolytes?)\b/i },
+];
+
+const BEHAVIORAL_RULES: Array<{ kind: BehavioralKind; pattern: RegExp }> = [
+  { kind: "sleep", pattern: /\b(sleep|bedtime routine|sleep hygiene|hours of sleep|wind-?down)\b/i },
+  { kind: "activity", pattern: /\b(walk|walking|exercise|steps|cardio|strength training|resistance|zone 2|zone two|aerobic|workout|movement|physical activity|swim|cycling|yoga)\b/i },
+  { kind: "mindfulness", pattern: /\b(mindfulness|meditat|breathing|breathwork|stress (?:reduction|management)|relaxation|journaling)\b/i },
+  { kind: "monitoring", pattern: /\b(log|track|monitor|check (?:your )?(?:glucose|blood sugar|blood pressure|bp|weight)|weigh|cgm|home blood pressure|diary)\b/i },
+  { kind: "substance", pattern: /\b(reduce alcohol|cut back on alcohol|quit smoking|stop smoking|tobacco|nicotine|caffeine reduction|limit alcohol)\b/i },
+];
+
+const ACTIVITY_TARGET_PATTERN =
+  /\b(\d+(?:[-–]\d+)?\s*(?:hours?|hrs?|minutes?|mins?|steps|miles?|km|reps?|days?\s*(?:a|per)\s*week|x\s*(?:a|per)\s*week))\b/i;
+
+/** Pull a quantified behavioral target ("30 minutes", "7–8 hours", "10,000 steps"). */
+export function extractBehavioralTarget(text: string): string | null {
+  const steps = text.match(/\b[\d,]{3,}\s*steps\b/i);
+  if (steps) return steps[0].replace(/\s+/g, " ").trim();
+  const m = text.match(ACTIVITY_TARGET_PATTERN);
+  return m ? m[0].replace(/\s+/g, " ").trim() : null;
+}
+
+/** Normalize a fasting/eating window to "H:MM"-style "14:10". */
+export function extractFastingWindow(text: string): string | null {
+  const m = text.match(FASTING_WINDOW_PATTERN);
+  if (!m) return null;
+  return `${Number(m[1])}:${Number(m[2])}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Main entry                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const DIET_BEHAVIOR_HINT =
+  /\b(fasting|fast\b|eating window|time-?restricted|intermittent|low-?carb|keto|protein|macro|hydration|water|walk|exercise|steps|sleep|mindful|meditat|breathing|stress|cardio|zone 2|alcohol|smoking|caffeine|monitor|log|track|weigh)\b/i;
+
+function classifyDietary(text: string): DietaryProtocol | null {
+  for (const { kind, pattern } of DIETARY_RULES) {
+    if (pattern.test(text)) {
+      return { kind, window: extractFastingWindow(text), detail: text, raw: text };
+    }
+  }
+  return null;
+}
+
+function classifyBehavioral(text: string): BehavioralItem | null {
+  for (const { kind, pattern } of BEHAVIORAL_RULES) {
+    if (pattern.test(text)) {
+      return { kind, target: extractBehavioralTarget(text), detail: text, raw: text };
+    }
+  }
+  return null;
+}
+
+function classifyMedication(text: string): MedicationAction | null {
+  const action = classifyMedicationAction(text);
+  if (!action) return null;
+  const dose = extractDose(text);
+  const route = extractRoute(text);
+  const timing = extractTiming(text);
+  const molecule = extractMolecule(text);
+  // Require a real medication signal so "continue walking daily" doesn't
+  // masquerade as a MAINTAIN order.
+  const hasSignal = Boolean(dose || route || (molecule && isKnownMolecule(molecule)));
+  if (!hasSignal && !molecule) return null;
+  if (!hasSignal && DIET_BEHAVIOR_HINT.test(text)) return null;
+  return { action, molecule: molecule ?? "Medication", dose, route, timing, raw: text };
+}
+
+function isKnownMolecule(name: string): boolean {
+  const lower = name.toLowerCase();
+  return MOLECULE_LEXICON.some((d) => d === lower);
+}
+
+/**
+ * Decompose signed plan text into the structured care-change buckets.
+ *
+ * Per-sentence priority: diet/behavior keywords win over a medication verb
+ * (so "continue 14:10 fasting" is dietary, not a MAINTAIN drug order); a
+ * medication is only recorded when there's a dose, route, or known molecule.
+ */
+export function decomposeCarePlan(planText: string): DecomposedCarePlan {
+  const out: DecomposedCarePlan = {
+    medications: [],
+    dietary: [],
+    behavioral: [],
+    unclassified: [],
+  };
+
+  for (const sentence of segmentPlan(planText)) {
+    const dietary = classifyDietary(sentence);
+    if (dietary) {
+      out.dietary.push(dietary);
+      continue;
+    }
+    const behavioral = classifyBehavioral(sentence);
+    if (behavioral) {
+      out.behavioral.push(behavioral);
+      continue;
+    }
+    const medication = classifyMedication(sentence);
+    if (medication) {
+      out.medications.push(medication);
+      continue;
+    }
+    out.unclassified.push(sentence);
+  }
+
+  return out;
+}

--- a/src/lib/domain/avs/index.ts
+++ b/src/lib/domain/avs/index.ts
@@ -1,0 +1,7 @@
+// Public API for the After-Visit Summary domain module (EMR-1149..1152).
+export * from "./types";
+export * from "./care-plan-decomposition";
+export * from "./readability";
+export * from "./localization";
+export * from "./schedule";
+export * from "./build-avs-document";

--- a/src/lib/domain/avs/localization.ts
+++ b/src/lib/domain/avs/localization.ts
@@ -1,0 +1,235 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1151 — Medical localization layer
+// ───────────────────────────────────────────────────────────────────────────
+// Doc Phase 3: route non-English summaries through clinical-intent-preserving
+// dictionaries (no unsafe literal idioms) with culturally sensitive
+// substitutions. The hard safety invariant: translation NEVER alters a dose,
+// number, or universal unit. We enforce that mechanically by masking numeric
+// tokens before substitution and restoring them afterward, plus assert-equal
+// helpers the pipeline + tests use to prove doses survived.
+
+import type { AvsDocument, SupportedLanguage } from "./types";
+
+export interface LocalizationResult {
+  language: SupportedLanguage;
+  text: string;
+  /** The dictionary substitutions that fired (for auditability). */
+  substitutions: Array<{ from: string; to: string }>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cultural / plain-language substitutions (English → English), pre-translation */
+/* -------------------------------------------------------------------------- */
+
+const PLAIN_LANGUAGE_SUBSTITUTIONS: Array<[RegExp, string]> = [
+  [/\binsulin resistance\b/gi, "how your body cells process energy from your food"],
+  [/\bhypertension\b/gi, "high blood pressure"],
+  [/\bhyperglycemia\b/gi, "high blood sugar"],
+  [/\bhypoglycemia\b/gi, "low blood sugar"],
+  [/\bdyslipidemia\b/gi, "unhealthy cholesterol levels"],
+  [/\bhepatic\b/gi, "liver"],
+  [/\brenal\b/gi, "kidney"],
+];
+
+/* -------------------------------------------------------------------------- */
+/* Translation dictionaries — controlled AVS vocabulary, longest phrase first   */
+/* -------------------------------------------------------------------------- */
+
+type Dict = Array<[RegExp, string]>;
+
+const ES: Dict = [
+  [/\bwhat to do next\b/gi, "qué hacer a continuación"],
+  [/\byour care plan\b/gi, "su plan de cuidado"],
+  [/\bhigh blood pressure\b/gi, "presión arterial alta"],
+  [/\bhigh blood sugar\b/gi, "azúcar alta en la sangre"],
+  [/\blow blood sugar\b/gi, "azúcar baja en la sangre"],
+  [/\bfollow-?up\b/gi, "seguimiento"],
+  [/\bnext steps\b/gi, "próximos pasos"],
+  [/\btwice daily\b/gi, "dos veces al día"],
+  [/\bthree times daily\b/gi, "tres veces al día"],
+  [/\bonce daily\b/gi, "una vez al día"],
+  [/\bat bedtime\b/gi, "a la hora de dormir"],
+  [/\bevery morning\b/gi, "cada mañana"],
+  [/\bwith meals\b/gi, "con las comidas"],
+  [/\bas needed\b/gi, "según sea necesario"],
+  [/\bby mouth\b/gi, "por la boca"],
+  [/\bunder the tongue\b/gi, "debajo de la lengua"],
+  [/\binhaled\b/gi, "inhalado"],
+  [/\bminutes?\b/gi, "minutos"],
+  [/\bhours?\b/gi, "horas"],
+  [/\bsleep\b/gi, "dormir"],
+  [/\bwalk\b/gi, "caminar"],
+  [/\bplease\b/gi, "por favor"],
+  [/\btake\b/gi, "tome"],
+  [/\bstart\b/gi, "comience"],
+  [/\bstop\b/gi, "deje de tomar"],
+  [/\bcontinue\b/gi, "continúe"],
+  [/\btoday\b/gi, "hoy"],
+  [/\byour\b/gi, "su"],
+];
+
+const VI: Dict = [
+  [/\bwhat to do next\b/gi, "việc cần làm tiếp theo"],
+  [/\byour care plan\b/gi, "kế hoạch chăm sóc của bạn"],
+  [/\bhigh blood pressure\b/gi, "huyết áp cao"],
+  [/\bhigh blood sugar\b/gi, "đường huyết cao"],
+  [/\blow blood sugar\b/gi, "đường huyết thấp"],
+  [/\bfollow-?up\b/gi, "tái khám"],
+  [/\bnext steps\b/gi, "các bước tiếp theo"],
+  [/\btwice daily\b/gi, "hai lần mỗi ngày"],
+  [/\bthree times daily\b/gi, "ba lần mỗi ngày"],
+  [/\bonce daily\b/gi, "một lần mỗi ngày"],
+  [/\bat bedtime\b/gi, "trước khi đi ngủ"],
+  [/\bevery morning\b/gi, "mỗi buổi sáng"],
+  [/\bwith meals\b/gi, "trong bữa ăn"],
+  [/\bas needed\b/gi, "khi cần"],
+  [/\bby mouth\b/gi, "bằng đường uống"],
+  [/\bunder the tongue\b/gi, "đặt dưới lưỡi"],
+  [/\binhaled\b/gi, "hít vào"],
+  [/\bminutes?\b/gi, "phút"],
+  [/\bhours?\b/gi, "giờ"],
+  [/\bsleep\b/gi, "ngủ"],
+  [/\bwalk\b/gi, "đi bộ"],
+  [/\bplease\b/gi, "vui lòng"],
+  [/\btake\b/gi, "uống"],
+  [/\bstart\b/gi, "bắt đầu"],
+  [/\bstop\b/gi, "ngừng dùng"],
+  [/\bcontinue\b/gi, "tiếp tục"],
+  [/\btoday\b/gi, "hôm nay"],
+  [/\byour\b/gi, "của bạn"],
+];
+
+const DICTIONARIES: Record<Exclude<SupportedLanguage, "en">, Dict> = { es: ES, vi: VI };
+
+/* -------------------------------------------------------------------------- */
+/* Number protection — the dose-safety mechanism                               */
+/* -------------------------------------------------------------------------- */
+
+// A number core, optionally followed by a *universal* unit that must not be
+// translated (mg/mcg/g/ml/iu/%/units, and clock-style windows like 14:10).
+const NUMERIC_TOKEN =
+  /\b\d[\d.,:/-]*(?:\s?(?:mg|mcg|µg|g|ml|iu|units?|%))?\b/gi;
+
+// Printable, regex-safe sentinels that never appear in clinical prose or in the
+// translation dictionaries. A masked dose looks like "@@N0@@".
+const MASK_OPEN = "@@N";
+const MASK_CLOSE = "@@";
+
+function protectNumbers(text: string): { masked: string; tokens: string[] } {
+  const tokens: string[] = [];
+  const masked = text.replace(NUMERIC_TOKEN, (m) => {
+    const i = tokens.push(m) - 1;
+    return `${MASK_OPEN}${i}${MASK_CLOSE}`;
+  });
+  return { masked, tokens };
+}
+
+function restoreNumbers(masked: string, tokens: string[]): string {
+  return masked.replace(/@@N(\d+)@@/g, (_, i) => tokens[Number(i)] ?? "");
+}
+
+/** The dose/number tokens in a string (used by the assert-equal guarantee). */
+export function numericTokens(text: string): string[] {
+  return (text.match(NUMERIC_TOKEN) || []).map((t) => t.replace(/\s+/g, " ").trim());
+}
+
+/** True when `after` preserves every numeric/dose token from `before`, in order. */
+export function assertNumericTokensPreserved(before: string, after: string): boolean {
+  const a = numericTokens(before);
+  const b = numericTokens(after);
+  if (a.length !== b.length) return false;
+  return a.every((tok, i) => tok === b[i]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Localize a single string. Always applies the plain-language substitutions;
+ * for es/vi it then runs the translation dictionary over number-masked text so
+ * doses/units pass through verbatim. English input returns the plain-language
+ * (de-jargoned) form.
+ */
+export function localizeText(text: string, lang: SupportedLanguage): LocalizationResult {
+  const substitutions: Array<{ from: string; to: string }> = [];
+
+  let working = text;
+  for (const [pattern, replacement] of PLAIN_LANGUAGE_SUBSTITUTIONS) {
+    if (pattern.test(working)) {
+      working = working.replace(pattern, replacement);
+      substitutions.push({ from: pattern.source, to: replacement });
+    }
+  }
+
+  if (lang === "en") {
+    return { language: "en", text: working, substitutions };
+  }
+
+  const { masked, tokens } = protectNumbers(working);
+  let translated = masked;
+  for (const [pattern, replacement] of DICTIONARIES[lang]) {
+    if (pattern.test(translated)) {
+      translated = translated.replace(pattern, replacement);
+      substitutions.push({ from: pattern.source, to: replacement });
+    }
+  }
+  return { language: lang, text: restoreNumbers(translated, tokens), substitutions };
+}
+
+function localizeList(items: string[], lang: SupportedLanguage): string[] {
+  return items.map((s) => localizeText(s, lang).text);
+}
+
+/**
+ * Localize an AVS document's patient-facing prose into `lang`.
+ *
+ * Structured medication fields (dose, route, timing, molecule) are left
+ * BYTE-IDENTICAL — the dose-safety invariant — so the calendar renderer and
+ * the verification panel keep exact values. Only narrative/instruction/roadmap
+ * prose is translated. Use `assertDosesUnchanged` to prove the invariant held.
+ */
+export function localizeAvsDocument(doc: AvsDocument, lang: SupportedLanguage): AvsDocument {
+  return {
+    ...doc,
+    language: lang,
+    narrative: localizeText(doc.narrative, lang).text,
+    nextSteps: localizeList(doc.nextSteps, lang),
+    followUp: localizeText(doc.followUp, lang).text,
+    roadmap: {
+      nutrition: doc.roadmap.nutrition.map((i) => ({
+        icon: i.icon,
+        label: localizeText(i.label, lang).text,
+        detail: localizeText(i.detail, lang).text,
+      })),
+      behavior: doc.roadmap.behavior.map((i) => ({
+        icon: i.icon,
+        label: localizeText(i.label, lang).text,
+        detail: localizeText(i.detail, lang).text,
+      })),
+    },
+    // calendars + decomposed.medications keep their structured dose/timing.
+  };
+}
+
+/** Assert no medication dose/timing/route/molecule changed across localization. */
+export function assertDosesUnchanged(before: AvsDocument, after: AvsDocument): boolean {
+  if (before.decomposed.medications.length !== after.decomposed.medications.length) return false;
+  const sameMeds = before.decomposed.medications.every((m, i) => {
+    const n = after.decomposed.medications[i];
+    return (
+      m.dose === n.dose &&
+      m.timing === n.timing &&
+      m.route === n.route &&
+      m.molecule === n.molecule
+    );
+  });
+  if (!sameMeds) return false;
+
+  if (before.calendars.length !== after.calendars.length) return false;
+  return before.calendars.every((cal, i) => {
+    const n = after.calendars[i];
+    if (!n || cal.molecule !== n.molecule || cal.steps.length !== n.steps.length) return false;
+    return cal.steps.every((s, j) => s.instruction === n.steps[j].instruction);
+  });
+}

--- a/src/lib/domain/avs/localization.ts
+++ b/src/lib/domain/avs/localization.ts
@@ -233,3 +233,35 @@ export function assertDosesUnchanged(before: AvsDocument, after: AvsDocument): b
     return cal.steps.every((s, j) => s.instruction === n.steps[j].instruction);
   });
 }
+
+/* -------------------------------------------------------------------------- */
+/* Patient language preference (EMR-1149 context compilation)                  */
+/* -------------------------------------------------------------------------- */
+
+const LANGUAGE_HINTS: Array<[RegExp, SupportedLanguage]> = [
+  [/(^|\b)(es|spa|spanish|espanol|español|castellano)(\b|$)/i, "es"],
+  [/(^|\b)(vi|vie|vietnamese|tieng viet|tiếng việt)(\b|$)/i, "vi"],
+];
+
+/**
+ * Resolve a patient's preferred AVS language from their intake answers JSON.
+ * Defaults safely to English when nothing recognizable is present (EMR-1149:
+ * "Missing preferences default safely — English, 6th–8th grade").
+ */
+export function resolvePatientLanguage(intakeAnswers: unknown): SupportedLanguage {
+  if (!intakeAnswers || typeof intakeAnswers !== "object") return "en";
+  const obj = intakeAnswers as Record<string, unknown>;
+  const candidates = [
+    obj.language,
+    obj.preferredLanguage,
+    obj.preferred_language,
+    obj.locale,
+    obj.lang,
+  ];
+  for (const c of candidates) {
+    if (typeof c !== "string" || !c.trim()) continue;
+    for (const [re, lang] of LANGUAGE_HINTS) if (re.test(c)) return lang;
+    if (/^en/i.test(c.trim())) return "en";
+  }
+  return "en";
+}

--- a/src/lib/domain/avs/readability.test.ts
+++ b/src/lib/domain/avs/readability.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeReadability,
+  countSyllables,
+  fleschKincaidGrade,
+  medicalDensity,
+  simplifyForReadability,
+} from "./readability";
+import {
+  assertDosesUnchanged,
+  assertNumericTokensPreserved,
+  localizeAvsDocument,
+  localizeText,
+  numericTokens,
+} from "./localization";
+import type { AvsDocument } from "./types";
+
+describe("readability scoring", () => {
+  it("counts syllables sensibly", () => {
+    expect(countSyllables("cat")).toBe(1);
+    expect(countSyllables("medicine")).toBeGreaterThanOrEqual(2);
+    expect(countSyllables("")).toBe(0);
+  });
+
+  it("scores simple copy below complex copy", () => {
+    const simple = "Take your pill each day. Drink water. Rest well.";
+    const complex =
+      "Subsequently, the patient should administer the pharmacological intervention approximately twice daily notwithstanding gastrointestinal contraindications.";
+    expect(fleschKincaidGrade(simple)).toBeLessThan(fleschKincaidGrade(complex));
+  });
+
+  it("produces a full readability profile with the 6-8 grade band", () => {
+    const score = computeReadability("Take your pill each day. Drink water.");
+    expect(score.targetGradeMin).toBe(6);
+    expect(score.targetGradeMax).toBe(8);
+    expect(score.meetsTarget).toBe(true);
+    expect(score.index).toBeGreaterThan(0);
+  });
+
+  it("flags above-band clinical prose as not meeting target", () => {
+    const score = computeReadability(
+      "Subsequently the patient must administer pharmacological agents notwithstanding gastrointestinal contraindications associated with hepatic dysfunction.",
+    );
+    expect(score.meetsTarget).toBe(false);
+    expect(score.medicalDensity).toBeGreaterThan(0);
+  });
+
+  it("medicalDensity ignores common long words", () => {
+    expect(medicalDensity("medicine appointment tomorrow")).toBe(0);
+  });
+
+  it("simplifyForReadability swaps complex words and keeps numbers", () => {
+    const out = simplifyForReadability("Administer 500 mg and discontinue prior to your appointment.");
+    expect(out.toLowerCase()).toContain("take");
+    expect(out.toLowerCase()).toContain("stop");
+    expect(out).toContain("500 mg");
+  });
+});
+
+describe("localization — dose safety", () => {
+  it("extracts numeric/dose tokens", () => {
+    expect(numericTokens("metformin 500 mg twice daily, 14:10 window")).toEqual(["500 mg", "14:10"]);
+  });
+
+  it("Spanish translation preserves doses and translates frequency", () => {
+    const before = "Take metformin 500 mg twice daily with meals.";
+    const { text } = localizeText(before, "es");
+    expect(text).toContain("500 mg");
+    expect(text.toLowerCase()).toContain("dos veces al día");
+    expect(text.toLowerCase()).toContain("con las comidas");
+    expect(assertNumericTokensPreserved(before, text)).toBe(true);
+  });
+
+  it("Vietnamese translation preserves doses and translates frequency", () => {
+    const before = "Take metformin 500 mg twice daily.";
+    const { text } = localizeText(before, "vi");
+    expect(text).toContain("500 mg");
+    expect(text.toLowerCase()).toContain("hai lần mỗi ngày");
+    expect(assertNumericTokensPreserved(before, text)).toBe(true);
+  });
+
+  it("applies culturally sensitive plain-language substitution", () => {
+    const { text } = localizeText("You have insulin resistance.", "en");
+    expect(text).toContain("how your body cells process energy from your food");
+  });
+
+  it("preserves a clock-window dose like 14:10 across translation", () => {
+    const before = "Begin a 14:10 fasting window today.";
+    expect(assertNumericTokensPreserved(before, localizeText(before, "es").text)).toBe(true);
+    expect(assertNumericTokensPreserved(before, localizeText(before, "vi").text)).toBe(true);
+  });
+});
+
+describe("localization — AVS document structured-field safety", () => {
+  const doc: AvsDocument = {
+    version: 1,
+    language: "en",
+    patientFirstName: "Maria",
+    visitDate: "June 13, 2026",
+    provider: "Dr. Patel",
+    narrative: "Today we talked about your high blood pressure. Continue your care plan.",
+    decomposed: {
+      medications: [
+        { action: "INITIATE", molecule: "Metformin", dose: "500 mg", route: "by mouth", timing: "twice daily", raw: "Start metformin 500 mg twice daily" },
+      ],
+      dietary: [],
+      behavioral: [],
+      unclassified: [],
+    },
+    calendars: [
+      {
+        molecule: "Metformin",
+        steps: [
+          { startDay: 1, endDay: 14, dayRange: "Days 1–14", timeOfDay: "With meals", instruction: "Take 500 mg twice daily", goal: null },
+        ],
+      },
+    ],
+    roadmap: { nutrition: [], behavior: [] },
+    nextSteps: ["Take your 500 mg dose twice daily."],
+    followUp: "Follow-up in 4 weeks.",
+    readability: {
+      grade: 5, avgWordLength: 4, avgSentenceLength: 8, medicalDensity: 0,
+      index: 10, targetGradeMin: 6, targetGradeMax: 8, meetsTarget: true,
+    },
+    sourceNote: "Plan: start metformin 500 mg BID.",
+    generatedAt: "2026-06-13T00:00:00.000Z",
+  };
+
+  it("es localization leaves medication dose/timing byte-identical", () => {
+    const localized = localizeAvsDocument(doc, "es");
+    expect(localized.language).toBe("es");
+    expect(localized.decomposed.medications[0].dose).toBe("500 mg");
+    expect(localized.decomposed.medications[0].timing).toBe("twice daily");
+    expect(assertDosesUnchanged(doc, localized)).toBe(true);
+  });
+
+  it("vi localization preserves doses in translated nextSteps", () => {
+    const localized = localizeAvsDocument(doc, "vi");
+    expect(localized.nextSteps[0]).toContain("500 mg");
+    expect(assertDosesUnchanged(doc, localized)).toBe(true);
+  });
+});

--- a/src/lib/domain/avs/readability.test.ts
+++ b/src/lib/domain/avs/readability.test.ts
@@ -12,6 +12,7 @@ import {
   localizeAvsDocument,
   localizeText,
   numericTokens,
+  resolvePatientLanguage,
 } from "./localization";
 import type { AvsDocument } from "./types";
 
@@ -138,5 +139,22 @@ describe("localization — AVS document structured-field safety", () => {
     const localized = localizeAvsDocument(doc, "vi");
     expect(localized.nextSteps[0]).toContain("500 mg");
     expect(assertDosesUnchanged(doc, localized)).toBe(true);
+  });
+});
+
+describe("resolvePatientLanguage", () => {
+  it("defaults to English when nothing recognizable", () => {
+    expect(resolvePatientLanguage(null)).toBe("en");
+    expect(resolvePatientLanguage({})).toBe("en");
+    expect(resolvePatientLanguage({ language: "Klingon" })).toBe("en");
+  });
+
+  it("reads common intake keys and spellings", () => {
+    expect(resolvePatientLanguage({ language: "es" })).toBe("es");
+    expect(resolvePatientLanguage({ preferredLanguage: "Spanish" })).toBe("es");
+    expect(resolvePatientLanguage({ locale: "español" })).toBe("es");
+    expect(resolvePatientLanguage({ preferred_language: "Vietnamese" })).toBe("vi");
+    expect(resolvePatientLanguage({ lang: "vi" })).toBe("vi");
+    expect(resolvePatientLanguage({ language: "English" })).toBe("en");
   });
 });

--- a/src/lib/domain/avs/readability.ts
+++ b/src/lib/domain/avs/readability.ts
@@ -1,0 +1,158 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1151 — Readability layer
+// ───────────────────────────────────────────────────────────────────────────
+// Doc Phase 3: compute the Linguistic Accessibility Target Index (word length +
+// sentence structure + medical-density weights) and drive generated copy toward
+// a 6th–8th grade profile.
+//
+// The Flesch–Kincaid grade math mirrors `approximateGradeLevel` in
+// src/lib/education/medication-explainer.ts (same coefficients) so the AVS and
+// the medication explainer report consistent grades; it's re-implemented here
+// to keep the AVS domain module free of the med-catalog import.
+
+import type { ReadabilityScore } from "./types";
+
+export const DEFAULT_TARGET_GRADE_MIN = 6;
+export const DEFAULT_TARGET_GRADE_MAX = 8;
+
+/** Approximate syllable count for a single word. */
+export function countSyllables(word: string): number {
+  const w = word.toLowerCase().replace(/[^a-z]/g, "");
+  if (!w) return 0;
+  if (w.length <= 3) return 1;
+  const matches = w
+    .replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/, "")
+    .replace(/^y/, "")
+    .match(/[aeiouy]{1,2}/g);
+  return matches ? matches.length : 1;
+}
+
+function words(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function sentenceCount(text: string): number {
+  return (text.match(/[.!?]+/g) || []).length || 1;
+}
+
+/** Flesch–Kincaid grade approximation (matches the med-explainer formula). */
+export function fleschKincaidGrade(text: string): number {
+  const sentences = sentenceCount(text);
+  const ws = words(text);
+  const wordCount = ws.length || 1;
+  const syllables = ws.reduce((sum, w) => sum + countSyllables(w), 0);
+  return Math.max(
+    0,
+    0.39 * (wordCount / sentences) + 11.8 * (syllables / wordCount) - 15.59,
+  );
+}
+
+/**
+ * Density of "hard" words — 3+ syllables and not a common safe long word.
+ * Stands in for clinical/medical complexity without a full term list.
+ */
+export function medicalDensity(text: string): number {
+  const ws = words(text).map((w) => w.replace(/[^a-z]/gi, "")).filter(Boolean);
+  if (ws.length === 0) return 0;
+  const hard = ws.filter((w) => countSyllables(w) >= 3 && !COMMON_LONG_WORDS.has(w.toLowerCase()));
+  return hard.length / ws.length;
+}
+
+// Long but everyday words that shouldn't count as "clinical complexity".
+const COMMON_LONG_WORDS = new Set([
+  "medicine", "medication", "important", "appointment", "remember",
+  "exercise", "another", "everyday", "together", "tomorrow", "family",
+  "energy", "morning", "evening", "feeling", "better", "water",
+]);
+
+export interface ReadabilityOptions {
+  targetGradeMin?: number;
+  targetGradeMax?: number;
+}
+
+/**
+ * Compute the full readability profile + composite accessibility index.
+ *
+ * The index is a transparent weighted blend (higher = harder to read):
+ *   index = 1.0·avgWordLength + 0.5·avgSentenceLength + 30·medicalDensity
+ * so longer words, longer sentences, and denser clinical vocabulary each push
+ * the score up. `meetsTarget` is driven by the FK grade band, not the index.
+ */
+export function computeReadability(
+  text: string,
+  opts: ReadabilityOptions = {},
+): ReadabilityScore {
+  const targetGradeMin = opts.targetGradeMin ?? DEFAULT_TARGET_GRADE_MIN;
+  const targetGradeMax = opts.targetGradeMax ?? DEFAULT_TARGET_GRADE_MAX;
+
+  const ws = words(text);
+  const wordCount = ws.length || 1;
+  const sentences = sentenceCount(text);
+  const totalChars = ws.reduce((sum, w) => sum + w.replace(/[^a-z]/gi, "").length, 0);
+
+  const avgWordLength = totalChars / wordCount;
+  const avgSentenceLength = wordCount / sentences;
+  const density = medicalDensity(text);
+  const grade = round2(fleschKincaidGrade(text));
+  const index = round2(1.0 * avgWordLength + 0.5 * avgSentenceLength + 30 * density);
+
+  return {
+    grade,
+    avgWordLength: round2(avgWordLength),
+    avgSentenceLength: round2(avgSentenceLength),
+    medicalDensity: round2(density),
+    index,
+    targetGradeMin,
+    targetGradeMax,
+    // A summary below the band is fine (simpler than asked); only above-band
+    // copy fails the target.
+    meetsTarget: grade <= targetGradeMax,
+  };
+}
+
+/** Plain-language swaps for the handful of complex words AVS copy tends to use. */
+const SIMPLIFY_MAP: Array<[RegExp, string]> = [
+  [/\butilize\b/gi, "use"],
+  [/\badminister\b/gi, "take"],
+  [/\bdiscontinue\b/gi, "stop"],
+  [/\binitiate\b/gi, "start"],
+  [/\bphysician\b/gi, "doctor"],
+  [/\bhypertension\b/gi, "high blood pressure"],
+  [/\bapproximately\b/gi, "about"],
+  [/\bsubsequent(ly)?\b/gi, "next"],
+  [/\bmonitor\b/gi, "keep an eye on"],
+  [/\badditional\b/gi, "more"],
+  [/\bprior to\b/gi, "before"],
+];
+
+const MAX_SENTENCE_WORDS = 18;
+
+/**
+ * Deterministic readability fallback the generator can apply: swap a few
+ * complex words for plain ones and split over-long sentences at natural breaks.
+ * Never touches numbers/units, so doses and timings survive untouched.
+ */
+export function simplifyForReadability(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of SIMPLIFY_MAP) out = out.replace(pattern, replacement);
+
+  const sentences = out.split(/(?<=[.!?])\s+/);
+  const rebuilt = sentences.map((sentence) => {
+    if (words(sentence).length <= MAX_SENTENCE_WORDS) return sentence;
+    // Split a long sentence at the first clause break past the midpoint.
+    const parts = sentence.split(/,\s+(?:and|but|so|because|which|while)\s+/i);
+    if (parts.length > 1) {
+      return parts
+        .map((p) => p.trim())
+        .map((p) => (/[.!?]$/.test(p) ? p : `${p}.`))
+        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+        .join(" ");
+    }
+    return sentence;
+  });
+  return rebuilt.join(" ").replace(/\s+/g, " ").trim();
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/lib/domain/avs/schedule.test.ts
+++ b/src/lib/domain/avs/schedule.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { decomposeCarePlan } from "./care-plan-decomposition";
+import {
+  buildLifestyleRoadmap,
+  buildTitrationCalendars,
+  parseDelayDays,
+  timeOfDayFromTiming,
+} from "./schedule";
+
+describe("schedule helpers", () => {
+  it("maps timing to a plain time-of-day", () => {
+    expect(timeOfDayFromTiming("twice daily")).toBe("Morning and evening");
+    expect(timeOfDayFromTiming("at bedtime")).toBe("At bedtime");
+    expect(timeOfDayFromTiming(null)).toBe("As your care team directed");
+  });
+
+  it("parses titration delays in days/weeks/months and word numbers", () => {
+    expect(parseDelayDays("titrate up after two weeks")).toBe(14);
+    expect(parseDelayDays("increase in 10 days")).toBe(10);
+    expect(parseDelayDays("after 1 month")).toBe(30);
+    expect(parseDelayDays("increase the dose")).toBeNull();
+  });
+});
+
+describe("titration calendar from the metformin fixture", () => {
+  const decomposed = decomposeCarePlan(
+    [
+      "Start metformin 500 mg by mouth twice daily with meals.",
+      "Plan to titrate metformin up to 1000 mg twice daily after two weeks if tolerated.",
+      "Discontinue glipizide.",
+    ].join("\n"),
+  );
+  const calendars = buildTitrationCalendars(decomposed);
+
+  it("builds one calendar for metformin (discontinue excluded)", () => {
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].molecule).toBe("Metformin");
+  });
+
+  it("produces a two-step titration: Days 1–14 then Day 15 onward", () => {
+    const steps = calendars[0].steps;
+    expect(steps).toHaveLength(2);
+    expect(steps[0].dayRange).toBe("Days 1–14");
+    expect(steps[0].instruction).toContain("500 mg");
+    expect(steps[0].timeOfDay).toBe("Morning and evening");
+    expect(steps[1].dayRange).toBe("Day 15 onward");
+    expect(steps[1].instruction).toContain("1000 mg");
+    expect(steps[1].goal).toContain("1000 mg");
+  });
+
+  it("never emits a long-paragraph instruction", () => {
+    for (const step of calendars[0].steps) {
+      expect(step.instruction.length).toBeLessThan(80);
+    }
+  });
+});
+
+describe("single INITIATE produces a one-step calendar", () => {
+  it("renders Day 1 onward", () => {
+    const decomposed = decomposeCarePlan("Start CBD oil 0.25 mL under the tongue at bedtime.");
+    const calendars = buildTitrationCalendars(decomposed);
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].steps).toHaveLength(1);
+    expect(calendars[0].steps[0].dayRange).toBe("Day 1 onward");
+    expect(calendars[0].steps[0].timeOfDay).toBe("At bedtime");
+  });
+});
+
+describe("lifestyle roadmap", () => {
+  const decomposed = decomposeCarePlan(
+    [
+      "Begin a 14:10 intermittent fasting schedule.",
+      "Increase water intake.",
+      "Walk for 30 minutes daily.",
+      "Aim for 7-8 hours of sleep.",
+    ].join("\n"),
+  );
+  const roadmap = buildLifestyleRoadmap(decomposed);
+
+  it("splits nutrition and behavior with icons + labels", () => {
+    expect(roadmap.nutrition.length).toBe(2);
+    expect(roadmap.behavior.length).toBe(2);
+    const eatingWindow = roadmap.nutrition.find((i) => i.label.includes("14:10"));
+    expect(eatingWindow?.icon).toBe("🕒");
+    const activity = roadmap.behavior.find((i) => i.label.startsWith("Move your body"));
+    expect(activity?.label).toContain("30 minutes");
+    const sleep = roadmap.behavior.find((i) => i.icon === "😴");
+    expect(sleep?.label).toContain("7-8 hours");
+  });
+});

--- a/src/lib/domain/avs/schedule.ts
+++ b/src/lib/domain/avs/schedule.ts
@@ -1,0 +1,209 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1152 — Titration calendars + lifestyle roadmaps (pure render model)
+// ───────────────────────────────────────────────────────────────────────────
+// Doc Phases 4–6: render the decomposed care plan as scannable visual
+// schedules — a medication titration calendar (day-range × time-of-day × plain
+// instruction × goal) per the metformin example, plus nutrition + behavior
+// roadmaps in encouraging plain language. "No long paragraphs" — everything is
+// a time-ordered component. This module produces the data model; the RSC
+// renders it.
+
+import type {
+  BehavioralItem,
+  DecomposedCarePlan,
+  DietaryProtocol,
+  LifestyleRoadmap,
+  MedicationAction,
+  RoadmapItem,
+  TitrationCalendar,
+  TitrationStep,
+} from "./types";
+
+/* -------------------------------------------------------------------------- */
+/* Time-of-day + duration helpers                                              */
+/* -------------------------------------------------------------------------- */
+
+export function timeOfDayFromTiming(timing: string | null): string {
+  switch (timing) {
+    case "twice daily":
+      return "Morning and evening";
+    case "three times daily":
+      return "Morning, midday, and evening";
+    case "four times daily":
+      return "Spread through the day";
+    case "at bedtime":
+      return "At bedtime";
+    case "every morning":
+      return "Morning";
+    case "with meals":
+      return "With meals";
+    case "once daily":
+      return "Once a day";
+    case "as needed":
+      return "Only when you need it";
+    case "every other day":
+      return "Every other day";
+    case "weekly":
+      return "Once a week";
+    default:
+      return "As your care team directed";
+  }
+}
+
+const WORD_NUMBERS: Record<string, number> = {
+  one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8,
+  nine: 9, ten: 10, twelve: 12,
+};
+
+/**
+ * Parse a "start later" delay from titration prose into days:
+ * "after two weeks" → 14, "in 10 days" → 10, "after 1 month" → 30.
+ */
+export function parseDelayDays(text: string): number | null {
+  const m = text
+    .toLowerCase()
+    .match(/\b(?:after|in)\s+(\d+|one|two|three|four|five|six|seven|eight|nine|ten|twelve)\s*(day|days|week|weeks|month|months)\b/);
+  if (!m) return null;
+  const n = WORD_NUMBERS[m[1]] ?? Number(m[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = m[2];
+  if (unit.startsWith("day")) return n;
+  if (unit.startsWith("week")) return n * 7;
+  return n * 30;
+}
+
+function dayRangeLabel(startDay: number, endDay: number | null): string {
+  if (endDay == null) return `Day ${startDay} onward`;
+  if (startDay === endDay) return `Day ${startDay}`;
+  return `Days ${startDay}–${endDay}`;
+}
+
+function instructionFor(med: MedicationAction): string {
+  const dose = med.dose ?? "your dose";
+  const route = med.route ? ` ${med.route}` : "";
+  return `Take ${dose}${route}`;
+}
+
+const DOSING_ACTIONS = new Set(["INITIATE", "TITRATE", "MAINTAIN"]);
+
+/* -------------------------------------------------------------------------- */
+/* Titration calendars                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Group dosing medication actions by molecule into a step-by-step calendar.
+ * An INITIATE followed by a TITRATE "after two weeks" becomes two steps:
+ * Days 1–14 at the starting dose, then Day 15 onward at the titrated dose.
+ * DISCONTINUE actions are excluded (they're "stop" instructions, not a schedule).
+ */
+export function buildTitrationCalendars(decomposed: DecomposedCarePlan): TitrationCalendar[] {
+  const byMolecule = new Map<string, MedicationAction[]>();
+  for (const med of decomposed.medications) {
+    if (!DOSING_ACTIONS.has(med.action)) continue;
+    const key = med.molecule.toLowerCase();
+    const list = byMolecule.get(key) ?? [];
+    list.push(med);
+    byMolecule.set(key, list);
+  }
+
+  const calendars: TitrationCalendar[] = [];
+  for (const meds of byMolecule.values()) {
+    // Stable order: the starting dose (INITIATE/MAINTAIN) before titrations.
+    const ordered = [...meds].sort((a, b) => actionRank(a.action) - actionRank(b.action));
+    const steps: TitrationStep[] = [];
+    let cursor = 1;
+
+    ordered.forEach((med, idx) => {
+      const isLast = idx === ordered.length - 1;
+      const nextMed = ordered[idx + 1];
+      const delay = nextMed ? parseDelayDays(nextMed.raw) : null;
+      const endDay = !isLast && delay ? delay : null;
+
+      steps.push({
+        startDay: cursor,
+        endDay,
+        dayRange: dayRangeLabel(cursor, endDay),
+        timeOfDay: timeOfDayFromTiming(med.timing),
+        instruction: instructionFor(med),
+        goal:
+          med.action === "TITRATE" && med.dose
+            ? `Reach your target of ${med.dose}`
+            : null,
+      });
+
+      if (endDay) cursor = endDay + 1;
+    });
+
+    calendars.push({ molecule: meds[0].molecule, steps });
+  }
+
+  return calendars;
+}
+
+function actionRank(action: MedicationAction["action"]): number {
+  switch (action) {
+    case "INITIATE":
+      return 0;
+    case "MAINTAIN":
+      return 1;
+    case "TITRATE":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Lifestyle roadmap                                                           */
+/* -------------------------------------------------------------------------- */
+
+const DIETARY_ICON: Record<DietaryProtocol["kind"], string> = {
+  time_restricted_eating: "🕒",
+  fasting: "🌙",
+  macronutrient: "🥗",
+  hydration: "💧",
+  other: "🍽️",
+};
+
+const DIETARY_LABEL: Record<DietaryProtocol["kind"], string> = {
+  time_restricted_eating: "Eating window",
+  fasting: "Fasting plan",
+  macronutrient: "Food choices",
+  hydration: "Hydration",
+  other: "Nutrition",
+};
+
+const BEHAVIOR_ICON: Record<BehavioralItem["kind"], string> = {
+  sleep: "😴",
+  activity: "🚶",
+  mindfulness: "🧘",
+  monitoring: "📊",
+  substance: "🚭",
+  other: "✅",
+};
+
+const BEHAVIOR_LABEL: Record<BehavioralItem["kind"], string> = {
+  sleep: "Sleep",
+  activity: "Move your body",
+  mindfulness: "Calm your mind",
+  monitoring: "Track your numbers",
+  substance: "Cut back",
+  other: "Healthy habit",
+};
+
+function dietaryRoadmapItem(d: DietaryProtocol): RoadmapItem {
+  const label = d.window ? `${DIETARY_LABEL[d.kind]} (${d.window})` : DIETARY_LABEL[d.kind];
+  return { icon: DIETARY_ICON[d.kind], label, detail: d.detail };
+}
+
+function behaviorRoadmapItem(b: BehavioralItem): RoadmapItem {
+  const label = b.target ? `${BEHAVIOR_LABEL[b.kind]} — ${b.target}` : BEHAVIOR_LABEL[b.kind];
+  return { icon: BEHAVIOR_ICON[b.kind], label, detail: b.detail };
+}
+
+export function buildLifestyleRoadmap(decomposed: DecomposedCarePlan): LifestyleRoadmap {
+  return {
+    nutrition: decomposed.dietary.map(dietaryRoadmapItem),
+    behavior: decomposed.behavioral.map(behaviorRoadmapItem),
+  };
+}

--- a/src/lib/domain/avs/types.ts
+++ b/src/lib/domain/avs/types.ts
@@ -1,0 +1,256 @@
+// ───────────────────────────────────────────────────────────────────────────
+// After-Visit Summary (AVS) — shared types
+// Workflows Revisions doc: "Dynamic Patient-Facing Summaries" (EMR-1123).
+// ───────────────────────────────────────────────────────────────────────────
+// These types are the contract that flows through the whole AVS pipeline:
+//   EMR-1150 care-plan decomposition  → DecomposedCarePlan
+//   EMR-1152 calendar/roadmap render  → TitrationCalendar + LifestyleRoadmap
+//   EMR-1151 readability/localization → ReadabilityScore + localized copy
+//   EMR-1149 generation job           → AvsDocument (persisted in payload)
+// Kept dependency-free so every layer (agent worker, server action, RSC, and
+// the unit tests) can import it without pulling in Prisma or React.
+
+import { z } from "zod";
+
+/* -------------------------------------------------------------------------- */
+/* Care-plan decomposition (EMR-1150)                                          */
+/* -------------------------------------------------------------------------- */
+
+/** The four discrete medication changes a plan can express. */
+export type MedicationActionTag =
+  | "DISCONTINUE"
+  | "INITIATE"
+  | "TITRATE"
+  | "MAINTAIN";
+
+export interface MedicationAction {
+  action: MedicationActionTag;
+  /** Plain molecule / product name ("metformin", "CBD oil"). */
+  molecule: string;
+  /** Dose as written ("500 mg", "0.25 mL"), or null when not stated. */
+  dose: string | null;
+  /** Route in plain language ("by mouth", "under the tongue"), or null. */
+  route: string | null;
+  /** Timing/frequency ("twice daily", "at bedtime"), or null. */
+  timing: string | null;
+  /** Source sentence the action was lifted from (provenance for review). */
+  raw: string;
+}
+
+export type DietaryKind =
+  | "time_restricted_eating"
+  | "fasting"
+  | "macronutrient"
+  | "hydration"
+  | "other";
+
+export interface DietaryProtocol {
+  kind: DietaryKind;
+  /** Eating/fasting window when present ("14:10", "16:8", "12-hour"). */
+  window: string | null;
+  /** Plain-language instruction. */
+  detail: string;
+  raw: string;
+}
+
+export type BehavioralKind =
+  | "sleep"
+  | "activity"
+  | "mindfulness"
+  | "monitoring"
+  | "substance"
+  | "other";
+
+export interface BehavioralItem {
+  kind: BehavioralKind;
+  /** Quantified target when present ("7–8 hours", "Zone 2", "10 minutes"). */
+  target: string | null;
+  detail: string;
+  raw: string;
+}
+
+export interface DecomposedCarePlan {
+  medications: MedicationAction[];
+  dietary: DietaryProtocol[];
+  behavioral: BehavioralItem[];
+  /** Plan sentences that didn't match any structured bucket. */
+  unclassified: string[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Schedules + roadmaps (EMR-1152)                                            */
+/* -------------------------------------------------------------------------- */
+
+export interface TitrationStep {
+  /** Inclusive 1-based day the step starts on. */
+  startDay: number;
+  /** Inclusive day the step ends on, or null for "ongoing". */
+  endDay: number | null;
+  /** Human range label ("Days 1–7", "Day 15 onward"). */
+  dayRange: string;
+  /** When in the day to take it ("Morning", "With dinner", "At bedtime"). */
+  timeOfDay: string;
+  /** Plain instruction for this step. */
+  instruction: string;
+  /** Optional goal/checkpoint for the step. */
+  goal: string | null;
+}
+
+export interface TitrationCalendar {
+  molecule: string;
+  steps: TitrationStep[];
+}
+
+export interface RoadmapItem {
+  /** Soft cartoon emoji per the Data Collection Philosophy (Apple-iOS feel). */
+  icon: string;
+  label: string;
+  detail: string;
+}
+
+export interface LifestyleRoadmap {
+  nutrition: RoadmapItem[];
+  behavior: RoadmapItem[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Readability + localization (EMR-1151)                                      */
+/* -------------------------------------------------------------------------- */
+
+export type SupportedLanguage = "en" | "es" | "vi";
+
+export interface ReadabilityScore {
+  /** Flesch–Kincaid grade approximation. */
+  grade: number;
+  avgWordLength: number;
+  avgSentenceLength: number;
+  /** Fraction (0–1) of words flagged as long/clinical. */
+  medicalDensity: number;
+  /** Composite Linguistic Accessibility Target Index (lower = more accessible). */
+  index: number;
+  targetGradeMin: number;
+  targetGradeMax: number;
+  /** True when `grade` lands inside the target band. */
+  meetsTarget: boolean;
+}
+
+/* -------------------------------------------------------------------------- */
+/* The persisted AVS document (EMR-1149 payload)                              */
+/* -------------------------------------------------------------------------- */
+
+export interface AvsMedicationSummary {
+  name: string;
+  dosage: string;
+  instructions: string | null;
+}
+
+export interface AvsDocument {
+  /** Schema version so persisted payloads can migrate forward safely. */
+  version: 1;
+  language: SupportedLanguage;
+  patientFirstName: string;
+  visitDate: string;
+  provider: string;
+  /** Warm 1–3 sentence recap (already localized + readability-checked). */
+  narrative: string;
+  decomposed: DecomposedCarePlan;
+  calendars: TitrationCalendar[];
+  roadmap: LifestyleRoadmap;
+  nextSteps: string[];
+  followUp: string;
+  readability: ReadabilityScore;
+  /** Verbatim signed-note text, for the provider side-by-side verification. */
+  sourceNote: string;
+  generatedAt: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Zod schema — validates payloads at the persistence boundary                 */
+/* -------------------------------------------------------------------------- */
+
+const medicationActionSchema = z.object({
+  action: z.enum(["DISCONTINUE", "INITIATE", "TITRATE", "MAINTAIN"]),
+  molecule: z.string(),
+  dose: z.string().nullable(),
+  route: z.string().nullable(),
+  timing: z.string().nullable(),
+  raw: z.string(),
+});
+
+const dietarySchema = z.object({
+  kind: z.enum(["time_restricted_eating", "fasting", "macronutrient", "hydration", "other"]),
+  window: z.string().nullable(),
+  detail: z.string(),
+  raw: z.string(),
+});
+
+const behavioralSchema = z.object({
+  kind: z.enum(["sleep", "activity", "mindfulness", "monitoring", "substance", "other"]),
+  target: z.string().nullable(),
+  detail: z.string(),
+  raw: z.string(),
+});
+
+export const decomposedCarePlanSchema = z.object({
+  medications: z.array(medicationActionSchema),
+  dietary: z.array(dietarySchema),
+  behavioral: z.array(behavioralSchema),
+  unclassified: z.array(z.string()),
+});
+
+const titrationStepSchema = z.object({
+  startDay: z.number(),
+  endDay: z.number().nullable(),
+  dayRange: z.string(),
+  timeOfDay: z.string(),
+  instruction: z.string(),
+  goal: z.string().nullable(),
+});
+
+const roadmapItemSchema = z.object({
+  icon: z.string(),
+  label: z.string(),
+  detail: z.string(),
+});
+
+const readabilitySchema = z.object({
+  grade: z.number(),
+  avgWordLength: z.number(),
+  avgSentenceLength: z.number(),
+  medicalDensity: z.number(),
+  index: z.number(),
+  targetGradeMin: z.number(),
+  targetGradeMax: z.number(),
+  meetsTarget: z.boolean(),
+});
+
+export const avsDocumentSchema = z.object({
+  version: z.literal(1),
+  language: z.enum(["en", "es", "vi"]),
+  patientFirstName: z.string(),
+  visitDate: z.string(),
+  provider: z.string(),
+  narrative: z.string(),
+  decomposed: decomposedCarePlanSchema,
+  calendars: z.array(z.object({ molecule: z.string(), steps: z.array(titrationStepSchema) })),
+  roadmap: z.object({
+    nutrition: z.array(roadmapItemSchema),
+    behavior: z.array(roadmapItemSchema),
+  }),
+  nextSteps: z.array(z.string()),
+  followUp: z.string(),
+  readability: readabilitySchema,
+  sourceNote: z.string(),
+  generatedAt: z.string(),
+});
+
+/** Parse + validate a persisted AVS payload (JSON from Prisma). */
+export function parseAvsDocument(payload: unknown): AvsDocument {
+  return avsDocumentSchema.parse(payload) as AvsDocument;
+}
+
+/** Non-throwing variant for render surfaces that should degrade gracefully. */
+export function safeParseAvsDocument(payload: unknown): AvsDocument | null {
+  const result = avsDocumentSchema.safeParse(payload);
+  return result.success ? (result.data as AvsDocument) : null;
+}

--- a/src/lib/orchestration/workflows.ts
+++ b/src/lib/orchestration/workflows.ts
@@ -71,6 +71,22 @@ export const workflows: WorkflowDefinition[] = [
       },
     ],
   },
+  // EMR-1149 — generate the plain-language after-visit summary draft the moment
+  // the chart is signed. Deterministic + read-only to the chart, so no approval.
+  {
+    name: "avs-generation",
+    on: ["note.finalized"],
+    steps: [
+      {
+        agent: "avsGenerator",
+        input: (e) => ({
+          noteId: (e as any).noteId,
+          encounterId: (e as any).encounterId,
+        }),
+        requiresApproval: false,
+      },
+    ],
+  },
   {
     name: "research-synth",
     on: ["research.query.submitted"],


### PR DESCRIPTION
## Wave 3 — Dynamic Patient-Facing Summaries (AVS pipeline)

Implements the full **plain-language After-Visit Summary** vertical slice from the WorkFlows Revisions doc (epic **EMR-1123**), cards **EMR-1149 / 1150 / 1151 / 1152**. Builds on the existing leaflet/visit-completion surfaces rather than duplicating them.

> Note: this is the user-facing AVS pipeline. The sibling Wave-3 IR_risk inline-CDS slice (EMR-1126–1130) is being built on a separate branch — no overlap with these files.

### What's here

**EMR-1150 — Care-plan decomposition** (`src/lib/domain/avs/care-plan-decomposition.ts`)
Deterministic parse of signed plan text into structured buckets: medication action array (`DISCONTINUE/INITIATE/TITRATE/MAINTAIN` + molecule/dose/route/timing), dietary protocols (time-restricted eating windows, fasting, macros, hydration), and a behavioral manifest (sleep/activity/mindfulness/monitoring/substance). Fixtures: metformin titration, 14:10 IF, walking+breathing.

**EMR-1151 — Readability + localization** (`readability.ts`, `localization.ts`)
Flesch–Kincaid grade + the Linguistic Accessibility Target Index (word length + sentence structure + medical density), driven to a 6th–8th-grade band. Medical-safe `es`/`vi` localization with culturally-sensitive plain-language substitutions (e.g. *insulin resistance → "how your body cells process energy from your food"*). **Doses/timings are mechanically protected** — masked before translation, restored after — with `assertNumericTokensPreserved` / `assertDosesUnchanged` proving the invariant in tests.

**EMR-1149 — Generation job on chart-sign** (`src/lib/agents/avs-generator-agent.ts`)
`avsGenerator` agent fires on the `note.finalized` event (chart-sign), compiles the signed note + the patient's language preference (from `intakeAnswers`, safe `en`/6–8 default) + runs the deterministic pipeline, persisting a **draft** `AfterVisitSummary` (new relation-less Prisma model, JSON payload). Idempotent per note; never clobbers a released summary. Registered in `agentRegistry` + a new `avs-generation` workflow. No model call → reproducible for research datasets, runs unattended on the job queue.

**EMR-1152 — Titration calendar / roadmap + verify + portal delivery**
- `schedule.ts` turns the decomposition into a scannable titration calendar (day-range × time-of-day × instruction × goal) + lifestyle roadmap — time-ordered components, no long paragraphs.
- Provider surface on the signed-note page (`avs-review-panel.tsx`, **inline, no popup** per the Fleet Command directive): side-by-side signed-note vs generated summary; **release is blocked until the provider affirms the summary matches the note**, then one click delivers.
- Release writes a patient `Notification` + `avs.released` audit and revalidates the portal.
- New patient page **`/portal/visit-summary`** renders the calendar + roadmap (shared `AvsSummaryView`), linked from the My Health ribbon — patient sees it immediately after release.

### Verification (local, CI-parity)
- `tsc --noEmit`: clean
- `next lint` + `manifests:lint`: exit 0
- `vitest run`: **3491 passed** (374 files) — incl. **46 new AVS tests**
- `next build`: exit 0

### Notes
- `AfterVisitSummary` is relation-less by design (same pattern as `AgentJob`/`AuditLog`) → zero back-relations on the hot Patient/Encounter/Note/User models. Migration to apply on deploy; CI regenerates the client from schema.
- Generation is deterministic (no LLM); a model-polish seam can be added later without changing the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
