### PR TITLE
Workflows Revisions wave 3: spoken-intent order drafting (EMR-1157)

### DIFF
--- a/src/app/(clinician)/clinic/patients/[id]/orders/labs/page.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/labs/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Eyebrow } from "@/components/ui/ornament";
 import { LabOrderForm } from "./lab-order-form";
 import { OrderHistory } from "../order-history";
+import { SpokenIntentCheckout } from "../spoken-intent-checkout";
 
 interface PageProps {
   params: { id: string };
@@ -55,6 +56,8 @@ export default async function LabOrdersPage({ params }: PageProps) {
       </div>
 
       <div className="space-y-6">
+        <SpokenIntentCheckout patientId={patient.id} />
+
         <LabOrderForm
           patientId={patient.id}
           patientName={`${patient.firstName} ${patient.lastName}`}

--- a/src/app/(clinician)/clinic/patients/[id]/orders/spoken-intent-actions.ts
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/spoken-intent-actions.ts
@@ -1,0 +1,261 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { requireUser } from "@/lib/auth/session";
+import { assertChartAccess, requirePermission, ForbiddenError } from "@/lib/rbac/permissions";
+import { parseSpokenIntent } from "@/lib/clinical/spoken-intent/parse-intent";
+import type { DraftOrder } from "@/lib/clinical/spoken-intent/types";
+
+// ---------------------------------------------------------------------------
+// EMR-1157 — Spoken-intent order drafting: stage / sign / discard.
+//
+// Drafts persist as ClinicalOrder rows with status="draft" (free-string status
+// — no migration). Nothing transmits while a row is a draft. "Authorize & Sign"
+// flips draft→placed (labs route to the diagnostic center, simulated) and drops
+// lifestyle CarePlans to the patient app via a portal Notification.
+// ---------------------------------------------------------------------------
+
+const ORDER_TYPE_FOR_KIND: Record<DraftOrder["kind"], string> = {
+  lab: "lab",
+  imaging: "imaging",
+  lifestyle: "lifestyle",
+};
+
+export interface CheckoutDraft {
+  id: string;
+  orderType: string;
+  resourceType: DraftOrder["resourceType"];
+  code: { system: string; code: string; display: string };
+  name: string;
+  occurrenceLabel: string | null;
+  fastingInstruction: string | null;
+  detail: string | null;
+  confidence: number;
+}
+
+export type StageResult =
+  | { ok: true; staged: CheckoutDraft[]; lowConfidence: DraftOrder[] }
+  | { ok: false; error: string };
+
+function toCheckoutDraft(row: {
+  id: string;
+  orderType: string;
+  orderCode: string;
+  orderName: string;
+  payload: unknown;
+}): CheckoutDraft {
+  const p = (row.payload ?? {}) as Partial<DraftOrder> & { system?: string };
+  return {
+    id: row.id,
+    orderType: row.orderType,
+    resourceType: p.resourceType ?? "ServiceRequest",
+    code: {
+      system: p.code?.system ?? "internal",
+      code: p.code?.code ?? row.orderCode,
+      display: p.code?.display ?? row.orderName,
+    },
+    name: row.orderName,
+    occurrenceLabel: p.occurrencePeriod?.label ?? null,
+    fastingInstruction: p.fasting?.instruction ?? null,
+    detail: p.detail ?? null,
+    confidence: typeof p.confidence === "number" ? p.confidence : 1,
+  };
+}
+
+const stageSchema = z.object({
+  patientId: z.string().min(1),
+  encounterId: z.string().min(1).nullable().optional(),
+  utterance: z.string().min(1).max(2000),
+});
+
+/** Parse a directive and stage the high-confidence drafts in the checkout queue. */
+export async function stageSpokenIntent(input: {
+  patientId: string;
+  encounterId?: string | null;
+  utterance: string;
+}): Promise<StageResult> {
+  const user = await requireUser();
+  const parsed = stageSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: "Invalid input." };
+
+  try {
+    await assertChartAccess(user, parsed.data.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) return { ok: false, error: "You don't have access to this chart." };
+    throw err;
+  }
+
+  const result = parseSpokenIntent(parsed.data.utterance);
+  if (result.drafts.length === 0) {
+    return { ok: true, staged: [], lowConfidence: result.lowConfidence };
+  }
+
+  // Skip drafts already staged for this encounter (idempotent re-dictation).
+  const existing = await prisma.clinicalOrder.findMany({
+    where: {
+      patientId: parsed.data.patientId,
+      encounterId: parsed.data.encounterId ?? undefined,
+      status: "draft",
+    },
+    select: { orderCode: true },
+  });
+  const have = new Set(existing.map((o) => o.orderCode));
+
+  const orderedByName = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() || user.email;
+  const created: CheckoutDraft[] = [];
+
+  for (const draft of result.drafts) {
+    if (have.has(draft.code.code)) continue;
+    const row = await prisma.clinicalOrder.create({
+      data: {
+        organizationId: user.organizationId!,
+        patientId: parsed.data.patientId,
+        encounterId: parsed.data.encounterId ?? null,
+        orderType: ORDER_TYPE_FOR_KIND[draft.kind],
+        orderCode: draft.code.code,
+        orderName: draft.name,
+        priority: "routine",
+        diagnosisCodes: [] as unknown as Prisma.InputJsonValue,
+        payload: { ...draft, sourceUtterance: parsed.data.utterance } as unknown as Prisma.InputJsonValue,
+        status: "draft",
+        transmissionMode: "simulated",
+        orderedById: user.id,
+        orderedByName,
+      },
+      select: { id: true, orderType: true, orderCode: true, orderName: true, payload: true },
+    });
+    created.push(toCheckoutDraft(row));
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: "order.intent.drafted",
+      subjectType: "Patient",
+      subjectId: parsed.data.patientId,
+      metadata: {
+        staged: created.length,
+        lowConfidence: result.lowConfidence.length,
+        codes: created.map((c) => c.code.code),
+      } as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${parsed.data.patientId}/orders`);
+  return { ok: true, staged: created, lowConfidence: result.lowConfidence };
+}
+
+/** List the patient's (optionally encounter-scoped) draft checkout queue. */
+export async function getCheckoutQueue(
+  patientId: string,
+  encounterId?: string | null,
+): Promise<{ ok: true; drafts: CheckoutDraft[] } | { ok: false; error: string }> {
+  const user = await requireUser();
+  try {
+    await assertChartAccess(user, patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) return { ok: false, error: "No access." };
+    throw err;
+  }
+  const rows = await prisma.clinicalOrder.findMany({
+    where: { patientId, status: "draft", ...(encounterId ? { encounterId } : {}) },
+    orderBy: { createdAt: "asc" },
+    select: { id: true, orderType: true, orderCode: true, orderName: true, payload: true },
+  });
+  return { ok: true, drafts: rows.map(toCheckoutDraft) };
+}
+
+/** Authorize & sign drafts: draft → placed; labs route out, lifestyle → patient app. */
+export async function signSpokenIntentOrders(
+  orderIds: string[],
+): Promise<{ ok: true; signed: number } | { ok: false; error: string }> {
+  const user = await requireUser();
+  if (!Array.isArray(orderIds) || orderIds.length === 0) {
+    return { ok: false, error: "Nothing to sign." };
+  }
+
+  const rows = await prisma.clinicalOrder.findMany({
+    where: { id: { in: orderIds }, status: "draft", organizationId: user.organizationId! },
+    select: { id: true, patientId: true, orderType: true, orderName: true },
+  });
+  if (rows.length === 0) return { ok: false, error: "No matching drafts to sign." };
+
+  try {
+    requirePermission(user, "labs.sign");
+    await assertChartAccess(user, rows[0].patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) return { ok: false, error: "You don't have permission to sign orders." };
+    throw err;
+  }
+
+  const now = new Date();
+  for (const row of rows) {
+    const isLifestyle = row.orderType === "lifestyle";
+    await prisma.clinicalOrder.update({
+      where: { id: row.id },
+      data: {
+        status: "placed",
+        transmissionMode: isLifestyle ? "patient_app" : "simulated",
+        updatedAt: now,
+      },
+    });
+
+    if (isLifestyle) {
+      const patient = await prisma.patient.findUnique({
+        where: { id: row.patientId },
+        select: { userId: true },
+      });
+      if (patient?.userId) {
+        await prisma.notification.create({
+          data: {
+            userId: patient.userId,
+            type: "lifestyle_rx",
+            priority: "normal",
+            title: "New plan from your care team",
+            body: `Your care team added "${row.orderName}" to your plan. Open the app to see the details.`,
+            href: "/portal/care-plan",
+          },
+        });
+      }
+    }
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: user.organizationId!,
+      actorUserId: user.id,
+      action: "order.intent.signed",
+      subjectType: "Patient",
+      subjectId: rows[0].patientId,
+      metadata: { signed: rows.map((r) => r.id) } as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  revalidatePath(`/clinic/patients/${rows[0].patientId}/orders`);
+  return { ok: true, signed: rows.length };
+}
+
+/** Discard a draft from the checkout queue (status → cancelled). */
+export async function discardDraft(
+  orderId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser();
+  const row = await prisma.clinicalOrder.findFirst({
+    where: { id: orderId, status: "draft", organizationId: user.organizationId! },
+    select: { id: true, patientId: true },
+  });
+  if (!row) return { ok: false, error: "Draft not found." };
+  try {
+    await assertChartAccess(user, row.patientId);
+  } catch (err) {
+    if (err instanceof ForbiddenError) return { ok: false, error: "No access." };
+    throw err;
+  }
+  await prisma.clinicalOrder.update({ where: { id: row.id }, data: { status: "cancelled" } });
+  revalidatePath(`/clinic/patients/${row.patientId}/orders`);
+  return { ok: true };
+}

--- a/src/app/(clinician)/clinic/patients/[id]/orders/spoken-intent-checkout.tsx
+++ b/src/app/(clinician)/clinic/patients/[id]/orders/spoken-intent-checkout.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DictationTextarea } from "@/components/ui/dictation-input";
+import {
+  discardDraft,
+  getCheckoutQueue,
+  signSpokenIntentOrders,
+  stageSpokenIntent,
+  type CheckoutDraft,
+} from "./spoken-intent-actions";
+import type { DraftOrder } from "@/lib/clinical/spoken-intent/types";
+
+const EXAMPLE =
+  "e.g. Let's check your fasting insulin and NMR lipoprofile next week, and start a 14:10 intermittent fasting schedule";
+
+// EMR-1157 — spoken-intent order drafting. The provider dictates or types a
+// directive; specific targets stage silently as draft orders (soft-hue,
+// Zen-Density); "Authorize & Sign" is the only thing that transmits anything.
+export function SpokenIntentCheckout({
+  patientId,
+  encounterId = null,
+}: {
+  patientId: string;
+  encounterId?: string | null;
+}) {
+  const [utterance, setUtterance] = React.useState("");
+  const [drafts, setDrafts] = React.useState<CheckoutDraft[]>([]);
+  const [lowConfidence, setLowConfidence] = React.useState<DraftOrder[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [signedCount, setSignedCount] = React.useState(0);
+  const [drafting, startDrafting] = React.useTransition();
+  const [signing, startSigning] = React.useTransition();
+
+  React.useEffect(() => {
+    let active = true;
+    getCheckoutQueue(patientId, encounterId).then((res) => {
+      if (active && res.ok) setDrafts(res.drafts);
+    });
+    return () => {
+      active = false;
+    };
+  }, [patientId, encounterId]);
+
+  function draft() {
+    if (!utterance.trim()) return;
+    setError(null);
+    setSignedCount(0);
+    startDrafting(async () => {
+      const res = await stageSpokenIntent({ patientId, encounterId, utterance });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      setDrafts((cur) => {
+        const seen = new Set(cur.map((d) => d.id));
+        return [...cur, ...res.staged.filter((d) => !seen.has(d.id))];
+      });
+      setLowConfidence(res.lowConfidence);
+      setUtterance("");
+    });
+  }
+
+  function sign() {
+    if (drafts.length === 0) return;
+    setError(null);
+    const ids = drafts.map((d) => d.id);
+    startSigning(async () => {
+      const res = await signSpokenIntentOrders(ids);
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      setSignedCount(res.signed);
+      setDrafts([]);
+      setLowConfidence([]);
+    });
+  }
+
+  function remove(id: string) {
+    startDrafting(async () => {
+      const res = await discardDraft(id);
+      if (res.ok) setDrafts((cur) => cur.filter((d) => d.id !== id));
+      else setError(res.error);
+    });
+  }
+
+  return (
+    <section
+      aria-labelledby="spoken-intent-heading"
+      className="overflow-hidden rounded-xl border border-border bg-surface shadow-sm"
+    >
+      <div className="border-b border-border/70 bg-surface-muted/60 px-5 py-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">
+          Spoken-intent drafting
+        </p>
+        <h2 id="spoken-intent-heading" className="mt-1 font-display text-xl font-semibold tracking-tight text-text">
+          Say it; we'll draft the orders
+        </h2>
+        <p className="mt-1 text-sm text-text-muted">
+          Dictate or type what you want. Labs and lifestyle plans stage as drafts below — nothing
+          is sent until you Authorize &amp; Sign.
+        </p>
+      </div>
+
+      <div className="space-y-4 px-5 py-5">
+        <div className="space-y-2">
+          <DictationTextarea
+            value={utterance}
+            onChange={setUtterance}
+            rows={3}
+            placeholder={EXAMPLE}
+            aria-label="Order directive"
+            className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text shadow-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
+          />
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-text-subtle">
+              Tap the mic to dictate, or type the directive.
+            </span>
+            <Button type="button" size="sm" variant="secondary" onClick={draft} disabled={drafting || !utterance.trim()}>
+              {drafting ? "Drafting…" : "Draft orders"}
+            </Button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-danger/30 bg-red-50/40 px-4 py-2.5 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        {signedCount > 0 && (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50/60 px-4 py-2.5 text-sm font-medium text-emerald-700">
+            ✓ Signed {signedCount} order{signedCount === 1 ? "" : "s"} — labs routed to the diagnostic
+            center; lifestyle plans sent to the patient app.
+          </div>
+        )}
+
+        {drafts.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Checkout queue · {drafts.length} draft{drafts.length === 1 ? "" : "s"}
+            </p>
+            <ul className="space-y-2">
+              {drafts.map((d) => (
+                <li
+                  key={d.id}
+                  className="flex items-start gap-3 rounded-lg border border-accent/20 bg-accent-soft/30 px-4 py-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold text-text">{d.name}</span>
+                      <Badge tone={d.resourceType === "CarePlan" ? "accent" : "neutral"}>
+                        {d.resourceType === "CarePlan" ? "Lifestyle" : "Lab"}
+                      </Badge>
+                      <Badge tone="neutral">
+                        {d.code.system} {d.code.code}
+                      </Badge>
+                      {d.occurrenceLabel && (
+                        <span className="rounded-full bg-surface px-2 py-0.5 text-xs font-medium text-text-muted">
+                          🗓 {d.occurrenceLabel}
+                        </span>
+                      )}
+                      {d.detail && (
+                        <span className="rounded-full bg-surface px-2 py-0.5 text-xs font-medium text-text-muted">
+                          {d.detail}
+                        </span>
+                      )}
+                    </div>
+                    {d.fastingInstruction && (
+                      <p className="mt-1 text-xs text-text-muted">🚰 {d.fastingInstruction}</p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => remove(d.id)}
+                    disabled={drafting}
+                    className="shrink-0 rounded-md px-2 py-1 text-xs text-text-subtle hover:bg-surface hover:text-danger"
+                    aria-label={`Remove ${d.name}`}
+                    title="Remove from checkout"
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {lowConfidence.length > 0 && (
+          <div className="rounded-lg border border-highlight/30 bg-highlight-soft px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-text-subtle">
+              Needs a clearer name — not staged
+            </p>
+            <ul className="mt-1 space-y-0.5 text-sm text-text-muted">
+              {lowConfidence.map((d, i) => (
+                <li key={i}>
+                  “{d.raw}” → did you mean <span className="font-medium text-text">{d.name}</span>? Say it
+                  more specifically to stage it.
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {drafts.length > 0 && (
+          <div className="flex items-center justify-between gap-3 border-t border-border/60 pt-4">
+            <p className="text-xs text-text-muted">
+              Drafts stay private until you sign. Signing transmits labs and notifies the patient.
+            </p>
+            <Button type="button" size="sm" variant="primary" onClick={sign} disabled={signing}>
+              {signing ? "Signing…" : `Authorize & Sign (${drafts.length})`}
+            </Button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/clinical/spoken-intent/catalog.ts
+++ b/src/lib/clinical/spoken-intent/catalog.ts
@@ -1,0 +1,198 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1157 — Order intent catalog
+// ───────────────────────────────────────────────────────────────────────────
+// Maps the clinical targets a provider names out loud to codeable, schedulable
+// orders. `primary` synonyms are specific phrases (high I_match); `loose`
+// synonyms are generic single terms (borderline → verify queue). LOINC for
+// labs (→ ServiceRequest), SNOMED for lifestyle regimens (→ CarePlan).
+
+import type { CodeSystem, DraftKind, DraftResourceType } from "./types";
+
+export interface IntentCatalogEntry {
+  id: string;
+  kind: DraftKind;
+  resourceType: DraftResourceType;
+  system: CodeSystem;
+  code: string;
+  display: string;
+  /** Specific multi-word phrases → high confidence (0.93). */
+  primary: string[];
+  /** Generic single terms → borderline confidence (0.82). */
+  loose: string[];
+  /** Labs that require a fasting prep instruction. */
+  fasting: boolean;
+}
+
+// Confidence weights — primary lands above the 0.88 auto-stage cutoff, loose
+// below it, so a vague mention ("check her sugar") routes to verify.
+export const PRIMARY_CONFIDENCE = 0.93;
+export const LOOSE_CONFIDENCE = 0.82;
+
+export const INTENT_CATALOG: IntentCatalogEntry[] = [
+  // ── Labs (LOINC → ServiceRequest) ──────────────────────────────────────
+  {
+    id: "fasting-insulin",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "2492-2",
+    display: "Insulin, fasting (serum/plasma)",
+    primary: ["fasting insulin"],
+    loose: ["insulin"],
+    fasting: true,
+  },
+  {
+    id: "nmr-lipoprofile",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "43396-1",
+    display: "NMR LipoProfile (lipoprotein particles)",
+    primary: ["nmr lipoprofile", "nmr lipoprotein", "nmr lipid panel", "lipoprofile"],
+    loose: ["nmr"],
+    fasting: true,
+  },
+  {
+    id: "fasting-glucose",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "1558-6",
+    display: "Glucose, fasting (serum/plasma)",
+    primary: ["fasting glucose", "fasting blood sugar"],
+    loose: ["glucose", "blood sugar", "sugar"],
+    fasting: true,
+  },
+  {
+    id: "hba1c",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "4548-4",
+    display: "Hemoglobin A1c",
+    primary: ["hemoglobin a1c", "hba1c", "a1c"],
+    loose: [],
+    fasting: false,
+  },
+  {
+    id: "lipid-panel",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "57698-3",
+    display: "Lipid panel",
+    primary: ["lipid panel", "cholesterol panel"],
+    loose: ["lipids", "cholesterol"],
+    fasting: true,
+  },
+  {
+    id: "cmp",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "24323-8",
+    display: "Comprehensive metabolic panel",
+    primary: ["comprehensive metabolic panel", "metabolic panel", "cmp"],
+    loose: [],
+    fasting: true,
+  },
+  {
+    id: "cbc",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "58410-2",
+    display: "Complete blood count with differential",
+    primary: ["complete blood count", "cbc"],
+    loose: [],
+    fasting: false,
+  },
+  {
+    id: "tsh",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "3016-3",
+    display: "Thyroid stimulating hormone",
+    primary: ["thyroid stimulating hormone", "tsh"],
+    loose: ["thyroid"],
+    fasting: false,
+  },
+  {
+    id: "vitamin-d",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "1989-3",
+    display: "Vitamin D, 25-hydroxy",
+    primary: ["vitamin d", "25-hydroxy vitamin d"],
+    loose: ["vit d"],
+    fasting: false,
+  },
+  {
+    id: "hs-crp",
+    kind: "lab",
+    resourceType: "ServiceRequest",
+    system: "LOINC",
+    code: "30522-7",
+    display: "C-reactive protein, high sensitivity",
+    primary: ["high sensitivity crp", "hs-crp", "c-reactive protein"],
+    loose: ["crp", "inflammation"],
+    fasting: false,
+  },
+
+  // ── Lifestyle regimens (SNOMED → CarePlan) ─────────────────────────────
+  {
+    id: "dietary-regimen",
+    kind: "lifestyle",
+    resourceType: "CarePlan",
+    system: "SNOMED",
+    code: "410606002",
+    display: "Dietary regimen",
+    primary: [
+      "intermittent fasting",
+      "time-restricted eating",
+      "time restricted eating",
+      "fasting schedule",
+      "eating window",
+      "low-carb diet",
+      "ketogenic diet",
+      "mediterranean diet",
+    ],
+    loose: ["diet", "nutrition plan"],
+    fasting: false,
+  },
+  {
+    id: "exercise-regimen",
+    kind: "lifestyle",
+    resourceType: "CarePlan",
+    system: "SNOMED",
+    code: "229065009",
+    display: "Exercise regimen",
+    primary: ["exercise regimen", "physical activity", "walking program", "zone 2 cardio", "strength training"],
+    loose: ["exercise", "walking", "cardio"],
+    fasting: false,
+  },
+  {
+    id: "sleep-hygiene",
+    kind: "lifestyle",
+    resourceType: "CarePlan",
+    system: "SNOMED",
+    code: "226992006",
+    display: "Sleep hygiene regimen",
+    primary: ["sleep hygiene", "sleep schedule", "consistent bedtime"],
+    loose: ["sleep"],
+    fasting: false,
+  },
+  {
+    id: "mindfulness-regimen",
+    kind: "lifestyle",
+    resourceType: "CarePlan",
+    system: "SNOMED",
+    code: "228557008",
+    display: "Mindfulness / stress-reduction regimen",
+    primary: ["mindfulness practice", "stress reduction", "breathing exercises", "meditation practice"],
+    loose: ["meditation", "mindfulness"],
+    fasting: false,
+  },
+];

--- a/src/lib/clinical/spoken-intent/index.ts
+++ b/src/lib/clinical/spoken-intent/index.ts
@@ -1,0 +1,4 @@
+// Public API for the spoken-intent order-drafting module (EMR-1157).
+export * from "./types";
+export * from "./catalog";
+export * from "./parse-intent";

--- a/src/lib/clinical/spoken-intent/parse-intent.test.ts
+++ b/src/lib/clinical/spoken-intent/parse-intent.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractWindow,
+  parseSpokenIntent,
+  parseTemporal,
+  splitSegments,
+} from "./parse-intent";
+
+const NOW = new Date("2026-06-15T12:00:00.000Z"); // a Monday
+
+describe("segmentation + temporal + window helpers", () => {
+  it("keeps 'A and B <temporal>' in one clause", () => {
+    const segs = splitSegments("check fasting insulin and NMR lipoprofile next week, and start a 14:10 schedule");
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toContain("fasting insulin and NMR lipoprofile next week");
+  });
+
+  it("resolves temporal phrases to concrete windows", () => {
+    const nextWeek = parseTemporal("draw it next week", NOW);
+    expect(nextWeek?.label).toBe("next week");
+    expect(nextWeek?.start).toBe(new Date("2026-06-22T12:00:00.000Z").toISOString());
+    expect(parseTemporal("in 3 days", NOW)?.label).toBe("in 3 days");
+    expect(parseTemporal("in two weeks", NOW)?.start).toBe(new Date("2026-06-29T12:00:00.000Z").toISOString());
+    expect(parseTemporal("no time here", NOW)).toBeNull();
+  });
+
+  it("extracts an eating window", () => {
+    expect(extractWindow("start a 14:10 intermittent fasting schedule")).toBe("14:10");
+    expect(extractWindow("16/8 eating window")).toBe("16:8");
+  });
+});
+
+// ── Headline acceptance fixture: the doc's exact example utterance ──────────
+describe("doc example utterance", () => {
+  const result = parseSpokenIntent(
+    "Let's check your fasting insulin and NMR lipoprofile next week, and start a 14:10 intermittent fasting schedule.",
+    { now: NOW },
+  );
+
+  it("produces exactly 2 ServiceRequests + 1 CarePlan", () => {
+    expect(result.drafts).toHaveLength(3);
+    expect(result.lowConfidence).toHaveLength(0);
+    const serviceRequests = result.drafts.filter((d) => d.resourceType === "ServiceRequest");
+    const carePlans = result.drafts.filter((d) => d.resourceType === "CarePlan");
+    expect(serviceRequests).toHaveLength(2);
+    expect(carePlans).toHaveLength(1);
+  });
+
+  it("codes the labs with the doc's LOINC codes", () => {
+    const codes = result.drafts.filter((d) => d.kind === "lab").map((d) => d.code.code).sort();
+    expect(codes).toEqual(["2492-2", "43396-1"]); // fasting insulin, NMR lipoprofile
+    expect(result.drafts.every((d) => d.kind !== "lab" || d.code.system === "LOINC")).toBe(true);
+  });
+
+  it("codes the lifestyle regimen as SNOMED dietary regimen with the window", () => {
+    const carePlan = result.drafts.find((d) => d.resourceType === "CarePlan")!;
+    expect(carePlan.code.system).toBe("SNOMED");
+    expect(carePlan.code.code).toBe("410606002");
+    expect(carePlan.detail).toBe("14:10");
+  });
+
+  it("applies 'next week' as a concrete occurrencePeriod to both labs", () => {
+    for (const lab of result.drafts.filter((d) => d.kind === "lab")) {
+      expect(lab.occurrencePeriod?.label).toBe("next week");
+      expect(lab.occurrencePeriod?.start).toBe(new Date("2026-06-22T12:00:00.000Z").toISOString());
+    }
+  });
+
+  it("auto-appends the 12-hour water-fast instruction to fasting labs", () => {
+    for (const lab of result.drafts.filter((d) => d.kind === "lab")) {
+      expect(lab.fasting?.required).toBe(true);
+      expect(lab.fasting?.instruction).toMatch(/12 hours/);
+    }
+  });
+
+  it("keeps everything intent=draft (nothing transmits unsigned)", () => {
+    expect(result.drafts.every((d) => d.intent === "draft")).toBe(true);
+  });
+});
+
+describe("confidence routing (I_match ≥ 0.88)", () => {
+  it("routes a vague single-term mention to the verify queue", () => {
+    const result = parseSpokenIntent("let's check her sugar", { now: NOW });
+    expect(result.drafts).toHaveLength(0);
+    expect(result.lowConfidence.length).toBeGreaterThanOrEqual(1);
+    expect(result.lowConfidence[0].confidence).toBeLessThan(0.88);
+  });
+
+  it("auto-stages a specific phrase", () => {
+    const result = parseSpokenIntent("order an HbA1c", { now: NOW });
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].code.code).toBe("4548-4");
+  });
+
+  it("dedupes a target named twice, keeping the higher confidence", () => {
+    const result = parseSpokenIntent("check insulin, specifically a fasting insulin", { now: NOW });
+    const insulin = result.drafts.filter((d) => d.code.code === "2492-2");
+    expect(insulin).toHaveLength(1);
+    expect(insulin[0].confidence).toBe(0.93);
+  });
+});

--- a/src/lib/clinical/spoken-intent/parse-intent.ts
+++ b/src/lib/clinical/spoken-intent/parse-intent.ts
@@ -1,0 +1,181 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1157 — Spoken-intent parser
+// ───────────────────────────────────────────────────────────────────────────
+// Turn a provider directive into draft, codeable orders:
+//   • clinical targets → LOINC (labs → ServiceRequest) / SNOMED (lifestyle →
+//     CarePlan), matched against the intent catalog
+//   • temporal modifiers ("next week") → a concrete occurrencePeriod
+//   • fasting labs auto-append the 12-hour water-fast instruction
+//   • I_match ≥ threshold auto-stages; below routes to the verify queue
+//
+// Deterministic (a `now` is injectable) so the doc's example utterance always
+// yields the same 2 ServiceRequests + 1 CarePlan the acceptance fixture asserts.
+
+import {
+  INTENT_CATALOG,
+  LOOSE_CONFIDENCE,
+  PRIMARY_CONFIDENCE,
+  type IntentCatalogEntry,
+} from "./catalog";
+import {
+  FASTING_INSTRUCTION,
+  INTENT_MATCH_THRESHOLD,
+  type DraftOrder,
+  type OccurrencePeriod,
+  type ParsedIntent,
+} from "./types";
+
+export interface ParseOptions {
+  /** Injected clock for deterministic occurrencePeriod resolution. */
+  now?: Date;
+  /** Override the I_match auto-stage cutoff (default 0.88). */
+  threshold?: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Segmentation                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Split a directive into clauses on punctuation + "and then". We deliberately
+ * do NOT split bare " and " so "fasting insulin and NMR lipoprofile next week"
+ * stays one clause and the trailing temporal applies to both labs.
+ */
+export function splitSegments(utterance: string): string[] {
+  return utterance
+    .split(/[,;]|\.\s+|\band then\b/i)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Temporal resolution                                                        */
+/* -------------------------------------------------------------------------- */
+
+const WORD_NUMBERS: Record<string, number> = {
+  a: 1, an: 1, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6,
+  seven: 7, eight: 8, nine: 9, ten: 10, twelve: 12,
+};
+
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base.getTime());
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function period(now: Date, startOffset: number, endOffset: number, label: string): OccurrencePeriod {
+  return {
+    start: addDays(now, startOffset).toISOString(),
+    end: addDays(now, endOffset).toISOString(),
+    label,
+  };
+}
+
+/** Resolve a temporal phrase in `text` to a concrete window, or null. */
+export function parseTemporal(text: string, now: Date): OccurrencePeriod | null {
+  const t = text.toLowerCase();
+  if (/\btoday\b/.test(t)) return period(now, 0, 1, "today");
+  if (/\btomorrow\b/.test(t)) return period(now, 1, 2, "tomorrow");
+  if (/\bnext week\b/.test(t)) return period(now, 7, 14, "next week");
+  if (/\bthis week\b/.test(t)) return period(now, 0, 7, "this week");
+  if (/\bnext month\b/.test(t)) return period(now, 30, 60, "next month");
+
+  const rel = t.match(
+    /\bin\s+(\d+|a|an|one|two|three|four|five|six|seven|eight|nine|ten|twelve)\s*(day|days|week|weeks|month|months)\b/,
+  );
+  if (rel) {
+    const n = WORD_NUMBERS[rel[1]] ?? Number(rel[1]);
+    if (Number.isFinite(n) && n > 0) {
+      const unit = rel[2];
+      const days = unit.startsWith("day") ? n : unit.startsWith("week") ? n * 7 : n * 30;
+      return period(now, days, days + 1, `in ${rel[1]} ${rel[2]}`);
+    }
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Catalog matching                                                           */
+/* -------------------------------------------------------------------------- */
+
+function phraseRegex(phrase: string): RegExp {
+  const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
+  return new RegExp(`\\b${escaped}\\b`, "i");
+}
+
+interface Match {
+  entry: IntentCatalogEntry;
+  phrase: string;
+  confidence: number;
+}
+
+function matchTargets(segment: string): Match[] {
+  const matches: Match[] = [];
+  for (const entry of INTENT_CATALOG) {
+    const primaryHit = entry.primary.find((p) => phraseRegex(p).test(segment));
+    if (primaryHit) {
+      matches.push({ entry, phrase: primaryHit, confidence: PRIMARY_CONFIDENCE });
+      continue;
+    }
+    const looseHit = entry.loose.find((p) => phraseRegex(p).test(segment));
+    if (looseHit) {
+      matches.push({ entry, phrase: looseHit, confidence: LOOSE_CONFIDENCE });
+    }
+  }
+  return matches;
+}
+
+/** Eating/fasting window for a lifestyle regimen ("14:10", "16:8" → "16:8"). */
+export function extractWindow(text: string): string | null {
+  const m = text.match(/\b(\d{1,2})\s*[:\/]\s*(\d{1,2})\b/);
+  return m ? `${Number(m[1])}:${Number(m[2])}` : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Main entry                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export function parseSpokenIntent(utterance: string, opts: ParseOptions = {}): ParsedIntent {
+  const now = opts.now ?? new Date();
+  const threshold = opts.threshold ?? INTENT_MATCH_THRESHOLD;
+
+  // Dedupe by catalog entry; keep the highest-confidence occurrence.
+  const byEntry = new Map<string, DraftOrder>();
+
+  for (const segment of splitSegments(utterance)) {
+    const temporal = parseTemporal(segment, now);
+    const window = extractWindow(segment);
+
+    for (const { entry, phrase, confidence } of matchTargets(segment)) {
+      const draft: DraftOrder = {
+        resourceType: entry.resourceType,
+        kind: entry.kind,
+        code: { system: entry.system, code: entry.code, display: entry.display },
+        name: entry.display,
+        occurrencePeriod: temporal,
+        fasting: entry.fasting ? { required: true, instruction: FASTING_INSTRUCTION } : null,
+        detail: entry.kind === "lifestyle" ? window : null,
+        confidence,
+        intent: "draft",
+        raw: phrase,
+      };
+
+      const existing = byEntry.get(entry.id);
+      if (!existing || confidence > existing.confidence) {
+        byEntry.set(entry.id, draft);
+      }
+    }
+  }
+
+  // ServiceRequests before CarePlans, then by code — deterministic ordering.
+  const all = [...byEntry.values()].sort((a, b) => {
+    if (a.resourceType !== b.resourceType) return a.resourceType === "ServiceRequest" ? -1 : 1;
+    return a.code.code.localeCompare(b.code.code);
+  });
+
+  return {
+    utterance,
+    drafts: all.filter((d) => d.confidence >= threshold),
+    lowConfidence: all.filter((d) => d.confidence < threshold),
+  };
+}

--- a/src/lib/clinical/spoken-intent/types.ts
+++ b/src/lib/clinical/spoken-intent/types.ts
@@ -1,0 +1,70 @@
+// ───────────────────────────────────────────────────────────────────────────
+// EMR-1157 — Spoken-intent order drafting: shared types
+// ───────────────────────────────────────────────────────────────────────────
+// Doc "Autonomous Order & Script Drafting" (epic EMR-1124). A provider's spoken
+// or typed directive is parsed into draft, codeable orders that stage silently
+// in the encounter checkout queue until the provider signs. Nothing transmits
+// while a draft has intent="draft".
+//
+// FHIR-shaped on purpose: lab/imaging requests serialize as ServiceRequest,
+// lifestyle/dietary regimens as CarePlan — the card's acceptance fixture asserts
+// the doc utterance yields exactly 2 ServiceRequests + 1 CarePlan.
+
+export type DraftResourceType = "ServiceRequest" | "CarePlan";
+export type DraftKind = "lab" | "imaging" | "lifestyle";
+export type CodeSystem = "LOINC" | "SNOMED" | "internal";
+
+export interface CodeableConcept {
+  system: CodeSystem;
+  code: string;
+  display: string;
+}
+
+/** Concrete scheduling window resolved from a temporal phrase ("next week"). */
+export interface OccurrencePeriod {
+  /** ISO-8601 start of the window. */
+  start: string;
+  /** ISO-8601 end of the window. */
+  end: string;
+  /** The phrase that produced it ("next week", "in 3 days"). */
+  label: string;
+}
+
+export interface FastingModifier {
+  required: boolean;
+  /** Patient-facing prep instruction appended to fasting labs. */
+  instruction: string;
+}
+
+export interface DraftOrder {
+  resourceType: DraftResourceType;
+  kind: DraftKind;
+  code: CodeableConcept;
+  /** Display name for the checkout queue row. */
+  name: string;
+  occurrencePeriod: OccurrencePeriod | null;
+  fasting: FastingModifier | null;
+  /** Free detail for lifestyle regimens (e.g. the "14:10" eating window). */
+  detail: string | null;
+  /** Intent-match confidence I_match ∈ [0,1]. */
+  confidence: number;
+  /** Always "draft" — nothing is signed/transmitted by the parser. */
+  intent: "draft";
+  /** The matched source phrase, for provenance + the verify queue. */
+  raw: string;
+}
+
+export interface ParsedIntent {
+  utterance: string;
+  /** I_match ≥ threshold — auto-staged drafts. */
+  drafts: DraftOrder[];
+  /** Below threshold — routed to the low-confidence verify queue. */
+  lowConfidence: DraftOrder[];
+}
+
+/** Auto-stage cutoff from the doc (I_match ≥ 0.88). */
+export const INTENT_MATCH_THRESHOLD = 0.88;
+
+/** The 12-hour water-fast prep auto-appended to fasting labs. */
+export const FASTING_INSTRUCTION =
+  "Fast for 12 hours before this lab — water only, no food or other drinks.";


### PR DESCRIPTION
## Wave 3 — Spoken-intent order drafting (EMR-1157)

Implements "Autonomous Order & Script Drafting" (epic **EMR-1124**): a provider's spoken or typed directive is parsed into **draft, codeable orders** that stage silently in an encounter checkout queue and only transmit on **Authorize & Sign**.

### Flow
Dictate/type → parse → draft `ServiceRequest`s (labs) + `CarePlan`s (lifestyle) stage in the checkout queue (soft-hue, Zen-Density) → **Authorize & Sign** routes labs to the diagnostic center (simulated) and drops lifestyle plans to the patient app.

### What's here

**Parser — `src/lib/clinical/spoken-intent/`** (deterministic, 12 tests)
- `catalog.ts` — maps named targets to **LOINC** (labs → ServiceRequest) / **SNOMED** (lifestyle → CarePlan), with `primary` (specific) vs `loose` (generic) synonyms and fasting flags.
- `parse-intent.ts` — segments the directive; resolves temporal phrases (`"next week"` → concrete `occurrencePeriod`); auto-appends the **12-hour water-fast** instruction to fasting labs; scores intent match (**I_match ≥ 0.88 auto-stages**, below → verify queue); dedupes repeated targets.
- **Headline fixture:** the doc's exact utterance — *"Let's check your fasting insulin and NMR lipoprofile next week, and start a 14:10 intermittent fasting schedule"* → **2 ServiceRequests** (LOINC `2492-2`, `43396-1`) **+ 1 CarePlan** (SNOMED `410606002`, window `14:10`), both labs scheduled "next week" with fasting prep.

**Persistence — `spoken-intent-actions.ts`**
- Drafts persist as `ClinicalOrder` `status="draft"` (lab) / `orderType="lifestyle"` (CarePlan) — free-string columns, **no migration**.
- `stageSpokenIntent` (idempotent per encounter), `getCheckoutQueue`, `signSpokenIntentOrders` (draft→placed + audit; lifestyle → patient `Notification`), `discardDraft`.
- **intent stays "draft" until signed — nothing transmits unsigned.**

**UI — `spoken-intent-checkout.tsx`** on the labs orders page
- `DictationTextarea` directive input (voice or type), soft-hue draft cards (code + occurrence + fasting prep + window), a low-confidence "needs a clearer name" verify section, and one `Authorize & Sign (N)`.

### Verification (local, CI-parity)
- `tsc --noEmit`: clean · `next lint` + `manifests:lint`: OK · `vitest run`: **3457 passed** (371 files, 12 new) · `next build`: OK

### Notes
- No schema migration — reuses `ClinicalOrder`'s free-string `status`/`orderType`.
- Deterministic parser (no LLM) → reproducible + testable; an LLM intent-extraction seam can be layered behind the same `ParsedIntent` contract later.
- Mounted on the labs orders page (patient-scoped queue) as the discoverable home; the same component takes an `encounterId` for an encounter-scoped side panel when wired into the encounter view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
